### PR TITLE
Fix Dockerfile build issues for Fly.io deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Node.js 18 Alpine for building
-FROM node:18-alpine AS builder
+# Use Node.js 20 Alpine for building
+FROM node:20-alpine AS builder
 
 # Set working directory
 WORKDIR /app
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install dependencies (skip postinstall scripts like husky)
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- Fix Node.js version compatibility (upgrade to Node 20)
- Skip husky postinstall script in Docker builds
- Update npm flags to use recommended syntax

## Problem
The previous Dockerfile was failing during deployment with:
- `EBADENGINE` error due to `marked` package requiring Node 20+
- `husky: not found` error during npm postinstall
- Deprecated `--only=production` flag

## Solution
- **Node 20**: Updated base image from `node:18-alpine` to `node:20-alpine`
- **Skip Scripts**: Added `--ignore-scripts` to prevent husky from running in Docker
- **Modern npm**: Changed `--only=production` to `--omit=dev`

## Testing
- ✅ Docusaurus build completes successfully
- ✅ All tests pass
- ✅ Docker image should now build without errors

This should resolve the Fly.io deployment failures and allow the docs site to deploy successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)