### PR TITLE
Add optional advertising_policies field to list_authorized_properties

### DIFF
--- a/docs/media-buy/capability-discovery/authorized-properties.md
+++ b/docs/media-buy/capability-discovery/authorized-properties.md
@@ -114,7 +114,7 @@ Sales agents use the [`list_authorized_properties`](../task-reference/list_autho
     },
     {
       "property_type": "radio",
-      "name": "WXYZ-FM Chicago", 
+      "name": "WXYZ-FM Chicago",
       "identifiers": [
         {"type": "call_sign", "value": "WXYZ-FM"},
         {"type": "market", "value": "chicago"}
@@ -132,7 +132,8 @@ Sales agents use the [`list_authorized_properties`](../task-reference/list_autho
       "name": "Local Radio Stations",
       "description": "1847 local radio stations across US markets"
     }
-  }
+  },
+  "advertising_policies": "We maintain strict brand safety standards. Prohibited categories include: tobacco and vaping products, online gambling and sports betting, cannabis and CBD products, political advertising, and speculative financial products (crypto, NFTs, penny stocks).\n\nWe also prohibit misleading tactics such as clickbait headlines, false scarcity claims, hidden pricing, and ads targeting vulnerable populations.\n\nCompetitor brands in the streaming media space are blocked by policy.\n\nFull advertising guidelines: https://publisher.com/advertising-policies"
 }
 ```
 

--- a/docs/media-buy/task-reference/list_authorized_properties.md
+++ b/docs/media-buy/task-reference/list_authorized_properties.md
@@ -92,6 +92,7 @@ The message is returned differently in each protocol:
 - **primary_channels** *(optional)*: Main advertising channels (see [Channels enum](/schemas/v1/enums/channels.json))
 - **primary_countries** *(optional)*: Main countries (ISO 3166-1 alpha-2 codes)
 - **portfolio_description** *(optional)*: Markdown description of the property portfolio
+- **advertising_policies** *(optional)*: Publisher's advertising content policies, restrictions, and guidelines in natural language. May include prohibited categories, blocked advertisers, restricted tactics, brand safety requirements, or links to full policy documentation.
 
 ## Integration with get_products
 

--- a/static/schemas/v1/media-buy/list-authorized-properties-response.json
+++ b/static/schemas/v1/media-buy/list-authorized-properties-response.json
@@ -57,6 +57,12 @@
       "minLength": 1,
       "maxLength": 5000
     },
+    "advertising_policies": {
+      "type": "string",
+      "description": "Publisher's advertising content policies, restrictions, and guidelines in natural language. May include prohibited categories, blocked advertisers, restricted tactics, brand safety requirements, or links to full policy documentation.",
+      "minLength": 1,
+      "maxLength": 10000
+    },
     "errors": {
       "type": "array",
       "description": "Task-specific errors and warnings (e.g., property availability issues)",


### PR DESCRIPTION
## Summary

Adds a simple, LLM-friendly way for publishers to communicate advertising policies upfront to buying agents.

## Changes

- Add optional `advertising_policies` string field to `list-authorized-properties-response` schema
- Natural language format (not structured enums) - easier for LLMs to understand and reason about
- Updated schema examples and field descriptions in documentation
- Bumped `adcp_version` to 1.9.0 (minor version bump for new optional field)

## Benefits

- **Buyer transparency**: Buyers know policy restrictions before investing time in campaigns
- **Reduced friction**: Buyers can self-qualify campaigns against policies upfront
- **Better error prevention**: Prevents wasted effort on campaigns that will be rejected
- **Publisher flexibility**: Publishers can express policies naturally without complex taxonomies
- **No breaking changes**: Field is optional - existing implementations unaffected

## Example

```json
{
  "properties": [...],
  "advertising_policies": "We maintain strict brand safety standards. Prohibited categories include: tobacco and vaping products, online gambling and sports betting, cannabis and CBD products, political advertising, and speculative financial products (crypto, NFTs, penny stocks).\n\nWe also prohibit misleading tactics such as clickbait headlines, false scarcity claims, hidden pricing, and ads targeting vulnerable populations.\n\nFull advertising guidelines: https://publisher.com/advertising-policies"
}
```

## Reference Implementation

This pattern is already implemented in the AdCP Sales Agent reference implementation: https://github.com/adcontextprotocol/salesagent/pull/398

🤖 Generated with [Claude Code](https://claude.com/claude-code)