### PR TITLE
fix: use relative paths for Mintlify logo

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,8 +2,8 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "logo": {
-    "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg"
+    "light": "logo/light.svg",
+    "dark": "logo/dark.svg"
   },
   "favicon": "/static/img/favicon.ico",
   "theme": "mint",


### PR DESCRIPTION
Quick fix to test logo path resolution in Mintlify.

Changed from  (absolute) to  (relative) as Mintlify may serve assets differently than expected.

Testing in production to see if this resolves the logo display issue.