### PR TITLE
Fix admin tools in Slack DMs, add timeframe filter to stats, improve feedback UI

### DIFF
--- a/.changeset/wacky-worms-speak.md
+++ b/.changeset/wacky-worms-speak.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix admin tools not being available in Slack DM threads, add timeframe filtering to conversation stats, and fix feedback UI re-rendering after save

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -1419,6 +1419,12 @@
             </p>
           </div>
           <div class="filter-row">
+            <select id="stats-timeframe">
+              <option value="7d" selected>This Week</option>
+              <option value="24h">Last 24 Hours</option>
+              <option value="30d">Last 30 Days</option>
+              <option value="all">All Time</option>
+            </select>
             <select id="channel-filter">
               <option value="">All Channels</option>
               <option value="web">Web</option>
@@ -2200,6 +2206,7 @@
       const channel = document.getElementById('channel-filter').value;
       const flaggedOnly = document.getElementById('threads-flagged-only').checked;
       const unreviewedOnly = document.getElementById('threads-unreviewed-only').checked;
+      const timeframe = document.getElementById('stats-timeframe').value;
 
       const params = new URLSearchParams();
       params.append('limit', '50');
@@ -2207,10 +2214,26 @@
       if (flaggedOnly) params.append('flagged_only', 'true');
       if (unreviewedOnly) params.append('unreviewed_only', 'true');
 
+      // Add timeframe filter to threads query
+      if (timeframe !== 'all') {
+        const now = new Date();
+        let since;
+        if (timeframe === '24h') {
+          since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        } else if (timeframe === '7d') {
+          since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        } else if (timeframe === '30d') {
+          since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+        }
+        if (since) {
+          params.append('since', since.toISOString());
+        }
+      }
+
       try {
         const [threadsRes, statsRes] = await Promise.all([
           fetch(`/api/admin/addie/threads?${params.toString()}`),
-          fetch('/api/admin/addie/threads/stats')
+          fetch(`/api/admin/addie/threads/stats?timeframe=${timeframe}`)
         ]);
 
         const data = await threadsRes.json();
@@ -2227,12 +2250,27 @@
           };
           const totalTokens = (stats.total_input_tokens || 0) + (stats.total_output_tokens || 0);
 
+          // Get thread count based on timeframe
+          const getThreadCount = (ch) => {
+            if (timeframe === '24h') return ch.threads_last_24h || 0;
+            if (timeframe === '7d') return ch.threads_last_7d || 0;
+            return ch.total_threads || 0;
+          };
+
+          // Get timeframe label
+          const timeframeLabel = {
+            '24h': '(24h)',
+            '7d': '(7d)',
+            '30d': '(30d)',
+            'all': ''
+          }[timeframe];
+
           statsEl.innerHTML = `
             <div class="conversation-stats">
               ${stats.by_channel.map(ch => `
                 <div class="conversation-stat">
-                  <div class="conversation-stat-value">${ch.thread_count || 0}</div>
-                  <div class="conversation-stat-label">${ch.channel.charAt(0).toUpperCase() + ch.channel.slice(1)} Threads</div>
+                  <div class="conversation-stat-value">${getThreadCount(ch)}</div>
+                  <div class="conversation-stat-label">${ch.channel.charAt(0).toUpperCase() + ch.channel.slice(1)} Threads ${timeframeLabel}</div>
                 </div>
               `).join('')}
               <div class="conversation-stat">
@@ -3570,6 +3608,7 @@
 
       // Need at least a rating
       if (!feedback.rating) {
+        alert('Please select thumbs up or thumbs down');
         return;
       }
 
@@ -3591,20 +3630,29 @@
             msg.rating = feedback.rating;
             msg.rating_notes = feedback.rating_notes;
             msg.feedback_tags = feedback.feedback_tags;
+            msg.rating_source = 'admin';
           }
         }
 
         // Clear pending feedback for this message
         delete pendingMessageFeedback[messageId];
 
-        // Show brief success indicator
-        const feedbackEl = document.querySelector(`.message-feedback[data-message-id="${messageId}"]`);
-        if (feedbackEl) {
-          const savedIndicator = document.createElement('span');
-          savedIndicator.textContent = 'Saved';
-          savedIndicator.style.cssText = 'color: var(--color-success-600); font-size: var(--text-xs); margin-left: var(--space-2);';
-          feedbackEl.appendChild(savedIndicator);
-          setTimeout(() => savedIndicator.remove(), 2000);
+        // Re-render the message to show updated feedback state
+        if (currentThreadData && currentThreadData.messages) {
+          const msg = currentThreadData.messages.find(m => m.message_id === messageId);
+          if (msg) {
+            // Find the message element and replace it with re-rendered version
+            const assistantMessages = document.querySelectorAll('.message-item.assistant');
+            for (const el of assistantMessages) {
+              const feedbackEl = el.querySelector(`.message-feedback[data-message-id="${messageId}"]`);
+              if (feedbackEl) {
+                // Re-render this message
+                const newHtml = renderThreadMessage(msg);
+                el.outerHTML = newHtml;
+                break;
+              }
+            }
+          }
         }
       } catch (error) {
         console.error('Error saving message feedback:', error);
@@ -3880,6 +3928,7 @@
     loadQueue();
 
     // Event listeners for thread filters
+    document.getElementById('stats-timeframe').addEventListener('change', loadThreads);
     document.getElementById('channel-filter').addEventListener('change', loadThreads);
     document.getElementById('threads-flagged-only').addEventListener('change', loadThreads);
     document.getElementById('threads-unreviewed-only').addEventListener('change', loadThreads);

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -387,12 +387,21 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   apiRouter.get("/threads/stats", requireAuth, requireAdmin, async (req, res) => {
     try {
       const threadService = getThreadService();
-      const stats = await threadService.getStats();
-      const channelStats = await threadService.getChannelStats();
+      const { timeframe } = req.query;
+
+      // Validate timeframe parameter
+      const validTimeframes = ['24h', '7d', '30d', 'all'] as const;
+      const tf = validTimeframes.includes(timeframe as typeof validTimeframes[number])
+        ? (timeframe as '24h' | '7d' | '30d' | 'all')
+        : 'all';
+
+      const stats = await threadService.getStats(tf);
+      const channelStats = await threadService.getChannelStats(tf);
 
       res.json({
         ...stats,
         by_channel: channelStats,
+        timeframe: tf,
       });
     } catch (error) {
       logger.error({ err: error }, "Error fetching thread stats");


### PR DESCRIPTION
## Summary
- Fix Save button showing no feedback when rating not selected (now shows alert)
- Fix admin tools (find_prospect, get_organization_details, etc.) not being available in Slack DM threads - `createUserScopedTools` now includes admin and event tools for admin users
- Re-render message after feedback save to immediately show updated state
- Add timeframe dropdown to conversation stats (This Week, Last 24 Hours, Last 30 Days, All Time) with proper filtering
- Use explicit SQL queries instead of string interpolation for timeframe filtering to avoid potential injection issues
- Set rating_source to 'admin' when saving feedback from admin UI

## Test plan
- [ ] Test Save button with no rating selected shows alert
- [ ] Test admin can access admin tools in Slack DMs (find_prospect, get_organization_details, etc.)
- [ ] Test feedback UI updates immediately after save (shows rating, notes preview, "Edit notes" button)
- [ ] Test timeframe dropdown filters stats correctly (check counts change per timeframe)
- [ ] Test thread list filters by selected timeframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)