### PR TITLE
Clarify asset key usage in manifests

### DIFF
--- a/.changeset/clarify-asset-id-usage.md
+++ b/.changeset/clarify-asset-id-usage.md
@@ -2,4 +2,22 @@
 "adcontextprotocol": patch
 ---
 
-Clarify asset_id usage in creative manifests. Updated documentation and schemas to explicitly state that creative manifest asset keys must match asset_id values from format definitions.
+Clarify asset_id usage in creative manifests
+
+Previously ambiguous: The relationship between `asset_id` in format definitions and the keys used in creative manifest `assets` objects was unclear.
+
+Now explicit:
+- Creative manifest keys MUST exactly match `asset_id` values from the format's `assets_required` array
+- `asset_role` is optional/documentary—not used for manifest construction
+- Added validation guidance: what creative agents should do with mismatched keys
+
+Example: If a format defines `asset_id: "banner_image"`, your manifest must use:
+```json
+{
+  "assets": {
+    "banner_image": { ... }  // ← Must match asset_id
+  }
+}
+```
+
+Changes: Updated creative-manifest.json, format.json schemas and creative-manifests.md documentation.

--- a/docs/creative/creative-manifests.md
+++ b/docs/creative/creative-manifests.md
@@ -45,7 +45,7 @@ For an overview of how formats, manifests, and creative agents work together, se
 
 ### Asset IDs
 
-Each asset in a manifest is keyed by its `asset_id`, which must match an `asset_id` defined in the format's `assets_required` array. The asset ID serves as a semantic identifier for the asset's purpose in the creative.
+Each asset in a manifest is keyed by its `asset_id`, which must match an `asset_id` defined in the format's `assets_required` array. The asset ID serves as the technical identifier for referencing the asset requirement in the format specification.
 
 **How Asset IDs Work**:
 
@@ -271,11 +271,20 @@ Use `build_creative` to have a creative agent generate manifests from natural la
 Before using a manifest, validate it against format requirements:
 
 1. **Format Compatibility**: Ensure `format_id` matches intended format
-2. **Required Assets**: All required asset roles are present
-3. **Asset Specifications**: Each asset meets format requirements (dimensions, file size, etc.)
-4. **Macro Support**: Dynamic manifests properly handle required macros
+2. **Required Assets**: All required `asset_id` values from the format are present as keys in the manifest's `assets` object
+3. **Asset Key Matching**: Each key in the manifest's `assets` object MUST match an `asset_id` from the format's `assets_required` array
+4. **Asset Specifications**: Each asset meets format requirements (dimensions, file size, duration, etc.)
+5. **Macro Support**: Dynamic manifests properly handle required macros
+
+**What happens with invalid asset keys?**
+
+- **Missing required asset_id**: Creative agents MUST reject the manifest with an error listing which required assets are missing
+- **Unknown asset_id**: Creative agents SHOULD reject manifests containing asset keys that don't match any `asset_id` in the format. This catches typos and incompatible formats.
+- **Wrong asset_type**: If an asset's `asset_type` doesn't match the format's requirement for that `asset_id`, reject with a clear type mismatch error
 
 Creative agents that implement `build_creative` handle validation automatically. For manually constructed manifests, validate against the format specification returned by `list_creative_formats`.
+
+**Validation is runtime, not schema-time**: The JSON schema for creative manifests uses a flexible pattern (`^[a-z0-9_]+$`) for asset keys because the valid keys depend on which format you're using. Validation against the specific format's `assets_required` happens when you submit the manifest to a creative agent.
 
 ### Previewing Manifests
 

--- a/static/schemas/v1/core/creative-manifest.json
+++ b/static/schemas/v1/core/creative-manifest.json
@@ -15,7 +15,7 @@
     },
     "assets": {
       "type": "object",
-      "description": "Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets_required array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id serves as the semantic identifier for the asset's purpose in the creative.",
+      "description": "Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets_required array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.",
       "patternProperties": {
         "^[a-z0-9_]+$": {
           "oneOf": [

--- a/static/schemas/v1/core/format.json
+++ b/static/schemas/v1/core/format.json
@@ -124,7 +124,7 @@
               },
               "asset_role": {
                 "type": "string",
-                "description": "Optional semantic description of this asset's purpose. Note: asset_id serves as the primary identifier - asset_role is for human-readable documentation only."
+                "description": "Optional descriptive label for this asset's purpose (e.g., 'hero_image', 'logo'). Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
               },
               "required": {
                 "type": "boolean",
@@ -178,7 +178,7 @@
                     },
                     "asset_role": {
                       "type": "string",
-                      "description": "Optional semantic description of this asset's purpose. Note: asset_id serves as the primary identifier - asset_role is for human-readable documentation only."
+                      "description": "Optional descriptive label for this asset's purpose (e.g., 'hero_image', 'logo'). Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
                     },
                     "required": {
                       "type": "boolean",


### PR DESCRIPTION
## Background
The relationship between `asset_id` in format definitions and the keys used in creative manifests was unclear, leading to potential confusion and implementation issues.

## Changes
- **`docs/creative/creative-manifests.md`**:
    - Renamed "Asset Roles" section to "Asset IDs".
    - Added detailed explanation and examples demonstrating that manifest asset keys must match `asset_id` from format specifications.
    - Updated inline comments in examples to highlight `asset_id` usage.
- **`static/schemas/v1/core/creative-manifest.json`**:
    - Updated the `assets` object description to explicitly state that keys must match `asset_id` from the format's `assets_required` array.
- **`static/schemas/v1/core/format.json`**:
    - Clarified the description for the `asset_id` field to state that creative manifests MUST use this exact value as the key.
    - Differentiated `asset_id` as the primary identifier from `asset_role` as an optional descriptive field.
    - Updated `assets_required` description to emphasize the manifest key requirement.

## Testing
- [ ] Review documentation changes for clarity on `asset_id` usage.
- [ ] Verify schema descriptions accurately reflect the intent for `asset_id` as manifest keys.
