### PR TITLE
Remove unused legacy fields from list_creatives response

### DIFF
--- a/.changeset/remove-legacy-creative-fields.md
+++ b/.changeset/remove-legacy-creative-fields.md
@@ -1,0 +1,34 @@
+---
+"adcontextprotocol": minor
+---
+
+Remove unused legacy fields from list_creatives response schema.
+
+**Fields removed:**
+- `media_url` - URL of the creative file
+- `click_url` - Landing page URL
+- `duration` - Duration in milliseconds
+- `width` - Width in pixels
+- `height` - Height in pixels
+
+**Why this is a minor change (not breaking):**
+
+These fields were never implemented or populated by any AdCP server implementation. They existed in the schema from the initial creative library implementation but were non-functional. All creative metadata is accessed through the structured `assets` dictionary, which has been the only working approach since AdCP v2.0.
+
+**Migration:**
+
+No migration needed - if you were parsing these fields, they were always empty/null. Use the `assets` dictionary to access creative properties:
+
+```json
+{
+  "creative_id": "hero_video_30s",
+  "assets": {
+    "vast": {
+      "url": "https://vast.example.com/video/123",
+      "vast_version": "4.1"
+    }
+  }
+}
+```
+
+All creative asset metadata (URLs, dimensions, durations, click destinations) is contained within the typed asset objects in the `assets` dictionary.

--- a/static/schemas/v1/media-buy/list-creatives-response.json
+++ b/static/schemas/v1/media-buy/list-creatives-response.json
@@ -117,11 +117,6 @@
             "format": "date-time",
             "description": "When the creative was last modified"
           },
-          "media_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "URL of the creative file (for hosted assets)"
-          },
           "assets": {
             "type": "object",
             "description": "Assets for this creative, keyed by asset_role",
@@ -142,26 +137,6 @@
                 ]
               }
             }
-          },
-          "click_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "Landing page URL for the creative"
-          },
-          "duration": {
-            "type": "number",
-            "description": "Duration in milliseconds (for video/audio)",
-            "minimum": 0
-          },
-          "width": {
-            "type": "number",
-            "description": "Width in pixels (for video/display)",
-            "minimum": 0
-          },
-          "height": {
-            "type": "number",
-            "description": "Height in pixels (for video/display)",
-            "minimum": 0
           },
           "tags": {
             "type": "array",
@@ -375,10 +350,6 @@
                 "vast_version": "4.1"
               }
             },
-            "click_url": "https://example.com/products",
-            "duration": 30000,
-            "width": 1920,
-            "height": 1080,
             "tags": [
               "q1_2024",
               "video",


### PR DESCRIPTION
## Summary

Removed 5 non-functional legacy fields from the `list_creatives` response schema that were never implemented or populated by any AdCP server.

## Changes

- Removed: `media_url`, `click_url`, `duration`, `width`, `height`
- All creative metadata is accessed through the structured `assets` dictionary (since AdCP v2.0)
- This is a minor version bump (not breaking) since these fields never worked

## Test Status

✅ All schema validation tests pass
✅ All example validation tests pass
✅ TypeScript type checking passes