### PR TITLE
Fix broken documentation links by adding .mdx extensions

### DIFF
--- a/.changeset/fix-broken-doc-links.md
+++ b/.changeset/fix-broken-doc-links.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix broken documentation links by adding .mdx file extensions.
+
+All internal documentation links were missing the `.mdx` file extension, causing 404 errors when users clicked them. This fix adds the proper `.mdx` extension to 181 internal links across 26 documentation files, ensuring all navigation links work correctly.
+
+Fixes #167

--- a/docs/creative/brand-manifest.mdx
+++ b/docs/creative/brand-manifest.mdx
@@ -470,7 +470,7 @@ For implementations using the legacy `brand_guidelines` field in `build_creative
 
 ## Related Documentation
 
-- **[create_media_buy](../media-buy/task-reference/create_media_buy)** - Media buy creation with brand context
-- **[build_creative](./task-reference/build_creative)** - AI-powered creative generation
+- **[create_media_buy](../media-buy/task-reference/create_media_buy.mdx)** - Media buy creation with brand context
+- **[build_creative](./task-reference/build_creative.mdx)** - AI-powered creative generation
 - **[Creative Lifecycle](../media-buy/creatives/)** - Managing creative assets
-- **[Data Models](../reference/data-models)** - Core AdCP data structures
+- **[Data Models](../reference/data-models.mdx)** - Core AdCP data structures

--- a/docs/creative/channels/carousels.mdx
+++ b/docs/creative/channels/carousels.mdx
@@ -674,5 +674,5 @@ https://track.brand.com/view?buy={MEDIA_BUY_ID}&item={CAROUSEL_INDEX}&total={CAR
 - [Creative Manifests](../creative-manifests.mdx) - Complete manifest specification
 - [Universal Macros](../universal-macros.mdx) - Supported macros for tracking
 - [Asset Types](../asset-types.mdx) - Asset type specifications
-- [Display Ads](./display) - Standard display formats
-- [Video Ads](./video) - Video format specifications
+- [Display Ads](./display.mdx) - Standard display formats
+- [Video Ads](./video.mdx) - Video format specifications

--- a/docs/creative/generative-creative.mdx
+++ b/docs/creative/generative-creative.mdx
@@ -2,7 +2,7 @@
 
 The Creative Protocol enables AI-powered creative generation and asset management for advertising campaigns. This guide will help you create your first creative in 5 minutes.
 
-> **Technical Reference**: This guide shows how to use the [`build_creative` task](./task-reference/build_creative). For complete API specifications, see the task reference documentation.
+> **Technical Reference**: This guide shows how to use the [`build_creative` task](./task-reference/build_creative.mdx). For complete API specifications, see the task reference documentation.
 
 ## Overview
 
@@ -12,7 +12,7 @@ The Creative Protocol provides AI-powered creative generation:
 - **`preview_creative`**: Generate previews of creative manifests
 - **`list_creative_formats`**: Discover supported creative formats
 
-Assets are provided via [Brand Manifest](./brand-manifest) - no separate asset library management needed.
+Assets are provided via [Brand Manifest](./brand-manifest.mdx) - no separate asset library management needed.
 
 ## Quick Start: Generate Your First Creative
 
@@ -121,7 +121,7 @@ Provide brand context for better creative generation:
 }
 ```
 
-See [Brand Manifest Reference](./brand-manifest) for comprehensive examples.
+See [Brand Manifest Reference](./brand-manifest.mdx) for comprehensive examples.
 
 ### Using Your Own Assets
 
@@ -190,7 +190,7 @@ For custom publisher formats, specify the source:
 
 ## Next Steps
 
-- **Browse Examples**: See [Task Reference](./task-reference/build_creative) for detailed examples
+- **Browse Examples**: See [Task Reference](./task-reference/build_creative.mdx) for detailed examples
 - **Learn Advanced Features**: Explore real-time inference and dynamic creative generation
 - **Integration Guide**: Learn how to integrate with your existing creative workflows
 - **Best Practices**: Asset organization and creative optimization strategies
@@ -210,7 +210,7 @@ To improve creative output:
 3. Use the conversational refinement feature to iterate (via `context_id`)
 
 ### Asset Management
-Assets are provided via [Brand Manifest](./brand-manifest):
+Assets are provided via [Brand Manifest](./brand-manifest.mdx):
 1. Include assets in brand manifest with descriptive tags
 2. Use `asset_filters` in requests to select specific assets
 3. Reference product catalogs for large inventories

--- a/docs/creative/index.mdx
+++ b/docs/creative/index.mdx
@@ -90,7 +90,7 @@ Assets are the raw materials. Each has a type that determines its purpose:
 - **javascript**: JavaScript tags
 - **url**: Tracking pixels, clickthrough URLs, webhooks
 
-See [Asset Types](./asset-types) for detailed specifications.
+See [Asset Types](./asset-types.mdx) for detailed specifications.
 
 ### Formats & Format Authority
 Each format has an authoritative source - the creative agent that defines it (indicated by `agent_url`). That agent:
@@ -104,32 +104,32 @@ Each format has an authoritative source - the creative agent that defines it (in
 - **Custom formats** are defined by individual publishers or creative platforms for specialized inventory
 - Technically, both work the same way - the `agent_url` field identifies which agent is authoritative for each format
 
-See the [Channel Guides](./channels/video) for format examples and patterns across video, display, audio, DOOH, and carousels.
+See the [Channel Guides](./channels/video.mdx) for format examples and patterns across video, display, audio, DOOH, and carousels.
 
 ### Manifests
 Manifests are JSON structures pairing asset IDs from the format with actual asset content. They provide the URLs, text, and tracking pixels needed to assemble a complete creative.
 
-See [Creative Manifests](./creative-manifests) for detailed documentation.
+See [Creative Manifests](./creative-manifests.mdx) for detailed documentation.
 
 ### Universal Macros
 Macros are placeholders in tracking URLs that get replaced with actual values at impression time (e.g., `{MEDIA_BUY_ID}`, `{DEVICE_ID}`, `{CACHEBUSTER}`). AdCP defines universal macros that work across all platforms - sales agents translate them to their ad server's syntax.
 
-See [Universal Macros](./universal-macros) for complete reference.
+See [Universal Macros](./universal-macros.mdx) for complete reference.
 
 ## Common Patterns
 
 ### Third-Party Tags
-For third-party served ads, formats specify HTML or JavaScript asset requirements. See the [Display Channel Guide](./channels/display) for third-party tag format examples.
+For third-party served ads, formats specify HTML or JavaScript asset requirements. See the [Display Channel Guide](./channels/display.mdx) for third-party tag format examples.
 
 ### Repeatable Asset Groups
-For carousels, slideshows, stories, playlists - anything with multiple repetitions of the same structure. See the [Carousel & Multi-Asset Formats](./channels/carousels) guide for complete documentation on repeatable asset groups.
+For carousels, slideshows, stories, playlists - anything with multiple repetitions of the same structure. See the [Carousel & Multi-Asset Formats](./channels/carousels.mdx) guide for complete documentation on repeatable asset groups.
 
 ### DOOH Impression Tracking
-Digital Out-of-Home formats use impression tracking with venue-specific macros instead of device identifiers. See the [DOOH Channel Guide](./channels/dooh) for DOOH-specific macro details.
+Digital Out-of-Home formats use impression tracking with venue-specific macros instead of device identifiers. See the [DOOH Channel Guide](./channels/dooh.mdx) for DOOH-specific macro details.
 
 ## Channel-Specific Information
 
-For detailed information on specific ad formats and channels, see the [Creative Manifests](./creative-manifests) documentation which covers:
+For detailed information on specific ad formats and channels, see the [Creative Manifests](./creative-manifests.mdx) documentation which covers:
 
 - **Video Ads** - VAST, hosted video, CTV formats
 - **Display Ads** - Banners, third-party tags, responsive formats
@@ -148,5 +148,5 @@ For detailed information on specific ad formats and channels, see the [Creative 
 
 ## Additional Resources
 
-- [Creative Task Reference](./task-reference/list_creative_formats) - API documentation for creative tasks
-- [Generative Creative](./generative-creative) - AI-powered creative generation guide
+- [Creative Task Reference](./task-reference/list_creative_formats.mdx) - API documentation for creative tasks
+- [Generative Creative](./generative-creative.mdx) - AI-powered creative generation guide

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -8,7 +8,7 @@ keywords: [advertising automation protocol, programmatic advertising API, MCP ad
 # Getting Started with Ad Context Protocol
 
 :::info **🎉 AdCP v2.3.0 Released**
-Major improvements: Publisher-owned property definitions via adagents.json, placement targeting for creative assignments, flexible product discovery with optional brand context, and streamlined budget management at package level. Plus webhook payload clarification and comprehensive security documentation. [See what's new →](./reference/release-notes)
+Major improvements: Publisher-owned property definitions via adagents.json, placement targeting for creative assignments, flexible product discovery with optional brand context, and streamlined budget management at package level. Plus webhook payload clarification and comprehensive security documentation. [See what's new →](./reference/release-notes.mdx)
 :::
 
 Welcome to the Ad Context Protocol (AdCP) documentation. AdCP is an **open standard for advertising automation** that enables AI assistants to interact with advertising platforms through unified, standardized interfaces.
@@ -159,7 +159,7 @@ Want to try AdCP right now?
 ### 🚀 [**Interactive Testing Platform**](https://testing.adcontextprotocol.org)
 Test all AdCP tasks in your browser - no code required.
 
-### 📖 [**Quickstart Guide**](./quickstart)
+### 📖 [**Quickstart Guide**](./quickstart.mdx)
 Get started in 5 minutes with authentication, testing, and your first request.
 
 ### 💻 **Install the NPM Client**
@@ -180,7 +180,7 @@ The AI assistant will:
 
 ## Available Protocols
 
-### 🎯 [Signals Activation Protocol](./signals/overview)
+### 🎯 [Signals Activation Protocol](./signals/overview.mdx)
 **Status**: RFC/v0.1
 
 Discover and activate data signals (audiences, contextual, geographical, temporal) using natural language.
@@ -209,7 +209,7 @@ Generate and optimize creative assets using AI-powered agents.
 
 If you operate a signal platform, DSP, or ad tech solution:
 
-1. [Review the Protocol Specifications](./signals/specification)
+1. [Review the Protocol Specifications](./signals/specification.mdx)
 
 ## For Advertisers & Agencies
 
@@ -227,18 +227,18 @@ AdCP's task-first architecture means you can access the same functionality throu
 - **Using A2A**: Perfect for complex workflows with approvals and multi-agent collaboration
 - **Protocol Agnostic**: Implementers write tasks once, support all protocols automatically
 
-Learn more in the [Protocols section](./protocols/getting-started).
+Learn more in the [Protocols section](./protocols/getting-started.mdx).
 
 ## Next Steps
 
 ### Getting Started
-- 🚀 **New to AdCP?** Start with the [**Quickstart Guide**](./quickstart)
+- 🚀 **New to AdCP?** Start with the [**Quickstart Guide**](./quickstart.mdx)
 - 🧪 **Want to test?** Try the [**Interactive Testing Platform**](https://testing.adcontextprotocol.org)
-- 📚 **Building an integration?** Choose [MCP](./protocols/mcp-guide) or [A2A](./protocols/a2a-guide) protocol guide
+- 📚 **Building an integration?** Choose [MCP](./protocols/mcp-guide.mdx) or [A2A](./protocols/a2a-guide.mdx) protocol guide
 
 ### By Role
-- **Platform Providers**: Start with the [Signals Protocol Specification](./signals/specification) or [Media Buy Protocol](./media-buy/)
-- **Developers**: Review the [Protocol Comparison](./protocols/protocol-comparison) and [Task Reference](./media-buy/task-reference/)
+- **Platform Providers**: Start with the [Signals Protocol Specification](./signals/specification.mdx) or [Media Buy Protocol](./media-buy/)
+- **Developers**: Review the [Protocol Comparison](./protocols/protocol-comparison.mdx) and [Task Reference](./media-buy/task-reference/)
 - **Everyone**: Join the [Slack Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
 
 ## Need Help?

--- a/docs/media-buy/advanced-topics/index.mdx
+++ b/docs/media-buy/advanced-topics/index.mdx
@@ -21,27 +21,27 @@ Advanced topics include:
 ### Targeting
 AdCP uses a brief-first targeting philosophy with technical overlays for specific needs:
 
-- **[Targeting](./targeting)** - Brief-based targeting with geographic overlays and real-time signals
+- **[Targeting](./targeting.mdx)** - Brief-based targeting with geographic overlays and real-time signals
 
 This approach enables natural language targeting specifications while supporting technical requirements for compliance and testing.
 
 ### Security & Access Control
 Enterprise-grade security features for multi-tenant environments:
 
-- **[Principals & Security](./principals-and-security)** - Multi-tenant security model and access control
-- **[Policy Compliance](../media-buys/policy-compliance)** - Automated compliance checking and enforcement
+- **[Principals & Security](./principals-and-security.mdx)** - Multi-tenant security model and access control
+- **[Policy Compliance](../media-buys/policy-compliance.mdx)** - Automated compliance checking and enforcement
 
 ### Implementation Architecture
 Deep technical details for implementers:
 
-- **[Orchestrator Design](./orchestrator-design)** - Technical architecture for AdCP orchestrators
+- **[Orchestrator Design](./orchestrator-design.mdx)** - Technical architecture for AdCP orchestrators
 
 ## Development & Testing
 
 ### Development Tools
 Accelerate development with AdCP's testing capabilities:
 
-- **[Testing](./testing)** - Time simulation and dry run capabilities for faster development
+- **[Testing](./testing.mdx)** - Time simulation and dry run capabilities for faster development
 - **Time simulation** for testing campaign timing without waiting
 - **Dry run modes** for safe testing of live operations
 
@@ -116,5 +116,5 @@ Detailed understanding of system performance:
 ## Next Steps
 
 For practical application of these advanced concepts:
-- **Review [Testing](./testing)** for development best practices
-- **Explore [Orchestrator Design](./orchestrator-design)** for architecture guidance
+- **Review [Testing](./testing.mdx)** for development best practices
+- **Explore [Orchestrator Design](./orchestrator-design.mdx)** for architecture guidance

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -263,7 +263,7 @@ Orchestrators can provide **real-time targeting signals** to publishers for dyna
 - **Audience targeting** - Dynamic audience segments updated in real-time
 - **Contextual targeting** - Page-level or moment-level targeting decisions
 
-Real-time signals are provided through the [AdCP Signals Protocol](../../signals/overview), which allows orchestrators to supply targeting data at impression time.
+Real-time signals are provided through the [AdCP Signals Protocol](../../signals/overview.mdx), which allows orchestrators to supply targeting data at impression time.
 
 ### Key Differences: Signals vs Overlays
 
@@ -317,7 +317,7 @@ Real-time signals are provided through the [AdCP Signals Protocol](../../signals
 
 ## Related Documentation
 
-- **[Signals Protocol](../../signals/overview)** - Real-time targeting signals for brand safety and contextual targeting
+- **[Signals Protocol](../../signals/overview.mdx)** - Real-time targeting signals for brand safety and contextual targeting
 - **[Product Discovery](../product-discovery/)** - How briefs lead to targeted product recommendations
-- **[Example Briefs](../product-discovery/example-briefs)** - Real examples of effective targeting briefs
-- **[Policy Compliance](../media-buys/policy-compliance)** - Automated compliance checking and enforcement
+- **[Example Briefs](../product-discovery/example-briefs.mdx)** - Real examples of effective targeting briefs
+- **[Policy Compliance](../media-buys/policy-compliance.mdx)** - Automated compliance checking and enforcement

--- a/docs/media-buy/capability-discovery/authorized-properties.mdx
+++ b/docs/media-buy/capability-discovery/authorized-properties.mdx
@@ -92,7 +92,7 @@ Publishers authorize sales agents by hosting an `adagents.json` file at `/.well-
 
 ## How Sales Agents Share Authorized Properties
 
-Sales agents use the [`list_authorized_properties`](../task-reference/list_authorized_properties) task to declare all properties they are authorized to represent. This serves multiple purposes:
+Sales agents use the [`list_authorized_properties`](../task-reference/list_authorized_properties.mdx) task to declare all properties they are authorized to represent. This serves multiple purposes:
 
 1. **Transparency**: Buyers can see what properties an agent represents
 2. **Validation enablement**: Provides the data buyers need to verify authorization
@@ -247,7 +247,7 @@ if (!authorized) {
 
 Authorization validation integrates seamlessly with [Product Discovery](../product-discovery/):
 
-1. **Discover products** using [`get_products`](../task-reference/get_products)
+1. **Discover products** using [`get_products`](../task-reference/get_products.mdx)
 2. **Validate authorization** for properties referenced in products
 3. **Proceed confidently** with authorized inventory
 4. **Flag unauthorized** products for manual review
@@ -266,11 +266,11 @@ For complete technical details on implementing the `adagents.json` file format, 
 - Validation code examples and error handling
 - Security considerations and best practices
 
-See the **[adagents.json Tech Spec](./adagents)** for complete implementation guidance.
+See the **[adagents.json Tech Spec](./adagents.mdx)** for complete implementation guidance.
 
 ## Related Documentation
 
-- **[`list_authorized_properties`](../task-reference/list_authorized_properties)** - API reference for property discovery
+- **[`list_authorized_properties`](../task-reference/list_authorized_properties.mdx)** - API reference for property discovery
 - **[Product Discovery](../product-discovery/)** - How authorization integrates with product discovery
 - **[Properties Schema](https://adcontextprotocol.org/schemas/v1/core/property.json)** - Technical property data model
-- **[adagents.json Tech Spec](./adagents)** - Complete `adagents.json` implementation guide
+- **[adagents.json Tech Spec](./adagents.mdx)** - Complete `adagents.json` implementation guide

--- a/docs/media-buy/capability-discovery/index.mdx
+++ b/docs/media-buy/capability-discovery/index.mdx
@@ -11,7 +11,7 @@ Before you can effectively buy advertising through AdCP, you need to understand 
 
 ## What You'll Learn
 
-### [Implementing Standard Format Support](./implementing-standard-formats) 🎨
+### [Implementing Standard Format Support](./implementing-standard-formats.mdx) 🎨
 Learn how sales agents can support standard creative formats through the reference creative agent. Learn how to:
 
 - Reference standard IAB formats without replicating them
@@ -22,7 +22,7 @@ Learn how sales agents can support standard creative formats through the referen
 - Leverage the Standard Creative Agent for standard formats
 - Work with publisher-specific creative agents for custom formats
 
-### [Authorized Properties](./authorized-properties) 🔐
+### [Authorized Properties](./authorized-properties.mdx) 🔐
 Learn how AdCP prevents unauthorized resale and ensures sales agents are legitimate. Understand:
 
 - The problem of unauthorized resale in digital advertising
@@ -35,19 +35,19 @@ Learn how AdCP prevents unauthorized resale and ensures sales agents are legitim
 
 These capability discovery tasks provide the reference data needed for effective AdCP workflows:
 
-### [`list_creative_formats`](../task-reference/list_creative_formats)
+### [`list_creative_formats`](../task-reference/list_creative_formats.mdx)
 Discover all supported creative formats with detailed specifications including dimensions, file types, duration limits, and technical requirements.
 
-### [`list_authorized_properties`](../task-reference/list_authorized_properties)  
+### [`list_authorized_properties`](../task-reference/list_authorized_properties.mdx)  
 Get all properties a sales agent is authorized to represent, including property tags for efficient organization and authorization validation data.
 
 ## Integration Pattern
 
 Capability discovery typically happens early in your AdCP workflow:
 
-1. **Understand Formats**: Call [`list_creative_formats`](../task-reference/list_creative_formats) to learn supported creative types
-2. **Validate Authorization**: Use [`list_authorized_properties`](../task-reference/list_authorized_properties) to verify sales agent legitimacy
-3. **Discover Products**: Search for advertising inventory with [`get_products`](../task-reference/get_products)
+1. **Understand Formats**: Call [`list_creative_formats`](../task-reference/list_creative_formats.mdx) to learn supported creative types
+2. **Validate Authorization**: Use [`list_authorized_properties`](../task-reference/list_authorized_properties.mdx) to verify sales agent legitimacy
+3. **Discover Products**: Search for advertising inventory with [`get_products`](../task-reference/get_products.mdx)
 4. **Plan Creatives**: Match discovered products to available formats for production planning
 5. **Execute Campaigns**: Create media buys with confidence in format compatibility and authorization
 
@@ -75,6 +75,6 @@ Together, these capabilities provide the foundation for safe, efficient, and eff
 - **[Product Discovery](../product-discovery/)** - Finding advertising inventory
 - **[Creatives](../creatives/)** - Creative asset management
 - **[Creative Protocol](../../creative/)** - Creative agents and manifests
-- **[Creative Channel Guides](../../creative/channels/video)** - Format examples and patterns
+- **[Creative Channel Guides](../../creative/channels/video.mdx)** - Format examples and patterns
 - **[Creative Manifests](../../creative/creative-manifests.mdx)** - Understanding creative specifications
-- **[AdAgents Specification](./adagents)** - Technical authorization details
+- **[AdAgents Specification](./adagents.mdx)** - Technical authorization details

--- a/docs/media-buy/creatives/index.mdx
+++ b/docs/media-buy/creatives/index.mdx
@@ -20,10 +20,10 @@ AdCP's creative management system handles:
 ## Key Creative Tasks
 
 ### Creative Synchronization
-Use [`sync_creatives`](../task-reference/sync_creatives) to upload and manage creative assets in the centralized library. This ensures your creatives are available across all platforms and campaigns.
+Use [`sync_creatives`](../task-reference/sync_creatives.mdx) to upload and manage creative assets in the centralized library. This ensures your creatives are available across all platforms and campaigns.
 
 ### Creative Library Management  
-Use [`list_creatives`](../task-reference/list_creatives) to view and manage your creative asset library, including status tracking and performance metadata.
+Use [`list_creatives`](../task-reference/list_creatives.mdx) to view and manage your creative asset library, including status tracking and performance metadata.
 
 ## The Three Main Phases
 
@@ -126,7 +126,7 @@ AdCP uses a centralized creative library where assets are uploaded once and assi
 - Reuse creatives across multiple media buys
 - Track performance across all assignments
 
-Asset management is handled through [Brand Manifests](../../creative/brand-manifest), which provide brand-level assets with tags for discovery.
+Asset management is handled through [Brand Manifests](../../creative/brand-manifest.mdx), which provide brand-level assets with tags for discovery.
 
 ## Platform Considerations
 
@@ -167,10 +167,10 @@ Creative operations have varying response times:
 
 ## Related Documentation
 
-- **[`sync_creatives`](../task-reference/sync_creatives)** - Bulk creative management with upsert semantics
-- **[`list_creatives`](../task-reference/list_creatives)** - Advanced creative library querying and filtering
-- **[`list_creative_formats`](../task-reference/list_creative_formats)** - Understanding format requirements
-- **[Brand Manifest](../../creative/brand-manifest)** - Brand identity and asset management
-- **[Creative Formats](../../creative/formats)** - Understanding format specifications and discovery
-- **[Creative Channel Guides](../../creative/channels/video)** - Format examples across video, display, audio, DOOH, and carousels
-- **[Asset Types](../../creative/asset-types)** - Understanding asset roles and specifications
+- **[`sync_creatives`](../task-reference/sync_creatives.mdx)** - Bulk creative management with upsert semantics
+- **[`list_creatives`](../task-reference/list_creatives.mdx)** - Advanced creative library querying and filtering
+- **[`list_creative_formats`](../task-reference/list_creative_formats.mdx)** - Understanding format requirements
+- **[Brand Manifest](../../creative/brand-manifest.mdx)** - Brand identity and asset management
+- **[Creative Formats](../../creative/formats.mdx)** - Understanding format specifications and discovery
+- **[Creative Channel Guides](../../creative/channels/video.mdx)** - Format examples across video, display, audio, DOOH, and carousels
+- **[Asset Types](../../creative/asset-types.mdx)** - Understanding asset roles and specifications

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -12,31 +12,31 @@ The Media Buy protocol is AdCP's core advertising automation interface, providin
 
 Media Buy tasks are accessible through multiple protocols:
 
-- **[MCP (Model Context Protocol)](../protocols/mcp-guide)**: Direct integration with AI assistants like Claude
-- **[A2A (Agent-to-Agent)](../protocols/a2a-guide)**: Complex agent workflows and collaboration
+- **[MCP (Model Context Protocol)](../protocols/mcp-guide.mdx)**: Direct integration with AI assistants like Claude
+- **[A2A (Agent-to-Agent)](../protocols/a2a-guide.mdx)**: Complex agent workflows and collaboration
 - **REST API**: Coming soon for traditional integrations
 
-All protocols provide identical functionality - choose based on your integration needs. See [Protocol Comparison](../protocols/protocol-comparison) for guidance.
+All protocols provide identical functionality - choose based on your integration needs. See [Protocol Comparison](../protocols/protocol-comparison.mdx) for guidance.
 
 ## The 8 Core Media Buy Tasks
 
 The Media Buy protocol provides these essential operations:
 
 ### Discovery & Planning
-- **[`get_products`](./task-reference/get_products)**: Discover advertising inventory using natural language briefs
-- **[`list_creative_formats`](./task-reference/list_creative_formats)**: Understand creative requirements and specifications
-- **[`list_authorized_properties`](./task-reference/list_authorized_properties)**: Verify publisher authorization and available properties
+- **[`get_products`](./task-reference/get_products.mdx)**: Discover advertising inventory using natural language briefs
+- **[`list_creative_formats`](./task-reference/list_creative_formats.mdx)**: Understand creative requirements and specifications
+- **[`list_authorized_properties`](./task-reference/list_authorized_properties.mdx)**: Verify publisher authorization and available properties
 
 ### Campaign Execution
-- **[`create_media_buy`](./task-reference/create_media_buy)**: Launch advertising campaigns with complete lifecycle management
-- **[`update_media_buy`](./task-reference/update_media_buy)**: Modify budgets, targeting, and campaign settings
+- **[`create_media_buy`](./task-reference/create_media_buy.mdx)**: Launch advertising campaigns with complete lifecycle management
+- **[`update_media_buy`](./task-reference/update_media_buy.mdx)**: Modify budgets, targeting, and campaign settings
 
 ### Creative Management
-- **[`list_creatives`](./task-reference/list_creatives)**: Browse and filter creative asset libraries
-- **[`sync_creatives`](./task-reference/sync_creatives)**: Upload and synchronize creative assets across platforms
+- **[`list_creatives`](./task-reference/list_creatives.mdx)**: Browse and filter creative asset libraries
+- **[`sync_creatives`](./task-reference/sync_creatives.mdx)**: Upload and synchronize creative assets across platforms
 
 ### Performance Optimization
-- **[`get_media_buy_delivery`](./task-reference/get_media_buy_delivery)**: Track performance metrics and campaign delivery
+- **[`get_media_buy_delivery`](./task-reference/get_media_buy_delivery.mdx)**: Track performance metrics and campaign delivery
 
 ## Key Design Principles
 
@@ -222,7 +222,7 @@ Advanced features including targeting dimensions, security models, design ration
 Choose your path based on your role and needs:
 
 ### **For AI Agent Developers**
-1. **Start with [Protocol Selection](../protocols/protocol-comparison)** - Choose MCP or A2A based on your use case
+1. **Start with [Protocol Selection](../protocols/protocol-comparison.mdx)** - Choose MCP or A2A based on your use case
 2. **Learn [Capability Discovery](./capability-discovery/)** - Understand creative formats and property authorization
 3. **Try [Product Discovery](./product-discovery/)** - See how natural language briefs work
 4. **Reference [Task Reference](./task-reference/)** - Implement the 8 core tasks
@@ -230,16 +230,16 @@ Choose your path based on your role and needs:
 ### **For Campaign Managers**
 1. **Understand the [Media Buy Lifecycle](./media-buys/)** - Learn the complete workflow
 2. **Review [Product Discovery](./product-discovery/)** - See how to find inventory with briefs
-3. **Study [Policy Compliance](./media-buys/policy-compliance)** - Understand approval requirements
-4. **Explore [Optimization & Reporting](./media-buys/optimization-reporting)** - Learn performance management
+3. **Study [Policy Compliance](./media-buys/policy-compliance.mdx)** - Understand approval requirements
+4. **Explore [Optimization & Reporting](./media-buys/optimization-reporting.mdx)** - Learn performance management
 
 ### **For Publishers/Sales Agents**
-1. **Learn [Authorized Properties](./capability-discovery/authorized-properties)** - Understand authorization requirements
-2. **Review [Creative Formats](../creative/formats)** - See supported creative specifications
+1. **Learn [Authorized Properties](./capability-discovery/authorized-properties.mdx)** - Understand authorization requirements
+2. **Review [Creative Formats](../creative/formats.mdx)** - See supported creative specifications
 3. **Study [Advanced Topics](./advanced-topics/)** - Deep dive into technical implementation
 
 ### **For Technical Implementers**
-1. **Choose your [Protocol](../protocols/protocol-comparison)** - MCP vs A2A comparison
+1. **Choose your [Protocol](../protocols/protocol-comparison.mdx)** - MCP vs A2A comparison
 2. **Study [Task Reference](./task-reference/)** - Complete API documentation
 3. **Review [Advanced Topics](./advanced-topics/)** - Security, testing, and architecture
 4. **Explore [Creative Management](./creatives/)** - Asset lifecycle and synchronization

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -22,7 +22,7 @@ AdCP's media buy management provides a unified interface for:
 ## The Media Buy Lifecycle Phases
 
 ### 1. Creation Phase
-Transform discovered products into active advertising campaigns using [`create_media_buy`](../task-reference/create_media_buy):
+Transform discovered products into active advertising campaigns using [`create_media_buy`](../task-reference/create_media_buy.mdx):
 
 - **Package Configuration**: Combine products with formats, targeting, and budget
 - **Campaign Setup**: Define timing, overall budget, and promoted offering
@@ -40,7 +40,7 @@ This phase may involve:
 - **Triton Digital**: Creates a Campaign with Flights
 
 ### 2. Creative Upload Phase
-Once created, the media buy requires creative assets via [`sync_creatives`](../task-reference/sync_creatives):
+Once created, the media buy requires creative assets via [`sync_creatives`](../task-reference/sync_creatives.mdx):
 
 - **Platform-specific format support** (video, audio, display, custom)
 - **Validation and policy review** for creative compliance
@@ -51,7 +51,7 @@ Monitor and manage active campaigns:
 
 - **Status Tracking**: Campaign transitions from `pending_activation` to `active`
 - **Creative Assignment**: Attach assets from the creative library
-- **Delivery Monitoring**: Track pacing and performance metrics with [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery)
+- **Delivery Monitoring**: Track pacing and performance metrics with [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx)
 - **Issue Resolution**: Handle approval delays and platform issues
 
 ### 4. Optimization & Reporting Phase
@@ -63,7 +63,7 @@ Key activities include:
 - **Dimensional reporting** using the same targeting dimensions for consistent analysis
 - **AI-driven insights** through performance feedback loops
 
-For complete details on optimization strategies, performance monitoring, standard metrics, and best practices, see **[Optimization & Reporting](./optimization-reporting)**.
+For complete details on optimization strategies, performance monitoring, standard metrics, and best practices, see **[Optimization & Reporting](./optimization-reporting.mdx)**.
 
 ## Key Concepts
 
@@ -189,17 +189,17 @@ Campaign state transitions:
 
 Media buy operations use a unified status system with predictable timing:
 
-- **[`create_media_buy`](../task-reference/create_media_buy)**: Instant to days
+- **[`create_media_buy`](../task-reference/create_media_buy.mdx)**: Instant to days
   - `completed`: Simple campaigns created immediately  
   - `working`: Processing within 120 seconds (validation, setup)
   - `submitted`: Complex campaigns requiring hours to days (human approval)
   
-- **[`update_media_buy`](../task-reference/update_media_buy)**: Instant to days
+- **[`update_media_buy`](../task-reference/update_media_buy.mdx)**: Instant to days
   - `completed`: Budget changes applied immediately
   - `working`: Targeting updates within 120 seconds
   - `submitted`: Package modifications requiring approval (hours to days)
 
-- **[`get_media_buy_delivery`](../task-reference/get_media_buy_delivery)**: ~60 seconds (data aggregation)
+- **[`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx)**: ~60 seconds (data aggregation)
 - **Performance analysis**: ~1 second (cached metrics)
 
 **Status Meanings:**
@@ -330,10 +330,10 @@ Different platforms offer varying reporting and optimization capabilities:
 
 ### Discovery to Media Buy
 Seamless flow from product discovery to campaign creation:
-1. Use [`get_products`](../task-reference/get_products) to find inventory
+1. Use [`get_products`](../task-reference/get_products.mdx) to find inventory
 2. Select products that align with campaign objectives
 3. Configure packages with appropriate targeting and formats
-4. Create media buy with [`create_media_buy`](../task-reference/create_media_buy)
+4. Create media buy with [`create_media_buy`](../task-reference/create_media_buy.mdx)
 
 ### Creative Integration
 Coordinate with creative management:
@@ -345,7 +345,7 @@ Coordinate with creative management:
 ### Performance Optimization
 Data-driven campaign improvement leveraging comprehensive analytics:
 
-1. **Track delivery** with [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery)
+1. **Track delivery** with [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx)
    - Monitor real-time delivery metrics and pacing analysis
    - Get package-level performance breakdown for optimization opportunities
    - Track performance across different targeting approaches
@@ -355,7 +355,7 @@ Data-driven campaign improvement leveraging comprehensive analytics:
    - Monitor performance index scores for AI-driven optimization
    - Identify high and low performing segments
 
-3. **Update campaigns** with [`update_media_buy`](../task-reference/update_media_buy)
+3. **Update campaigns** with [`update_media_buy`](../task-reference/update_media_buy.mdx)
    - Reallocate budgets between high and low performing packages
    - Adjust targeting based on performance data
    - Pause underperforming packages and scale successful ones
@@ -377,4 +377,4 @@ Data-driven campaign improvement leveraging comprehensive analytics:
 - **[Product Discovery](../product-discovery/)** - Finding inventory for media buys
 - **[Task Reference](../task-reference/)** - Complete API documentation
 - **[Creatives](../creatives/)** - Creative asset management
-- **[Orchestrator Design Guide](../advanced-topics/orchestrator-design)** - Implementation best practices
+- **[Orchestrator Design Guide](../advanced-topics/orchestrator-design.mdx)** - Implementation best practices

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -15,12 +15,12 @@ Performance data feeds into AdCP's [Accountability & Trust Framework](../index.m
 ## Key Optimization Tasks
 
 ### Delivery Reporting
-Use [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery) to retrieve comprehensive performance data including impressions, spend, clicks, and conversions across all campaign packages.
+Use [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx) to retrieve comprehensive performance data including impressions, spend, clicks, and conversions across all campaign packages.
 
 Alternatively, configure **webhook-based reporting** during media buy creation to receive automated delivery notifications at regular intervals.
 
 ### Campaign Updates
-Use [`update_media_buy`](../task-reference/update_media_buy) to modify campaign settings, budgets, and configurations based on performance insights.
+Use [`update_media_buy`](../task-reference/update_media_buy.mdx) to modify campaign settings, budgets, and configurations based on performance insights.
 
 ## Optimization Workflow
 
@@ -176,7 +176,7 @@ When a reporting webhook is configured, publishers commit to sending:
 
 ### Webhook Payload
 
-Reporting webhooks use the same payload structure as [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery) with additional metadata:
+Reporting webhooks use the same payload structure as [`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx) with additional metadata:
 
 ```json
 {
@@ -647,7 +647,7 @@ See [Core Concepts: Webhook Reliability](../../protocols/core-concepts.mdx#webho
 - **Temporal adjustments** for optimal timing
 
 ## Performance Feedback Loop
-The performance feedback system enables AI-driven optimization by feeding back business outcomes to publishers. See [`provide_performance_feedback`](../task-reference/provide_performance_feedback) for detailed API documentation.
+The performance feedback system enables AI-driven optimization by feeding back business outcomes to publishers. See [`provide_performance_feedback`](../task-reference/provide_performance_feedback.mdx) for detailed API documentation.
 
 ### Performance Index Concept
 
@@ -659,7 +659,7 @@ A normalized score indicating relative performance:
 
 ### Sharing Performance Data
 
-Buyers can voluntarily share performance outcomes using the [`provide_performance_feedback`](../task-reference/provide_performance_feedback) task:
+Buyers can voluntarily share performance outcomes using the [`provide_performance_feedback`](../task-reference/provide_performance_feedback.mdx) task:
 
 ```json
 {
@@ -704,7 +704,7 @@ Publishers can leverage performance indices to:
 Future implementations may support dimensional performance feedback, allowing optimization at the intersection of multiple dimensions (e.g., "mobile users in NYC perform 80% above baseline").
 
 ## Targeting Consistency
-Reporting aligns with AdCP's [Targeting](../advanced-topics/targeting) approach, enabling:
+Reporting aligns with AdCP's [Targeting](../advanced-topics/targeting.mdx) approach, enabling:
 - **Consistent analysis** across campaign lifecycle
 - **Granular breakdowns** by targeting parameters
 - **Cross-campaign insights** for portfolio optimization
@@ -783,7 +783,7 @@ Optimization and reporting is the ongoing phase that runs throughout active camp
 
 ## Related Documentation
 
-- **[`get_media_buy_delivery`](../task-reference/get_media_buy_delivery)** - Retrieve delivery reports
-- **[`update_media_buy`](../task-reference/update_media_buy)** - Modify campaigns based on performance
+- **[`get_media_buy_delivery`](../task-reference/get_media_buy_delivery.mdx)** - Retrieve delivery reports
+- **[`update_media_buy`](../task-reference/update_media_buy.mdx)** - Modify campaigns based on performance
 - **[Media Buy Lifecycle](./index.mdx)** - Complete campaign management workflow
-- **[Targeting](../advanced-topics/targeting)** - Brief-based targeting and overlays
+- **[Targeting](../advanced-topics/targeting.mdx)** - Brief-based targeting and overlays

--- a/docs/media-buy/media-buys/policy-compliance.mdx
+++ b/docs/media-buy/media-buys/policy-compliance.mdx
@@ -23,7 +23,7 @@ All product discovery and media buy creation requests must include a clear `prom
 - What is being promoted (product, service, cause, candidate, program, etc.)
 - Key attributes or positioning of the offering
 
-For comprehensive guidance on brief structure and the role of `promoted_offering`, see [Brief Expectations](../product-discovery/brief-expectations).
+For comprehensive guidance on brief structure and the role of `promoted_offering`, see [Brief Expectations](../product-discovery/brief-expectations.mdx).
 
 ### Examples
 
@@ -190,6 +190,6 @@ Policy decisions can trigger Human-in-the-Loop workflows:
 
 ## Related Documentation
 
-- [`get_products`](../task-reference/get_products) - Product discovery with policy checks
-- [`create_media_buy`](../task-reference/create_media_buy) - Media buy creation with validation
-- [Principals & Security](../advanced-topics/principals-and-security) - Authentication and authorization
+- [`get_products`](../task-reference/get_products.mdx) - Product discovery with policy checks
+- [`create_media_buy`](../task-reference/create_media_buy.mdx) - Media buy creation with validation
+- [Principals & Security](../advanced-topics/principals-and-security.mdx) - Authentication and authorization

--- a/docs/media-buy/product-discovery/index.mdx
+++ b/docs/media-buy/product-discovery/index.mdx
@@ -24,7 +24,7 @@ Start with a natural language description of your campaign objectives:
 *"Mike's Plumbing Services needs to reach homeowners in the Denver, Colorado area who might need plumbing services. We have $8,000 USD to spend from October 15-31, 2024. Looking for display and native formats to drive phone calls."*
 
 ### 2. Discover Products  
-Use [`get_products`](../task-reference/get_products) to find matching inventory based on your brief and promoted offering.
+Use [`get_products`](../task-reference/get_products.mdx) to find matching inventory based on your brief and promoted offering.
 
 ### 3. Evaluate Results
 Review returned products for:
@@ -49,7 +49,7 @@ Instead, describe your campaign naturally:
 - ✅ "Local restaurant targeting dinner rush commuters"
 - ✅ "B2B software for marketing managers"
 
-Learn more in [Brief Expectations](./brief-expectations).
+Learn more in [Brief Expectations](./brief-expectations.mdx).
 
 ### Product Model
 Products represent sellable advertising inventory with:
@@ -58,13 +58,13 @@ Products represent sellable advertising inventory with:
 - **Pricing structure** (fixed rates or auction guidance)
 - **Delivery characteristics** (guaranteed reach vs best-effort)
 
-Understand the complete product structure in [Media Products](./media-products).
+Understand the complete product structure in [Media Products](./media-products.mdx).
 
 ### Format Discovery Integration
 Product discovery works hand-in-hand with creative planning:
 
 1. **Products return format IDs** for required creative specifications
-2. **Use [`list_creative_formats`](../task-reference/list_creative_formats)** to get detailed format requirements
+2. **Use [`list_creative_formats`](../task-reference/list_creative_formats.mdx)** to get detailed format requirements
 3. **Plan creative production** based on discovered format needs
 
 ## Brief Examples & Patterns
@@ -76,7 +76,7 @@ Real-world examples of effective briefs for different campaign types:
 - **B2B**: Job titles, company characteristics, lead generation
 - **Brand Awareness**: Lifestyle attributes, media consumption, reach objectives
 
-Explore comprehensive examples in [Example Briefs](./example-briefs).
+Explore comprehensive examples in [Example Briefs](./example-briefs.mdx).
 
 ## Discovery Best Practices
 
@@ -102,8 +102,8 @@ Explore comprehensive examples in [Example Briefs](./example-briefs).
 ## Response Times
 
 Product discovery operations:
-- **[`get_products`](../task-reference/get_products)**: ~60 seconds (AI processing)
-- **[`list_creative_formats`](../task-reference/list_creative_formats)**: ~1 second (database lookup)
+- **[`get_products`](../task-reference/get_products.mdx)**: ~60 seconds (AI processing)
+- **[`list_creative_formats`](../task-reference/list_creative_formats.mdx)**: ~1 second (database lookup)
 
 ## Next Steps
 
@@ -114,7 +114,7 @@ After discovering products:
 
 ## Related Documentation
 
-- **[Brief Expectations](./brief-expectations)** - Comprehensive guide to brief structure
-- **[Example Briefs](./example-briefs)** - Real-world campaign brief patterns  
-- **[Media Products](./media-products)** - Understanding product model and attributes
-- **[`get_products` Task](../task-reference/get_products)** - Complete API reference
+- **[Brief Expectations](./brief-expectations.mdx)** - Comprehensive guide to brief structure
+- **[Example Briefs](./example-briefs.mdx)** - Real-world campaign brief patterns  
+- **[Media Products](./media-products.mdx)** - Understanding product model and attributes
+- **[`get_products` Task](../task-reference/get_products.mdx)** - Complete API reference

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -7,7 +7,7 @@ title: Media Products
 A **Product** is the core sellable unit in AdCP. This document details the Product model, including its pricing and delivery types, and how products are discovered and structured in the system.
 
 :::tip **Pricing Models**
-Products declare which pricing models they support. Buyers select a specific pricing option when creating media buys. See the complete [Pricing Models Guide](../advanced-topics/pricing-models) for details on CPM, CPCV, CPP, CPC, vCPM, and flat rate pricing.
+Products declare which pricing models they support. Buyers select a specific pricing option when creating media buys. See the complete [Pricing Models Guide](../advanced-topics/pricing-models.mdx) for details on CPM, CPCV, CPP, CPC, vCPM, and flat rate pricing.
 :::
 
 ## The Product Model

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -9,7 +9,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 
 **Response Time**: Instant to days (returns `completed`, `working` < 120s, or `submitted` for hours/days)
 
-**Pricing & Currency**: Each package specifies its own `pricing_option_id`, which determines currency, pricing model (CPM, CPCV, CPP, etc.), and rates. Packages can use different currencies when sellers support it—sellers validate and reject incompatible combinations. See [Pricing Models](../advanced-topics/pricing-models) for details.
+**Pricing & Currency**: Each package specifies its own `pricing_option_id`, which determines currency, pricing model (CPM, CPCV, CPP, etc.), and rates. Packages can use different currencies when sellers support it—sellers validate and reject incompatible combinations. See [Pricing Models](../advanced-topics/pricing-models.mdx) for details.
 
 **Format Specification Required**: Each package must specify the creative formats that will be used. This enables placeholder creation in ad servers and ensures both parties have clear expectations for creative asset requirements.
 
@@ -23,7 +23,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this media buy |
 | `packages` | Package[] | Yes | Array of package configurations (see Package Object below) |
-| `brand_manifest` | BrandManifestRef | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided as an inline object or URL reference to a hosted manifest. Can be cached and reused across multiple requests. See [Brand Manifest](../../creative/brand-manifest) for details. |
+| `brand_manifest` | BrandManifestRef | Yes | Brand information manifest serving as the namespace and identity for this media buy. Provides brand context, assets, and product catalog. Can be provided as an inline object or URL reference to a hosted manifest. Can be cached and reused across multiple requests. See [Brand Manifest](../../creative/brand-manifest.mdx) for details. |
 | `promoted_products` | PromotedProducts | No | Products or offerings being promoted in this media buy. Useful for campaign-level reporting, policy compliance, and publisher understanding of what's being advertised. Selects from brand manifest's product catalog using SKUs, tags, categories, or natural language queries. |
 | `po_number` | string | No | Purchase order number for tracking |
 | `start_time` | string | Yes | Campaign start time: `"asap"` to start as soon as possible, or ISO 8601 date-time for scheduled start |
@@ -36,7 +36,7 @@ Create a media buy from selected packages. This task handles the complete workfl
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Buyer's reference identifier for this package |
 | `product_id` | string | Yes | Product ID for this package |
-| `pricing_option_id` | string | Yes | Pricing option ID from the product's `pricing_options` array - specifies pricing model and currency for this package. See [Pricing Models](../advanced-topics/pricing-models) for details. |
+| `pricing_option_id` | string | Yes | Pricing option ID from the product's `pricing_options` array - specifies pricing model and currency for this package. See [Pricing Models](../advanced-topics/pricing-models.mdx) for details. |
 | `format_ids` | FormatID[] | Yes | Array of structured format ID objects that will be used for this package - must be supported by the product |
 | `budget` | number | Yes | Budget allocation for this package in the currency specified by the pricing option |
 | `pacing` | string | No | Pacing strategy: `"even"` (default), `"asap"`, or `"front_loaded"` |
@@ -1130,7 +1130,7 @@ If validation fails, return an error:
 - Each package is based on a single product with specific targeting, budget allocation, and format requirements
 - **Format specification is required** for each package - this enables placeholder creation and validation
 - Both media buys and packages have `buyer_ref` fields for the buyer's reference tracking
-- The `brand_manifest` field is required and provides brand identity, context, and product catalog (see [Brand Manifest](../../creative/brand-manifest) for guidance)
+- The `brand_manifest` field is required and provides brand identity, context, and product catalog (see [Brand Manifest](../../creative/brand-manifest.mdx) for guidance)
 - Publishers will validate the promoted offering against their policies before creating the media buy
 - Package-level targeting overlay applies additional criteria on top of product-level targeting
 - The total budget is distributed across packages based on their individual `budget` settings (or proportionally if not specified)

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -9,9 +9,9 @@ Discover available advertising products based on campaign requirements, using na
 
 **Response Time**: ~60 seconds (inference/RAG with back-end systems)
 
-**Pricing Information**: Products include pricing options that buyers select when creating media buys. See [Pricing Models](../advanced-topics/pricing-models) for complete details on CPM, CPCV, CPP, and other pricing models.
+**Pricing Information**: Products include pricing options that buyers select when creating media buys. See [Pricing Models](../advanced-topics/pricing-models.mdx) for complete details on CPM, CPCV, CPP, and other pricing models.
 
-**Format Discovery**: Products return format references (IDs only). Use [`list_creative_formats`](./list_creative_formats) to get full format specifications. **See [Creative Lifecycle](../creatives/index.mdx) for the complete workflow.**
+**Format Discovery**: Products return format references (IDs only). Use [`list_creative_formats`](./list_creative_formats.mdx) to get full format specifications. **See [Creative Lifecycle](../creatives/index.mdx) for the complete workflow.**
 
 **Request Schema**: [`https://adcontextprotocol.org/schemas/v1/media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v1/media-buy/get-products-request.json)
 **Response Schema**: [`https://adcontextprotocol.org/schemas/v1/media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v1/media-buy/get-products-response.json)
@@ -138,7 +138,7 @@ Products include **EITHER** `properties` (for specific property lists) **OR** `p
 - **product_id**: Unique identifier for the product
 - **name**: Human-readable product name
 - **description**: Detailed description of the product and its inventory
-- **pricing_options**: Array of available pricing models for this product. Each option has a unique `pricing_option_id` that buyers reference in `create_media_buy`. See [Pricing Models](../advanced-topics/pricing-models) for complete documentation of supported pricing models (CPM, CPCV, CPP, CPC, vCPM, flat_rate).
+- **pricing_options**: Array of available pricing models for this product. Each option has a unique `pricing_option_id` that buyers reference in `create_media_buy`. See [Pricing Models](../advanced-topics/pricing-models.mdx) for complete documentation of supported pricing models (CPM, CPCV, CPP, CPC, vCPM, flat_rate).
 - **properties**: Array of specific advertising properties covered by this product (see [Property Schema](https://adcontextprotocol.org/schemas/v1/core/property.json))
   - **property_type**: Type of advertising property ("website", "mobile_app", "ctv_app", "dooh", "podcast", "radio", "streaming_audio")
   - **name**: Human-readable property name
@@ -148,7 +148,7 @@ Products include **EITHER** `properties` (for specific property lists) **OR** `p
   - **tags**: Optional array of tags for categorization (e.g., network membership, content categories)
   - **publisher_domain**: Domain where adagents.json should be checked for authorization validation
 - **property_tags**: Array of tags referencing groups of properties (alternative to `properties` array)
-  - Use [`list_authorized_properties`](./list_authorized_properties) to resolve tags to actual property objects
+  - Use [`list_authorized_properties`](./list_authorized_properties.mdx) to resolve tags to actual property objects
   - Recommended for products with large property sets (e.g., radio networks with 1000+ stations)
 - **format_ids**: Array of supported creative format ID objects (structured with `agent_url` and `id` fields) - use `list_creative_formats` to get full format details
 - **delivery_type**: Either `"guaranteed"` or `"non_guaranteed"`
@@ -179,7 +179,7 @@ Products include **EITHER** `properties` (for specific property lists) **OR** `p
 
 ## Property Tag Resolution
 
-When products use `property_tags` instead of full `properties` arrays, buyer agents must resolve the tags to actual property objects using [`list_authorized_properties`](./list_authorized_properties).
+When products use `property_tags` instead of full `properties` arrays, buyer agents must resolve the tags to actual property objects using [`list_authorized_properties`](./list_authorized_properties.mdx).
 
 ### Resolution Process
 
@@ -223,7 +223,7 @@ for (const property of productProperties) {
 
 1. **Get Properties**: For each product, get property objects either:
    - Directly from the `properties` array, OR
-   - By resolving `property_tags` via [`list_authorized_properties`](./list_authorized_properties)
+   - By resolving `property_tags` via [`list_authorized_properties`](./list_authorized_properties.mdx)
 2. **Check Publisher Domains**: For each property, fetch `/.well-known/adagents.json` from `publisher_domain`
 3. **Validate Domain Identifiers**: For website properties, also check each domain identifier
 4. **Validate Agent**: Confirm the sales agent URL appears in `authorized_agents`
@@ -736,7 +736,7 @@ When the promoted offering is subject to policy restrictions, the response will 
 - The `message` field provides a human-readable summary of the response
 - Publishers may request clarification when briefs are incomplete
 ## Brief Requirements
-For comprehensive guidance on brief structure and expectations, see the [Brief Expectations](../product-discovery/brief-expectations) documentation. Key points:
+For comprehensive guidance on brief structure and expectations, see the [Brief Expectations](../product-discovery/brief-expectations.mdx) documentation. Key points:
 - **Optional**: The `brief` field - include for recommendations, omit for run-of-network
 - **Run-of-Network**: Omit brief to get broad reach products (not entire catalog)
 - **Recommendations**: Include brief when you want publisher help selecting products
@@ -994,6 +994,6 @@ for brief in test_briefs:
 ## Integration with Media Buy Flow
 Discovery is just the first step. Ensure smooth transitions to the next phases:
 1. **Discovery** → `get_products` finds relevant inventory
-2. **Purchase** → [`create_media_buy`](./create_media_buy) executes the campaign
-3. **Creative** → [`sync_creatives`](./sync_creatives) uploads assets
+2. **Purchase** → [`create_media_buy`](./create_media_buy.mdx) executes the campaign
+3. **Creative** → [`sync_creatives`](./sync_creatives.mdx) uploads assets
 4. **Monitor** → Track delivery and optimize

--- a/docs/media-buy/task-reference/index.mdx
+++ b/docs/media-buy/task-reference/index.mdx
@@ -13,14 +13,14 @@ Complete reference for all AdCP Media Buy tasks. Each task is designed for AI ag
 
 | Task | Purpose | Response Time | Phase |
 |------|---------|---------------|-------|
-| [`get_products`](./get_products) | Discover inventory using natural language briefs | ~60s | Discovery |
-| [`create_media_buy`](./create_media_buy) | Create campaigns from selected products | Minutes-Days | Media Buys |
-| [`update_media_buy`](./update_media_buy) | Modify campaign settings and budgets | Minutes-Days | Media Buys |
-| [`list_creative_formats`](./list_creative_formats) | View supported creative specifications | ~1s | Capability |
-| [`list_authorized_properties`](./list_authorized_properties) | See available publisher properties | ~1s | Capability |
-| [`sync_creatives`](./sync_creatives) | Upload and manage creative assets | Minutes-Days | Creatives |
-| [`list_creatives`](./list_creatives) | Query creative library with filtering | ~1s | Creatives |
-| [`get_media_buy_delivery`](./get_media_buy_delivery) | Retrieve performance and delivery data | ~60s | Reporting |
+| [`get_products`](./get_products.mdx) | Discover inventory using natural language briefs | ~60s | Discovery |
+| [`create_media_buy`](./create_media_buy.mdx) | Create campaigns from selected products | Minutes-Days | Media Buys |
+| [`update_media_buy`](./update_media_buy.mdx) | Modify campaign settings and budgets | Minutes-Days | Media Buys |
+| [`list_creative_formats`](./list_creative_formats.mdx) | View supported creative specifications | ~1s | Capability |
+| [`list_authorized_properties`](./list_authorized_properties.mdx) | See available publisher properties | ~1s | Capability |
+| [`sync_creatives`](./sync_creatives.mdx) | Upload and manage creative assets | Minutes-Days | Creatives |
+| [`list_creatives`](./list_creatives.mdx) | Query creative library with filtering | ~1s | Creatives |
+| [`get_media_buy_delivery`](./get_media_buy_delivery.mdx) | Retrieve performance and delivery data | ~60s | Reporting |
 
 ## Response Time Categories
 
@@ -28,46 +28,46 @@ AdCP tasks fall into four response time categories:
 
 ### 🟢 Instant (~1 second)
 **Simple database lookups**
-- [`list_creative_formats`](./list_creative_formats) - Format specifications
-- [`list_authorized_properties`](./list_authorized_properties) - Available properties  
-- [`list_creatives`](./list_creatives) - Creative library queries
+- [`list_creative_formats`](./list_creative_formats.mdx) - Format specifications
+- [`list_authorized_properties`](./list_authorized_properties.mdx) - Available properties  
+- [`list_creatives`](./list_creatives.mdx) - Creative library queries
 
 ### 🟡 Processing (~60 seconds)  
 **AI/LLM inference with backend systems**
-- [`get_products`](./get_products) - Natural language product discovery
-- [`get_media_buy_delivery`](./get_media_buy_delivery) - Performance data aggregation
+- [`get_products`](./get_products.mdx) - Natural language product discovery
+- [`get_media_buy_delivery`](./get_media_buy_delivery.mdx) - Performance data aggregation
 
 ### 🟠 Asynchronous (Minutes to Days)
 **Complex operations with potential human approval**
-- [`create_media_buy`](./create_media_buy) - Campaign creation and validation
-- [`update_media_buy`](./update_media_buy) - Campaign modifications
-- [`sync_creatives`](./sync_creatives) - Creative asset processing
+- [`create_media_buy`](./create_media_buy.mdx) - Campaign creation and validation
+- [`update_media_buy`](./update_media_buy.mdx) - Campaign modifications
+- [`sync_creatives`](./sync_creatives.mdx) - Creative asset processing
 
 ## Task Categories by Workflow
 
 ### Discovery & Planning
 Start here to understand what's available and plan your campaign.
 
-- **[`get_products`](./get_products)** - The core discovery task using natural language briefs
-- **[`list_creative_formats`](./list_creative_formats)** - Understand creative requirements
-- **[`list_authorized_properties`](./list_authorized_properties)** - See available placements
+- **[`get_products`](./get_products.mdx)** - The core discovery task using natural language briefs
+- **[`list_creative_formats`](./list_creative_formats.mdx)** - Understand creative requirements
+- **[`list_authorized_properties`](./list_authorized_properties.mdx)** - See available placements
 
 ### Media Buy Management  
 Create and manage your advertising campaigns.
 
-- **[`create_media_buy`](./create_media_buy)** - Create campaigns from discovered products
-- **[`update_media_buy`](./update_media_buy)** - Modify budgets, targeting, and settings
+- **[`create_media_buy`](./create_media_buy.mdx)** - Create campaigns from discovered products
+- **[`update_media_buy`](./update_media_buy.mdx)** - Modify budgets, targeting, and settings
 
 ### Creative Management
 Handle creative assets throughout their lifecycle.
 
-- **[`sync_creatives`](./sync_creatives)** - Upload assets to centralized library
-- **[`list_creatives`](./list_creatives)** - Search and manage your creative library
+- **[`sync_creatives`](./sync_creatives.mdx)** - Upload assets to centralized library
+- **[`list_creatives`](./list_creatives.mdx)** - Search and manage your creative library
 
 ### Performance & Optimization
 Monitor and optimize campaign performance.
 
-- **[`get_media_buy_delivery`](./get_media_buy_delivery)** - Track delivery and performance metrics
+- **[`get_media_buy_delivery`](./get_media_buy_delivery.mdx)** - Track delivery and performance metrics
 
 
 ## Schema Reference
@@ -103,11 +103,11 @@ Long-running tasks provide:
 
 ## Getting Started
 
-1. **Start with Discovery**: Use [`get_products`](./get_products) to find relevant inventory
-2. **Understand Formats**: Check [`list_creative_formats`](./list_creative_formats) for requirements  
-3. **Create Campaign**: Use [`create_media_buy`](./create_media_buy) with selected products
-4. **Upload Creatives**: Use [`sync_creatives`](./sync_creatives) for asset management
-5. **Monitor Performance**: Track results with [`get_media_buy_delivery`](./get_media_buy_delivery)
+1. **Start with Discovery**: Use [`get_products`](./get_products.mdx) to find relevant inventory
+2. **Understand Formats**: Check [`list_creative_formats`](./list_creative_formats.mdx) for requirements  
+3. **Create Campaign**: Use [`create_media_buy`](./create_media_buy.mdx) with selected products
+4. **Upload Creatives**: Use [`sync_creatives`](./sync_creatives.mdx) for asset management
+5. **Monitor Performance**: Track results with [`get_media_buy_delivery`](./get_media_buy_delivery.mdx)
 
 ## Related Documentation
 

--- a/docs/media-buy/task-reference/list_creatives.mdx
+++ b/docs/media-buy/task-reference/list_creatives.mdx
@@ -501,9 +501,9 @@ const response = await adcp.list_creatives({
 
 ## Related Tasks
 
-- [`sync_creatives`](./sync_creatives) - Upload and manage creative assets
-- [`create_media_buy`](./create_media_buy) - Create campaigns using library creatives
-- [`list_creative_formats`](./list_creative_formats) - Discover supported creative formats
+- [`sync_creatives`](./sync_creatives.mdx) - Upload and manage creative assets
+- [`create_media_buy`](./create_media_buy.mdx) - Create campaigns using library creatives
+- [`list_creative_formats`](./list_creative_formats.mdx) - Discover supported creative formats
 
 ---
 

--- a/docs/media-buy/task-reference/provide_performance_feedback.mdx
+++ b/docs/media-buy/task-reference/provide_performance_feedback.mdx
@@ -357,6 +357,6 @@ def get_metric_type(campaign_objective):
 
 ## Related Documentation
 
-- [`get_media_buy_delivery`](./get_media_buy_delivery) - Retrieve delivery metrics
-- [Optimization & Reporting](../media-buys/optimization-reporting) - Performance feedback concepts
-- [Targeting](../advanced-topics/targeting) - Understanding targeting for optimization
+- [`get_media_buy_delivery`](./get_media_buy_delivery.mdx) - Retrieve delivery metrics
+- [Optimization & Reporting](../media-buys/optimization-reporting.mdx) - Performance feedback concepts
+- [Targeting](../advanced-topics/targeting.mdx) - Understanding targeting for optimization

--- a/docs/media-buy/task-reference/sync_creatives.mdx
+++ b/docs/media-buy/task-reference/sync_creatives.mdx
@@ -556,9 +556,9 @@ The `sync_creatives` task replaces previous action-based creative management app
 
 ## Related Tasks
 
-- [`list_creatives`](./list_creatives) - Query creative library with filtering and search
-- [`create_media_buy`](./create_media_buy) - Create campaigns that use library creatives
-- [`list_creative_formats`](./list_creative_formats) - Discover supported creative formats
+- [`list_creatives`](./list_creatives.mdx) - Query creative library with filtering and search
+- [`create_media_buy`](./create_media_buy.mdx) - Create campaigns that use library creatives
+- [`list_creative_formats`](./list_creative_formats.mdx) - Discover supported creative formats
 
 ---
 

--- a/docs/protocols/getting-started.mdx
+++ b/docs/protocols/getting-started.mdx
@@ -5,7 +5,7 @@ title: Getting Started
 
 # Getting Started with AdCP Protocols
 
-> **New to AdCP?** Start with the [**Quickstart Guide**](../quickstart) for a complete introduction including authentication, testing, and your first request.
+> **New to AdCP?** Start with the [**Quickstart Guide**](../quickstart.mdx) for a complete introduction including authentication, testing, and your first request.
 
 ## Quick Overview
 

--- a/docs/protocols/task-management.mdx
+++ b/docs/protocols/task-management.mdx
@@ -649,8 +649,8 @@ See **[Core Concepts: Webhook Reliability](./core-concepts.mdx#webhook-reliabili
 
 ## Related Documentation
 
-- **[Core Concepts](./core-concepts)** - Protocol fundamentals and design principles
-- **[MCP Guide](./mcp-guide)** - MCP-specific implementation patterns
-- **[A2A Guide](./a2a-guide)** - A2A-specific integration examples
+- **[Core Concepts](./core-concepts.mdx)** - Protocol fundamentals and design principles
+- **[MCP Guide](./mcp-guide.mdx)** - MCP-specific implementation patterns
+- **[A2A Guide](./a2a-guide.mdx)** - A2A-specific integration examples
 - **[Media Buy Reference](../media-buy/task-reference/)** - Domain-specific task documentation
-- **[Signals Reference](../signals/overview)** - Signal-specific task documentation
+- **[Signals Reference](../signals/overview.mdx)** - Signal-specific task documentation

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -254,10 +254,10 @@ Generating $12K/day in signal revenue
 
 The Signals Activation Protocol supports two primary tasks:
 
-### 1. [get_signals](./tasks/get_signals)
+### 1. [get_signals](./tasks/get_signals.mdx)
 Discover signals across providers using natural language, with visibility into available identity keys.
 
-### 2. [activate_signal](./tasks/activate_signal)  
+### 2. [activate_signal](./tasks/activate_signal.mdx)  
 Deploy signals to platforms with automatic identity resolution.
 
 ## How It Works
@@ -292,9 +292,9 @@ flowchart LR
 
 ## Next Steps
 
-- 📖 **Technical Teams**: Review the [Protocol Specification](./specification)
+- 📖 **Technical Teams**: Review the [Protocol Specification](./specification.mdx)
 - 💻 **Developers**: Explore the [Reference Implementation](https://github.com/adcontextprotocol/signals-agent)
-- 🏗️ **Platform Providers**: See [Integration Guide](./tasks/get_signals)
+- 🏗️ **Platform Providers**: See [Integration Guide](./tasks/get_signals.mdx)
 - 💬 **Everyone**: Join the [Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
 
 ---

--- a/docs/signals/specification.mdx
+++ b/docs/signals/specification.mdx
@@ -174,11 +174,11 @@ This is relative to each signal agent's capabilities - a 50% coverage signal fro
 
 The Signals Activation Protocol defines the following tasks that agents can perform:
 
-### [get_signals](./tasks/get_signals)
+### [get_signals](./tasks/get_signals.mdx)
 
 Discover relevant signals based on a marketing specification across multiple platforms. This task enables natural language search for audiences, contextual signals, and other targeting data.
 
-### [activate_signal](./tasks/activate_signal)
+### [activate_signal](./tasks/activate_signal.mdx)
 
 Activate a signal for use on a specific platform/account. This task handles the entire activation lifecycle, including initiating the request, monitoring progress, and returning the final deployment status.
 


### PR DESCRIPTION
## Summary

This PR fixes all broken internal documentation links by adding the `.mdx` file extension to relative paths.

- **Issue**: #167
- **Root cause**: All internal links were missing the `.mdx` file extension, causing 404 errors
- **Fix**: Added `.mdx` extensions to 181 internal links across 26 documentation files
- **Status**: ✅ All tests passing, documentation builds successfully

## Changes

- 26 documentation files updated with proper `.mdx` extensions
- 181 internal links fixed across media-buy, creative, protocols, and signals sections
- 1 changeset added for version tracking
- Documentation builds without errors

## Test Results

✅ Schema validation tests: Passed
✅ Example validation tests: Passed  
✅ TypeScript checks: Passed
✅ Documentation build: Passed

## Impact

Users will now be able to click all internal documentation links and navigate correctly without encountering 404 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)