### PR TITLE
fix: migrate onBrokenMarkdownLinks to markdown.hooks for Docusaurus v4

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -65,7 +65,6 @@ const config: Config = {
   projectName: 'adcp', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -78,6 +77,9 @@ const config: Config = {
   themes: ['@docusaurus/theme-mermaid'],
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
   },
 
   plugins: [


### PR DESCRIPTION
## Summary
- Migrated deprecated `onBrokenMarkdownLinks` config option to `markdown.hooks.onBrokenMarkdownLinks`
- Resolves Docusaurus v4 deprecation warning

## Changes
- Moved `onBrokenMarkdownLinks: 'warn'` from root config to `markdown.hooks.onBrokenMarkdownLinks`
- Config now compatible with Docusaurus v4 future flag

## Test plan
- [x] Started Docusaurus with `npm start`
- [x] Verified no deprecation warnings
- [x] Confirmed site builds successfully
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)