### PR TITLE
Fix Addie not including GitHub issue link in response

### DIFF
--- a/.changeset/fix-addie-github-link.md
+++ b/.changeset/fix-addie-github-link.md
@@ -1,4 +1,7 @@
 ---
+"adcontextprotocol": patch
 ---
 
 Fix Addie not including GitHub issue link in response when using draft_github_issue tool.
+
+Updated the GitHub Issue Drafting rule in the database to emphasize that tool outputs are invisible to users. The rule now explicitly instructs Addie to copy the full tool output (including the GitHub link) into her response text, rather than saying "see the link above" which doesn't work since users cannot see tool outputs.

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -221,15 +221,7 @@ When asked "what's the latest news" - interpret as AD TECH news. Search for AdCP
 - **Bias awareness**: Careful with potentially offensive statements; handle adversarial questions thoughtfully
 - **Escalation**: Refer to humans for controversial, legal, confrontational, or business-critical topics
 - **Source attribution**: Always cite sources; link to documentation; distinguish fact from interpretation
-- **GitHub issues**: When users report bugs, broken links, or feature requests, use draft_github_issue to help them create an issue.
-
-  **CRITICAL TOOL OUTPUT RULE**: The user CANNOT see tool outputs directly. When using draft_github_issue, you MUST include the full tool output (the GitHub link, preview, etc.) in your response. DO NOT say "I've drafted an issue above" or "click the link above" - there IS no link "above" because tool outputs are invisible to users. Instead, copy the entire formatted output from the tool into your response so the user can see and click the link.
-
-  Infer the right repo from channel/context:
-  - adcp: Core protocol, schemas, SDKs
-  - salesagent: Sales agent implementation (#salesagent-users, #salesagent-dev)
-  - creative-agent: Creative agent, standard formats
-  - aao-server: AgenticAdvertising.org website, community, Addie
+- **GitHub issues**: When users report bugs, broken links, or feature requests, use draft_github_issue to help them create an issue. Important: Always include the full tool output (GitHub link, preview) in your response since users cannot see tool outputs directly.
 
 ## Fact-Checking (CRITICAL)
 

--- a/server/src/db/migrations/112_fix_github_link_visibility.sql
+++ b/server/src/db/migrations/112_fix_github_link_visibility.sql
@@ -1,0 +1,55 @@
+-- Fix GitHub Issue Drafting rule to include critical instruction about tool output visibility
+--
+-- Problem: When Addie uses draft_github_issue, she says "see the link above" but the actual
+-- link doesn't appear because users cannot see tool outputs directly. The tool output goes
+-- back to Claude, and Claude must include the link in its response text.
+--
+-- Solution: Update the GitHub Issue Drafting rule to emphasize that tool outputs are invisible
+-- to users and must be copied into the response.
+
+-- Update the existing GitHub Issue Drafting rule
+UPDATE addie_rules
+SET content = 'You have a draft_github_issue tool to help users create GitHub issues for bugs or feature requests. When users:
+- Report a bug or broken link
+- Request a feature or enhancement
+- Ask you to create a GitHub issue
+- Discuss something that should be tracked
+
+Use draft_github_issue to generate a pre-filled GitHub URL.
+
+**CRITICAL - TOOL OUTPUT VISIBILITY**: Users CANNOT see tool outputs directly. When you use draft_github_issue, the tool returns a formatted response with the GitHub link, but this output is only visible to you, not the user. You MUST copy the entire tool output (the GitHub link, title preview, body preview) into your response text.
+
+NEVER say "click the link above" or "see the link I created" - there is no link visible to the user unless you explicitly include it. Always format your response like:
+
+"I''ve drafted a GitHub issue for you:
+
+**[Create Issue on GitHub](https://github.com/...)**
+
+**Title:** [the title]
+**Body preview:** [summary of the body]"
+
+Infer the appropriate repo from context (channel name, conversation topic):
+
+**adcontextprotocol organization repos:**
+- "adcp" - Core protocol specification, JSON schemas, TypeScript/Python SDKs (@adcp/client, adcp PyPI)
+- "salesagent" - Reference sales agent implementation, salesagent docs, salesagent-users channel issues
+- "aao-server" - AgenticAdvertising.org website, community features, membership, Addie herself
+- "creative-agent" - Reference creative agent, standard formats, creative workflow
+
+**Channel → Repo hints:**
+- #salesagent-users, #salesagent-dev → salesagent repo
+- #creative-agent, #creative-formats → creative-agent repo
+- #adcp-dev, #protocol-* → adcp repo
+- #general, #community, #membership → aao-server repo
+
+Draft clear, actionable issues with:
+- Descriptive title summarizing the issue
+- Context about where the issue was discovered
+- Steps to reproduce (for bugs) or detailed description (for features)
+- Appropriate labels (bug, enhancement, documentation, etc.)
+
+You can proactively offer to draft issues when you notice problems being discussed.',
+    updated_at = NOW()
+WHERE name = 'GitHub Issue Drafting'
+  AND rule_type = 'behavior'
+  AND content NOT LIKE '%CRITICAL - TOOL OUTPUT VISIBILITY%';


### PR DESCRIPTION
## Summary

- Fix Addie not including the actual GitHub issue link when using `draft_github_issue` tool
- Users would see "click the link above" but no link was visible because tool outputs are invisible to users

## Changes

- Add migration 112 that updates the GitHub Issue Drafting rule to explicitly tell Claude that tool outputs are invisible
- Claude must now copy the entire tool output (GitHub link, title, body preview) into the response text
- Added idempotency check to prevent re-running the migration
- Simplified fallback prompt in prompts.ts (database rules are source of truth)

## Test plan

- [x] Typecheck passes
- [x] All tests pass
- [x] Tested locally with Docker - Addie now properly includes the clickable GitHub link in her response
- [x] Verified in browser using Vibium - the link appears correctly in the chat UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)