### PR TITLE
Fix ambiguous column reference in add domain query

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2475,7 +2475,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
 
         // Check if domain is already claimed by another org
         const existingResult = await pool.query(
-          `SELECT workos_organization_id, o.name as org_name
+          `SELECT od.workos_organization_id, o.name as org_name
            FROM organization_domains od
            JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
            WHERE od.domain = $1`,


### PR DESCRIPTION
## Summary
Fix SQL error "column reference 'workos_organization_id' is ambiguous" in the POST `/api/admin/organizations/:orgId/domains` endpoint.

The SELECT query was missing a table alias - both `organization_domains` (od) and `organizations` (o) tables have `workos_organization_id` column.

## Test plan
- [x] TypeScript compiles
- [x] All tests pass
- [ ] Test adding domain in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)