### PR TITLE
Fix organization member lookup in email webhook

### DIFF
--- a/.changeset/fix-org-memberships-table.md
+++ b/.changeset/fix-org-memberships-table.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix organization member lookup table name in inbound email webhook

--- a/server/src/routes/webhooks.ts
+++ b/server/src/routes/webhooks.ts
@@ -228,16 +228,23 @@ async function getOrCreateEmailContact(
   }
 
   // New contact - check if they match an existing org member
-  const memberResult = await pool.query(
-    `SELECT om.organization_id, om.workos_user_id
-     FROM organization_members om
-     WHERE om.email = $1
-     LIMIT 1`,
-    [email]
-  );
-
-  const organizationId = memberResult.rows[0]?.organization_id || null;
-  const workosUserId = memberResult.rows[0]?.workos_user_id || null;
+  // organization_memberships is synced from WorkOS and contains user-org mappings
+  let organizationId: string | null = null;
+  let workosUserId: string | null = null;
+  try {
+    const memberResult = await pool.query(
+      `SELECT om.workos_organization_id, om.workos_user_id
+       FROM organization_memberships om
+       WHERE om.email = $1
+       LIMIT 1`,
+      [email]
+    );
+    organizationId = memberResult.rows[0]?.workos_organization_id || null;
+    workosUserId = memberResult.rows[0]?.workos_user_id || null;
+  } catch (memberLookupError) {
+    // Table may not exist in all environments - proceed with unmapped contact
+    logger.debug({ error: memberLookupError, email }, 'Org member lookup failed, proceeding with unmapped contact');
+  }
   const mappingStatus = organizationId ? 'mapped' : 'unmapped';
   const mappingSource = organizationId ? 'email_auto' : null;
 


### PR DESCRIPTION
## Summary

- Fix table name: `organization_members` → `organization_memberships` (WorkOS sync table)
- Fix column name: `organization_id` → `workos_organization_id`
- Add graceful fallback if table lookup fails

## Root Cause

The inbound email webhook was referencing a non-existent table `organization_members` when it should have been `organization_memberships` (the table synced from WorkOS). Additionally, the column was `organization_id` but should be `workos_organization_id`.

## Test plan

- [x] TypeScript compiles
- [x] Unit tests pass
- [ ] Deploy and test with real inbound email

🤖 Generated with [Claude Code](https://claude.com/claude-code)