### PR TITLE
Fix Lusha API request format for bulk company enrichment

### DIFF
--- a/server/src/services/lusha.ts
+++ b/server/src/services/lusha.ts
@@ -185,6 +185,7 @@ export class LushaClient {
   async enrichCompanyByDomain(domain: string): Promise<CompanyEnrichmentResult> {
     try {
       // Use the v2 bulk API with a single company
+      // Each company needs a unique `id` string to correlate request/response
       const response = await fetch(`${LUSHA_API_BASE}/bulk/company/v2`, {
         method: 'POST',
         headers: {
@@ -192,8 +193,7 @@ export class LushaClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          requestId: `enrich-${domain}-${Date.now()}`,
-          companies: [{ domain }],
+          companies: [{ id: '1', domain }],
         }),
       });
 


### PR DESCRIPTION
## Summary
- Fix Lusha v2 bulk company API request format that was causing 400 errors
- Changed from invalid format (`{requestId: ..., companies: [{domain}]}`) to correct format (`{companies: [{id: '1', domain}]}`)

Error from production logs:
```
"property requestId should not exist", "companies.0.id must be a string"
```

## Test plan
- [x] Deploy to production
- [ ] Test enrichment endpoint with existing prospect

🤖 Generated with [Claude Code](https://claude.com/claude-code)