### PR TITLE
fix: use relative path for favicon in top nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
     "light": "logo/light.svg",
     "dark": "logo/dark.svg"
   },
-  "favicon": "/static/img/favicon.ico",
+  "favicon": "static/img/favicon.ico",
   "theme": "mint",
   "colors": {
     "primary": "#0D9373",


### PR DESCRIPTION
Fixes the top navigation icon/favicon display issue.

Changed favicon path from absolute to relative path to match logo configuration.

**Before**:  (absolute)
**After**:  (relative)