### PR TITLE
fix: eliminate HTTP redirect in URL normalization

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,6 +52,9 @@ http {
         if ($http_x_forwarded_proto = 'https') {
             set $real_scheme https;
         }
+        
+        # Force HTTPS in absolute redirects
+        absolute_redirect off;
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -65,6 +68,14 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
+        # Handle trailing slash redirects with proper scheme
+        location ~ ^([^.]*[^/])$ {
+            if (-d $document_root$1/) {
+                return 301 $real_scheme://$host$1/;
+            }
+            try_files $uri /index.html;
+        }
+        
         # Handle client-side routing for SPA
         location / {
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary
- Eliminates the intermediate HTTP redirect that occurs during URL normalization
- Ensures all redirects maintain HTTPS protocol when behind Fly.io load balancer
- Fixes the issue where URLs without trailing slash redirect to HTTP before redirecting back to HTTPS

## Changes Made
- Added `absolute_redirect off;` to prevent HTTP downgrades in nginx redirects
- Added explicit trailing slash handling with proper HTTPS scheme detection
- Custom location block ensures directory-style URLs get proper HTTPS redirects

## Before
`https://adcontextprotocol.org/docs/path` → `http://adcontextprotocol.org/docs/path/` → `https://adcontextprotocol.org/docs/path/` → 200 OK

## After  
`https://adcontextprotocol.org/docs/path` → `https://adcontextprotocol.org/docs/path/` → 200 OK

## Test Plan
- [x] Verify nginx configuration builds successfully  
- [x] All existing tests pass
- [ ] Deploy and test HTTPS redirects work without HTTP intermediate step

🤖 Generated with [Claude Code](https://claude.ai/code)