### PR TITLE
Fix admin organization links and add clickable member names

### DIFF
--- a/.changeset/fix-admin-member-links.md
+++ b/.changeset/fix-admin-member-links.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix broken admin organization links and make member names clickable.

--- a/server/public/admin-members.html
+++ b/server/public/admin-members.html
@@ -111,6 +111,15 @@
     .members-table tr:hover {
       background: var(--color-gray-50);
     }
+    .company-link {
+      color: var(--color-text-heading);
+      text-decoration: none;
+      font-weight: var(--font-medium);
+    }
+    .company-link:hover {
+      color: var(--color-brand);
+      text-decoration: underline;
+    }
     .status-badge {
       display: inline-block;
       padding: var(--space-1) var(--space-2);
@@ -600,7 +609,7 @@
 
         return `
           <tr id="row-${member.company_id}">
-            <td><strong>${member.company_name || 'Unknown'}</strong></td>
+            <td><a href="/admin/organizations/${member.company_id}" class="company-link">${member.company_name || 'Unknown'}</a></td>
             <td>${companyTypeText}</td>
             <td>${revenueTierText}</td>
             <td>${member.owner_email || 'No email'}</td>

--- a/server/public/admin-prospects.html
+++ b/server/public/admin-prospects.html
@@ -2225,7 +2225,7 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
         return `
           <tr style="vertical-align: top;">
             <td>
-              <a href="/admin/member.html?org=${analysis.org_id}" target="_blank">
+              <a href="/admin/organizations/${analysis.org_id}" target="_blank">
                 <strong>${analysis.org_name}</strong>
               </a>
             </td>
@@ -2249,7 +2249,7 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
 
       // Update table headers for cleanup view
       document.querySelector('thead tr').innerHTML = `
-        <th>Organization</th>
+        <th style="width: 180px;">Organization</th>
         <th>Issues</th>
         <th>Suggested Actions</th>
         <th style="width: 120px;">Actions</th>


### PR DESCRIPTION
## Summary
- Fix broken link in prospects data cleanup view from `/admin/member.html?org=` to `/admin/organizations/`
- Make company names clickable in admin members table
- Add width constraint to data cleanup Organization column

## Test plan
- [x] Tested links work correctly in browser
- [x] Verified clicking member name navigates to org detail page
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)