### PR TITLE
Add testing environment link to homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,6 +55,11 @@ function HomepageHeader() {
                 Start Building
               </Link>
               <Link
+                className="button button--secondary button--lg margin-right--md"
+                to="https://testing.adcontextprotocol.org">
+                Try It Live
+              </Link>
+              <Link
                 className="button button--outline button--secondary button--lg"
                 to="https://github.com/adcontextprotocol/adcp">
                 View on GitHub


### PR DESCRIPTION
## Summary
- Add "Try It Live" button to homepage hero section linking to testing.adcontextprotocol.org
- Positioned between "Start Building" and "View on GitHub" for optimal user flow
- Encourages hands-on experimentation with AdCP before diving into documentation

## Test plan
- [x] Homepage renders correctly with new button
- [x] Button styling matches existing design system
- [x] Link opens testing environment in new tab
- [x] All tests pass (schemas, examples, typecheck)

🤖 Generated with [Claude Code](https://claude.ai/code)