### PR TITLE
feat: add advertiser and product description to briefs

### DIFF
--- a/docs/media-buy/api-reference.md
+++ b/docs/media-buy/api-reference.md
@@ -136,6 +136,7 @@ Creates a media buy from selected packages.
 ```json
 {
   "packages": ["pkg_ctv_prime_ca_ny", "pkg_audio_drive_ca_ny"],
+  "advertiser_and_product_description": "Purina is a trusted leader in pet nutrition, providing high-quality food and treats that help pets live longer, healthier lives",  // Required - advertiser and product/service description
   "po_number": "PO-2024-Q1-0123",
   "total_budget": 50000,
   "targeting_overlay": {
@@ -680,6 +681,7 @@ Lists available advertising products for the authenticated principal with option
 ```json
 {
   "brief": "Looking for premium sports inventory",  // Optional - natural language brief
+  "advertiser_and_product_description": "Nike is a global leader in athletic footwear and apparel, inspiring athletes worldwide with innovative products and the Just Do It spirit",  // Required - advertiser and product/service description
   "filters": {  // Optional filters based on product fields
     "delivery_type": "guaranteed",  // "guaranteed" or "non_guaranteed"
     "formats": ["video"],  // Filter by specific formats
@@ -712,11 +714,46 @@ Lists available advertising products for the authenticated principal with option
       "is_custom": false,
       "brief_relevance": "Premium CTV inventory aligns with sports content request and prime time targeting"  // If brief was provided
     }
-  ]
+  ],
+  "policy_compliance": {
+    "status": "approved",
+    "message": "Advertiser and products approved for all inventory"
+  }
 }
 ```
 
 **Note**: If no brief is provided, returns all available products for the principal.
+
+**Policy Compliance Response:**
+When products array is empty due to policy restrictions, the response includes:
+
+For advertisers that cannot be supported:
+```json
+{
+  "products": [],
+  "policy_compliance": {
+    "status": "blocked",
+    "message": "Alcoholic beverage advertising requires age-gated inventory. This publisher does not support age verification."
+  }
+}
+```
+
+For advertisers that may be approved through manual review:
+```json
+{
+  "products": [],
+  "policy_compliance": {
+    "status": "restricted",
+    "message": "Cryptocurrency advertising is restricted but may be approved on a case-by-case basis.",
+    "contact": "sales@publisher.com"
+  }
+}
+```
+
+Policy compliance statuses:
+- `approved`: Advertiser and products approved for available inventory
+- `restricted`: Advertiser category requires manual approval (contact provided)
+- `blocked`: Advertiser category cannot be supported by this publisher
 
 ### 17. get_targeting_capabilities
 
@@ -816,6 +853,66 @@ Publishers may optionally implement the `get_signals` endpoint from the [Signals
 - The protocol supports various audience types: owned, marketplace, and destination audiences
 - Publishers should coordinate with their data providers on which segments to expose
 
+## Policy Compliance
+
+### Advertiser and Product Description
+
+All briefs in `get_products` and `create_media_buy` requests must include a clear `advertiser_and_product_description` field that describes:
+- The advertiser/brand making the request
+- The specific product or service being promoted
+- Key brand attributes or positioning
+
+### Policy Checks
+
+Publishers must implement policy checks at two key points:
+
+#### 1. During Product Discovery (`get_products`)
+
+When a `get_products` request is received, the publisher should:
+- Validate that the `advertiser_and_product_description` is present and meaningful
+- Check if the described advertiser/product aligns with publisher policies
+- Filter out any products that are not suitable for the advertiser's category
+
+**Example Policy Check Flow:**
+```
+1. Extract advertiser and product category from advertiser_and_product_description
+2. Check against publisher's blocked categories list
+3. Check against publisher's restricted categories (may require approval)
+4. Return only products available for this advertiser category
+```
+
+#### 2. During Media Buy Creation (`create_media_buy`)
+
+When a `create_media_buy` request is received, the publisher should:
+- Validate the `advertiser_and_product_description` against publisher policies
+- Ensure the brief content aligns with the described advertiser/product
+- Check that any uploaded creatives match the advertiser and product description
+- Flag for manual review if automated checks raise concerns
+
+**Policy Check Response:**
+If a policy violation is detected, return an appropriate error:
+```json
+{
+  "error": {
+    "code": "POLICY_VIOLATION",
+    "message": "Brand or product category not permitted on this publisher",
+    "field": "advertiser_and_product_description",
+    "suggestion": "Contact publisher for category approval process"
+  }
+}
+```
+
+### Creative Validation
+
+All uploaded creatives should be compared against the provided `advertiser_and_product_description` by either:
+- Automated creative analysis engines
+- Human review processes
+- Combination of both
+
+This ensures that:
+- Creative content matches the declared brand
+- No misleading or deceptive advertising occurs
+- Brand safety is maintained for all parties
 
 ## Creative Macro Signal
 

--- a/docs/media-buy/media-buys.md
+++ b/docs/media-buy/media-buys.md
@@ -11,6 +11,7 @@ The Media Buy represents the client's commitment to purchase inventory.
 The `create_media_buy` tool creates the buy.
 
 - `product_ids` (list[string], required)
+- `advertiser_and_product_description` (string, required): Clear description of the advertiser/brand and product/service being advertised
 - `flight_start_date` / `flight_end_date` (date, required)
 - `total_budget` (float, required)
 - `targeting_overlay` (Targeting, required)
@@ -23,6 +24,7 @@ The `create_media_buy` tool creates the buy.
 ```json
 {
   "product_ids": ["prod_video_takeover", "prod_display_ros"],
+  "advertiser_and_product_description": "Coca-Cola is the world's leading beverage company, refreshing consumers with more than 500 sparkling and still brands",
   "flight_start_date": "2025-08-01",
   "flight_end_date": "2025-08-15",
   "total_budget": 50000.00,

--- a/docs/media-buy/product-discovery.md
+++ b/docs/media-buy/product-discovery.md
@@ -19,7 +19,8 @@ The `get_products` tool accepts a natural language brief and optional format fil
 **Basic Discovery:**
 ```json
 {
-  "brief": "I want to reach pet owners in California with video ads during prime time"
+  "brief": "I want to reach pet owners in California with video ads during prime time",
+  "advertiser_and_product_description": "PetSmart is the leading pet specialty retailer offering products, services, and solutions for the lifetime needs of pets"
 }
 ```
 
@@ -27,6 +28,7 @@ The `get_products` tool accepts a natural language brief and optional format fil
 ```json
 {
   "brief": "I want to reach sports fans with audio ads",
+  "advertiser_and_product_description": "ESPN is the worldwide leader in sports entertainment, delivering comprehensive coverage across all platforms",
   "format_types": ["audio"],           // Filter by format type
   "format_ids": ["audio_standard_30s"], // Filter by specific formats
   "standard_formats_only": true         // Only return IAB standard formats
@@ -60,6 +62,7 @@ The `get_products` tool accepts a natural language brief and optional format fil
 2. **Smart Matching**: Uses AI to match briefs against available inventory
 3. **Principal-Specific**: Returns products available to the authenticated principal
 4. **Custom Products**: Can generate custom products for unique requirements
+5. **Policy Compliance**: Validates advertiser/product descriptions against publisher policies
 
 ## Implementation Guide
 
@@ -93,10 +96,19 @@ def get_products(req: GetProductsRequest, context: Context) -> GetProductsRespon
     # Authenticate principal
     principal_id = _get_principal_id_from_context(context)
     
-    # Get all products
-    all_products = get_product_catalog()
+    # Validate advertiser and product description is provided
+    if not req.advertiser_and_product_description:
+        raise ToolError("Advertiser and product description is required", code="MISSING_ADVERTISER_PRODUCT_DESCRIPTION")
     
-    # If no brief provided, return all products
+    # Run policy checks on advertiser/product
+    policy_result = check_advertiser_policy(req.advertiser_and_product_description)
+    if not policy_result.approved:
+        raise ToolError(policy_result.message, code="POLICY_VIOLATION")
+    
+    # Get products filtered by policy
+    all_products = get_products_for_category(policy_result.category)
+    
+    # If no brief provided, return all policy-approved products
     if not req.brief:
         return ListProductsResponse(products=all_products)
     
@@ -232,6 +244,7 @@ Use format knowledge to filter products:
 // Only discover products that accept standard audio formats
 const products = await client.call_tool("get_products", {
   brief: "Reach young adults interested in gaming",
+  advertiser_and_product_description: "Xbox is Microsoft's gaming brand, offering consoles, games, and services for gamers worldwide",
   format_types: ["audio"],
   standard_formats_only: true
 });


### PR DESCRIPTION
## Summary
- Added required `advertiser_and_product_description` field to `get_products` and `create_media_buy` endpoints
- Implemented policy compliance checking with three clear statuses: approved, restricted, and blocked
- Enhanced API responses to provide clear feedback when advertisers are blocked or restricted

## Changes
1. **Renamed field for clarity**: Changed `brand_description` to `advertiser_and_product_description` to better capture that both advertiser AND product/service information is required

2. **Added policy compliance to get_products response**:
   - `approved`: Advertiser and products approved for available inventory
   - `restricted`: Advertiser category requires manual approval (contact provided)
   - `blocked`: Advertiser category cannot be supported by this publisher

3. **Updated all documentation**:
   - API Reference: Complete specification with examples
   - Product Discovery: Implementation guide with policy checks
   - Media Buys: Updated parameter documentation

## Benefits
- Publishers can enforce policy compliance at the earliest stage
- Clear differentiation between "cannot support" vs "may support with approval"
- No extra API calls needed - policy checking is integrated into existing endpoints
- Enables validation that creative content matches declared advertiser/product

## Test plan
- [ ] Verify all documentation examples are consistent
- [ ] Test that TypeScript compilation passes
- [ ] Review that all references to the old field name have been updated

🤖 Generated with [Claude Code](https://claude.ai/code)