### PR TITLE
Enhance AdCP schemas with comprehensive targeting and format types

### DIFF
--- a/docs/media-buy/tasks/create_media_buy.md
+++ b/docs/media-buy/tasks/create_media_buy.md
@@ -18,7 +18,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this media buy |
 | `packages` | Package[] | Yes | Array of package configurations (see Package Object below) |
 | `promoted_offering` | string | Yes | Description of advertiser and what is being promoted |
-| `po_number` | string | Yes | Purchase order number for tracking |
+| `po_number` | string | No | Purchase order number for tracking |
 | `start_time` | string | Yes | Campaign start date/time in ISO 8601 format (UTC unless timezone specified) |
 | `end_time` | string | Yes | Campaign end date/time in ISO 8601 format (UTC unless timezone specified) |
 | `budget` | Budget | Yes | Budget configuration for the media buy (see Budget Object below) |
@@ -38,6 +38,12 @@ Create a media buy from selected packages. This task handles the complete workfl
 |-----------|------|----------|-------------|
 | `geo_country_any_of` | string[] | No | Target specific countries (ISO codes) |
 | `geo_region_any_of` | string[] | No | Target specific regions/states |
+| `geo_metro_any_of` | string[] | No | Target specific metro areas (DMA codes) |
+| `geo_postal_code_any_of` | string[] | No | Target specific postal/ZIP codes |
+| `geo_lat_long_radius` | object | No | Target by geographic coordinates and radius |
+| `device_type_any_of` | string[] | No | Target specific device types (desktop, mobile, tablet, connected_tv, smart_speaker) |
+| `os_any_of` | string[] | No | Target specific operating systems (windows, macos, ios, android, linux, roku, tvos, other) |
+| `browser_any_of` | string[] | No | Target specific browsers (chrome, firefox, safari, edge, other) |
 | `axe_include_segment` | string | No | AXE segment ID to include for targeting |
 | `axe_exclude_segment` | string | No | AXE segment ID to exclude from targeting |
 | `signals` | string[] | No | Signal IDs from get_signals |

--- a/static/schemas/v1/core/format.json
+++ b/static/schemas/v1/core/format.json
@@ -15,8 +15,8 @@
     },
     "type": {
       "type": "string",
-      "description": "Format type (e.g., audio, video, display)",
-      "enum": ["audio", "video", "display"]
+      "description": "Format type (e.g., audio, video, display, native, dooh)",
+      "enum": ["audio", "video", "display", "native", "dooh"]
     },
     "is_standard": {
       "type": "boolean",

--- a/static/schemas/v1/core/targeting.json
+++ b/static/schemas/v1/core/targeting.json
@@ -20,6 +20,45 @@
         "type": "string"
       }
     },
+    "geo_metro_any_of": {
+      "type": "array",
+      "description": "Target specific metro areas (DMA codes)",
+      "items": {
+        "type": "string"
+      }
+    },
+    "geo_postal_code_any_of": {
+      "type": "array",
+      "description": "Target specific postal/ZIP codes",
+      "items": {
+        "type": "string"
+      }
+    },
+    "geo_lat_long_radius": {
+      "type": "object",
+      "description": "Target by geographic coordinates and radius",
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Latitude coordinate"
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Longitude coordinate"
+        },
+        "radius_km": {
+          "type": "number",
+          "minimum": 0.1,
+          "description": "Radius in kilometers"
+        }
+      },
+      "required": ["latitude", "longitude", "radius_km"],
+      "additionalProperties": false
+    },
     "audience_segment_any_of": {
       "type": "array",
       "description": "Audience segment IDs to target",
@@ -40,6 +79,30 @@
       "description": "Signal IDs from get_signals",
       "items": {
         "type": "string"
+      }
+    },
+    "device_type_any_of": {
+      "type": "array",
+      "description": "Target specific device types",
+      "items": {
+        "type": "string",
+        "enum": ["desktop", "mobile", "tablet", "connected_tv", "smart_speaker"]
+      }
+    },
+    "os_any_of": {
+      "type": "array",
+      "description": "Target specific operating systems",
+      "items": {
+        "type": "string",
+        "enum": ["windows", "macos", "ios", "android", "linux", "roku", "tvos", "other"]
+      }
+    },
+    "browser_any_of": {
+      "type": "array",
+      "description": "Target specific browsers",
+      "items": {
+        "type": "string",
+        "enum": ["chrome", "firefox", "safari", "edge", "other"]
       }
     },
     "frequency_cap": {

--- a/static/schemas/v1/media-buy/create-media-buy-request.json
+++ b/static/schemas/v1/media-buy/create-media-buy-request.json
@@ -59,6 +59,6 @@
       "$ref": "/schemas/v1/core/budget.json"
     }
   },
-  "required": ["buyer_ref", "packages", "promoted_offering", "po_number", "start_time", "end_time", "budget"],
+  "required": ["buyer_ref", "packages", "promoted_offering", "start_time", "end_time", "budget"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- Make po_number optional in CreateMediaBuyRequest for practical business needs
- Expand format types to include 'native' and 'dooh' formats
- Add comprehensive targeting dimensions for enhanced campaign control

## Schema Changes
### CreateMediaBuyRequest
- ✅ **po_number made optional** - Aligns with business reality where PO numbers aren't always available at campaign creation

### Format Types  
- ✅ **Added 'native' and 'dooh'** - Supports formats already documented and used in examples

### Targeting Enhancements
- ✅ **Enhanced geo targeting**: metro areas (DMA), postal codes, lat/long radius
- ✅ **Device/platform targeting**: device types, operating systems, browsers
- ✅ **Proper validation**: All new fields have appropriate enum constraints

## Documentation Updates
- Updated create_media_buy.md to reflect po_number as optional
- Added comprehensive targeting overlay parameter documentation
- Maintains full backwards compatibility

## Test Results
✅ All schema validation tests pass  
✅ All example validation tests pass  
✅ TypeScript compilation successful

## Impact
These changes align the JSON schemas with documented capabilities and practical implementation needs, providing advertisers with comprehensive targeting options while maintaining backwards compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)