### PR TITLE
Fix migration 103: users table uses workos_user_id as PK

### DIFF
--- a/server/src/db/migrations/103_sensitive_topics.sql
+++ b/server/src/db/migrations/103_sensitive_topics.sql
@@ -211,7 +211,7 @@ CREATE TABLE IF NOT EXISTS flagged_conversations (
   severity VARCHAR(20),
   response_given TEXT,
   was_deflected BOOLEAN DEFAULT FALSE,
-  reviewed_by INTEGER REFERENCES users(id),
+  reviewed_by VARCHAR(255) REFERENCES users(workos_user_id),
   reviewed_at TIMESTAMP WITH TIME ZONE,
   review_notes TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -242,7 +242,7 @@ CREATE TABLE IF NOT EXISTS known_media_contacts (
   handling_level VARCHAR(20) DEFAULT 'standard'
     CHECK (handling_level IN ('standard', 'careful', 'executive_only')),
   is_active BOOLEAN DEFAULT TRUE,
-  added_by INTEGER REFERENCES users(id),
+  added_by VARCHAR(255) REFERENCES users(workos_user_id),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- Fixed foreign key references in migration 103 (sensitive_topics.sql)
- The `users` table uses `workos_user_id VARCHAR(255)` as its primary key, not `id INTEGER`

## Problem
Migration 103 was failing with:
```
error: column "id" referenced in foreign key constraint does not exist
```

The `flagged_conversations` and `known_media_contacts` tables were trying to reference `users(id)` which doesn't exist.

## Fix
Changed:
```sql
reviewed_by INTEGER REFERENCES users(id)
added_by INTEGER REFERENCES users(id)
```

To:
```sql
reviewed_by VARCHAR(255) REFERENCES users(workos_user_id)
added_by VARCHAR(255) REFERENCES users(workos_user_id)
```

## Test plan
- [x] All tests pass
- [ ] Verify migration runs successfully on Fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)