### PR TITLE
Fix navigation login state and improve user activity stats

### DIFF
--- a/.changeset/fix-login-display-and-stats.md
+++ b/.changeset/fix-login-display-and-stats.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix navigation login state and improve user activity stats
+
+- Fix navigation showing "Log in/Sign up" when user is authenticated by adding session refresh to `getUserFromRequest()`
+- Hide "0 Messages" and "0 Active Days" stats when there's no activity
+- Include web chat messages in user stats alongside Slack activity by querying `addie_threads` table

--- a/server/src/addie/home/builders/stats.ts
+++ b/server/src/addie/home/builders/stats.ts
@@ -16,15 +16,27 @@ export function buildStats(memberContext: MemberContext): UserStats | null {
     return null;
   }
 
+  // Prefer conversation_activity (from addie_threads) as it includes both Slack and web chat
+  // Fall back to slack_activity for backwards compatibility
+  const conversationActivity = memberContext.conversation_activity
+    ? {
+        messages30d: memberContext.conversation_activity.total_messages_30d,
+        activeDays30d: memberContext.conversation_activity.active_days_30d,
+      }
+    : null;
+
+  const slackActivity = memberContext.slack_activity
+    ? {
+        messages30d: memberContext.slack_activity.total_messages_30d,
+        activeDays30d: memberContext.slack_activity.active_days_30d,
+      }
+    : null;
+
   return {
     memberSince: memberContext.org_membership?.joined_at ?? null,
     workingGroupCount: memberContext.engagement?.working_group_count ?? 0,
-    slackActivity: memberContext.slack_activity
-      ? {
-          messages30d: memberContext.slack_activity.total_messages_30d,
-          activeDays30d: memberContext.slack_activity.active_days_30d,
-        }
-      : null,
+    conversationActivity,
+    slackActivity,
     subscriptionStatus: memberContext.subscription?.status ?? null,
     renewalDate: memberContext.subscription?.current_period_end ?? null,
   };

--- a/server/src/addie/home/html-renderer.ts
+++ b/server/src/addie/home/html-renderer.ts
@@ -164,9 +164,12 @@ function renderStats(stats: UserStats): string | null {
     statItems.push(`<div class="addie-home-stat"><span class="stat-value">${stats.workingGroupCount}</span><span class="stat-label">Working Groups</span></div>`);
   }
 
-  if (stats.slackActivity) {
-    statItems.push(`<div class="addie-home-stat"><span class="stat-value">${stats.slackActivity.messages30d}</span><span class="stat-label">Messages (30d)</span></div>`);
-    statItems.push(`<div class="addie-home-stat"><span class="stat-value">${stats.slackActivity.activeDays30d}</span><span class="stat-label">Active Days</span></div>`);
+  // Prefer conversationActivity (Slack + web chat) over slackActivity (Slack only)
+  // Only show if there's actual activity
+  const activity = stats.conversationActivity || stats.slackActivity;
+  if (activity && (activity.messages30d > 0 || activity.activeDays30d > 0)) {
+    statItems.push(`<div class="addie-home-stat"><span class="stat-value">${activity.messages30d}</span><span class="stat-label">Messages (30d)</span></div>`);
+    statItems.push(`<div class="addie-home-stat"><span class="stat-value">${activity.activeDays30d}</span><span class="stat-label">Active Days</span></div>`);
   }
 
   if (stats.subscriptionStatus) {

--- a/server/src/addie/home/types.ts
+++ b/server/src/addie/home/types.ts
@@ -86,6 +86,12 @@ export interface ActivityItem {
 export interface UserStats {
   memberSince: Date | null;
   workingGroupCount: number;
+  /** Combined activity from Slack and web chat (preferred over slackActivity) */
+  conversationActivity: {
+    messages30d: number;
+    activeDays30d: number;
+  } | null;
+  /** Slack-only activity (fallback when conversationActivity is not available) */
   slackActivity: {
     messages30d: number;
     activeDays30d: number;


### PR DESCRIPTION
## Summary

- **Fix navigation showing "Log in/Sign up" when user is authenticated** - The `getUserFromRequest()` function wasn't refreshing expired WorkOS sessions, causing the nav bar to show logged-out state even when API calls correctly authenticated the user. Now properly refreshes the session and updates the cookie.

- **Hide empty activity stats** - No longer display "0 Messages" and "0 Active Days" when there's no activity - not useful UX.

- **Include web chat messages in user stats** - Previously only counted Slack activity. Now queries the unified `addie_threads` table which includes both Slack and web chat conversations, so users who prefer web chat see their activity reflected.

## Test plan

- [ ] Verify navigation shows logged-in state after page load with valid session
- [ ] Verify navigation still shows logged-in state when session needs refresh
- [ ] Verify "Your Stats" section hides when user has no messages/activity
- [ ] Verify "Your Stats" section shows combined Slack + web chat activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)