### PR TITLE
Add min_width / min_height to Image asset (optional sizeless minimums)

### DIFF
--- a/.changeset/whole-needles-look.md
+++ b/.changeset/whole-needles-look.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Added min_width, min_height and aspect_ratio to ImageAsset type

--- a/docs/creative/asset-types.md
+++ b/docs/creative/asset-types.md
@@ -77,11 +77,19 @@ Static image assets for banners, logos, and visual content.
 **Properties:**
 - `width` / `height`: Dimensions in pixels
 - `min_width` / `min_height`: Minimum dimensions (px; typically used by responsive/sizeless formats)
+- `aspect_ratio`: Required aspect ratio
 - `acceptable_formats`: Image formats (jpg, png, gif, webp, svg)
 - `max_file_size_kb`: Maximum file size in kilobytes
 - `transparency`: Whether transparency is required/supported
 - `animation_allowed`: Whether animated GIFs are accepted
 - `notes`: Additional requirements (e.g., "Must be free of text")
+
+**Use Cases:**
+- Fixed layout: provide `width` and `height`. Do not include `min_width`, `min_height`, or `aspect_ratio`.
+- Responsive (fixed image aspect ratio): provide `min_width`, `min_height` and `aspect_ratio`. Do not include `width` or `height`.
+- Responsive (any image aspect ratio): provide `min_width` and `min_height` only. Do not include `width`, `height`, or `aspect_ratio`.
+
+**Note**: In fixed layouts, the image slot is an exact pixel box, so specify `width` and `height`. In responsive layouts, the renderer will resize the image; use `min_width`/`min_height` to ensure there are enough pixels for a sharp result after scaling. Use `aspect_ratio` only when the image asset itself must be a specific shape (e.g., 16:9); omit it if any image aspect ratio is acceptable
 
 ### Text Asset
 

--- a/static/schemas/asset-types-v1.json
+++ b/static/schemas/asset-types-v1.json
@@ -113,6 +113,10 @@
             "type": "integer",
             "description": "Minimum required height in pixels"
           },
+          "aspect_ratio": {
+            "type": "string",
+            "description": "Required aspect ratio (e.g., '16:9', '9:16', '1:1')"
+          },
           "acceptable_formats": {
             "type": "array",
             "items": {


### PR DESCRIPTION
### Rationale
- **Avoid arbitrary global floors:** Sizeless formats span many placements; a fixed pixel minimum would be brittle.
- **Flexible per use-case:** Optional `min_width` / `min_height` let renderers enforce quality only when needed.
- **Backward-compatible:** No mandatory fields; existing creatives continue to validate unchanged.