### PR TITLE
docs: Clarify A2A skill invocation with explicit examples

### DIFF
--- a/docs/media-buy/tasks/add_creative_assets.md
+++ b/docs/media-buy/tasks/add_creative_assets.md
@@ -155,28 +155,47 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "add_creative_assets",
-  "input": {
-    
-    "media_buy_id": "mb_12345",
-    "assets": [
-      {
-        "creative_id": "hero_video_30s",
-        "name": "Nike Air Max Hero 30s",
-        "format": "video",
-        "media_url": "https://cdn.example.com/nike-hero-30s.mp4",
-        "click_url": "https://nike.com/airmax",
-        "duration": 30000,
-        "width": 1920,
-        "height": 1080,
-        "package_assignments": ["pkg_ctv_001"]
-      }
-    ]
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Please upload my Nike Air Max hero video creative to the media buy mb_12345. It's a 30-second video at https://cdn.example.com/nike-hero-30s.mp4 that should direct to nike.com/airmax and be assigned to package pkg_ctv_001."
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "add_creative_assets",
+        parameters: {
+          media_buy_id: "mb_12345",
+          assets: [
+            {
+              creative_id: "hero_video_30s",
+              name: "Nike Air Max Hero 30s",
+              format: "video",
+              media_url: "https://cdn.example.com/nike-hero-30s.mp4",
+              click_url: "https://nike.com/airmax",
+              duration: 30000,
+              width: 1920,
+              height: 1080,
+              package_assignments: ["pkg_ctv_001"]
+            }
+          ]
+        }
+      }
+    }]
+  }
+});
 ```
 
 ### A2A Response (with streaming)

--- a/docs/media-buy/tasks/create_media_buy.md
+++ b/docs/media-buy/tasks/create_media_buy.md
@@ -223,56 +223,82 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "create_media_buy",
-  "input": {
-    "buyer_ref": "nike_q1_campaign_2024",
-    "packages": [
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Create a $100K Nike campaign from Feb 1 to Mar 31. Use the CTV sports and audio drive time products we discussed. Split budget 60/40."
+    }]
+  }
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [
       {
-        "buyer_ref": "nike_ctv_sports_package",
-        "products": ["ctv_sports_premium", "ctv_prime_time"],
-        "formats": ["video_standard_30s", "video_standard_15s"],
-        "budget": {
-          "total": 60000,
-          "currency": "USD",
-          "pacing": "even"
-        },
-        "targeting_overlay": {
-          "geo_country_any_of": ["US"],
-          "geo_region_any_of": ["CA", "NY"],
-          "axe_include_segment": "x8dj3k"
-        }
+        kind: "text",
+        text: "Creating Nike Q1 campaign"  // Optional context
       },
       {
-        "buyer_ref": "nike_audio_drive_package",
-        "products": ["audio_drive_time"],
-        "formats": ["audio_standard_30s"],
-        "budget": {
-          "total": 40000,
-          "currency": "USD",
-          "pacing": "front_loaded"
-        },
-        "targeting_overlay": {
-          "geo_country_any_of": ["US"],
-          "geo_region_any_of": ["CA"],
-          "axe_exclude_segment": "x9m2p"
+        kind: "data",
+        data: {
+          skill: "create_media_buy",  // Must match skill name in Agent Card
+          parameters: {
+            "buyer_ref": "nike_q1_campaign_2024",
+            "packages": [
+              {
+                "buyer_ref": "nike_ctv_sports_package",
+                "products": ["ctv_sports_premium", "ctv_prime_time"],
+                "formats": ["video_standard_30s", "video_standard_15s"],
+                "budget": {
+                  "total": 60000,
+                  "currency": "USD",
+                  "pacing": "even"
+                },
+                "targeting_overlay": {
+                  "geo_country_any_of": ["US"],
+                  "geo_region_any_of": ["CA", "NY"],
+                  "axe_include_segment": "x8dj3k"
+                }
+              },
+              {
+                "buyer_ref": "nike_audio_drive_package",
+                "products": ["audio_drive_time"],
+                "formats": ["audio_standard_30s"],
+                "budget": {
+                  "total": 40000,
+                  "currency": "USD",
+                  "pacing": "front_loaded"
+                },
+                "targeting_overlay": {
+                  "geo_country_any_of": ["US"],
+                  "geo_region_any_of": ["CA"],
+                  "axe_exclude_segment": "x9m2p"
+                }
+              }
+            ],
+            "promoted_offering": "Nike Air Max 2024 - premium running shoes",
+            "po_number": "PO-2024-Q1-001",
+            "start_time": "2024-02-01T00:00:00Z",
+            "end_time": "2024-03-31T23:59:59Z",
+            "budget": {
+              "total": 100000,
+              "currency": "USD",
+              "daily_cap": 5000,
+              "pacing": "even"
+            }
+          }
         }
       }
-    ],
-    "promoted_offering": "Nike Air Max 2024 - premium running shoes",
-    "po_number": "PO-2024-Q1-001",
-    "start_time": "2024-02-01T00:00:00Z",
-    "end_time": "2024-03-31T23:59:59Z",
-    "budget": {
-      "total": 100000,
-      "currency": "USD",
-      "daily_cap": 5000,
-      "pacing": "even"
-    }
+    ]
   }
-}
+});
 ```
 
 ### A2A Response (with streaming)

--- a/docs/media-buy/tasks/get_media_buy_delivery.md
+++ b/docs/media-buy/tasks/get_media_buy_delivery.md
@@ -183,17 +183,36 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "get_media_buy_delivery",
-  "input": {
-    
-    "media_buy_ids": ["mb_12345"],
-    "start_date": "2024-01-01",
-    "end_date": "2024-01-31"
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Show me the delivery metrics for media buy mb_12345 from January 1st through January 31st, 2024."
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "get_media_buy_delivery",
+        parameters: {
+          media_buy_ids: ["mb_12345"],
+          start_date: "2024-01-01",
+          end_date: "2024-01-31"
+        }
+      }
+    }]
+  }
+});
 ```
 
 ### A2A Response

--- a/docs/media-buy/tasks/get_products.md
+++ b/docs/media-buy/tasks/get_products.md
@@ -129,19 +129,46 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 }
 ```
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "get_products",
-  "input": {
-    "brief": "Premium video inventory for sports fans",
-    "promoted_offering": "Nike Air Max 2024 - latest innovation in cushioning",
-    "filters": {
-      "format_types": ["video"],
-      "delivery_type": "guaranteed"
-    }
+A2A supports both natural language and explicit skill invocation:
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Find premium video inventory for sports fans. We're promoting Nike Air Max 2024 - latest innovation in cushioning. Looking for guaranteed delivery."
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "text",
+        text: "Looking for sports inventory for Nike campaign"  // Optional context
+      },
+      {
+        kind: "data",
+        data: {
+          skill: "get_products",  // Must match skill name in Agent Card
+          parameters: {
+            brief: "Premium video inventory for sports fans",
+            promoted_offering: "Nike Air Max 2024 - latest innovation in cushioning",
+            filters: {
+              format_types: ["video"],
+              delivery_type: "guaranteed"
+            }
+          }
+        }
+      }
+    ]
+  }
+});
 ```
 ### A2A Response
 A2A returns results as artifacts with text and data parts:
@@ -179,8 +206,8 @@ A2A returns results as artifacts with text and data parts:
 ```
 ### Key Differences
 - **MCP**: Direct tool call with arguments, returns flat JSON response
-- **A2A**: Skill invocation with input, returns artifacts with text and data parts
-- **Payload**: The `input` field in A2A contains the exact same structure as MCP's `arguments`
+- **A2A**: Message-based invocation (natural language or explicit skill with parameters), returns artifacts with text and data parts
+- **Payload**: The `parameters` field in A2A explicit invocation contains the exact same structure as MCP's `arguments`
 ## Scenarios
 ### Request with Natural Language Brief
 ```json

--- a/docs/media-buy/tasks/list_creative_formats.md
+++ b/docs/media-buy/tasks/list_creative_formats.md
@@ -136,50 +136,74 @@ I found 2 audio formats available. The standard 30-second format is recommended 
 ```
 
 ### A2A Request
-```json
-{
-  "skill": "list_creative_formats",
-  "input": {
-    "standard_only": false
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Show me all your supported creative formats"
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "list_creative_formats",
+        parameters: {
+          standard_only: false
+        }
+      }
+    }]
+  }
+});
 ```
 
 ### A2A Response
 
-**Message:**
-```
-We support 47 creative formats across video, audio, and display. Video formats dominate with 23 options including standard pre-roll and innovative interactive formats. For maximum compatibility, I recommend using IAB standard formats which are accepted by 95% of our inventory.
-```
-
-**Artifacts:**
 ```json
-[
-  {
-    "type": "application/json",
-    "data": {
-      "formats": [
-        {
-          "format_id": "video_standard_30s",
-          "name": "Standard Video - 30 seconds",
-          "type": "video",
-          "is_standard": true,
-          "iab_specification": "VAST 4.2",
-          "requirements": {
-            "duration": 30,
-            "width": 1920,
-            "height": 1080,
-            "file_types": ["mp4", "webm"],
-            "max_file_size": 50000000,
-            "min_bitrate": 2500,
-            "max_bitrate": 8000
-          }
+{
+  "artifacts": [{
+    "name": "creative_formats",
+    "parts": [
+      {
+        "kind": "text",
+        "text": "We support 47 creative formats across video, audio, and display. Video formats dominate with 23 options including standard pre-roll and innovative interactive formats. For maximum compatibility, I recommend using IAB standard formats which are accepted by 95% of our inventory."
+      },
+      {
+        "kind": "data",
+        "data": {
+          "formats": [
+            {
+              "format_id": "video_standard_30s",
+              "name": "Standard Video - 30 seconds",
+              "type": "video",
+              "is_standard": true,
+              "iab_specification": "VAST 4.2",
+              "requirements": {
+                "duration": 30,
+                "width": 1920,
+                "height": 1080,
+                "file_types": ["mp4", "webm"],
+                "max_file_size": 50000000,
+                "min_bitrate": 2500,
+                "max_bitrate": 8000
+              }
+            }
+            // ... 46 more formats
+          ]
         }
-        // ... 46 more formats
-      ]
-    }
-  }
-]
+      }
+    ]
+  }]
+}
 ```
 
 ## Scenarios

--- a/docs/media-buy/tasks/update_media_buy.md
+++ b/docs/media-buy/tasks/update_media_buy.md
@@ -130,28 +130,48 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "update_media_buy",
-  "input": {
-    "buyer_ref": "nike_q1_campaign_2024",
-    "budget": {
-      "total": 150000,
-      "currency": "USD",
-      "pacing": "front_loaded"
-    },
-    "packages": [
-      {
-        "buyer_ref": "nike_ctv_sports_package",
-        "budget": {
-          "total": 100000,
-          "currency": "USD"
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Please update my Nike Q1 campaign budget to $150,000 with front-loaded pacing. Also increase the CTV sports package budget to $100,000."
+    }]
+  }
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "update_media_buy",
+        parameters: {
+          buyer_ref: "nike_q1_campaign_2024",
+          budget: {
+            total: 150000,
+            currency: "USD",
+            pacing: "front_loaded"
+          },
+          packages: [
+            {
+              buyer_ref: "nike_ctv_sports_package",
+              budget: {
+                total: 100000,
+                currency: "USD"
+              }
+            }
+          ]
         }
       }
-    ]
+    }]
   }
-}
+});
 ```
 
 ### A2A Response (Synchronous)

--- a/docs/protocols/a2a-guide.md
+++ b/docs/protocols/a2a-guide.md
@@ -41,6 +41,89 @@ const result = await task.complete();
 console.log(result.artifacts);
 ```
 
+## Skill Invocation
+
+A2A supports two methods for invoking skills:
+
+### Natural Language Invocation
+The agent interprets natural language to determine which skill to execute:
+
+```javascript
+// Agent infers this should use the get_products skill
+const task = await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Find premium CTV inventory for sports fans"
+    }]
+  }
+});
+```
+
+### Explicit Skill Invocation
+For deterministic execution, explicitly specify the skill name and parameters:
+
+```javascript
+// Explicitly invoke the get_products skill
+const task = await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "text",
+        text: "Looking for video products"  // Optional human context
+      },
+      {
+        kind: "data",
+        data: {
+          skill: "get_products",  // Exact skill name from Agent Card
+          parameters: {
+            audience: "sports fans",
+            format: "video",
+            max_cpm: 50,
+            platforms: ["ctv", "online_video"]
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+**Important**: When using explicit invocation, the `skill` field must exactly match the skill name advertised in the Agent Card.
+
+### Combining Natural Language with Explicit Skills
+You can include both natural language context and explicit skill invocation:
+
+```javascript
+// Hybrid approach - provides context AND explicit execution
+const task = await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "text",
+        text: "I'm looking for inventory for our spring campaign targeting millennials"
+      },
+      {
+        kind: "data", 
+        data: {
+          skill: "get_products",
+          parameters: {
+            audience: "millennials",
+            season: "Q2_2024",
+            categories: ["lifestyle", "entertainment"]
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+This hybrid approach:
+- Provides human context for logging and understanding
+- Ensures deterministic skill execution
+- Allows the agent to use context for clarifications if needed
+
 ## Understanding A2A Responses
 
 A2A uses two types of responses:
@@ -305,6 +388,276 @@ await a2a.send({
 });
 ```
 
+## AdCP Skill Examples
+
+Here are explicit invocation examples for each AdCP skill:
+
+### Media Buy Skills
+
+#### get_products
+```javascript
+// Explicit skill invocation
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "get_products",
+          parameters: {
+            audience: "pet owners",
+            geo: ["US-CA", "US-NY"],
+            format: "video",
+            max_cpm: 75,
+            min_impressions: 1000000
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+#### list_creative_formats
+```javascript
+// List all supported formats
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "list_creative_formats",
+          parameters: {
+            category: "video"  // Optional: filter by category
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+#### create_media_buy
+```javascript
+// Create campaign with selected products
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "create_media_buy",
+          parameters: {
+            package_selections: [
+              {
+                package_id: "pkg_12345",
+                budget_amount: 50000,
+                impressions: 2000000
+              },
+              {
+                package_id: "pkg_67890",
+                budget_amount: 25000,
+                impressions: 1000000
+              }
+            ],
+            buyer_ref: "Q1_2024_campaign",
+            start_date: "2024-01-01",
+            end_date: "2024-03-31",
+            pacing: "even"
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+#### add_creative_assets
+```javascript
+// Upload and assign creative assets
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "add_creative_assets",
+          parameters: {
+            media_buy_id: "mb_12345",
+            assignments: [
+              {
+                package_id: "pkg_12345",
+                format_id: "video_30s"
+              }
+            ]
+          }
+        }
+      },
+      {
+        kind: "file",
+        uri: "https://cdn.example.com/video-30s.mp4",
+        name: "hero_video_30s.mp4"
+      }
+    ]
+  }
+});
+```
+
+#### get_media_buy_delivery
+```javascript
+// Get campaign performance metrics
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "get_media_buy_delivery",
+          parameters: {
+            media_buy_id: "mb_12345",
+            date_range: {
+              start: "2024-01-01",
+              end: "2024-01-31"
+            },
+            metrics: ["impressions", "clicks", "video_completions"]
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+#### update_media_buy
+```javascript
+// Update campaign settings
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "update_media_buy",
+          parameters: {
+            media_buy_id: "mb_12345",
+            updates: {
+              budget_amount: 150000,
+              pacing: "front_loaded",
+              end_date: "2024-04-30"
+            }
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+### Signals Skills
+
+#### get_signals
+```javascript
+// Discover relevant signals
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "get_signals",
+          parameters: {
+            requirements: {
+              audience: "luxury car intenders",
+              categories: ["automotive", "lifestyle"],
+              platforms: ["ttd", "amazon_dsp"]
+            },
+            limit: 10
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+#### activate_signal
+```javascript
+// Activate signal on platform
+await a2a.send({
+  message: {
+    parts: [
+      {
+        kind: "data",
+        data: {
+          skill: "activate_signal",
+          parameters: {
+            signal_id: "sig_luxury_auto_123",
+            platform: "ttd",
+            account_id: "account_456",
+            activation_name: "Q1_luxury_segment"
+          }
+        }
+      }
+    ]
+  }
+});
+```
+
+## Skill Response Formats
+
+All skill invocations return results as artifacts with structured data:
+
+### Successful Skill Response
+```json
+{
+  "taskId": "task_123",
+  "contextId": "ctx_456",
+  "status": "completed",
+  "artifacts": [
+    {
+      "name": "skill_result",
+      "parts": [
+        {
+          "kind": "text",
+          "text": "Human-readable summary of the result"
+        },
+        {
+          "kind": "data",
+          "data": {
+            // Structured data specific to the skill
+            // e.g., for get_products: { products: [...], total: 5 }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Asynchronous Skills
+Some skills (like `create_media_buy` or `activate_signal`) may require time to complete:
+
+1. **Initial Response**: Returns task ID with status "working"
+2. **Status Updates**: Available via SSE at `/a2a/tasks/{taskId}/events`
+3. **Final Result**: Contains artifacts with the completed data
+
+### Error Responses
+When a skill fails, the response includes an error message:
+
+```json
+{
+  "taskId": "task_123",
+  "status": "failed",
+  "message": {
+    "parts": [{
+      "kind": "text",
+      "text": "Unable to find products matching criteria: No inventory available for the specified audience"
+    }]
+  }
+}
+```
+
 ## Agent Cards for AdCP
 
 A2A agents advertise their capabilities via Agent Cards served at `.well-known/agent.json`. Here are sample agent cards for AdCP implementations:
@@ -405,15 +758,28 @@ Here's a full campaign creation workflow using A2A:
 async function createCampaignWithA2A() {
   const a2a = new A2AClient({ /* config */ });
   
-  // 1. Natural language product discovery
+  // 1. Product discovery using explicit skill invocation
   const discovery = await a2a.send({
     message: {
-      parts: [{
-        kind: "text",
-        text: `I need to create a Q1 campaign for BMW Series 5.
-               Budget is $200K, targeting luxury car intenders.
-               Looking for premium CTV and audio inventory.`
-      }]
+      parts: [
+        {
+          kind: "text",
+          text: "Finding inventory for BMW Q1 campaign"
+        },
+        {
+          kind: "data",
+          data: {
+            skill: "get_products",
+            parameters: {
+              audience: "luxury car intenders",
+              format: ["ctv", "audio"],
+              tier: "premium",
+              min_impressions: 5000000,
+              max_cpm: 100
+            }
+          }
+        }
+      ]
     }
   });
   
@@ -480,7 +846,34 @@ async function createCampaignWithA2A() {
 
 ## Best Practices
 
-### 1. Distinguish Messages from Artifacts
+### 1. Choose the Right Invocation Method
+```javascript
+// Use natural language for flexible, human-like interaction
+if (userProvidedNaturalLanguageQuery) {
+  await a2a.send({
+    message: {
+      parts: [{ kind: "text", text: userQuery }]
+    }
+  });
+}
+
+// Use explicit skills for programmatic, deterministic execution
+if (needPredictableExecution) {
+  await a2a.send({
+    message: {
+      parts: [{
+        kind: "data",
+        data: {
+          skill: "get_products",
+          parameters: structuredParams
+        }
+      }]
+    }
+  });
+}
+```
+
+### 2. Distinguish Messages from Artifacts
 ```javascript
 // Check what type of response
 if (response.artifacts && response.artifacts.length > 0) {
@@ -492,7 +885,7 @@ if (response.artifacts && response.artifacts.length > 0) {
 }
 ```
 
-### 2. Use Context for Conversations
+### 3. Use Context for Conversations
 ```javascript
 class A2AConversation {
   constructor(client) {
@@ -514,7 +907,7 @@ class A2AConversation {
 }
 ```
 
-### 3. Handle Multi-Part Artifacts
+### 4. Handle Multi-Part Artifacts
 ```javascript
 function processArtifact(artifact) {
   artifact.parts.forEach(part => {

--- a/docs/signals/tasks/activate_signal.md
+++ b/docs/signals/tasks/activate_signal.md
@@ -107,17 +107,36 @@ After polling for completion:
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "activate_signal",
-  "input": {
-    
-    "signal_agent_segment_id": "luxury_auto_intenders",
-    "platform": "the-trade-desk",
-    "account": "agency-123-ttd"
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Please activate the luxury_auto_intenders signal on The Trade Desk for account agency-123-ttd."
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "activate_signal",
+        parameters: {
+          signal_agent_segment_id: "luxury_auto_intenders",
+          platform: "the-trade-desk",
+          account: "agency-123-ttd"
+        }
+      }
+    }]
+  }
+});
 ```
 
 ### A2A Response (with streaming)

--- a/docs/signals/tasks/get_signals.md
+++ b/docs/signals/tasks/get_signals.md
@@ -171,24 +171,43 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
 ```
 
 ### A2A Request
-For A2A, the skill and input are sent as:
-```json
-{
-  "skill": "get_signals",
-  "input": {
-    
-    "signal_spec": "High-income households interested in luxury goods",
-    "deliver_to": {
-      "platforms": ["the-trade-desk", "amazon-dsp"],
-      "countries": ["US"]
-    },
-    "filters": {
-      "max_cpm": 5.0,
-      "catalog_types": ["marketplace"]
-    },
-    "max_results": 5
+
+#### Natural Language Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "text",
+      text: "Find me signals for high-income households interested in luxury goods that can be deployed on The Trade Desk and Amazon DSP in the US, with a maximum CPM of $5.00."
+    }]
   }
-}
+});
+```
+
+#### Explicit Skill Invocation
+```javascript
+await a2a.send({
+  message: {
+    parts: [{
+      kind: "data",
+      data: {
+        skill: "get_signals",
+        parameters: {
+          signal_spec: "High-income households interested in luxury goods",
+          deliver_to: {
+            platforms: ["the-trade-desk", "amazon-dsp"],
+            countries: ["US"]
+          },
+          filters: {
+            max_cpm: 5.0,
+            catalog_types: ["marketplace"]
+          },
+          max_results: 5
+        }
+      }
+    }]
+  }
+});
 ```
 
 ### A2A Response


### PR DESCRIPTION
## Summary
- Clarifies how A2A skill invocation works with comprehensive documentation and examples
- Adds both natural language and explicit skill invocation patterns for all AdCP skills
- Aligns documentation with the actual A2A protocol specification

## Changes Made

### A2A Guide Updates (`docs/protocols/a2a-guide.md`)
- ✨ Added new "Skill Invocation" section explaining two methods: Natural Language and Explicit Skill
- 📚 Added "AdCP Skill Examples" section with detailed examples for all 8 AdCP skills
- 📄 Added "Skill Response Formats" section documenting successful responses, async handling, and errors
- 🎯 Updated Best Practices to include guidance on choosing invocation methods
- 🔄 Added hybrid approach examples combining natural language with explicit skills

### Task Documentation Updates (All 8 Task Files)
Updated each task's A2A Request section to show:
- **Natural Language Invocation**: How users can invoke skills using plain English
- **Explicit Skill Invocation**: How to directly invoke skills with structured parameters
- Proper message format with `parts` array containing `text` and/or `data` parts
- Correct skill names that match Agent Card definitions

### Files Modified
- `docs/media-buy/tasks/get_products.md`
- `docs/media-buy/tasks/list_creative_formats.md`
- `docs/media-buy/tasks/create_media_buy.md`
- `docs/media-buy/tasks/add_creative_assets.md`
- `docs/media-buy/tasks/get_media_buy_delivery.md`
- `docs/media-buy/tasks/update_media_buy.md`
- `docs/signals/tasks/get_signals.md`
- `docs/signals/tasks/activate_signal.md`

## Key Clarifications

1. **Skills are precise**: Skills like `get_products`, `create_media_buy`, etc. are the actual AdCP skills
2. **Two invocation methods**: Both natural language and explicit skill invocation are valid
3. **Message structure**: A2A uses message parts with `kind` field (`text`, `data`, or `file`)
4. **Skill names must match**: When using explicit invocation, the skill name must exactly match what's in the Agent Card
5. **Parameters mapping**: The `parameters` field in explicit invocation contains the same structure as MCP's `arguments`

## Test plan
- [x] All schema validation tests pass
- [x] All example validation tests pass
- [x] TypeScript compilation succeeds
- [x] Documentation builds successfully
- [ ] Review A2A examples for correctness
- [ ] Verify skill names match Agent Card definitions

🤖 Generated with [Claude Code](https://claude.ai/code)