### PR TITLE
fix: keep minimum 1 Fly.io machine running to prevent 502 errors

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,7 @@ primary_region = 'iad'
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [[http_service.checks]]


### PR DESCRIPTION
## Summary
- Updates Fly.io configuration to keep at least one machine running at all times
- Fixes sporadic 502 Bad Gateway errors caused by VM cold starts

## Problem
With `min_machines_running=0`, the Fly.io VM stops during inactivity and causes 502 errors when requests arrive during startup (e.g., schema validation checks, initial page loads).

## Solution
Set `min_machines_running=1` to ensure at least one machine is always active and ready to serve requests.

## Trade-offs
- **Benefit**: Eliminates cold start 502 errors, ensures consistent availability
- **Cost**: Small increase in hosting costs to keep one machine running 24/7

## Test Plan
- [x] Configuration change builds successfully
- [x] All tests pass (schema validation, example validation, typecheck)
- [ ] Deploy to production and verify no more 502 errors
- [ ] Monitor for consistent uptime over 24-48 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)