### PR TITLE
Add generative format input/output relationship support

### DIFF
--- a/docs/creative/task-reference/build_creative.md
+++ b/docs/creative/task-reference/build_creative.md
@@ -15,12 +15,63 @@ For information about format IDs and how to reference formats, see [Creative For
 |-----------|------|----------|-------------|
 | `message` | string | Yes | The request message (initial brief or refinement instructions) |
 | `source_format_id` | object | No | Format ID of existing creative to transform (optional - omit when creating from scratch). Object with `agent_url` and `id` fields. |
-| `target_format_id` | object | Yes | Format ID to generate. Object with `agent_url` and `id` fields. The format definition specifies whether output is manifest-based or code-based. |
+| `target_format_id` | object | Yes | Format ID to generate. Object with `agent_url` and `id` fields. For generative formats, this should be the input format (e.g., `300x250_banner_generative`). The creative agent will return a manifest in one of the `output_format_ids`. |
 | `context_id` | string | No | Session context from previous message for continuity |
 | `brand_manifest` | BrandManifest | No | Brand information manifest containing all assets, themes, and information necessary to ensure creatives are aligned with the brand's goals and that the publisher is comfortable with what's being advertised. See [Brand Manifest](../../reference/brand-manifest) for details. |
 | `assets` | array | No | References to asset libraries and specific assets |
 | `preview_options` | object | No | Options for generating preview |
 | `finalize` | boolean | No | Set to true to finalize the creative (default: false) |
+
+## Generative Formats
+
+Generative formats accept high-level inputs (like brand manifests and natural language messages) and produce concrete creative assets in a traffickable output format.
+
+### How It Works
+
+1. **Sales agent** advertises both input and output formats via `list_creative_formats`:
+   - Input format: `300x250_banner_generative` (accepts `brand_manifest` + `message`)
+   - Output format: `300x250_banner_image` (produces actual image asset)
+
+2. **Buyer** calls `build_creative` with the **input format**:
+   ```json
+   {
+     "message": "Create a banner promoting our winter sale",
+     "target_format_id": {
+       "agent_url": "https://creative.adcontextprotocol.org",
+       "id": "300x250_banner_generative"
+     },
+     "brand_manifest": {
+       "url": "https://mybrand.com",
+       "colors": {"primary": "#FF0000"}
+     }
+   }
+   ```
+
+3. **Creative agent** returns a manifest in the **output format**:
+   ```json
+   {
+     "creative_output": {
+       "type": "creative_manifest",
+       "target_format_id": {
+         "agent_url": "https://creative.adcontextprotocol.org",
+         "id": "300x250_banner_image"
+       },
+       "assets": {
+         "banner_creative": {
+           "url": "https://cdn.example.com/generated-banner.png",
+           "width": 300,
+           "height": 250
+         }
+       }
+     }
+   }
+   ```
+
+### Benefits
+
+- **Simpler buyer experience**: Submit brand context instead of designing assets
+- **Format flexibility**: One generative format can output multiple standard formats
+- **Automated creative generation**: AI handles asset creation and composition
 
 ### Message Examples
 

--- a/docs/creative/task-reference/list_creative_formats.md
+++ b/docs/creative/task-reference/list_creative_formats.md
@@ -38,7 +38,7 @@ Buyers can recursively query creative_agents to discover all available formats. 
 
 ```json
 {
-  "adcp_version": "1.6.0",
+  "adcp_version": "1.7.0",
   "agent_url": "https://creative.adcontextprotocol.org",
   "agent_name": "AdCP Reference Creative Agent",
   "capabilities": ["validation", "assembly", "preview"],
@@ -99,7 +99,7 @@ Response:
 
 ```json
 {
-  "adcp_version": "1.6.0",
+  "adcp_version": "1.7.0",
   "agent_url": "https://creative.adcontextprotocol.org",
   "agent_name": "AdCP Reference Creative Agent",
   "capabilities": ["validation", "assembly", "preview"],
@@ -142,7 +142,7 @@ Response:
 
 ```json
 {
-  "adcp_version": "1.6.0",
+  "adcp_version": "1.7.0",
   "agent_url": "https://dco.example.com",
   "agent_name": "Custom DCO Platform",
   "capabilities": ["validation", "assembly", "generation", "preview"],
@@ -182,6 +182,79 @@ Response:
 ```
 
 Response returns all formats with "vertical" in the name.
+
+## Example 4: Generative Format with Output Formats
+
+"What generative formats do you support for 300x250 banners?"
+
+```json
+{
+  "dimensions": "300x250"
+}
+```
+
+Response:
+
+```json
+{
+  "adcp_version": "1.7.0",
+  "agent_url": "https://creative.adcontextprotocol.org",
+  "agent_name": "AdCP Reference Creative Agent",
+  "capabilities": ["validation", "assembly", "generation", "preview"],
+  "formats": [
+    {
+      "format_id": "300x250_banner_generative",
+      "agent_url": "https://creative.adcontextprotocol.org",
+      "name": "300x250 Generative Banner",
+      "type": "display",
+      "category": "custom",
+      "accepts_3p_tags": false,
+      "assets_required": [
+        {
+          "asset_type": "brand_manifest",
+          "asset_role": "brand_context",
+          "required": true
+        },
+        {
+          "asset_type": "text",
+          "asset_role": "message",
+          "required": true,
+          "requirements": {
+            "description": "Natural language description of the creative to generate"
+          }
+        }
+      ],
+      "output_format_ids": ["300x250_banner_image"],
+      "description": "Accepts a brand manifest and message, generates a complete 300x250 banner creative"
+    },
+    {
+      "format_id": "300x250_banner_image",
+      "agent_url": "https://creative.adcontextprotocol.org",
+      "name": "300x250 Standard Banner",
+      "type": "display",
+      "category": "standard",
+      "is_standard": true,
+      "accepts_3p_tags": false,
+      "assets_required": [
+        {
+          "asset_type": "image",
+          "asset_role": "banner_creative",
+          "required": true,
+          "requirements": {
+            "width": 300,
+            "height": 250,
+            "formats": ["jpg", "png", "gif"],
+            "max_file_size_kb": 150
+          }
+        }
+      ],
+      "description": "Standard 300x250 banner accepting a complete creative image"
+    }
+  ]
+}
+```
+
+**Usage**: Sales agents can provide the generative format `300x250_banner_generative` to buyers who submit brand manifests and messages. The creative agent generates creatives in the `300x250_banner_image` format that can be trafficked.
 
 ## Usage Workflow
 

--- a/static/schemas/v1/core/format.json
+++ b/static/schemas/v1/core/format.json
@@ -161,6 +161,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "output_format_ids": {
+      "type": "array",
+      "description": "For generative formats: array of format IDs that this format can generate. When a format accepts inputs like brand_manifest and message, this specifies what concrete output formats can be produced (e.g., a generative banner format might output standard image banner formats).",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": ["format_id", "name", "type"],

--- a/static/schemas/v1/creative/list-creative-formats-response.json
+++ b/static/schemas/v1/creative/list-creative-formats-response.json
@@ -9,7 +9,7 @@
       "type": "string",
       "description": "AdCP schema version used for this response",
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
+      "default": "1.7.0"
     },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",


### PR DESCRIPTION
## Summary
Adds support for generative creative formats that accept high-level inputs (brand manifest + message) and produce concrete creative assets in traffickable output formats.

This enables workflows where:
1. Sales agents advertise generative formats (e.g., `300x250_banner_generative`) that accept `brand_manifest` + `message` as inputs
2. The format specifies which output formats it can produce via `output_format_ids` (e.g., `["300x250_banner_image"]`)
3. Buyers call `build_creative` with the generative format
4. Creative agent returns a manifest in the output format that can be trafficked

## Changes
- **Schema**: Added `output_format_ids` optional array field to `format.json` core schema
- **Documentation**: 
  - Added Example 4 to `list_creative_formats.md` showing the generative format pattern
  - Added "Generative Formats" section to `build_creative.md` explaining the workflow and benefits
- **Version**: No version bump - keeping at 1.7.0 (optional field addition)

## Test Plan
- [x] All schema validation tests pass
- [x] All example validation tests pass
- [x] TypeScript compilation succeeds
- [x] Documentation builds successfully

## Example

```json
{
  "format_id": "300x250_banner_generative",
  "name": "300x250 Generative Banner",
  "type": "display",
  "assets_required": [
    {
      "asset_type": "brand_manifest",
      "asset_role": "brand_context",
      "required": true
    },
    {
      "asset_type": "text",
      "asset_role": "message",
      "required": true
    }
  ],
  "output_format_ids": ["300x250_banner_image"]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)