### PR TITLE
fix: correct broken links to signals protocol specification

### DIFF
--- a/docs/media-buy/api-reference.md
+++ b/docs/media-buy/api-reference.md
@@ -800,11 +800,11 @@ Use this before creating a media buy to ensure the publisher can provide require
 
 ### 19. get_signals (Optional)
 
-Publishers may optionally implement the `get_signals` endpoint from the [Signals Discovery Protocol](../../signals-protocol-v1.md#get_signals) to advertise available signals for targeting.
+Publishers may optionally implement the `get_signals` endpoint from the [Signals Discovery Protocol](../signals/specification.md#get_signals) to advertise available signals for targeting.
 
 **Purpose:** Allows buyers to discover what signals (audiences, contextual, geographic, etc.) are available through the publisher's data partnerships.
 
-**Implementation:** See the [Signals Discovery Protocol specification](../../signals-protocol-v1.md#get_signals) for the complete interface definition.
+**Implementation:** See the [Signals Discovery Protocol specification](../signals/specification.md#get_signals) for the complete interface definition.
 
 **Integration with Media Buy:**
 - The signal IDs returned by `get_signals` can be used in the `targeting.signals` array when creating a media buy


### PR DESCRIPTION
## Summary
- Fixed broken links in the media buy API reference documentation
- Updated links from `../../signals-protocol-v1.md` to `../signals/specification.md`
- This fixes the build errors that were blocking PR #17

## Root Cause
The signals protocol documentation is located at `docs/signals/specification.md`, not at the root level as the broken links suggested.

## Test plan
- [x] Verified `npm run build` passes locally
- [x] Pre-push hook validated the build before pushing
- [ ] CI/CD should pass on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)