### PR TITLE
Fix admin info showing to non-admin users and mobile pane width

### DIFF
--- a/.changeset/fix-admin-checks-mobile-pane.md
+++ b/.changeset/fix-admin-checks-mobile-pane.md
@@ -1,0 +1,4 @@
+---
+---
+
+No protocol changes - internal admin check consistency fix and mobile CSS improvement.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -44,7 +44,6 @@ import {
   ADMIN_TOOLS,
   createAdminToolHandlers,
   isSlackUserAdmin,
-  isAdmin,
 } from './mcp/admin-tools.js';
 import {
   EVENT_TOOLS,
@@ -461,7 +460,8 @@ async function createUserScopedTools(
   const allTools = [...MEMBER_TOOLS];
   const allHandlers = new Map(memberHandlers);
 
-  const userIsAdmin = isAdmin(memberContext);
+  // Check if user is AAO admin (based on aao-admin working group membership)
+  const userIsAdmin = slackUserId ? await isSlackUserAdmin(slackUserId) : false;
 
   // Add admin tools if user is admin
   if (userIsAdmin) {

--- a/server/src/addie/email-handler.ts
+++ b/server/src/addie/email-handler.ts
@@ -13,7 +13,7 @@ import {
   generateInteractionId,
 } from './security.js';
 import { getWebMemberContext, formatMemberContextForPrompt, type MemberContext } from './member-context.js';
-import { isAdmin, ADMIN_TOOLS, createAdminToolHandlers } from './mcp/admin-tools.js';
+import { isWebUserAdmin, ADMIN_TOOLS, createAdminToolHandlers } from './mcp/admin-tools.js';
 import { MEMBER_TOOLS, createMemberToolHandlers } from './mcp/member-tools.js';
 import { BILLING_TOOLS, createBillingToolHandlers } from './mcp/billing-tools.js';
 import { sendEmailReply, type EmailThreadContext } from '../notifications/email.js';
@@ -213,7 +213,8 @@ export async function handleEmailInvocation(
 
     if (senderWorkosUserId) {
       memberContext = await getWebMemberContext(senderWorkosUserId);
-      isUserAdmin = isAdmin(memberContext);
+      // Check if user is AAO admin (based on aao-admin working group membership)
+      isUserAdmin = await isWebUserAdmin(senderWorkosUserId);
     }
 
     // Sanitize input

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -28,7 +28,6 @@ import {
   ADMIN_TOOLS,
   createAdminToolHandlers,
   isSlackUserAdmin,
-  isAdmin,
 } from './mcp/admin-tools.js';
 import {
   MEMBER_TOOLS,
@@ -192,7 +191,8 @@ async function createUserScopedTools(
   const allTools = [...MEMBER_TOOLS];
   const allHandlers = new Map(memberHandlers);
 
-  const userIsAdmin = isAdmin(memberContext);
+  // Check if user is AAO admin (based on aao-admin working group membership)
+  const userIsAdmin = slackUserId ? await isSlackUserAdmin(slackUserId) : false;
 
   // Add admin tools if user is admin
   if (userIsAdmin) {

--- a/server/src/addie/home/html-renderer.ts
+++ b/server/src/addie/home/html-renderer.ts
@@ -276,6 +276,8 @@ export const ADDIE_HOME_CSS = `
 .addie-home {
   max-width: 600px;
   margin: 0 auto;
+  padding: 0 16px;
+  box-sizing: border-box;
 }
 
 .addie-home-greeting {

--- a/server/src/addie/home/web-home-service.ts
+++ b/server/src/addie/home/web-home-service.ts
@@ -7,7 +7,7 @@
 
 import type { HomeContent, GreetingSection } from './types.js';
 import { getWebMemberContext, type MemberContext } from '../member-context.js';
-import { isAdmin } from '../mcp/admin-tools.js';
+import { isWebUserAdmin } from '../mcp/admin-tools.js';
 import { buildAlerts } from './builders/alerts.js';
 import { buildQuickActions } from './builders/quick-actions.js';
 import { buildActivityFeed } from './builders/activity.js';
@@ -24,8 +24,8 @@ export async function getWebHomeContent(workosUserId: string): Promise<HomeConte
   // Get member context for web user
   const memberContext = await getWebMemberContext(workosUserId);
 
-  // Check if user is admin (based on org membership role)
-  const userIsAdmin = isAdmin(memberContext);
+  // Check if user is AAO admin (based on aao-admin working group membership)
+  const userIsAdmin = await isWebUserAdmin(workosUserId);
 
   // Build all sections in parallel for speed
   const [alerts, activity, adminPanel] = await Promise.all([


### PR DESCRIPTION
## Summary
- Fixed admin content (like "Flagged Threads" button and admin panel) showing to non-admin users on the web Addie Home page
- Fixed mobile pane width cutoff by adding proper padding to `.addie-home` CSS

## The Problem
The codebase had **two different admin concepts** that were being confused:

1. **WorkOS Organization Admin**: Someone with `role === 'admin'` in their own organization (e.g., the billing admin at "Acme Corp")
2. **AAO Platform Admin**: A member of the `aao-admin` working group (AgenticAdvertising.org staff/volunteers)

The web home service was checking WorkOS org role to determine who sees AAO platform admin content, so any organization admin could see "Flagged Threads", admin panel, etc.

## The Fix
Now all admin feature checks consistently use **AAO Platform Admin** (working group membership in `aao-admin`):

- `isSlackUserAdmin(slackUserId)` - for Slack users (existing)
- `isWebUserAdmin(workosUserId)` - for web users (new)
- Both check `aao-admin` working group membership

## Changes
- **admin-tools.ts**: Added `isWebUserAdmin()` function and cache invalidation for web admin status
- **web-home-service.ts**: Use `isWebUserAdmin()` instead of `isAdmin()`
- **handler.ts**, **bolt-app.ts**: Use `isSlackUserAdmin()` consistently
- **email-handler.ts**: Use `isWebUserAdmin()` for email handling
- **html-renderer.ts**: Added padding to fix mobile pane width

## Test plan
- [ ] As a non-AAO-admin user, verify "Flagged Threads" button doesn't appear in Addie Home
- [ ] As an AAO admin (member of aao-admin working group), verify admin content still appears
- [ ] On mobile, verify Addie Home content isn't cut off on the left side

🤖 Generated with [Claude Code](https://claude.com/claude-code)