### PR TITLE
Enable Addie chat for all users in navigation

### DIFF
--- a/.changeset/enable-addie-public.md
+++ b/.changeset/enable-addie-public.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Enable Addie chat for all users in main navigation
+
+- Remove admin-only restriction on "Ask Addie" link in nav.js
+- Add membership tier guidance to Addie's system prompt to prevent hallucinating tier names like "silver" or "gold"
+- Addie now always uses find_membership_products tool for current pricing

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -253,7 +253,7 @@
           </div>
           <div class="navbar__items navbar__items--right">
             <div class="navbar__links-desktop">
-              ${user?.isAdmin ? `<a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>` : ''}
+              <a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>
               <a href="${docsUrl}" class="navbar__link">Docs</a>
               <a href="https://github.com/adcontextprotocol/adcp" target="_blank" rel="noopener noreferrer" class="navbar__link">GitHub</a>
             </div>
@@ -290,7 +290,7 @@
           <a href="${aboutUrl}" class="navbar__link ${currentPath === '/about' ? 'active' : ''}">About</a>
           <a href="${membershipUrl}" class="navbar__link navbar__link--indent ${currentPath === '/membership' ? 'active' : ''}">Membership</a>
           <a href="${governanceUrl}" class="navbar__link navbar__link--indent ${currentPath === '/governance' ? 'active' : ''}">Governance</a>
-          ${user?.isAdmin ? `<a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>` : ''}
+          <a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>
           <a href="${docsUrl}" class="navbar__link">Docs</a>
           <a href="https://github.com/adcontextprotocol/adcp" target="_blank" rel="noopener noreferrer" class="navbar__link">GitHub</a>
         </div>

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -188,6 +188,16 @@ This enables automatic enrichment and better deduplication
 - create_payment_link: Generate a Stripe checkout URL for credit card payment
 - send_invoice: Send an invoice via email for companies that need to pay via PO/invoice
 
+**CRITICAL - Membership Tiers:**
+AgenticAdvertising.org membership is based on organization type and size, NOT named tiers. There is NO "silver", "gold", "bronze", "starter", "pro", "enterprise", or similar tier names.
+
+Membership categories are:
+- Company memberships (pricing varies by annual revenue)
+- Individual memberships
+- Discounted memberships for students, academics, and non-profits
+
+ALWAYS use find_membership_products to get current pricing - never quote prices from memory as they may change.
+
 Example flows:
 Admin: "I need to get Boltive set up with membership"
 → Use find_membership_products to find the right product for their size
@@ -227,6 +237,7 @@ When asked "what's the latest news" - interpret as AD TECH news. Search for AdCP
 
 **NEVER invent or assume facts.** If you're unsure about something, use your tools to verify:
 
+- **Membership tiers**: AgenticAdvertising.org does NOT have named tiers like "silver", "gold", "bronze", "starter", "pro", or "enterprise". Memberships are based on organization type and revenue size. ALWAYS use find_membership_products to get current pricing - never quote prices from memory.
 - **Working groups**: ALWAYS use list_working_groups to check what groups exist before mentioning them. Don't invent group names.
 - **Documentation topics**: Use search_docs to verify information about AdCP, protocols, and features before citing them.
 - **Member info**: Only reference information provided in the user's context. Don't assume job titles, companies, or memberships.


### PR DESCRIPTION
## Summary

- Remove admin-only restriction on "Ask Addie" link in nav.js (desktop and mobile views)
- Add membership tier guidance to Addie's system prompt to prevent hallucinating tier names like "silver", "gold", "bronze", etc.
- Direct Addie to always use `find_membership_products` tool for current pricing rather than quoting prices from memory

## Test plan

- [x] Verified "Ask Addie" link appears in navigation for non-admin users
- [x] Verified clicking the link loads the chat page correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)