### PR TITLE
Fixed schema URLs - missing v2

### DIFF
--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -11,7 +11,7 @@
         "$schema": {
           "type": "string",
           "description": "JSON Schema identifier for this adagents.json file",
-          "default": "https://adcontextprotocol.org/schemas/adagents.json"
+          "default": "https://adcontextprotocol.org/schemas/v2/adagents.json"
         },
         "authoritative_location": {
           "type": "string",
@@ -35,7 +35,7 @@
         "$schema": {
           "type": "string",
           "description": "JSON Schema identifier for this adagents.json file",
-          "default": "https://adcontextprotocol.org/schemas/adagents.json"
+          "default": "https://adcontextprotocol.org/schemas/v2/adagents.json"
         },
         "contact": {
       "type": "object",
@@ -247,12 +247,12 @@
   ],
   "examples": [
     {
-      "$schema": "https://adcontextprotocol.org/schemas/adagents.json",
+      "$schema": "https://adcontextprotocol.org/schemas/v2/adagents.json",
       "authoritative_location": "https://cdn.example.com/adagents/v2/adagents.json",
       "last_updated": "2025-01-15T10:00:00Z"
     },
     {
-      "$schema": "https://adcontextprotocol.org/schemas/adagents.json",
+      "$schema": "https://adcontextprotocol.org/schemas/v2/adagents.json",
       "properties": [
         {
           "property_type": "website",
@@ -280,7 +280,7 @@
       "last_updated": "2025-01-10T12:00:00Z"
     },
     {
-      "$schema": "https://adcontextprotocol.org/schemas/adagents.json",
+      "$schema": "https://adcontextprotocol.org/schemas/v2/adagents.json",
       "contact": {
         "name": "Meta Advertising Operations",
         "email": "adops@meta.com",
@@ -345,7 +345,7 @@
       "last_updated": "2025-01-10T15:30:00Z"
     },
     {
-      "$schema": "https://adcontextprotocol.org/schemas/adagents.json",
+      "$schema": "https://adcontextprotocol.org/schemas/v2/adagents.json",
       "contact": {
         "name": "Tumblr Advertising"
       },
@@ -377,7 +377,7 @@
       "last_updated": "2025-01-10T16:00:00Z"
     },
     {
-      "$schema": "https://adcontextprotocol.org/schemas/adagents.json",
+      "$schema": "https://adcontextprotocol.org/schemas/v2/adagents.json",
       "contact": {
         "name": "Example Third-Party Sales Agent",
         "email": "sales@agent.example",


### PR DESCRIPTION
Replaced
https://adcontextprotocol.org/schemas/adagents.json with
https://adcontextprotocol.org/schemas/v2/adagents.json