### PR TITLE
feat: support inline creatives in create_media_buy

### DIFF
--- a/static/schemas/v1/media-buy/package-request.json
+++ b/static/schemas/v1/media-buy/package-request.json
@@ -40,10 +40,18 @@
         },
         "creative_ids": {
           "type": "array",
-          "description": "Creative IDs to assign to this package at creation time",
+          "description": "Creative IDs to assign to this package at creation time (references existing library creatives)",
           "items": {
             "type": "string"
           }
+        },
+        "creatives": {
+          "type": "array",
+          "description": "Full creative objects to upload and assign to this package at creation time (alternative to creative_ids - creatives will be added to library)",
+          "items": {
+            "$ref": "/schemas/v1/core/creative-asset.json"
+          },
+          "maxItems": 100
         }
       },
       "anyOf": [
@@ -87,10 +95,18 @@
         },
         "creative_ids": {
           "type": "array",
-          "description": "Creative IDs to assign to this package at creation time",
+          "description": "Creative IDs to assign to this package at creation time (references existing library creatives)",
           "items": {
             "type": "string"
           }
+        },
+        "creatives": {
+          "type": "array",
+          "description": "Full creative objects to upload and assign to this package at creation time (alternative to creative_ids - creatives will be added to library)",
+          "items": {
+            "$ref": "/schemas/v1/core/creative-asset.json"
+          },
+          "maxItems": 100
         }
       },
       "anyOf": [


### PR DESCRIPTION
## Summary
Add ability to specify full creative manifest directly in `create_media_buy` packages, eliminating the need for a separate `sync_creatives` call.

## Benefits
- **Single API call** reduces latency
- **Atomic operation** - creatives and media buy succeed/fail together  
- **Simpler workflow** for buyers
- **Maintains library model** - creatives are added to library and automatically assigned

## Changes
- ✅ Add optional `creatives` array to `package-request.json` (accepts full `CreativeAsset` objects, max 100)
- ✅ Update `create_media_buy.md` with inline creatives example
- ✅ Clarify `creative_ids` references existing library creatives
- ✅ Maintain backward compatibility with existing `creative_ids` approach

## Example Usage

```json
{
  "buyer_ref": "nike_q1_campaign_2024",
  "packages": [
    {
      "buyer_ref": "nike_ctv_sports_package",
      "product_id": "ctv_sports_premium",
      "format_ids": ["video_standard_30s"],
      "creatives": [
        {
          "creative_id": "hero_video_30s",
          "name": "Nike Air Max Hero 30s",
          "format": "video_standard_30s",
          "snippet": "https://vast.example.com/nike/hero-30s",
          "snippet_type": "vast_url"
        }
      ]
    }
  ],
  "promoted_offering": "Nike Air Max 2024",
  "start_time": "2024-02-01T00:00:00Z",
  "end_time": "2024-03-31T23:59:59Z",
  "budget": {"total": 60000, "currency": "USD"}
}
```

## Test plan
- [x] All schema validation tests pass
- [x] All example validation tests pass  
- [x] TypeScript compilation successful
- [x] Documentation updated with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)