### PR TITLE
Enforce strict format ID objects everywhere

### DIFF
--- a/docs/creative/task-reference/list_creative_formats.md
+++ b/docs/creative/task-reference/list_creative_formats.md
@@ -28,7 +28,7 @@ Buyers can recursively query creative_agents to discover all available formats. 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `format_ids` | string[] | No | Return only these specific format IDs |
+| `format_ids` | FormatID[] | No | Return only these specific structured format ID objects |
 | `type` | string | No | Filter by format type: `"audio"`, `"video"`, `"display"`, `"dooh"` (technical categories with distinct requirements) |
 | `asset_types` | string[] | No | Filter to formats that include these asset types. For third-party tags, search for `["html"]` or `["javascript"]`. E.g., `["image", "text"]` returns formats with images and text, `["javascript"]` returns formats accepting JavaScript tags. Values: `image`, `video`, `audio`, `text`, `html`, `javascript`, `url` |
 | `max_width` | integer | No | Maximum width in pixels (inclusive). Returns formats with width ≤ this value. |

--- a/docs/media-buy/task-reference/create_media_buy.md
+++ b/docs/media-buy/task-reference/create_media_buy.md
@@ -37,7 +37,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this package |
 | `product_id` | string | Yes* | Product ID for this package (recommended - use instead of deprecated `products`) |
 | `products` | string[] | Yes* | **DEPRECATED**: Use `product_id` instead. Array of product IDs - only first product will be used |
-| `format_ids` | string[] | Yes | Array of format IDs that will be used for this package - must be supported by the product |
+| `format_ids` | FormatID[] | Yes | Array of structured format ID objects that will be used for this package - must be supported by the product |
 | `budget` | Budget | No | Budget configuration for this package (overrides media buy level budget if specified) |
 | `targeting_overlay` | TargetingOverlay | No | Additional targeting criteria for this package (see Targeting Overlay Object below) |
 | `creative_ids` | string[] | No | Creative IDs to assign to this package at creation time (references existing library creatives) |

--- a/docs/media-buy/task-reference/get_products.md
+++ b/docs/media-buy/task-reference/get_products.md
@@ -27,7 +27,7 @@ Discover available advertising products based on campaign requirements, using na
 | `delivery_type` | string | No | Filter by delivery type: `"guaranteed"` or `"non_guaranteed"` |
 | `is_fixed_price` | boolean | No | Filter for fixed price vs auction products |
 | `format_types` | string[] | No | Filter by format types (e.g., `["video", "display"]`) |
-| `format_ids` | string[] | No | Filter by specific format IDs (e.g., `["video_standard_30s"]`) |
+| `format_ids` | FormatID[] | No | Filter by specific structured format ID objects |
 | `standard_formats_only` | boolean | No | Only return products accepting IAB standard formats |
 | `min_exposures` | integer | No | Minimum exposures/impressions needed for measurement validity |
 ## Response (Message)

--- a/docs/media-buy/task-reference/list_creative_formats.md
+++ b/docs/media-buy/task-reference/list_creative_formats.md
@@ -28,7 +28,7 @@ Buyers can recursively query creative_agents to discover all available formats. 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `format_ids` | string[] | No | Return only these specific format IDs (e.g., from `get_products` response) |
+| `format_ids` | FormatID[] | No | Return only these specific structured format ID objects (e.g., from `get_products` response) |
 | `type` | string | No | Filter by format type: `"audio"`, `"video"`, `"display"`, `"dooh"` (technical categories with distinct requirements) |
 | `asset_types` | string[] | No | Filter to formats that include these asset types. For third-party tags, search for `["html"]` or `["javascript"]`. E.g., `["image", "text"]` returns formats with images and text, `["javascript"]` returns formats accepting JavaScript tags. Values: `image`, `video`, `audio`, `text`, `html`, `javascript`, `url` |
 | `max_width` | integer | No | Maximum width in pixels (inclusive). Returns formats where **any render** has width ≤ this value. For multi-render formats (e.g., video with companion banner), matches if at least one render fits. |

--- a/static/schemas/v1/core/format.json
+++ b/static/schemas/v1/core/format.json
@@ -6,8 +6,8 @@
   "type": "object",
   "properties": {
     "format_id": {
-      "type": "string",
-      "description": "Unique identifier for the format"
+      "$ref": "/schemas/v1/core/format-id.json",
+      "description": "Structured format identifier with agent URL and format name"
     },
     "agent_url": {
       "type": "string",
@@ -220,7 +220,7 @@
       "type": "array",
       "description": "For generative formats: array of format IDs that this format can generate. When a format accepts inputs like brand_manifest and message, this specifies what concrete output formats can be produced (e.g., a generative banner format might output standard image banner formats).",
       "items": {
-        "type": "string"
+        "$ref": "/schemas/v1/core/format-id.json"
       }
     }
   },

--- a/tests/example-validation-simple.test.js
+++ b/tests/example-validation-simple.test.js
@@ -92,7 +92,7 @@ async function runTests() {
       description: 'Response example'
     },
     {
-      data: { "format_id": "video_standard_30s", "name": "Standard Video - 30 seconds", "type": "video" },
+      data: { "format_id": {"agent_url": "https://creatives.adcontextprotocol.org", "id": "video_standard_30s"}, "name": "Standard Video - 30 seconds", "type": "video" },
       schema: '/schemas/v1/core/format.json',
       description: 'Format example'
     },


### PR DESCRIPTION
## Summary
Enforce strict format ID objects throughout the codebase, eliminating all union types that allow string format_ids. Format IDs must now consistently be structured objects with `agent_url` and `id` fields in all contexts.

## Changes

### Schema Updates
- **`static/schemas/v1/core/format.json`**:
  - Changed `format_id` field from plain string to `$ref` to format-id.json
  - Changed `output_format_ids` array items from strings to format-id objects

### Documentation Updates
- Updated type annotations from `string[]` to `FormatID[]` in:
  - `docs/media-buy/task-reference/create_media_buy.md`
  - `docs/media-buy/task-reference/get_products.md`
  - `docs/media-buy/task-reference/list_creative_formats.md`
  - `docs/creative/task-reference/list_creative_formats.md`

### Test Updates
- Fixed test example in `tests/example-validation-simple.test.js` to use structured format_id object

## Format ID Structure
All format IDs now follow this consistent pattern:
```json
{
  "agent_url": "https://creatives.adcontextprotocol.org",
  "id": "video_standard_30s"
}
```

## Test Status
✅ All schema validation tests pass
✅ All example validation tests pass
✅ TypeScript compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)