### PR TITLE
feat: add creative_ids support to create_media_buy

### DIFF
--- a/docs/media-buy/task-reference/create_media_buy.md
+++ b/docs/media-buy/task-reference/create_media_buy.md
@@ -37,6 +37,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 | `format_ids` | string[] | Yes | Array of format IDs that will be used for this package - must be supported by all products |
 | `budget` | Budget | No | Budget configuration for this package (overrides media buy level budget if specified) |
 | `targeting_overlay` | TargetingOverlay | No | Additional targeting criteria for this package (see Targeting Overlay Object below) |
+| `creative_ids` | string[] | No | Creative IDs to assign to this package at creation time |
 
 ### Targeting Overlay Object
 
@@ -146,7 +147,8 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
           "geo_country_any_of": ["US"],
           "geo_region_any_of": ["CA", "NY"],
           "axe_include_segment": "x8dj3k"
-        }
+        },
+        "creative_ids": ["creative_abc123", "creative_def456"]
       },
       {
         "buyer_ref": "nike_audio_drive_package",
@@ -288,7 +290,8 @@ await a2a.send({
                   "geo_country_any_of": ["US"],
                   "geo_region_any_of": ["CA", "NY"],
                   "axe_include_segment": "x8dj3k"
-                }
+                },
+                "creative_ids": ["creative_abc123", "creative_def456"]
               },
               {
                 "buyer_ref": "nike_audio_drive_package",

--- a/static/schemas/v1/media-buy/create-media-buy-request.json
+++ b/static/schemas/v1/media-buy/create-media-buy-request.json
@@ -45,6 +45,13 @@
           },
           "targeting_overlay": {
             "$ref": "/schemas/v1/core/targeting.json"
+          },
+          "creative_ids": {
+            "type": "array",
+            "description": "Creative IDs to assign to this package at creation time",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "anyOf": [


### PR DESCRIPTION
## Summary

- Add optional `creative_ids` field to Package object in `create_media_buy` request
- Update documentation with parameter description and examples

## Motivation

Previously, buyers could only assign creative IDs to packages via `update_media_buy`. This change enables a more streamlined workflow where creatives can be specified upfront at media buy creation time.

## Changes

- **Schema**: Added `creative_ids` array field to Package object in `create-media-buy-request.json`
- **Documentation**: Updated `create_media_buy.md` with parameter table entry and usage examples (both MCP and A2A)

## Test plan

- [x] All schema validation tests pass
- [x] All example validation tests pass
- [x] TypeScript compilation succeeds
- [x] Schema remains backward compatible (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)