### PR TITLE
Add brand_manifest parameter to test_adcp_agent tool

### DIFF
--- a/.changeset/wet-keys-wash.md
+++ b/.changeset/wet-keys-wash.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add brand_manifest parameter to test_adcp_agent tool, allowing users to specify custom brands when testing agents. Defaults to Nike if not provided.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -464,6 +464,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
             },
             url: {
               type: 'string',
+              format: 'uri',
               description: 'Brand website URL',
             },
             tagline: {
@@ -1288,7 +1289,7 @@ export function createMemberToolHandlers(
     const dryRun = input.dry_run as boolean | undefined;
     const channels = input.channels as string[] | undefined;
     const pricingModels = input.pricing_models as string[] | undefined;
-    const brandManifest = input.brand_manifest as { name: string; url?: string; tagline?: string } | undefined;
+    const brandManifest = input.brand_manifest as TestOptions['brand_manifest'];
     let authToken = input.auth_token as string | undefined;
 
     // Look up saved token for organization


### PR DESCRIPTION
Allow users to specify brand manifests when testing agents with Addie, enabling realistic testing with well-known brands (Nike, Coca-Cola) or custom brands. Use Nike as the default instead of a placeholder URL that real agents would reject.

**Changes:**
- Add brand_manifest input parameter to test_adcp_agent tool schema
- Update handler to pass brand manifest to @adcp/client testing library
- Use Nike as realistic default brand manifest

This addresses the issue where testing would fail against real sales agents due to invalid brand references.