### PR TITLE
docs: clarify webhook behavior for async operations

### DIFF
--- a/docs/media-buy/task-reference/create_media_buy.md
+++ b/docs/media-buy/task-reference/create_media_buy.md
@@ -824,18 +824,68 @@ For MCP implementations using polling, use this endpoint to check the status of 
 
 #### Option 2: Webhooks (MCP)
 
-Register a callback URL to receive push notifications:
-```json
-{
-  "tool": "create_media_buy",
-  "arguments": {
-    "buyer_ref": "campaign_2024",
-    "packages": [...],
-    "webhook_url": "https://buyer.example.com/mcp/webhooks",
-    "webhook_auth_token": "bearer-token-xyz"
+Register a callback URL to receive push notifications for long-running operations. Webhooks are ONLY used when the initial response is `submitted`.
+
+**Configuration:**
+```javascript
+const response = await session.call('create_media_buy',
+  {
+    buyer_ref: "campaign_2024",
+    packages: [...]
+  },
+  {
+    webhook_url: "https://buyer.example.com/webhooks/adcp/create_media_buy/agent_id/op_id",
+    webhook_auth: { type: "bearer", credentials: "bearer-token-xyz" }
   }
+);
+```
+
+**Response patterns:**
+- **`completed`** - Synchronous success, webhook NOT called (you have the result)
+- **`working`** - Will complete within ~120s, webhook NOT called (wait for response)
+- **`submitted`** - Long-running operation, webhook WILL be called on status changes
+
+**Example webhook flow (only for `submitted` operations):**
+
+Webhook POST for human approval needed:
+```http
+POST /webhooks/adcp/create_media_buy/agent_id/op_id HTTP/1.1
+Host: buyer.example.com
+Authorization: Bearer bearer-token-xyz
+Content-Type: application/json
+
+{
+  "adcp_version": "1.6.0",
+  "status": "input-required",
+  "task_id": "task_456",
+  "buyer_ref": "campaign_2024",
+  "message": "Campaign budget $150K requires approval to proceed"
 }
 ```
+
+**Webhook POST when complete (after approval - full create_media_buy response):**
+```http
+POST /webhooks/adcp/create_media_buy/agent_id/op_id HTTP/1.1
+Host: buyer.example.com
+Authorization: Bearer bearer-token-xyz
+Content-Type: application/json
+
+{
+  "adcp_version": "1.6.0",
+  "status": "completed",
+  "media_buy_id": "mb_12345",
+  "buyer_ref": "campaign_2024",
+  "creative_deadline": "2024-01-30T23:59:59Z",
+  "packages": [
+    {
+      "package_id": "pkg_001",
+      "buyer_ref": "ctv_package"
+    }
+  ]
+}
+```
+
+Each webhook receives the full response object for that status. See **[Task Management: Webhook Integration](../../protocols/task-management.md#webhook-integration)** for complete details.
 
 ### A2A Status Checking
 

--- a/docs/protocols/task-management.md
+++ b/docs/protocols/task-management.md
@@ -446,34 +446,135 @@ await a2a.send({
 
 Task management integrates with protocol-level webhook configuration for push notifications.
 
-### Webhook Events
+### Webhook Configuration
 
-AdCP sends webhook notifications for task status changes:
+Configure webhooks at the protocol level when making async task calls. See **[Core Concepts: Protocol-Level Webhook Configuration](./core-concepts.md#protocol-level-webhook-configuration)** for complete setup examples.
 
-```json
-{
-  "event_type": "task_status_changed",
-  "task_id": "task_456",
-  "previous_status": "working", 
-  "current_status": "completed",
-  "timestamp": "2025-01-22T10:25:00Z",
-  "task_type": "create_media_buy",
-  "domain": "media-buy",
-  "context": {
-    "buyer_ref": "nike_q1_2025"
-  },
-  "result": {
-    // Included for completed tasks
-    "media_buy_id": "mb_987654321"
+**Quick example:**
+```javascript
+const response = await session.call('create_media_buy',
+  { /* task params */ },
+  {
+    webhook_url: "https://buyer.com/webhooks/adcp/create_media_buy/agent_id/operation_id",
+    webhook_auth: { type: "bearer", credentials: "secret" }
   }
+);
+```
+
+### Webhook POST Format
+
+When a task's status changes, the publisher POSTs the **complete task response object** to your webhook URL.
+
+**Webhook trigger rule:** Webhooks are ONLY used when the initial response status is `submitted` (long-running operations).
+
+**When webhooks are NOT triggered:**
+- Initial response is `completed`, `failed`, or `rejected` → Synchronous response, client already has result
+- Initial response is `working` → Will complete synchronously within ~120 seconds, client should wait for response
+
+**When webhooks ARE triggered (for `submitted` operations only):**
+- Status changes to `input-required` → Webhook called (alerts that human input needed)
+- Status changes to `completed` → Webhook called (final result available)
+- Status changes to `failed` → Webhook called (error details provided)
+- Status changes to `canceled` → Webhook called (cancellation confirmed)
+
+**Example: `input-required` webhook (human approval needed):**
+```http
+POST /webhooks/adcp/create_media_buy/agent_123/op_456 HTTP/1.1
+Host: buyer.example.com
+Authorization: Bearer your-secret-token
+Content-Type: application/json
+
+{
+  "adcp_version": "1.6.0",
+  "status": "input-required",
+  "task_id": "task_456",
+  "buyer_ref": "nike_q1_campaign_2024",
+  "message": "Campaign budget $150K requires VP approval to proceed"
 }
+```
+
+**Example: `completed` webhook (after approval granted - full create_media_buy response):**
+```http
+POST /webhooks/adcp/create_media_buy/agent_123/op_456 HTTP/1.1
+Host: buyer.example.com
+Authorization: Bearer your-secret-token
+Content-Type: application/json
+
+{
+  "adcp_version": "1.6.0",
+  "status": "completed",
+  "media_buy_id": "mb_12345",
+  "buyer_ref": "nike_q1_campaign_2024",
+  "creative_deadline": "2024-01-30T23:59:59Z",
+  "packages": [
+    { "package_id": "pkg_12345_001", "buyer_ref": "nike_ctv_package" }
+  ]
+}
+```
+
+The webhook receives the **full response object** for each status, not just a notification. This means your webhook handler gets all the context and data needed to take appropriate action.
+
+### Webhook Handling Example
+
+```javascript
+app.post('/webhooks/adcp/:task_type/:agent_id/:operation_id', async (req, res) => {
+  const { task_type, agent_id, operation_id } = req.params;
+  const response = req.body;
+
+  // Webhooks are only called for 'submitted' operations
+  // So we only need to handle status changes that occur after submission
+  switch (response.status) {
+    case 'input-required':
+      // Alert human that input is needed
+      await notifyHuman({
+        operation_id,
+        message: response.message,
+        context_id: response.context_id,
+        approval_data: response.data
+      });
+      break;
+
+    case 'completed':
+      // Process the completed operation
+      if (task_type === 'media_buy') {
+        await handleMediaBuyCreated({
+          media_buy_id: response.media_buy_id,
+          buyer_ref: response.buyer_ref,
+          packages: response.packages,
+          creative_deadline: response.creative_deadline
+        });
+      }
+      break;
+
+    case 'failed':
+      // Handle failure
+      await handleOperationFailed({
+        operation_id,
+        error: response.error,
+        message: response.message
+      });
+      break;
+
+    case 'canceled':
+      // Handle cancellation
+      await handleOperationCanceled(operation_id, response.message);
+      break;
+  }
+
+  res.status(200).json({ status: 'processed' });
+});
 ```
 
 ### Webhook Reliability
 
 **Important**: Webhooks use at-least-once delivery semantics and may be duplicated or arrive out of order.
 
-See **[Core Concepts: Webhook Reliability](./core-concepts.md#webhook-reliability)** for detailed implementation guidance including idempotent handlers, sequence handling, security considerations, and polling as backup.
+See **[Core Concepts: Webhook Reliability](./core-concepts.md#webhook-reliability)** for detailed implementation guidance including:
+- Idempotent webhook handlers
+- Sequence handling and out-of-order detection
+- Security considerations (signature verification)
+- Polling as backup mechanism
+- Replay attack prevention
 
 ## Error Handling
 

--- a/docs/signals/tasks/activate_signal.md
+++ b/docs/signals/tasks/activate_signal.md
@@ -185,9 +185,45 @@ data: {"status": {"state": "completed"}, "artifacts": [{
 ```
 
 ### Protocol Transport
-- **MCP**: Returns task_id for polling-based asynchronous operation tracking
+- **MCP**: Returns task_id for polling-based asynchronous operation tracking or webhook-based push notifications
 - **A2A**: Uses Server-Sent Events for real-time progress updates and completion
 - **Data Consistency**: Both protocols contain identical AdCP data structures and version information
+
+### Webhook Support
+
+For long-running activations (when initial response is `submitted`), configure a webhook to receive the complete response when activation completes:
+
+```javascript
+const response = await session.call('activate_signal',
+  {
+    signal_agent_segment_id: "luxury_auto_intenders",
+    platform: "the-trade-desk",
+    account: "agency-123-ttd"
+  },
+  {
+    webhook_url: "https://buyer.com/webhooks/adcp/activate_signal/agent_id/op_id",
+    webhook_auth: { type: "bearer", credentials: "secret-token" }
+  }
+);
+```
+
+When activation completes, you receive the full `activate_signal` response:
+
+```http
+POST /webhooks/adcp/activate_signal/agent_id/op_id HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer secret-token
+
+{
+  "adcp_version": "1.0.0",
+  "status": "deployed",
+  "task_id": "activation_789",
+  "decisioning_platform_segment_id": "ttd_agency123_lux_auto",
+  "deployed_at": "2025-01-15T14:30:00Z"
+}
+```
+
+See **[Task Management: Webhook Integration](../../protocols/task-management.md#webhook-integration)** for complete details on webhook configuration and reliability.
 
 ## Scenarios
 


### PR DESCRIPTION
## Summary
Documents webhook notification format and trigger behavior for asynchronous AdCP operations, addressing confusion about when webhooks are called and what payload format is sent.

## Key Changes

### 🎯 Webhook Trigger Behavior
- **Key rule**: Webhooks are ONLY called when initial response is `submitted`
- `completed`/`failed` responses are synchronous - no webhook needed
- `working` responses complete within ~120s - no webhook, just wait for response
- `submitted` responses are long-running (hours/days) - webhooks will be used

### 📦 Webhook Payload Format
- Webhooks POST the **complete task response object** (not just status notification)
- Each webhook matches the task's response schema exactly
- For `create_media_buy`: full `create-media-buy-response.json` structure
- For `activate_signal`: full `activate-signal-response.json` structure

### 🔗 Webhook URL Pattern
- Use task name in URL: `/webhooks/adcp/{task_name}/{agent_id}/{operation_id}`
- Examples: `/create_media_buy/...`, `/activate_signal/...`
- Enables clear routing based on task type

### 📢 Status Change Notifications
For `submitted` operations, webhooks are called on:
- `input-required` → Human needs to respond/approve
- `completed` → Operation finished successfully  
- `failed` → Operation failed with error details
- `canceled` → Operation was canceled

## Files Modified
- `docs/protocols/core-concepts.md` - Added comprehensive webhook section with examples
- `docs/protocols/task-management.md` - Updated webhook integration documentation
- `docs/media-buy/task-reference/create_media_buy.md` - Clarified webhook flow
- `docs/signals/tasks/activate_signal.md` - Added webhook examples

## Examples Added
- Human-in-the-loop approval flow with webhooks
- Synchronous vs async operation handling
- Complete webhook payload structures matching schemas
- Webhook handler implementation patterns

## Test Results
✅ All schema validation tests passed  
✅ All example validation tests passed  
✅ TypeScript compilation successful  
✅ Documentation build successful