### PR TITLE
Adding swivel agent to registry

### DIFF
--- a/registry/sales/swivel-sales-agent.json
+++ b/registry/sales/swivel-sales-agent.json
@@ -1,0 +1,14 @@
+{
+  "name": "Swivel Seller Agent",
+  "url": "https://adcp-mcp-server-286099387629.us-central1.run.app/mcp",
+  "type": "sales",
+  "protocol": "mcp",
+  "description": "Swivel AdCP media sales agent",
+  "mcp_endpoint": "https://adcp-mcp-server-286099387629.us-central1.run.app/mcp",
+  "contact": {
+    "name": "Swivel Team",
+    "email": "hello@swivel.ai",
+    "website": "https://swivel.ai/"
+  },
+  "added_date": "2025-12-15"
+}


### PR DESCRIPTION
This PR adds our Seller MCP Agent to the AdCP registry, making it discoverable and usable by AdCP-compatible clients and integrations. 

We will update the endpoint URL in the future but this should get us started. 