### PR TITLE
Fix Addie using wrong bot token to send messages

### DIFF
--- a/.changeset/addie-bot-token-fix.md
+++ b/.changeset/addie-bot-token-fix.md
@@ -1,0 +1,8 @@
+---
+---
+
+Server-only: Fix Addie using wrong bot token to send messages.
+
+Addie was using SLACK_BOT_TOKEN (AAO bot) to send messages, which
+failed with channel_not_found because Addie's DM channels are only
+accessible via ADDIE_BOT_TOKEN.

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -163,12 +163,12 @@ export async function handleAssistantMessage(
   // Validate output
   const outputValidation = validateOutput(response.text);
 
-  // Send response
+  // Send response using Addie's bot token
   try {
     await sendChannelMessage(channelId, {
       text: outputValidation.sanitized,
       thread_ts: event.thread_ts,
-    });
+    }, true); // useAddieToken = true
   } catch (error) {
     logger.error({ error }, 'Addie: Failed to send response');
   }
@@ -249,12 +249,12 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
   // Validate output
   const outputValidation = validateOutput(response.text);
 
-  // Send response in thread
+  // Send response in thread using Addie's bot token
   try {
     await sendChannelMessage(event.channel, {
       text: outputValidation.sanitized,
       thread_ts: event.thread_ts || event.ts,
-    });
+    }, true); // useAddieToken = true
   } catch (error) {
     logger.error({ error }, 'Addie: Failed to send mention response');
   }


### PR DESCRIPTION
## Summary

Addie was using `SLACK_BOT_TOKEN` (AAO bot) to send messages, which failed with `channel_not_found` because Addie's DM channels are only accessible via `ADDIE_BOT_TOKEN`.

## Changes

- Add `useAddieToken` parameter to `slackPostRequest` and `sendChannelMessage`
- Update Addie handler to use `ADDIE_BOT_TOKEN` for all responses

## Test plan

- [x] TypeScript compiles
- [x] All tests pass
- [ ] Test Addie DMs in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)