### PR TITLE
Add output_format discriminator to preview render schema

### DIFF
--- a/.changeset/preview-output-format-discriminator.md
+++ b/.changeset/preview-output-format-discriminator.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": patch
+---
+
+Add output_format discriminator to preview render schema for improved validation performance.
+
+Replaces oneOf constraint on render objects with an explicit output_format field ("url", "html", or "both") that indicates which preview fields are present. This eliminates the need for validators to try all three combinations when validating preview responses, significantly improving validation speed for responses with multiple renders (companion ads, multi-placement formats).
+
+**Schema change:**
+- Added required `output_format` field to render objects in preview-creative-response.json
+- Replaced `oneOf` validation with conditional `allOf` based on discriminator value
+- Updated field descriptions to reference the discriminator
+
+**Backward compatibility:**
+- Breaking change: Existing preview responses must add the output_format field
+- Creative agents implementing preview_creative task must update responses

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -403,7 +403,9 @@ The response format depends on the request mode:
   preview_id: string;            // Unique identifier for this preview variant
   renders: [{                    // Array of rendered pieces (most formats have one)
     render_id: string;           // Unique identifier for this rendered piece
-    preview_url: string;         // URL to HTML page - can be embedded in iframe
+    output_format: "url" | "html" | "both";  // Discriminator indicating which fields are present
+    preview_url?: string;        // URL to HTML page (present when output_format is "url" or "both")
+    preview_html?: string;       // Raw HTML for embedding (present when output_format is "html" or "both")
     role: string;                // Semantic role: "primary", "companion", or descriptive custom string
     dimensions?: {               // Dimensions for this rendered piece (enables iframe sizing)
       width: number;             // Width in pixels
@@ -440,16 +442,17 @@ Some formats render as multiple pieces in a single preview variant:
 - **DOOH installations**: Multiple screens in a venue
 
 Each rendered piece has:
+- **output_format**: Discriminator field indicating which preview fields are provided (`"url"`, `"html"`, or `"both"`)
 - **role**: Semantic role (`"primary"`, `"companion"`, or descriptive strings for device variants)
 - **dimensions**: Width and height for iframe sizing (especially important when multiple pieces have different sizes)
-- **preview_url**: Iframe URL for rendering (present based on `output_format` request)
-- **preview_html**: Raw HTML for rendering (present based on `output_format` request)
+- **preview_url**: Iframe URL for rendering (present when `output_format` is `"url"` or `"both"`)
+- **preview_html**: Raw HTML for rendering (present when `output_format` is `"html"` or `"both"`)
 
 **Output Format Behavior:**
-- When `output_format: "url"` (default), creative agents return `preview_url`
-- When `output_format: "html"`, creative agents return `preview_html`
-- Creative agents MAY provide both fields for client flexibility
-- Clients should check which field(s) are present and use accordingly
+- When `output_format: "url"` (default) in request, creative agents return `output_format: "url"` with `preview_url` field
+- When `output_format: "html"` in request, creative agents return `output_format: "html"` with `preview_html` field
+- Creative agents MAY provide both fields by returning `output_format: "both"` with both `preview_url` and `preview_html`
+- Clients should check the `output_format` discriminator to determine which fields are present
 
 **Optional Fields:**
 - **embedding**: Security metadata for safe iframe integration (sandbox policies, HTTPS requirements, CSP)
@@ -651,6 +654,7 @@ Response contains results in the same order:
             "renders": [
               {
                 "render_id": "render_1",
+                "output_format": "url",
                 "preview_url": "https://creative-agent.example.com/preview/abc123",
                 "role": "primary",
                 "dimensions": {"width": 300, "height": 250}
@@ -674,6 +678,7 @@ Response contains results in the same order:
             "renders": [
               {
                 "render_id": "render_2",
+                "output_format": "url",
                 "preview_url": "https://creative-agent.example.com/preview/def456",
                 "role": "primary",
                 "dimensions": {"width": 728, "height": 90}
@@ -697,6 +702,7 @@ Response contains results in the same order:
             "renders": [
               {
                 "render_id": "render_3",
+                "output_format": "url",
                 "preview_url": "https://creative-agent.example.com/preview/video789",
                 "role": "primary",
                 "dimensions": {"width": 1920, "height": 1080}
@@ -761,6 +767,7 @@ Response with HTML for direct embedding:
             "renders": [
               {
                 "render_id": "render_1",
+                "output_format": "html",
                 "preview_html": "<div class=\"creative-300x250\"><img src=\"https://...\"/><div class=\"headline\">Ad 1</div></div>",
                 "role": "primary",
                 "dimensions": {"width": 300, "height": 250}
@@ -781,6 +788,7 @@ Response with HTML for direct embedding:
             "renders": [
               {
                 "render_id": "render_2",
+                "output_format": "html",
                 "preview_html": "<div class=\"creative-300x250\"><img src=\"https://...\"/><div class=\"headline\">Ad 2</div></div>",
                 "role": "primary",
                 "dimensions": {"width": 300, "height": 250}

--- a/static/schemas/v1/creative/preview-creative-response.json
+++ b/static/schemas/v1/creative/preview-creative-response.json
@@ -28,14 +28,19 @@
                       "type": "string",
                       "description": "Unique identifier for this rendered piece within the variant"
                     },
+                    "output_format": {
+                      "type": "string",
+                      "enum": ["url", "html", "both"],
+                      "description": "Discriminator field indicating which preview format(s) are provided. 'url' = preview_url only, 'html' = preview_html only, 'both' = both preview_url and preview_html."
+                    },
                     "preview_url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "URL to an HTML page that renders this piece. Can be embedded in an iframe. Typically returned when output_format='url' (default). Creative agents MAY provide both preview_url and preview_html for client flexibility."
+                      "description": "URL to an HTML page that renders this piece. Can be embedded in an iframe. Present when output_format is 'url' or 'both'."
                     },
                     "preview_html": {
                       "type": "string",
-                      "description": "Raw HTML for this rendered piece. Can be embedded directly in the page without iframe. Typically returned when output_format='html'. Security warning: Only use with trusted creative agents as this bypasses iframe sandboxing. Creative agents MAY provide both formats."
+                      "description": "Raw HTML for this rendered piece. Can be embedded directly in the page without iframe. Present when output_format is 'html' or 'both'. Security warning: Only use with trusted creative agents as this bypasses iframe sandboxing."
                     },
                     "role": {
                       "type": "string",
@@ -79,16 +84,43 @@
                       }
                     }
                   },
-                  "required": ["render_id", "role"],
-                  "oneOf": [
+                  "required": ["render_id", "role", "output_format"],
+                  "allOf": [
                     {
-                      "required": ["preview_url"]
+                      "if": {
+                        "properties": {
+                          "output_format": { "const": "url" }
+                        }
+                      },
+                      "then": {
+                        "required": ["preview_url"],
+                        "not": {
+                          "required": ["preview_html"]
+                        }
+                      }
                     },
                     {
-                      "required": ["preview_html"]
+                      "if": {
+                        "properties": {
+                          "output_format": { "const": "html" }
+                        }
+                      },
+                      "then": {
+                        "required": ["preview_html"],
+                        "not": {
+                          "required": ["preview_url"]
+                        }
+                      }
                     },
                     {
-                      "required": ["preview_url", "preview_html"]
+                      "if": {
+                        "properties": {
+                          "output_format": { "const": "both" }
+                        }
+                      },
+                      "then": {
+                        "required": ["preview_url", "preview_html"]
+                      }
                     }
                   ]
                 },
@@ -173,14 +205,19 @@
                               "render_id": {
                                 "type": "string"
                               },
+                              "output_format": {
+                                "type": "string",
+                                "enum": ["url", "html", "both"],
+                                "description": "Discriminator field indicating which preview format(s) are provided. 'url' = preview_url only, 'html' = preview_html only, 'both' = both preview_url and preview_html."
+                              },
                               "preview_url": {
                                 "type": "string",
                                 "format": "uri",
-                                "description": "URL to iframe-embeddable HTML page. Typically present when output_format='url'."
+                                "description": "URL to iframe-embeddable HTML page. Present when output_format is 'url' or 'both'."
                               },
                               "preview_html": {
                                 "type": "string",
-                                "description": "Raw HTML for direct embedding. Typically present when output_format='html'. Security: Only use with trusted agents."
+                                "description": "Raw HTML for direct embedding. Present when output_format is 'html' or 'both'. Security: Only use with trusted agents."
                               },
                               "role": {
                                 "type": "string"
@@ -217,16 +254,43 @@
                                 }
                               }
                             },
-                            "required": ["render_id", "role"],
-                            "oneOf": [
+                            "required": ["render_id", "role", "output_format"],
+                            "allOf": [
                               {
-                                "required": ["preview_url"]
+                                "if": {
+                                  "properties": {
+                                    "output_format": { "const": "url" }
+                                  }
+                                },
+                                "then": {
+                                  "required": ["preview_url"],
+                                  "not": {
+                                    "required": ["preview_html"]
+                                  }
+                                }
                               },
                               {
-                                "required": ["preview_html"]
+                                "if": {
+                                  "properties": {
+                                    "output_format": { "const": "html" }
+                                  }
+                                },
+                                "then": {
+                                  "required": ["preview_html"],
+                                  "not": {
+                                    "required": ["preview_url"]
+                                  }
+                                }
                               },
                               {
-                                "required": ["preview_url", "preview_html"]
+                                "if": {
+                                  "properties": {
+                                    "output_format": { "const": "both" }
+                                  }
+                                },
+                                "then": {
+                                  "required": ["preview_url", "preview_html"]
+                                }
                               }
                             ]
                           },


### PR DESCRIPTION
## Summary

Add an `output_format` discriminator field to preview render responses to improve validation performance. Replaces inefficient `oneOf` constraint with conditional `allOf` validation based on discriminator value.

## Changes

- Added required `output_format` field with enum values: "url", "html", "both"
- Updated schema validation logic in both single and batch preview responses
- Updated documentation and examples to reflect discriminator usage

## Benefits

Validation performance improvement, especially for responses with multiple renders (companion ads, multi-placement formats).