### PR TITLE
Add role-aware dynamic suggestions for Addie

### DIFF
--- a/.changeset/addie-role-suggestions.md
+++ b/.changeset/addie-role-suggestions.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Add role-aware dynamic suggestions for Addie
+
+- Admin users now see admin-specific suggestions (pending invoices, company lookup, prospect pipeline)
+- Deprecate AAO bot slash commands - Addie now uses get_account_link tool for direct sign-in links
+- Extract buildDynamicSuggestedPrompts to shared module to reduce code duplication

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -35,7 +35,7 @@ import {
   createMemberToolHandlers,
 } from './mcp/member-tools.js';
 import { AddieDatabase } from '../db/addie-db.js';
-import { SUGGESTED_PROMPTS, STATUS_MESSAGES } from './prompts.js';
+import { SUGGESTED_PROMPTS, STATUS_MESSAGES, buildDynamicSuggestedPrompts } from './prompts.js';
 import { AddieModelConfig } from '../config/models.js';
 import { getMemberContext, formatMemberContextForPrompt, type MemberContext } from './member-context.js';
 import type { RequestTools } from './claude-client.js';
@@ -194,64 +194,13 @@ function createUserScopedTools(memberContext: MemberContext | null): RequestTool
 }
 
 /**
- * Build dynamic suggested prompts based on user context
+ * Get dynamic suggested prompts for a Slack user
  */
-async function buildDynamicSuggestedPrompts(userId: string): Promise<SuggestedPrompt[]> {
+async function getDynamicSuggestedPrompts(userId: string): Promise<SuggestedPrompt[]> {
   try {
     const memberContext = await getMemberContext(userId);
-
-    // Not linked - prioritize account setup
-    if (!memberContext.workos_user?.workos_user_id) {
-      return [
-        {
-          title: 'Link my account',
-          message: 'Help me link my Slack account to AgenticAdvertising.org',
-        },
-        {
-          title: 'Learn about AdCP',
-          message: 'What is AdCP and how does it work?',
-        },
-        {
-          title: 'Why join AgenticAdvertising.org?',
-          message: 'What are the benefits of joining AgenticAdvertising.org?',
-        },
-      ];
-    }
-
-    // Linked but maybe not a member - suggest getting involved
-    const prompts: SuggestedPrompt[] = [];
-
-    // Personalized: Show working groups if they have some
-    if (memberContext.working_groups && memberContext.working_groups.length > 0) {
-      prompts.push({
-        title: 'My working groups',
-        message: 'What\'s happening in my working groups?',
-      });
-    } else {
-      prompts.push({
-        title: 'Find a working group',
-        message: 'What working groups can I join based on my interests?',
-      });
-    }
-
-    // Add agent testing prompt
-    prompts.push({
-      title: 'Test my agent',
-      message: 'Help me verify my AdCP agent is working correctly',
-    });
-
-    // Standard prompts
-    prompts.push({
-      title: 'Learn about AdCP',
-      message: 'What is AdCP and how does it work?',
-    });
-
-    prompts.push({
-      title: 'AdCP vs programmatic',
-      message: 'How is agentic advertising different from programmatic?',
-    });
-
-    return prompts.slice(0, 4); // Slack limits to 4 prompts
+    const userIsAdmin = await isSlackUserAdmin(userId);
+    return buildDynamicSuggestedPrompts(memberContext, userIsAdmin);
   } catch (error) {
     logger.warn({ error, userId }, 'Addie: Failed to build dynamic prompts, using defaults');
     return SUGGESTED_PROMPTS;
@@ -276,7 +225,7 @@ export async function handleAssistantThreadStarted(
 
   // Set dynamic suggested prompts based on user context
   try {
-    const prompts = await buildDynamicSuggestedPrompts(event.assistant_thread.user_id);
+    const prompts = await getDynamicSuggestedPrompts(event.assistant_thread.user_id);
     await setAssistantSuggestedPrompts(event.channel_id, prompts);
   } catch (error) {
     logger.error({ error }, 'Addie: Failed to set suggested prompts');

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -3,6 +3,10 @@
  */
 
 import type { SuggestedPrompt } from './types.js';
+import type { MemberContext } from './member-context.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('addie-prompts');
 
 export const ADDIE_SYSTEM_PROMPT = `You are Addie, the AI assistant for AgenticAdvertising.org. Your mission is to help the ad tech industry transition from programmatic to agentic advertising.
 
@@ -17,7 +21,7 @@ If the user is NOT authenticated/linked:
 - **For Slack**: Use the get_account_link tool to generate a sign-in link they can click directly
 - In BOTH cases, be gentle and don't push too hard - let them continue if they prefer
 
-IMPORTANT: Never tell users to type "/aao link" - instead, always provide direct clickable links. For web chat, use relative URLs like /auth/login (the user is already on the website).
+IMPORTANT: Never tell users to type any Slack slash commands (like "/aao link", "/aao status", etc.) - the AAO bot commands are deprecated. Instead, always use the get_account_link tool to generate direct clickable sign-in links. For web chat, use relative URLs like /auth/login.
 
 This is your FIRST priority - helping users get connected to the community.
 
@@ -113,7 +117,7 @@ When users set up agents or publishers, walk through the full verification chain
 **Account Linking:**
 - get_account_link: Generate a sign-in link for users who need to authenticate
 
-IMPORTANT: Never tell users to type Slack slash commands like "/aao link" or "/aao status". Instead, always provide direct clickable links.
+IMPORTANT: Never tell users to use Slack slash commands - the AAO bot commands are deprecated. Instead, always use the get_account_link tool to generate direct clickable sign-in links.
 
 **GitHub Issue Drafting:**
 - draft_github_issue: Draft a GitHub issue and generate a pre-filled URL for users to create it
@@ -245,6 +249,91 @@ export const STATUS_MESSAGES = {
   searching: 'Searching documentation...',
   generating: 'Generating response...',
 };
+
+/**
+ * Build dynamic suggested prompts based on user context and role
+ *
+ * @param memberContext - User's member context (or null if lookup failed)
+ * @param isAdmin - Whether the user has admin privileges
+ * @returns Array of suggested prompts tailored to the user
+ */
+export function buildDynamicSuggestedPrompts(
+  memberContext: MemberContext | null,
+  isAdmin: boolean
+): SuggestedPrompt[] {
+  // Not linked - prioritize account setup
+  if (!memberContext?.workos_user?.workos_user_id) {
+    return [
+      {
+        title: 'Link my account',
+        message: 'Help me link my Slack account to AgenticAdvertising.org',
+      },
+      {
+        title: 'Learn about AdCP',
+        message: 'What is AdCP and how does it work?',
+      },
+      {
+        title: 'Why join AgenticAdvertising.org?',
+        message: 'What are the benefits of joining AgenticAdvertising.org?',
+      },
+    ];
+  }
+
+  // Admin users get admin-specific suggestions
+  if (isAdmin) {
+    return [
+      {
+        title: 'Pending invoices',
+        message: 'Show me all organizations with pending invoices',
+      },
+      {
+        title: 'Look up a company',
+        message: 'What is the membership status for [company name]?',
+      },
+      {
+        title: 'Prospect pipeline',
+        message: 'Show me the current prospect pipeline',
+      },
+      {
+        title: 'My working groups',
+        message: "What's happening in my working groups?",
+      },
+    ];
+  }
+
+  // Linked non-admin users - personalized prompts
+  const prompts: SuggestedPrompt[] = [];
+
+  // Show working groups if they have some, otherwise suggest finding one
+  if (memberContext.working_groups && memberContext.working_groups.length > 0) {
+    prompts.push({
+      title: 'My working groups',
+      message: "What's happening in my working groups?",
+    });
+  } else {
+    prompts.push({
+      title: 'Find a working group',
+      message: 'What working groups can I join based on my interests?',
+    });
+  }
+
+  prompts.push({
+    title: 'Test my agent',
+    message: 'Help me verify my AdCP agent is working correctly',
+  });
+
+  prompts.push({
+    title: 'Learn about AdCP',
+    message: 'What is AdCP and how does it work?',
+  });
+
+  prompts.push({
+    title: 'AdCP vs programmatic',
+    message: 'How is agentic advertising different from programmatic?',
+  });
+
+  return prompts.slice(0, 4); // Slack limits to 4 prompts
+}
 
 /**
  * Build context with thread history

--- a/server/src/db/migrations/069_remove_aao_status_reference.sql
+++ b/server/src/db/migrations/069_remove_aao_status_reference.sql
@@ -1,0 +1,27 @@
+-- Migration: Remove /aao status reference from Account Linking rule
+-- The AAO bot commands are being deprecated in favor of direct sign-in links via get_account_link tool
+
+-- Update the Account Linking rule to remove /aao status reference
+UPDATE addie_rules
+SET content = 'Users can link their Slack account to their AgenticAdvertising.org account for a better experience. You have a get_account_link tool that generates a personalized sign-in link.
+
+When a user''s Slack account is not linked (you can see this in their context):
+- Use get_account_link to generate their personalized sign-in link
+- Explain that clicking the link will sign them in and automatically link accounts
+- If they don''t have an account yet, they can sign up through the same flow
+- Once linked, they''ll have access to personalized features
+
+When you detect an unlinked user trying to use user-scoped tools:
+- Use get_account_link to provide them with a sign-in link
+- Explain they need to link their account to use that feature
+- Offer to help after they''ve linked
+
+IMPORTANT: Never tell users to use Slack slash commands (like /aao link or /aao status) - these are deprecated. Always use the get_account_link tool to generate direct clickable sign-in links.
+
+IMPORTANT: If in a previous message you asked a user to link their account, and now their context shows they ARE linked (has workos_user_id):
+- Acknowledge and thank them for linking! Say something like "Thanks for linking your account!"
+- Greet them by name if available
+- Now proceed to help them with what they originally asked',
+    updated_at = NOW()
+WHERE name = 'Account Linking'
+  AND is_active = TRUE;

--- a/server/tests/unit/dynamic-prompts.test.ts
+++ b/server/tests/unit/dynamic-prompts.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for buildDynamicSuggestedPrompts functionality
+ *
+ * Tests the role-based suggestion logic:
+ * - Unlinked users see account setup prompts
+ * - Admin users see admin-specific prompts
+ * - Regular linked users see member prompts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDynamicSuggestedPrompts } from '../../src/addie/prompts.js';
+import type { MemberContext } from '../../src/addie/member-context.js';
+
+describe('buildDynamicSuggestedPrompts', () => {
+  describe('unlinked users', () => {
+    it('should return account setup prompts for users without WorkOS mapping', () => {
+      const memberContext = {
+        is_mapped: false,
+        is_member: false,
+        slack_linked: false,
+        workos_user: null,
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      expect(prompts).toHaveLength(3);
+      expect(prompts[0].title).toBe('Link my account');
+      expect(prompts[1].title).toBe('Learn about AdCP');
+      expect(prompts[2].title).toBe('Why join AgenticAdvertising.org?');
+    });
+
+    it('should return account setup prompts for null member context', () => {
+      const prompts = buildDynamicSuggestedPrompts(null, false);
+
+      expect(prompts).toHaveLength(3);
+      expect(prompts[0].title).toBe('Link my account');
+    });
+
+    it('should ignore admin flag for unlinked users', () => {
+      const memberContext = {
+        is_mapped: false,
+        workos_user: null,
+      } as unknown as MemberContext;
+
+      // Even if admin flag is true, unlinked users get setup prompts
+      const prompts = buildDynamicSuggestedPrompts(memberContext, true);
+
+      expect(prompts[0].title).toBe('Link my account');
+    });
+  });
+
+  describe('admin users', () => {
+    it('should return admin-specific prompts for admin users', () => {
+      const memberContext = {
+        is_mapped: true,
+        is_member: true,
+        workos_user: { workos_user_id: 'user_admin123' },
+        working_groups: [{ slug: 'aao-admin', name: 'AAO Admin' }],
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, true);
+
+      expect(prompts).toHaveLength(4);
+      expect(prompts[0].title).toBe('Pending invoices');
+      expect(prompts[1].title).toBe('Look up a company');
+      expect(prompts[2].title).toBe('Prospect pipeline');
+      expect(prompts[3].title).toBe('My working groups');
+    });
+
+    it('should include admin-only actions in suggestions', () => {
+      const memberContext = {
+        is_mapped: true,
+        workos_user: { workos_user_id: 'user_admin123' },
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, true);
+
+      const titles = prompts.map((p) => p.title);
+      expect(titles).toContain('Pending invoices');
+      expect(titles).toContain('Look up a company');
+      expect(titles).toContain('Prospect pipeline');
+    });
+  });
+
+  describe('linked non-admin users', () => {
+    it('should return member prompts with working groups for users in groups', () => {
+      const memberContext = {
+        is_mapped: true,
+        is_member: true,
+        workos_user: { workos_user_id: 'user_member123' },
+        working_groups: [
+          { slug: 'protocol-dev', name: 'Protocol Development' },
+        ],
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      expect(prompts).toHaveLength(4);
+      expect(prompts[0].title).toBe('My working groups');
+      expect(prompts[1].title).toBe('Test my agent');
+      expect(prompts[2].title).toBe('Learn about AdCP');
+      expect(prompts[3].title).toBe('AdCP vs programmatic');
+    });
+
+    it('should suggest finding groups for users without working groups', () => {
+      const memberContext = {
+        is_mapped: true,
+        is_member: true,
+        workos_user: { workos_user_id: 'user_newmember' },
+        working_groups: [],
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      expect(prompts[0].title).toBe('Find a working group');
+    });
+
+    it('should suggest finding groups for users with undefined working groups', () => {
+      const memberContext = {
+        is_mapped: true,
+        workos_user: { workos_user_id: 'user_newmember' },
+        working_groups: undefined,
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      expect(prompts[0].title).toBe('Find a working group');
+    });
+
+    it('should not include admin prompts for non-admin users', () => {
+      const memberContext = {
+        is_mapped: true,
+        workos_user: { workos_user_id: 'user_member123' },
+        working_groups: [],
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      const titles = prompts.map((p) => p.title);
+      expect(titles).not.toContain('Pending invoices');
+      expect(titles).not.toContain('Look up a company');
+      expect(titles).not.toContain('Prospect pipeline');
+    });
+  });
+
+  describe('prompt limits', () => {
+    it('should return maximum 4 prompts (Slack limit)', () => {
+      const memberContext = {
+        is_mapped: true,
+        workos_user: { workos_user_id: 'user_123' },
+        working_groups: [{ slug: 'test', name: 'Test' }],
+      } as unknown as MemberContext;
+
+      const prompts = buildDynamicSuggestedPrompts(memberContext, false);
+
+      expect(prompts.length).toBeLessThanOrEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Admin users now see admin-specific suggestions when opening Addie (pending invoices, company lookup, prospect pipeline)
- Deprecate AAO bot slash commands - Addie now uses `get_account_link` tool for direct sign-in links
- Extract `buildDynamicSuggestedPrompts` to shared module to reduce code duplication between handler.ts and bolt-app.ts

## Changes

### Admin-specific suggestions
When an admin opens Addie, they'll now see:
- "Pending invoices" - Show all organizations with pending invoices
- "Look up a company" - What is the membership status for [company name]?
- "Prospect pipeline" - Show me the current prospect pipeline
- "My working groups" - What's happening in my working groups?

### Deprecate AAO bot commands
- Updated system prompt to clarify that `/aao` commands are deprecated
- Added migration (069) to update the Account Linking operating rule in database
- Addie now always uses `get_account_link` tool instead of referencing slash commands

### Code cleanup
- Extracted shared `buildDynamicSuggestedPrompts()` function to `prompts.ts`
- Both `handler.ts` and `bolt-app.ts` now use `getDynamicSuggestedPrompts()` wrapper
- Added unit tests for the suggestion logic

## Test plan

- [x] Unit tests pass for `buildDynamicSuggestedPrompts`
- [x] All existing tests pass
- [x] TypeScript compiles without errors
- [ ] Manual test: Open Addie as admin user, verify admin suggestions appear
- [ ] Manual test: Open Addie as regular user, verify member suggestions appear
- [ ] Manual test: Open Addie as unlinked user, verify account setup suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)