### PR TITLE
Fix ToS changeset to empty (no protocol change)

### DIFF
--- a/.changeset/tos-checkbox-onboarding.md
+++ b/.changeset/tos-checkbox-onboarding.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
-Add Terms of Service checkbox to onboarding forms. Users must now explicitly agree to the Terms of Service and Privacy Policy before creating an organization or personal workspace.
+Add Terms of Service checkbox to onboarding forms (registry UI change, no protocol impact).


### PR DESCRIPTION
## Summary
- Changes the ToS checkbox changeset from `patch` to empty
- This was a registry UI change, not a protocol change, so it shouldn't bump the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)