### PR TITLE
Fix Addie's response to empty mentions

### DIFF
--- a/.changeset/brave-forks-crash.md
+++ b/.changeset/brave-forks-crash.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Addie's response to empty mentions - when mentioned with just "@Addie" (no question), she no longer incorrectly welcomes the mentioner as if they were new to the channel.


### PR DESCRIPTION
## Summary

- Fixes Addie's behavior when mentioned with just "@Addie" (no question)
- She now provides a brief self-introduction instead of incorrectly welcoming the mentioner as if they were new to the channel

## Changes

- Detect empty mentions after stripping bot mention from message
- Provide clear context to Claude about the situation (empty mention prompt)
- Preserve original empty input for audit logging (don't pollute logs with synthetic instructions)

## Test plan

- [x] TypeScript type checking passes
- [x] All unit tests pass (131 tests)
- [x] Server runs correctly (verified via Vibium browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)