### PR TITLE
Fix ON CONFLICT clause in domain insert queries

### DIFF
--- a/.changeset/plain-needles-smell.md
+++ b/.changeset/plain-needles-smell.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix ON CONFLICT clause in domain insert queries to match database schema constraint.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -3342,7 +3342,8 @@ export function createAdminToolHandlers(
           await pool.query(
             `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
              VALUES ($1, $2, $3, true, 'workos')
-             ON CONFLICT (workos_organization_id, domain) DO UPDATE SET
+             ON CONFLICT (domain) DO UPDATE SET
+               workos_organization_id = EXCLUDED.workos_organization_id,
                is_primary = EXCLUDED.is_primary,
                verified = true,
                source = 'workos',

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -969,7 +969,8 @@ export function setupDomainRoutes(
         await pool.query(
           `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
            VALUES ($1, $2, $3, true, 'workos')
-           ON CONFLICT (workos_organization_id, domain) DO UPDATE SET
+           ON CONFLICT (domain) DO UPDATE SET
+             workos_organization_id = EXCLUDED.workos_organization_id,
              is_primary = EXCLUDED.is_primary,
              verified = true,
              source = 'workos',


### PR DESCRIPTION
## Summary
- Fixed bug where adding domains to organizations failed with "Internal server error"
- The `organization_domains` table has a unique constraint on `(domain)` only, but the INSERT queries incorrectly used `ON CONFLICT (workos_organization_id, domain)`
- This caused PostgreSQL to fail with "there is no unique or exclusion constraint matching the ON CONFLICT specification"

## Test plan
- [x] Verified fix with direct SQL test in PostgreSQL
- [x] Confirmed original query fails with expected error
- [x] All tests pass (153 tests)
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)