### PR TITLE
feat: add campaign brief documentation and examples

### DIFF
--- a/docs/media-buy/example-briefs.md
+++ b/docs/media-buy/example-briefs.md
@@ -5,318 +5,417 @@ title: Example Campaign Briefs
 
 # Example Campaign Briefs
 
-These examples demonstrate realistic campaign briefs at different quality levels, showcasing how natural language descriptions translate into effective media buying instructions.
+These annotated examples demonstrate how to create effective campaign briefs at different complexity levels, showcasing the progression from essential elements to comprehensive strategies.
 
-## Minimal Briefs
+## 1. Minimal Brief: Essential Elements
 
-### Example 1: Local Service Business
-```
-Advertiser: Mike's Plumbing Services
-Promoted offering: Emergency plumbing repairs and routine maintenance in the Denver metro area
-Objective: Drive phone calls for service appointments
-Budget: $5,000
-Flight dates: October 15-31, 2024
-```
+### Local Service Business Campaign
 
-### Example 2: E-commerce Product Launch
-```
-Advertiser: TechGear Pro
-Promoted offering: New wireless noise-canceling headphones with 40-hour battery life
-Objective: Drive online sales during launch week
-Success metric: Achieve 2.5% CTR and $50 CPA
-Flight dates: November 1-7, 2024
-Budget: $15,000
+```json
+{
+  "advertiser": "Mike's Plumbing Services",
+  "promoted_offering": "24/7 emergency plumbing repairs and routine maintenance in Denver metro area",
+  "objectives": "Drive phone calls for service appointments",
+  "flight_dates": "October 15-31, 2024",
+  "budget": "$8,000"
+}
 ```
 
-## Standard Briefs
+**Why This Works:**
+- ✅ **Clear advertiser and offering** - Specifies service type and geographic scope
+- ✅ **Specific objective** - "Phone calls" is measurable and actionable
+- ✅ **Defined budget and timing** - Realistic for local service campaign
+- ⚠️ **Could improve** - Add target CPA ($40-60 per call typical for plumbing)
+- ⚠️ **Missing** - Audience definition (homeowners, property managers)
 
-### Example 3: Retail Holiday Campaign
-```
-Advertiser: StyleForward Fashion
-Promoted offering: Black Friday and Cyber Monday deals on winter apparel collection featuring sustainable materials and inclusive sizing
+**Publisher Response:**
+Publishers will likely recommend:
+- Local inventory products with call tracking
+- Mobile-first placements (emergency searches)
+- Request clarification on success metrics
+- Suggest dayparting for emergency service hours
 
-Objectives: 
-- Primary: Drive in-store and online conversions
-- Secondary: Build brand awareness for sustainable fashion line
+**AdCP Workflow:**
+1. `get_products` - Query local inventory with geographic constraints
+2. `list_creative_formats` - Identify call-to-action enabled formats
+3. `create_media_buy` - Submit with phone tracking requirements
 
-Target audience: Women and men aged 25-45 interested in sustainable fashion, environmentally conscious consumers, and value-seekers during holiday shopping season
+---
 
-Success metrics:
-- 3% conversion rate
-- $75 CPA for online sales
-- 150% ROAS
+## 2. Standard Brief: Audience + Metrics
 
-Geographic markets: Major US metropolitan areas with physical store presence (NYC, LA, Chicago, Dallas, Atlanta)
+### E-commerce Product Launch
 
-Flight dates: November 24 - December 2, 2024
-Budget: $50,000
-
-Creative formats: Display banners, video ads, and native content featuring product imagery and promotional offers
-```
-
-### Example 4: B2B Software Campaign
-```
-Advertiser: CloudSync Solutions
-Promoted offering: Enterprise data synchronization platform for hybrid cloud environments
-
-Business objectives:
-- Generate qualified leads for sales team
-- Position as leader in hybrid cloud data management
-
-Target audience:
-- IT decision makers and CTOs at companies with 500+ employees
-- Industries: Financial services, healthcare, retail, manufacturing
-- Currently using multiple cloud providers (AWS, Azure, GCP)
-
-Success metrics:
-- 50 qualified leads (MQL)
-- $200 cost per lead
-- 0.5% conversion rate on landing page
-
-Flight dates: October 1 - December 31, 2024
-Budget: $30,000 monthly
-
-Geographic focus: United States and Canada
-
-Creative requirements: Professional B2B creative with technical credibility, case study content, and clear value propositions
-```
-
-## Comprehensive Briefs
-
-### Example 5: Automotive Model Launch
-```
-Advertiser: EcoMotion Automotive
-Promoted offering: 2025 EcoMotion Hybrid SUV - The first luxury hybrid SUV with 500-mile range and advanced autonomous driving features
-
-Campaign overview:
-Launching our flagship hybrid SUV targeted at environmentally conscious families who don't want to compromise on luxury or performance. This vehicle represents our brand's commitment to sustainable transportation without sacrifice.
-
-Business objectives:
-1. Awareness: Reach 10M unique users in target demographic
-2. Consideration: Drive 100,000 configurator sessions
-3. Conversion: Generate 5,000 test drive appointments
-4. Brand: Increase consideration as eco-luxury brand by 15%
-
-Target audience:
-Primary segment:
-- Households with income $75,000-$150,000
-- Ages 35-55 with families
-- Currently own SUVs or considering SUV purchase
-- Environmental values important in purchase decisions
-- Technology early adopters
-
-Secondary segment:
-- Young professionals 28-40
-- Urban and suburban markets
-- Interest in outdoor activities and adventure
-
-Behavioral signals:
-- In-market for vehicles (especially SUVs)
-- Researching hybrid/electric vehicles
-- Visiting competitor sites (Tesla, Rivian, traditional luxury brands)
-- Consuming content about sustainability, technology, family travel
-
-Success metrics:
-- Reach: 10M unique users with 3+ frequency
-- Engagement: 1.5% CTR on display, 35% video completion rate
-- Site actions: 2% conversion to configurator from landing page
-- Test drives: $250 cost per test drive appointment
-- Brand lift: 15% increase in consideration (measured via brand study)
-
-Geographic markets:
-Primary DMAs:
-- California: Los Angeles, San Francisco, San Diego
-- Northeast: New York, Boston, Philadelphia
-- Pacific Northwest: Seattle, Portland
-- Texas: Austin, Dallas, Houston
-
-Flight schedule:
-- Phase 1 (Awareness): October 1-15, 2024 - 40% of budget
-- Phase 2 (Consideration): October 16-31, 2024 - 35% of budget
-- Phase 3 (Conversion): November 1-15, 2024 - 25% of budget
-
-Total budget: $500,000
-
-Creative formats and requirements:
-- Video: 30-second and 15-second spots showcasing family adventures and eco features
-- Display: Rich media expandable units with 360-degree vehicle views
-- Native: Editorial-style content about sustainable family travel
-- Connected TV: Premium placements during family and lifestyle programming
-- All creative must include dealer locator and "Build & Price" CTAs
-
-Brand safety requirements:
-- No placement near automotive recalls or accidents
-- Avoid controversial political content
-- Family-friendly environments only
-- Premium publisher list preferred
-
-Additional requirements:
-- Dayparting: Weekday evenings (6-10pm) and weekends
-- Frequency cap: 3 per day, 10 per week
-- Mobile-first approach with 60% mobile allocation
-- A/B testing for creative messages and CTAs
+```json
+{
+  "advertiser": "TechGear Pro",
+  "promoted_offering": "New ANC-Pro wireless headphones with 40-hour battery life, premium audio drivers",
+  
+  "objectives": {
+    "primary": "Drive online sales during launch week",
+    "secondary": "Build brand awareness in audio enthusiast community"
+  },
+  
+  "target_audience": {
+    "demographics": "Ages 25-45, household income $50K+",
+    "interests": "Technology, music, fitness, travel",
+    "behaviors": "Early tech adopters, premium audio purchasers"
+  },
+  
+  "success_metrics": {
+    "ctr": "0.8-1.2%",
+    "cpa": "$45-55",
+    "roas": "300%",
+    "conversion_rate": "2.5%"
+  },
+  
+  "flight_dates": "November 1-14, 2024",
+  "budget": "$25,000",
+  
+  "creative_requirements": "Product demos, lifestyle imagery, launch offer messaging"
+}
 ```
 
-### Example 6: Financial Services Customer Acquisition
-```
-Advertiser: NextGen Banking
-Promoted offering: High-yield savings account with 4.5% APY, no minimum balance, and no monthly fees
+**Why This Works:**
+- ✅ **Realistic metrics** - CTR of 0.8-1.2% achievable for targeted campaigns
+- ✅ **Clear audience definition** - Actionable demographic and behavioral signals
+- ✅ **Multiple success metrics** - Allows optimization flexibility
+- ✅ **Appropriate budget** - $25K reasonable for 2-week product launch
+- ⚠️ **Could improve** - Specify creative formats needed (video vs. display)
+- ⚠️ **Missing** - Competitive considerations, measurement preferences
 
-Campaign context:
-We're launching a competitive high-yield savings product targeted at mass affluent consumers looking to maximize their savings in the current interest rate environment. This campaign needs to balance aggressive growth targets with responsible customer acquisition costs and regulatory compliance.
+**Publisher Response:**
+Publishers will optimize for:
+- Audience matching against tech/audio enthusiast segments
+- Performance optimization toward CPA goals
+- Creative format recommendations based on inventory
+- Suggest retargeting pool creation
 
-Multi-tiered objectives:
-1. Immediate (Month 1): Generate awareness of rate offering
-2. Short-term (Months 1-2): Drive 10,000 account applications
-3. Long-term (Month 3): Achieve 5,000 funded accounts with $25K+ average balance
+**AdCP Workflow:**
+1. `get_products` with filters for audience targeting capabilities
+2. `list_creative_formats` to match product demo requirements
+3. Signal activation for tech enthusiast audiences
+4. Performance monitoring via `get_media_buy_delivery`
 
-Detailed audience strategy:
+---
 
-Tier 1 - High-value prospects:
-- Income: $100,000+
-- Age: 30-60
-- Currently have savings accounts with traditional banks
-- Show interest in financial planning and investment content
-- Life events: Recent job change, inheritance, home sale
+## 3. Comprehensive Brief: Full Strategy
 
-Tier 2 - Growth segment:
-- Income: $60,000-$100,000
-- Age: 25-45
-- Digital-first banking preferences
-- Price-sensitive savers comparing rates
-- Engaged with personal finance content/apps
+### B2B Software Campaign
 
-Exclusions:
-- Existing NextGen Banking customers
-- Recent credit defaults or bankruptcies
-- Under 18 or over 75
-
-Performance targets by funnel stage:
-- Impression to click: 0.8% CTR minimum
-- Click to application start: 15% conversion
-- Application start to complete: 60% completion
-- Application to approval: 80% approval rate
-- Approval to funding: 50% funding rate
-- Overall CAC target: $150 per funded account
-
-Geographic and market prioritization:
-Tier 1 markets (50% budget):
-- High-cost-of-living metros where rate sensitivity is highest
-- New York, San Francisco, Los Angeles, Seattle, Boston
-
-Tier 2 markets (35% budget):
-- Growing metros with strong employment
-- Austin, Denver, Nashville, Phoenix, Atlanta
-
-Tier 3 markets (15% budget):
-- Emerging opportunities
-- Salt Lake City, Portland, San Diego, Minneapolis
-
-Campaign timeline and budget pacing:
-Total budget: $750,000
-
-Month 1: $350,000
-- Week 1-2: Heavy awareness push (60% of month budget)
-- Week 3-4: Optimization based on early results (40%)
-
-Month 2: $250,000
-- Steady-state optimization
-- Retargeting pool activation
-
-Month 3: $150,000
-- Focus on conversion optimization
-- Lookalike expansion from converters
-
-Creative and messaging strategy:
-Hero message: "Your money deserves 4.5% APY"
-
-Creative variations by audience:
-- Mass affluent: Focus on maximizing returns, comparison to traditional banks
-- Young professionals: Mobile-first experience, no fees, easy setup
-- Families: Security, FDIC insurance, saving for goals
-
-Required formats:
-- Display: Standard IAB sizes with dynamic rate display
-- Video: 6-second bumpers and 15-second explainers
-- Native: Financial education content with product integration
-- Social: Carousel ads with rate calculators
-- CTV: 30-second spots during financial news programming
-
-Compliance and brand safety:
-- All creative requires legal disclaimer about rates subject to change
-- FDIC insurance messaging required
-- No targeting based on medical or protected class information
-- Avoid placement near financial crisis or bank failure content
-- Geo-fence competitor branch locations excluded
-
-Measurement and optimization:
-- Daily performance reporting required
-- Weekly optimization meetings expected
-- Multi-touch attribution model
-- Incrementality testing via geo-experiments
-- Brand lift study in Month 2
-- Post-campaign analysis of customer lifetime value
-
-Integration requirements:
-- Pixel placement for conversion tracking
-- API integration for real-time application status
-- Customer match lists for suppression
-- CRM integration for lead scoring
-```
-
-## Industry-Specific Brief Templates
-
-### Streaming Service Acquisition
-```
-Advertiser: StreamPlus Entertainment
-Promoted offering: New streaming service with exclusive original content and live sports
-
-Objective: Drive new subscriber sign-ups during free trial promotion
-Audience: Cord-cutters and streaming enthusiasts aged 25-54
-Success metrics: $25 cost per trial start, 60% trial-to-paid conversion
-Geographic: US National with emphasis on NFL markets
-Budget: $2M for Q4 2024
-Creative focus: Highlight exclusive content and sports coverage
-```
-
-### Healthcare Service Awareness
-```
-Advertiser: HealthFirst Urgent Care
-Promoted offering: Walk-in urgent care with online scheduling and minimal wait times
-
-Objectives: Build awareness and drive appointment bookings
-Target: Families with children, adults 25-65 within 10-mile radius of clinics
-Success metrics: 500 online appointments, $30 cost per appointment
-Markets: Geo-targeted around 15 clinic locations in Ohio
-Flight: Ongoing with seasonal adjustments for flu season
-Budget: $20,000 monthly
-Requirements: HIPAA-compliant targeting, no health condition targeting
+```json
+{
+  "advertiser": "CloudSync Solutions",
+  "promoted_offering": "Enterprise data synchronization platform for hybrid cloud environments",
+  
+  "campaign_context": "Q4 push to meet annual pipeline targets, focusing on enterprises actively evaluating cloud migration strategies",
+  
+  "business_objectives": {
+    "immediate": "Generate 150 Marketing Qualified Leads (MQLs)",
+    "quarterly": "Build pipeline of $2M in opportunities",
+    "strategic": "Position as leader in hybrid cloud data management"
+  },
+  
+  "target_audience": {
+    "firmographics": {
+      "company_size": "500-5000 employees",
+      "industries": ["financial_services", "healthcare", "retail", "manufacturing"],
+      "technology": "Multi-cloud environment (AWS, Azure, GCP)"
+    },
+    "personas": {
+      "primary": "IT Directors, Cloud Architects, CTOs",
+      "secondary": "DevOps Engineers, Data Engineers",
+      "influencers": "IT Consultants, System Integrators"
+    },
+    "signals": {
+      "intent": "Researching cloud migration, data sync, hybrid cloud",
+      "technographic": "Using Kubernetes, Docker, cloud-native tools",
+      "competitive": "Visiting competitor sites (Informatica, Talend, MuleSoft)"
+    }
+  },
+  
+  "success_metrics": {
+    "lead_generation": {
+      "mql_target": "150 leads",
+      "cost_per_mql": "$200-250",
+      "mql_to_sql_rate": "30%"
+    },
+    "engagement": {
+      "content_downloads": "500 whitepapers/guides",
+      "demo_requests": "50 qualified demos",
+      "webinar_registrations": "200 attendees"
+    },
+    "brand": {
+      "site_traffic_lift": "25%",
+      "branded_search_increase": "40%"
+    }
+  },
+  
+  "campaign_execution": {
+    "flight_dates": "October 1 - December 31, 2024",
+    "budget": {
+      "total": "$90,000",
+      "monthly": "$30,000",
+      "allocation": {
+        "lead_gen": "60%",
+        "brand_awareness": "25%",
+        "retargeting": "15%"
+      }
+    },
+    "geographic_focus": {
+      "primary": ["US", "Canada"],
+      "secondary": ["UK", "Germany"]
+    }
+  },
+  
+  "creative_and_messaging": {
+    "formats_needed": {
+      "display": ["300x250", "728x90", "160x600"],
+      "video": ["in-stream_15s", "in-stream_30s"],
+      "native": ["sponsored_content", "in-feed_units"]
+    },
+    "messaging_framework": {
+      "pain_points": "Data silos, sync failures, compliance risks",
+      "value_props": "Real-time sync, zero downtime, SOC2 certified",
+      "proof_points": "Fortune 500 case studies, Gartner recognition"
+    },
+    "content_assets": {
+      "whitepapers": "Hybrid Cloud Best Practices Guide",
+      "case_studies": "Financial Services Digital Transformation",
+      "demo_videos": "5-minute platform overview"
+    }
+  },
+  
+  "measurement_and_privacy": {
+    "attribution": "Multi-touch with 30-day window",
+    "analytics": "Google Analytics 4, Salesforce integration",
+    "privacy": "GDPR/CCPA compliant, no third-party cookies",
+    "brand_safety": "No competitor adjacency, B2B environments only"
+  },
+  
+  "adcp_workflow": {
+    "product_discovery": "Query B2B inventory with ABM capabilities",
+    "format_matching": "Professional formats supporting lead capture",
+    "signal_activation": "Intent and technographic data providers",
+    "approval_required": "Legal review for compliance claims"
+  }
+}
 ```
 
-### Mobile App Install Campaign
+**Why This Works:**
+- ✅ **Complete strategic context** - Clear business goals and constraints
+- ✅ **Detailed audience definition** - Firmographics, personas, and signals
+- ✅ **Comprehensive metrics** - Lead gen, engagement, and brand KPIs
+- ✅ **AdCP-specific workflow** - Shows protocol integration points
+- ✅ **Privacy-forward approach** - GDPR/CCPA compliance specified
+- ✅ **Realistic B2B economics** - $200-250 CPL standard for enterprise
+
+**Publisher Optimization:**
+- ABM platform activation for target account lists
+- Intent data integration for in-market buyers
+- LinkedIn and professional publisher prioritization
+- Lead quality scoring and feedback loops
+
+---
+
+## 4. Complex Multi-Phase: Advanced Orchestration
+
+### Automotive Model Launch
+
+```json
+{
+  "advertiser": "EcoMotion Automotive",
+  "promoted_offering": "2025 EcoMotion Hybrid SUV - Luxury hybrid with 500-mile range",
+  
+  "campaign_overview": "Three-phase launch targeting eco-conscious families transitioning from traditional luxury SUVs",
+  
+  "phased_execution": {
+    "phase_1_awareness": {
+      "dates": "October 1-31, 2024",
+      "budget": "$200,000",
+      "objectives": "Build awareness, reach 10M unique users",
+      "success_metrics": {
+        "reach": "10M uniques",
+        "frequency": "3-5x",
+        "video_completion_rate": "70%",
+        "brand_lift": "12% awareness increase"
+      },
+      "formats_discovery": {
+        "connected_tv": "30-second spots during family programming",
+        "online_video": "15-second and 6-second bumpers",
+        "display": "High-impact takeovers on auto sites"
+      }
+    },
+    
+    "phase_2_consideration": {
+      "dates": "November 1-30, 2024",
+      "budget": "$150,000",
+      "objectives": "Drive configurator sessions and brochure downloads",
+      "success_metrics": {
+        "configurator_sessions": "50,000",
+        "cost_per_session": "$3.00",
+        "brochure_downloads": "10,000",
+        "site_engagement_time": "3+ minutes"
+      },
+      "audience_refinement": {
+        "retargeting": "Phase 1 video completers",
+        "lookalikes": "Current hybrid owners",
+        "conquest": "Competitive SUV intenders"
+      }
+    },
+    
+    "phase_3_conversion": {
+      "dates": "December 1-31, 2024",
+      "budget": "$100,000",
+      "objectives": "Generate test drive appointments",
+      "success_metrics": {
+        "test_drives": "500 appointments",
+        "cost_per_appointment": "$200",
+        "dealer_locator_uses": "5,000",
+        "appointment_show_rate": "70%"
+      },
+      "activation_strategy": {
+        "geo_targeting": "10-mile radius of dealers",
+        "dayparting": "Weekends and evenings",
+        "weather_triggers": "Activate during good weather"
+      }
+    }
+  },
+  
+  "audience_strategy": {
+    "primary": {
+      "demographics": "HHI $75K-150K, ages 35-55, families",
+      "psychographics": "Environmentally conscious, tech-savvy, safety-focused",
+      "behaviors": "SUV owners, outdoor enthusiasts, suburban lifestyle"
+    },
+    "signals": {
+      "auto_intender": "In-market for SUVs",
+      "green_interests": "EV/hybrid research, environmental content",
+      "competitive": "Visiting Toyota Highlander, Honda Pilot pages"
+    }
+  },
+  
+  "creative_specifications": {
+    "asset_requirements": {
+      "video": {
+        "hero_30s": "1920x1080, 16:9, max 50MB",
+        "social_15s": "1080x1080, 1:1, max 30MB",
+        "mobile_vertical": "1080x1920, 9:16, max 40MB"
+      },
+      "display": {
+        "standard_sizes": "300x250, 728x90, 320x50",
+        "rich_media": "HTML5 with 360-degree view",
+        "file_size": "Max 150KB initial load"
+      }
+    },
+    "dynamic_elements": {
+      "dealer_locator": "Real-time nearest dealer",
+      "inventory_status": "Available colors/trims",
+      "incentive_offers": "Regional lease/finance offers"
+    }
+  },
+  
+  "measurement_framework": {
+    "attribution": "Data-driven attribution with store visit tracking",
+    "brand_study": "Control/exposed lift measurement",
+    "incrementality": "Geo-experiments in 5 test markets",
+    "competitive": "Share of voice and consideration tracking"
+  },
+  
+  "adcp_integration": {
+    "workflow": [
+      "get_products: Query automotive inventory with CTV capability",
+      "list_creative_formats: Discover video and rich media options",
+      "activate_signal: Auto intender and green interest signals",
+      "create_media_buy: Submit phased campaign with approval gates",
+      "sync_creatives: Upload video and display assets per phase",
+      "get_media_buy_delivery: Daily performance monitoring",
+      "update_media_buy: Optimize based on phase performance"
+    ],
+    "approval_requirements": {
+      "legal": "Claim substantiation for MPG/range",
+      "brand": "Creative and placement approval",
+      "dealer": "Regional offer coordination"
+    }
+  }
+}
 ```
-Advertiser: FitTrack Fitness App
-Promoted offering: AI-powered personal training app with custom workout plans
 
-Goals: 
-- 50,000 app installs in first month
-- 30% day-7 retention rate
-- $3.50 target CPI
+**Why This Works:**
+- ✅ **Sophisticated phasing** - Clear progression through funnel
+- ✅ **Detailed technical specs** - Asset requirements and file sizes
+- ✅ **Advanced targeting** - Signals, weather triggers, dayparting
+- ✅ **Complete AdCP workflow** - All protocol tools demonstrated
+- ✅ **Realistic automotive KPIs** - $200 per test drive achievable
+- ✅ **Multi-stakeholder coordination** - Legal, brand, dealer alignment
 
-Audience: Fitness enthusiasts, gym-goers, and New Year resolution makers
-Timing: January 1-31, 2025 (New Year fitness surge)
-Budget: $175,000
-Creative: Video demos of app features, before/after testimonials
-Platform requirements: iOS and Android, app store optimization
-```
+---
 
-## Notes on Brief Quality
+## Industry Quick Reference
 
-These examples demonstrate the spectrum from minimal viable briefs to comprehensive campaign strategies. Key observations:
+### Key Considerations by Vertical
 
-1. **Minimal briefs** still include the essential elements: advertiser, offering, objective, and timing
-2. **Standard briefs** add audience definition and specific success metrics
-3. **Comprehensive briefs** layer in detailed strategy, phased approaches, and specific requirements
-4. **Industry context** matters - financial services requires compliance considerations, automotive needs longer consideration cycles
+#### Financial Services
+- **Compliance**: FINRA, truth in advertising, fair lending
+- **Targeting restrictions**: No credit score or medical targeting
+- **Success metrics**: Account opens, funded accounts, AUM growth
+- **Typical CPAs**: $100-300 per funded account
+- **Creative requirements**: Disclaimers, FDIC/SIPC notices
 
-Each brief level serves different advertiser needs and campaign complexities. Publishers should be prepared to work with all levels, using the brief to inform product recommendations and campaign optimization strategies.
+#### Healthcare
+- **Privacy**: HIPAA compliance, no condition targeting
+- **Geographic**: Service area restrictions
+- **Metrics**: Appointment bookings, patient acquisition
+- **Typical costs**: $30-80 per appointment
+- **Requirements**: Provider credentials, insurance accepted
+
+#### Streaming/Entertainment
+- **Objectives**: Trial starts, subscriber retention
+- **Metrics**: Cost per trial, trial-to-paid conversion
+- **Typical costs**: $20-50 per trial start
+- **Creative**: Content highlights, exclusive programming
+
+#### Retail/E-commerce
+- **Seasonality**: Holiday, back-to-school, Prime Day
+- **Metrics**: ROAS, cart value, repeat purchase rate
+- **Typical ROAS**: 300-500% for established brands
+- **Formats**: Shopping ads, dynamic product ads
+
+#### Mobile Apps
+- **Objectives**: Installs, DAU, retention
+- **Metrics**: CPI, D7/D30 retention, LTV
+- **Typical CPI**: $2-5 for non-gaming apps
+- **Requirements**: App store links, deep linking
+
+---
+
+## Brief Evaluation Checklist
+
+Before submitting your brief, ensure you have:
+
+### Essential Elements
+- [ ] Advertiser name and promoted offering
+- [ ] Clear business objectives
+- [ ] Budget and flight dates
+- [ ] Geographic scope (if applicable)
+
+### Recommended Elements
+- [ ] Target audience definition
+- [ ] Success metrics with targets
+- [ ] Creative format preferences
+- [ ] Brand safety requirements
+
+### Advanced Elements
+- [ ] Signal activation requirements
+- [ ] Measurement framework
+- [ ] Privacy compliance needs
+- [ ] Approval workflow requirements
+
+---
+
+## Related Documentation
+
+- [Brief Expectations](./brief-expectations.md) - Processing guidelines and requirements
+- [Media Buy Lifecycle](./media-buy-lifecycle.md) - Campaign execution workflow
+- [Creative Formats](./creative-formats.md) - Available format specifications
+- [Targeting Dimensions](./targeting-dimensions.md) - Audience capabilities

--- a/docs/media-buy/example-briefs.md
+++ b/docs/media-buy/example-briefs.md
@@ -1,0 +1,322 @@
+---
+sidebar_label: Example Briefs
+title: Example Campaign Briefs
+---
+
+# Example Campaign Briefs
+
+These examples demonstrate realistic campaign briefs at different quality levels, showcasing how natural language descriptions translate into effective media buying instructions.
+
+## Minimal Briefs
+
+### Example 1: Local Service Business
+```
+Advertiser: Mike's Plumbing Services
+Promoted offering: Emergency plumbing repairs and routine maintenance in the Denver metro area
+Objective: Drive phone calls for service appointments
+Budget: $5,000
+Flight dates: October 15-31, 2024
+```
+
+### Example 2: E-commerce Product Launch
+```
+Advertiser: TechGear Pro
+Promoted offering: New wireless noise-canceling headphones with 40-hour battery life
+Objective: Drive online sales during launch week
+Success metric: Achieve 2.5% CTR and $50 CPA
+Flight dates: November 1-7, 2024
+Budget: $15,000
+```
+
+## Standard Briefs
+
+### Example 3: Retail Holiday Campaign
+```
+Advertiser: StyleForward Fashion
+Promoted offering: Black Friday and Cyber Monday deals on winter apparel collection featuring sustainable materials and inclusive sizing
+
+Objectives: 
+- Primary: Drive in-store and online conversions
+- Secondary: Build brand awareness for sustainable fashion line
+
+Target audience: Women and men aged 25-45 interested in sustainable fashion, environmentally conscious consumers, and value-seekers during holiday shopping season
+
+Success metrics:
+- 3% conversion rate
+- $75 CPA for online sales
+- 150% ROAS
+
+Geographic markets: Major US metropolitan areas with physical store presence (NYC, LA, Chicago, Dallas, Atlanta)
+
+Flight dates: November 24 - December 2, 2024
+Budget: $50,000
+
+Creative formats: Display banners, video ads, and native content featuring product imagery and promotional offers
+```
+
+### Example 4: B2B Software Campaign
+```
+Advertiser: CloudSync Solutions
+Promoted offering: Enterprise data synchronization platform for hybrid cloud environments
+
+Business objectives:
+- Generate qualified leads for sales team
+- Position as leader in hybrid cloud data management
+
+Target audience:
+- IT decision makers and CTOs at companies with 500+ employees
+- Industries: Financial services, healthcare, retail, manufacturing
+- Currently using multiple cloud providers (AWS, Azure, GCP)
+
+Success metrics:
+- 50 qualified leads (MQL)
+- $200 cost per lead
+- 0.5% conversion rate on landing page
+
+Flight dates: October 1 - December 31, 2024
+Budget: $30,000 monthly
+
+Geographic focus: United States and Canada
+
+Creative requirements: Professional B2B creative with technical credibility, case study content, and clear value propositions
+```
+
+## Comprehensive Briefs
+
+### Example 5: Automotive Model Launch
+```
+Advertiser: EcoMotion Automotive
+Promoted offering: 2025 EcoMotion Hybrid SUV - The first luxury hybrid SUV with 500-mile range and advanced autonomous driving features
+
+Campaign overview:
+Launching our flagship hybrid SUV targeted at environmentally conscious families who don't want to compromise on luxury or performance. This vehicle represents our brand's commitment to sustainable transportation without sacrifice.
+
+Business objectives:
+1. Awareness: Reach 10M unique users in target demographic
+2. Consideration: Drive 100,000 configurator sessions
+3. Conversion: Generate 5,000 test drive appointments
+4. Brand: Increase consideration as eco-luxury brand by 15%
+
+Target audience:
+Primary segment:
+- Households with income $75,000-$150,000
+- Ages 35-55 with families
+- Currently own SUVs or considering SUV purchase
+- Environmental values important in purchase decisions
+- Technology early adopters
+
+Secondary segment:
+- Young professionals 28-40
+- Urban and suburban markets
+- Interest in outdoor activities and adventure
+
+Behavioral signals:
+- In-market for vehicles (especially SUVs)
+- Researching hybrid/electric vehicles
+- Visiting competitor sites (Tesla, Rivian, traditional luxury brands)
+- Consuming content about sustainability, technology, family travel
+
+Success metrics:
+- Reach: 10M unique users with 3+ frequency
+- Engagement: 1.5% CTR on display, 35% video completion rate
+- Site actions: 2% conversion to configurator from landing page
+- Test drives: $250 cost per test drive appointment
+- Brand lift: 15% increase in consideration (measured via brand study)
+
+Geographic markets:
+Primary DMAs:
+- California: Los Angeles, San Francisco, San Diego
+- Northeast: New York, Boston, Philadelphia
+- Pacific Northwest: Seattle, Portland
+- Texas: Austin, Dallas, Houston
+
+Flight schedule:
+- Phase 1 (Awareness): October 1-15, 2024 - 40% of budget
+- Phase 2 (Consideration): October 16-31, 2024 - 35% of budget
+- Phase 3 (Conversion): November 1-15, 2024 - 25% of budget
+
+Total budget: $500,000
+
+Creative formats and requirements:
+- Video: 30-second and 15-second spots showcasing family adventures and eco features
+- Display: Rich media expandable units with 360-degree vehicle views
+- Native: Editorial-style content about sustainable family travel
+- Connected TV: Premium placements during family and lifestyle programming
+- All creative must include dealer locator and "Build & Price" CTAs
+
+Brand safety requirements:
+- No placement near automotive recalls or accidents
+- Avoid controversial political content
+- Family-friendly environments only
+- Premium publisher list preferred
+
+Additional requirements:
+- Dayparting: Weekday evenings (6-10pm) and weekends
+- Frequency cap: 3 per day, 10 per week
+- Mobile-first approach with 60% mobile allocation
+- A/B testing for creative messages and CTAs
+```
+
+### Example 6: Financial Services Customer Acquisition
+```
+Advertiser: NextGen Banking
+Promoted offering: High-yield savings account with 4.5% APY, no minimum balance, and no monthly fees
+
+Campaign context:
+We're launching a competitive high-yield savings product targeted at mass affluent consumers looking to maximize their savings in the current interest rate environment. This campaign needs to balance aggressive growth targets with responsible customer acquisition costs and regulatory compliance.
+
+Multi-tiered objectives:
+1. Immediate (Month 1): Generate awareness of rate offering
+2. Short-term (Months 1-2): Drive 10,000 account applications
+3. Long-term (Month 3): Achieve 5,000 funded accounts with $25K+ average balance
+
+Detailed audience strategy:
+
+Tier 1 - High-value prospects:
+- Income: $100,000+
+- Age: 30-60
+- Currently have savings accounts with traditional banks
+- Show interest in financial planning and investment content
+- Life events: Recent job change, inheritance, home sale
+
+Tier 2 - Growth segment:
+- Income: $60,000-$100,000
+- Age: 25-45
+- Digital-first banking preferences
+- Price-sensitive savers comparing rates
+- Engaged with personal finance content/apps
+
+Exclusions:
+- Existing NextGen Banking customers
+- Recent credit defaults or bankruptcies
+- Under 18 or over 75
+
+Performance targets by funnel stage:
+- Impression to click: 0.8% CTR minimum
+- Click to application start: 15% conversion
+- Application start to complete: 60% completion
+- Application to approval: 80% approval rate
+- Approval to funding: 50% funding rate
+- Overall CAC target: $150 per funded account
+
+Geographic and market prioritization:
+Tier 1 markets (50% budget):
+- High-cost-of-living metros where rate sensitivity is highest
+- New York, San Francisco, Los Angeles, Seattle, Boston
+
+Tier 2 markets (35% budget):
+- Growing metros with strong employment
+- Austin, Denver, Nashville, Phoenix, Atlanta
+
+Tier 3 markets (15% budget):
+- Emerging opportunities
+- Salt Lake City, Portland, San Diego, Minneapolis
+
+Campaign timeline and budget pacing:
+Total budget: $750,000
+
+Month 1: $350,000
+- Week 1-2: Heavy awareness push (60% of month budget)
+- Week 3-4: Optimization based on early results (40%)
+
+Month 2: $250,000
+- Steady-state optimization
+- Retargeting pool activation
+
+Month 3: $150,000
+- Focus on conversion optimization
+- Lookalike expansion from converters
+
+Creative and messaging strategy:
+Hero message: "Your money deserves 4.5% APY"
+
+Creative variations by audience:
+- Mass affluent: Focus on maximizing returns, comparison to traditional banks
+- Young professionals: Mobile-first experience, no fees, easy setup
+- Families: Security, FDIC insurance, saving for goals
+
+Required formats:
+- Display: Standard IAB sizes with dynamic rate display
+- Video: 6-second bumpers and 15-second explainers
+- Native: Financial education content with product integration
+- Social: Carousel ads with rate calculators
+- CTV: 30-second spots during financial news programming
+
+Compliance and brand safety:
+- All creative requires legal disclaimer about rates subject to change
+- FDIC insurance messaging required
+- No targeting based on medical or protected class information
+- Avoid placement near financial crisis or bank failure content
+- Geo-fence competitor branch locations excluded
+
+Measurement and optimization:
+- Daily performance reporting required
+- Weekly optimization meetings expected
+- Multi-touch attribution model
+- Incrementality testing via geo-experiments
+- Brand lift study in Month 2
+- Post-campaign analysis of customer lifetime value
+
+Integration requirements:
+- Pixel placement for conversion tracking
+- API integration for real-time application status
+- Customer match lists for suppression
+- CRM integration for lead scoring
+```
+
+## Industry-Specific Brief Templates
+
+### Streaming Service Acquisition
+```
+Advertiser: StreamPlus Entertainment
+Promoted offering: New streaming service with exclusive original content and live sports
+
+Objective: Drive new subscriber sign-ups during free trial promotion
+Audience: Cord-cutters and streaming enthusiasts aged 25-54
+Success metrics: $25 cost per trial start, 60% trial-to-paid conversion
+Geographic: US National with emphasis on NFL markets
+Budget: $2M for Q4 2024
+Creative focus: Highlight exclusive content and sports coverage
+```
+
+### Healthcare Service Awareness
+```
+Advertiser: HealthFirst Urgent Care
+Promoted offering: Walk-in urgent care with online scheduling and minimal wait times
+
+Objectives: Build awareness and drive appointment bookings
+Target: Families with children, adults 25-65 within 10-mile radius of clinics
+Success metrics: 500 online appointments, $30 cost per appointment
+Markets: Geo-targeted around 15 clinic locations in Ohio
+Flight: Ongoing with seasonal adjustments for flu season
+Budget: $20,000 monthly
+Requirements: HIPAA-compliant targeting, no health condition targeting
+```
+
+### Mobile App Install Campaign
+```
+Advertiser: FitTrack Fitness App
+Promoted offering: AI-powered personal training app with custom workout plans
+
+Goals: 
+- 50,000 app installs in first month
+- 30% day-7 retention rate
+- $3.50 target CPI
+
+Audience: Fitness enthusiasts, gym-goers, and New Year resolution makers
+Timing: January 1-31, 2025 (New Year fitness surge)
+Budget: $175,000
+Creative: Video demos of app features, before/after testimonials
+Platform requirements: iOS and Android, app store optimization
+```
+
+## Notes on Brief Quality
+
+These examples demonstrate the spectrum from minimal viable briefs to comprehensive campaign strategies. Key observations:
+
+1. **Minimal briefs** still include the essential elements: advertiser, offering, objective, and timing
+2. **Standard briefs** add audience definition and specific success metrics
+3. **Comprehensive briefs** layer in detailed strategy, phased approaches, and specific requirements
+4. **Industry context** matters - financial services requires compliance considerations, automotive needs longer consideration cycles
+
+Each brief level serves different advertiser needs and campaign complexities. Publishers should be prepared to work with all levels, using the brief to inform product recommendations and campaign optimization strategies.

--- a/docs/media-buy/example-briefs.md
+++ b/docs/media-buy/example-briefs.md
@@ -5,229 +5,213 @@ title: Example Campaign Briefs
 
 # Example Campaign Briefs
 
-These annotated examples demonstrate how natural language briefs work in AdCP, showing progression from essential elements to comprehensive campaign strategies.
+These annotated examples demonstrate how natural language briefs work in AdCP for audience-enabled media buying, showing progression from basic to sophisticated targeting strategies.
 
 ## 1. Minimal Brief: Essential Elements
 
-### Local Service Business Campaign
+### Local Service Business
 
 ```json
 {
-  "brief": "Mike's Plumbing Services needs to drive phone calls for emergency plumbing repairs and routine maintenance in the Denver metro area. We have $8,000 to spend from October 15-31, 2024. Looking for local inventory that can drive calls, ideally during emergency hours when people need immediate service."
+  "brief": "Mike's Plumbing Services needs to reach homeowners in the Denver metro area who might need emergency plumbing repairs or routine maintenance. We have $8,000 to spend from October 15-31, 2024. Looking to drive phone calls for service appointments."
 }
 ```
 
 **Why This Works:**
-- ✅ **Clear advertiser and offering** - Specifies service type and geographic scope
-- ✅ **Specific objective** - "Phone calls" is measurable and actionable
-- ✅ **Defined budget and timing** - Realistic for local service campaign
-- ⚠️ **Could improve** - Add target CPA ($40-60 per call typical for plumbing)
-- ⚠️ **Missing** - Audience definition (homeowners, property managers)
+- ✅ **Clear advertiser** - Mike's Plumbing Services
+- ✅ **Target audience** - Homeowners in Denver metro
+- ✅ **Objective** - Drive phone calls
+- ✅ **Budget and timing** - $8,000 over 2 weeks
+- ⚠️ **Could improve** - Add more audience details (age, income)
 
-**Publisher Response:**
-Publishers will likely:
-- Parse "Denver metro area" for geographic targeting
-- Identify "phone calls" as conversion goal
-- Recommend local inventory with call tracking
-- Suggest mobile-first placements for emergency searches
-- Request clarification on success metrics
-
-**AdCP Workflow:**
-1. `get_products` - Query with filters matching brief requirements
-2. `list_creative_formats` - Identify call-to-action enabled formats
-3. `create_media_buy` - Submit with brief and selected products
+**Publisher Interpretation:**
+- Geographic targeting: Denver DMA
+- Audience: Homeowners (property owners)
+- Optimization goal: Phone call conversions
+- Budget pacing: ~$500/day
 
 ---
 
-## 2. Standard Brief: Audience + Metrics
+## 2. Standard Brief: Clear Audience Definition
 
 ### E-commerce Product Launch
 
 ```json
 {
-  "brief": "TechGear Pro is launching our new ANC-Pro wireless headphones with 40-hour battery life and premium audio drivers. Our goal is to drive online sales during launch week (November 1-14, 2024) with a secondary objective of building brand awareness in the audio enthusiast community. Target audience is ages 25-45 with household income $50K+, interested in technology, music, fitness, and travel - early tech adopters who buy premium audio products. Success metrics: 0.8-1.2% CTR, $45-55 CPA, 300% ROAS, 2.5% conversion rate. Budget is $25,000. Need creative that showcases product demos, lifestyle imagery, and launch offer messaging."
+  "brief": "TechGear Pro is launching new wireless headphones. We need to reach tech enthusiasts and early adopters aged 25-45 with household income over $50K who are interested in premium audio, music, fitness, and travel. Campaign runs November 1-14, 2024 with $25,000 budget. Goal is to drive online sales with target CPA of $45-55."
 }
 ```
 
 **Why This Works:**
-- ✅ **Realistic metrics** - CTR of 0.8-1.2% achievable for targeted campaigns
-- ✅ **Clear audience definition** - Actionable demographic and behavioral signals
-- ✅ **Multiple success metrics** - Allows optimization flexibility
-- ✅ **Appropriate budget** - $25K reasonable for 2-week product launch
-- ✅ **Creative direction** - Helps with format selection
+- ✅ **Demographic targeting** - Age 25-45, HHI $50K+
+- ✅ **Interest targeting** - Tech, audio, music, fitness, travel
+- ✅ **Behavioral targeting** - Early adopters, premium buyers
+- ✅ **Clear KPIs** - Sales with $45-55 CPA target
+- ✅ **Defined flight** - 2-week launch period
 
-**Publisher Response:**
-Publishers will:
-- Extract demographic targeting (25-45, $50K+ HHI)
-- Build interest segments (technology, music, fitness, travel)
-- Optimize toward specified CPA and ROAS goals
-- Match creative requirements to available formats
-- Create retargeting pools for launch period
-
-**AdCP Workflow:**
-1. `get_products` - Filter for audience targeting capabilities
-2. `list_creative_formats` - Match product demo requirements
-3. `create_media_buy` - Include full brief with success metrics
-4. `get_media_buy_delivery` - Monitor against KPI targets
+**Publisher Interpretation:**
+- Build audience segments from demographics and interests
+- Optimize toward conversion goals
+- Apply frequency caps for launch period
+- Use lookalike modeling from converter profiles
 
 ---
 
-## 3. Comprehensive Brief: Full Strategy
+## 3. Comprehensive Brief: B2B Targeting
 
-### B2B Software Campaign
+### Enterprise Software Campaign
 
 ```json
 {
-  "brief": "CloudSync Solutions needs to generate 150 Marketing Qualified Leads (MQLs) for our enterprise data synchronization platform for hybrid cloud environments. This is our Q4 push to meet annual pipeline targets, focusing on enterprises actively evaluating cloud migration strategies. We need to build a pipeline of $2M in opportunities while positioning ourselves as the leader in hybrid cloud data management.\n\nTarget companies with 500-5000 employees in financial services, healthcare, retail, and manufacturing that use multi-cloud environments (AWS, Azure, GCP). Decision makers include IT Directors, Cloud Architects, and CTOs, with DevOps Engineers and Data Engineers as secondary targets. Also want to reach IT Consultants and System Integrators who influence decisions.\n\nLook for signals indicating intent around cloud migration, data sync, and hybrid cloud research. Target companies using Kubernetes, Docker, and cloud-native tools. Include competitive conquest against visitors to Informatica, Talend, and MuleSoft.\n\nSuccess metrics: 150 MQLs at $200-250 per lead with 30% MQL-to-SQL conversion rate. Also targeting 500 whitepaper downloads, 50 qualified demo requests, and 200 webinar registrations. For brand metrics, looking for 25% site traffic lift and 40% increase in branded search.\n\nCampaign runs October 1 - December 31, 2024 with $90,000 total budget ($30,000 monthly). Allocate 60% to lead gen, 25% to brand awareness, and 15% to retargeting. Focus on US and Canada primarily, with UK and Germany as secondary markets.\n\nNeed display formats (300x250, 728x90, 160x600), video (15s and 30s in-stream), and native (sponsored content and in-feed units). Messaging should address pain points like data silos, sync failures, and compliance risks. Emphasize our real-time sync, zero downtime, and SOC2 certification. Use Fortune 500 case studies and Gartner recognition as proof points.\n\nContent assets include our Hybrid Cloud Best Practices Guide whitepaper, Financial Services Digital Transformation case study, and 5-minute platform overview video. Require multi-touch attribution with 30-day window, Google Analytics 4 and Salesforce integration. Must be GDPR/CCPA compliant with no third-party cookies. No competitor adjacency and B2B environments only for brand safety."
+  "brief": "CloudSync Solutions needs to reach IT decision makers at mid-market companies (500-5000 employees) in financial services, healthcare, retail, and manufacturing. Target titles include IT Directors, Cloud Architects, CTOs, and DevOps Engineers. Focus on companies showing intent signals around cloud migration, hybrid cloud, and data synchronization. Also target visitors to competitor sites like Informatica, Talend, and MuleSoft. We want to generate 150 qualified leads at $200-250 per lead. Campaign runs October through December 2024 with $90,000 total budget. Primary markets are US and Canada, secondary markets UK and Germany."
 }
 ```
 
 **Why This Works:**
-- ✅ **Complete context** - Business goals, timeline, and constraints clear
-- ✅ **Detailed targeting** - Firmographics, personas, and intent signals
-- ✅ **Comprehensive metrics** - Lead gen, engagement, and brand KPIs
-- ✅ **Budget allocation** - Clear spending priorities
-- ✅ **Content strategy** - Specific assets and messaging framework
-- ✅ **Compliance requirements** - Privacy and brand safety specified
+- ✅ **Firmographic targeting** - Company size, industries
+- ✅ **Title/persona targeting** - Specific decision makers
+- ✅ **Intent signals** - Cloud migration, data sync research
+- ✅ **Competitive conquest** - Competitor site visitors
+- ✅ **Lead generation focus** - Clear volume and cost targets
+- ✅ **Geographic priorities** - Primary and secondary markets
 
-**Publisher Response:**
-Publishers will:
-- Activate ABM platforms for target account lists
-- Integrate intent data for in-market identification
-- Prioritize LinkedIn and B2B publisher inventory
-- Set up lead quality scoring and feedback loops
-- Implement specified attribution and analytics
-- Ensure GDPR/CCPA compliance in targeting
+**Publisher Interpretation:**
+- Activate B2B data providers for firmographics
+- Use intent data for in-market identification
+- Apply title-based targeting from professional data
+- Set up competitive conquesting campaigns
+- Implement lead scoring and quality filters
 
 ---
 
-## 4. Complex Multi-Phase: Advanced Orchestration
+## 4. Advanced Brief: Multi-Segment Strategy
 
-### Automotive Model Launch
+### Automotive Launch Campaign
 
 ```json
 {
-  "brief": "EcoMotion Automotive is launching the 2025 EcoMotion Hybrid SUV, our first luxury hybrid with 500-mile range targeting eco-conscious families transitioning from traditional luxury SUVs. This is a three-phase campaign with different objectives and budgets for each phase.\n\nPHASE 1 - AWARENESS (October 1-31, 2024, $200,000):\nBuild awareness reaching 10M unique users with 3-5x frequency. Success metrics: 70% video completion rate and 12% brand lift. Need connected TV (30-second spots during family programming), online video (15-second and 6-second bumpers), and high-impact display takeovers on auto sites.\n\nPHASE 2 - CONSIDERATION (November 1-30, 2024, $150,000):\nDrive 50,000 configurator sessions at $3.00 cost per session and 10,000 brochure downloads. Expecting 3+ minute site engagement. Retarget Phase 1 video completers, create lookalikes from current hybrid owners, and conquest competitive SUV intenders.\n\nPHASE 3 - CONVERSION (December 1-31, 2024, $100,000):\nGenerate 500 test drive appointments at $200 per appointment with 70% show rate. Expect 5,000 dealer locator uses. Target 10-mile radius around dealers, focus on weekends and evenings, activate during good weather conditions.\n\nPRIMARY AUDIENCE:\nHouseholds with $75K-150K income, ages 35-55 with families. Environmentally conscious, tech-savvy, safety-focused. Current SUV owners, outdoor enthusiasts with suburban lifestyle. Target in-market SUV shoppers researching EVs/hybrids and environmental content. Conquest shoppers looking at Toyota Highlander and Honda Pilot.\n\nCREATIVE REQUIREMENTS:\nVideo assets: Hero 30s (1920x1080, 16:9, max 50MB), Social 15s (1080x1080, 1:1, max 30MB), Mobile vertical (1080x1920, 9:16, max 40MB). Display: Standard sizes (300x250, 728x90, 320x50) plus HTML5 rich media with 360-degree vehicle view (max 150KB initial load). Include dynamic elements: real-time nearest dealer, available colors/trims, regional lease/finance offers.\n\nMEASUREMENT:\nImplement data-driven attribution with store visit tracking. Run control/exposed brand lift study. Set up geo-experiments in 5 test markets. Track share of voice and consideration versus competitors.\n\nAPPROVAL REQUIREMENTS:\nLegal review needed for MPG and range claims. Brand team approval for creative and placements. Coordinate with dealer network for regional offers.\n\nPRIMARY MARKETS:\nCalifornia (Los Angeles, San Francisco, San Diego), Northeast (New York, Boston, Philadelphia), Pacific Northwest (Seattle, Portland), Texas (Austin, Dallas, Houston)."
+  "brief": "EcoMotion is launching our new hybrid SUV. Primary audience: eco-conscious families with household income $75K-150K, ages 35-55, who currently own SUVs and are interested in environmental topics. Secondary audience: affluent early adopters interested in luxury vehicles and new technology. Conquest audience: people actively shopping for Toyota Highlander, Honda Pilot, or other 3-row SUVs. Also target based on behaviors: outdoor enthusiasts, suburban families with children, and people who've visited EV/hybrid content. Geographic focus on California, Pacific Northwest, and Northeast metros. October through December with $450,000 total budget. Success is measured by test drive appointments and dealer visits."
 }
 ```
 
 **Why This Works:**
-- ✅ **Sophisticated phasing** - Clear progression through purchase funnel
-- ✅ **Phase-specific KPIs** - Different metrics for each objective
-- ✅ **Detailed technical specs** - Asset requirements clearly defined
-- ✅ **Advanced targeting** - Weather triggers, dayparting, geo-radius
-- ✅ **Multi-stakeholder needs** - Legal, brand, and dealer coordination
-- ✅ **Realistic automotive metrics** - $200 per test drive is achievable
+- ✅ **Multiple audience segments** - Primary, secondary, conquest
+- ✅ **Rich behavioral data** - Current SUV owners, outdoor enthusiasts
+- ✅ **Competitive targeting** - Specific model conquest
+- ✅ **Interest + intent** - Environmental interest + auto shopping
+- ✅ **Geographic strategy** - EV-friendly markets
+- ✅ **Clear success metrics** - Test drives and dealer visits
 
-**Publisher Orchestration:**
-Publishers will:
-- Set up sequential campaign phases with different objectives
-- Implement audience pools that flow between phases
-- Configure weather-based activation triggers
-- Coordinate dealer inventory feeds for dynamic creative
-- Establish brand study and incrementality testing
-- Manage approval workflows for claims and creative
+**Publisher Interpretation:**
+- Create separate audience segments for testing
+- Layer demographics with auto-intender data
+- Apply geographic and behavioral targeting
+- Use dynamic optimization across segments
+- Focus on lower-funnel automotive metrics
 
 ---
 
-## Industry Quick Reference
+## Industry-Specific Brief Examples
 
-### How Different Industries Structure Briefs
-
-#### Financial Services
+### Financial Services
 ```json
 {
-  "brief": "NextGen Banking launching high-yield savings account with 4.5% APY, no minimum balance, no fees. Target mass affluent consumers ($100K+ income, ages 30-60) currently with traditional banks. Need to generate 5,000 funded accounts at $150 CAC. Must include FDIC insurance messaging and comply with FINRA regulations. No credit score or medical condition targeting. Campaign runs January with $400,000 budget."
+  "brief": "NextGen Banking wants to reach mass affluent consumers ($100K+ income, ages 30-60) who currently have savings accounts with traditional banks and are researching high-yield savings options. Exclude existing customers. Focus on major metros. January campaign with $400,000 budget targeting 5,000 new account opens."
 }
 ```
 
-#### Healthcare
+### Healthcare
 ```json
 {
-  "brief": "HealthFirst Urgent Care needs to build awareness and drive appointment bookings for our 15 Ohio clinic locations. Target families with children and adults 25-65 within 10-mile radius of each clinic. Goal is 500 online appointments at $30-50 per appointment. Emphasize minimal wait times and online scheduling. Must be HIPAA compliant with no health condition targeting. $20,000 monthly ongoing budget."
+  "brief": "HealthFirst Urgent Care needs to reach families with children and adults 25-65 within 10 miles of our 15 Ohio clinic locations. Target people with employer-sponsored health insurance who haven't visited an urgent care in the past year. $20,000 monthly ongoing budget to drive appointment bookings."
 }
 ```
 
-#### Streaming Service
+### Streaming Service
 ```json
 {
-  "brief": "StreamPlus Entertainment promoting new streaming service with exclusive original content and live sports during Q4 free trial promotion. Target cord-cutters and streaming enthusiasts aged 25-54 in NFL markets. Drive trial sign-ups at $25 cost per trial with 60% trial-to-paid conversion goal. Need video creative highlighting exclusive content. $2M Q4 2024 budget."
+  "brief": "StreamPlus needs to reach cord-cutters and cord-nevers aged 25-54 who are sports fans, particularly NFL and NBA followers, in markets where we have local broadcast rights. Also target households that subscribe to 2+ streaming services. Q4 campaign with $2M budget to drive free trial sign-ups."
 }
 ```
 
-#### Mobile App
+### Mobile Gaming
 ```json
 {
-  "brief": "FitTrack Fitness App needs 50,000 installs in January 2025 for our AI-powered personal training app. Target fitness enthusiasts and New Year resolution makers. $3.50 target CPI with 30% day-7 retention. Need video demos of app features and before/after testimonials. $175,000 budget. Requires iOS and Android app store links with deep linking support."
+  "brief": "GameStudio targeting casual mobile gamers aged 25-45 who play puzzle and match-3 games, have made in-app purchases before, and use iOS devices. Focus on users who've played competitor games like Candy Crush or Gardenscapes. January launch with $175,000 budget, goal of 50,000 installs."
 }
 ```
+
+---
+
+## What NOT to Include in Briefs
+
+Briefs should focus on **who** to reach and **what** business outcome to drive. They should NOT include:
+
+### ❌ Creative Specifications
+- Asset sizes, formats, or technical specs
+- Creative messaging or copy
+- Production requirements
+
+### ❌ Technical Implementation
+- Attribution models
+- Pixel placement
+- Analytics integration
+- Measurement vendors
+
+### ❌ Media Tactics
+- Specific channels or publishers
+- Bid strategies
+- Frequency caps
+- Dayparting rules
+
+These are either handled separately (creative via `sync_creatives`) or determined by the publisher based on their capabilities and optimization strategies.
 
 ---
 
 ## Brief Writing Best Practices
 
-### Structure Your Brief Effectively
+### Focus on Audience Insights
+- **Demographics**: Age, income, gender, education
+- **Firmographics**: Company size, industry, revenue (B2B)
+- **Interests**: Topics, hobbies, content consumption
+- **Behaviors**: Purchase history, website visits, app usage
+- **Intent signals**: In-market status, research behavior
+- **Geography**: Markets, DMAs, radius targeting
 
-1. **Start with the essentials**
-   - Who you are (advertiser/brand)
-   - What you're promoting
-   - Core objective
-   - Budget and timing
+### Specify Business Outcomes
+- **Direct response**: Leads, sales, app installs, sign-ups
+- **Engagement**: Website visits, content downloads, video views
+- **Awareness**: Reach, brand lift, consideration
+- **Offline**: Store visits, phone calls, test drives
 
-2. **Add targeting details**
-   - Demographics and firmographics
-   - Interests and behaviors
-   - Intent signals
-   - Geographic markets
-
-3. **Specify success metrics**
-   - Primary KPIs with targets
-   - Secondary metrics
-   - Attribution preferences
-
-4. **Include creative requirements**
-   - Format preferences
-   - Asset specifications
-   - Messaging guidelines
-   - Dynamic elements
-
-5. **Note compliance needs**
-   - Industry regulations
-   - Privacy requirements
-   - Brand safety
-   - Approval workflows
-
-### Natural Language Tips
-
-- **Be specific but conversational** - Write as you would explain to a colleague
-- **Group related information** - Keep audience details together, metrics together
-- **Use industry-standard terms** - CPM, CPA, ROAS are understood
-- **Include context** - Why this campaign, why now
-- **Specify what's flexible** - "Prefer video but open to display if performance better"
+### Provide Context
+- **Campaign purpose**: Launch, promotion, seasonal, always-on
+- **Competitive landscape**: Conquest targets, differentiation
+- **Budget parameters**: Total, monthly, or daily limits
+- **Success definitions**: KPIs, benchmarks, goals
 
 ---
 
 ## Brief Evaluation Checklist
 
-Before submitting your brief, ensure it includes:
-
 ### Essential Elements
-- [ ] Advertiser name and promoted offering
-- [ ] Clear business objectives
-- [ ] Budget and flight dates
-- [ ] Geographic scope (if applicable)
-
-### Recommended Elements
+- [ ] Clear advertiser/brand identification
 - [ ] Target audience description
-- [ ] Success metrics with targets
-- [ ] Creative format preferences
-- [ ] Brand safety requirements
+- [ ] Business objective or KPI
+- [ ] Budget amount
+- [ ] Campaign timing
 
-### Advanced Elements
-- [ ] Intent signals to activate
-- [ ] Measurement framework
-- [ ] Privacy compliance needs
-- [ ] Approval workflow requirements
+### Audience Definition
+- [ ] Demographics or firmographics
+- [ ] Interests or behaviors
+- [ ] Geographic scope
+- [ ] Exclusions (existing customers, etc.)
+
+### Optional Enhancements
+- [ ] Intent signals to leverage
+- [ ] Competitive conquest targets
+- [ ] Multiple audience segments
+- [ ] Success metrics/benchmarks
 
 ---
 
@@ -235,5 +219,5 @@ Before submitting your brief, ensure it includes:
 
 - [Brief Expectations](./brief-expectations.md) - How publishers process briefs
 - [Media Buy Lifecycle](./media-buy-lifecycle.md) - Campaign execution workflow
-- [Creative Formats](./creative-formats.md) - Available format specifications
-- [Targeting Dimensions](./targeting-dimensions.md) - Audience capabilities
+- [Targeting Dimensions](./targeting-dimensions.md) - Available audience capabilities
+- [Product Discovery](./product-discovery.md) - How briefs influence product selection

--- a/docs/media-buy/example-briefs.md
+++ b/docs/media-buy/example-briefs.md
@@ -5,7 +5,7 @@ title: Example Campaign Briefs
 
 # Example Campaign Briefs
 
-These annotated examples demonstrate how to create effective campaign briefs at different complexity levels, showcasing the progression from essential elements to comprehensive strategies.
+These annotated examples demonstrate how natural language briefs work in AdCP, showing progression from essential elements to comprehensive campaign strategies.
 
 ## 1. Minimal Brief: Essential Elements
 
@@ -13,11 +13,7 @@ These annotated examples demonstrate how to create effective campaign briefs at 
 
 ```json
 {
-  "advertiser": "Mike's Plumbing Services",
-  "promoted_offering": "24/7 emergency plumbing repairs and routine maintenance in Denver metro area",
-  "objectives": "Drive phone calls for service appointments",
-  "flight_dates": "October 15-31, 2024",
-  "budget": "$8,000"
+  "brief": "Mike's Plumbing Services needs to drive phone calls for emergency plumbing repairs and routine maintenance in the Denver metro area. We have $8,000 to spend from October 15-31, 2024. Looking for local inventory that can drive calls, ideally during emergency hours when people need immediate service."
 }
 ```
 
@@ -29,16 +25,17 @@ These annotated examples demonstrate how to create effective campaign briefs at 
 - ⚠️ **Missing** - Audience definition (homeowners, property managers)
 
 **Publisher Response:**
-Publishers will likely recommend:
-- Local inventory products with call tracking
-- Mobile-first placements (emergency searches)
+Publishers will likely:
+- Parse "Denver metro area" for geographic targeting
+- Identify "phone calls" as conversion goal
+- Recommend local inventory with call tracking
+- Suggest mobile-first placements for emergency searches
 - Request clarification on success metrics
-- Suggest dayparting for emergency service hours
 
 **AdCP Workflow:**
-1. `get_products` - Query local inventory with geographic constraints
+1. `get_products` - Query with filters matching brief requirements
 2. `list_creative_formats` - Identify call-to-action enabled formats
-3. `create_media_buy` - Submit with phone tracking requirements
+3. `create_media_buy` - Submit with brief and selected products
 
 ---
 
@@ -48,31 +45,7 @@ Publishers will likely recommend:
 
 ```json
 {
-  "advertiser": "TechGear Pro",
-  "promoted_offering": "New ANC-Pro wireless headphones with 40-hour battery life, premium audio drivers",
-  
-  "objectives": {
-    "primary": "Drive online sales during launch week",
-    "secondary": "Build brand awareness in audio enthusiast community"
-  },
-  
-  "target_audience": {
-    "demographics": "Ages 25-45, household income $50K+",
-    "interests": "Technology, music, fitness, travel",
-    "behaviors": "Early tech adopters, premium audio purchasers"
-  },
-  
-  "success_metrics": {
-    "ctr": "0.8-1.2%",
-    "cpa": "$45-55",
-    "roas": "300%",
-    "conversion_rate": "2.5%"
-  },
-  
-  "flight_dates": "November 1-14, 2024",
-  "budget": "$25,000",
-  
-  "creative_requirements": "Product demos, lifestyle imagery, launch offer messaging"
+  "brief": "TechGear Pro is launching our new ANC-Pro wireless headphones with 40-hour battery life and premium audio drivers. Our goal is to drive online sales during launch week (November 1-14, 2024) with a secondary objective of building brand awareness in the audio enthusiast community. Target audience is ages 25-45 with household income $50K+, interested in technology, music, fitness, and travel - early tech adopters who buy premium audio products. Success metrics: 0.8-1.2% CTR, $45-55 CPA, 300% ROAS, 2.5% conversion rate. Budget is $25,000. Need creative that showcases product demos, lifestyle imagery, and launch offer messaging."
 }
 ```
 
@@ -81,21 +54,21 @@ Publishers will likely recommend:
 - ✅ **Clear audience definition** - Actionable demographic and behavioral signals
 - ✅ **Multiple success metrics** - Allows optimization flexibility
 - ✅ **Appropriate budget** - $25K reasonable for 2-week product launch
-- ⚠️ **Could improve** - Specify creative formats needed (video vs. display)
-- ⚠️ **Missing** - Competitive considerations, measurement preferences
+- ✅ **Creative direction** - Helps with format selection
 
 **Publisher Response:**
-Publishers will optimize for:
-- Audience matching against tech/audio enthusiast segments
-- Performance optimization toward CPA goals
-- Creative format recommendations based on inventory
-- Suggest retargeting pool creation
+Publishers will:
+- Extract demographic targeting (25-45, $50K+ HHI)
+- Build interest segments (technology, music, fitness, travel)
+- Optimize toward specified CPA and ROAS goals
+- Match creative requirements to available formats
+- Create retargeting pools for launch period
 
 **AdCP Workflow:**
-1. `get_products` with filters for audience targeting capabilities
-2. `list_creative_formats` to match product demo requirements
-3. Signal activation for tech enthusiast audiences
-4. Performance monitoring via `get_media_buy_delivery`
+1. `get_products` - Filter for audience targeting capabilities
+2. `list_creative_formats` - Match product demo requirements
+3. `create_media_buy` - Include full brief with success metrics
+4. `get_media_buy_delivery` - Monitor against KPI targets
 
 ---
 
@@ -105,116 +78,26 @@ Publishers will optimize for:
 
 ```json
 {
-  "advertiser": "CloudSync Solutions",
-  "promoted_offering": "Enterprise data synchronization platform for hybrid cloud environments",
-  
-  "campaign_context": "Q4 push to meet annual pipeline targets, focusing on enterprises actively evaluating cloud migration strategies",
-  
-  "business_objectives": {
-    "immediate": "Generate 150 Marketing Qualified Leads (MQLs)",
-    "quarterly": "Build pipeline of $2M in opportunities",
-    "strategic": "Position as leader in hybrid cloud data management"
-  },
-  
-  "target_audience": {
-    "firmographics": {
-      "company_size": "500-5000 employees",
-      "industries": ["financial_services", "healthcare", "retail", "manufacturing"],
-      "technology": "Multi-cloud environment (AWS, Azure, GCP)"
-    },
-    "personas": {
-      "primary": "IT Directors, Cloud Architects, CTOs",
-      "secondary": "DevOps Engineers, Data Engineers",
-      "influencers": "IT Consultants, System Integrators"
-    },
-    "signals": {
-      "intent": "Researching cloud migration, data sync, hybrid cloud",
-      "technographic": "Using Kubernetes, Docker, cloud-native tools",
-      "competitive": "Visiting competitor sites (Informatica, Talend, MuleSoft)"
-    }
-  },
-  
-  "success_metrics": {
-    "lead_generation": {
-      "mql_target": "150 leads",
-      "cost_per_mql": "$200-250",
-      "mql_to_sql_rate": "30%"
-    },
-    "engagement": {
-      "content_downloads": "500 whitepapers/guides",
-      "demo_requests": "50 qualified demos",
-      "webinar_registrations": "200 attendees"
-    },
-    "brand": {
-      "site_traffic_lift": "25%",
-      "branded_search_increase": "40%"
-    }
-  },
-  
-  "campaign_execution": {
-    "flight_dates": "October 1 - December 31, 2024",
-    "budget": {
-      "total": "$90,000",
-      "monthly": "$30,000",
-      "allocation": {
-        "lead_gen": "60%",
-        "brand_awareness": "25%",
-        "retargeting": "15%"
-      }
-    },
-    "geographic_focus": {
-      "primary": ["US", "Canada"],
-      "secondary": ["UK", "Germany"]
-    }
-  },
-  
-  "creative_and_messaging": {
-    "formats_needed": {
-      "display": ["300x250", "728x90", "160x600"],
-      "video": ["in-stream_15s", "in-stream_30s"],
-      "native": ["sponsored_content", "in-feed_units"]
-    },
-    "messaging_framework": {
-      "pain_points": "Data silos, sync failures, compliance risks",
-      "value_props": "Real-time sync, zero downtime, SOC2 certified",
-      "proof_points": "Fortune 500 case studies, Gartner recognition"
-    },
-    "content_assets": {
-      "whitepapers": "Hybrid Cloud Best Practices Guide",
-      "case_studies": "Financial Services Digital Transformation",
-      "demo_videos": "5-minute platform overview"
-    }
-  },
-  
-  "measurement_and_privacy": {
-    "attribution": "Multi-touch with 30-day window",
-    "analytics": "Google Analytics 4, Salesforce integration",
-    "privacy": "GDPR/CCPA compliant, no third-party cookies",
-    "brand_safety": "No competitor adjacency, B2B environments only"
-  },
-  
-  "adcp_workflow": {
-    "product_discovery": "Query B2B inventory with ABM capabilities",
-    "format_matching": "Professional formats supporting lead capture",
-    "signal_activation": "Intent and technographic data providers",
-    "approval_required": "Legal review for compliance claims"
-  }
+  "brief": "CloudSync Solutions needs to generate 150 Marketing Qualified Leads (MQLs) for our enterprise data synchronization platform for hybrid cloud environments. This is our Q4 push to meet annual pipeline targets, focusing on enterprises actively evaluating cloud migration strategies. We need to build a pipeline of $2M in opportunities while positioning ourselves as the leader in hybrid cloud data management.\n\nTarget companies with 500-5000 employees in financial services, healthcare, retail, and manufacturing that use multi-cloud environments (AWS, Azure, GCP). Decision makers include IT Directors, Cloud Architects, and CTOs, with DevOps Engineers and Data Engineers as secondary targets. Also want to reach IT Consultants and System Integrators who influence decisions.\n\nLook for signals indicating intent around cloud migration, data sync, and hybrid cloud research. Target companies using Kubernetes, Docker, and cloud-native tools. Include competitive conquest against visitors to Informatica, Talend, and MuleSoft.\n\nSuccess metrics: 150 MQLs at $200-250 per lead with 30% MQL-to-SQL conversion rate. Also targeting 500 whitepaper downloads, 50 qualified demo requests, and 200 webinar registrations. For brand metrics, looking for 25% site traffic lift and 40% increase in branded search.\n\nCampaign runs October 1 - December 31, 2024 with $90,000 total budget ($30,000 monthly). Allocate 60% to lead gen, 25% to brand awareness, and 15% to retargeting. Focus on US and Canada primarily, with UK and Germany as secondary markets.\n\nNeed display formats (300x250, 728x90, 160x600), video (15s and 30s in-stream), and native (sponsored content and in-feed units). Messaging should address pain points like data silos, sync failures, and compliance risks. Emphasize our real-time sync, zero downtime, and SOC2 certification. Use Fortune 500 case studies and Gartner recognition as proof points.\n\nContent assets include our Hybrid Cloud Best Practices Guide whitepaper, Financial Services Digital Transformation case study, and 5-minute platform overview video. Require multi-touch attribution with 30-day window, Google Analytics 4 and Salesforce integration. Must be GDPR/CCPA compliant with no third-party cookies. No competitor adjacency and B2B environments only for brand safety."
 }
 ```
 
 **Why This Works:**
-- ✅ **Complete strategic context** - Clear business goals and constraints
-- ✅ **Detailed audience definition** - Firmographics, personas, and signals
+- ✅ **Complete context** - Business goals, timeline, and constraints clear
+- ✅ **Detailed targeting** - Firmographics, personas, and intent signals
 - ✅ **Comprehensive metrics** - Lead gen, engagement, and brand KPIs
-- ✅ **AdCP-specific workflow** - Shows protocol integration points
-- ✅ **Privacy-forward approach** - GDPR/CCPA compliance specified
-- ✅ **Realistic B2B economics** - $200-250 CPL standard for enterprise
+- ✅ **Budget allocation** - Clear spending priorities
+- ✅ **Content strategy** - Specific assets and messaging framework
+- ✅ **Compliance requirements** - Privacy and brand safety specified
 
-**Publisher Optimization:**
-- ABM platform activation for target account lists
-- Intent data integration for in-market buyers
-- LinkedIn and professional publisher prioritization
-- Lead quality scoring and feedback loops
+**Publisher Response:**
+Publishers will:
+- Activate ABM platforms for target account lists
+- Integrate intent data for in-market identification
+- Prioritize LinkedIn and B2B publisher inventory
+- Set up lead quality scoring and feedback loops
+- Implement specified attribution and analytics
+- Ensure GDPR/CCPA compliance in targeting
 
 ---
 
@@ -224,174 +107,109 @@ Publishers will optimize for:
 
 ```json
 {
-  "advertiser": "EcoMotion Automotive",
-  "promoted_offering": "2025 EcoMotion Hybrid SUV - Luxury hybrid with 500-mile range",
-  
-  "campaign_overview": "Three-phase launch targeting eco-conscious families transitioning from traditional luxury SUVs",
-  
-  "phased_execution": {
-    "phase_1_awareness": {
-      "dates": "October 1-31, 2024",
-      "budget": "$200,000",
-      "objectives": "Build awareness, reach 10M unique users",
-      "success_metrics": {
-        "reach": "10M uniques",
-        "frequency": "3-5x",
-        "video_completion_rate": "70%",
-        "brand_lift": "12% awareness increase"
-      },
-      "formats_discovery": {
-        "connected_tv": "30-second spots during family programming",
-        "online_video": "15-second and 6-second bumpers",
-        "display": "High-impact takeovers on auto sites"
-      }
-    },
-    
-    "phase_2_consideration": {
-      "dates": "November 1-30, 2024",
-      "budget": "$150,000",
-      "objectives": "Drive configurator sessions and brochure downloads",
-      "success_metrics": {
-        "configurator_sessions": "50,000",
-        "cost_per_session": "$3.00",
-        "brochure_downloads": "10,000",
-        "site_engagement_time": "3+ minutes"
-      },
-      "audience_refinement": {
-        "retargeting": "Phase 1 video completers",
-        "lookalikes": "Current hybrid owners",
-        "conquest": "Competitive SUV intenders"
-      }
-    },
-    
-    "phase_3_conversion": {
-      "dates": "December 1-31, 2024",
-      "budget": "$100,000",
-      "objectives": "Generate test drive appointments",
-      "success_metrics": {
-        "test_drives": "500 appointments",
-        "cost_per_appointment": "$200",
-        "dealer_locator_uses": "5,000",
-        "appointment_show_rate": "70%"
-      },
-      "activation_strategy": {
-        "geo_targeting": "10-mile radius of dealers",
-        "dayparting": "Weekends and evenings",
-        "weather_triggers": "Activate during good weather"
-      }
-    }
-  },
-  
-  "audience_strategy": {
-    "primary": {
-      "demographics": "HHI $75K-150K, ages 35-55, families",
-      "psychographics": "Environmentally conscious, tech-savvy, safety-focused",
-      "behaviors": "SUV owners, outdoor enthusiasts, suburban lifestyle"
-    },
-    "signals": {
-      "auto_intender": "In-market for SUVs",
-      "green_interests": "EV/hybrid research, environmental content",
-      "competitive": "Visiting Toyota Highlander, Honda Pilot pages"
-    }
-  },
-  
-  "creative_specifications": {
-    "asset_requirements": {
-      "video": {
-        "hero_30s": "1920x1080, 16:9, max 50MB",
-        "social_15s": "1080x1080, 1:1, max 30MB",
-        "mobile_vertical": "1080x1920, 9:16, max 40MB"
-      },
-      "display": {
-        "standard_sizes": "300x250, 728x90, 320x50",
-        "rich_media": "HTML5 with 360-degree view",
-        "file_size": "Max 150KB initial load"
-      }
-    },
-    "dynamic_elements": {
-      "dealer_locator": "Real-time nearest dealer",
-      "inventory_status": "Available colors/trims",
-      "incentive_offers": "Regional lease/finance offers"
-    }
-  },
-  
-  "measurement_framework": {
-    "attribution": "Data-driven attribution with store visit tracking",
-    "brand_study": "Control/exposed lift measurement",
-    "incrementality": "Geo-experiments in 5 test markets",
-    "competitive": "Share of voice and consideration tracking"
-  },
-  
-  "adcp_integration": {
-    "workflow": [
-      "get_products: Query automotive inventory with CTV capability",
-      "list_creative_formats: Discover video and rich media options",
-      "activate_signal: Auto intender and green interest signals",
-      "create_media_buy: Submit phased campaign with approval gates",
-      "sync_creatives: Upload video and display assets per phase",
-      "get_media_buy_delivery: Daily performance monitoring",
-      "update_media_buy: Optimize based on phase performance"
-    ],
-    "approval_requirements": {
-      "legal": "Claim substantiation for MPG/range",
-      "brand": "Creative and placement approval",
-      "dealer": "Regional offer coordination"
-    }
-  }
+  "brief": "EcoMotion Automotive is launching the 2025 EcoMotion Hybrid SUV, our first luxury hybrid with 500-mile range targeting eco-conscious families transitioning from traditional luxury SUVs. This is a three-phase campaign with different objectives and budgets for each phase.\n\nPHASE 1 - AWARENESS (October 1-31, 2024, $200,000):\nBuild awareness reaching 10M unique users with 3-5x frequency. Success metrics: 70% video completion rate and 12% brand lift. Need connected TV (30-second spots during family programming), online video (15-second and 6-second bumpers), and high-impact display takeovers on auto sites.\n\nPHASE 2 - CONSIDERATION (November 1-30, 2024, $150,000):\nDrive 50,000 configurator sessions at $3.00 cost per session and 10,000 brochure downloads. Expecting 3+ minute site engagement. Retarget Phase 1 video completers, create lookalikes from current hybrid owners, and conquest competitive SUV intenders.\n\nPHASE 3 - CONVERSION (December 1-31, 2024, $100,000):\nGenerate 500 test drive appointments at $200 per appointment with 70% show rate. Expect 5,000 dealer locator uses. Target 10-mile radius around dealers, focus on weekends and evenings, activate during good weather conditions.\n\nPRIMARY AUDIENCE:\nHouseholds with $75K-150K income, ages 35-55 with families. Environmentally conscious, tech-savvy, safety-focused. Current SUV owners, outdoor enthusiasts with suburban lifestyle. Target in-market SUV shoppers researching EVs/hybrids and environmental content. Conquest shoppers looking at Toyota Highlander and Honda Pilot.\n\nCREATIVE REQUIREMENTS:\nVideo assets: Hero 30s (1920x1080, 16:9, max 50MB), Social 15s (1080x1080, 1:1, max 30MB), Mobile vertical (1080x1920, 9:16, max 40MB). Display: Standard sizes (300x250, 728x90, 320x50) plus HTML5 rich media with 360-degree vehicle view (max 150KB initial load). Include dynamic elements: real-time nearest dealer, available colors/trims, regional lease/finance offers.\n\nMEASUREMENT:\nImplement data-driven attribution with store visit tracking. Run control/exposed brand lift study. Set up geo-experiments in 5 test markets. Track share of voice and consideration versus competitors.\n\nAPPROVAL REQUIREMENTS:\nLegal review needed for MPG and range claims. Brand team approval for creative and placements. Coordinate with dealer network for regional offers.\n\nPRIMARY MARKETS:\nCalifornia (Los Angeles, San Francisco, San Diego), Northeast (New York, Boston, Philadelphia), Pacific Northwest (Seattle, Portland), Texas (Austin, Dallas, Houston)."
 }
 ```
 
 **Why This Works:**
-- ✅ **Sophisticated phasing** - Clear progression through funnel
-- ✅ **Detailed technical specs** - Asset requirements and file sizes
-- ✅ **Advanced targeting** - Signals, weather triggers, dayparting
-- ✅ **Complete AdCP workflow** - All protocol tools demonstrated
-- ✅ **Realistic automotive KPIs** - $200 per test drive achievable
-- ✅ **Multi-stakeholder coordination** - Legal, brand, dealer alignment
+- ✅ **Sophisticated phasing** - Clear progression through purchase funnel
+- ✅ **Phase-specific KPIs** - Different metrics for each objective
+- ✅ **Detailed technical specs** - Asset requirements clearly defined
+- ✅ **Advanced targeting** - Weather triggers, dayparting, geo-radius
+- ✅ **Multi-stakeholder needs** - Legal, brand, and dealer coordination
+- ✅ **Realistic automotive metrics** - $200 per test drive is achievable
+
+**Publisher Orchestration:**
+Publishers will:
+- Set up sequential campaign phases with different objectives
+- Implement audience pools that flow between phases
+- Configure weather-based activation triggers
+- Coordinate dealer inventory feeds for dynamic creative
+- Establish brand study and incrementality testing
+- Manage approval workflows for claims and creative
 
 ---
 
 ## Industry Quick Reference
 
-### Key Considerations by Vertical
+### How Different Industries Structure Briefs
 
 #### Financial Services
-- **Compliance**: FINRA, truth in advertising, fair lending
-- **Targeting restrictions**: No credit score or medical targeting
-- **Success metrics**: Account opens, funded accounts, AUM growth
-- **Typical CPAs**: $100-300 per funded account
-- **Creative requirements**: Disclaimers, FDIC/SIPC notices
+```json
+{
+  "brief": "NextGen Banking launching high-yield savings account with 4.5% APY, no minimum balance, no fees. Target mass affluent consumers ($100K+ income, ages 30-60) currently with traditional banks. Need to generate 5,000 funded accounts at $150 CAC. Must include FDIC insurance messaging and comply with FINRA regulations. No credit score or medical condition targeting. Campaign runs January with $400,000 budget."
+}
+```
 
 #### Healthcare
-- **Privacy**: HIPAA compliance, no condition targeting
-- **Geographic**: Service area restrictions
-- **Metrics**: Appointment bookings, patient acquisition
-- **Typical costs**: $30-80 per appointment
-- **Requirements**: Provider credentials, insurance accepted
+```json
+{
+  "brief": "HealthFirst Urgent Care needs to build awareness and drive appointment bookings for our 15 Ohio clinic locations. Target families with children and adults 25-65 within 10-mile radius of each clinic. Goal is 500 online appointments at $30-50 per appointment. Emphasize minimal wait times and online scheduling. Must be HIPAA compliant with no health condition targeting. $20,000 monthly ongoing budget."
+}
+```
 
-#### Streaming/Entertainment
-- **Objectives**: Trial starts, subscriber retention
-- **Metrics**: Cost per trial, trial-to-paid conversion
-- **Typical costs**: $20-50 per trial start
-- **Creative**: Content highlights, exclusive programming
+#### Streaming Service
+```json
+{
+  "brief": "StreamPlus Entertainment promoting new streaming service with exclusive original content and live sports during Q4 free trial promotion. Target cord-cutters and streaming enthusiasts aged 25-54 in NFL markets. Drive trial sign-ups at $25 cost per trial with 60% trial-to-paid conversion goal. Need video creative highlighting exclusive content. $2M Q4 2024 budget."
+}
+```
 
-#### Retail/E-commerce
-- **Seasonality**: Holiday, back-to-school, Prime Day
-- **Metrics**: ROAS, cart value, repeat purchase rate
-- **Typical ROAS**: 300-500% for established brands
-- **Formats**: Shopping ads, dynamic product ads
+#### Mobile App
+```json
+{
+  "brief": "FitTrack Fitness App needs 50,000 installs in January 2025 for our AI-powered personal training app. Target fitness enthusiasts and New Year resolution makers. $3.50 target CPI with 30% day-7 retention. Need video demos of app features and before/after testimonials. $175,000 budget. Requires iOS and Android app store links with deep linking support."
+}
+```
 
-#### Mobile Apps
-- **Objectives**: Installs, DAU, retention
-- **Metrics**: CPI, D7/D30 retention, LTV
-- **Typical CPI**: $2-5 for non-gaming apps
-- **Requirements**: App store links, deep linking
+---
+
+## Brief Writing Best Practices
+
+### Structure Your Brief Effectively
+
+1. **Start with the essentials**
+   - Who you are (advertiser/brand)
+   - What you're promoting
+   - Core objective
+   - Budget and timing
+
+2. **Add targeting details**
+   - Demographics and firmographics
+   - Interests and behaviors
+   - Intent signals
+   - Geographic markets
+
+3. **Specify success metrics**
+   - Primary KPIs with targets
+   - Secondary metrics
+   - Attribution preferences
+
+4. **Include creative requirements**
+   - Format preferences
+   - Asset specifications
+   - Messaging guidelines
+   - Dynamic elements
+
+5. **Note compliance needs**
+   - Industry regulations
+   - Privacy requirements
+   - Brand safety
+   - Approval workflows
+
+### Natural Language Tips
+
+- **Be specific but conversational** - Write as you would explain to a colleague
+- **Group related information** - Keep audience details together, metrics together
+- **Use industry-standard terms** - CPM, CPA, ROAS are understood
+- **Include context** - Why this campaign, why now
+- **Specify what's flexible** - "Prefer video but open to display if performance better"
 
 ---
 
 ## Brief Evaluation Checklist
 
-Before submitting your brief, ensure you have:
+Before submitting your brief, ensure it includes:
 
 ### Essential Elements
 - [ ] Advertiser name and promoted offering
@@ -400,13 +218,13 @@ Before submitting your brief, ensure you have:
 - [ ] Geographic scope (if applicable)
 
 ### Recommended Elements
-- [ ] Target audience definition
+- [ ] Target audience description
 - [ ] Success metrics with targets
 - [ ] Creative format preferences
 - [ ] Brand safety requirements
 
 ### Advanced Elements
-- [ ] Signal activation requirements
+- [ ] Intent signals to activate
 - [ ] Measurement framework
 - [ ] Privacy compliance needs
 - [ ] Approval workflow requirements
@@ -415,7 +233,7 @@ Before submitting your brief, ensure you have:
 
 ## Related Documentation
 
-- [Brief Expectations](./brief-expectations.md) - Processing guidelines and requirements
+- [Brief Expectations](./brief-expectations.md) - How publishers process briefs
 - [Media Buy Lifecycle](./media-buy-lifecycle.md) - Campaign execution workflow
 - [Creative Formats](./creative-formats.md) - Available format specifications
 - [Targeting Dimensions](./targeting-dimensions.md) - Audience capabilities

--- a/docs/media-buy/example-briefs.md
+++ b/docs/media-buy/example-briefs.md
@@ -5,7 +5,7 @@ title: Example Campaign Briefs
 
 # Example Campaign Briefs
 
-These annotated examples demonstrate how natural language briefs work in AdCP for audience-enabled media buying, showing progression from basic to sophisticated targeting strategies.
+These annotated examples demonstrate how natural language briefs work in AdCP, describing target customers and campaign objectives to help publishers recommend appropriate media products.
 
 ## 1. Minimal Brief: Essential Elements
 
@@ -13,182 +13,208 @@ These annotated examples demonstrate how natural language briefs work in AdCP fo
 
 ```json
 {
-  "brief": "Mike's Plumbing Services needs to reach homeowners in the Denver metro area who might need emergency plumbing repairs or routine maintenance. We have $8,000 to spend from October 15-31, 2024. Looking to drive phone calls for service appointments."
+  "brief": "Mike's Plumbing Services needs to reach homeowners in the Denver, Colorado area who might need plumbing services. We have $8,000 USD to spend from October 15-31, 2024. Looking for display and native formats to drive phone calls."
 }
 ```
 
 **Why This Works:**
-- ✅ **Clear advertiser** - Mike's Plumbing Services
-- ✅ **Target audience** - Homeowners in Denver metro
-- ✅ **Objective** - Drive phone calls
-- ✅ **Budget and timing** - $8,000 over 2 weeks
-- ⚠️ **Could improve** - Add more audience details (age, income)
+- ✅ **Clear business** - Mike's Plumbing Services
+- ✅ **Customer description** - Homeowners needing plumbing
+- ✅ **Geographic market** - Denver, Colorado (USA implied)
+- ✅ **Format preferences** - Display and native
+- ✅ **Budget and timing** - $8,000 USD over 2 weeks
+- ✅ **Business outcome** - Phone calls
 
 **Publisher Interpretation:**
-- Geographic targeting: Denver DMA
-- Audience: Homeowners (property owners)
-- Optimization goal: Phone call conversions
-- Budget pacing: ~$500/day
+Publishers can suggest targeting approaches like:
+- Homeownership signals
+- Home improvement interest
+- Local service searchers
+- Emergency service needs
 
 ---
 
-## 2. Standard Brief: Clear Audience Definition
+## 2. Standard Brief: Customer Story
 
 ### E-commerce Product Launch
 
 ```json
 {
-  "brief": "TechGear Pro is launching new wireless headphones. We need to reach tech enthusiasts and early adopters aged 25-45 with household income over $50K who are interested in premium audio, music, fitness, and travel. Campaign runs November 1-14, 2024 with $25,000 budget. Goal is to drive online sales with target CPA of $45-55."
+  "brief": "TechGear Pro is launching premium wireless headphones in the United States. Our customers are typically young professionals who commute, work out regularly, and value high-quality audio for both music and calls. They're willing to pay more for products that last longer and perform better. We need video and display formats to drive online sales during our launch November 1-14, 2024. Budget is $25,000 USD with a target of acquiring customers at $45-55 each."
 }
 ```
 
 **Why This Works:**
-- ✅ **Demographic targeting** - Age 25-45, HHI $50K+
-- ✅ **Interest targeting** - Tech, audio, music, fitness, travel
-- ✅ **Behavioral targeting** - Early adopters, premium buyers
-- ✅ **Clear KPIs** - Sales with $45-55 CPA target
-- ✅ **Defined flight** - 2-week launch period
+- ✅ **Customer profile** - Young professionals with active lifestyles
+- ✅ **Customer values** - Quality, durability, performance
+- ✅ **Geographic market** - United States
+- ✅ **Format needs** - Video and display
+- ✅ **Clear economics** - $45-55 customer acquisition cost
+- ✅ **Natural description** - Lets publishers suggest targeting
 
-**Publisher Interpretation:**
-- Build audience segments from demographics and interests
-- Optimize toward conversion goals
-- Apply frequency caps for launch period
-- Use lookalike modeling from converter profiles
+**Publisher Suggestions Might Include:**
+- Commuter targeting
+- Fitness enthusiast segments
+- Premium brand affinity
+- Audio equipment researchers
+- Professional demographic overlays
 
 ---
 
-## 3. Comprehensive Brief: B2B Targeting
+## 3. Comprehensive Brief: B2B Customer Description
 
 ### Enterprise Software Campaign
 
 ```json
 {
-  "brief": "CloudSync Solutions needs to reach IT decision makers at mid-market companies (500-5000 employees) in financial services, healthcare, retail, and manufacturing. Target titles include IT Directors, Cloud Architects, CTOs, and DevOps Engineers. Focus on companies showing intent signals around cloud migration, hybrid cloud, and data synchronization. Also target visitors to competitor sites like Informatica, Talend, and MuleSoft. We want to generate 150 qualified leads at $200-250 per lead. Campaign runs October through December 2024 with $90,000 total budget. Primary markets are US and Canada, secondary markets UK and Germany."
+  "brief": "CloudSync Solutions helps companies manage data across multiple cloud platforms. Our ideal customers are growing businesses in the United States, Canada, United Kingdom, and Germany that have recently adopted cloud services and are struggling to keep data synchronized. These companies typically have distributed teams, use multiple SaaS tools, and are concerned about data security and compliance. The decision makers are usually technical leaders who report directly to the C-suite and are tasked with modernizing their company's infrastructure. We're looking for native content and display formats to generate qualified leads at $200-250 per lead. Q4 2024 campaign with $90,000 USD total budget."
 }
 ```
 
 **Why This Works:**
-- ✅ **Firmographic targeting** - Company size, industries
-- ✅ **Title/persona targeting** - Specific decision makers
-- ✅ **Intent signals** - Cloud migration, data sync research
-- ✅ **Competitive conquest** - Competitor site visitors
-- ✅ **Lead generation focus** - Clear volume and cost targets
-- ✅ **Geographic priorities** - Primary and secondary markets
+- ✅ **Customer context** - Growing businesses with cloud challenges
+- ✅ **Customer pain points** - Data sync, security, compliance
+- ✅ **Decision maker profile** - Technical leaders near C-suite
+- ✅ **Multiple countries** - US, CA, UK, DE specified
+- ✅ **Format preferences** - Native content and display
+- ✅ **Flexible targeting** - Publishers can interpret signals
 
-**Publisher Interpretation:**
-- Activate B2B data providers for firmographics
-- Use intent data for in-market identification
-- Apply title-based targeting from professional data
-- Set up competitive conquesting campaigns
-- Implement lead scoring and quality filters
+**Publisher Interpretation Opportunities:**
+- Cloud adoption signals
+- Company growth indicators
+- Technology stack analysis
+- Title and seniority matching
+- Industry compliance needs
 
 ---
 
-## 4. Advanced Brief: Multi-Segment Strategy
+## 4. Advanced Brief: Multi-Audience Campaign
 
-### Automotive Launch Campaign
+### Automotive Launch
 
 ```json
 {
-  "brief": "EcoMotion is launching our new hybrid SUV. Primary audience: eco-conscious families with household income $75K-150K, ages 35-55, who currently own SUVs and are interested in environmental topics. Secondary audience: affluent early adopters interested in luxury vehicles and new technology. Conquest audience: people actively shopping for Toyota Highlander, Honda Pilot, or other 3-row SUVs. Also target based on behaviors: outdoor enthusiasts, suburban families with children, and people who've visited EV/hybrid content. Geographic focus on California, Pacific Northwest, and Northeast metros. October through December with $450,000 total budget. Success is measured by test drive appointments and dealer visits."
+  "brief": "EcoMotion is launching our new hybrid SUV in the United States, specifically California, Pacific Northwest, and Northeast regions. We have three distinct customer groups we want to reach with video, Connected TV, and display formats:
+
+1. Eco-conscious families who currently drive older SUVs and are concerned about their environmental impact but need the space for kids and activities. They research extensively and value safety ratings and environmental certifications.
+
+2. Tech-forward professionals who see their vehicle as an extension of their digital lifestyle. They're early adopters who want the latest features and are willing to pay premium prices for innovation.
+
+3. Current owners of competitor vehicles (Toyota Highlander, Honda Pilot) who might be in market for their next vehicle. They value reliability and total cost of ownership.
+
+Campaign runs October-December 2024 with $450,000 USD budget. Success means driving dealership visits and test drive appointments."
 }
 ```
 
 **Why This Works:**
-- ✅ **Multiple audience segments** - Primary, secondary, conquest
-- ✅ **Rich behavioral data** - Current SUV owners, outdoor enthusiasts
-- ✅ **Competitive targeting** - Specific model conquest
-- ✅ **Interest + intent** - Environmental interest + auto shopping
-- ✅ **Geographic strategy** - EV-friendly markets
-- ✅ **Clear success metrics** - Test drives and dealer visits
+- ✅ **Three distinct customer stories** - Each with different motivations
+- ✅ **Regional focus** - Specific US regions identified
+- ✅ **Format strategy** - Video, CTV, and display
+- ✅ **Competitive context** - Without being prescriptive
+- ✅ **Customer journey insights** - Research behavior, values
+- ✅ **Clear success metrics** - Dealership engagement
 
-**Publisher Interpretation:**
-- Create separate audience segments for testing
-- Layer demographics with auto-intender data
-- Apply geographic and behavioral targeting
-- Use dynamic optimization across segments
-- Focus on lower-funnel automotive metrics
-
----
-
-## Industry-Specific Brief Examples
-
-### Financial Services
-```json
-{
-  "brief": "NextGen Banking wants to reach mass affluent consumers ($100K+ income, ages 30-60) who currently have savings accounts with traditional banks and are researching high-yield savings options. Exclude existing customers. Focus on major metros. January campaign with $400,000 budget targeting 5,000 new account opens."
-}
-```
-
-### Healthcare
-```json
-{
-  "brief": "HealthFirst Urgent Care needs to reach families with children and adults 25-65 within 10 miles of our 15 Ohio clinic locations. Target people with employer-sponsored health insurance who haven't visited an urgent care in the past year. $20,000 monthly ongoing budget to drive appointment bookings."
-}
-```
-
-### Streaming Service
-```json
-{
-  "brief": "StreamPlus needs to reach cord-cutters and cord-nevers aged 25-54 who are sports fans, particularly NFL and NBA followers, in markets where we have local broadcast rights. Also target households that subscribe to 2+ streaming services. Q4 campaign with $2M budget to drive free trial sign-ups."
-}
-```
-
-### Mobile Gaming
-```json
-{
-  "brief": "GameStudio targeting casual mobile gamers aged 25-45 who play puzzle and match-3 games, have made in-app purchases before, and use iOS devices. Focus on users who've played competitor games like Candy Crush or Gardenscapes. January launch with $175,000 budget, goal of 50,000 installs."
-}
-```
+**Publisher Value-Add:**
+- Suggest family-oriented contexts
+- Identify early adopter signals
+- Find competitive conquesting opportunities
+- Layer in environmental interest data
+- Apply automotive shopping behaviors
 
 ---
 
-## What NOT to Include in Briefs
+## Industry-Specific Examples
 
-Briefs should focus on **who** to reach and **what** business outcome to drive. They should NOT include:
+### Financial Services - United States
+```json
+{
+  "brief": "NextGen Banking is promoting our high-yield savings account across the United States. Our target customers are professionals who have accumulated some savings but keep it in traditional banks earning minimal interest. They're financially responsible but not necessarily investment-savvy, and they value security and ease of use over complex features. Looking for display and native formats to acquire 5,000 new accounts in January 2025 with $400,000 USD budget."
+}
+```
 
-### ❌ Creative Specifications
-- Asset sizes, formats, or technical specs
-- Creative messaging or copy
-- Production requirements
+### Healthcare - Regional US
+```json
+{
+  "brief": "HealthFirst Urgent Care serves families in Ohio who need convenient, affordable healthcare. Our patients typically have insurance but want to avoid emergency room costs and wait times. They're parents with young children, working professionals who can't take time off for appointments, and seniors who need accessible care close to home. We need display and video formats to drive appointment bookings. $20,000 USD monthly budget."
+}
+```
 
-### ❌ Technical Implementation
-- Attribution models
-- Pixel placement
-- Analytics integration
-- Measurement vendors
+### Streaming Service - North America
+```json
+{
+  "brief": "StreamPlus is expanding in the United States and Canada. Our subscribers love live sports but have cut the cord on traditional cable. They're social viewers who watch games with friends and family, follow multiple teams, and want access to both local and national broadcasts. We need Connected TV, video, and display formats for our Q4 2024 campaign with $2M USD budget to drive free trial sign-ups."
+}
+```
 
-### ❌ Media Tactics
-- Specific channels or publishers
-- Bid strategies
-- Frequency caps
-- Dayparting rules
-
-These are either handled separately (creative via `sync_creatives`) or determined by the publisher based on their capabilities and optimization strategies.
+### Mobile Gaming - Global English Markets
+```json
+{
+  "brief": "GameStudio is launching our puzzle game in the United States, United Kingdom, Canada, and Australia. Our players are typically adults who play mobile games during commutes, breaks, and before bed. They've played games like Candy Crush or Wordle and enjoy mental challenges that don't require long time commitments. Looking for video and display formats to acquire 50,000 players at $3.50 each in January 2025 with $175,000 USD budget."
+}
+```
 
 ---
 
 ## Brief Writing Best Practices
 
-### Focus on Audience Insights
-- **Demographics**: Age, income, gender, education
-- **Firmographics**: Company size, industry, revenue (B2B)
-- **Interests**: Topics, hobbies, content consumption
-- **Behaviors**: Purchase history, website visits, app usage
-- **Intent signals**: In-market status, research behavior
-- **Geography**: Markets, DMAs, radius targeting
+### Describe Your Customer Naturally
 
-### Specify Business Outcomes
-- **Direct response**: Leads, sales, app installs, sign-ups
-- **Engagement**: Website visits, content downloads, video views
-- **Awareness**: Reach, brand lift, consideration
-- **Offline**: Store visits, phone calls, test drives
+Instead of prescribing targeting tactics, describe your customer's:
+- **Situation**: What's happening in their life/business?
+- **Challenges**: What problems do they face?
+- **Values**: What matters to them?
+- **Behaviors**: How do they research and buy?
+- **Context**: When and why do they need you?
 
-### Provide Context
-- **Campaign purpose**: Launch, promotion, seasonal, always-on
-- **Competitive landscape**: Conquest targets, differentiation
-- **Budget parameters**: Total, monthly, or daily limits
-- **Success definitions**: KPIs, benchmarks, goals
+### Always Include Geographic Scope
+
+- Specify countries explicitly
+- Include currency (USD, EUR, GBP, etc.)
+- Note regional focuses within countries
+- Consider time zones for global campaigns
+
+### Specify Format Preferences
+
+Include format types to indicate channel strategy:
+- **Display**: Standard web advertising
+- **Video**: In-stream and out-stream video
+- **Connected TV**: Television streaming ads
+- **Audio**: Podcast and music streaming
+- **Native**: Content-style advertising
+
+### Let Publishers Add Value
+
+Good briefs leave room for publisher expertise:
+- Describe customers, not targeting parameters
+- Share context, not just demographics
+- Explain the "why" behind your campaign
+- Allow for creative targeting suggestions
+
+---
+
+## What's Different About AdCP Briefs
+
+### ✅ DO Include:
+- Customer descriptions and stories
+- Geographic markets and currencies
+- Format preferences (indicates channels)
+- Business objectives and KPIs
+- Budget and timing
+- Competitive context
+
+### ❌ DON'T Prescribe:
+- Specific targeting parameters
+- Exact audience segments
+- Technical implementations
+- Frequency caps or bid strategies
+- Attribution methodologies
+
+### 🤝 Let Publishers:
+- Suggest targeting approaches
+- Recommend audience strategies
+- Optimize based on their data
+- Apply their platform expertise
+- Test and learn what works
 
 ---
 
@@ -196,28 +222,30 @@ These are either handled separately (creative via `sync_creatives`) or determine
 
 ### Essential Elements
 - [ ] Clear advertiser/brand identification
-- [ ] Target audience description
-- [ ] Business objective or KPI
-- [ ] Budget amount
-- [ ] Campaign timing
+- [ ] Geographic markets specified
+- [ ] Currency indicated
+- [ ] Format preferences stated
+- [ ] Budget and timing included
+- [ ] Business objective defined
 
-### Audience Definition
-- [ ] Demographics or firmographics
-- [ ] Interests or behaviors
-- [ ] Geographic scope
-- [ ] Exclusions (existing customers, etc.)
+### Customer Description
+- [ ] Customer situation/context
+- [ ] Problems they're solving
+- [ ] How they make decisions
+- [ ] What they value
+- [ ] Natural, conversational tone
 
-### Optional Enhancements
-- [ ] Intent signals to leverage
-- [ ] Competitive conquest targets
-- [ ] Multiple audience segments
-- [ ] Success metrics/benchmarks
+### Campaign Context
+- [ ] Why this campaign now?
+- [ ] Success metrics defined
+- [ ] Competitive landscape mentioned
+- [ ] Flexibility for publisher input
 
 ---
 
 ## Related Documentation
 
 - [Brief Expectations](./brief-expectations.md) - How publishers process briefs
+- [Creative Formats](./creative-formats.md) - Available format types
 - [Media Buy Lifecycle](./media-buy-lifecycle.md) - Campaign execution workflow
-- [Targeting Dimensions](./targeting-dimensions.md) - Available audience capabilities
 - [Product Discovery](./product-discovery.md) - How briefs influence product selection

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -79,6 +79,8 @@ const sidebars: SidebarsConfig = {
             'media-buy/media-products',
             'media-buy/media-buys',
             'media-buy/dimensions',
+            'media-buy/brief-expectations',
+            'media-buy/example-briefs',
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Added brief-expectations page to the navigation sidebar under Core Concepts
- Created comprehensive example-briefs.md with realistic, industry-specific campaign briefs
- Provided examples at different quality levels (minimal, standard, comprehensive) to demonstrate the brief structure spectrum

## Changes
- Updated `sidebars.ts` to include both brief-expectations and example-briefs in the Media Buy > Core Concepts section
- Created new `docs/media-buy/example-briefs.md` with:
  - 6 detailed campaign brief examples across different industries
  - 3 industry-specific templates for common use cases
  - Clear demonstration of minimal vs standard vs comprehensive brief quality levels

## Test plan
- [x] Verify navigation updates display correctly
- [x] Review example briefs for accuracy and completeness
- [x] Ensure examples follow the structure defined in brief-expectations.md
- [x] All tests pass (schemas, examples, typecheck)

🤖 Generated with [Claude Code](https://claude.ai/code)