### PR TITLE
Improve industry news alert format for engagement

### DIFF
--- a/.changeset/funky-bars-chew.md
+++ b/.changeset/funky-bars-chew.md
@@ -1,0 +1,9 @@
+---
+---
+
+Improve industry news alert format for engagement
+
+- Replace priority headers with article title in Slack alerts
+- Add "Addie's take" with emoji and discussion prompt to drive engagement
+- Decode HTML entities in RSS feed titles
+- Reduce false positives in agentic mention detection by only checking original content

--- a/server/src/addie/services/feed-fetcher.ts
+++ b/server/src/addie/services/feed-fetcher.ts
@@ -16,6 +16,23 @@ import {
   type RssArticleInput,
 } from '../../db/industry-feeds-db.js';
 
+/**
+ * Decode common HTML entities in RSS feed content
+ */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&#x22;/g, '"')
+    .replace(/&#34;/g, '"')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ');
+}
+
 const parser = new Parser({
   timeout: 30000,
   headers: {
@@ -100,10 +117,12 @@ async function fetchFeed(feed: IndustryFeed): Promise<RssArticleInput[]> {
       feed_id: feed.id,
       feed_name: feed.name,
       guid,
-      title: item.title,
+      // Decode title since it displays in UI/Slack where entities look bad
+      title: decodeHtmlEntities(item.title),
       link: item.link,
       author: item.creator || item.author,
       published_at: publishedAt,
+      // Description is used for content processing, not direct display
       description: item.contentSnippet || item.content?.substring(0, 1000),
       category: feed.category || undefined,
     });


### PR DESCRIPTION
## Summary

- Replace verbose priority headers (":star: HIGH - Agentic AI in Advertising") with clean article title as the Slack header
- Change "addie_notes" prompt from explanatory to engagement-driving "addie_take" with spicy, opinionated takes that end with discussion prompts
- Remove summary section from Slack alerts (Slack unrolls links anyway)
- Remove tags from Slack output (kept in DB for filtering)
- Fix HTML entity decoding in RSS feed titles (&#x27; → ')
- Reduce false positives in agentic/AdCP mention detection by only checking original article content, not AI-generated summaries

## Before/After

**Before:**
```
:star: HIGH - Agentic AI in Advertising
Algorithm chaos and power plays close digital advertising's turbulent year
Source: PPC Land

[summary paragraph]

*Why this matters:* This article directly showcases the transformation toward agentic advertising systems...

Tags: `ai-agents` `advertising` `programmatic`
```

**After:**
```
Algorithm chaos and power plays close digital advertising's turbulent year
PPC Land

🤖 Big Tech is building AI agents that lock you into their walled gardens. Is open-source AdCP the antidote? What's your take?
```

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Code review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)