### PR TITLE
Fix invoice modal positioning: center modals on screen

### DIFF
--- a/.changeset/chubby-baboons-kick.md
+++ b/.changeset/chubby-baboons-kick.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix invoice modal positioning: modals now appear centered on screen instead of at page bottom.

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -662,7 +662,7 @@
   </div>
 
   <!-- Invoice Request Modal -->
-  <div id="invoiceRequestModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: var(--color-surface-overlay); z-index: 1000; align-items: center; justify-content: center; padding: 20px;">
+  <div id="invoiceRequestModal" class="profile-modal-overlay" style="display: none;">
     <div style="background: var(--color-bg-card); border-radius: 12px; max-width: 500px; width: 100%; max-height: 90vh; overflow-y: auto; box-shadow: var(--shadow-xl);">
       <div style="padding: 20px 24px; border-bottom: 1px solid var(--color-border); display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 18px; color: var(--color-text-heading);">Request an Invoice</h2>
@@ -736,7 +736,7 @@
   </div>
 
   <!-- Agreement Modal -->
-  <div id="agreementModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: var(--color-surface-overlay); z-index: 1000; display: none; align-items: center; justify-content: center; padding: 20px;">
+  <div id="agreementModal" class="profile-modal-overlay" style="display: none;">
     <div style="background: var(--color-bg-card); border-radius: 12px; max-width: 700px; width: 100%; max-height: 90vh; display: flex; flex-direction: column; box-shadow: var(--shadow-xl);">
       <div style="padding: 20px 24px; border-bottom: 1px solid var(--color-border); display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 18px; color: var(--color-text-heading);">Membership Agreement</h2>

--- a/server/public/join-cta.js
+++ b/server/public/join-cta.js
@@ -504,6 +504,9 @@ function formatCurrency(amountCents, currency = 'usd') {
  * Open the invoice request modal
  */
 async function openInvoiceRequestModal() {
+  // Ensure styles are injected
+  injectJoinCtaStyles();
+
   // Remove any existing modal
   const existingModal = document.getElementById('invoiceRequestModal');
   if (existingModal) {


### PR DESCRIPTION
## Summary

- Fix invoice request modal appearing at bottom of page instead of centered
- The issue occurred because inline styles had flexbox alignment properties but when JS set `display: flex`, the centering didn't work properly

## Changes

- **dashboard-membership.html**: Use existing `.profile-modal-overlay` class instead of inline styles for both invoice and agreement modals
- **join-cta.js**: Call `injectJoinCtaStyles()` in `openInvoiceRequestModal()` to ensure the modal overlay CSS is loaded before creating the modal

## Test plan

- [x] Tested with Vibium browser - modal now centers properly on both personal and company org membership pages
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)