### PR TITLE
Add discriminator fields to preview_creative schemas

### DIFF
--- a/.changeset/preview-discriminated-union.md
+++ b/.changeset/preview-discriminated-union.md
@@ -1,0 +1,43 @@
+---
+"adcontextprotocol": "patch"
+---
+
+Add discriminator fields to preview_creative request and response schemas.
+
+**Changes:**
+- Added `request_type` discriminator to preview-creative-request.json ("single" | "batch")
+- Added `response_type` discriminator to preview-creative-response.json ("single" | "batch")
+
+**Why:**
+Explicit discriminator fields enable TypeScript generators to produce proper discriminated unions with excellent type narrowing and IDE autocomplete. Without discriminators, generators produce index signatures or massive union types with poor type safety.
+
+**Migration:**
+Request format:
+```json
+// Before
+{ "format_id": {...}, "creative_manifest": {...} }
+
+// After (single)
+{ "request_type": "single", "format_id": {...}, "creative_manifest": {...} }
+
+// Before
+{ "requests": [...] }
+
+// After (batch)
+{ "request_type": "batch", "requests": [...] }
+```
+
+Response format:
+```json
+// Before
+{ "previews": [...], "expires_at": "..." }
+
+// After (single)
+{ "response_type": "single", "previews": [...], "expires_at": "..." }
+
+// Before
+{ "results": [...] }
+
+// After (batch)
+{ "response_type": "batch", "results": [...] }
+```

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -15,6 +15,7 @@ The simplest preview request returns a single URL you can iframe:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "native_responsive"
@@ -27,6 +28,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/abc123",
@@ -55,6 +57,7 @@ For faster rendering and grid layouts, request HTML directly instead of URLs:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "native_responsive"
@@ -68,6 +71,7 @@ Response contains raw HTML:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_html": "<div class=\"creative\"><img src=\"...\"/><h3>Headline</h3></div>",
@@ -101,6 +105,7 @@ Preview multiple different creatives in one API call (5-10x faster):
 
 ```json
 {
+  "request_type": "batch",
   "requests": [
     {
       "format_id": {
@@ -124,6 +129,7 @@ Response contains results in the same order:
 
 ```json
 {
+  "response_type": "batch",
   "results": [
     {
       "success": true,
@@ -270,7 +276,7 @@ The `preview_creative` task supports two modes:
 
 ## Request Parameters
 
-The request format depends on the mode:
+The request format depends on the mode. To enable proper type generation in TypeScript and other languages, requests and responses use explicit discriminator fields (`request_type` and `response_type`) to distinguish between single and batch modes.
 
 ### Single Mode Parameters
 
@@ -278,6 +284,7 @@ Use these top-level fields to preview one creative:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `request_type` | string | Yes | Discriminator field with value `"single"` |
 | `format_id` | FormatID | Yes | Format identifier for rendering (structured object with agent_url and id) |
 | `creative_manifest` | object | Yes | Complete creative manifest with all required assets |
 | `inputs` | array | No | Array of input sets for generating multiple preview variants |
@@ -290,7 +297,8 @@ Use a top-level `requests` array to preview multiple creatives:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `requests` | array | Yes | Array of 1-50 preview requests. Each item has the same structure as single mode parameters (including `output_format`). |
+| `request_type` | string | Yes | Discriminator field with value `"batch"` |
+| `requests` | array | Yes | Array of 1-50 preview requests. Each item has the same structure as single mode parameters (excluding `request_type`). |
 | `output_format` | string | No | Default output format for all requests. Individual requests can override this with their own `output_format`. |
 
 ### Creative Manifest Structure
@@ -354,6 +362,7 @@ The response format depends on the request mode:
 
 ```json
 {
+  "response_type": "single",
   "previews": "array",
   "interactive_url": "string",
   "expires_at": "string"
@@ -361,6 +370,7 @@ The response format depends on the request mode:
 ```
 
 **Field Descriptions:**
+- **response_type**: Discriminator field with value `"single"`
 - **previews**: Array of preview variants. One preview per input set from the request. If no inputs provided, returns a single default preview.
 - **interactive_url**: Optional URL to interactive testing page with controls to switch between variants
 - **expires_at**: ISO 8601 timestamp when preview links expire
@@ -369,6 +379,7 @@ The response format depends on the request mode:
 
 ```json
 {
+  "response_type": "batch",
   "results": [
     {
       "success": true,
@@ -391,9 +402,10 @@ The response format depends on the request mode:
 ```
 
 **Field Descriptions:**
+- **response_type**: Discriminator field with value `"batch"`
 - **results**: Array of preview results matching the order of requests
 - **success**: Whether this specific preview request succeeded
-- **response**: Preview response for successful requests (same structure as single mode)
+- **response**: Preview response for successful requests (excludes `response_type` field)
 - **error**: Error information for failed requests (code, message, optional details)
 
 ### Preview Variant Structure
@@ -466,6 +478,7 @@ Request previews for desktop, mobile, and tablet:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "native_responsive"
@@ -524,6 +537,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/abc123/desktop",
@@ -574,6 +588,7 @@ Preview three different banner creatives in one API call:
 
 ```json
 {
+  "request_type": "batch",
   "requests": [
     {
       "format_id": {
@@ -645,6 +660,7 @@ Response contains results in the same order:
 
 ```json
 {
+  "response_type": "batch",
   "results": [
     {
       "success": true,
@@ -733,6 +749,7 @@ Request HTML directly for 50 creatives to build a preview grid without 50 iframe
 
 ```json
 {
+  "request_type": "batch",
   "output_format": "html",
   "requests": [
     {
@@ -758,6 +775,7 @@ Response with HTML for direct embedding:
 
 ```json
 {
+  "response_type": "batch",
   "results": [
     {
       "success": true,
@@ -836,6 +854,7 @@ Preview a dynamic creative with different geographic and device contexts:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "display_dynamic_300x250"
@@ -887,6 +906,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/xyz789/nyc-mobile",
@@ -926,6 +946,7 @@ Preview an audio ad with AI-generated host reads for different podcast contexts:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "audio_host_read_30s"
@@ -971,6 +992,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/audio123/weather",
@@ -1019,6 +1041,7 @@ Preview a video creative with geo-specific end cards:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_30s_vast"
@@ -1062,6 +1085,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/video456/us-ne",
@@ -1095,12 +1119,13 @@ Response:
 
 Each `preview_url` returns an HTML page with an embedded video player showing the geo-specific variant.
 
-### Example 4: Dynamic Creative with Template Variables
+### Example 5: Dynamic Creative with Template Variables
 
 Preview a dynamic creative that uses template variables for personalization:
 
 ```json
 {
+  "request_type": "single",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "native_responsive"
@@ -1152,6 +1177,7 @@ Response:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/dynamic123/a",
@@ -1179,12 +1205,13 @@ Response:
 }
 ```
 
-### Example 5: Video Preview with Optimization Hints
+### Example 6: Video Preview with Optimization Hints
 
 Response showing optional hints and embedding metadata:
 
 ```json
 {
+  "response_type": "single",
   "previews": [
     {
       "preview_url": "https://creative-agent.example.com/preview/video789",

--- a/static/schemas/v1/creative/preview-creative-request.json
+++ b/static/schemas/v1/creative/preview-creative-request.json
@@ -8,6 +8,11 @@
       "type": "object",
       "description": "Single creative preview request",
       "properties": {
+        "request_type": {
+          "type": "string",
+          "const": "single",
+          "description": "Discriminator indicating this is a single preview request"
+        },
         "format_id": {
           "$ref": "/schemas/v1/core/format-id.json",
           "description": "Format identifier for rendering the preview"
@@ -61,6 +66,7 @@
         }
       },
       "required": [
+        "request_type",
         "format_id",
         "creative_manifest"
       ],
@@ -70,6 +76,11 @@
       "type": "object",
       "description": "Batch preview request for multiple creatives (5-10x faster than individual calls)",
       "properties": {
+        "request_type": {
+          "type": "string",
+          "const": "batch",
+          "description": "Discriminator indicating this is a batch preview request"
+        },
         "requests": {
           "type": "array",
           "description": "Array of preview requests (1-50 items). Each follows the single request structure.",
@@ -145,6 +156,7 @@
         }
       },
       "required": [
+        "request_type",
         "requests"
       ],
       "additionalProperties": false

--- a/static/schemas/v1/creative/preview-creative-response.json
+++ b/static/schemas/v1/creative/preview-creative-response.json
@@ -8,6 +8,11 @@
       "type": "object",
       "description": "Single preview response - each preview URL returns an HTML page that can be embedded in an iframe",
       "properties": {
+        "response_type": {
+          "type": "string",
+          "const": "single",
+          "description": "Discriminator indicating this is a single preview response"
+        },
         "previews": {
           "type": "array",
           "description": "Array of preview variants. Each preview corresponds to an input set from the request. If no inputs were provided, returns a single default preview.",
@@ -70,6 +75,7 @@
         }
       },
       "required": [
+        "response_type",
         "previews",
         "expires_at"
       ],
@@ -79,6 +85,11 @@
       "type": "object",
       "description": "Batch preview response - contains results for multiple creative requests",
       "properties": {
+        "response_type": {
+          "type": "string",
+          "const": "batch",
+          "description": "Discriminator indicating this is a batch preview response"
+        },
         "results": {
           "type": "array",
           "description": "Array of preview results corresponding to each request in the same order. results[0] is the result for requests[0], results[1] for requests[1], etc. Order is guaranteed even when some requests fail. Each result contains either a successful preview response or an error.",
@@ -189,6 +200,7 @@
         }
       },
       "required": [
+        "response_type",
         "results"
       ],
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Add explicit `request_type` and `response_type` discriminator fields to the `preview_creative` request and response schemas. This enables TypeScript and other code generators to produce proper discriminated union types with excellent type narrowing instead of implicit `oneOf` detection.

## Changes

- Added `request_type` discriminator ("single" | "batch") to request schema
- Added `response_type` discriminator ("single" | "batch") to response schema
- Updated all documentation and examples to include discriminator fields
- Created patch changeset (atomic deployment with reference creative server)

## Test Plan

- ✅ All schema validation tests pass
- ✅ All example validation tests pass
- ✅ TypeScript type checking passes
- ✅ Documentation examples updated and consistent