### PR TITLE
Enable automatic GitHub releases and tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -24,11 +26,13 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Tag Release
+        id: changesets
         uses: changesets/action@v1
         with:
           version: npm run version
           commit: 'Version Packages'
           title: 'Version Packages'
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enables automatic GitHub release creation and git tagging when version PRs are merged.

**Changes:**
- Added `fetch-depth: 0` for full git history access
- Enabled `createGithubReleases: true` in Changesets action

After merging PR #165 (or future version PRs), releases and tags will be created automatically.