### PR TITLE
Fix industry feeds pending article count mismatch

### DIFF
--- a/.changeset/fix-pending-articles.md
+++ b/.changeset/fix-pending-articles.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix industry feeds pending article count mismatch

--- a/server/public/admin-feeds.html
+++ b/server/public/admin-feeds.html
@@ -537,6 +537,14 @@
           <div class="stat-label">Pending</div>
         </div>
         <div class="stat-card">
+          <div class="stat-value">${stats.processed_success || 0}</div>
+          <div class="stat-label">Processed</div>
+        </div>
+        <div class="stat-card" ${(stats.processed_failed || 0) > 0 ? 'style="border-color: var(--color-error);"' : ''}>
+          <div class="stat-value" ${(stats.processed_failed || 0) > 0 ? 'style="color: var(--color-error);"' : ''}>${stats.processed_failed || 0}</div>
+          <div class="stat-label">Failed</div>
+        </div>
+        <div class="stat-card">
           <div class="stat-value">${stats.alerts_sent_today || 0}</div>
           <div class="stat-label">Alerts Today</div>
         </div>


### PR DESCRIPTION
## Summary

Fixed a mismatch between the pending article count shown in the UI and the actual articles that get processed. The stats query was missing filters that the processing query had, causing false counts and infinite retry loops for failed articles.

**Changes:**
- Aligned pending count query with processing query (add status filter, feed join, exclude failed)
- Prevent failed articles from being retried infinitely
- Added processed/failed counts to dashboard for better visibility