### PR TITLE
feat: align with signals agent spec and add get_signals endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Implementation details can be mentioned as:
 5. **AI-Optimized**: Designed for AI agents
 
 ### What Exists vs What Doesn't
-- ✅ `list_products` - discovers inventory
+- ✅ `get_products` - discovers inventory
 - ❌ `discover_products` - doesn't exist
 - ❌ `get_avails` - removed in favor of direct purchase
 - ✅ `create_media_buy` - creates campaigns

--- a/docs/media-buy/api-reference.md
+++ b/docs/media-buy/api-reference.md
@@ -142,6 +142,7 @@ Creates a media buy from selected packages.
     "geo_country_any_of": ["US"],
     "geo_region_any_of": ["CA", "NY"],
     "audience_segment_any_of": ["3p:pet_owners"],
+    "signals": ["auto_intenders_q1_2025"],  // Optional: Signal IDs from get_signals
     "frequency_cap": {
       "suppress_minutes": 30,
       "scope": "media_buy"
@@ -671,7 +672,7 @@ Retrieves delivery data for all active media buys across all principals.
 
 **Response:** Same format as get_media_buy_delivery but includes all media buys.
 
-### 16. list_products
+### 16. get_products
 
 Lists available advertising products for the authenticated principal with optional natural language brief and filtering.
 
@@ -797,12 +798,58 @@ Verify if required AEE dimensions are supported for a channel.
 
 Use this before creating a media buy to ensure the publisher can provide required AEE signals.
 
+### 19. get_signals (Optional)
+
+Lists available audience segments and signals that the publisher can activate for targeting. This optional endpoint allows publishers to advertise the segments they have available through their data partnerships.
+
+**Request:**
+```json
+{
+  "signal_type": "audience",  // Optional: "audience", "contextual", "geographic", etc.
+  "category": "string",       // Optional: Filter by category (e.g., "demographics", "interests")
+  "search": "string"          // Optional: Natural language search for signals
+}
+```
+
+**Response:**
+```json
+{
+  "signals": [
+    {
+      "signal_id": "auto_intenders_q1_2025",
+      "name": "Auto Intenders Q1 2025",
+      "description": "In-market for new vehicles in Q1 2025",
+      "type": "audience",
+      "category": "purchase_intent",
+      "size": {
+        "value": 2500000,
+        "unit": "individuals"  // "individuals", "devices", or "households"
+      },
+      "geography": ["US", "CA"],
+      "freshness": "2025-01-15",  // Last update date
+      "provider": "LiveRamp",
+      "cost": {
+        "cpm": 2.50,
+        "revenue_share": 0.05,
+        "pricing_model": "both"  // "cpm", "revenue_share", or "both"
+      }
+    }
+  ]
+}
+```
+
+**Notes:**
+- This is an optional endpoint for publishers who want to expose available segments
+- The signal_id returned here can be used in create_media_buy's targeting.signals array
+- Publishers may choose to expose all segments or only premium/differentiated ones
+- Cost information helps buyers understand incremental data costs
+
 
 ## Creative Macro Signal
 
-The creative macro is a third type of provided signal from AEE, enabling dynamic creative customization.
+The creative macro is a third type of AEE signal, enabling dynamic creative customization.
 
-### AEE Provided Signals
+### AEE Signals
 
 1. **may_include** - Signals to include for targeting
 2. **must_exclude** - Signals that must be excluded  
@@ -824,7 +871,7 @@ The AEE can then provide a creative_macro string in its response:
 {
   "should_bid": true,
   "bid_price": 5.50,
-  "provided_signals": {
+  "aee_signals": {
     "may_include": ["sports", "premium_user"],
     "must_exclude": ["competitor_xyz"],
     "creative_macro": "city:San Francisco|weather:sunny|segment:tech_professional"
@@ -1135,6 +1182,9 @@ interface Targeting {
   // Audience targeting
   audience_segment_any_of?: string[];    // ["1p:loyalty", "3p:auto_intenders"]
   audience_segment_none_of?: string[];
+  
+  // Signal-based targeting (from get_signals)
+  signals?: string[];                    // ["auto_intenders_q1_2025", "high_income_households"]
   
   // Media type targeting
   media_type_any_of?: string[];          // ["video", "audio", "display", "native"]

--- a/docs/media-buy/product-discovery.md
+++ b/docs/media-buy/product-discovery.md
@@ -6,13 +6,13 @@ title: Product Discovery
 
 Product discovery is the foundation of the Media Buy Protocol, enabling AI agents to find relevant advertising inventory using natural language. This document explains the discovery lifecycle and how to implement the discovery tools.
 
-## The Discovery Tool: `list_products`
+## The Discovery Tool: `get_products`
 
 AdCP provides a single discovery tool that uses natural language to find relevant advertising inventory.
 
 ### How it Works
 
-The `list_products` tool accepts a natural language brief and optional format filters to return matching products from the catalog. If no brief is provided, it returns all available products for the authenticated principal.
+The `get_products` tool accepts a natural language brief and optional format filters to return matching products from the catalog. If no brief is provided, it returns all available products for the authenticated principal.
 
 **Request Options:**
 
@@ -85,11 +85,11 @@ def get_product_catalog():
 
 ### Step 2: Implement Natural Language Processing
 
-The `list_products` tool needs to interpret natural language briefs:
+The `get_products` tool needs to interpret natural language briefs:
 
 ```python
 @mcp.tool
-def list_products(req: ListProductsRequest, context: Context) -> ListProductsResponse:
+def get_products(req: GetProductsRequest, context: Context) -> GetProductsResponse:
     # Authenticate principal
     principal_id = _get_principal_id_from_context(context)
     
@@ -203,7 +203,7 @@ The complete discovery workflow with format awareness:
 graph TD
     A[list_creative_formats] --> B[Identify available formats]
     B --> C[User provides brief + format filters]
-    C --> D[list_products]
+    C --> D[get_products]
     D --> E{Products found?}
     E -->|Yes| F[Review products]
     E -->|No| G[Generate custom products]
@@ -230,7 +230,7 @@ Use format knowledge to filter products:
 
 ```javascript
 // Only discover products that accept standard audio formats
-const products = await client.call_tool("list_products", {
+const products = await client.call_tool("get_products", {
   brief: "Reach young adults interested in gaming",
   format_types: ["audio"],
   standard_formats_only: true
@@ -310,7 +310,7 @@ Common error scenarios and handling:
 
 ```python
 @mcp.tool
-def list_products(req: ListProductsRequest, context: Context) -> ListProductsResponse:
+def get_products(req: GetProductsRequest, context: Context) -> GetProductsResponse:
     try:
         principal_id = _get_principal_id_from_context(context)
     except:
@@ -342,7 +342,7 @@ test_briefs = [
 ]
 
 for brief in test_briefs:
-    result = list_products(ListProductsRequest(brief=brief), context)
+    result = get_products(GetProductsRequest(brief=brief), context)
     assert len(result.products) > 0
     print(f"Brief: {brief} -> Found {len(result.products)} products")
 ```
@@ -351,7 +351,7 @@ for brief in test_briefs:
 
 Discovery is just the first step. Ensure smooth transitions to the next phases:
 
-1. **Discovery** → `list_products` finds relevant inventory
+1. **Discovery** → `get_products` finds relevant inventory
 2. **Purchase** → `create_media_buy` executes the campaign
 4. **Creative** → `add_creative_assets` uploads assets
 5. **Monitor** → Track delivery and optimize


### PR DESCRIPTION
## Summary
- Renamed `list_products` to `get_products` to align with signals agent spec terminology
- Added optional `get_signals` endpoint for publishers to advertise available audience segments
- Updated `create_media_buy` to support signals activation via the targeting overlay

## Changes

### 1. Renamed list_products → get_products
Updated all references across documentation to use consistent naming with the signals agent spec.

### 2. Added get_signals endpoint
Added a new optional endpoint (tool #19) that allows publishers to expose their available audience segments and signals. This enables:
- Discovery of available segments with metadata (size, cost, geography, freshness)
- Natural language search for signals
- Filtering by signal type and category

### 3. Enhanced create_media_buy targeting
- Added `signals` field to the targeting overlay
- Signal IDs from `get_signals` can be directly used for activation
- Complements existing `audience_segment_any_of` field

### 4. Clarified AEE signals
- Renamed `provided_signals` to `aee_signals` for clarity
- Better distinguishes between AEE signals and audience signals

## Test plan
- [x] TypeScript compilation passes
- [ ] Review documentation for consistency
- [ ] Verify examples are valid

🤖 Generated with [Claude Code](https://claude.ai/code)