### PR TITLE
Fix feedback modal not displaying saved feedback when viewing threads

### DIFF
--- a/.changeset/fix-feedback-modal.md
+++ b/.changeset/fix-feedback-modal.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix feedback modal not displaying saved feedback when viewing threads

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -3146,6 +3146,12 @@
         document.getElementById('thread-feedback-panel').style.display = 'block';
         clearThreadFeedback();
 
+        // Load existing feedback from last assistant message if present
+        const lastAssistantMsg = [...data.messages].reverse().find(m => m.role === 'assistant');
+        if (lastAssistantMsg && lastAssistantMsg.rating) {
+          loadExistingFeedback(lastAssistantMsg);
+        }
+
         // Show actions panel
         const actionsEl = document.getElementById('conversation-actions');
         actionsEl.style.display = 'block';
@@ -3701,6 +3707,36 @@
       document.getElementById('thread-thumbs-down').classList.remove('selected');
       document.querySelectorAll('#thread-feedback-tags .feedback-tag').forEach(tag => tag.classList.remove('selected'));
       document.getElementById('thread-feedback-notes').value = '';
+    }
+
+    function loadExistingFeedback(message) {
+      // Set sentiment based on rating (5 = positive, 1 = negative)
+      // Rating 3 is intentionally neutral and leaves sentiment unset
+      if (message.rating >= 4) {
+        setThreadRating('positive');
+      } else if (message.rating <= 2) {
+        setThreadRating('negative');
+      }
+
+      // Load feedback tags (validate against known tags for security)
+      const validTags = ['accurate', 'helpful', 'well_cited', 'good_tone', 'inaccurate', 'missing_info', 'wrong_source', 'too_verbose', 'too_brief', 'wrong_tone'];
+      if (message.feedback_tags && Array.isArray(message.feedback_tags)) {
+        message.feedback_tags.forEach(tag => {
+          if (validTags.includes(tag)) {
+            const tagEl = document.querySelector(`#thread-feedback-tags .feedback-tag[data-tag="${tag}"]`);
+            if (tagEl) {
+              tagEl.classList.add('selected');
+              threadFeedbackState.tags.push(tag);
+            }
+          }
+        });
+      }
+
+      // Load notes (rating_notes contains the text feedback)
+      if (message.rating_notes) {
+        document.getElementById('thread-feedback-notes').value = message.rating_notes;
+        threadFeedbackState.notes = message.rating_notes;
+      }
     }
 
     async function saveThreadFeedback() {

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -103,6 +103,12 @@ async function initializeChatClient(): Promise<void> {
 interface ConversationMessage {
   role: "user" | "assistant";
   content: string;
+  message_id?: string;
+  rating?: number | null;
+  rating_category?: string | null;
+  rating_notes?: string | null;
+  feedback_tags?: string[] | null;
+  improvement_suggestion?: string | null;
 }
 
 /**
@@ -675,6 +681,12 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         .map((m) => ({
           role: m.role as 'user' | 'assistant',
           content: m.content,
+          message_id: m.message_id,
+          rating: m.rating,
+          rating_category: m.rating_category,
+          rating_notes: m.rating_notes,
+          feedback_tags: m.feedback_tags,
+          improvement_suggestion: m.improvement_suggestion,
         }));
 
       res.json({


### PR DESCRIPTION
## Summary
- Add `rating_notes` field to `ConversationMessage` interface and API response
- Add `loadExistingFeedback()` function to populate feedback form when viewing a thread that has existing feedback
- Validate feedback tags against allowed values for security
- Call `loadExistingFeedback()` after clearing the form when viewing a thread

Fixes issue where:
1. Feedback typed and saved didn't show up when revisiting the thread
2. The feedback form was always blank even for threads with existing feedback

## Test plan
- [ ] Navigate to admin Addie dashboard
- [ ] View a thread that has existing feedback
- [ ] Verify the feedback form shows the saved sentiment (thumbs up/down), tags, and notes
- [ ] Save new feedback on a thread, then close and reopen
- [ ] Verify the feedback is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)