### PR TITLE
Update homepage with agentic advertising messaging

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -210,59 +210,6 @@ AdCP's task-first architecture means you can access the same functionality throu
 
 Learn more in the [Protocols section](./protocols/getting-started).
 
-## Founding Members
-
-AdCP is supported by leading advertising technology companies committed to open standards:
-
-<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '3rem', alignItems: 'center', justifyItems: 'center', margin: '3rem auto', maxWidth: '1200px'}}>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/optable.png" alt="Optable" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/pubmatic.png" alt="PubMatic" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/scope3-bright.png" alt="Scope3" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/swivel.png" alt="Swivel" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/triton-digital.png" alt="Triton Digital" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'}}>
-    <img src="/img/members/yahoo-purple.png" alt="Yahoo" style={{maxWidth: '180px', maxHeight: '80px', objectFit: 'contain'}} />
-  </div>
-</div>
-
-## Launch Members
-
-AdCP is proud to welcome these launch members to the ecosystem:
-
-<div style={{display: 'flex', flexWrap: 'wrap', gap: '1.5rem', justifyContent: 'center', maxWidth: '1000px', margin: '2rem auto'}}>
-  <span style={{padding: '0.5rem 1rem'}}>Accuweather</span>
-  <span style={{padding: '0.5rem 1rem'}}>Adgent</span>
-  <span style={{padding: '0.5rem 1rem'}}>Bidcliq</span>
-  <span style={{padding: '0.5rem 1rem'}}>Butler/Till</span>
-  <span style={{padding: '0.5rem 1rem'}}>Classify</span>
-  <span style={{padding: '0.5rem 1rem'}}>HYPD</span>
-  <span style={{padding: '0.5rem 1rem'}}>Kargo</span>
-  <span style={{padding: '0.5rem 1rem'}}>Kiln</span>
-  <span style={{padding: '0.5rem 1rem'}}>LG Ad Solutions</span>
-  <span style={{padding: '0.5rem 1rem'}}>Locala</span>
-  <span style={{padding: '0.5rem 1rem'}}>Magnite</span>
-  <span style={{padding: '0.5rem 1rem'}}>Media.net</span>
-  <span style={{padding: '0.5rem 1rem'}}>MiQ</span>
-  <span style={{padding: '0.5rem 1rem'}}>Nativo</span>
-  <span style={{padding: '0.5rem 1rem'}}>Newton Research</span>
-  <span style={{padding: '0.5rem 1rem'}}>OpenAds</span>
-  <span style={{padding: '0.5rem 1rem'}}>Raptive</span>
-  <span style={{padding: '0.5rem 1rem'}}>Samba TV</span>
-  <span style={{padding: '0.5rem 1rem'}}>Scribd</span>
-  <span style={{padding: '0.5rem 1rem'}}>The Product Counsel</span>
-  <span style={{padding: '0.5rem 1rem'}}>The Weather Company</span>
-</div>
-
 ## Next Steps
 
 - **Platform Providers**: Start with the [Signals Protocol Specification](./signals/specification)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,36 +16,34 @@ function HomepageHeader() {
         <div className="row">
           <div className="col col--8 col--offset-2">
             <Heading as="h1" className={styles.heroTitle}>
-              Open Standard for Advertising Automation
+              AdCP: The Open Standard for Agentic Advertising
             </Heading>
             <p className={styles.heroSubtitle}>
-              Stop jumping between dozens of different advertising platform APIs.
-              <br />
-              <strong>AdCP unifies programmatic advertising workflows with a single, AI-powered protocol.</strong>
+              From brief to buy, helping agents advertise anywhere: from CTV to chat, from tiny blog to the World Cup.
             </p>
             <div className={styles.heroPoints}>
               <div className={styles.point}>
-                <div className={styles.pointIcon}>🔌</div>
+                <div className={styles.pointIcon}>🎯</div>
                 <div className={styles.pointText}>
-                  <strong>Unified Advertising API</strong>
+                  <strong>Built for outcomes</strong>
                   <br />
-                  Connect once, automate everywhere
+                  Buy the way you want to grow
                 </div>
               </div>
               <div className={styles.point}>
-                <div className={styles.pointIcon}>💬</div>
+                <div className={styles.pointIcon}>🤖</div>
                 <div className={styles.pointText}>
-                  <strong>AI-Powered Workflows</strong>
+                  <strong>Built for agents</strong>
                   <br />
-                  Built on Model Context Protocol (MCP)
+                  Supports MCP and A2A protocols
                 </div>
               </div>
               <div className={styles.point}>
-                <div className={styles.pointIcon}>🔓</div>
+                <div className={styles.pointIcon}>🌍</div>
                 <div className={styles.pointText}>
-                  <strong>Open Advertising Standard</strong>
+                  <strong>Built for everyone</strong>
                   <br />
-                  No vendor lock-in, complete flexibility
+                  A diverse ecosystem of tech and content
                 </div>
               </div>
             </div>
@@ -533,11 +531,11 @@ export default function Home(): ReactNode {
         <HomepageHeader />
         <main>
           <TheProblem />
+          <FoundingMembers />
+          <LaunchMembers />
           <TheSolution />
           <HowItWorks />
           <GetStarted />
-          <FoundingMembers />
-          <LaunchMembers />
           <CommunityAndSupport />
         </main>
       </Layout>


### PR DESCRIPTION
## Summary
- Changed main header to "AdCP: The Open Standard for Agentic Advertising"
- Updated hero tagline to emphasize workflow and advertising reach: "From brief to buy, helping agents advertise anywhere: from CTV to chat, from tiny blog to the World Cup"
- Revised three feature points to highlight outcomes, agent protocols, and ecosystem diversity
- Moved Founding Members and Launch Members sections higher on homepage (after "Why we built AdCP" section)
- Removed member logos from intro.md documentation page (kept on homepage only for better separation)

## Test plan
- [x] All tests pass
- [x] Build succeeds
- [x] Homepage displays new messaging correctly
- [x] Member sections appear in proper order on homepage
- [x] Documentation page no longer shows member logos

🤖 Generated with [Claude Code](https://claude.com/claude-code)