### PR TITLE
Link domain directly when clicking 'Link to Org' on domain health page

### DIFF
--- a/.changeset/link-org-direct.md
+++ b/.changeset/link-org-direct.md
@@ -1,0 +1,4 @@
+---
+---
+
+Link domain directly when clicking "Link to Org" on domain health page instead of showing modal

--- a/server/public/admin-org-detail.html
+++ b/server/public/admin-org-detail.html
@@ -2272,18 +2272,35 @@
         // Wait for org to load
         await loadOrganization();
 
-        // Pre-fill domain modal and show it
-        document.getElementById('domainInput').value = linkDomain;
-        document.getElementById('domainIsPrimary').checked = true;
-        openAddDomainModal();
-
-        // Clean up URL (wrap in try/catch for edge cases)
+        // Clean up URL immediately (wrap in try/catch for edge cases)
         try {
           const url = new URL(window.location);
           url.searchParams.delete('link_domain');
           window.history.replaceState({}, '', url);
         } catch (e) {
           console.warn('Could not clean up URL:', e);
+        }
+
+        // Directly add the domain to the org
+        try {
+          const response = await fetch(`/api/admin/organizations/${orgId}/domains`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ domain: linkDomain.toLowerCase(), is_primary: true })
+          });
+
+          if (!response.ok) {
+            if (response.status === 401) {
+              window.AdminNav.redirectToLogin();
+              return;
+            }
+            throw new Error(await getErrorMessage(response, 'Failed to link domain'));
+          }
+
+          // Refresh domains to show the newly added domain
+          await refreshDomains();
+        } catch (error) {
+          alert('Error linking domain: ' + error.message);
         }
       } else {
         loadOrganization();


### PR DESCRIPTION
## Summary
- When clicking "Link to Org" on the domain health page, the domain is now directly linked to the organization via API call instead of showing a modal requiring confirmation
- Reduces friction for admins performing bulk domain linking tasks

## Test plan
- [x] Navigate to Domain Health admin page
- [x] Find an unlinked domain with one existing org
- [x] Click "Link to [OrgName]" button
- [x] Verify no modal appears
- [x] Verify the domain is added to the org (appears in domains list)
- [x] Verify error handling shows alert if API fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)