### PR TITLE
Extract property ID and tag patterns into reusable schemas

### DIFF
--- a/.changeset/deduplicate-property-schemas.md
+++ b/.changeset/deduplicate-property-schemas.md
@@ -1,0 +1,23 @@
+---
+"adcontextprotocol": patch
+---
+
+Extract duplicated property ID and tag patterns into reusable core schemas.
+
+**New schemas:**
+- `property-id.json` - Single source of truth for property identifier validation
+- `property-tag.json` - Single source of truth for property tag validation
+
+**Updated schemas:**
+- `publisher-property-selector.json` - Now references shared property-id and property-tag schemas
+- `adagents.json` - Now references shared property-id and property-tag schemas
+- `property.json` - Now references shared property-id and property-tag schemas for property_id and tags fields
+
+**Benefits:**
+- Eliminates inline pattern duplication across multiple schemas
+- SDK generators now produce single types for property IDs and tags instead of multiple incompatible types
+- Single source of truth for validation rules - changes apply everywhere
+- Clearer semantic meaning with explicit type names
+- Easier to maintain and evolve constraints in the future
+
+**Breaking change:** No - validation behavior is identical, this is a refactoring only.

--- a/static/schemas/v1/adagents.json
+++ b/static/schemas/v1/adagents.json
@@ -103,8 +103,7 @@
                 "type": "array",
                 "description": "Property IDs this agent is authorized for. Resolved against the top-level properties array in this file",
                 "items": {
-                  "type": "string",
-                  "pattern": "^[a-z0-9_]+$"
+                  "$ref": "/schemas/v1/core/property-id.json"
                 },
                 "minItems": 1
               }
@@ -135,8 +134,7 @@
                 "type": "array",
                 "description": "Tags identifying which properties this agent is authorized for. Resolved against the top-level properties array in this file using tag matching",
                 "items": {
-                  "type": "string",
-                  "pattern": "^[a-z0-9_]+$"
+                  "$ref": "/schemas/v1/core/property-tag.json"
                 },
                 "minItems": 1
               }

--- a/static/schemas/v1/core/property-id.json
+++ b/static/schemas/v1/core/property-id.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/core/property-id.json",
+  "title": "Property ID",
+  "description": "Identifier for a publisher property. Must be lowercase alphanumeric with underscores only.",
+  "type": "string",
+  "pattern": "^[a-z0-9_]+$",
+  "examples": ["cnn_ctv_app", "homepage", "mobile_ios", "instagram"]
+}

--- a/static/schemas/v1/core/property-tag.json
+++ b/static/schemas/v1/core/property-tag.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/core/property-tag.json",
+  "title": "Property Tag",
+  "description": "Tag for categorizing publisher properties. Must be lowercase alphanumeric with underscores only.",
+  "type": "string",
+  "pattern": "^[a-z0-9_]+$",
+  "examples": ["ctv", "premium", "news", "sports", "meta_network", "social_media"]
+}

--- a/static/schemas/v1/core/property.json
+++ b/static/schemas/v1/core/property.json
@@ -6,9 +6,8 @@
   "type": "object",
   "properties": {
     "property_id": {
-      "type": "string",
-      "description": "Unique identifier for this property (optional). Enables referencing properties by ID instead of repeating full objects. Recommended format: lowercase with underscores (e.g., 'cnn_ctv_app', 'instagram_mobile')",
-      "pattern": "^[a-z0-9_]+$"
+      "$ref": "/schemas/v1/core/property-id.json",
+      "description": "Unique identifier for this property (optional). Enables referencing properties by ID instead of repeating full objects."
     },
     "property_type": {
       "$ref": "/schemas/v1/enums/property-type.json",
@@ -42,9 +41,7 @@
       "type": "array",
       "description": "Tags for categorization and grouping (e.g., network membership, content categories)",
       "items": {
-        "type": "string",
-        "pattern": "^[a-z0-9_]+$",
-        "description": "Lowercase tag with underscores (e.g., 'conde_nast_network', 'premium_content')"
+        "$ref": "/schemas/v1/core/property-tag.json"
       },
       "uniqueItems": true
     },

--- a/static/schemas/v1/core/publisher-property-selector.json
+++ b/static/schemas/v1/core/publisher-property-selector.json
@@ -43,8 +43,7 @@
           "type": "array",
           "description": "Specific property IDs from the publisher's adagents.json",
           "items": {
-            "type": "string",
-            "pattern": "^[a-z0-9_]+$"
+            "$ref": "/schemas/v1/core/property-id.json"
           },
           "minItems": 1
         }
@@ -70,8 +69,7 @@
           "type": "array",
           "description": "Property tags from the publisher's adagents.json. Selector covers all properties with these tags",
           "items": {
-            "type": "string",
-            "pattern": "^[a-z0-9_]+$"
+            "$ref": "/schemas/v1/core/property-tag.json"
           },
           "minItems": 1
         }

--- a/static/schemas/v1/index.json
+++ b/static/schemas/v1/index.json
@@ -160,6 +160,14 @@
         "signal-filters": {
           "$ref": "/schemas/v1/core/signal-filters.json",
           "description": "Filters to refine signal discovery results"
+        },
+        "property-id": {
+          "$ref": "/schemas/v1/core/property-id.json",
+          "description": "Identifier for a publisher property - lowercase alphanumeric with underscores only"
+        },
+        "property-tag": {
+          "$ref": "/schemas/v1/core/property-tag.json",
+          "description": "Tag for categorizing publisher properties - lowercase alphanumeric with underscores only"
         }
       }
     },


### PR DESCRIPTION
## Summary

Eliminates inline duplication of property ID and tag validation patterns across multiple schema files. Creates reusable core schemas that serve as a single source of truth for these common validation rules.

## Changes

Creates `property-id.json` and `property-tag.json` core schemas, then updates `publisher-property-selector.json`, `adagents.json`, and `property.json` to reference them via `$ref`. SDK generators now produce single types instead of multiple incompatible types for the same semantic concepts.

## Test Plan

- ✅ All schema validation tests pass (142 schemas)
- ✅ All example validation tests pass (7 examples)
- ✅ TypeScript compilation passes
- ✅ Precommit hooks satisfied
- ✅ No breaking changes to validation behavior