### PR TITLE
Fix migration 101: Remove CURRENT_DATE from index predicate

### DIFF
--- a/server/src/db/migrations/101_outreach_sentiment.sql
+++ b/server/src/db/migrations/101_outreach_sentiment.sql
@@ -35,7 +35,7 @@ CREATE INDEX IF NOT EXISTS idx_outreach_sentiment ON member_outreach(response_se
 CREATE INDEX IF NOT EXISTS idx_outreach_intent ON member_outreach(response_intent)
   WHERE response_intent IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_outreach_follow_up ON member_outreach(follow_up_date)
-  WHERE follow_up_date IS NOT NULL AND follow_up_date > CURRENT_DATE;
+  WHERE follow_up_date IS NOT NULL;
 
 -- =====================================================
 -- ENHANCE SLACK_USER_MAPPINGS


### PR DESCRIPTION
## Summary
- Fixed migration 101_outreach_sentiment.sql which was failing because PostgreSQL partial indexes require IMMUTABLE functions in predicates
- `CURRENT_DATE` is STABLE (not IMMUTABLE), so removed it from the index predicate
- The date filtering can happen at query time instead

## Problem
The app wasn't starting because migration 101 was failing with:
```
error: functions in index predicate must be marked IMMUTABLE
```

## Test plan
- [x] All existing tests pass
- [ ] Verify app starts after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)