### PR TITLE
feat: add response time expectations to AdCP documentation

### DIFF
--- a/docs/media-buy/index.md
+++ b/docs/media-buy/index.md
@@ -12,7 +12,7 @@ The Advertising Context Protocol (AdCP) provides a simple, expressive, and AI-fi
 
 1. **MCP-Based Interface**: Built on Model Context Protocol (MCP) for standardized AI agent interaction, not REST APIs.
 
-2. **Asynchronous by Design**: Operations may take seconds to days to complete. The protocol embraces pending states as normal workflow elements.
+2. **Asynchronous by Design**: Operations may take seconds to days to complete. The protocol embraces pending states as normal workflow elements. **This is not a real-time protocol** - response times range from 1 second for simple lookups to days for operations requiring human approval.
 
 3. **Human-in-the-Loop**: Publishers can require manual approval for any operation. The protocol includes comprehensive task management for human intervention.
 
@@ -28,6 +28,17 @@ The Advertising Context Protocol (AdCP) provides a simple, expressive, and AI-fi
 - **Creative Flexibility**: Support for standard IAB and custom publisher formats
 - **Real-time Optimization**: Continuous performance monitoring and adjustment
 - **Human-in-the-Loop**: Optional manual approval workflows where needed
+
+## Response Time Expectations
+
+AdCP is designed as a **timely but not real-time** protocol. Response times fall into four categories:
+
+- **Simple database lookups** (~1 second): Format and creative listings
+- **Inference/RAG operations** (~60 seconds): Product discovery, signal discovery with AI/LLM processing  
+- **Reporting queries** (~60 seconds): Delivery metrics with data aggregation
+- **Asynchronous operations** (minutes to days): Campaign creation/updates, creative sync, signal activation with potential human-in-the-loop approval
+
+Implementers should design for asynchronous operation and provide appropriate user feedback during processing.
 
 ## Separation of Concerns: A Collaborative Model
 
@@ -91,12 +102,12 @@ The following diagram illustrates the complete lifecycle of a media buy in AdCP:
 ### Tasks
 Core operations available in the Media Buy Protocol:
 
-- **[get_products](./tasks/get_products)** - Discover available advertising products
-- **[list_creative_formats](./tasks/list_creative_formats)** - View supported creative formats
-- **[create_media_buy](./tasks/create_media_buy)** - Create a media buy from selected packages
-- **[sync_creatives](./tasks/sync_creatives)** - Centralized creative library management
-- **[get_media_buy_delivery](./tasks/get_media_buy_delivery)** - Retrieve performance metrics and monitor delivery
-- **[update_media_buy](./tasks/update_media_buy)** - Update campaign settings
+- **[get_products](./tasks/get_products)** - Discover available advertising products *(~60s)*
+- **[list_creative_formats](./tasks/list_creative_formats)** - View supported creative formats *(~1s)*
+- **[create_media_buy](./tasks/create_media_buy)** - Create a media buy from selected packages *(minutes to days)*
+- **[sync_creatives](./tasks/sync_creatives)** - Centralized creative library management *(minutes to days)*
+- **[get_media_buy_delivery](./tasks/get_media_buy_delivery)** - Retrieve performance metrics and monitor delivery *(~60s)*
+- **[update_media_buy](./tasks/update_media_buy)** - Update campaign settings *(minutes to days)*
 
 ### Core Concepts
 Foundational elements of the Advertising Context Protocol:

--- a/docs/media-buy/tasks/create_media_buy.md
+++ b/docs/media-buy/tasks/create_media_buy.md
@@ -7,6 +7,8 @@ sidebar_position: 3
 
 Create a media buy from selected packages. This task handles the complete workflow including validation, approval if needed, and campaign creation.
 
+**Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
+
 **Format Specification Required**: Each package must specify the creative formats that will be used. This enables placeholder creation in ad servers and ensures both parties have clear expectations for creative asset requirements.
 
 

--- a/docs/media-buy/tasks/get_media_buy_delivery.md
+++ b/docs/media-buy/tasks/get_media_buy_delivery.md
@@ -7,6 +7,8 @@ sidebar_position: 6
 
 Retrieve comprehensive delivery metrics and performance data for reporting.
 
+**Response Time**: ~60 seconds (reporting query)
+
 
 **Request Schema**: [`/schemas/v1/media-buy/get-media-buy-delivery-request.json`](/schemas/v1/media-buy/get-media-buy-delivery-request.json)  
 **Response Schema**: [`/schemas/v1/media-buy/get-media-buy-delivery-response.json`](/schemas/v1/media-buy/get-media-buy-delivery-response.json)

--- a/docs/media-buy/tasks/get_products.md
+++ b/docs/media-buy/tasks/get_products.md
@@ -5,6 +5,8 @@ sidebar_position: 1
 # get_products
 Discover available advertising products based on campaign requirements, using natural language briefs or structured filters.
 
+**Response Time**: ~60 seconds (inference/RAG with back-end systems)
+
 **Format Discovery**: Products return format references (IDs only). Use [`list_creative_formats`](./list_creative_formats) to get full format specifications including requirements, file types, and dimensions.
 
 **Request Schema**: [`/schemas/v1/media-buy/get-products-request.json`](/schemas/v1/media-buy/get-products-request.json)  

--- a/docs/media-buy/tasks/list_creative_formats.md
+++ b/docs/media-buy/tasks/list_creative_formats.md
@@ -7,6 +7,7 @@ sidebar_position: 2
 
 Discover all supported creative formats in the system.
 
+**Response Time**: ~1 second (simple database lookup)
 
 **Request Schema**: [`/schemas/v1/media-buy/list-creative-formats-request.json`](/schemas/v1/media-buy/list-creative-formats-request.json)  
 **Response Schema**: [`/schemas/v1/media-buy/list-creative-formats-response.json`](/schemas/v1/media-buy/list-creative-formats-response.json)

--- a/docs/media-buy/tasks/list_creatives.md
+++ b/docs/media-buy/tasks/list_creatives.md
@@ -6,6 +6,8 @@ title: list_creatives
 
 Query and search the centralized creative library with advanced filtering, sorting, pagination, and optional data enrichment. This task enables efficient discovery and management of creative assets with flexible query capabilities.
 
+**Response Time**: ~1 second (simple database lookup)
+
 ## Overview
 
 The `list_creatives` task provides comprehensive search and filtering capabilities for the creative library. It supports complex queries with multiple filter types, sorting options, pagination for large result sets, and optional inclusion of enriched data like assignments and performance metrics.

--- a/docs/media-buy/tasks/sync_creatives.md
+++ b/docs/media-buy/tasks/sync_creatives.md
@@ -6,6 +6,8 @@ title: sync_creatives
 
 Synchronize creative assets with the centralized creative library using upsert semantics. This task supports bulk operations, partial updates, assignment management, and comprehensive validation for efficient creative library management.
 
+**Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
+
 ## Overview
 
 The `sync_creatives` task provides a powerful, efficient approach to creative library management using **upsert semantics** - creatives are either created (if they don't exist) or updated (if they do exist) based on their `creative_id`. This eliminates the need to check existence before uploading and enables seamless bulk operations.

--- a/docs/media-buy/tasks/update_media_buy.md
+++ b/docs/media-buy/tasks/update_media_buy.md
@@ -7,6 +7,8 @@ sidebar_position: 7
 
 Update campaign and package settings. This task supports partial updates and handles any required approvals.
 
+**Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
+
 
 **Request Schema**: [`/schemas/v1/media-buy/update-media-buy-request.json`](/schemas/v1/media-buy/update-media-buy-request.json)  
 **Response Schema**: [`/schemas/v1/media-buy/update-media-buy-response.json`](/schemas/v1/media-buy/update-media-buy-response.json)

--- a/docs/signals/tasks/activate_signal.md
+++ b/docs/signals/tasks/activate_signal.md
@@ -7,6 +7,8 @@ title: activate_signal
 
 **Task**: Activate a signal for use on a specific platform/account.
 
+**Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
+
 **Request Schema**: [`/schemas/v1/signals/activate-signal-request.json`](/schemas/v1/signals/activate-signal-request.json)  
 **Response Schema**: [`/schemas/v1/signals/activate-signal-response.json`](/schemas/v1/signals/activate-signal-response.json)
 

--- a/docs/signals/tasks/get_signals.md
+++ b/docs/signals/tasks/get_signals.md
@@ -7,6 +7,8 @@ title: get_signals
 
 **Task**: Discover signals based on description, with details about where they are deployed.
 
+**Response Time**: ~60 seconds (inference/RAG with back-end systems)
+
 **Request Schema**: [`/schemas/v1/signals/get-signals-request.json`](/schemas/v1/signals/get-signals-request.json)  
 **Response Schema**: [`/schemas/v1/signals/get-signals-response.json`](/schemas/v1/signals/get-signals-response.json)
 


### PR DESCRIPTION
## Summary

Add clear response time guidelines across all AdCP tasks using a simplified 4-bucket system to help implementers set proper expectations.

### Response Time Categories

- **Simple database lookups (~1 second)**: `list_creative_formats`, `list_creatives`  
- **Inference/RAG operations (~60 seconds)**: `get_products`, `get_signals` (AI/LLM processing)
- **Reporting queries (~60 seconds)**: `get_media_buy_delivery` (data aggregation)
- **Asynchronous operations (minutes to days)**: `create_media_buy`, `update_media_buy`, `sync_creatives`, `activate_signal` (potential human approval)

### Key Changes

- Added **Response Time** section to all task documentation pages
- Updated protocol overview with comprehensive response time expectations section  
- Clarified that AdCP is "timely but not real-time" protocol
- Set proper expectations that human-in-the-loop processes can take days, not just minutes
- Added timing annotations to task list in main documentation index

### Files Changed

- `docs/media-buy/index.md` - Protocol overview with new response time section
- `docs/media-buy/tasks/*.md` - All media buy tasks updated with response times
- `docs/signals/tasks/*.md` - All signal tasks updated with response times

## Test plan

- [x] All existing tests pass
- [x] Documentation builds successfully  
- [x] Response time categories are consistent across all tasks
- [x] Overview messaging aligns with individual task specifications

🤖 Generated with [Claude Code](https://claude.ai/code)