### PR TITLE
Add pricing, pacing, and bid_price fields to Package schema

### DIFF
--- a/docs/media-buy/media-buys/index.md
+++ b/docs/media-buy/media-buys/index.md
@@ -81,6 +81,9 @@ Packages are the building blocks of media buys:
 - **Creative formats** to be provided for this package
 - **Targeting overlays** for audience refinement beyond product defaults
 - **Budget allocation** as portion of overall media buy budget
+- **Pricing option** selection from product's available pricing models
+- **Pacing strategy** for budget delivery (even, asap, or front_loaded)
+- **Bid price** for auction-based pricing models (when applicable)
 
 ### Lifecycle States
 Media buys progress through predictable states:

--- a/static/schemas/v1/core/package.json
+++ b/static/schemas/v1/core/package.json
@@ -22,6 +22,18 @@
       "description": "Budget allocation for this package in the currency specified by the pricing option",
       "minimum": 0
     },
+    "pacing": {
+      "$ref": "/schemas/v1/enums/pacing.json"
+    },
+    "pricing_option_id": {
+      "type": "string",
+      "description": "ID of the selected pricing option from the product's pricing_options array"
+    },
+    "bid_price": {
+      "type": "number",
+      "description": "Bid price for auction-based CPM pricing (present if using cpm-auction-option)",
+      "minimum": 0
+    },
     "impressions": {
       "type": "number",
       "description": "Impression goal for this package",


### PR DESCRIPTION
## Summary

- Add `pricing_option_id`, `pacing`, and `bid_price` fields to Package response schema
- Update Package model documentation to reflect complete configuration
- Enables buyers to query media buy status and see their original pricing/pacing configuration

## Context

Package responses were missing fields that buyers specify when creating media buys. These fields are present in `package-request.json` (input) but were missing from `package.json` (response/state).

## Changes

### Schema Updates (`static/schemas/v1/core/package.json`)

Added three fields to Package response:

1. **`pricing_option_id`** (string) - ID of the selected pricing option from product's pricing_options array
2. **`pacing`** (enum) - Budget delivery strategy: even, asap, or front_loaded  
3. **`bid_price`** (number, optional) - Bid price for auction-based CPM pricing models

### Documentation Updates

Updated `docs/media-buy/media-buys/index.md` Package Model section to document all configuration fields including the newly added pricing/pacing/bidding fields.

## Test Results

✅ All schema validation tests pass  
✅ All example validation tests pass  
✅ TypeScript compilation succeeds

## Why These Fields Are Needed

When buyers create media buys via `create_media_buy`, they specify:
- Which pricing model to use (`pricing_option_id`)
- How to pace budget delivery (`pacing`)  
- Their bid price for auction models (`bid_price`)

Without these fields in Package responses, buyers querying media buy status later (via MediaBuy object which includes Packages) cannot see the configuration they originally specified. This creates an incomplete state representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)