### PR TITLE
Require structured format_id objects everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,9 +262,9 @@ For major version changes:
 
 ### Format ID Structure
 
-**CRITICAL**: Format IDs are structured objects, not strings, to avoid parsing issues and provide clear namespacing.
+**CRITICAL**: Format IDs are ALWAYS structured objects, never strings, to avoid parsing ambiguity and handle namespace collisions.
 
-**Structured Format ID**:
+**Structured Format ID (REQUIRED EVERYWHERE)**:
 ```json
 {
   "agent_url": "https://creatives.adcontextprotocol.org",
@@ -272,24 +272,32 @@ For major version changes:
 }
 ```
 
-**When to use structured format IDs**:
-- **Request parameters** that accept a format ID (e.g., `target_format_id` in `build_creative`)
-- **Creative asset objects** that specify which format they conform to
-- Anywhere a format is being **referenced for action**
+**Where structured format IDs are used (everywhere)**:
+- **All request parameters** accepting format_id (sync_creatives, build_creative, preview_creative, etc.)
+- **All response fields** containing format_id (list_creatives, get_products, list_creative_formats, etc.)
+- **Creative asset objects** specifying which format they conform to
+- **Product responses** listing supported formats
+- **Filter parameters** in list operations (format_ids plural = array of objects)
+- **Creative manifests** specifying the format
 
-**When to use string format IDs**:
-- **Product responses** listing supported formats (for compactness)
-- **Format definition objects** themselves (they have separate `format_id` and `agent_url` fields)
-- Lists where verbosity is a concern
+**Why structured objects everywhere?**
+- No parsing ambiguity - components are explicit
+- Handles format ID collisions between different creative agents
+- Simpler mental model - one pattern, no exceptions
+- Future-proof for versioning and extensions
 
 **Schema reference**:
 ```json
 {
-  "target_format_id": {
+  "format_id": {
     "$ref": "/schemas/v1/core/format-id.json"
   }
 }
 ```
+
+**Validation rule**: All AdCP agents MUST reject string format_ids in ALL contexts with clear error messages. No exceptions.
+
+**Legacy handling**: If supporting legacy clients sending strings, you MAY auto-upgrade during a deprecation period (max 6 months), but MUST log warnings and fail on unknown format strings. Recommended approach is strict rejection from day one.
 
 ## Common Tasks
 

--- a/docs/creative/creative-manifests.md
+++ b/docs/creative/creative-manifests.md
@@ -16,7 +16,10 @@ For an overview of how formats, manifests, and creative agents work together, se
 
 ```typescript
 {
-  format_id: string;           // Format this manifest is for
+  format_id: {                 // Format this manifest is for
+    agent_url: string;         // Creative agent URL
+    id: string;                // Format identifier
+  };
   promoted_offering?: string;  // Product being advertised (maps to create_media_buy)
   assets: {
     [asset_role: string]: {    // Keyed by asset role from format spec

--- a/docs/creative/task-reference/preview_creative.md
+++ b/docs/creative/task-reference/preview_creative.md
@@ -59,7 +59,7 @@ To test multiple scenarios, provide an `inputs` array - you'll get one preview p
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `format_id` | string | Yes | Format identifier for rendering |
+| `format_id` | FormatID | Yes | Format identifier for rendering (structured object with agent_url and id) |
 | `creative_manifest` | object | Yes | Complete creative manifest with all required assets (brand_manifest should be included in the manifest for dynamic creatives) |
 | `inputs` | array | No | Array of input sets for generating multiple preview variants |
 | `template_id` | string | No | Specific template for custom format rendering |
@@ -70,7 +70,10 @@ The creative manifest must include all assets required by the format. See [Creat
 
 ```typescript
 {
-  format_id: string;           // Must match format_id parameter
+  format_id: {                 // Must match format_id parameter
+    agent_url: string;         // Creative agent URL
+    id: string;                // Format identifier
+  };
   assets: {
     [asset_role: string]: {    // Asset role from format spec (e.g., 'hero_image', 'logo')
       asset_type: string;      // Type: image, video, audio, vast_tag, text, url, etc.

--- a/docs/media-buy/task-reference/get_products.md
+++ b/docs/media-buy/task-reference/get_products.md
@@ -67,7 +67,12 @@ Products include **EITHER** `properties` (for specific property lists) **OR** `p
           "publisher_domain": "string"
         }
       ],
-      "format_ids": ["format_id_string"],
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_30s_hosted"
+        }
+      ],
       "delivery_type": "string",
       "is_fixed_price": "boolean",
       "cpm": "number",
@@ -99,7 +104,16 @@ Products include **EITHER** `properties` (for specific property lists) **OR** `p
       "name": "Midwest Radio Network",
       "description": "500+ local radio stations across midwest markets",
       "property_tags": ["local_radio", "midwest"],
-      "format_ids": ["audio_30s", "audio_60s"],
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "audio_30s"
+        },
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "audio_60s"
+        }
+      ],
       "delivery_type": "guaranteed",
       "is_fixed_price": true,
       "cpm": 25.00,
@@ -346,7 +360,12 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
           "publisher_domain": "sportsnetwork.com"
         }
       ],
-      "format_ids": ["video_16x9_30s"],
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_16x9_30s"
+        }
+      ],
       "delivery_type": "guaranteed",
       "is_fixed_price": true,
       "cpm": 45.00,
@@ -419,7 +438,12 @@ A2A returns results as artifacts with text and data parts:
               "product_id": "ctv_sports_premium",
               "name": "CTV Sports Premium",
               "description": "Premium CTV inventory on sports content",
-              "format_ids": ["video_16x9_30s"],
+              "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_16x9_30s"
+        }
+      ],
               "delivery_type": "guaranteed",
               "is_fixed_price": true,
               "cpm": 45.00,
@@ -540,7 +564,12 @@ When buyers specify `min_exposures` in the request, products are filtered to onl
       "product_id": "open_exchange_video",
       "name": "Open Exchange - Video",
       "description": "Programmatic video inventory across all publishers",
-      "format_ids": ["video_standard"],
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_standard"
+        }
+      ],
       "delivery_type": "non_guaranteed",
       "is_fixed_price": false,
       "currency": "USD",
@@ -565,7 +594,12 @@ When buyers specify `min_exposures` in the request, products are filtered to onl
       "product_id": "connected_tv_prime",
       "name": "Connected TV - Prime Time",
       "description": "Premium CTV inventory 8PM-11PM",
-      "format_ids": ["video_standard"],
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_standard"
+        }
+      ],
       "delivery_type": "guaranteed",
       "is_fixed_price": true,
       "cpm": 45.00,
@@ -590,8 +624,14 @@ When buyers specify `min_exposures` in the request, products are filtered to onl
       "name": "Pet Category Shoppers - Syndicated",
       "description": "Target Albertsons shoppers who have purchased pet products in the last 90 days across offsite display and video inventory.",
       "format_ids": [
-        "display_300x250",
-        "video_15s_vast"
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "display_300x250"
+        },
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_15s_vast"
+        }
       ],
       "delivery_type": "guaranteed",
       "is_fixed_price": true,
@@ -624,8 +664,14 @@ When buyers specify `min_exposures` in the request, products are filtered to onl
       "name": "Custom: Competitive Dog Food Buyers",
       "description": "Custom audience of Albertsons shoppers who buy competitive dog food brands. Higher precision targeting for conquest campaigns.",
       "format_ids": [
-        "display_300x250",
-        "display_728x90"
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "display_300x250"
+        },
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "display_728x90"
+        }
       ],
       "delivery_type": "guaranteed",
       "is_fixed_price": true,

--- a/docs/media-buy/task-reference/list_creatives.md
+++ b/docs/media-buy/task-reference/list_creatives.md
@@ -172,8 +172,11 @@ The response provides comprehensive creative data with optional enrichment:
   "creatives": [
     {
       "creative_id": "hero_video_30s",
-      "name": "Brand Hero Video 30s", 
-      "format": "video_30s_vast",
+      "name": "Brand Hero Video 30s",
+      "format_id": {
+        "agent_url": "https://creative.adcontextprotocol.org",
+        "id": "video_30s_vast"
+      },
       "status": "approved",
       "created_date": "2024-01-15T10:30:00Z",
       "updated_date": "2024-01-15T14:20:00Z",

--- a/static/schemas/v1/core/creative-manifest.json
+++ b/static/schemas/v1/core/creative-manifest.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "format_id": {
-      "type": "string",
+      "$ref": "/schemas/v1/core/format-id.json",
       "description": "Format identifier this manifest is for"
     },
     "promoted_offering": {

--- a/static/schemas/v1/core/product.json
+++ b/static/schemas/v1/core/product.json
@@ -37,10 +37,9 @@
     },
     "format_ids": {
       "type": "array",
-      "description": "Array of supported creative format IDs - use list_creative_formats to get full format details",
+      "description": "Array of supported creative format IDs - structured format_id objects with agent_url and id",
       "items": {
-        "type": "string",
-        "description": "Format ID referencing a format from list_creative_formats"
+        "$ref": "/schemas/v1/core/format-id.json"
       }
     },
     "delivery_type": {

--- a/static/schemas/v1/creative/preview-creative-request.json
+++ b/static/schemas/v1/creative/preview-creative-request.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "format_id": {
-      "type": "string",
+      "$ref": "/schemas/v1/core/format-id.json",
       "description": "Format identifier for rendering the preview"
     },
     "creative_manifest": {

--- a/static/schemas/v1/media-buy/list-creatives-response.json
+++ b/static/schemas/v1/media-buy/list-creatives-response.json
@@ -107,9 +107,9 @@
             "type": "string",
             "description": "Human-readable creative name"
           },
-          "format": {
-            "type": "string",
-            "description": "Creative format type"
+          "format_id": {
+            "$ref": "/schemas/v1/core/format-id.json",
+            "description": "Format identifier specifying which format this creative conforms to"
           },
           "status": {
             "$ref": "/schemas/v1/enums/creative-status.json",
@@ -271,7 +271,7 @@
         "required": [
           "creative_id",
           "name",
-          "format",
+          "format_id",
           "status",
           "created_date",
           "updated_date"
@@ -355,7 +355,10 @@
           {
             "creative_id": "hero_video_30s",
             "name": "Brand Hero Video 30s",
-            "format": "video_30s_vast",
+            "format_id": {
+              "agent_url": "https://creative.adcontextprotocol.org",
+              "id": "video_30s_vast"
+            },
             "status": "approved",
             "created_date": "2024-01-15T10:30:00Z",
             "updated_date": "2024-01-15T14:20:00Z",
@@ -401,7 +404,10 @@
           {
             "creative_id": "hero_video_30s",
             "name": "Brand Hero Video 30s",
-            "format": "video_30s_vast",
+            "format_id": {
+              "agent_url": "https://creative.adcontextprotocol.org",
+              "id": "video_30s_vast"
+            },
             "status": "approved",
             "created_date": "2024-01-15T10:30:00Z",
             "updated_date": "2024-01-15T14:20:00Z",


### PR DESCRIPTION
## Summary

This PR standardizes `format_id` to **always use structured objects** throughout the AdCP specification, eliminating string format_id exceptions.

## Breaking Change

⚠️ **BREAKING CHANGE**: `format_id` must now be `{agent_url, id}` objects in ALL contexts.

## Changes

### Schemas Updated
- ✅ `list-creatives-response.json` - Changed `"format"` field → `"format_id"` with proper $ref
- ✅ `product.json` - Changed `format_ids` array items from strings → structured objects
- ✅ `creative-manifest.json` - Changed `format_id` from string → structured object
- ✅ `preview-creative-request.json` - Changed `format_id` from string → structured object

### Documentation Updated
- ✅ `formats.md` - Complete rewrite of "Referencing Formats" section
- ✅ `CLAUDE.md` - Updated Format ID Structure guidance to require objects everywhere
- ✅ `get_products.md` - Updated all examples with structured format_ids
- ✅ `list_creatives.md` - Updated response examples
- ✅ `preview_creative.md` - Updated parameter docs and TypeScript examples
- ✅ `creative-manifests.md` - Updated structure examples

## Why This Change?

**Problems with string format_ids:**
- Parsing ambiguity - which creative agent owns "display_300x250"?
- Collision risk - different agents can't use same format ID
- Exception complexity - hard to remember when strings vs objects

**Benefits of structured objects everywhere:**
- ✅ **No parsing needed** - Components are explicit
- ✅ **Handles collisions** - `agent_url` provides namespace
- ✅ **Simpler mental model** - One pattern, no exceptions
- ✅ **Future-proof** - Easy to add versioning or metadata later

## Migration Guidance

### For Implementers

**Recommended approach (strict validation):**
```json
{
  "error": "invalid_format_id",
  "message": "format_id must be a structured object with 'agent_url' and 'id' fields",
  "received": "display_300x250",
  "required_structure": {
    "agent_url": "https://creative-agent-url.com",
    "id": "display_300x250"
  }
}
```

**Alternative (temporary auto-upgrade):**
- Accept strings temporarily during deprecation period (max 6 months)
- Log warnings on every request
- Fail loudly for unknown format strings
- Set and communicate removal date

### Before
```json
{
  "creative_id": "hero_video",
  "format": "video_30s_vast"
}
```

### After
```json
{
  "creative_id": "hero_video",
  "format_id": {
    "agent_url": "https://creative.adcontextprotocol.org",
    "id": "video_30s_vast"
  }
}
```

## Testing

✅ All schema validation tests pass (7/7)
✅ All example validation tests pass (7/7)
✅ TypeScript compilation successful
✅ Pre-commit hooks pass

## Impact Analysis

**Affects:**
- Sales agents implementing Media Buy Protocol
- Creative agents implementing Creative Protocol
- Any client code constructing format_id references

**Does not affect:**
- Existing standard format definitions (still work, just referenced differently)
- Task signatures (same tasks, different parameter structure)
- Protocol message patterns

## Related Issues

Addresses questions raised in spec team review about format_id handling consistency and collision management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)