### PR TITLE
Remove redundant adcp_version fields and adopt path-based versioning

### DIFF
--- a/static/schemas/v1/core/tasks-get-request.json
+++ b/static/schemas/v1/core/tasks-get-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for retrieving a specific task by ID with optional conversation history across all AdCP domains",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "task_id": {
       "type": "string",
       "description": "Unique identifier of the task to retrieve"

--- a/static/schemas/v1/core/tasks-get-response.json
+++ b/static/schemas/v1/core/tasks-get-response.json
@@ -5,11 +5,6 @@
   "description": "Response containing detailed information about a specific task including status and optional conversation history across all AdCP domains",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable status message for this task"
@@ -146,6 +141,6 @@
       }
     }
   },
-  "required": ["adcp_version", "message", "task_id", "task_type", "domain", "status", "created_at", "updated_at"],
+  "required": ["message", "task_id", "task_type", "domain", "status", "created_at", "updated_at"],
   "additionalProperties": false
 }

--- a/static/schemas/v1/core/tasks-list-request.json
+++ b/static/schemas/v1/core/tasks-list-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for listing and filtering async tasks across all AdCP domains with state reconciliation capabilities",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "filters": {
       "type": "object",
       "description": "Filter criteria for querying tasks",
@@ -18,14 +12,20 @@
         "domain": {
           "type": "string",
           "description": "Filter by single AdCP domain",
-          "enum": ["media-buy", "signals"]
+          "enum": [
+            "media-buy",
+            "signals"
+          ]
         },
         "domains": {
           "type": "array",
           "description": "Filter by multiple AdCP domains",
           "items": {
             "type": "string",
-            "enum": ["media-buy", "signals"]
+            "enum": [
+              "media-buy",
+              "signals"
+            ]
           }
         },
         "status": {
@@ -42,14 +42,26 @@
         "task_type": {
           "type": "string",
           "description": "Filter by single task type",
-          "enum": ["create_media_buy", "update_media_buy", "sync_creatives", "activate_signal", "get_signals"]
+          "enum": [
+            "create_media_buy",
+            "update_media_buy",
+            "sync_creatives",
+            "activate_signal",
+            "get_signals"
+          ]
         },
         "task_types": {
           "type": "array",
           "description": "Filter by multiple task types",
           "items": {
             "type": "string",
-            "enum": ["create_media_buy", "update_media_buy", "sync_creatives", "activate_signal", "get_signals"]
+            "enum": [
+              "create_media_buy",
+              "update_media_buy",
+              "sync_creatives",
+              "activate_signal",
+              "get_signals"
+            ]
           }
         },
         "created_after": {
@@ -97,13 +109,22 @@
       "properties": {
         "field": {
           "type": "string",
-          "enum": ["created_at", "updated_at", "status", "task_type", "domain"],
+          "enum": [
+            "created_at",
+            "updated_at",
+            "status",
+            "task_type",
+            "domain"
+          ],
           "default": "created_at",
           "description": "Field to sort by"
         },
         "direction": {
           "type": "string",
-          "enum": ["asc", "desc"],
+          "enum": [
+            "asc",
+            "desc"
+          ],
           "default": "desc",
           "description": "Sort direction"
         }
@@ -142,7 +163,11 @@
       "description": "List all pending tasks across domains",
       "data": {
         "filters": {
-          "statuses": ["submitted", "working", "input-required"]
+          "statuses": [
+            "submitted",
+            "working",
+            "input-required"
+          ]
         }
       }
     },
@@ -151,7 +176,10 @@
       "data": {
         "filters": {
           "domain": "media-buy",
-          "statuses": ["input-required", "failed"]
+          "statuses": [
+            "input-required",
+            "failed"
+          ]
         },
         "sort": {
           "field": "updated_at",

--- a/static/schemas/v1/core/tasks-list-response.json
+++ b/static/schemas/v1/core/tasks-list-response.json
@@ -5,11 +5,6 @@
   "description": "Response from task listing query with filtered results and state reconciliation data across all AdCP domains",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable result message summarizing task query results"
@@ -73,14 +68,23 @@
             },
             "direction": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           },
-          "required": ["field", "direction"],
+          "required": [
+            "field",
+            "direction"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["total_matching", "returned"],
+      "required": [
+        "total_matching",
+        "returned"
+      ],
       "additionalProperties": false
     },
     "tasks": {
@@ -96,12 +100,21 @@
           "task_type": {
             "type": "string",
             "description": "Type of AdCP operation",
-            "enum": ["create_media_buy", "update_media_buy", "sync_creatives", "activate_signal", "get_signals"]
+            "enum": [
+              "create_media_buy",
+              "update_media_buy",
+              "sync_creatives",
+              "activate_signal",
+              "get_signals"
+            ]
           },
           "domain": {
             "type": "string",
             "description": "AdCP domain this task belongs to",
-            "enum": ["media-buy", "signals"]
+            "enum": [
+              "media-buy",
+              "signals"
+            ]
           },
           "status": {
             "$ref": "/schemas/v1/enums/task-status.json",
@@ -131,7 +144,15 @@
             "description": "Whether this task has webhook configuration"
           }
         },
-        "required": ["task_id", "task_type", "domain", "status", "created_at", "updated_at", "message"],
+        "required": [
+          "task_id",
+          "task_type",
+          "domain",
+          "status",
+          "created_at",
+          "updated_at",
+          "message"
+        ],
         "additionalProperties": false
       }
     },
@@ -145,7 +166,7 @@
           "minimum": 1
         },
         "offset": {
-          "type": "integer", 
+          "type": "integer",
           "description": "Offset that was applied to this query",
           "minimum": 0
         },
@@ -159,10 +180,19 @@
           "minimum": 0
         }
       },
-      "required": ["limit", "offset", "has_more"],
+      "required": [
+        "limit",
+        "offset",
+        "has_more"
+      ],
       "additionalProperties": false
     }
   },
-  "required": ["adcp_version", "message", "query_summary", "tasks", "pagination"],
+  "required": [
+    "message",
+    "query_summary",
+    "tasks",
+    "pagination"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/creative/list-creative-formats-request.json
+++ b/static/schemas/v1/creative/list-creative-formats-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for discovering creative formats provided by this creative agent",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "format_ids": {
       "type": "array",
       "description": "Return only these specific format IDs",
@@ -21,14 +15,27 @@
     "type": {
       "type": "string",
       "description": "Filter by format type (technical categories with distinct requirements)",
-      "enum": ["audio", "video", "display", "dooh"]
+      "enum": [
+        "audio",
+        "video",
+        "display",
+        "dooh"
+      ]
     },
     "asset_types": {
       "type": "array",
       "description": "Filter to formats that include these asset types. For third-party tags, search for 'html' or 'javascript'. E.g., ['image', 'text'] returns formats with images and text, ['javascript'] returns formats accepting JavaScript tags.",
       "items": {
         "type": "string",
-        "enum": ["image", "video", "audio", "text", "html", "javascript", "url"]
+        "enum": [
+          "image",
+          "video",
+          "audio",
+          "text",
+          "html",
+          "javascript",
+          "url"
+        ]
       }
     },
     "max_width": {

--- a/static/schemas/v1/creative/list-creative-formats-response.json
+++ b/static/schemas/v1/creative/list-creative-formats-response.json
@@ -5,16 +5,9 @@
   "description": "Response payload for list_creative_formats task from creative agent - returns full format definitions",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.7.0"
-    },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
-      "description": "Current task state",
-      "default": "completed"
+      "description": "Current task state"
     },
     "formats": {
       "type": "array",
@@ -43,11 +36,18 @@
             "description": "Capabilities this creative agent provides",
             "items": {
               "type": "string",
-              "enum": ["validation", "assembly", "generation", "preview"]
+              "enum": [
+                "validation",
+                "assembly",
+                "generation",
+                "preview"
+              ]
             }
           }
         },
-        "required": ["agent_url"]
+        "required": [
+          "agent_url"
+        ]
       }
     },
     "errors": {
@@ -58,6 +58,8 @@
       }
     }
   },
-  "required": ["adcp_version", "formats"],
+  "required": [
+    "formats"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/creative/preview-creative-request.json
+++ b/static/schemas/v1/creative/preview-creative-request.json
@@ -5,12 +5,6 @@
   "description": "Request to generate a preview of a creative manifest in a specific format",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.0.0"
-    },
     "format_id": {
       "type": "string",
       "description": "Format identifier for rendering the preview"
@@ -41,7 +35,9 @@
             "description": "Natural language description of the context for AI-generated content (e.g., 'User just searched for running shoes', 'Podcast discussing weather patterns', 'Article about electric vehicles')"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -54,6 +50,9 @@
       "description": "Complete offering specification for dynamic creative previews - includes brand manifest, product selectors, inline offerings, and asset filters"
     }
   },
-  "required": ["format_id", "creative_manifest"],
+  "required": [
+    "format_id",
+    "creative_manifest"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/creative/preview-creative-response.json
+++ b/static/schemas/v1/creative/preview-creative-response.json
@@ -5,11 +5,6 @@
   "description": "Response containing preview links for a creative. Each preview URL returns an HTML page that can be embedded in an iframe to display the rendered creative.",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "previews": {
       "type": "array",
       "description": "Array of preview variants. Each preview corresponds to an input set from the request. If no inputs were provided, returns a single default preview.",
@@ -41,7 +36,9 @@
                 "description": "Context description applied to this variant"
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           },
           "hints": {
             "type": "object",
@@ -49,7 +46,12 @@
             "properties": {
               "primary_media_type": {
                 "type": "string",
-                "enum": ["image", "video", "audio", "interactive"],
+                "enum": [
+                  "image",
+                  "video",
+                  "audio",
+                  "interactive"
+                ],
                 "description": "Primary media type contained in the preview (for optimization only)"
               },
               "estimated_dimensions": {
@@ -65,7 +67,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["width", "height"]
+                "required": [
+                  "width",
+                  "height"
+                ]
               },
               "estimated_duration_seconds": {
                 "type": "number",
@@ -105,7 +110,10 @@
             }
           }
         },
-        "required": ["preview_url", "input"]
+        "required": [
+          "preview_url",
+          "input"
+        ]
       },
       "minItems": 1
     },
@@ -120,6 +128,9 @@
       "description": "ISO 8601 timestamp when preview links expire"
     }
   },
-  "required": ["adcp_version", "previews", "expires_at"],
+  "required": [
+    "previews",
+    "expires_at"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/index.json
+++ b/static/schemas/v1/index.json
@@ -7,9 +7,9 @@
   "adcp_version": "1.8.0",
   "standard_formats_version": "1.0.0",
   "versioning": {
-    "note": "All request/response schemas include adcp_version field. Compatibility follows semantic versioning rules."
+    "note": "AdCP uses path-based versioning. The schema URL path (/schemas/v1/) indicates the version. Individual request/response schemas do NOT include adcp_version fields. Compatibility follows semantic versioning rules."
   },
-  "lastUpdated": "2025-10-12",
+  "lastUpdated": "2025-10-13",
   "baseUrl": "/schemas/v1",
   "schemas": {
     "core": {

--- a/static/schemas/v1/media-buy/build-creative-request.json
+++ b/static/schemas/v1/media-buy/build-creative-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for building creative assets using AI-powered creative generation",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "message": {
       "type": "string",
       "description": "Natural language description of the creative brief or requirements"
@@ -31,6 +25,9 @@
       }
     }
   },
-  "required": ["message", "target_format_id"],
+  "required": [
+    "message",
+    "target_format_id"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/build-creative-response.json
+++ b/static/schemas/v1/media-buy/build-creative-response.json
@@ -5,11 +5,6 @@
   "description": "Response payload for build_creative task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "context_id": {
       "type": "string",
       "description": "Context identifier for iterative refinement"
@@ -22,15 +17,28 @@
           "type": "object",
           "description": "Format specification used for this creative",
           "properties": {
-            "id": {"type": "string"},
-            "name": {"type": "string"},
-            "type": {"type": "string"}
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
           },
-          "required": ["id", "name", "type"]
+          "required": [
+            "id",
+            "name",
+            "type"
+          ]
         },
         "output_mode": {
           "type": "string",
-          "enum": ["manifest", "code"],
+          "enum": [
+            "manifest",
+            "code"
+          ],
           "description": "Type of creative output generated"
         },
         "security_requirements": {
@@ -43,7 +51,9 @@
             },
             "sandbox_attributes": {
               "type": "array",
-              "items": {"type": "string"},
+              "items": {
+                "type": "string"
+              },
               "description": "Required iframe sandbox attributes"
             },
             "xss_protection": {
@@ -51,14 +61,19 @@
               "description": "XSS protection must be enabled"
             }
           },
-          "required": ["content_security_policy", "xss_protection"]
+          "required": [
+            "content_security_policy",
+            "xss_protection"
+          ]
         }
       },
       "allOf": [
         {
           "if": {
             "properties": {
-              "output_mode": {"const": "manifest"}
+              "output_mode": {
+                "const": "manifest"
+              }
             }
           },
           "then": {
@@ -74,19 +89,29 @@
                 "type": "object",
                 "description": "Creative layout and composition instructions",
                 "properties": {
-                  "composition": {"type": "string"},
-                  "positioning": {"type": "object"},
-                  "animations": {"type": "array"}
+                  "composition": {
+                    "type": "string"
+                  },
+                  "positioning": {
+                    "type": "object"
+                  },
+                  "animations": {
+                    "type": "array"
+                  }
                 }
               }
             },
-            "required": ["assets"]
+            "required": [
+              "assets"
+            ]
           }
         },
         {
           "if": {
             "properties": {
-              "output_mode": {"const": "code"}
+              "output_mode": {
+                "const": "code"
+              }
             }
           },
           "then": {
@@ -95,10 +120,18 @@
                 "type": "object",
                 "description": "Executable creative code",
                 "properties": {
-                  "html": {"type": "string"},
-                  "css": {"type": "string"},
-                  "javascript": {"type": "string"},
-                  "preview_url": {"type": "string"}
+                  "html": {
+                    "type": "string"
+                  },
+                  "css": {
+                    "type": "string"
+                  },
+                  "javascript": {
+                    "type": "string"
+                  },
+                  "preview_url": {
+                    "type": "string"
+                  }
                 }
               },
               "dynamic_elements": {
@@ -107,18 +140,29 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "element_id": {"type": "string"},
-                    "type": {"type": "string"},
-                    "data_source": {"type": "string"}
+                    "element_id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "data_source": {
+                      "type": "string"
+                    }
                   }
                 }
               }
             },
-            "required": ["code"]
+            "required": [
+              "code"
+            ]
           }
         }
       ],
-      "required": ["format", "output_mode"]
+      "required": [
+        "format",
+        "output_mode"
+      ]
     },
     "suggestions": {
       "type": "array",
@@ -128,26 +172,44 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["variation", "improvement", "format_adaptation"]
+            "enum": [
+              "variation",
+              "improvement",
+              "format_adaptation"
+            ]
           },
-          "description": {"type": "string"},
-          "prompt": {"type": "string"}
+          "description": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          }
         },
-        "required": ["type", "description", "prompt"]
+        "required": [
+          "type",
+          "description",
+          "prompt"
+        ]
       }
     },
     "performance_insights": {
       "type": "object",
       "description": "AI-generated insights about creative performance potential",
       "properties": {
-        "predicted_ctr": {"type": "number"},
+        "predicted_ctr": {
+          "type": "number"
+        },
         "engagement_factors": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "optimization_opportunities": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -159,6 +221,9 @@
       }
     }
   },
-  "required": ["adcp_version", "context_id", "creative"],
+  "required": [
+    "context_id",
+    "creative"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/create-media-buy-request.json
+++ b/static/schemas/v1/media-buy/create-media-buy-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for creating a media buy",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.1"
-    },
     "buyer_ref": {
       "type": "string",
       "description": "Buyer's reference identifier for this media buy"
@@ -58,7 +52,11 @@
           "properties": {
             "reporting_frequency": {
               "type": "string",
-              "enum": ["hourly", "daily", "monthly"],
+              "enum": [
+                "hourly",
+                "daily",
+                "monthly"
+              ],
               "description": "Frequency for automated reporting delivery. Must be supported by all products in the media buy."
             },
             "requested_metrics": {
@@ -66,23 +64,45 @@
               "description": "Optional list of metrics to include in webhook notifications. If omitted, all available metrics are included. Must be subset of product's available_metrics.",
               "items": {
                 "type": "string",
-                "enum": ["impressions", "spend", "clicks", "ctr", "video_completions", "completion_rate", "conversions", "viewability", "engagement_rate"]
+                "enum": [
+                  "impressions",
+                  "spend",
+                  "clicks",
+                  "ctr",
+                  "video_completions",
+                  "completion_rate",
+                  "conversions",
+                  "viewability",
+                  "engagement_rate"
+                ]
               },
               "uniqueItems": true
             }
           },
-          "required": ["reporting_frequency"]
+          "required": [
+            "reporting_frequency"
+          ]
         }
       ]
     }
   },
-  "required": ["buyer_ref", "packages", "start_time", "end_time", "budget"],
+  "required": [
+    "buyer_ref",
+    "packages",
+    "start_time",
+    "end_time",
+    "budget"
+  ],
   "oneOf": [
     {
-      "required": ["promoted_offering"]
+      "required": [
+        "promoted_offering"
+      ]
     },
     {
-      "required": ["brand_manifest"]
+      "required": [
+        "brand_manifest"
+      ]
     }
   ],
   "additionalProperties": false

--- a/static/schemas/v1/media-buy/create-media-buy-response.json
+++ b/static/schemas/v1/media-buy/create-media-buy-response.json
@@ -5,12 +5,6 @@
   "description": "Response payload for create_media_buy task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.1"
-    },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
       "description": "Current task state - 'completed' for immediate success, 'working' for operations under 120s, 'submitted' for long-running operations, 'input-required' if approval needed"
@@ -47,7 +41,10 @@
             "description": "Buyer's reference identifier for the package"
           }
         },
-        "required": ["package_id", "buyer_ref"],
+        "required": [
+          "package_id",
+          "buyer_ref"
+        ],
         "additionalProperties": false
       }
     },
@@ -59,6 +56,9 @@
       }
     }
   },
-  "required": ["adcp_version", "status", "buyer_ref"],
+  "required": [
+    "status",
+    "buyer_ref"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/get-media-buy-delivery-request.json
+++ b/static/schemas/v1/media-buy/get-media-buy-delivery-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for retrieving comprehensive delivery metrics",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "media_buy_ids": {
       "type": "array",
       "description": "Array of publisher media buy IDs to get delivery data for",
@@ -29,13 +23,26 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["active", "pending", "paused", "completed", "failed", "all"]
+          "enum": [
+            "active",
+            "pending",
+            "paused",
+            "completed",
+            "failed",
+            "all"
+          ]
         },
         {
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["active", "pending", "paused", "completed", "failed"]
+            "enum": [
+              "active",
+              "pending",
+              "paused",
+              "completed",
+              "failed"
+            ]
           }
         }
       ],

--- a/static/schemas/v1/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/v1/media-buy/get-media-buy-delivery-response.json
@@ -5,14 +5,14 @@
   "description": "Response payload for get_media_buy_delivery task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "notification_type": {
       "type": "string",
-      "enum": ["scheduled", "final", "delayed", "adjusted"],
+      "enum": [
+        "scheduled",
+        "final",
+        "delayed",
+        "adjusted"
+      ],
       "description": "Type of webhook notification (only present in webhook deliveries): scheduled = regular periodic update, final = campaign completed, delayed = data not yet available, adjusted = resending period with updated data"
     },
     "partial_data": {
@@ -49,7 +49,10 @@
           "description": "ISO 8601 end timestamp in UTC (e.g., 2024-02-05T23:59:59Z)"
         }
       },
-      "required": ["start", "end"],
+      "required": [
+        "start",
+        "end"
+      ],
       "additionalProperties": false
     },
     "currency": {
@@ -87,7 +90,11 @@
           "minimum": 0
         }
       },
-      "required": ["impressions", "spend", "media_buy_count"],
+      "required": [
+        "impressions",
+        "spend",
+        "media_buy_count"
+      ],
       "additionalProperties": false
     },
     "media_buy_deliveries": {
@@ -107,7 +114,14 @@
           "status": {
             "type": "string",
             "description": "Current media buy status. In webhook context, reporting_delayed indicates data temporarily unavailable.",
-            "enum": ["pending", "active", "paused", "completed", "failed", "reporting_delayed"]
+            "enum": [
+              "pending",
+              "active",
+              "paused",
+              "completed",
+              "failed",
+              "reporting_delayed"
+            ]
           },
           "message": {
             "type": "string",
@@ -141,7 +155,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["spend"]
+                "required": [
+                  "spend"
+                ]
               }
             ]
           },
@@ -170,7 +186,10 @@
                       "minimum": 0
                     }
                   },
-                  "required": ["package_id", "spend"]
+                  "required": [
+                    "package_id",
+                    "spend"
+                  ]
                 }
               ]
             }
@@ -197,12 +216,21 @@
                   "minimum": 0
                 }
               },
-              "required": ["date", "impressions", "spend"],
+              "required": [
+                "date",
+                "impressions",
+                "spend"
+              ],
               "additionalProperties": false
             }
           }
         },
-        "required": ["media_buy_id", "status", "totals", "by_package"],
+        "required": [
+          "media_buy_id",
+          "status",
+          "totals",
+          "by_package"
+        ],
         "additionalProperties": false
       }
     },
@@ -214,6 +242,10 @@
       }
     }
   },
-  "required": ["adcp_version", "reporting_period", "currency", "media_buy_deliveries"],
+  "required": [
+    "reporting_period",
+    "currency",
+    "media_buy_deliveries"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/get-products-request.json
+++ b/static/schemas/v1/media-buy/get-products-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for discovering available advertising products",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "brief": {
       "type": "string",
       "description": "Natural language description of campaign requirements"
@@ -39,7 +33,11 @@
           "description": "Filter by format types",
           "items": {
             "type": "string",
-            "enum": ["video", "display", "audio"]
+            "enum": [
+              "video",
+              "display",
+              "audio"
+            ]
           }
         },
         "format_ids": {
@@ -64,10 +62,14 @@
   },
   "oneOf": [
     {
-      "required": ["promoted_offering"]
+      "required": [
+        "promoted_offering"
+      ]
     },
     {
-      "required": ["brand_manifest"]
+      "required": [
+        "brand_manifest"
+      ]
     }
   ],
   "additionalProperties": false

--- a/static/schemas/v1/media-buy/get-products-response.json
+++ b/static/schemas/v1/media-buy/get-products-response.json
@@ -5,16 +5,9 @@
   "description": "Response payload for get_products task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
-      "description": "Current task state",
-      "default": "completed"
+      "description": "Current task state"
     },
     "products": {
       "type": "array",
@@ -31,6 +24,8 @@
       }
     }
   },
-  "required": ["adcp_version", "products"],
+  "required": [
+    "products"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/list-authorized-properties-request.json
+++ b/static/schemas/v1/media-buy/list-authorized-properties-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for discovering all properties this agent is authorized to represent",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.0.0"
-    },
     "tags": {
       "type": "array",
       "description": "Filter properties by specific tags (optional)",

--- a/static/schemas/v1/media-buy/list-authorized-properties-response.json
+++ b/static/schemas/v1/media-buy/list-authorized-properties-response.json
@@ -5,11 +5,6 @@
   "description": "Response payload for list_authorized_properties task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "properties": {
       "type": "array",
       "description": "Array of all properties this agent is authorized to represent",
@@ -32,7 +27,10 @@
             "description": "Description of what this tag represents"
           }
         },
-        "required": ["name", "description"],
+        "required": [
+          "name",
+          "description"
+        ],
         "additionalProperties": false
       }
     },
@@ -67,6 +65,8 @@
       }
     }
   },
-  "required": ["adcp_version", "properties"],
+  "required": [
+    "properties"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/list-creative-formats-request.json
+++ b/static/schemas/v1/media-buy/list-creative-formats-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for discovering supported creative formats",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "format_ids": {
       "type": "array",
       "description": "Return only these specific format IDs (e.g., from get_products response)",
@@ -21,14 +15,27 @@
     "type": {
       "type": "string",
       "description": "Filter by format type (technical categories with distinct requirements)",
-      "enum": ["audio", "video", "display", "dooh"]
+      "enum": [
+        "audio",
+        "video",
+        "display",
+        "dooh"
+      ]
     },
     "asset_types": {
       "type": "array",
       "description": "Filter to formats that include these asset types. For third-party tags, search for 'html' or 'javascript'. E.g., ['image', 'text'] returns formats with images and text, ['javascript'] returns formats accepting JavaScript tags.",
       "items": {
         "type": "string",
-        "enum": ["image", "video", "audio", "text", "html", "javascript", "url"]
+        "enum": [
+          "image",
+          "video",
+          "audio",
+          "text",
+          "html",
+          "javascript",
+          "url"
+        ]
       }
     },
     "max_width": {

--- a/static/schemas/v1/media-buy/list-creative-formats-response.json
+++ b/static/schemas/v1/media-buy/list-creative-formats-response.json
@@ -5,16 +5,9 @@
   "description": "Response payload for list_creative_formats task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
-      "description": "Current task state",
-      "default": "completed"
+      "description": "Current task state"
     },
     "formats": {
       "type": "array",
@@ -43,11 +36,18 @@
             "description": "Capabilities this creative agent provides",
             "items": {
               "type": "string",
-              "enum": ["validation", "assembly", "generation", "preview"]
+              "enum": [
+                "validation",
+                "assembly",
+                "generation",
+                "preview"
+              ]
             }
           }
         },
-        "required": ["agent_url"]
+        "required": [
+          "agent_url"
+        ]
       }
     },
     "errors": {
@@ -58,6 +58,8 @@
       }
     }
   },
-  "required": ["adcp_version", "formats"],
+  "required": [
+    "formats"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/list-creatives-request.json
+++ b/static/schemas/v1/media-buy/list-creatives-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for querying creative assets from the centralized library with filtering, sorting, and pagination",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "filters": {
       "type": "object",
       "description": "Filter criteria for querying creatives",
@@ -70,7 +64,7 @@
         },
         "created_before": {
           "type": "string",
-          "format": "date-time", 
+          "format": "date-time",
           "description": "Filter creatives created before this date (ISO 8601)"
         },
         "updated_after": {
@@ -115,13 +109,23 @@
       "properties": {
         "field": {
           "type": "string",
-          "enum": ["created_date", "updated_date", "name", "status", "assignment_count", "performance_score"],
+          "enum": [
+            "created_date",
+            "updated_date",
+            "name",
+            "status",
+            "assignment_count",
+            "performance_score"
+          ],
           "default": "created_date",
           "description": "Field to sort by"
         },
         "direction": {
           "type": "string",
-          "enum": ["asc", "desc"],
+          "enum": [
+            "asc",
+            "desc"
+          ],
           "default": "desc",
           "description": "Sort direction"
         }
@@ -129,7 +133,7 @@
       "additionalProperties": false
     },
     "pagination": {
-      "type": "object", 
+      "type": "object",
       "description": "Pagination parameters",
       "properties": {
         "limit": {
@@ -168,7 +172,18 @@
       "description": "Specific fields to include in response (omit for all fields)",
       "items": {
         "type": "string",
-        "enum": ["creative_id", "name", "format", "status", "created_date", "updated_date", "tags", "assignments", "performance", "sub_assets"]
+        "enum": [
+          "creative_id",
+          "name",
+          "format",
+          "status",
+          "created_date",
+          "updated_date",
+          "tags",
+          "assignments",
+          "performance",
+          "sub_assets"
+        ]
       }
     }
   },
@@ -211,7 +226,11 @@
     {
       "description": "Lightweight list with minimal fields",
       "data": {
-        "fields": ["creative_id", "name", "status"],
+        "fields": [
+          "creative_id",
+          "name",
+          "status"
+        ],
         "include_assignments": false
       }
     }

--- a/static/schemas/v1/media-buy/list-creatives-response.json
+++ b/static/schemas/v1/media-buy/list-creatives-response.json
@@ -5,11 +5,6 @@
   "description": "Response from creative library query with filtered results, metadata, and optional enriched data",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable result message"
@@ -48,12 +43,18 @@
             },
             "direction": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         }
       },
-      "required": ["total_matching", "returned"],
+      "required": [
+        "total_matching",
+        "returned"
+      ],
       "additionalProperties": false
     },
     "pagination": {
@@ -85,7 +86,11 @@
           "minimum": 1
         }
       },
-      "required": ["limit", "offset", "has_more"],
+      "required": [
+        "limit",
+        "offset",
+        "has_more"
+      ],
       "additionalProperties": false
     },
     "creatives": {
@@ -190,16 +195,26 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["active", "paused", "ended"],
+                      "enum": [
+                        "active",
+                        "paused",
+                        "ended"
+                      ],
                       "description": "Status of this specific assignment"
                     }
                   },
-                  "required": ["package_id", "assigned_date", "status"],
+                  "required": [
+                    "package_id",
+                    "assigned_date",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["assignment_count"],
+            "required": [
+              "assignment_count"
+            ],
             "additionalProperties": false
           },
           "performance": {
@@ -240,7 +255,9 @@
                 "description": "When performance data was last updated"
               }
             },
-            "required": ["last_updated"],
+            "required": [
+              "last_updated"
+            ],
             "additionalProperties": false
           },
           "sub_assets": {
@@ -251,7 +268,14 @@
             }
           }
         },
-        "required": ["creative_id", "name", "format", "status", "created_date", "updated_date"],
+        "required": [
+          "creative_id",
+          "name",
+          "format",
+          "status",
+          "created_date",
+          "updated_date"
+        ],
         "additionalProperties": false
       }
     },
@@ -295,19 +319,26 @@
       "additionalProperties": false
     }
   },
-  "required": ["adcp_version", "message", "query_summary", "pagination", "creatives"],
+  "required": [
+    "message",
+    "query_summary",
+    "pagination",
+    "creatives"
+  ],
   "additionalProperties": false,
   "examples": [
     {
       "description": "Successful library query with results",
       "data": {
-        "adcp_version": "1.5.0",
         "message": "Found 3 creatives matching your query",
         "context_id": "ctx_list_456789",
         "query_summary": {
           "total_matching": 3,
           "returned": 3,
-          "filters_applied": ["format=video", "status=approved"],
+          "filters_applied": [
+            "format=video",
+            "status=approved"
+          ],
           "sort_applied": {
             "field": "created_date",
             "direction": "desc"
@@ -334,7 +365,11 @@
             "duration": 30000,
             "width": 1920,
             "height": 1080,
-            "tags": ["q1_2024", "video", "brand_awareness"]
+            "tags": [
+              "q1_2024",
+              "video",
+              "brand_awareness"
+            ]
           }
         ],
         "format_summary": {
@@ -352,7 +387,6 @@
     {
       "description": "Query with assignments and performance data",
       "data": {
-        "adcp_version": "1.5.0",
         "message": "Found 1 creative with performance data",
         "query_summary": {
           "total_matching": 1,

--- a/static/schemas/v1/media-buy/provide-performance-feedback-request.json
+++ b/static/schemas/v1/media-buy/provide-performance-feedback-request.json
@@ -5,12 +5,6 @@
   "description": "Request payload for provide_performance_feedback task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.0.0"
-    },
     "media_buy_id": {
       "type": "string",
       "description": "Publisher's media buy identifier",
@@ -27,11 +21,14 @@
         },
         "end": {
           "type": "string",
-          "format": "date-time", 
+          "format": "date-time",
           "description": "ISO 8601 end timestamp for measurement period"
         }
       },
-      "required": ["start", "end"],
+      "required": [
+        "start",
+        "end"
+      ],
       "additionalProperties": false
     },
     "performance_index": {
@@ -45,7 +42,7 @@
       "minLength": 1
     },
     "creative_id": {
-      "type": "string", 
+      "type": "string",
       "description": "Specific creative asset (if feedback is creative-specific)",
       "minLength": 1
     },
@@ -54,7 +51,7 @@
       "description": "The business metric being measured",
       "enum": [
         "overall_performance",
-        "conversion_rate", 
+        "conversion_rate",
         "brand_lift",
         "click_through_rate",
         "completion_rate",
@@ -69,7 +66,7 @@
       "description": "Source of the performance data",
       "enum": [
         "buyer_attribution",
-        "third_party_measurement", 
+        "third_party_measurement",
         "platform_analytics",
         "verification_partner"
       ],

--- a/static/schemas/v1/media-buy/provide-performance-feedback-response.json
+++ b/static/schemas/v1/media-buy/provide-performance-feedback-response.json
@@ -5,11 +5,6 @@
   "description": "Response payload for provide_performance_feedback task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "success": {
       "type": "boolean",
       "description": "Whether the performance feedback was successfully received"
@@ -27,7 +22,6 @@
     }
   },
   "required": [
-    "adcp_version",
     "success"
   ],
   "additionalProperties": false

--- a/static/schemas/v1/media-buy/sync-creatives-request.json
+++ b/static/schemas/v1/media-buy/sync-creatives-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for syncing creative assets with upsert semantics - supports bulk operations, patch updates, and assignment management",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "creatives": {
       "type": "array",
       "description": "Array of creative assets to sync (create or update)",
@@ -50,7 +44,10 @@
     },
     "validation_mode": {
       "type": "string",
-      "enum": ["strict", "lenient"],
+      "enum": [
+        "strict",
+        "lenient"
+      ],
       "default": "strict",
       "description": "Validation strictness. 'strict' fails entire sync on any validation error. 'lenient' processes valid creatives and reports errors."
     },
@@ -59,7 +56,9 @@
       "description": "Optional webhook configuration for async sync notifications. Publisher will send webhook when sync completes if operation takes longer than immediate response time (typically for large bulk operations or manual approval/HITL)."
     }
   },
-  "required": ["creatives"],
+  "required": [
+    "creatives"
+  ],
   "additionalProperties": false,
   "examples": [
     {
@@ -82,11 +81,17 @@
                 "duration_ms": 30000
               }
             },
-            "tags": ["q1_2024", "video"]
+            "tags": [
+              "q1_2024",
+              "video"
+            ]
           }
         ],
         "assignments": {
-          "hero_video_30s": ["pkg_ctv_001", "pkg_ctv_002"]
+          "hero_video_30s": [
+            "pkg_ctv_001",
+            "pkg_ctv_002"
+          ]
         }
       }
     },
@@ -115,7 +120,10 @@
                 "content": "Create a warm, festive holiday campaign featuring winter products"
               }
             },
-            "tags": ["holiday", "q4_2024"]
+            "tags": [
+              "holiday",
+              "q4_2024"
+            ]
           }
         ]
       }

--- a/static/schemas/v1/media-buy/sync-creatives-response.json
+++ b/static/schemas/v1/media-buy/sync-creatives-response.json
@@ -5,11 +5,6 @@
   "description": "Response from creative sync operation with results for each creative",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable result message (e.g., 'Synced 3 creatives: 2 created, 1 updated')"
@@ -20,8 +15,7 @@
     },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
-      "description": "Current task state - 'completed' for immediate success, 'working' for operations under 120s, 'submitted' for long-running operations",
-      "default": "completed"
+      "description": "Current task state - 'completed' for immediate success, 'working' for operations under 120s, 'submitted' for long-running operations"
     },
     "task_id": {
       "type": "string",
@@ -43,7 +37,13 @@
           },
           "action": {
             "type": "string",
-            "enum": ["created", "updated", "unchanged", "failed", "deleted"],
+            "enum": [
+              "created",
+              "updated",
+              "unchanged",
+              "failed",
+              "deleted"
+            ],
             "description": "Action taken for this creative"
           },
           "platform_id": {
@@ -100,11 +100,18 @@
             "additionalProperties": false
           }
         },
-        "required": ["creative_id", "action"],
+        "required": [
+          "creative_id",
+          "action"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["adcp_version", "message", "status", "creatives"],
+  "required": [
+    "message",
+    "status",
+    "creatives"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/media-buy/update-media-buy-request.json
+++ b/static/schemas/v1/media-buy/update-media-buy-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for updating campaign and package settings",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "media_buy_id": {
       "type": "string",
       "description": "Publisher's ID of the media buy to update"
@@ -72,10 +66,14 @@
         },
         "oneOf": [
           {
-            "required": ["package_id"]
+            "required": [
+              "package_id"
+            ]
           },
           {
-            "required": ["buyer_ref"]
+            "required": [
+              "buyer_ref"
+            ]
           }
         ],
         "additionalProperties": false
@@ -88,10 +86,14 @@
   },
   "oneOf": [
     {
-      "required": ["media_buy_id"]
+      "required": [
+        "media_buy_id"
+      ]
     },
     {
-      "required": ["buyer_ref"]
+      "required": [
+        "buyer_ref"
+      ]
     }
   ],
   "additionalProperties": false

--- a/static/schemas/v1/media-buy/update-media-buy-response.json
+++ b/static/schemas/v1/media-buy/update-media-buy-response.json
@@ -5,11 +5,6 @@
   "description": "Response payload for update_media_buy task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "status": {
       "$ref": "/schemas/v1/enums/task-status.json",
       "description": "Current task state - 'completed' for immediate success, 'working' for operations under 120s, 'submitted' for long-running operations, 'input-required' if approval needed"
@@ -27,7 +22,10 @@
       "description": "Buyer's reference identifier for the media buy"
     },
     "implementation_date": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "format": "date-time",
       "description": "ISO 8601 timestamp when changes take effect (null if pending approval)"
     },
@@ -46,7 +44,10 @@
             "description": "Buyer's reference for the package"
           }
         },
-        "required": ["package_id", "buyer_ref"],
+        "required": [
+          "package_id",
+          "buyer_ref"
+        ],
         "additionalProperties": false
       }
     },
@@ -58,6 +59,10 @@
       }
     }
   },
-  "required": ["adcp_version", "status", "media_buy_id", "buyer_ref"],
+  "required": [
+    "status",
+    "media_buy_id",
+    "buyer_ref"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/signals/activate-signal-request.json
+++ b/static/schemas/v1/signals/activate-signal-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for activating a signal on a specific platform/account",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.5.0"
-    },
     "signal_agent_segment_id": {
       "type": "string",
       "description": "The universal identifier for the signal to activate"
@@ -24,6 +18,9 @@
       "description": "Account identifier (required for account-specific activation)"
     }
   },
-  "required": ["signal_agent_segment_id", "platform"],
+  "required": [
+    "signal_agent_segment_id",
+    "platform"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/signals/activate-signal-response.json
+++ b/static/schemas/v1/signals/activate-signal-response.json
@@ -5,12 +5,6 @@
   "description": "Response payload for activate_signal task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.6.0"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable summary of the activation status"
@@ -49,6 +43,11 @@
       }
     }
   },
-  "required": ["adcp_version", "message", "context_id", "task_id", "status"],
+  "required": [
+    "message",
+    "context_id",
+    "task_id",
+    "status"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/signals/get-signals-request.json
+++ b/static/schemas/v1/signals/get-signals-request.json
@@ -5,12 +5,6 @@
   "description": "Request parameters for discovering signals based on description",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version for this request",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "default": "1.5.0"
-    },
     "signal_spec": {
       "type": "string",
       "description": "Natural language description of the desired signals"
@@ -49,7 +43,10 @@
                 "description": "Account identifier on that platform"
               }
             },
-            "required": ["platform", "account"],
+            "required": [
+              "platform",
+              "account"
+            ],
             "additionalProperties": false
           }
         },
@@ -62,7 +59,10 @@
           }
         }
       },
-      "required": ["platforms", "countries"],
+      "required": [
+        "platforms",
+        "countries"
+      ],
       "additionalProperties": false
     },
     "filters": {
@@ -74,7 +74,11 @@
           "description": "Filter by catalog type",
           "items": {
             "type": "string",
-            "enum": ["marketplace", "custom", "owned"]
+            "enum": [
+              "marketplace",
+              "custom",
+              "owned"
+            ]
           }
         },
         "data_providers": {
@@ -104,6 +108,9 @@
       "minimum": 1
     }
   },
-  "required": ["signal_spec", "deliver_to"],
+  "required": [
+    "signal_spec",
+    "deliver_to"
+  ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/signals/get-signals-response.json
+++ b/static/schemas/v1/signals/get-signals-response.json
@@ -5,11 +5,6 @@
   "description": "Response payload for get_signals task",
   "type": "object",
   "properties": {
-    "adcp_version": {
-      "type": "string",
-      "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
-    },
     "message": {
       "type": "string",
       "description": "Human-readable summary of the signal discovery results"
@@ -39,7 +34,11 @@
           "signal_type": {
             "type": "string",
             "description": "Type of signal",
-            "enum": ["marketplace", "custom", "owned"]
+            "enum": [
+              "marketplace",
+              "custom",
+              "owned"
+            ]
           },
           "data_provider": {
             "type": "string",
@@ -62,7 +61,10 @@
                   "description": "Platform name"
                 },
                 "account": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Specific account if applicable"
                 },
                 "is_live": {
@@ -72,7 +74,10 @@
                 "scope": {
                   "type": "string",
                   "description": "Deployment scope",
-                  "enum": ["platform-wide", "account-specific"]
+                  "enum": [
+                    "platform-wide",
+                    "account-specific"
+                  ]
                 },
                 "decisioning_platform_segment_id": {
                   "type": "string",
@@ -84,7 +89,11 @@
                   "minimum": 0
                 }
               },
-              "required": ["platform", "is_live", "scope"],
+              "required": [
+                "platform",
+                "is_live",
+                "scope"
+              ],
               "additionalProperties": false
             }
           },
@@ -103,11 +112,23 @@
                 "pattern": "^[A-Z]{3}$"
               }
             },
-            "required": ["cpm", "currency"],
+            "required": [
+              "cpm",
+              "currency"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["signal_agent_segment_id", "name", "description", "signal_type", "data_provider", "coverage_percentage", "deployments", "pricing"],
+        "required": [
+          "signal_agent_segment_id",
+          "name",
+          "description",
+          "signal_type",
+          "data_provider",
+          "coverage_percentage",
+          "deployments",
+          "pricing"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,6 +140,10 @@
       }
     }
   },
-  "required": ["adcp_version", "message", "context_id", "signals"],
+  "required": [
+    "message",
+    "context_id",
+    "signals"
+  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

Simplifies schema versioning by removing `adcp_version` fields from all request/response schemas and adopting path-based versioning where the schema URL path (`/schemas/v1/`) indicates the version.

## Changes

### Schema Cleanup (30 files)
- ✅ Removed `adcp_version` from all core task request/response schemas
- ✅ Removed `adcp_version` from all creative protocol schemas  
- ✅ Removed `adcp_version` from all media-buy task schemas
- ✅ Removed `adcp_version` from all signals protocol schemas
- ✅ Removed meaningless `"default": "completed"` from 4 response schemas

### Single Source of Truth
- ✅ Keep `adcp_version` only in `static/schemas/v1/index.json`
- ✅ Updated schema registry documentation to reflect path-based versioning

### Documentation
- ✅ Updated `CLAUDE.md` to document path-based versioning approach
- ✅ Removed outdated versioning examples showing per-schema version fields

## Benefits

1. **Eliminates redundancy** - No need to update version in 30+ files when incrementing
2. **Clearer semantics** - The schema path IS the version (e.g., `/schemas/v1/` vs `/schemas/v2/`)
3. **Follows conventions** - REST/HTTP pattern (version in path, not payload)
4. **Reduces errors** - Can't have version mismatches between related schemas
5. **Fixes type issues** - Removes string literal defaults on enum-typed fields (mypy strict mode compatibility)

## Versioning Approach

```
Current:  /schemas/v1/media-buy/create-media-buy-request.json
Future:   /schemas/v2/media-buy/create-media-buy-request.json
```

The schema registry at `/schemas/v1/index.json` contains `adcp_version: "1.8.0"` as the single source of truth for the current v1 schema version.

## Testing

- ✅ All schema validation tests pass
- ✅ All example validation tests pass
- ✅ TypeScript type checking passes
- ✅ Documentation builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)