### PR TITLE
Add get_recent_news tool for Addie to browse curated feeds

### DIFF
--- a/.changeset/addie-news-feeds.md
+++ b/.changeset/addie-news-feeds.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add get_recent_news tool to Addie for browsing curated industry feeds

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -95,6 +95,8 @@ You have access to these tools to help users:
 **Knowledge Search:**
 - search_docs: Search AdCP documentation
 - search_slack: Search community discussions
+- search_resources: Search curated industry articles with summaries and analysis
+- get_recent_news: Get recent ad tech news and articles (use for "what's happening?", "what's new?", industry updates)
 - web_search: Search the web for external information
 
 **Adagents & Agent Testing:**


### PR DESCRIPTION
## Summary
- Adds a new `get_recent_news` tool that allows Addie to answer questions like "What's happening in the news about agentic advertising?"
- Queries the 22+ RSS feeds that are already being fetched and curated by the content curator service
- Returns articles sorted by date with summaries, quality ratings, relevance tags, and "Addie's Take" analysis

## Changes
- Add `RecentNewsResult` interface and `getRecentNews()` database method with input validation
- Add `get_recent_news` tool with `days`, `topic`, `tags`, and `limit` parameters
- Update system prompt to document the new tool (also documented `search_resources` which was missing)
- Add integration tests for the database method

## Test plan
- [x] Typecheck passes
- [x] All existing tests pass
- [x] Tested locally via API - Addie successfully uses `get_recent_news` to answer news questions
- [x] Code review completed and suggestions addressed (input validation at DB layer, test isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)