### PR TITLE
Fix provide_performance_feedback to support buyer_ref

### DIFF
--- a/.changeset/fix-feedback-buyer-ref.md
+++ b/.changeset/fix-feedback-buyer-ref.md
@@ -1,0 +1,17 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix provide_performance_feedback to support buyer_ref identifier
+
+The provide_performance_feedback request schema now accepts either `media_buy_id` or `buyer_ref` to identify the media buy, matching the pattern used in update_media_buy and other operations. This was the only schema in the entire specification that forced buyers to track publisher-assigned IDs, creating an inconsistency.
+
+**What changed:**
+- Added `buyer_ref` field to provide-performance-feedback-request.json
+- Changed `required` array to `oneOf` pattern allowing either identifier
+- Buyers can now provide feedback using their own reference instead of having to track the publisher's media_buy_id
+
+**Impact:**
+- Backward compatible - existing calls using media_buy_id continue to work
+- Removes the only forced ID tracking requirement in the buyer workflow
+- Aligns with the principle that buyers use their own references throughout

--- a/static/schemas/v1/media-buy/provide-performance-feedback-request.json
+++ b/static/schemas/v1/media-buy/provide-performance-feedback-request.json
@@ -10,6 +10,11 @@
       "description": "Publisher's media buy identifier",
       "minLength": 1
     },
+    "buyer_ref": {
+      "type": "string",
+      "description": "Buyer's reference for the media buy",
+      "minLength": 1
+    },
     "measurement_period": {
       "type": "object",
       "description": "Time period for performance measurement",
@@ -62,10 +67,21 @@
       "additionalProperties": true
     }
   },
-  "required": [
-    "media_buy_id",
-    "measurement_period",
-    "performance_index"
+  "oneOf": [
+    {
+      "required": [
+        "media_buy_id",
+        "measurement_period",
+        "performance_index"
+      ]
+    },
+    {
+      "required": [
+        "buyer_ref",
+        "measurement_period",
+        "performance_index"
+      ]
+    }
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
The provide_performance_feedback request schema now accepts either `media_buy_id` or `buyer_ref` to identify the media buy. This was the only schema in the specification that forced buyers to track publisher-assigned IDs.

## Test plan
- [x] All schema validation tests pass
- [x] All example validation tests pass  
- [x] TypeScript type checking passes
- [x] Changeset created for patch version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)