### PR TITLE
Federated agent and publisher discovery

### DIFF
--- a/.changeset/federated-discovery.md
+++ b/.changeset/federated-discovery.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add federated agent and publisher discovery (server implementation only, no protocol changes)

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1,5 +1,8 @@
 import type { Agent } from "./types.js";
 import { PropertyCrawler, getPropertyIndex, type AgentInfo, type CrawlResult } from "@adcp/client";
+import { FederatedIndexService } from "./federated-index.js";
+import { AdAgentsManager } from "./adagents-manager.js";
+import { MemberDatabase } from "./db/member-db.js";
 
 export class CrawlerService {
   private crawler: PropertyCrawler;
@@ -7,9 +10,15 @@ export class CrawlerService {
   private lastCrawl: Date | null = null;
   private lastResult: CrawlResult | null = null;
   private intervalId: NodeJS.Timeout | null = null;
+  private federatedIndex: FederatedIndexService;
+  private adAgentsManager: AdAgentsManager;
+  private memberDb: MemberDatabase;
 
   constructor() {
     this.crawler = new PropertyCrawler({ logLevel: 'debug' });
+    this.federatedIndex = new FederatedIndexService();
+    this.adAgentsManager = new AdAgentsManager();
+    this.memberDb = new MemberDatabase();
   }
 
   async crawlAllAgents(agents: Agent[]): Promise<CrawlResult> {
@@ -64,6 +73,9 @@ export class CrawlerService {
           console.log(`  ${warning.domain}: ${warning.message}`);
         }
       }
+
+      // Populate federated index from PropertyIndex and adagents.json files
+      await this.populateFederatedIndex(agents);
 
       return result;
     } catch (error) {
@@ -122,5 +134,119 @@ export class CrawlerService {
       errors: [],
       warnings: [],
     };
+  }
+
+  /**
+   * Populate the federated index with discovered agents and publishers.
+   * This is called after the PropertyCrawler finishes to persist data to PostgreSQL.
+   */
+  private async populateFederatedIndex(agents: Agent[]): Promise<void> {
+    console.log("Populating federated index...");
+    const index = getPropertyIndex();
+
+    // Track domains we've already processed to avoid duplicates
+    const processedDomains = new Set<string>();
+
+    // 1. Crawl registered publishers' adagents.json files
+    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    const registeredPublisherDomains: string[] = [];
+    for (const profile of profiles) {
+      for (const pubConfig of profile.publishers || []) {
+        if (pubConfig.is_public && pubConfig.domain) {
+          registeredPublisherDomains.push(pubConfig.domain);
+        }
+      }
+    }
+    console.log(`Crawling ${registeredPublisherDomains.length} registered publishers: ${registeredPublisherDomains.join(', ') || '(none)'}`);
+
+    for (const profile of profiles) {
+      for (const pubConfig of profile.publishers || []) {
+        if (!pubConfig.is_public || !pubConfig.domain) continue;
+        if (processedDomains.has(pubConfig.domain)) continue;
+
+        try {
+          const validation = await this.adAgentsManager.validateDomain(pubConfig.domain);
+          processedDomains.add(pubConfig.domain);
+
+          if (validation.valid && validation.raw_data?.authorized_agents) {
+            console.log(`  ${pubConfig.domain}: found ${validation.raw_data.authorized_agents.length} authorized agents`);
+            for (const authorizedAgent of validation.raw_data.authorized_agents) {
+              if (!authorizedAgent.url) continue;
+
+              await this.federatedIndex.recordAgentFromAdagentsJson(
+                authorizedAgent.url,
+                pubConfig.domain,
+                authorizedAgent.authorized_for,
+                authorizedAgent.property_ids
+              );
+            }
+          } else {
+            console.log(`  ${pubConfig.domain}: no valid adagents.json`);
+          }
+        } catch (err) {
+          console.error(`  ${pubConfig.domain}: failed -`, err instanceof Error ? err.message : err);
+        }
+      }
+    }
+
+    // 2. Record publishers discovered from each sales agent's list_authorized_properties
+    console.log("Processing sales agent discovered publishers...");
+    for (const agent of agents) {
+      if (agent.type !== "sales") continue;
+
+      const auth = index.getAgentAuthorizations(agent.url);
+      if (!auth || auth.publisher_domains.length === 0) continue;
+
+      for (const domain of auth.publisher_domains) {
+        try {
+          // Check if domain has valid adagents.json
+          const validation = await this.adAgentsManager.validateDomain(domain);
+          await this.federatedIndex.recordPublisherFromAgent(
+            domain,
+            agent.url,
+            validation.valid
+          );
+
+          // If valid and not already processed, record agents from adagents.json
+          if (validation.valid && validation.raw_data?.authorized_agents && !processedDomains.has(domain)) {
+            await this.federatedIndex.markPublisherHasValidAdagents(domain);
+            processedDomains.add(domain);
+
+            for (const authorizedAgent of validation.raw_data.authorized_agents) {
+              if (!authorizedAgent.url) continue;
+
+              await this.federatedIndex.recordAgentFromAdagentsJson(
+                authorizedAgent.url,
+                domain,
+                authorizedAgent.authorized_for,
+                authorizedAgent.property_ids
+              );
+            }
+          }
+        } catch (err) {
+          console.error(`Failed to process domain ${domain}:`, err);
+        }
+      }
+    }
+
+    // Log stats
+    try {
+      const stats = await this.federatedIndex.getStats();
+      console.log(
+        `Federated index populated: ${stats.discovered_agents} discovered agents, ` +
+        `${stats.discovered_publishers} discovered publishers, ` +
+        `${stats.authorizations} authorizations ` +
+        `(${stats.authorizations_by_source.adagents_json} verified, ${stats.authorizations_by_source.agent_claim} claims)`
+      );
+    } catch {
+      // Stats are optional
+    }
+  }
+
+  /**
+   * Get the federated index service (for API access)
+   */
+  getFederatedIndex(): FederatedIndexService {
+    return this.federatedIndex;
   }
 }

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -1,0 +1,334 @@
+import { query } from './client.js';
+
+/**
+ * Discovered agent from adagents.json or list_authorized_properties
+ */
+export interface DiscoveredAgent {
+  id?: string;
+  agent_url: string;
+  source_type: 'adagents_json' | 'list_authorized_properties';
+  source_domain: string;
+  name?: string;
+  agent_type?: string;
+  protocol?: string;
+  discovered_at?: Date;
+  last_validated?: Date;
+  expires_at?: Date;
+}
+
+/**
+ * Discovered publisher from sales agent list_authorized_properties
+ */
+export interface DiscoveredPublisher {
+  id?: string;
+  domain: string;
+  discovered_by_agent: string;
+  discovered_at?: Date;
+  last_validated?: Date;
+  has_valid_adagents?: boolean;
+  expires_at?: Date;
+}
+
+/**
+ * Agent-publisher authorization (from adagents.json or agent claims)
+ */
+export interface AgentPublisherAuthorization {
+  id?: string;
+  agent_url: string;
+  publisher_domain: string;
+  authorized_for?: string;
+  property_ids?: string[];
+  source: 'adagents_json' | 'agent_claim';
+  discovered_at?: Date;
+  last_validated?: Date;
+}
+
+/**
+ * Database operations for federated discovery index
+ */
+export class FederatedIndexDatabase {
+  // ============================================
+  // Reverse Lookups (indexed for fast queries)
+  // ============================================
+
+  /**
+   * Get all agents authorized for a specific domain
+   * Uses idx_auth_by_publisher index
+   */
+  async getAgentsForDomain(domain: string): Promise<AgentPublisherAuthorization[]> {
+    const result = await query<AgentPublisherAuthorization>(
+      `SELECT agent_url, publisher_domain, authorized_for, property_ids, source, discovered_at, last_validated
+       FROM agent_publisher_authorizations
+       WHERE publisher_domain = $1
+       ORDER BY source, agent_url`,
+      [domain]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Get all publisher domains for a specific agent
+   * Uses idx_auth_by_agent index
+   */
+  async getDomainsForAgent(agentUrl: string): Promise<AgentPublisherAuthorization[]> {
+    const result = await query<AgentPublisherAuthorization>(
+      `SELECT agent_url, publisher_domain, authorized_for, property_ids, source, discovered_at, last_validated
+       FROM agent_publisher_authorizations
+       WHERE agent_url = $1
+       ORDER BY source, publisher_domain`,
+      [agentUrl]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Get sales agents that claim to sell for a domain
+   * Uses idx_discovered_publishers_domain index
+   */
+  async getSalesAgentsClaimingDomain(domain: string): Promise<DiscoveredPublisher[]> {
+    const result = await query<DiscoveredPublisher>(
+      `SELECT domain, discovered_by_agent, discovered_at, last_validated, has_valid_adagents, expires_at
+       FROM discovered_publishers
+       WHERE domain = $1
+       ORDER BY discovered_by_agent`,
+      [domain]
+    );
+    return result.rows;
+  }
+
+  // ============================================
+  // List All
+  // ============================================
+
+  /**
+   * Get all discovered agents, optionally filtered by type
+   */
+  async getAllDiscoveredAgents(agentType?: string): Promise<DiscoveredAgent[]> {
+    let sql = `
+      SELECT id, agent_url, source_type, source_domain, name, agent_type, protocol,
+             discovered_at, last_validated, expires_at
+      FROM discovered_agents
+    `;
+    const params: unknown[] = [];
+
+    if (agentType) {
+      sql += ` WHERE agent_type = $1`;
+      params.push(agentType);
+    }
+
+    sql += ` ORDER BY discovered_at DESC`;
+
+    const result = await query<DiscoveredAgent>(sql, params);
+    return result.rows;
+  }
+
+  /**
+   * Get all discovered publishers
+   */
+  async getAllDiscoveredPublishers(): Promise<DiscoveredPublisher[]> {
+    const result = await query<DiscoveredPublisher>(
+      `SELECT DISTINCT ON (domain)
+         domain, discovered_by_agent, discovered_at, last_validated, has_valid_adagents, expires_at
+       FROM discovered_publishers
+       ORDER BY domain, discovered_at DESC`
+    );
+    return result.rows;
+  }
+
+  /**
+   * Get all unique domains from discovered publishers
+   */
+  async getAllDiscoveredDomains(): Promise<string[]> {
+    const result = await query<{ domain: string }>(
+      `SELECT DISTINCT domain FROM discovered_publishers ORDER BY domain`
+    );
+    return result.rows.map(r => r.domain);
+  }
+
+  // ============================================
+  // CRUD Operations (for crawler)
+  // ============================================
+
+  /**
+   * Upsert a discovered agent
+   */
+  async upsertAgent(agent: DiscoveredAgent): Promise<DiscoveredAgent> {
+    const result = await query<DiscoveredAgent>(
+      `INSERT INTO discovered_agents (
+         agent_url, source_type, source_domain, name, agent_type, protocol, expires_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (agent_url) DO UPDATE SET
+         source_type = EXCLUDED.source_type,
+         source_domain = EXCLUDED.source_domain,
+         name = COALESCE(EXCLUDED.name, discovered_agents.name),
+         agent_type = COALESCE(EXCLUDED.agent_type, discovered_agents.agent_type),
+         protocol = COALESCE(EXCLUDED.protocol, discovered_agents.protocol),
+         last_validated = NOW(),
+         expires_at = EXCLUDED.expires_at
+       RETURNING *`,
+      [
+        agent.agent_url,
+        agent.source_type,
+        agent.source_domain,
+        agent.name || null,
+        agent.agent_type || null,
+        agent.protocol || 'mcp',
+        agent.expires_at || null,
+      ]
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Upsert a discovered publisher
+   */
+  async upsertPublisher(publisher: DiscoveredPublisher): Promise<DiscoveredPublisher> {
+    const result = await query<DiscoveredPublisher>(
+      `INSERT INTO discovered_publishers (
+         domain, discovered_by_agent, has_valid_adagents, expires_at
+       ) VALUES ($1, $2, $3, $4)
+       ON CONFLICT (domain, discovered_by_agent) DO UPDATE SET
+         last_validated = NOW(),
+         has_valid_adagents = COALESCE(EXCLUDED.has_valid_adagents, discovered_publishers.has_valid_adagents),
+         expires_at = EXCLUDED.expires_at
+       RETURNING *`,
+      [
+        publisher.domain,
+        publisher.discovered_by_agent,
+        publisher.has_valid_adagents ?? false,
+        publisher.expires_at || null,
+      ]
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Upsert an agent-publisher authorization
+   */
+  async upsertAuthorization(auth: AgentPublisherAuthorization): Promise<AgentPublisherAuthorization> {
+    const result = await query<AgentPublisherAuthorization>(
+      `INSERT INTO agent_publisher_authorizations (
+         agent_url, publisher_domain, authorized_for, property_ids, source
+       ) VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (agent_url, publisher_domain, source) DO UPDATE SET
+         authorized_for = COALESCE(EXCLUDED.authorized_for, agent_publisher_authorizations.authorized_for),
+         property_ids = COALESCE(EXCLUDED.property_ids, agent_publisher_authorizations.property_ids),
+         last_validated = NOW()
+       RETURNING *`,
+      [
+        auth.agent_url,
+        auth.publisher_domain,
+        auth.authorized_for || null,
+        auth.property_ids || null,
+        auth.source,
+      ]
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Update agent metadata (name, type, protocol) after probing
+   */
+  async updateAgentMetadata(
+    agentUrl: string,
+    metadata: { name?: string; agent_type?: string; protocol?: string }
+  ): Promise<void> {
+    await query(
+      `UPDATE discovered_agents
+       SET name = COALESCE($2, name),
+           agent_type = COALESCE($3, agent_type),
+           protocol = COALESCE($4, protocol),
+           last_validated = NOW()
+       WHERE agent_url = $1`,
+      [agentUrl, metadata.name || null, metadata.agent_type || null, metadata.protocol || null]
+    );
+  }
+
+  /**
+   * Mark publisher as having valid adagents.json
+   */
+  async markPublisherHasValidAdagents(domain: string): Promise<void> {
+    await query(
+      `UPDATE discovered_publishers
+       SET has_valid_adagents = TRUE, last_validated = NOW()
+       WHERE domain = $1`,
+      [domain]
+    );
+  }
+
+  // ============================================
+  // Cleanup
+  // ============================================
+
+  /**
+   * Delete expired records
+   */
+  async deleteExpired(): Promise<{ agents: number; publishers: number; authorizations: number }> {
+    const agentsResult = await query(
+      `DELETE FROM discovered_agents WHERE expires_at IS NOT NULL AND expires_at < NOW()`
+    );
+    const publishersResult = await query(
+      `DELETE FROM discovered_publishers WHERE expires_at IS NOT NULL AND expires_at < NOW()`
+    );
+    // Clean up authorizations for agents that no longer exist
+    const authResult = await query(
+      `DELETE FROM agent_publisher_authorizations
+       WHERE agent_url NOT IN (SELECT agent_url FROM discovered_agents)
+         AND agent_url NOT IN (
+           SELECT a.url FROM member_profiles m, jsonb_array_elements(m.agents) AS a(url)
+           WHERE a.url IS NOT NULL
+         )`
+    );
+
+    return {
+      agents: agentsResult.rowCount || 0,
+      publishers: publishersResult.rowCount || 0,
+      authorizations: authResult.rowCount || 0,
+    };
+  }
+
+  /**
+   * Clear all federated discovery data (for testing or reset)
+   */
+  async clearAll(): Promise<void> {
+    await query('DELETE FROM agent_publisher_authorizations');
+    await query('DELETE FROM discovered_publishers');
+    await query('DELETE FROM discovered_agents');
+  }
+
+  // ============================================
+  // Stats
+  // ============================================
+
+  /**
+   * Get statistics about the federated index
+   */
+  async getStats(): Promise<{
+    discovered_agents: number;
+    discovered_publishers: number;
+    authorizations: number;
+    authorizations_by_source: { adagents_json: number; agent_claim: number };
+  }> {
+    const [agentsResult, publishersResult, authResult, authBySourceResult] = await Promise.all([
+      query<{ count: string }>('SELECT COUNT(*) as count FROM discovered_agents'),
+      query<{ count: string }>('SELECT COUNT(DISTINCT domain) as count FROM discovered_publishers'),
+      query<{ count: string }>('SELECT COUNT(*) as count FROM agent_publisher_authorizations'),
+      query<{ source: string; count: string }>(
+        `SELECT source, COUNT(*) as count FROM agent_publisher_authorizations GROUP BY source`
+      ),
+    ]);
+
+    const bySource = { adagents_json: 0, agent_claim: 0 };
+    for (const row of authBySourceResult.rows) {
+      if (row.source === 'adagents_json') bySource.adagents_json = parseInt(row.count, 10);
+      if (row.source === 'agent_claim') bySource.agent_claim = parseInt(row.count, 10);
+    }
+
+    return {
+      discovered_agents: parseInt(agentsResult.rows[0].count, 10),
+      discovered_publishers: parseInt(publishersResult.rows[0].count, 10),
+      authorizations: parseInt(authResult.rows[0].count, 10),
+      authorizations_by_source: bySource,
+    };
+  }
+}

--- a/server/src/db/migrations/025_federated_discovery.sql
+++ b/server/src/db/migrations/025_federated_discovery.sql
@@ -1,0 +1,76 @@
+-- Migration: 025_federated_discovery.sql
+-- Purpose: Create tables for federated agent/publisher discovery
+-- This enables the directory to track agents discovered from publisher adagents.json files
+-- and publishers discovered from sales agents' list_authorized_properties responses.
+
+-- Discovered agents (from adagents.json crawling)
+-- These are agents we learn about by parsing publisher adagents.json files
+CREATE TABLE discovered_agents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_url TEXT NOT NULL UNIQUE,
+  source_type TEXT NOT NULL,  -- 'adagents_json' or 'list_authorized_properties'
+  source_domain TEXT NOT NULL, -- which domain we discovered this agent from
+
+  -- Cached agent metadata (nullable, refreshed when we can probe the agent)
+  name TEXT,
+  agent_type TEXT,  -- 'sales', 'creative', 'signals', 'buyer'
+  protocol TEXT DEFAULT 'mcp',
+
+  -- Discovery metadata
+  discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_validated TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ,
+
+  CONSTRAINT valid_source_type CHECK (source_type IN ('adagents_json', 'list_authorized_properties'))
+);
+
+-- Discovered publishers (from sales agent list_authorized_properties responses)
+-- These are publisher domains we learn about by querying sales agents
+CREATE TABLE discovered_publishers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain TEXT NOT NULL,
+  discovered_by_agent TEXT NOT NULL, -- which sales agent told us about this domain
+  discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_validated TIMESTAMPTZ,
+  has_valid_adagents BOOLEAN DEFAULT FALSE, -- whether we found a valid adagents.json
+  expires_at TIMESTAMPTZ,
+
+  UNIQUE(domain, discovered_by_agent)
+);
+
+-- Many-to-many: agent <-> publisher authorizations
+-- Records which agents are authorized for which publisher domains
+-- This is populated from both directions:
+--   1. From adagents.json authorized_agents array
+--   2. From sales agent list_authorized_properties responses (claimed but may not be verified)
+CREATE TABLE agent_publisher_authorizations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_url TEXT NOT NULL,
+  publisher_domain TEXT NOT NULL,
+  authorized_for TEXT,  -- scope description from adagents.json
+  property_ids TEXT[],  -- specific properties if authorization is limited
+  source TEXT NOT NULL, -- 'adagents_json' (verified) or 'agent_claim' (unverified)
+  discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_validated TIMESTAMPTZ,
+
+  UNIQUE(agent_url, publisher_domain, source)
+);
+
+-- Indexes for fast reverse lookups
+-- "Which agents are authorized for domain X?"
+CREATE INDEX idx_auth_by_publisher ON agent_publisher_authorizations(publisher_domain);
+
+-- "Which publishers does agent Y represent?"
+CREATE INDEX idx_auth_by_agent ON agent_publisher_authorizations(agent_url);
+
+-- "Which sales agents claim to sell for domain X?"
+CREATE INDEX idx_discovered_publishers_domain ON discovered_publishers(domain);
+
+-- "List all discovered agents of type X"
+CREATE INDEX idx_discovered_agents_type ON discovered_agents(agent_type);
+
+-- For cleanup of expired records
+CREATE INDEX idx_discovered_agents_expires ON discovered_agents(expires_at)
+  WHERE expires_at IS NOT NULL;
+CREATE INDEX idx_discovered_publishers_expires ON discovered_publishers(expires_at)
+  WHERE expires_at IS NOT NULL;

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -1,0 +1,324 @@
+import { FederatedIndexDatabase, type DiscoveredAgent, type DiscoveredPublisher, type AgentPublisherAuthorization } from './db/federated-index-db.js';
+import { MemberDatabase } from './db/member-db.js';
+import type { FederatedAgent, FederatedPublisher, DomainLookupResult, AgentType } from './types.js';
+
+/**
+ * Service layer for federated agent/publisher discovery.
+ * Merges registered data (from member_profiles) with discovered data (from crawling).
+ */
+export class FederatedIndexService {
+  private db: FederatedIndexDatabase;
+  private memberDb: MemberDatabase;
+
+  constructor() {
+    this.db = new FederatedIndexDatabase();
+    this.memberDb = new MemberDatabase();
+  }
+
+  // ============================================
+  // List All (merged view)
+  // ============================================
+
+  /**
+   * List all agents (registered + discovered), optionally filtered by type.
+   * Registered agents take precedence for deduplication.
+   */
+  async listAllAgents(type?: AgentType): Promise<FederatedAgent[]> {
+    // Get registered agents from member profiles
+    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    const registeredAgents = new Map<string, FederatedAgent>();
+
+    for (const profile of profiles) {
+      for (const agentConfig of profile.agents || []) {
+        if (!agentConfig.is_public) continue;
+
+        const agentType = agentConfig.type || 'unknown';
+        if (type && agentType !== type) continue;
+
+        registeredAgents.set(agentConfig.url, {
+          url: agentConfig.url,
+          name: agentConfig.name || profile.display_name,
+          type: agentType as FederatedAgent['type'],
+          protocol: 'mcp',
+          source: 'registered',
+          member: {
+            slug: profile.slug,
+            display_name: profile.display_name,
+          },
+        });
+      }
+    }
+
+    // Get discovered agents
+    const discoveredAgents = await this.db.getAllDiscoveredAgents(type);
+
+    // Get authorizations to find which domain discovered each agent
+    const allAuths = new Map<string, AgentPublisherAuthorization>();
+    for (const agent of discoveredAgents) {
+      const auths = await this.db.getDomainsForAgent(agent.agent_url);
+      if (auths.length > 0) {
+        allAuths.set(agent.agent_url, auths[0]); // Use first authorization as source
+      }
+    }
+
+    // Merge: registered takes precedence
+    const result: FederatedAgent[] = Array.from(registeredAgents.values());
+
+    for (const discovered of discoveredAgents) {
+      if (registeredAgents.has(discovered.agent_url)) {
+        continue; // Skip if already registered
+      }
+
+      const auth = allAuths.get(discovered.agent_url);
+
+      result.push({
+        url: discovered.agent_url,
+        name: discovered.name,
+        type: (discovered.agent_type as FederatedAgent['type']) || 'unknown',
+        protocol: (discovered.protocol as 'mcp' | 'a2a') || 'mcp',
+        source: 'discovered',
+        discovered_from: auth ? {
+          publisher_domain: auth.publisher_domain,
+          authorized_for: auth.authorized_for,
+        } : {
+          publisher_domain: discovered.source_domain,
+        },
+        discovered_at: discovered.discovered_at?.toISOString(),
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * List all publishers (registered + discovered).
+   * Registered publishers take precedence for deduplication.
+   */
+  async listAllPublishers(): Promise<FederatedPublisher[]> {
+    // Get registered publishers from member profiles
+    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    const registeredPublishers = new Map<string, FederatedPublisher>();
+
+    for (const profile of profiles) {
+      for (const pubConfig of profile.publishers || []) {
+        if (!pubConfig.is_public) continue;
+
+        registeredPublishers.set(pubConfig.domain, {
+          domain: pubConfig.domain,
+          source: 'registered',
+          member: {
+            slug: profile.slug,
+            display_name: profile.display_name,
+          },
+          agent_count: pubConfig.agent_count,
+          last_validated: pubConfig.last_validated,
+        });
+      }
+    }
+
+    // Get discovered publishers
+    const discoveredPublishers = await this.db.getAllDiscoveredPublishers();
+
+    // Merge: registered takes precedence
+    const result: FederatedPublisher[] = Array.from(registeredPublishers.values());
+
+    for (const discovered of discoveredPublishers) {
+      if (registeredPublishers.has(discovered.domain)) {
+        continue; // Skip if already registered
+      }
+
+      result.push({
+        domain: discovered.domain,
+        source: 'discovered',
+        discovered_from: {
+          agent_url: discovered.discovered_by_agent,
+        },
+        has_valid_adagents: discovered.has_valid_adagents,
+        discovered_at: discovered.discovered_at?.toISOString(),
+      });
+    }
+
+    return result;
+  }
+
+  // ============================================
+  // Reverse Lookups
+  // ============================================
+
+  /**
+   * Lookup a domain to find all authorized agents and sales agents claiming it.
+   */
+  async lookupDomain(domain: string): Promise<DomainLookupResult> {
+    // Build a map of registered agents for enrichment
+    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    const registeredAgentUrls = new Map<string, { slug: string; display_name: string }>();
+
+    for (const profile of profiles) {
+      for (const agentConfig of profile.agents || []) {
+        if (agentConfig.is_public) {
+          registeredAgentUrls.set(agentConfig.url, {
+            slug: profile.slug,
+            display_name: profile.display_name,
+          });
+        }
+      }
+    }
+
+    // Get agents authorized via adagents.json
+    const authorizations = await this.db.getAgentsForDomain(domain);
+    const authorizedAgents = authorizations
+      .filter(auth => auth.source === 'adagents_json')
+      .map(auth => {
+        const member = registeredAgentUrls.get(auth.agent_url);
+        return {
+          url: auth.agent_url,
+          authorized_for: auth.authorized_for,
+          source: member ? 'registered' as const : 'discovered' as const,
+          member,
+        };
+      });
+
+    // Get sales agents claiming this domain
+    const claims = await this.db.getSalesAgentsClaimingDomain(domain);
+    const salesAgentsClaiming = claims.map(claim => {
+      const member = registeredAgentUrls.get(claim.discovered_by_agent);
+      return {
+        url: claim.discovered_by_agent,
+        source: member ? 'registered' as const : 'discovered' as const,
+        member,
+      };
+    });
+
+    return {
+      domain,
+      authorized_agents: authorizedAgents,
+      sales_agents_claiming: salesAgentsClaiming,
+    };
+  }
+
+  /**
+   * Get all domains an agent is authorized for.
+   */
+  async getDomainsForAgent(agentUrl: string): Promise<string[]> {
+    const authorizations = await this.db.getDomainsForAgent(agentUrl);
+    return authorizations.map(auth => auth.publisher_domain);
+  }
+
+  // ============================================
+  // Recording discoveries (for crawler)
+  // ============================================
+
+  /**
+   * Record an agent discovered from an adagents.json file.
+   */
+  async recordAgentFromAdagentsJson(
+    agentUrl: string,
+    publisherDomain: string,
+    authorizedFor?: string,
+    propertyIds?: string[]
+  ): Promise<void> {
+    // Record the agent
+    await this.db.upsertAgent({
+      agent_url: agentUrl,
+      source_type: 'adagents_json',
+      source_domain: publisherDomain,
+    });
+
+    // Record the authorization
+    await this.db.upsertAuthorization({
+      agent_url: agentUrl,
+      publisher_domain: publisherDomain,
+      authorized_for: authorizedFor,
+      property_ids: propertyIds,
+      source: 'adagents_json',
+    });
+  }
+
+  /**
+   * Record a publisher discovered from a sales agent's list_authorized_properties.
+   */
+  async recordPublisherFromAgent(
+    domain: string,
+    salesAgentUrl: string,
+    hasValidAdagents?: boolean
+  ): Promise<void> {
+    await this.db.upsertPublisher({
+      domain,
+      discovered_by_agent: salesAgentUrl,
+      has_valid_adagents: hasValidAdagents,
+    });
+
+    // Also record the claim (unverified authorization)
+    await this.db.upsertAuthorization({
+      agent_url: salesAgentUrl,
+      publisher_domain: domain,
+      source: 'agent_claim',
+    });
+  }
+
+  /**
+   * Update agent metadata after probing.
+   */
+  async updateAgentMetadata(
+    agentUrl: string,
+    metadata: { name?: string; agent_type?: string; protocol?: string }
+  ): Promise<void> {
+    await this.db.updateAgentMetadata(agentUrl, metadata);
+  }
+
+  /**
+   * Mark a publisher domain as having valid adagents.json.
+   */
+  async markPublisherHasValidAdagents(domain: string): Promise<void> {
+    await this.db.markPublisherHasValidAdagents(domain);
+  }
+
+  // ============================================
+  // Maintenance
+  // ============================================
+
+  /**
+   * Clean up expired records.
+   */
+  async cleanupExpired(): Promise<{ agents: number; publishers: number; authorizations: number }> {
+    return this.db.deleteExpired();
+  }
+
+  /**
+   * Get statistics about the federated index.
+   */
+  async getStats(): Promise<{
+    registered_agents: number;
+    registered_publishers: number;
+    discovered_agents: number;
+    discovered_publishers: number;
+    authorizations: number;
+    authorizations_by_source: { adagents_json: number; agent_claim: number };
+  }> {
+    // Count registered
+    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    let registeredAgents = 0;
+    let registeredPublishers = 0;
+
+    for (const profile of profiles) {
+      registeredAgents += (profile.agents || []).filter(a => a.is_public).length;
+      registeredPublishers += (profile.publishers || []).filter(p => p.is_public).length;
+    }
+
+    // Get discovered stats
+    const dbStats = await this.db.getStats();
+
+    return {
+      registered_agents: registeredAgents,
+      registered_publishers: registeredPublishers,
+      ...dbStats,
+    };
+  }
+
+  /**
+   * Clear all discovered data (for testing or reset).
+   */
+  async clearDiscovered(): Promise<void> {
+    await this.db.clearAll();
+  }
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3278,6 +3278,98 @@ Disallow: /api/admin/
       res.sendFile(perspectivesPath);
     });
 
+    // Federated discovery endpoints
+    this.setupFederatedDiscoveryRoutes();
+  }
+
+  /**
+   * Setup federated discovery endpoints for merged registered + discovered data
+   */
+  private setupFederatedDiscoveryRoutes(): void {
+    const federatedIndex = this.crawler.getFederatedIndex();
+
+    // List all agents (registered + discovered)
+    this.app.get("/api/federated/agents", async (req, res) => {
+      try {
+        const type = req.query.type as AgentType | undefined;
+        const agents = await federatedIndex.listAllAgents(type);
+        const bySource = {
+          registered: agents.filter(a => a.source === 'registered').length,
+          discovered: agents.filter(a => a.source === 'discovered').length,
+        };
+        res.json({
+          agents,
+          count: agents.length,
+          sources: bySource,
+        });
+      } catch (error) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : "Failed to list federated agents",
+        });
+      }
+    });
+
+    // List all publishers (registered + discovered)
+    this.app.get("/api/federated/publishers", async (req, res) => {
+      try {
+        const publishers = await federatedIndex.listAllPublishers();
+        const bySource = {
+          registered: publishers.filter(p => p.source === 'registered').length,
+          discovered: publishers.filter(p => p.source === 'discovered').length,
+        };
+        res.json({
+          publishers,
+          count: publishers.length,
+          sources: bySource,
+        });
+      } catch (error) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : "Failed to list federated publishers",
+        });
+      }
+    });
+
+    // Lookup domain - find all agents authorized for a domain
+    this.app.get("/api/lookup/domain/:domain", async (req, res) => {
+      try {
+        const domain = req.params.domain;
+        const result = await federatedIndex.lookupDomain(domain);
+        res.json(result);
+      } catch (error) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : "Domain lookup failed",
+        });
+      }
+    });
+
+    // Get domains for a specific agent
+    this.app.get("/api/lookup/agent/:agentUrl/domains", async (req, res) => {
+      try {
+        const agentUrl = decodeURIComponent(req.params.agentUrl);
+        const domains = await federatedIndex.getDomainsForAgent(agentUrl);
+        res.json({
+          agent_url: agentUrl,
+          domains,
+          count: domains.length,
+        });
+      } catch (error) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : "Agent domain lookup failed",
+        });
+      }
+    });
+
+    // Get federated index stats
+    this.app.get("/api/federated/stats", async (req, res) => {
+      try {
+        const stats = await federatedIndex.getStats();
+        res.json(stats);
+      } catch (error) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : "Failed to get federated stats",
+        });
+      }
+    });
   }
 
   private setupAuthRoutes(): void {

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -8,6 +8,7 @@ import {
 import { AgentService } from "./agent-service.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { AgentValidator } from "./validator.js";
+import { FederatedIndexService } from "./federated-index.js";
 import type { AgentType, MemberOffering } from "./types.js";
 
 /**
@@ -196,6 +197,61 @@ export const TOOL_DEFINITIONS = [
       },
     },
   },
+  // Federated discovery tools
+  {
+    name: "list_federated_agents",
+    description:
+      "List all agents including both registered (from member profiles) and discovered (from publisher adagents.json files)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["creative", "signals", "sales"],
+          description: "Optional: Filter by agent type",
+        },
+      },
+    },
+  },
+  {
+    name: "list_federated_publishers",
+    description:
+      "List all publishers including both registered (from member profiles) and discovered (from sales agent responses)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "lookup_domain",
+    description:
+      "Find all agents authorized for a specific publisher domain, showing both verified (from adagents.json) and claimed (from sales agents)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        domain: {
+          type: "string",
+          description: "Publisher domain to look up (e.g., 'nytimes.com')",
+        },
+      },
+      required: ["domain"],
+    },
+  },
+  {
+    name: "get_agent_domains",
+    description:
+      "Get all publisher domains that an agent is authorized to sell for",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_url: {
+          type: "string",
+          description: "Agent URL to look up (e.g., 'https://sales.example.com')",
+        },
+      },
+      required: ["agent_url"],
+    },
+  },
 ];
 
 /**
@@ -248,11 +304,13 @@ export class MCPToolHandler {
   private agentService: AgentService;
   private memberDb: MemberDatabase;
   private validator: AgentValidator;
+  private federatedIndex: FederatedIndexService;
 
   constructor() {
     this.agentService = new AgentService();
     this.memberDb = new MemberDatabase();
     this.validator = new AgentValidator();
+    this.federatedIndex = new FederatedIndexService();
   }
 
   /**
@@ -694,6 +752,104 @@ export class MCPToolHandler {
             ],
           };
         }
+      }
+
+      // Federated discovery tools
+      case "list_federated_agents": {
+        const type = args?.type as AgentType | undefined;
+        const agents = await this.federatedIndex.listAllAgents(type);
+        const bySource = {
+          registered: agents.filter(a => a.source === 'registered').length,
+          discovered: agents.filter(a => a.source === 'discovered').length,
+        };
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: {
+                uri: type ? `federated://agents/${encodeURIComponent(type)}` : "federated://agents",
+                mimeType: "application/json",
+                text: JSON.stringify({ agents, count: agents.length, sources: bySource }, null, 2),
+              },
+            },
+          ],
+        };
+      }
+
+      case "list_federated_publishers": {
+        const publishers = await this.federatedIndex.listAllPublishers();
+        const bySource = {
+          registered: publishers.filter(p => p.source === 'registered').length,
+          discovered: publishers.filter(p => p.source === 'discovered').length,
+        };
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: {
+                uri: "federated://publishers",
+                mimeType: "application/json",
+                text: JSON.stringify({ publishers, count: publishers.length, sources: bySource }, null, 2),
+              },
+            },
+          ],
+        };
+      }
+
+      case "lookup_domain": {
+        const domain = args?.domain as string;
+        if (!domain) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ error: "Missing required parameter: domain" }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        const result = await this.federatedIndex.lookupDomain(domain);
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: {
+                uri: `federated://domain/${encodeURIComponent(domain)}`,
+                mimeType: "application/json",
+                text: JSON.stringify(result, null, 2),
+              },
+            },
+          ],
+        };
+      }
+
+      case "get_agent_domains": {
+        const agentUrl = args?.agent_url as string;
+        if (!agentUrl) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ error: "Missing required parameter: agent_url" }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        const domains = await this.federatedIndex.getDomainsForAgent(agentUrl);
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: {
+                uri: `federated://agent/${encodeURIComponent(agentUrl)}/domains`,
+                mimeType: "application/json",
+                text: JSON.stringify({ agent_url: agentUrl, domains, count: domains.length }, null, 2),
+              },
+            },
+          ],
+        };
       }
 
       default:

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -279,3 +279,68 @@ export interface ListMemberProfilesOptions {
   limit?: number;
   offset?: number;
 }
+
+// Federated Discovery Types
+
+/**
+ * An agent in the federated view (registered or discovered)
+ */
+export interface FederatedAgent {
+  url: string;
+  name?: string;
+  type?: AgentType | 'buyer' | 'unknown';
+  protocol?: 'mcp' | 'a2a';
+  source: 'registered' | 'discovered';
+  // For registered agents
+  member?: {
+    slug: string;
+    display_name: string;
+  };
+  // For discovered agents
+  discovered_from?: {
+    publisher_domain: string;
+    authorized_for?: string;
+  };
+  discovered_at?: string;
+}
+
+/**
+ * A publisher in the federated view (registered or discovered)
+ */
+export interface FederatedPublisher {
+  domain: string;
+  source: 'registered' | 'discovered';
+  // For registered publishers
+  member?: {
+    slug: string;
+    display_name: string;
+  };
+  agent_count?: number;
+  last_validated?: string;
+  // For discovered publishers
+  discovered_from?: {
+    agent_url: string;
+  };
+  has_valid_adagents?: boolean;
+  discovered_at?: string;
+}
+
+/**
+ * Result of a domain lookup showing all agents authorized for that domain
+ */
+export interface DomainLookupResult {
+  domain: string;
+  // Agents authorized via adagents.json (verified)
+  authorized_agents: Array<{
+    url: string;
+    authorized_for?: string;
+    source: 'registered' | 'discovered';
+    member?: { slug: string; display_name: string };
+  }>;
+  // Sales agents that claim to sell this domain (may not be verified)
+  sales_agents_claiming: Array<{
+    url: string;
+    source: 'registered' | 'discovered';
+    member?: { slug: string; display_name: string };
+  }>;
+}


### PR DESCRIPTION
## Summary

Implements federated agent and publisher discovery for the AdCP directory. The system now returns both directly registered agents/publishers and those discovered from publisher adagents.json files and sales agent responses.

## Key Features

- **Registered + Discovered Agents**: Lists agents from member profiles plus agents discovered from publisher `authorized_agents` arrays
- **Registered + Discovered Publishers**: Lists publishers from member profiles plus publishers discovered from sales agent `list_authorized_properties` responses  
- **Reverse Lookups**: Find agents authorized for a domain, domains an agent is authorized for, and sales agents claiming a domain
- **API Endpoints**: Five new federated endpoints plus MCP tools for discovery and lookups
- **Database-backed**: PostgreSQL cache with optimized indexes for fast queries

## Implementation

- New database schema with `discovered_agents`, `discovered_publishers`, and `agent_publisher_authorizations` tables
- FederatedIndexService merges registered and discovered data with proper deduplication
- Crawler automatically crawls both registered publishers and sales agent discovered domains
- Support for both verified authorizations (from adagents.json) and unverified claims (from agent responses)

🤖 Generated with Claude Code