### PR TITLE
Add availability and budget filters to get_products

### DIFF
--- a/.changeset/product-availability-filters.md
+++ b/.changeset/product-availability-filters.md
@@ -6,8 +6,7 @@ Add comprehensive filters to get_products request for efficient product discover
 
 Enables buyers to filter products by campaign requirements and constraints:
 - **start_date/end_date**: Campaign date range for availability checks (ISO 8601 date format)
-- **budget_range**: Min/max budget range to filter appropriate products
-- **currency**: ISO 4217 currency code for budget filtering
+- **budget_range**: Min/max budget range with required currency (ISO 4217 code). At least one of min or max must be specified.
 - **countries**: Target countries using ISO 3166-1 alpha-2 codes for geographic filtering
 - **channels**: Advertising channels using existing channels enum (display, video, audio, native, dooh, ctv, podcast, retail, social)
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -165,16 +165,18 @@ asyncio.run(discover_with_filters())
 | `start_date` | string | Campaign start date in ISO 8601 format (YYYY-MM-DD) for availability checks |
 | `end_date` | string | Campaign end date in ISO 8601 format (YYYY-MM-DD) for availability checks |
 | `budget_range` | object | Budget range to filter appropriate products (see Budget Range Object below) |
-| `currency` | string | ISO 4217 currency code (e.g., `"USD"`, `"EUR"`, `"GBP"`) for budget filtering |
 | `countries` | string[] | Filter by target countries using ISO 3166-1 alpha-2 codes (e.g., `["US", "CA", "GB"]`) |
 | `channels` | string[] | Filter by advertising channels (e.g., `["display", "video", "dooh", "ctv", "audio", "native"]`) |
 
 ### Budget Range Object
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `min` | number | Minimum budget amount |
-| `max` | number | Maximum budget amount |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `currency` | string | Yes | ISO 4217 currency code (e.g., `"USD"`, `"EUR"`, `"GBP"`) |
+| `min` | number | No* | Minimum budget amount |
+| `max` | number | No* | Maximum budget amount |
+
+*At least one of `min` or `max` must be specified.
 
 ## Response
 
@@ -307,9 +309,9 @@ const result = await testAgent.getProducts({
     end_date: '2025-06-30',
     budget_range: {
       min: 50000,
-      max: 100000
+      max: 100000,
+      currency: 'USD'
     },
-    currency: 'USD',
     countries: ['US', 'CA'],
     channels: ['display', 'video', 'ctv'],
     delivery_type: 'guaranteed'
@@ -338,9 +340,9 @@ async def discover_with_budget_and_dates():
             'end_date': '2025-06-30',
             'budget_range': {
                 'min': 50000,
-                'max': 100000
+                'max': 100000,
+                'currency': 'USD'
             },
-            'currency': 'USD',
             'countries': ['US', 'CA'],
             'channels': ['display', 'video', 'ctv'],
             'delivery_type': 'guaranteed'

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -58,14 +58,19 @@
           "type": "number",
           "description": "Maximum budget amount",
           "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code (e.g., 'USD', 'EUR', 'GBP')",
+          "pattern": "^[A-Z]{3}$"
         }
       },
+      "required": ["currency"],
+      "anyOf": [
+        {"required": ["min"]},
+        {"required": ["max"]}
+      ],
       "additionalProperties": false
-    },
-    "currency": {
-      "type": "string",
-      "description": "ISO 4217 currency code (e.g., 'USD', 'EUR', 'GBP') for budget filtering",
-      "pattern": "^[A-Z]{3}$"
     },
     "countries": {
       "type": "array",


### PR DESCRIPTION
## Summary

Add optional availability and budget filters to `get_products` request to help sales agents return only products matching buyer constraints.

**New filters:**
- `start_date`/`end_date`: Campaign date range for availability checks (ISO 8601 format)
- `budget_range`: Min/max budget to filter products by cost
- `currency`: ISO 4217 currency code for budget filtering

## Test plan

- ✅ Schema validation tests pass
- ✅ Example validation tests pass  
- ✅ TypeScript type checking passes
- All fields are optional and backward-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)