### PR TITLE
fix: update GitHub Actions to allow builds on all branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,16 @@
-name: Deploy to GitHub Pages
+name: Build and Deploy
 
 on:
   push:
     branches:
-      - main
+      - '**'  # Run on all branches
   pull_request:
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  # Build job runs on all branches
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,9 +27,36 @@ jobs:
       - name: Build website
         run: npm run build
 
+      - name: Upload build artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: ./build
+
+  # Deploy job only runs on main branch
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: ./build
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
-      - name: Upload artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./build


### PR DESCRIPTION
## Summary
- Split workflow into separate build and deploy jobs
- Build job runs on all branches for validation  
- Deploy job only runs on main branch pushes
- Prevents workflow failures on feature branches

## Test plan
- [ ] Push to a feature branch and verify build job runs successfully
- [ ] Merge to main and verify both build and deploy jobs run
- [ ] Confirm GitHub Pages deployment only happens from main

🤖 Generated with [Claude Code](https://claude.ai/code)