### PR TITLE
Add vCPM (viewable CPM) pricing option

### DIFF
--- a/docs/media-buy/advanced-topics/pricing-models.md
+++ b/docs/media-buy/advanced-topics/pricing-models.md
@@ -86,6 +86,33 @@ By accepting the product, buyers agree to use the declared measurement provider 
 
 ---
 
+### vCPM (Viewable Cost Per Mille)
+**Cost per 1,000 viewable impressions** - Payment only for impressions meeting MRC viewability standard.
+
+**Use Cases**: Display, native, video advertising with viewability guarantee
+
+**Viewability Standard**: MRC (Media Rating Council) standard requires:
+- **Display ads**: 50% of pixels in-view for at least 1 continuous second
+- **Video ads**: 50% of pixels in-view for at least 2 continuous seconds
+
+**Example**:
+```json
+{
+  "pricing_option_id": "vcpm_usd_guaranteed",
+  "pricing_model": "vcpm",
+  "rate": 18.50,
+  "currency": "USD",
+  "is_fixed": true,
+  "min_spend_per_package": 5000
+}
+```
+
+**Billing**: Charged per 1,000 viewable impressions (impressions meeting MRC viewability threshold). Viewability is measured by the declared measurement provider.
+
+**Measurement Requirements**: Publishers should declare their viewability measurement provider in the product's `delivery_measurement` field. Common providers include IAS (Integral Ad Science), DoubleVerify, MOAT, and Google Active View.
+
+---
+
 ### CPCV (Cost Per Completed View)
 **Cost per 100% video/audio completion** - Payment only for fully completed views.
 
@@ -378,6 +405,7 @@ Different pricing models report different primary metrics:
 | Pricing Model | Primary Metric | Secondary Metrics |
 |---------------|----------------|-------------------|
 | CPM | impressions | clicks, ctr, spend |
+| vCPM | viewable_impressions | impressions, viewability_rate, spend |
 | CPCV | completed_views | impressions, completion_rate, spend |
 | CPV | views | impressions, quartile_data, spend |
 | CPP | grps | reach, frequency, spend |

--- a/static/schemas/v1/core/pricing-option.json
+++ b/static/schemas/v1/core/pricing-option.json
@@ -11,6 +11,12 @@
       "$ref": "/schemas/v1/pricing-options/cpm-auction-option.json"
     },
     {
+      "$ref": "/schemas/v1/pricing-options/vcpm-fixed-option.json"
+    },
+    {
+      "$ref": "/schemas/v1/pricing-options/vcpm-auction-option.json"
+    },
+    {
       "$ref": "/schemas/v1/pricing-options/cpc-option.json"
     },
     {

--- a/static/schemas/v1/enums/pricing-model.json
+++ b/static/schemas/v1/enums/pricing-model.json
@@ -6,6 +6,7 @@
   "type": "string",
   "enum": [
     "cpm",
+    "vcpm",
     "cpc",
     "cpcv",
     "cpv",
@@ -14,6 +15,7 @@
   ],
   "enumDescriptions": {
     "cpm": "Cost Per Mille - cost per 1,000 impressions",
+    "vcpm": "Viewable Cost Per Mille - cost per 1,000 viewable impressions (MRC standard)",
     "cpc": "Cost Per Click - cost per click on the ad",
     "cpcv": "Cost Per Completed View - cost per 100% video/audio completion",
     "cpv": "Cost Per View - cost per view at publisher-defined threshold (e.g., 50% completion)",

--- a/static/schemas/v1/index.json
+++ b/static/schemas/v1/index.json
@@ -159,7 +159,7 @@
       }
     },
     "pricing-options": {
-      "description": "Individual pricing model schemas with model-specific validation. CPM supports both fixed and auction pricing; all other models are fixed-rate only.",
+      "description": "Individual pricing model schemas with model-specific validation. CPM and vCPM support both fixed and auction pricing; all other models are fixed-rate only.",
       "schemas": {
         "cpm-fixed-option": {
           "$ref": "/schemas/v1/pricing-options/cpm-fixed-option.json",
@@ -168,6 +168,14 @@
         "cpm-auction-option": {
           "$ref": "/schemas/v1/pricing-options/cpm-auction-option.json",
           "description": "Cost Per Mille (CPM) auction-based pricing for programmatic/non-guaranteed inventory"
+        },
+        "vcpm-fixed-option": {
+          "$ref": "/schemas/v1/pricing-options/vcpm-fixed-option.json",
+          "description": "Viewable Cost Per Mille (vCPM) fixed-rate pricing for viewability-guaranteed deals"
+        },
+        "vcpm-auction-option": {
+          "$ref": "/schemas/v1/pricing-options/vcpm-auction-option.json",
+          "description": "Viewable Cost Per Mille (vCPM) auction-based pricing for programmatic inventory with viewability guarantee"
         },
         "cpc-option": {
           "$ref": "/schemas/v1/pricing-options/cpc-option.json",

--- a/static/schemas/v1/pricing-options/vcpm-auction-option.json
+++ b/static/schemas/v1/pricing-options/vcpm-auction-option.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/pricing-options/vcpm-auction-option.json",
+  "title": "vCPM Auction Pricing Option",
+  "description": "Viewable Cost Per Mille (cost per 1,000 viewable impressions) with auction-based pricing - impressions meeting MRC viewability standard (50% pixels in-view for 1 second for display, 2 seconds for video)",
+  "type": "object",
+  "properties": {
+    "pricing_option_id": {
+      "type": "string",
+      "description": "Unique identifier for this pricing option within the product (e.g., 'vcpm_usd_auction')"
+    },
+    "pricing_model": {
+      "type": "string",
+      "const": "vcpm",
+      "description": "Cost per 1,000 viewable impressions (MRC standard)"
+    },
+    "currency": {
+      "type": "string",
+      "description": "ISO 4217 currency code",
+      "pattern": "^[A-Z]{3}$",
+      "examples": ["USD", "EUR", "GBP", "JPY"]
+    },
+    "price_guidance": {
+      "type": "object",
+      "description": "Statistical guidance for auction pricing",
+      "properties": {
+        "floor": {
+          "type": "number",
+          "description": "Minimum acceptable bid price",
+          "minimum": 0
+        },
+        "p25": {
+          "type": "number",
+          "description": "25th percentile of recent winning bids",
+          "minimum": 0
+        },
+        "p50": {
+          "type": "number",
+          "description": "Median of recent winning bids",
+          "minimum": 0
+        },
+        "p75": {
+          "type": "number",
+          "description": "75th percentile of recent winning bids",
+          "minimum": 0
+        },
+        "p90": {
+          "type": "number",
+          "description": "90th percentile of recent winning bids",
+          "minimum": 0
+        }
+      },
+      "required": ["floor"]
+    },
+    "min_spend_per_package": {
+      "type": "number",
+      "description": "Minimum spend requirement per package using this pricing option, in the specified currency",
+      "minimum": 0
+    }
+  },
+  "required": ["pricing_option_id", "pricing_model", "currency", "price_guidance"],
+  "additionalProperties": false
+}

--- a/static/schemas/v1/pricing-options/vcpm-fixed-option.json
+++ b/static/schemas/v1/pricing-options/vcpm-fixed-option.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/pricing-options/vcpm-fixed-option.json",
+  "title": "vCPM Fixed Rate Pricing Option",
+  "description": "Viewable Cost Per Mille (cost per 1,000 viewable impressions) with guaranteed fixed rate - impressions meeting MRC viewability standard (50% pixels in-view for 1 second for display, 2 seconds for video)",
+  "type": "object",
+  "properties": {
+    "pricing_option_id": {
+      "type": "string",
+      "description": "Unique identifier for this pricing option within the product (e.g., 'vcpm_usd_guaranteed')"
+    },
+    "pricing_model": {
+      "type": "string",
+      "const": "vcpm",
+      "description": "Cost per 1,000 viewable impressions (MRC standard)"
+    },
+    "rate": {
+      "type": "number",
+      "description": "Fixed vCPM rate (cost per 1,000 viewable impressions)",
+      "minimum": 0
+    },
+    "currency": {
+      "type": "string",
+      "description": "ISO 4217 currency code",
+      "pattern": "^[A-Z]{3}$",
+      "examples": ["USD", "EUR", "GBP", "JPY"]
+    },
+    "min_spend_per_package": {
+      "type": "number",
+      "description": "Minimum spend requirement per package using this pricing option, in the specified currency",
+      "minimum": 0
+    }
+  },
+  "required": ["pricing_option_id", "pricing_model", "rate", "currency"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- Add vCPM pricing model with both fixed and auction variants
- vCPM charges per 1,000 viewable impressions meeting MRC viewability standards
- Supports programmatic auction pricing (confirmed by industry research)

## Changes
- Add `vcpm` to pricing-model enum 
- Create `vcpm-fixed-option.json` and `vcpm-auction-option.json` schemas
- Update `pricing-option.json` to reference new vCPM schemas
- Add comprehensive vCPM documentation to pricing-models.md including:
  - MRC viewability standards (50% pixels for 1s display, 2s video)
  - Use cases and billing explanation
  - Measurement provider requirements
  - Reporting metrics (viewable_impressions, viewability_rate)
- Update schema registry description to note both CPM and vCPM support auction pricing

## Test plan
- [x] All schema validation tests pass
- [x] Example validation tests pass
- [x] TypeScript type checking passes
- [x] Schema references resolve correctly
- [x] Documentation build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)