### PR TITLE
Add changeset release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          version: npm run version
+          commit: 'Version Packages'
+          title: 'Version Packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add missing GitHub Actions workflow to create automated "Version Packages" PRs
- Enables changeset release automation when changes are merged to main
- Currently 11 pending changesets ready for version bump to 2.3.0

## How it works
1. Changesets are created and merged to main
2. Release workflow triggers automatically
3. Creates PR with:
   - Updated package.json version
   - Synced schema version in index.json
   - Generated CHANGELOG entries
   - Consumed changeset files

## Test plan
- [x] Schema validation passes
- [x] TypeScript compilation succeeds
- [x] Precommit tests pass
- [ ] Merge PR and verify "Version Packages" PR is created within minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)