### PR TITLE
feat: support inline creatives in create_media_buy

### DIFF
--- a/static/schemas/v1/media-buy/package-request.json
+++ b/static/schemas/v1/media-buy/package-request.json
@@ -52,10 +52,18 @@
     },
     "creative_ids": {
       "type": "array",
-      "description": "Creative IDs to assign to this package at creation time",
+      "description": "Creative IDs to assign to this package at creation time (references existing library creatives)",
       "items": {
         "type": "string"
       }
+    },
+    "creatives": {
+      "type": "array",
+      "description": "Full creative objects to upload and assign to this package at creation time (alternative to creative_ids - creatives will be added to library). Supports both static and generative creatives.",
+      "items": {
+        "$ref": "/schemas/v1/core/creative-asset.json"
+      },
+      "maxItems": 100
     }
   },
   "anyOf": [


### PR DESCRIPTION
## Summary
Add ability to specify full creative manifest directly in `create_media_buy` packages, eliminating the need for a separate `sync_creatives` call.

This enhancement is **particularly valuable** with the new generative creative system, allowing buyers to submit both static and AI-generated creatives alongside media buy creation in a single atomic operation.

## Why This Matters Now

The recent additions of:
- ✅ Generative creative formats (#99, #100)
- ✅ Brand manifests (#95)
- ✅ Format discovery with recursive agents (#94)

Make inline creatives **more important than ever**:
- Generative workflows are inherently async - submitting creatives with the media buy simplifies orchestration
- Brand manifest context is already present - generative creatives can leverage it immediately
- Reduces cognitive load - buyers think "campaign + creatives" not "creatives library, then campaign"

## Benefits
- **Single API call** reduces latency and simplifies orchestration
- **Atomic operation** - creatives and media buy succeed/fail together
- **Supports both static and generative** creative workflows in same request
- **Brand context available** - generative creatives leverage brand_manifest automatically
- **Maintains library model** - creatives are added to library and assigned

## Changes
- ✅ Add optional `creatives` array to `package-request.json` (max 100 per package)
- ✅ Update `create_media_buy.md` with comprehensive inline creatives example
- ✅ Show mixed static (video) + generative (display) workflow
- ✅ Clarify `creative_ids` references existing library creatives
- ✅ Full backward compatibility with existing `creative_ids` approach

## Example Usage

### Mixed Static + Generative Creatives

```json
{
  "buyer_ref": "nike_q1_campaign_2024",
  "brand_manifest": {
    "brand": {"name": "Nike", "website": "https://nike.com"},
    "products": [{"sku": "AIR_MAX_2024", "name": "Air Max 2024"}]
  },
  "packages": [
    {
      "buyer_ref": "nike_ctv_package",
      "product_id": "ctv_sports_premium",
      "format_ids": ["video_standard_30s"],
      "budget": 50000,
      "pricing_option_id": "cpm-fixed-sports",
      "creatives": [
        {
          "creative_id": "hero_video_30s",
          "name": "Air Max Hero Video",
          "format_id": {
            "agent_url": "https://creative.adcontextprotocol.org",
            "id": "video_standard_30s"
          },
          "assets": {
            "video": {
              "asset_type": "video",
              "url": "https://cdn.nike.com/hero-30s.mp4",
              "width": 1920,
              "height": 1080,
              "duration_ms": 30000
            }
          }
        }
      ]
    },
    {
      "buyer_ref": "nike_display_package",
      "product_id": "display_premium",
      "format_ids": ["premium_bespoke_display"],
      "budget": 30000,
      "pricing_option_id": "cpm-fixed-display",
      "creatives": [
        {
          "creative_id": "hero_display_generative",
          "name": "Air Max Display (AI Generated)",
          "format_id": {
            "agent_url": "https://publisher.com/.well-known/adcp/sales",
            "id": "premium_bespoke_display"
          },
          "assets": {
            "promoted_offerings": {
              "asset_type": "promoted_offerings",
              "url": "https://nike.com/air-max",
              "colors": {"primary": "#111111", "secondary": "#FFFFFF"}
            },
            "generation_prompt": {
              "asset_type": "text",
              "content": "Create bold athletic display ad for runners 25-45"
            }
          }
        }
      ]
    }
  ],
  "start_time": "asap",
  "end_time": "2024-03-31T23:59:59Z",
  "budget": 80000
}
```

**Result**: Single API call creates media buy, uploads static video, submits generative display for creation, and assigns both to packages.

## Test plan
- [x] All schema validation tests pass (115 schemas validated)
- [x] All example validation tests pass
- [x] TypeScript compilation successful
- [x] Documentation includes comprehensive example with both static and generative creatives
- [x] Demonstrates brand manifest integration with generative workflow

## Related PRs
- Builds on #99 (generative creative support)
- Leverages #95 (brand manifest)
- Complements #100 (format input/output relationships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)