### PR TITLE
Change abbreviation from AEE to AXE (Agentic eXecution Engine)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -70,7 +70,7 @@ MCP servers that provide:
 
 ### Bottom Layer: Technical Execution
 
-#### Agent Execution Environment (Left)
+#### Agentic eXecution Engine (Left)
 Real-time systems for:
 - **Brand Safety**: Ensuring appropriate ad placement
 - **Frequency Capping**: Managing exposure limits
@@ -94,7 +94,7 @@ The AdCP ecosystem coordinates multiple flows of information between participant
 - **Creative Flow**: Creative agents produce assets that flow through the ecosystem to reach consumers via properties
 - **Business Flow**: Advertisers work with principals who engage media sellers in the business layer
 - **Technical Flow**: Brand agents, media agents, and sales agents coordinate through the decisioning platform, with bidirectional communication enabling optimization
-- **Data Flow**: Signals flow between agents, with buyer signals and publisher signals enriching the decision-making process through the AEE (Agent Execution Environment)
+- **Data Flow**: Signals flow between agents, with buyer signals and publisher signals enriching the decision-making process through the AXE (Agentic eXecution Engine)
 
 These flows illustrate how AdCP enables seamless coordination between business stakeholders, technical systems, and creative processes.
 

--- a/docs/media-buy/brief-expectations.md
+++ b/docs/media-buy/brief-expectations.md
@@ -36,7 +36,7 @@ The `brief` field is **optional** because there are valid scenarios where buyers
 
 ### Run-of-Network Scenarios
 When buyers want broad reach with their own targeting:
-- Buyers bring their own audience segments via AEE
+- Buyers bring their own audience segments via AXE
 - They want **run-of-network inventory** (broadest reach products)
 - Targeting will be handled through real-time decisioning
 - Publisher should return high-volume, broad-reach products
@@ -65,7 +65,7 @@ In this case:
 1. Publisher returns **run-of-network products** (broad reach inventory)
 2. Not niche or highly targeted products
 3. Products optimized for scale and reach
-4. Buyer applies their own targeting through AEE
+4. Buyer applies their own targeting through AXE
 5. Focus is on volume and efficiency, not audience matching
 
 ## Core Brief Components
@@ -334,7 +334,7 @@ Publishers should implement NLP to extract:
   }
 }
 ```
-**Use Case**: Buyer has sophisticated audience segments in their DMP/CDP and will apply targeting through AEE. They just need broad inventory access.
+**Use Case**: Buyer has sophisticated audience segments in their DMP/CDP and will apply targeting through AXE. They just need broad inventory access.
 
 ### E-commerce Brief
 ```

--- a/docs/media-buy/index.md
+++ b/docs/media-buy/index.md
@@ -62,7 +62,7 @@ The orchestrator handles the technical mechanics, similar to a DSP in programmat
 - Information synchronization between parties
 - Creative asset management
 - Frequency capping enforcement
-- Real-time signal processing (AEE)
+- Real-time signal processing (AXE)
 - Campaign state management
 
 The orchestrator enables principals to stay focused on strategy rather than implementation details.

--- a/docs/media-buy/targeting-dimensions.md
+++ b/docs/media-buy/targeting-dimensions.md
@@ -4,12 +4,12 @@ title: Targeting Dimensions by Channel
 
 # Targeting Dimensions by Channel
 
-This document specifies which targeting dimensions are available by channel for both targeting overlays (buyer-specified) and AEE signals (publisher-provided context).
+This document specifies which targeting dimensions are available by channel for both targeting overlays (buyer-specified) and AXE signals (publisher-provided context).
 
 ## Design Principles
 
 1. **Overlay Targeting**: Limited set of dimensions that buyers can specify in targeting overlays
-2. **AEE Signals**: Comprehensive context passed to AEE for advanced decisioning
+2. **AXE Signals**: Comprehensive context passed to AXE for advanced decisioning
 3. **Channel-Specific**: Each channel has relevant dimensions for its medium
 
 ## Common Dimensions (All Channels)
@@ -28,8 +28,8 @@ These dimensions are available for buyer targeting across all channels:
 - **city**: City-level targeting
 - **user_ids**: Available identity providers
 
-### Additional AEE Dimensions
-These are provided to AEE but not available for overlay targeting:
+### Additional AXE Dimensions
+These are provided to AXE but not available for overlay targeting:
 
 - **timezone**: User's timezone (required for dayparting calculations)
 - **postal_code**: Full postal/ZIP code
@@ -44,7 +44,7 @@ These are provided to AEE but not available for overlay targeting:
 - **content_duration**: Length of content in seconds
 - **station_channel**: Radio station or podcast channel
 
-### AEE Dimensions (Audio-Specific)
+### AXE Dimensions (Audio-Specific)
 - **podcast_episode_id**: Unique episode GUID
 - **podcast_show_name**: Name of the podcast show
 
@@ -54,7 +54,7 @@ These are provided to AEE but not available for overlay targeting:
 - **content_categories**: IAB content categories
 - **keywords**: Page keywords for contextual targeting
 
-### AEE Dimensions (Web-Specific)
+### AXE Dimensions (Web-Specific)
 - **page_url**: Current page URL (required)
 - **referrer_url**: Referring page URL
 - **ad_slot_id**: Specific ad slot identifier
@@ -67,7 +67,7 @@ These are provided to AEE but not available for overlay targeting:
 - **app_bundle**: Mobile app bundle identifier
 - **app_categories**: App store categories
 
-### AEE Dimensions (Mobile-Specific)
+### AXE Dimensions (Mobile-Specific)
 - **app_bundle_id**: Current app's bundle identifier (required)
 - **app_version**: Current app version
 - **content_url**: URL for web-available content within app
@@ -82,7 +82,7 @@ These are provided to AEE but not available for overlay targeting:
 - **content_duration**: Length of content in seconds
 - **channel_network**: TV channel or streaming service
 
-### AEE Dimensions (CTV-Specific)
+### AXE Dimensions (CTV-Specific)
 - **show_name**: Name of the TV show or movie
 - **show_metadata**: Additional show information (season, episode, etc.)
 - **content_ids**: Industry-standard content identifiers
@@ -95,7 +95,7 @@ These are provided to AEE but not available for overlay targeting:
 - **venue_type**: Type of venue (transit, retail, office, gym, restaurant, gas_station, airport, mall)
 - **screen_size**: Physical screen dimensions
 
-### AEE Dimensions (DOOH-Specific)
+### AXE Dimensions (DOOH-Specific)
 - **venue_id**: Unique venue identifier
 - **screen_id**: Unique screen identifier
 - **venue_metadata**: Additional venue information
@@ -108,13 +108,13 @@ Publishers can expose their supported dimensions through the `get_targeting_capa
 ```json
 {
   "channels": ["web", "mobile_app"],
-  "include_aee_dimensions": true
+  "include_axe_dimensions": true
 }
 ```
 
-## AEE Requirements Checking
+## AXE Requirements Checking
 
-Buyers can verify if required AEE dimensions are available before creating a media buy:
+Buyers can verify if required AXE dimensions are available before creating a media buy:
 
 ```json
 {

--- a/docs/media-buy/targeting.md
+++ b/docs/media-buy/targeting.md
@@ -11,7 +11,7 @@ Targeting in AdCP builds upon the [Dimensions](dimensions.md) system to specify 
 AdCP provides two levels of targeting access:
 
 1. **Overlay Targeting**: Available to principals via API for campaign customization
-2. **Managed-Only Targeting**: Reserved for internal use (AEE signals, optimization)
+2. **Managed-Only Targeting**: Reserved for internal use (AXE signals, optimization)
 
 ## Targeting Model
 
@@ -87,7 +87,7 @@ Basic time-based impression suppression:
 }
 ```
 
-**Note**: This provides simple suppression. More sophisticated frequency management (cross-device, complex attribution windows, household-level) is handled by the AEE layer.
+**Note**: This provides simple suppression. More sophisticated frequency management (cross-device, complex attribution windows, household-level) is handled by the AXE layer.
 
 ### Custom Platform Targeting
 
@@ -110,20 +110,20 @@ These targeting dimensions are reserved for internal use and cannot be set via t
 
 ### Key-Value Pairs
 
-Used primarily for AEE (Ad Effectiveness Engine) signal integration:
+Used primarily for AXE (Agentic eXecution Engine) signal integration:
 
 ```json
 {
   "key_value_pairs": {
-    "aee_segment": "high_value_pet_owner",
-    "aee_score": "0.85",
-    "aee_recency": "7d",
-    "aee_context": "shopping_intent"
+    "axe_segment": "high_value_pet_owner",
+    "axe_score": "0.85",
+    "axe_recency": "7d",
+    "axe_context": "shopping_intent"
   }
 }
 ```
 
-**Important**: The `key_value_pairs` field is set internally by the orchestrator or AEE system. Principals cannot include this in their targeting overlay.
+**Important**: The `key_value_pairs` field is set internally by the orchestrator or AXE system. Principals cannot include this in their targeting overlay.
 
 ### Platform Internal Targeting
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -16,6 +16,9 @@ The process of making a signal available for targeting on a specific platform an
 **Ad Context Protocol (AdCP)**  
 An open standard based on Model Context Protocol (MCP) that enables AI-powered advertising workflows through natural language interfaces.
 
+**Agentic eXecution Engine (AXE)**  
+Real-time systems that handle brand safety, frequency capping, first-party data activation, and advanced signal processing for advertising campaigns.
+
 **Signal Discovery**  
 The process of finding relevant data signals (audiences, contextual, geographical, temporal) using natural language descriptions.
 
@@ -178,6 +181,7 @@ Advertising inventory available for purchase, discovered through natural languag
 
 - **AdCP**: Ad Context Protocol
 - **API**: Application Programming Interface
+- **AXE**: Agentic eXecution Engine
 - **CPM**: Cost Per Mille (thousand)
 - **DSP**: Demand-Side Platform
 - **DMP**: Data Management Platform


### PR DESCRIPTION
## Summary
- Updated all documentation references from AEE to AXE across the codebase
- Changed the full name from "Agentic Execution Engine" to "Agentic eXecution Engine"
- Standardized inconsistent references that used "Agent Execution Environment" or "Ad Effectiveness Engine"

## Changes Made
- **docs/intro.md**: Updated heading and flow description
- **docs/media-buy/targeting-dimensions.md**: Changed all AEE references to AXE (12 occurrences)
- **docs/media-buy/index.md**: Updated orchestrator role description
- **docs/media-buy/brief-expectations.md**: Updated targeting references (3 occurrences)
- **docs/media-buy/targeting.md**: Updated signal integration references and API examples (8 occurrences)
- **docs/reference/glossary.md**: Added new AXE entry and acronym

## Test plan
- [x] All documentation files have been updated consistently
- [x] No broken references or inconsistent terminology
- [x] Glossary includes proper definition for AXE
- [x] API examples use correct axe_ prefixes

🤖 Generated with [Claude Code](https://claude.ai/code)