### PR TITLE
Make brand_manifest optional for backwards compatibility

### DIFF
--- a/static/schemas/v1/media-buy/create-media-buy-request.json
+++ b/static/schemas/v1/media-buy/create-media-buy-request.json
@@ -76,6 +76,14 @@
       ]
     }
   },
-  "required": ["buyer_ref", "packages", "brand_manifest", "start_time", "end_time", "budget"],
+  "required": ["buyer_ref", "packages", "start_time", "end_time", "budget"],
+  "oneOf": [
+    {
+      "required": ["promoted_offering"]
+    },
+    {
+      "required": ["brand_manifest"]
+    }
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/get-products-request.json
+++ b/static/schemas/v1/media-buy/get-products-request.json
@@ -17,7 +17,11 @@
     },
     "promoted_offering": {
       "type": "string",
-      "description": "Description of advertiser and what is being promoted"
+      "description": "DEPRECATED: Use brand_manifest instead. Legacy field for describing what is being promoted."
+    },
+    "brand_manifest": {
+      "$ref": "/schemas/v1/core/brand-manifest-ref.json",
+      "description": "Brand information manifest providing brand context, assets, and product catalog. Can be provided inline or as a URL reference to a hosted manifest."
     },
     "filters": {
       "type": "object",
@@ -58,6 +62,13 @@
       "additionalProperties": false
     }
   },
-  "required": ["promoted_offering"],
+  "oneOf": [
+    {
+      "required": ["promoted_offering"]
+    },
+    {
+      "required": ["brand_manifest"]
+    }
+  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- Update `get_products` and `create_media_buy` schemas to accept either `promoted_offering` OR `brand_manifest`
- Mark `promoted_offering` as deprecated in favor of `brand_manifest`
- Ensures backwards compatibility with existing integrations

## Changes
- `get_products`: Added optional `brand_manifest` field, requires one of `promoted_offering` or `brand_manifest` via `oneOf`
- `create_media_buy`: Made `brand_manifest` optional, requires one of `promoted_offering` or `brand_manifest` via `oneOf`

## Test plan
- [x] Schema validation tests pass
- [x] Example validation tests pass
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)