### PR TITLE
Move brand manifest documentation to Creative section

### DIFF
--- a/docs/creative/brand-manifest.md
+++ b/docs/creative/brand-manifest.md
@@ -468,6 +468,6 @@ For implementations using the legacy `brand_guidelines` field in `build_creative
 ## Related Documentation
 
 - **[create_media_buy](../media-buy/task-reference/create_media_buy)** - Media buy creation with brand context
-- **[build_creative](../creative/task-reference/build_creative)** - AI-powered creative generation
+- **[build_creative](./task-reference/build_creative)** - AI-powered creative generation
 - **[Creative Lifecycle](../media-buy/creatives/)** - Managing creative assets
-- **[Data Models](./data-models)** - Core AdCP data structures
+- **[Data Models](../reference/data-models)** - Core AdCP data structures

--- a/docs/creative/generative-creative.md
+++ b/docs/creative/generative-creative.md
@@ -12,7 +12,7 @@ The Creative Protocol provides AI-powered creative generation:
 - **`preview_creative`**: Generate previews of creative manifests
 - **`list_creative_formats`**: Discover supported creative formats
 
-Assets are provided via [Brand Manifest](../reference/brand-manifest) - no separate asset library management needed.
+Assets are provided via [Brand Manifest](./brand-manifest) - no separate asset library management needed.
 
 ## Quick Start: Generate Your First Creative
 
@@ -113,7 +113,7 @@ Provide brand context for better creative generation:
 }
 ```
 
-See [Brand Manifest Reference](../reference/brand-manifest) for comprehensive examples.
+See [Brand Manifest Reference](./brand-manifest) for comprehensive examples.
 
 ### Using Your Own Assets
 
@@ -194,7 +194,7 @@ To improve creative output:
 3. Use the conversational refinement feature to iterate (via `context_id`)
 
 ### Asset Management
-Assets are provided via [Brand Manifest](../reference/brand-manifest):
+Assets are provided via [Brand Manifest](./brand-manifest):
 1. Include assets in brand manifest with descriptive tags
 2. Use `asset_filters` in requests to select specific assets
 3. Reference product catalogs for large inventories

--- a/docs/creative/task-reference/build_creative.md
+++ b/docs/creative/task-reference/build_creative.md
@@ -17,7 +17,7 @@ For information about format IDs and how to reference formats, see [Creative For
 | `source_format_id` | object | No | Format ID of existing creative to transform (optional - omit when creating from scratch). Object with `agent_url` and `id` fields. |
 | `target_format_id` | object | Yes | Format ID to generate. Object with `agent_url` and `id` fields. For generative formats, this should be the input format (e.g., `300x250_banner_generative`). The creative agent will return a manifest in one of the `output_format_ids`. |
 | `context_id` | string | No | Session context from previous message for continuity |
-| `brand_manifest` | BrandManifestRef | No | Brand information manifest containing all assets, themes, and information necessary to ensure creatives are aligned with the brand's goals and that the publisher is comfortable with what's being advertised. Can be provided as an inline object or URL reference to a hosted manifest. See [Brand Manifest](../../reference/brand-manifest) for details. |
+| `brand_manifest` | BrandManifestRef | No | Brand information manifest containing all assets, themes, and information necessary to ensure creatives are aligned with the brand's goals and that the publisher is comfortable with what's being advertised. Can be provided as an inline object or URL reference to a hosted manifest. See [Brand Manifest](../brand-manifest) for details. |
 | `assets` | array | No | References to asset libraries and specific assets |
 | `preview_options` | object | No | Options for generating preview |
 | `finalize` | boolean | No | Set to true to finalize the creative (default: false) |

--- a/docs/media-buy/creatives/index.md
+++ b/docs/media-buy/creatives/index.md
@@ -126,7 +126,7 @@ AdCP uses a centralized creative library where assets are uploaded once and assi
 - Reuse creatives across multiple media buys
 - Track performance across all assignments
 
-Asset management is handled through [Brand Manifests](../../reference/brand-manifest), which provide brand-level assets with tags for discovery.
+Asset management is handled through [Brand Manifests](../../creative/brand-manifest), which provide brand-level assets with tags for discovery.
 
 ## Platform Considerations
 
@@ -170,7 +170,7 @@ Creative operations have varying response times:
 - **[`sync_creatives`](../task-reference/sync_creatives)** - Bulk creative management with upsert semantics
 - **[`list_creatives`](../task-reference/list_creatives)** - Advanced creative library querying and filtering
 - **[`list_creative_formats`](../task-reference/list_creative_formats)** - Understanding format requirements
-- **[Brand Manifest](../../reference/brand-manifest)** - Brand identity and asset management
+- **[Brand Manifest](../../creative/brand-manifest)** - Brand identity and asset management
 - **[Creative Formats](../../creative/formats)** - Understanding format specifications and discovery
 - **[Creative Channel Guides](../../creative/channels/video)** - Format examples across video, display, audio, DOOH, and carousels
 - **[Asset Types](../../creative/asset-types)** - Understanding asset roles and specifications

--- a/docs/media-buy/task-reference/create_media_buy.md
+++ b/docs/media-buy/task-reference/create_media_buy.md
@@ -21,7 +21,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this media buy |
 | `packages` | Package[] | Yes | Array of package configurations (see Package Object below) |
-| `brand_manifest` | BrandManifestRef | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided as an inline object or URL reference to a hosted manifest. Can be cached and reused across multiple requests. See [Brand Manifest](../../reference/brand-manifest) for details. |
+| `brand_manifest` | BrandManifestRef | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided as an inline object or URL reference to a hosted manifest. Can be cached and reused across multiple requests. See [Brand Manifest](../../creative/brand-manifest) for details. |
 | `promoted_products` | PromotedProducts | No | Products or offerings being promoted in this media buy. Useful for campaign-level reporting, policy compliance, and publisher understanding of what's being advertised. Selects from brand manifest's product catalog using SKUs, tags, categories, or natural language queries. |
 | `promoted_offering` | string | No | **DEPRECATED**: Use `brand_manifest` with `promoted_products` instead. Legacy field for describing what is being promoted. |
 | `po_number` | string | No | Purchase order number for tracking |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -133,6 +133,7 @@ const sidebars: SidebarsConfig = {
         'creative/formats',
         'creative/asset-types',
         'creative/creative-manifests',
+        'creative/brand-manifest',
         'creative/universal-macros',
         'creative/implementing-creative-agents',
         'creative/generative-creative',


### PR DESCRIPTION
## Summary

The brand manifest is fundamental to creative workflows and should be prominently positioned in the Creative section rather than buried in the Reference section.

- Moved brand-manifest.md from `docs/reference/` to `docs/creative/`
- Added to Creative section navigation (positioned after Creative Manifests)
- Updated all cross-references across 6 documentation files
- Build verified with no broken links

## Rationale

The brand manifest is:
- **Core to creative workflows** - used in `build_creative` and generative creative tasks
- **Core to media buys** - used in `create_media_buy` to provide brand context
- **Referenced throughout creative documentation** but was not easily discoverable in Reference section

## Test plan

- [x] Build passes with no broken links
- [x] All cross-references updated correctly
- [x] Navigation includes brand manifest in Creative section
- [x] Pre-commit hooks pass (schema validation, examples, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)