### PR TITLE
docs: Add comprehensive standard formats documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,3 +313,89 @@ git push            # Push to remote
 3. Focus on protocol capabilities, not implementation
 4. Ask for clarification on design decisions
 5. Refer to the [API Reference](docs/media-buy/api-reference.md) for tool signatures
+
+## Standard Formats: Lessons Learned
+
+### Schema Simplification Best Practices
+
+Through the standard formats implementation, we've learned key principles for schema design:
+
+1. **Remove Platform-Specific Complexity**
+   - Formats should be platform-agnostic
+   - No `platform` or `placement_type` fields in format definitions
+   - Publishers adapt formats through placement, not specification changes
+
+2. **Simplify Selection Logic**
+   - Removed complex `format-selection.json` schema
+   - No placement types or format preferences in products
+   - Buyers directly specify formats they want to provide
+
+3. **Clear Asset Identification**
+   - Added `asset_role` field to identify asset purposes (e.g., 'hero_image', 'logo')
+   - Assets are self-describing with clear roles
+   - Enables better creative assembly and validation
+
+4. **Better Field Naming**
+   - `accepts_3p_tags` instead of `is_3p_served` (indicates optionality)
+   - `formats_to_provide` instead of `selected_formats` (clearer intent)
+   - Field names should indicate purpose, not state
+
+### Testing Considerations
+
+1. **Schema Registry Tests**
+   - Not all schemas need to be in the registry
+   - Registry only needs to reference core and enum schemas
+   - Standard format schemas are discovered through directory structure
+   - Test should validate registry references exist, not that all schemas are registered
+
+2. **Schema Validation Patterns**
+   - Include `index.json` files in schema discovery
+   - Validate examples match schema structure
+   - Ensure all `$ref` links resolve correctly
+   - Test both request and response schemas
+
+### Code Review Integration
+
+When addressing code review feedback:
+
+1. **Use Todo Lists**
+   - Create a todo for each review comment
+   - Track progress systematically
+   - Mark items complete as you address them
+
+2. **Batch Related Changes**
+   - Group similar schema updates together
+   - Use MultiEdit for multiple changes to same file
+   - Test after each batch of changes
+
+3. **Documentation Sync**
+   - Update documentation when changing schemas
+   - Keep examples consistent with schema changes
+   - Update both spec docs and CLAUDE.md as needed
+
+### Standard Formats Architecture
+
+The simplified standard formats structure:
+
+```
+static/schemas/v1/standard-formats/
+├── index.json                 # Registry of all standard formats
+├── asset-types/              # Reusable asset type definitions
+│   ├── image.json
+│   ├── video.json
+│   └── text.json
+├── display/                  # Display format definitions
+│   ├── display_300x250.json
+│   └── mobile_interstitial_320x480.json
+├── video/                    # Video format definitions
+│   ├── video_skippable_15s.json
+│   └── video_story_vertical.json
+└── native/                   # Native format definitions
+    └── native_responsive.json
+```
+
+Key principles:
+- Each format is self-contained with all requirements
+- No cross-references to placement or selection schemas
+- Assets are defined inline with clear specifications
+- Format categories match industry standards (display, video, native, etc.)

--- a/docs/media-buy/creative-formats.md
+++ b/docs/media-buy/creative-formats.md
@@ -6,6 +6,26 @@ title: Creative Formats
 
 All creative formats have a unique identifier and specify delivery methods. Formats can require either a single asset or multiple assets for rich media experiences.
 
+## Standard vs Custom Formats
+
+AdCP defines two categories of formats:
+
+### Standard Formats
+Pre-defined, industry-standard specifications that work consistently across publishers:
+- **Simplified**: No platform-specific complexity
+- **Portable**: One creative works everywhere  
+- **Validated**: Pre-tested specifications
+- **Discoverable**: Available via `list_creative_formats`
+
+See the [Standard Formats Guide](./standard-formats-guide.md) for complete documentation.
+
+### Custom Formats
+Publisher-specific formats for unique inventory:
+- **Unique**: Truly differentiated experiences
+- **Specialized**: Platform-specific capabilities
+- **Extended**: Often based on standard formats
+- **Documented**: Clear specifications required
+
 ## Authoritative Source
 
 The official JSON schema for standard creative formats is available at:
@@ -34,7 +54,8 @@ The JSON schema includes:
   - **required**: Boolean indicating if the asset is mandatory
   - **requirements**: Specific technical requirements for the asset
 - **delivery**: For VAST/third-party formats, delivery method and supported versions
-- **is_3p_served**: Boolean indicating if format accepts third-party tags
+- **accepts_3p_tags**: Boolean indicating if format can accept third-party tags as an alternative
+- **asset_role**: Identifies the purpose of each asset (e.g., 'hero_image', 'logo', 'cta_button')
 
 ### Version Management
 

--- a/docs/media-buy/index.md
+++ b/docs/media-buy/index.md
@@ -22,6 +22,7 @@ The Advertising Context Protocol (AdCP) provides a simple, expressive, and AI-fi
 
 - **Natural Language Discovery**: Find advertising inventory using plain English briefs
 - **Unified Targeting**: Consistent targeting dimensions across all platforms
+- **Standard Formats**: Pre-defined creative specifications that work everywhere
 - **Creative Flexibility**: Support for standard IAB and custom publisher formats
 - **Real-time Optimization**: Continuous performance monitoring and adjustment
 - **Human-in-the-Loop**: Optional manual approval workflows where needed
@@ -110,6 +111,8 @@ Managing creative assets throughout their lifecycle:
 
 - **[Creative Lifecycle](creative-lifecycle.md)** - Submit, track, and adapt creative assets
 - **[Creative Formats](creative-formats.md)** - Detailed specifications for supported creative types
+- **[Standard Formats Guide](standard-formats-guide.md)** - Pre-defined formats that work across all publishers
+- **[Asset Types](asset-types.md)** - Understanding asset roles and specifications
 
 ### Operations
 Running successful campaigns:

--- a/docs/media-buy/standard-formats-guide.md
+++ b/docs/media-buy/standard-formats-guide.md
@@ -1,0 +1,480 @@
+---
+title: Standard Formats Guide
+---
+
+# Standard Formats Guide
+
+This guide explains AdCP's standard ad formats, how to use them, and best practices for implementation.
+
+## Overview
+
+Standard formats are pre-defined, industry-standard creative specifications that work consistently across multiple publishers and platforms. They provide a common foundation for creative assets while allowing publishers to differentiate through placement, data, and optimization.
+
+### Why Standard Formats Matter
+
+1. **Simplified Creative Production**: One creative package works across multiple publishers
+2. **Reduced Complexity**: No platform-specific variations or complex selection logic
+3. **Faster Campaign Launch**: Pre-tested formats with known requirements
+4. **Better Interoperability**: Consistent asset specifications across the ecosystem
+5. **Focus on Performance**: Spend time optimizing, not adapting creatives
+
+## Core Concepts
+
+### Format Structure
+
+Each standard format is a self-contained specification with:
+
+- **format_id**: Unique identifier (e.g., `display_300x250`)
+- **type**: Media type (`display`, `video`, `native`, `retail`)
+- **category**: `standard` for AdCP-defined formats
+- **assets_required**: Array of required creative assets
+- **accepts_3p_tags**: Whether third-party tags are accepted
+
+### Asset Roles
+
+Every asset in a format has a specific role identified by the `asset_role` field:
+
+```json
+{
+  "asset_role": "hero_image",  // Identifies the purpose
+  "asset_type": "image",
+  "width": 1200,
+  "height": 627
+}
+```
+
+Common asset roles:
+- `hero_image`: Primary visual element
+- `logo`: Brand identifier
+- `headline`: Primary text message
+- `cta_button`: Call-to-action element
+- `background_video`: Ambient video content
+
+### Format Categories
+
+Standard formats are organized into categories:
+
+1. **Display**: Traditional banner formats (300x250, 728x90, etc.)
+2. **Video**: Time-based video content (15s, 30s, vertical)
+3. **Native**: Content-integrated formats (responsive, feed-based)
+4. **Retail**: Commerce-specific formats (product carousels)
+5. **Foundational**: Universal formats that work everywhere
+
+## Available Standard Formats
+
+### Display Formats
+
+#### display_300x250
+Standard medium rectangle banner
+- **Dimensions**: 300x250 pixels
+- **Assets**: Banner image, clickthrough URL
+- **Max file size**: 200KB
+
+#### display_728x90
+Leaderboard banner
+- **Dimensions**: 728x90 pixels
+- **Assets**: Banner image, clickthrough URL
+- **Max file size**: 200KB
+
+#### display_160x600
+Wide skyscraper
+- **Dimensions**: 160x600 pixels
+- **Assets**: Banner image, clickthrough URL
+- **Max file size**: 200KB
+
+#### display_970x250
+Billboard banner
+- **Dimensions**: 970x250 pixels
+- **Assets**: Banner image, clickthrough URL
+- **Max file size**: 300KB
+
+#### mobile_interstitial_320x480
+Full-screen mobile interstitial
+- **Dimensions**: 320x480 pixels
+- **Assets**: Interstitial image, clickthrough URL
+- **Platform**: Mobile-optimized
+
+### Video Formats
+
+#### video_skippable_15s
+15-second skippable video
+- **Duration**: 15 seconds
+- **Skippable after**: 5 seconds
+- **Aspect ratios**: 16:9, 9:16, 1:1
+- **Delivery**: Hosted or VAST
+
+#### video_non_skippable_30s
+30-second non-skippable video
+- **Duration**: 30 seconds
+- **Aspect ratio**: 16:9
+- **Resolution**: 1920x1080 or 1280x720
+- **Max bitrate**: 10 Mbps
+
+#### video_story_vertical
+Vertical story format
+- **Duration**: 6-15 seconds
+- **Aspect ratio**: 9:16
+- **Resolution**: 1080x1920
+- **Platform**: Mobile-first
+
+#### video_outstream_native
+In-content video player
+- **Duration**: 15-30 seconds
+- **Autoplay**: Muted by default
+- **Player size**: Responsive
+- **Context**: Within article content
+
+### Native Formats
+
+#### native_responsive
+Responsive native ad
+- **Components**: Headline, description, image, logo, CTA
+- **Image ratio**: 1.91:1 or 1:1
+- **Headline**: Max 80 characters
+- **Description**: Max 200 characters
+
+### Retail Formats
+
+#### retail_product_carousel
+Multi-product carousel
+- **Products**: 3-10 items
+- **Per product**: Image, name, price, URL
+- **Navigation**: Swipe or click
+- **Layout**: Horizontal scroll
+
+### Foundational Formats
+
+#### foundational_immersive_canvas
+Premium responsive canvas that adapts across devices
+- **Hero image**: 1200x627
+- **Optional video**: 15-30s
+- **Responsive**: Adapts to viewport
+- **Rich media**: Interactive elements supported
+
+#### foundational_video_15s
+Universal 15-second video
+- **Works everywhere**: All publishers support this
+- **Multiple aspects**: 16:9, 9:16, 1:1
+- **Delivery flexible**: Hosted or VAST
+
+## Implementation Guide
+
+### For Publishers
+
+#### Step 1: Declare Format Support
+
+```json
+{
+  "supported_formats": [
+    {
+      "format_id": "display_300x250",
+      "placements": ["sidebar", "in-article"],
+      "min_cpm": 2.00
+    },
+    {
+      "format_id": "video_skippable_15s",
+      "placements": ["pre-roll", "mid-roll"],
+      "min_cpm": 10.00
+    }
+  ]
+}
+```
+
+#### Step 2: Return in list_creative_formats
+
+```json
+{
+  "formats": [
+    {
+      "format_id": "display_300x250",
+      "name": "Medium Rectangle",
+      "type": "display",
+      "category": "standard",
+      "dimensions": "300x250",
+      "assets_required": [
+        {
+          "asset_id": "banner_image",
+          "asset_type": "image",
+          "asset_role": "hero_image",
+          "width": 300,
+          "height": 250,
+          "acceptable_formats": ["jpg", "png", "gif"],
+          "max_file_size_kb": 200
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Step 3: Accept Standard Assets
+
+When receiving creative assets with standard format IDs, validate against the standard specification rather than custom requirements.
+
+### For Buyers
+
+#### Step 1: Query Available Formats
+
+```json
+{
+  "tool": "list_creative_formats",
+  "parameters": {
+    "category": "standard"  // Filter for standard formats
+  }
+}
+```
+
+#### Step 2: Select Formats for Campaign
+
+```json
+{
+  "tool": "create_media_buy",
+  "parameters": {
+    "packages": [
+      {
+        "formats_to_provide": [
+          "display_300x250",
+          "video_skippable_15s"
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Step 3: Submit Creative Assets
+
+```json
+{
+  "tool": "add_creative_assets",
+  "parameters": {
+    "format_id": "display_300x250",
+    "assets": [
+      {
+        "asset_role": "hero_image",
+        "asset_type": "image",
+        "url": "https://cdn.example.com/banner.jpg",
+        "width": 300,
+        "height": 250
+      },
+      {
+        "asset_role": "clickthrough_url",
+        "asset_type": "url",
+        "url": "https://example.com/landing"
+      }
+    ]
+  }
+}
+```
+
+## Extending Standard Formats
+
+Publishers can extend standard formats while maintaining compatibility:
+
+```json
+{
+  "format_id": "publisher_premium_300x250",
+  "extends": "display_300x250",
+  "publisher": "example_publisher",
+  "modifications": {
+    "placement": {
+      "positions": ["above-fold-only"],
+      "viewability": "100% in view for 1s"
+    },
+    "performance": {
+      "min_ctr": 0.5,
+      "optimization": "auto-refresh-30s"
+    }
+  }
+}
+```
+
+### Extension Rules
+
+1. **Must accept base format assets**: Extensions cannot require different core assets
+2. **Can add optional enhancements**: Additional assets or features are allowed
+3. **Maintain compatibility**: Base format creatives must work without modification
+4. **Document clearly**: Specify what makes your extension unique
+
+## Migration Path
+
+### From Custom to Standard
+
+1. **Audit existing formats**: Map custom formats to standard equivalents
+2. **Identify gaps**: Document any unique requirements
+3. **Implement support**: Add standard format handling alongside custom
+4. **Test thoroughly**: Verify standard creatives render correctly
+5. **Communicate changes**: Update documentation and notify partners
+6. **Monitor performance**: Track adoption and performance metrics
+
+### Compatibility Matrix
+
+| Custom Format | Standard Equivalent | Migration Effort |
+|--------------|-------------------|-----------------|
+| Banner 300x250 | display_300x250 | Low |
+| Video Pre-roll | video_skippable_15s | Low |
+| Native In-feed | native_responsive | Medium |
+| Product Gallery | retail_product_carousel | Medium |
+| Custom Canvas | foundational_immersive_canvas | High |
+
+## Best Practices
+
+### For Publishers
+
+1. **Start with common formats**: Support widely-used formats first
+2. **Be transparent**: Clearly document any extensions or modifications
+3. **Maintain compatibility**: Always accept base format specifications
+4. **Focus on differentiation**: Compete on placement and performance, not specs
+
+### For Buyers
+
+1. **Use standard formats when possible**: Maximize reach with minimal variants
+2. **Provide all required assets**: Include every asset specified in the format
+3. **Use asset_role consistently**: Properly identify each asset's purpose
+4. **Test across publishers**: Verify creatives work as expected
+
+### For Platforms
+
+1. **Validate strictly**: Ensure formats meet specifications exactly
+2. **Cache format definitions**: Store standard format schemas locally
+3. **Version carefully**: Track format version changes
+4. **Provide clear errors**: Help users understand validation failures
+
+## Examples
+
+### Example 1: Display Campaign
+
+Creating a display campaign with standard banner:
+
+```json
+// Step 1: Get products
+{
+  "tool": "get_products",
+  "parameters": {
+    "supported_formats": ["display_300x250"]
+  }
+}
+
+// Step 2: Create media buy
+{
+  "tool": "create_media_buy",
+  "parameters": {
+    "packages": [
+      {
+        "product_id": "sidebar_placement",
+        "formats_to_provide": ["display_300x250"],
+        "budget": 5000
+      }
+    ]
+  }
+}
+
+// Step 3: Add creative
+{
+  "tool": "add_creative_assets",
+  "parameters": {
+    "media_buy_id": "mb_123",
+    "format_id": "display_300x250",
+    "assets": [
+      {
+        "asset_role": "hero_image",
+        "url": "https://cdn.example.com/banner.jpg"
+      }
+    ]
+  }
+}
+```
+
+### Example 2: Video Campaign
+
+Multi-format video campaign:
+
+```json
+{
+  "formats_to_provide": [
+    "video_skippable_15s",     // Desktop/CTV
+    "video_story_vertical",     // Mobile
+    "video_outstream_native"    // In-article
+  ],
+  "creative_strategy": "format_optimization",
+  "delivery_preferences": {
+    "desktop": "video_skippable_15s",
+    "mobile": "video_story_vertical",
+    "tablet": "video_skippable_15s"
+  }
+}
+```
+
+### Example 3: Retail Campaign
+
+Product carousel with dynamic content:
+
+```json
+{
+  "format_id": "retail_product_carousel",
+  "products": [
+    {
+      "product_id": "sku_001",
+      "image_url": "https://cdn.example.com/product1.jpg",
+      "name": "Premium Headphones",
+      "price": "$199.99",
+      "sale_price": "$149.99",
+      "url": "https://shop.example.com/product1"
+    },
+    // ... more products
+  ],
+  "global_assets": {
+    "brand_logo": "https://cdn.example.com/logo.png",
+    "cta_text": "Shop Now"
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Asset validation fails**
+   - Verify asset dimensions match exactly
+   - Check file size limits
+   - Ensure HTTPS URLs
+
+2. **Format not accepted**
+   - Confirm publisher supports the format
+   - Check format_id spelling
+   - Verify all required assets provided
+
+3. **Creative not rendering**
+   - Validate against schema
+   - Check asset_role assignments
+   - Verify URL accessibility
+
+### Validation Tools
+
+Use the schema validator to check format compliance:
+
+```bash
+# Validate format definition
+curl -X POST https://api.adcp.org/validate \
+  -d @my-format.json
+
+# Check creative assets
+curl -X POST https://api.adcp.org/validate-creative \
+  -d @my-creative.json
+```
+
+## Resources
+
+- [Format Schemas](https://github.com/adcontextprotocol/adcp/tree/main/static/schemas/v1/standard-formats)
+- [Creative Formats Reference](./creative-formats.md)
+- [Asset Types Documentation](./asset-types.md)
+- [Task Reference](./tasks/get_products.md)
+
+## Next Steps
+
+1. Review available [standard formats](#available-standard-formats)
+2. Implement support for relevant formats
+3. Test with example creatives
+4. Monitor performance and iterate
+
+For questions or to propose new standard formats, please open an issue in the [AdCP GitHub repository](https://github.com/adcontextprotocol/adcp).

--- a/docs/media-buy/tasks/add_creative_assets.md
+++ b/docs/media-buy/tasks/add_creative_assets.md
@@ -28,6 +28,7 @@ Upload creative assets and assign them to packages. This task includes validatio
 | `creative_id` | string | Yes | Unique identifier for the creative |
 | `name` | string | Yes | Human-readable creative name |
 | `format` | string | Yes | Creative format type (e.g., `"video"`, `"audio"`, `"display"`) |
+| `asset_role` | string | No | Role/purpose of this asset (e.g., `"hero_image"`, `"logo"`, `"cta_button"`) |
 | `media_url` | string | Yes | URL of the creative file |
 | `click_url` | string | No | Landing page URL for the creative |
 | `duration` | number | No | Duration in milliseconds (for video/audio) |
@@ -42,6 +43,7 @@ Upload creative assets and assign them to packages. This task includes validatio
 |-----------|------|----------|-------------|
 | `asset_type` | string | Yes | Type of asset (e.g., `"product_image"`, `"logo"`, `"headline"`) |
 | `asset_id` | string | Yes | Unique identifier for the asset |
+| `asset_role` | string | Yes | Role identifier matching format specification (e.g., `"hero_image"`, `"background_video"`) |
 | `content_uri` | string | No | URL for media assets |
 | `assets[].assets[].content` | array | No | Text content for text assets |
 
@@ -102,6 +104,99 @@ The message is returned differently in each protocol:
 ## Protocol-Specific Examples
 
 The AdCP payload is identical across protocols. Only the request/response wrapper differs.
+
+### Example 1: Standard Format with Asset Roles
+
+Using a standard format (display_300x250) with properly identified asset roles:
+
+#### MCP Request
+```json
+{
+  "tool": "add_creative_assets",
+  "arguments": {
+    "media_buy_id": "mb_12345",
+    "assets": [
+      {
+        "creative_id": "spring_banner_001",
+        "name": "Spring Collection Banner",
+        "format": "display_300x250",
+        "asset_role": "hero_image",
+        "media_url": "https://cdn.example.com/spring-banner-300x250.jpg",
+        "click_url": "https://example.com/spring-collection",
+        "width": 300,
+        "height": 250,
+        "package_assignments": ["pkg_display_001"]
+      }
+    ]
+  }
+}
+```
+
+#### Response
+```json
+{
+  "asset_statuses": [
+    {
+      "creative_id": "spring_banner_001",
+      "status": "approved",
+      "platform_id": "platform_creative_123",
+      "review_feedback": "Standard format validated successfully"
+    }
+  ]
+}
+```
+
+### Example 2: Multi-Asset Format with Roles
+
+Product carousel with multiple assets, each with specific roles:
+
+#### MCP Request
+```json
+{
+  "tool": "add_creative_assets",
+  "arguments": {
+    "media_buy_id": "mb_12345",
+    "assets": [
+      {
+        "creative_id": "product_carousel_001",
+        "name": "Summer Products Carousel",
+        "format": "retail_product_carousel",
+        "package_assignments": ["pkg_native_001"],
+        "assets": [
+          {
+            "asset_id": "prod_001",
+            "asset_type": "image",
+            "asset_role": "product_image_1",
+            "content_uri": "https://cdn.example.com/product1.jpg"
+          },
+          {
+            "asset_id": "prod_002",
+            "asset_type": "image",
+            "asset_role": "product_image_2",
+            "content_uri": "https://cdn.example.com/product2.jpg"
+          },
+          {
+            "asset_id": "logo_001",
+            "asset_type": "image",
+            "asset_role": "brand_logo",
+            "content_uri": "https://cdn.example.com/logo.png"
+          },
+          {
+            "asset_id": "cta_001",
+            "asset_type": "text",
+            "asset_role": "cta_button",
+            "content": ["Shop Now"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Example 3: Video Format
+
+Standard video format upload:
 
 ### MCP Request
 ```json

--- a/docs/media-buy/tasks/list_creative_formats.md
+++ b/docs/media-buy/tasks/list_creative_formats.md
@@ -16,7 +16,8 @@ Discover all supported creative formats in the system.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `type` | string | No | Filter by format type (e.g., `"audio"`, `"video"`, `"display"`) |
-| `standard_only` | boolean | No | Only return IAB standard formats |
+| `category` | string | No | Filter by category (`"standard"` or `"custom"`) |
+| `standard_only` | boolean | No | Only return standard formats (deprecated, use `category: "standard"`) |
 
 ## Response (Message)
 
@@ -52,16 +53,80 @@ The message is returned differently in each protocol:
 - **format_id**: Unique identifier for the format
 - **name**: Human-readable format name
 - **type**: Format type (e.g., `"audio"`, `"video"`, `"display"`)
-- **is_standard**: Whether this follows IAB standards
-- **iab_specification**: Name of the IAB specification (if applicable)
+- **category**: Format category (`"standard"` or `"custom"`)
+- **is_standard**: Whether this follows IAB or AdCP standards
+- **accepts_3p_tags**: Whether format can accept third-party tags
 - **requirements**: Format-specific requirements (varies by format type)
-- **assets_required**: Array of required assets for composite formats
+- **assets_required**: Array of required assets with `asset_role` identifiers
 
 ## Protocol-Specific Examples
 
 The AdCP payload is identical across protocols. Only the request/response wrapper differs.
 
-### MCP Request
+### Example 1: Standard Formats Only
+
+#### MCP Request
+```json
+{
+  "tool": "list_creative_formats",
+  "arguments": {
+    "category": "standard"
+  }
+}
+```
+
+#### Response
+```json
+{
+  "formats": [
+    {
+      "format_id": "display_300x250",
+      "name": "Medium Rectangle",
+      "type": "display",
+      "category": "standard",
+      "is_standard": true,
+      "dimensions": "300x250",
+      "accepts_3p_tags": false,
+      "assets_required": [
+        {
+          "asset_id": "banner_image",
+          "asset_type": "image",
+          "asset_role": "hero_image",
+          "required": true,
+          "width": 300,
+          "height": 250,
+          "acceptable_formats": ["jpg", "png", "gif"],
+          "max_file_size_kb": 200
+        },
+        {
+          "asset_id": "clickthrough_url",
+          "asset_type": "url",
+          "asset_role": "clickthrough_url",
+          "required": true
+        }
+      ]
+    },
+    {
+      "format_id": "video_skippable_15s",
+      "name": "15-Second Skippable Video",
+      "type": "video",
+      "category": "standard",
+      "is_standard": true,
+      "duration": "15s",
+      "accepts_3p_tags": true,
+      "requirements": {
+        "aspect_ratios": ["16:9", "9:16", "1:1"],
+        "max_file_size_mb": 30,
+        "codec": "H.264"
+      }
+    }
+  ]
+}
+```
+
+### Example 2: Filter by Type
+
+#### MCP Request
 ```json
 {
   "tool": "list_creative_formats",


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the standard formats feature that was implemented in PR #45.

## Changes

### New Documentation
- **Standard Formats Guide** (`docs/media-buy/standard-formats-guide.md`): Complete guide explaining standard formats, how to use them, and best practices

### Documentation Updates  
- **CLAUDE.md**: Added "Lessons Learned" section documenting schema simplification best practices and testing considerations
- **creative-formats.md**: Added section explaining standard vs custom formats
- **list_creative_formats.md**: Added examples showing standard format responses with `asset_role` fields
- **add_creative_assets.md**: Updated with `asset_role` examples showing proper asset identification
- **index.md**: Added standard formats links to media-buy documentation index

## Why This Is Needed

PR #45 implemented the technical changes for standard formats but didn't include comprehensive documentation. This PR adds:
- User-facing guide for understanding and using standard formats
- Developer documentation of lessons learned
- Updated examples showing the new simplified approach

## Testing
✅ All tests pass
✅ Documentation builds successfully
✅ No schema changes (only documentation)

🤖 Generated with [Claude Code](https://claude.ai/code)