### PR TITLE
Link email contacts to orgs when domains are added

### DIFF
--- a/.changeset/addie-email-domain-linking.md
+++ b/.changeset/addie-email-domain-linking.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Link email contacts to organizations when domains are added, and show email activities on org detail pages via join

--- a/server/src/routes/webhooks.ts
+++ b/server/src/routes/webhooks.ts
@@ -682,33 +682,9 @@ async function handleProspectEmail(data: ResendInboundPayload['data']): Promise<
     );
   }
 
-  // If primary contact is linked to an org, also store in org_activities
-  if (primaryContact.organizationId) {
-    await pool.query(
-      `INSERT INTO org_activities (
-        organization_id,
-        activity_type,
-        description,
-        logged_by_name,
-        activity_date,
-        metadata
-      ) VALUES ($1, $2, $3, $4, $5, $6)`,
-      [
-        primaryContact.organizationId,
-        'email_inbound',
-        insights,
-        'Addie',
-        new Date(data.created_at),
-        JSON.stringify({
-          ...metadata,
-          message_id: data.message_id,
-          primary_contact_email: primaryContact.email,
-          insight_method: method,
-          tokens_used: tokensUsed,
-        }),
-      ]
-    );
-  }
+  // Note: Email activities are shown on org detail pages via a JOIN query
+  // through email_contacts.organization_id, so we don't need to duplicate
+  // the activity into org_activities here.
 
   return {
     activityId: activityResult.rows[0].id,


### PR DESCRIPTION
## Summary

- When a domain is added to an organization via admin, link all unmapped email contacts with that domain to the org
- Show email activities on org detail pages via a UNION query that joins through `email_contacts.organization_id`
- Remove duplicate write to `org_activities` in email webhook since the UNION query now handles it

This ensures prospect emails from Addie show up on org detail pages automatically:
1. When a new email comes in and the domain is already registered
2. When a domain is added to an org and historical contacts exist

## Test plan

- [x] Typecheck passes
- [x] All tests pass
- [x] Local testing verified:
  - Created unmapped contact with test domain
  - Created email activity for that contact
  - Manually linked contact to org
  - Verified activity shows on org detail page via UNION query

🤖 Generated with [Claude Code](https://claude.com/claude-code)