### PR TITLE
Fix chat page showing logged-out state for authenticated users

### DIFF
--- a/.changeset/humble-clouds-smell.md
+++ b/.changeset/humble-clouds-smell.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix chat page showing logged-out state for authenticated users.

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -13,6 +13,7 @@ import { validate as uuidValidate } from "uuid";
 import rateLimit from "express-rate-limit";
 import { createLogger } from "../logger.js";
 import { optionalAuth } from "../middleware/auth.js";
+import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient } from "../addie/claude-client.js";
 import {
   sanitizeInput,
@@ -145,9 +146,13 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
   // PAGE ROUTES (mounted at /chat)
   // =========================================================================
 
-  // Note: The chat page (/chat -> chat.html) is served by the global middleware
-  // in http.ts that handles extensionless paths. This middleware injects the
-  // user config needed for the navigation bar. No explicit route needed here.
+  // GET / - Serve the chat page (mounted at /chat, so this serves /chat)
+  pageRouter.get("/", optionalAuth, (req, res) => {
+    serveHtmlWithConfig(req, res, "chat.html").catch((err) => {
+      logger.error({ err }, "Error serving chat page");
+      res.status(500).send("Internal server error");
+    });
+  });
 
   // =========================================================================
   // API ROUTES (mounted at /api/addie/chat)


### PR DESCRIPTION
## Summary

- Fixed the /chat page showing "Log in" and "Sign up" buttons even when users were authenticated
- The page router mounted at /chat had no explicit route for serving the HTML, relying on a global middleware that was being bypassed due to Express router mounting order
- Added an explicit route in `server/src/routes/addie-chat.ts` using `serveHtmlWithConfig`, matching the pattern used by other page routes

## Test plan

- [x] Verified with Vibium browser testing
- [x] Anonymous users see "Log in / Sign up" buttons
- [x] Authenticated users see their name/dropdown in the nav
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)