### PR TITLE
fix: url_type enum documentation to match schema

### DIFF
--- a/.changeset/tangy-ravens-type.md
+++ b/.changeset/tangy-ravens-type.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix inconsistency in `url_type` enum documentation in asset-types.mdx to match schema
+
+- Changed `tracker` to `impression_tracker` to match the schema enum value
+- Added missing `video_tracker` and `landing_page` enum values to documentation
+- Documentation now correctly lists all four `url_type` values: `clickthrough`, `impression_tracker`, `video_tracker`, `landing_page`

--- a/docs/creative/asset-types.mdx
+++ b/docs/creative/asset-types.mdx
@@ -128,9 +128,11 @@ Links for clickthroughs, tracking, and landing pages.
 ```
 
 **Properties:**
-- `url_type`: Whether the URL is for human interaction (used only in format requirements):
+- `url_type`: The purpose of the URL (used only in format requirements):
   - `clickthrough` - User clicks this URL (may redirect through ad tech platforms before reaching destination)
-  - `tracker` - Fires in background (returns 1x1 pixel, JavaScript snippet, or 204 No Content)
+  - `impression_tracker` - Fires in background (returns 1x1 pixel, JavaScript snippet, or 204 No Content)
+  - `video_tracker` - Video ad tracking URL (for VAST, video events, etc.)
+  - `landing_page` - Landing page URL
 - `must_be_https`: Whether HTTPS is required
 - `allowed_domains`: List of allowed domains (if restricted)
 - `tracking_macros_supported`: Whether URL macros are supported


### PR DESCRIPTION
## Fix `url_type` enum documentation inconsistency

Fixes inconsistency between the `url_type` enum documentation in `asset-types.mdx` and the `asset-types-v1.json` schema.

### Changes
- Changed `tracker` → `impression_tracker` to match schema enum value
- Added missing `video_tracker` and `landing_page` enum values to documentation

The documentation now correctly lists all four `url_type` values from the schema:
- `clickthrough`
- `impression_tracker`
- `video_tracker`
- `landing_page`

In the adcp document example
<img width="1181" height="408" alt="image" src="https://github.com/user-attachments/assets/c31bf9d6-40a8-4e71-a86d-91e90a925062" />

In the schema
<img width="808" height="563" alt="image" src="https://github.com/user-attachments/assets/465faeba-dd26-47e1-9a25-57d993b5d5a4" />
