### PR TITLE
fix: rename destinations to deployments in signals requests

### DIFF
--- a/.changeset/signals-rename-destinations-to-deployments.md
+++ b/.changeset/signals-rename-destinations-to-deployments.md
@@ -1,0 +1,43 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix: Rename `destinations` field to `deployments` in all signal request schemas for terminology consistency.
+
+This change standardizes the field name to use "deployments" throughout both requests and responses, creating a simpler mental model where everything uses consistent "deployment" terminology.
+
+**What changed:**
+- `get_signals` request: `deliver_to.destinations` → `deliver_to.deployments`
+- `activate_signal` request: `destinations` → `deployments`
+
+**Migration guide:**
+
+**Before:**
+```json
+{
+  "signal_spec": "High-income households",
+  "deliver_to": {
+    "destinations": [{
+      "type": "platform",
+      "platform": "the-trade-desk"
+    }],
+    "countries": ["US"]
+  }
+}
+```
+
+**After:**
+```json
+{
+  "signal_spec": "High-income households",
+  "deliver_to": {
+    "deployments": [{
+      "type": "platform",
+      "platform": "the-trade-desk"
+    }],
+    "countries": ["US"]
+  }
+}
+```
+
+The `Destination` schema itself remains unchanged - only the field name in requests has been renamed to match the response field name (`deployments`).

--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -22,11 +22,11 @@ The `activate_signal` task handles the entire activation lifecycle, including:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `signal_agent_segment_id` | string | Yes | The universal identifier for the signal to activate |
-| `destinations` | Destination[] | Yes | Target destination(s) for activation (see Destination Object below) |
+| `deployments` | Destination[] | Yes | Target deployment(s) for activation (see Destination Object below) |
 
 ### Destination Object
 
-Each destination uses a `type` field to discriminate between platform-based and agent-based destinations:
+Each deployment target uses a `type` field to discriminate between platform-based and agent-based deployments:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -37,11 +37,11 @@ Each destination uses a `type` field to discriminate between platform-based and 
 
 *`platform` is required when `type="platform"`, `agent_url` is required when `type="agent"`.
 
-**Activation Keys**: If the authenticated caller has access to any of the destinations in the request, the signal agent will include `activation_key` in the response for those destinations.
+**Activation Keys**: If the authenticated caller has access to any of the deployment targets in the request, the signal agent will include `activation_key` in the response for those deployments.
 
 **Permission Model**: The signal agent determines key inclusion based on the caller's authentication and authorization. For example:
-- A sales agent receives keys for destinations matching its `agent_url`
-- A buyer with credentials for multiple DSP platforms receives keys for all those platforms
+- A sales agent receives keys for deployments matching its `agent_url`
+- A buyer with credentials for multiple DSP platforms receives keys for all those deployments
 - Access is determined by the signal agent's permission system, not by flags in the request
 
 ## Response Structure
@@ -90,11 +90,11 @@ For asynchronous operations like activation, both protocols support:
 
 ### Field Descriptions
 
-- **deployments**: Array of deployment results for each destination
+- **deployments**: Array of deployment results for each deployment target
   - **platform**: Platform identifier for DSPs (either platform or agent_url will be present)
-  - **agent_url**: URL identifying the destination agent (either platform or agent_url will be present)
+  - **agent_url**: URL identifying the deployment agent (either platform or agent_url will be present)
   - **account**: Account identifier if applicable
-  - **activation_key**: The key to use for targeting (see Activation Key below). Only present if the authenticated caller has access to this destination.
+  - **activation_key**: The key to use for targeting (see Activation Key below). Only present if the authenticated caller has access to this deployment.
   - **estimated_activation_duration_minutes**: Estimated completion time for async operations
   - **deployed_at**: ISO 8601 timestamp when activation completed
 - **errors**: Optional array of errors and warnings encountered during activation
@@ -106,7 +106,7 @@ For asynchronous operations like activation, both protocols support:
 
 ### Activation Key Object
 
-The activation key represents how to use the signal on a destination platform. It can be either a segment ID or a key-value pair:
+The activation key represents how to use the signal on a deployment target. It can be either a segment ID or a key-value pair:
 
 **Segment ID format (typical for DSP platforms):**
 ```json
@@ -135,7 +135,7 @@ The AdCP payload is identical across protocols. Only the request/response wrappe
   "tool": "activate_signal",
   "arguments": {
     "signal_agent_segment_id": "luxury_auto_intenders",
-    "destinations": [{
+    "deployments": [{
       "type": "agent",
       "agent_url": "https://wonderstruck.salesagents.com"
     }]
@@ -169,7 +169,7 @@ Immediate response with activation key:
   "tool": "activate_signal",
   "arguments": {
     "signal_agent_segment_id": "luxury_auto_intenders",
-    "destinations": [{
+    "deployments": [{
       "type": "platform",
       "platform": "the-trade-desk",
       "account": "agency-123-ttd"
@@ -237,7 +237,7 @@ await a2a.send({
         skill: "activate_signal",
         parameters: {
           signal_agent_segment_id: "luxury_auto_intenders",
-          destinations: [{
+          deployments: [{
             type: "platform",
             platform: "the-trade-desk",
             account: "agency-123-ttd"
@@ -297,7 +297,7 @@ For long-running activations (when initial response is `submitted`), configure a
 const response = await session.call('activate_signal',
   {
     signal_agent_segment_id: "luxury_auto_intenders",
-    destinations: [{
+    deployments: [{
       type: "platform",
       platform: "the-trade-desk",
       account: "agency-123-ttd"
@@ -435,11 +435,11 @@ See **[Task Management: Webhook Integration](/docs/protocols/task-management.mdx
     {
       "code": "DEPLOYMENT_UNAUTHORIZED",
       "message": "Account brand-456-pm not authorized for Peer39 data on PubMatic",
-      "field": "destination.account",
+      "field": "deployment.account",
       "suggestion": "Contact your PubMatic account manager to enable Peer39 data access for your account",
       "details": {
         "account_id": "brand-456-pm",
-        "destination_url": "https://pubmatic.com",
+        "deployment_url": "https://pubmatic.com",
         "data_provider": "peer39",
         "required_permission": "third_party_data_access"
       }

--- a/docs/signals/tasks/get_signals.mdx
+++ b/docs/signals/tasks/get_signals.mdx
@@ -19,7 +19,7 @@ The `get_signals` task returns both signal metadata and real-time deployment sta
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `signal_spec` | string | Yes | Natural language description of the desired signals |
-| `deliver_to` | DeliverTo | Yes | Destination platforms where signals need to be activated (see Deliver To Object below) |
+| `deliver_to` | DeliverTo | Yes | Deployment targets where signals need to be activated (see Deliver To Object below) |
 | `filters` | Filters | No | Filters to refine results (see Filters Object below) |
 | `max_results` | number | No | Maximum number of results to return |
 
@@ -27,12 +27,12 @@ The `get_signals` task returns both signal metadata and real-time deployment sta
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `destinations` | Destination[] | Yes | List of destination platforms (DSPs, sales agents, etc.) - see Destination Object below |
+| `deployments` | Destination[] | Yes | List of deployment targets (DSPs, sales agents, etc.) - see Destination Object below |
 | `countries` | string[] | Yes | Countries where signals will be used (ISO codes) |
 
 ### Destination Object
 
-Each destination uses a `type` field to discriminate between platform-based and agent-based destinations:
+Each deployment target uses a `type` field to discriminate between platform-based and agent-based deployments:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -43,11 +43,11 @@ Each destination uses a `type` field to discriminate between platform-based and 
 
 *`platform` is required when `type="platform"`, `agent_url` is required when `type="agent"`.
 
-**Activation Keys**: If the authenticated caller has access to any of the destinations in the request, the signal agent will include `activation_key` fields in the response for those destinations (when `is_live: true`).
+**Activation Keys**: If the authenticated caller has access to any of the deployment targets in the request, the signal agent will include `activation_key` fields in the response for those deployments (when `is_live: true`).
 
 **Permission Model**: The signal agent determines key inclusion based on the caller's authentication and authorization. For example:
-- A sales agent receives keys for destinations matching its `agent_url`
-- A buyer with credentials for multiple DSP platforms receives keys for all those platforms
+- A sales agent receives keys for deployments matching its `agent_url`
+- A buyer with credentials for multiple DSP platforms receives keys for all those deployments
 - Access is determined by the signal agent's permission system, not by flags in the request
 
 ### Filters Object
@@ -116,8 +116,8 @@ The response structure is identical across protocols, with only the transport wr
   - **deployments**: Array of destination deployments
     - **agent_url**: URL identifying the destination agent
     - **account**: Account identifier if applicable
-    - **is_live**: Whether signal is currently active on this destination
-    - **activation_key**: The key to use for targeting (see Activation Key below). **Only present if `is_live=true` AND this destination has `requester=true` in the request.**
+    - **is_live**: Whether signal is currently active on this deployment
+    - **activation_key**: The key to use for targeting (see Activation Key below). **Only present if `is_live=true` AND this deployment has `requester=true` in the request.**
     - **estimated_activation_duration_minutes**: Time to activate if not live
   - **pricing**: Pricing information
     - **cpm**: Cost per thousand impressions
@@ -125,7 +125,7 @@ The response structure is identical across protocols, with only the transport wr
 
 ### Activation Key Object
 
-The activation key represents how to use the signal on a destination platform. It can be either a segment ID or a key-value pair:
+The activation key represents how to use the signal on a deployment target. It can be either a segment ID or a key-value pair:
 
 **Segment ID format:**
 ```json
@@ -158,7 +158,7 @@ A sales agent querying for signals. Because the authenticated caller is wonderst
   "arguments": {
     "signal_spec": "High-income households interested in luxury goods",
     "deliver_to": {
-      "destinations": [
+      "deployments": [
         {
           "type": "agent",
           "agent_url": "https://wonderstruck.salesagents.com"
@@ -177,7 +177,7 @@ A sales agent querying for signals. Because the authenticated caller is wonderst
 
 ### MCP Response - With Activation Key
 
-Because the authenticated caller matches the destination, the response includes the activation key:
+Because the authenticated caller matches the deployment target, the response includes the activation key:
 
 ```json
 {
@@ -222,7 +222,7 @@ A buyer checking availability across multiple DSP platforms:
   "arguments": {
     "signal_spec": "High-income households interested in luxury goods",
     "deliver_to": {
-      "destinations": [
+      "deployments": [
         {
           "type": "platform",
           "platform": "the-trade-desk",
@@ -312,7 +312,7 @@ await a2a.send({
         parameters: {
           signal_spec: "High-income households interested in luxury goods",
           deliver_to: {
-            destinations: [
+            deployments: [
               {
                 type: "agent",
                 agent_url: "https://thetradedesk.com",
@@ -504,10 +504,10 @@ Discover all available deployments across platforms:
 
 ## Usage Notes
 
-1. **Authentication-Based Keys**: Activation keys are only returned when the authenticated caller matches one of the destinations
+1. **Authentication-Based Keys**: Activation keys are only returned when the authenticated caller matches one of the deployment targets
 2. **Permission Security**: The signal agent determines key inclusion based on caller identity, not request flags
 3. **Deployment Status**: Check `is_live` to determine if activation is needed
-4. **Multiple Destinations**: Query multiple destinations to check availability across platforms
+4. **Multiple Deployments**: Query multiple deployment targets to check availability across platforms
 5. **Activation Required**: If `is_live` is false, use the `activate_signal` task
 6. **The message field** provides a quick summary of the most relevant findings
 

--- a/static/schemas/v1/core/deployment.json
+++ b/static/schemas/v1/core/deployment.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/v1/core/deployment.json",
   "title": "Deployment",
-  "description": "A signal deployment to a specific destination platform with activation status and key",
+  "description": "A signal deployment to a specific deployment target with activation status and key",
   "oneOf": [
     {
       "type": "object",
@@ -22,11 +22,11 @@
         },
         "is_live": {
           "type": "boolean",
-          "description": "Whether signal is currently active on this destination"
+          "description": "Whether signal is currently active on this deployment"
         },
         "activation_key": {
           "$ref": "/schemas/v1/core/activation-key.json",
-          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this destination."
+          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this deployment."
         },
         "estimated_activation_duration_minutes": {
           "type": "number",
@@ -53,7 +53,7 @@
         "agent_url": {
           "type": "string",
           "format": "uri",
-          "description": "URL identifying the destination agent"
+          "description": "URL identifying the deployment agent"
         },
         "account": {
           "type": "string",
@@ -61,11 +61,11 @@
         },
         "is_live": {
           "type": "boolean",
-          "description": "Whether signal is currently active on this destination"
+          "description": "Whether signal is currently active on this deployment"
         },
         "activation_key": {
           "$ref": "/schemas/v1/core/activation-key.json",
-          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this destination."
+          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this deployment."
         },
         "estimated_activation_duration_minutes": {
           "type": "number",

--- a/static/schemas/v1/core/destination.json
+++ b/static/schemas/v1/core/destination.json
@@ -2,14 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/v1/core/destination.json",
   "title": "Destination",
-  "description": "A destination platform where signals can be activated (DSP, sales agent, etc.)",
+  "description": "A deployment target where signals can be activated (DSP, sales agent, etc.)",
   "oneOf": [
     {
       "type": "object",
       "properties": {
         "type": {
           "const": "platform",
-          "description": "Discriminator indicating this is a platform-based destination"
+          "description": "Discriminator indicating this is a platform-based deployment"
         },
         "platform": {
           "type": "string",
@@ -28,12 +28,12 @@
       "properties": {
         "type": {
           "const": "agent",
-          "description": "Discriminator indicating this is an agent URL-based destination"
+          "description": "Discriminator indicating this is an agent URL-based deployment"
         },
         "agent_url": {
           "type": "string",
           "format": "uri",
-          "description": "URL identifying the destination agent (for sales agents, etc.)"
+          "description": "URL identifying the deployment agent (for sales agents, etc.)"
         },
         "account": {
           "type": "string",

--- a/static/schemas/v1/signals/activate-signal-request.json
+++ b/static/schemas/v1/signals/activate-signal-request.json
@@ -2,16 +2,16 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/v1/signals/activate-signal-request.json",
   "title": "Activate Signal Request",
-  "description": "Request parameters for activating a signal on a specific destination",
+  "description": "Request parameters for activating a signal on a specific deployment target",
   "type": "object",
   "properties": {
     "signal_agent_segment_id": {
       "type": "string",
       "description": "The universal identifier for the signal to activate"
     },
-    "destinations": {
+    "deployments": {
       "type": "array",
-      "description": "Target destination(s) for activation. If the authenticated caller matches one of these destinations, activation keys will be included in the response.",
+      "description": "Target deployment(s) for activation. If the authenticated caller matches one of these deployment targets, activation keys will be included in the response.",
       "items": {
         "$ref": "/schemas/v1/core/destination.json"
       },
@@ -25,7 +25,7 @@
   },
   "required": [
     "signal_agent_segment_id",
-    "destinations"
+    "deployments"
   ],
   "additionalProperties": false
 }

--- a/static/schemas/v1/signals/activate-signal-response.json
+++ b/static/schemas/v1/signals/activate-signal-response.json
@@ -6,12 +6,12 @@
   "type": "object",
   "oneOf": [
     {
-      "description": "Success response - signal activated successfully to one or more destinations",
+      "description": "Success response - signal activated successfully to one or more deployment targets",
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "description": "Array of deployment results for each destination",
+          "description": "Array of deployment results for each deployment target",
           "items": {
             "$ref": "/schemas/v1/core/deployment.json"
           }

--- a/static/schemas/v1/signals/get-signals-request.json
+++ b/static/schemas/v1/signals/get-signals-request.json
@@ -11,11 +11,11 @@
     },
     "deliver_to": {
       "type": "object",
-      "description": "Destination platforms where signals need to be activated",
+      "description": "Deployment targets where signals need to be activated",
       "properties": {
-        "destinations": {
+        "deployments": {
           "type": "array",
-          "description": "List of destination platforms (DSPs, sales agents, etc.). If the authenticated caller matches one of these destinations, activation keys will be included in the response.",
+          "description": "List of deployment targets (DSPs, sales agents, etc.). If the authenticated caller matches one of these deployment targets, activation keys will be included in the response.",
           "items": {
             "$ref": "/schemas/v1/core/destination.json"
           },
@@ -31,7 +31,7 @@
         }
       },
       "required": [
-        "destinations",
+        "deployments",
         "countries"
       ],
       "additionalProperties": false

--- a/static/schemas/v1/signals/get-signals-response.json
+++ b/static/schemas/v1/signals/get-signals-response.json
@@ -44,7 +44,7 @@
           },
           "deployments": {
             "type": "array",
-            "description": "Array of destination deployments",
+            "description": "Array of deployment targets",
             "items": {
               "$ref": "/schemas/v1/core/deployment.json"
             }

--- a/tests/example-validation-simple.test.js
+++ b/tests/example-validation-simple.test.js
@@ -137,7 +137,7 @@ async function runTests() {
     {
       "signal_spec": "High-income households",
       "deliver_to": {
-        "destinations": [
+        "deployments": [
           {
             "type": "platform",
             "platform": "the-trade-desk"


### PR DESCRIPTION
## Summary

Standardizes field naming to use `deployments` consistently across both request and response schemas in the signals API for better clarity and consistency.

This simplifies the mental model by using "deployment" terminology everywhere instead of mixing "destination" (requests) and "deployment" (responses).

## Changes

### Schema Updates
- ✅ `get_signals` request: `deliver_to.destinations` → `deliver_to.deployments`
- ✅ `activate_signal` request: `destinations` → `deployments`
- ✅ Updated all schema descriptions to use deployment terminology
- ✅ Updated core `destination.json` and `deployment.json` schemas

### Documentation Updates  
- ✅ Updated `docs/signals/tasks/get_signals.mdx` with new field names
- ✅ Updated `docs/signals/tasks/activate_signal.mdx` with new field names
- ✅ Updated all code examples in documentation

### Test Updates
- ✅ Updated test examples to use `deployments` field

## Example Change

**Before:**
```json
{
  "signal_spec": "High-income households",
  "deliver_to": {
    "destinations": [{
      "type": "platform",
      "platform": "the-trade-desk"
    }],
    "countries": ["US"]
  }
}
```

**After:**
```json
{
  "signal_spec": "High-income households",
  "deliver_to": {
    "deployments": [{
      "type": "platform",
      "platform": "the-trade-desk"
    }],
    "countries": ["US"]
  }
}
```

## Testing

- ✅ All schema validation tests pass
- ✅ All example validation tests pass  
- ✅ TypeScript type checking passes
- ✅ Build succeeds

## Changeset

Patch version changeset created at `.changeset/signals-rename-destinations-to-deployments.md`

This will trigger a version bump from 2.4.0 → 2.4.1 when merged.

## Checklist

- [x] Tests pass
- [x] Build succeeds
- [x] Changeset created (patch)
- [x] Documentation updated
- [x] No TODOs or commented code
