### PR TITLE
Fix duplicate products in invoice request modal

### DIFF
--- a/.changeset/fix-invoice-products.md
+++ b/.changeset/fix-invoice-products.md
@@ -1,0 +1,4 @@
+---
+---
+
+Filter invoice modal dropdown to show only subscription products, excluding legacy one-time invoice products.

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1466,10 +1466,12 @@
       const modal = document.getElementById('invoiceRequestModal');
       const productSelect = document.getElementById('invoice-product');
 
-      // Populate product dropdown with available membership products
+      // Populate product dropdown with subscription products only
+      // (excludes legacy one-time invoice products)
       productSelect.innerHTML = '<option value="">Select a product...</option>';
       if (membershipProducts && membershipProducts.length > 0) {
-        membershipProducts.forEach(product => {
+        const subscriptionProducts = membershipProducts.filter(p => p.billing_type === 'subscription');
+        subscriptionProducts.forEach(product => {
           const price = formatCurrency(product.amount_cents);
           productSelect.innerHTML += `<option value="${product.lookup_key}">${escapeHtml(product.display_name)} - ${price}/year</option>`;
         });

--- a/server/public/join-cta.js
+++ b/server/public/join-cta.js
@@ -798,9 +798,11 @@ async function openInvoiceRequestModal(options = {}) {
   }
 
   // Generate product options HTML
+  // Filter to subscription products only (excludes legacy one-time invoice products)
   let productOptionsHtml = '<option value="">Select a product...</option>';
   if (membershipProducts.length > 0) {
-    for (const product of membershipProducts) {
+    const subscriptionProducts = membershipProducts.filter(p => p.billing_type === 'subscription');
+    for (const product of subscriptionProducts) {
       const price = formatCurrency(product.amount_cents, product.currency);
       const selected = options.selectedProduct === product.lookup_key ? ' selected' : '';
       const escapedLookupKey = escapeHtmlForInvoice(product.lookup_key);


### PR DESCRIPTION
## Summary
- Filter invoice modal dropdown to show only subscription products (`billing_type === 'subscription'`)
- Excludes legacy one-time invoice products (`aao_invoice_*`) that are no longer needed since subscription products can be invoiced directly

## Test plan
- [ ] Open the invoice request modal on the dashboard membership page
- [ ] Verify only one product option appears per price tier (no duplicates)
- [ ] Submit an invoice request and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)