### PR TITLE
Add brand manifest URL reference support

### DIFF
--- a/docs/creative/task-reference/build_creative.md
+++ b/docs/creative/task-reference/build_creative.md
@@ -17,7 +17,7 @@ For information about format IDs and how to reference formats, see [Creative For
 | `source_format_id` | object | No | Format ID of existing creative to transform (optional - omit when creating from scratch). Object with `agent_url` and `id` fields. |
 | `target_format_id` | object | Yes | Format ID to generate. Object with `agent_url` and `id` fields. For generative formats, this should be the input format (e.g., `300x250_banner_generative`). The creative agent will return a manifest in one of the `output_format_ids`. |
 | `context_id` | string | No | Session context from previous message for continuity |
-| `brand_manifest` | BrandManifest | No | Brand information manifest containing all assets, themes, and information necessary to ensure creatives are aligned with the brand's goals and that the publisher is comfortable with what's being advertised. See [Brand Manifest](../../reference/brand-manifest) for details. |
+| `brand_manifest` | BrandManifestRef | No | Brand information manifest containing all assets, themes, and information necessary to ensure creatives are aligned with the brand's goals and that the publisher is comfortable with what's being advertised. Can be provided as an inline object or URL reference to a hosted manifest. See [Brand Manifest](../../reference/brand-manifest) for details. |
 | `assets` | array | No | References to asset libraries and specific assets |
 | `preview_options` | object | No | Options for generating preview |
 | `finalize` | boolean | No | Set to true to finalize the creative (default: false) |
@@ -33,6 +33,8 @@ Generative formats accept high-level inputs (like brand manifests and natural la
    - Output format: `300x250_banner_image` (produces actual image asset)
 
 2. **Buyer** calls `build_creative` with the **input format**:
+
+   **Option A: Inline brand manifest**
    ```json
    {
      "message": "Create a banner promoting our winter sale",
@@ -44,6 +46,18 @@ Generative formats accept high-level inputs (like brand manifests and natural la
        "url": "https://mybrand.com",
        "colors": {"primary": "#FF0000"}
      }
+   }
+   ```
+
+   **Option B: URL string to hosted manifest**
+   ```json
+   {
+     "message": "Create a banner promoting our winter sale",
+     "target_format_id": {
+       "agent_url": "https://creative.adcontextprotocol.org",
+       "id": "300x250_banner_generative"
+     },
+     "brand_manifest": "https://cdn.mybrand.com/brand-manifest.json"
    }
    ```
 

--- a/docs/media-buy/task-reference/create_media_buy.md
+++ b/docs/media-buy/task-reference/create_media_buy.md
@@ -21,7 +21,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this media buy |
 | `packages` | Package[] | Yes | Array of package configurations (see Package Object below) |
-| `brand_manifest` | BrandCard | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be cached and reused across multiple requests. See [Brand Manifest](../../reference/brand-manifest) for details. |
+| `brand_manifest` | BrandManifestRef | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided as an inline object or URL reference to a hosted manifest. Can be cached and reused across multiple requests. See [Brand Manifest](../../reference/brand-manifest) for details. |
 | `promoted_products` | PromotedProducts | No | Products or offerings being promoted in this media buy. Useful for campaign-level reporting, policy compliance, and publisher understanding of what's being advertised. Selects from brand manifest's product catalog using SKUs, tags, categories, or natural language queries. |
 | `promoted_offering` | string | No | **DEPRECATED**: Use `brand_manifest` with `promoted_products` instead. Legacy field for describing what is being promoted. |
 | `po_number` | string | No | Purchase order number for tracking |

--- a/static/schemas/v1/core/brand-manifest-ref.json
+++ b/static/schemas/v1/core/brand-manifest-ref.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/core/brand-manifest-ref.json",
+  "title": "Brand Manifest Reference",
+  "description": "Brand manifest provided either as an inline object or a URL string pointing to a hosted manifest",
+  "oneOf": [
+    {
+      "$ref": "/schemas/v1/core/brand-manifest.json",
+      "description": "Inline brand manifest object"
+    },
+    {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to a hosted brand manifest JSON file. The manifest at this URL must conform to the brand-manifest.json schema."
+    }
+  ],
+  "examples": [
+    {
+      "description": "Inline brand manifest",
+      "data": {
+        "url": "https://acmecorp.com",
+        "name": "ACME Corporation",
+        "colors": {
+          "primary": "#FF6B35"
+        }
+      }
+    },
+    {
+      "description": "URL string reference to hosted manifest",
+      "data": "https://cdn.acmecorp.com/brand-manifest.json"
+    }
+  ]
+}

--- a/static/schemas/v1/core/promoted-offerings.json
+++ b/static/schemas/v1/core/promoted-offerings.json
@@ -6,8 +6,8 @@
   "type": "object",
   "properties": {
     "brand_manifest": {
-      "$ref": "/schemas/v1/core/brand-manifest.json",
-      "description": "Brand information manifest containing assets, themes, and guidelines"
+      "$ref": "/schemas/v1/core/brand-manifest-ref.json",
+      "description": "Brand information manifest containing assets, themes, and guidelines. Can be provided inline or as a URL reference to a hosted manifest."
     },
     "product_selectors": {
       "$ref": "/schemas/v1/core/promoted-products.json",

--- a/static/schemas/v1/index.json
+++ b/static/schemas/v1/index.json
@@ -87,6 +87,10 @@
           "$ref": "/schemas/v1/core/brand-manifest.json",
           "description": "Standardized brand information manifest for creative generation and media buying"
         },
+        "brand-manifest-ref": {
+          "$ref": "/schemas/v1/core/brand-manifest-ref.json",
+          "description": "Brand manifest reference (inline object or URL)"
+        },
         "promoted-products": {
           "$ref": "/schemas/v1/core/promoted-products.json",
           "description": "Product or offering selection for campaigns with multiple selection methods"

--- a/static/schemas/v1/media-buy/create-media-buy-request.json
+++ b/static/schemas/v1/media-buy/create-media-buy-request.json
@@ -23,8 +23,8 @@
       }
     },
     "brand_manifest": {
-      "$ref": "/schemas/v1/core/brand-manifest.json",
-      "description": "Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be cached and reused across multiple requests."
+      "$ref": "/schemas/v1/core/brand-manifest-ref.json",
+      "description": "Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided inline or as a URL reference to a hosted manifest. Can be cached and reused across multiple requests."
     },
     "promoted_offering": {
       "type": "string",


### PR DESCRIPTION
## Summary

Enable brand manifests to be specified either as **inline JSON objects** or as **URL strings** pointing to hosted manifest files. This provides a cleaner, more intuitive API design with the union type at the correct level.

## Changes

### Schema Updates
- ✅ Added `brand-manifest-ref.json` union schema (`oneOf[object, string]`)
- ✅ Updated `create-media-buy-request.json` to use union type
- ✅ Updated `promoted-offerings.json` to use union type  
- ✅ Added new schema to registry

### Documentation Updates
- ✅ Updated `brand-manifest.md` with both usage patterns
- ✅ Updated `create_media_buy.md` task reference
- ✅ Updated `build_creative.md` with examples showing both approaches

## Usage Examples

**Inline object (existing pattern):**
```json
{
  "brand_manifest": {
    "url": "https://acmecorp.com",
    "name": "ACME Corp",
    "colors": {"primary": "#FF6B35"}
  }
}
```

**URL string (new pattern):**
```json
{
  "brand_manifest": "https://cdn.acmecorp.com/brand-manifest.json"
}
```

## Benefits

- **Clearer API**: Union at top level avoids confusion between `brand_manifest.url` (brand's website) and manifest URL
- **Simpler**: Just pass a string URL instead of `{manifest_url: "..."}`
- **Centralized management**: Update brand information in one place
- **Version control**: Track changes to brand guidelines
- **Reduced payload size**: Large manifests don't bloat every request
- **CDN caching**: Leverage edge caching for faster access

## Testing

- ✅ All schema validation tests pass
- ✅ All example validation tests pass
- ✅ TypeScript type checking passes
- ✅ Pre-commit hooks pass

## Notes

- Versions kept at existing values per reviewer request (1.6.1 for create-media-buy, 1.8.0 for registry)
- Fully backward compatible - inline objects continue to work exactly as before