### PR TITLE
Fix Resend inbound webhook timeout

### DIFF
--- a/.changeset/fix-resend-inbound-webhook.md
+++ b/.changeset/fix-resend-inbound-webhook.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Resend inbound email webhook timeout by skipping global JSON parser

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -226,9 +226,11 @@ export class HTTPServer {
     this.app.use((req, res, next) => {
       // Skip global JSON parser for routes that need raw body capture:
       // - Stripe webhooks: need raw body for webhook signature verification
+      // - Resend inbound webhooks: need raw body for Svix signature verification
       // - Slack commands: need raw body for Slack signature verification (URL-encoded)
       // - Slack events: need raw body for Slack signature verification (JSON)
       if (req.path === '/api/webhooks/stripe' ||
+          req.path === '/api/webhooks/resend-inbound' ||
           req.path === '/api/slack/commands' ||
           req.path === '/api/slack/events' ||
           req.path === '/api/addie/slack/events') {


### PR DESCRIPTION
## Summary

- Fix timeout issue where `/api/webhooks/resend-inbound` was hanging indefinitely

## Root Cause

The webhook handler uses custom middleware to capture the raw request body for Svix signature verification (lines 717-735 in webhooks.ts). However, the route was not excluded from the global `express.json()` middleware, which consumed the body stream first.

This caused the custom middleware's `req.on('end')` callback to never fire because the stream was already exhausted, resulting in the webhook hanging until timeout.

## Fix

Add `/api/webhooks/resend-inbound` to the JSON parser skip list in `http.ts`, similar to how Stripe webhooks and Slack events are handled.

## Test plan

- [x] TypeScript compiles
- [x] Unit tests pass
- [ ] Deploy to production and test webhook with real Resend payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)