### PR TITLE
Add (me) indicator to owner dropdowns and quick follow-up form

### DIFF
--- a/.changeset/pretty-cameras-jog.md
+++ b/.changeset/pretty-cameras-jog.md
@@ -1,0 +1,4 @@
+---
+---
+
+Admin UI improvements: dynamic owner dropdowns with "(me)" indicator, quick follow-up form.

--- a/server/public/admin-org-detail.html
+++ b/server/public/admin-org-detail.html
@@ -594,6 +594,29 @@
     .btn-icon.danger:hover {
       color: var(--color-error-600);
     }
+    /* Quick follow-up inline form */
+    .quick-followup {
+      display: flex;
+      gap: var(--space-2);
+      margin-top: var(--space-4);
+      padding-top: var(--space-4);
+      border-top: var(--border-1) solid var(--color-gray-200);
+    }
+    .quick-followup-input {
+      flex: 1;
+      padding: var(--space-2) var(--space-3);
+      border: var(--border-1) solid var(--color-gray-300);
+      border-radius: var(--radius-md);
+      font-size: var(--text-sm);
+    }
+    .quick-followup-input:focus {
+      outline: none;
+      border-color: var(--color-brand);
+      box-shadow: 0 0 0 2px var(--color-brand-light);
+    }
+    .quick-followup-input::placeholder {
+      color: var(--color-text-muted);
+    }
   </style>
 </head>
 <body>
@@ -733,6 +756,10 @@
             <div id="nextStepsList" class="empty-state">
               No pending next steps
             </div>
+            <form id="quickFollowUpForm" class="quick-followup" onsubmit="saveQuickFollowUp(event)">
+              <input type="text" id="quickFollowUpText" placeholder="e.g. Talk to Dave Osborne about pricing..." class="quick-followup-input" autocomplete="off">
+              <button type="submit" class="btn btn-primary btn-sm" id="quickFollowUpBtn">Add</button>
+            </form>
           </div>
 
           <!-- Team Members -->
@@ -806,9 +833,6 @@
             <label>Owner</label>
             <select id="editOrgOwner">
               <option value="">Not assigned</option>
-              <option value="Brian">Brian</option>
-              <option value="Randy">Randy</option>
-              <option value="Matt">Matt</option>
             </select>
           </div>
         </div>
@@ -933,9 +957,6 @@
               <label>Owner</label>
               <select id="nextStepOwner">
                 <option value="">Not assigned</option>
-                <option value="Brian">Brian</option>
-                <option value="Randy">Randy</option>
-                <option value="Matt">Matt</option>
               </select>
             </div>
           </div>
@@ -1074,6 +1095,7 @@
 
         renderOrganization();
         renderOwnerSelector();
+        populateOwnerDropdowns();
         renderDomains();
 
         document.getElementById('loading').style.display = 'none';
@@ -1551,6 +1573,60 @@
       }
     }
 
+    async function saveQuickFollowUp(event) {
+      event.preventDefault();
+
+      const input = document.getElementById('quickFollowUpText');
+      const btn = document.getElementById('quickFollowUpBtn');
+      const description = input.value.trim();
+
+      if (!description) return;
+
+      // Get current user's name for the owner
+      const currentUserMember = teamMembers.find(m => currentUserId && m.user_id === currentUserId);
+      const ownerName = currentUserMember?.user_name || null;
+
+      // Default due date to tomorrow
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const dueDate = tomorrow.toISOString().split('T')[0];
+
+      const data = {
+        activity_type: 'note',
+        description: description,
+        is_next_step: true,
+        next_step_due_date: dueDate,
+        next_step_owner_name: ownerName
+      };
+
+      btn.disabled = true;
+      btn.textContent = '...';
+
+      try {
+        const response = await fetch(`/api/admin/organizations/${orgId}/activities`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            window.AdminNav.redirectToLogin();
+            return;
+          }
+          throw new Error('Failed to save follow-up');
+        }
+
+        input.value = '';
+        loadOrganization(); // Refresh data
+      } catch (error) {
+        alert('Error: ' + error.message);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Add';
+      }
+    }
+
     async function completeNextStep(activityId) {
       try {
         const response = await fetch(`/api/admin/organizations/${orgId}/activities/${activityId}`, {
@@ -1627,6 +1703,31 @@
         watchBtn.textContent = isWatching ? '⭐' : '☆';
         watchBtn.title = isWatching ? 'Stop watching' : 'Watch this organization';
       }
+    }
+
+    function populateOwnerDropdowns() {
+      const editOrgOwner = document.getElementById('editOrgOwner');
+      const nextStepOwner = document.getElementById('nextStepOwner');
+
+      editOrgOwner.innerHTML = '<option value="">Not assigned</option>';
+      nextStepOwner.innerHTML = '<option value="">Not assigned</option>';
+
+      teamMembers.forEach(member => {
+        const isMe = currentUserId && member.user_id === currentUserId;
+        const displayName = isMe ? `${member.user_name} (me)` : member.user_name;
+
+        // Edit modal uses legacy prospect_owner field (stores name)
+        const editOption = document.createElement('option');
+        editOption.value = member.user_name;
+        editOption.textContent = displayName;
+        editOrgOwner.appendChild(editOption);
+
+        // Next step dropdown uses name for next_step_owner_name field
+        const nextStepOption = document.createElement('option');
+        nextStepOption.value = member.user_name;
+        nextStepOption.textContent = displayName;
+        nextStepOwner.appendChild(nextStepOption);
+      });
     }
 
     function showOwnerDropdown() {

--- a/server/public/admin-prospects.html
+++ b/server/public/admin-prospects.html
@@ -831,9 +831,6 @@
             <label>Owner</label>
             <select id="filterOwner" onchange="applyFilters()">
               <option value="">All</option>
-              <option value="Brian">Brian</option>
-              <option value="Randy">Randy</option>
-              <option value="Matt">Matt</option>
             </select>
           </div>
           <div class="filter-group">
@@ -919,9 +916,6 @@
             <label>Owner</label>
             <select id="prospectOwner">
               <option value="">Not assigned</option>
-              <option value="Brian">Brian</option>
-              <option value="Randy">Randy</option>
-              <option value="Matt">Matt</option>
             </select>
           </div>
         </div>
@@ -1237,6 +1231,7 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
 
         if (teamRes.ok) {
           teamMembers = await teamRes.json();
+          populateOwnerFilter();
         }
 
         // Check if enrichment and cleanup are configured
@@ -1312,6 +1307,31 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       document.getElementById('count-renewals').textContent = viewCounts.renewals || 0;
       document.getElementById('count-my_accounts').textContent = viewCounts.my_accounts || 0;
       // hot_prospects and low_engagement are calculated client-side, so we don't show counts
+    }
+
+    function populateOwnerFilter() {
+      const filterOwner = document.getElementById('filterOwner');
+      const prospectOwner = document.getElementById('prospectOwner');
+
+      filterOwner.innerHTML = '<option value="">All</option>';
+      prospectOwner.innerHTML = '<option value="">Not assigned</option>';
+
+      teamMembers.forEach(member => {
+        const isMe = currentUser?.id && member.user_id === currentUser.id;
+        const displayName = isMe ? `${member.user_name} (me)` : member.user_name;
+
+        // Filter dropdown uses user_id (matches stakeholder records)
+        const filterOption = document.createElement('option');
+        filterOption.value = member.user_id;
+        filterOption.textContent = displayName;
+        filterOwner.appendChild(filterOption);
+
+        // Prospect owner dropdown uses name (legacy prospect_owner field)
+        const prospectOption = document.createElement('option');
+        prospectOption.value = member.user_name;
+        prospectOption.textContent = displayName;
+        prospectOwner.appendChild(prospectOption);
+      });
     }
 
     async function loadView(view) {
@@ -2735,7 +2755,11 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
         if (accountTypeFilter === 'company' && prospect.is_personal) return false;
         if (accountTypeFilter === 'individual' && !prospect.is_personal) return false;
 
-        if (ownerFilter && prospect.prospect_owner !== ownerFilter) return false;
+        // Filter by owner stakeholder (using user_id)
+        if (ownerFilter) {
+          const ownerStakeholder = prospect.stakeholders?.find(s => s.role === 'owner');
+          if (!ownerStakeholder || ownerStakeholder.user_id !== ownerFilter) return false;
+        }
         if (typeFilter && prospect.company_type !== typeFilter) return false;
 
         // Search filter: match name, email_domain, or any linked domain


### PR DESCRIPTION
## Summary
- Dynamic owner filter dropdown on prospects page with "(me)" indicator for logged-in user
- Dynamic owner dropdowns in all edit modals with "(me)" indicator
- Quick inline follow-up form in org detail "Next Steps" card for fast task creation
- Filter dropdown uses user_id for reliable stakeholder matching
- Edit modals use name for legacy prospect_owner field compatibility

## Changes
- `server/public/admin-prospects.html`: Dynamic owner dropdowns, filter uses stakeholder user_id
- `server/public/admin-org-detail.html`: Dynamic owner dropdowns, quick follow-up inline form

## Test plan
- [ ] Verify owner filter dropdown shows "(me)" next to logged-in user's name
- [ ] Verify filtering by owner works correctly (matches stakeholder records)
- [ ] Verify owner dropdown in edit modals shows "(me)" and saves correctly
- [ ] Verify quick follow-up form creates next step assigned to current user, due tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)