### PR TITLE
Add Upwave Signals agent to registry

### DIFF
--- a/registry/upwave-signals.json
+++ b/registry/upwave-signals.json
@@ -1,1 +1,16 @@
-
+{
+  "id": "upwave-signals",
+  "type": "signals",
+  "name": "Upwave Signals",
+  "description": "Upwave brand and audience signals, including campaign-level awareness lift and persuadability scores.",
+  "manifestUrl": "https://signals.upwave.ai/manifest.json",
+  "publisher": {
+    "name": "Upwave",
+    "website": "https://www.upwave.com"
+  },
+  "contact": {
+    "email": "support@upwave.com"
+  },
+  "status": "active",
+  "categories": ["measurement", "brand-lift", "audience-signals"]
+}


### PR DESCRIPTION
Adds Upwave Signals as a signals agent to the registry.
Manifest: https://signals.upwave.ai/manifest.json
Endpoint: /get-signals requiring campaignId and returning brand lift values