### PR TITLE
Fix missing newlines between context sections in Addie Slack messages

### DIFF
--- a/.changeset/addie-newline-fix.md
+++ b/.changeset/addie-newline-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix missing newlines between context sections in Addie message formatting

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -418,7 +418,7 @@ async function buildMessageWithMemberContext(
     let channelContextText = '';
     if (threadContext?.viewing_channel_name) {
       const channelLines: string[] = [];
-      channelLines.push(`\n## Channel Context`);
+      channelLines.push('## Channel Context');
       channelLines.push(`User is viewing **#${threadContext.viewing_channel_name}**`);
       if (threadContext.viewing_channel_description) {
         channelLines.push(`Channel description: ${threadContext.viewing_channel_description}`);
@@ -430,8 +430,10 @@ async function buildMessageWithMemberContext(
     }
 
     if (memberContextText || channelContextText) {
+      // Use double newline between sections for proper markdown spacing
+      const sections = [memberContextText, channelContextText].filter(Boolean);
       return {
-        message: `${memberContextText || ''}${channelContextText}\n---\n\n${sanitizedMessage}`,
+        message: `${sections.join('\n\n')}\n\n---\n\n${sanitizedMessage}`,
         memberContext,
       };
     }


### PR DESCRIPTION
## Summary
- Fixed missing newlines between member context and channel context sections in Addie Slack message formatting
- When both contexts were present, they were concatenated without proper markdown paragraph spacing, causing sections to run together
- Used array filter/join pattern for cleaner section joining with `\n\n`

## Test plan
- [ ] Verify Slack messages with both member and channel context display proper spacing
- [ ] Verify messages with only member context still work correctly
- [ ] Verify messages with only channel context still work correctly
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)