### PR TITLE
fix: remove empty line before frontmatter in creative-formats.md

### DIFF
--- a/docs/media-buy/creative-formats.md
+++ b/docs/media-buy/creative-formats.md
@@ -1,4 +1,3 @@
-
 ---
 title: Creative Formats
 ---


### PR DESCRIPTION
## Summary
- Fixed the creative formats documentation title display issue
- Removed empty line at the beginning of the file that prevented Docusaurus from recognizing the frontmatter

## Test plan
- [x] Verified the file now starts directly with frontmatter delimiter `---`
- [x] Confirmed the title "Creative Formats" displays correctly in the documentation
- [x] Matches the pattern of other documentation files in the project

🤖 Generated with [Claude Code](https://claude.ai/code)