### PR TITLE
Fix Package schema format field naming and type consistency

### DIFF
--- a/static/schemas/v1/core/package.json
+++ b/static/schemas/v1/core/package.json
@@ -37,10 +37,12 @@
         "$ref": "/schemas/v1/core/creative-assignment.json"
       }
     },
-    "formats_to_provide": {
+    "format_ids_to_provide": {
       "type": "array",
       "description": "Format IDs that creative assets will be provided for this package",
-      "items": {"type": "string"}
+      "items": {
+        "$ref": "/schemas/v1/core/format-id.json"
+      }
     },
     "status": {
       "$ref": "/schemas/v1/enums/package-status.json"


### PR DESCRIPTION
## Summary
- Renamed `formats_to_provide` to `format_ids_to_provide` for semantic clarity
- Changed field type from array of strings to array of structured FormatId objects
- Ensures consistency with established format field naming convention

## Changes
- **Package schema**: `formats_to_provide` → `format_ids_to_provide`
- **Type change**: `string[]` → `FormatId[]` (structured objects with `agent_url` and `id`)

## Rationale
This aligns with the established format field naming convention:
- `format_ids` = structured FormatId objects (never strings)
- Clear semantic distinction: Product.format_ids (what's supported) vs Package.format_ids_to_provide (what buyer will provide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)