### PR TITLE
chore: Update CSV headers to use underscores instead of dots for data wareho…

### DIFF
--- a/.changeset/csv-header-underscore-format.md
+++ b/.changeset/csv-header-underscore-format.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update CSV export example headers to use underscores instead of dots for better data warehouse compatibility (e.g., `totals_impressions` instead of `totals.impressions`).

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -498,7 +498,7 @@ CSV files require unnesting nested arrays. Each record should be unnested to the
 
 **Example CSV structure:**
 ```csv
-notification_type,sequence_number,next_expected_at,reporting_period.start,reporting_period.end,currency,media_buy_id,buyer_ref,status,totals.impressions,totals.spend,totals.clicks,totals.ctr,by_package.package_id,by_package.impressions,by_package.spend,by_package.clicks,by_package.pacing_index,by_package.pricing_model,by_package.rate,by_package.currency
+notification_type,sequence_number,next_expected_at,reporting_period_start,reporting_period_end,currency,media_buy_id,buyer_ref,status,totals_impressions,totals_spend,totals_clicks,totals_ctr,by_package_package_id,by_package_impressions,by_package_spend,by_package_clicks,by_package_pacing_index,by_package_pricing_model,by_package_rate,by_package_currency
 scheduled,5,2024-02-06T08:00:00Z,2024-02-05T00:00:00Z,2024-02-05T23:59:59Z,USD,mb_001,campaign_a,active,50000,1750.00,100,0.002,pkg_001,30000,1050.00,60,0.95,cpm,0.035,USD
 scheduled,5,2024-02-06T08:00:00Z,2024-02-05T00:00:00Z,2024-02-05T23:59:59Z,USD,mb_001,campaign_a,active,50000,1750.00,100,0.002,pkg_002,20000,700.00,40,0.98,cpm,0.035,USD
 scheduled,5,2024-02-06T08:00:00Z,2024-02-05T00:00:00Z,2024-02-05T23:59:59Z,USD,mb_002,campaign_b,active,200000,9000.00,400,0.002,pkg_003,200000,9000.00,400,1.02,cpm,45.00,USD


### PR DESCRIPTION
## Summary
Updates CSV export example headers to use underscores instead of dots (e.g., totals_impressions instead of totals.impressions) for better compatibility with data warehouse exports, which typically flatten nested field names to underscores.
## Changes:
Updated CSV header format in optimization reporting documentation
Changed all nested field headers from dot notation to underscore notation
This ensures the CSV format aligns with common data pipeline processing conventions.