### PR TITLE
Ignore Slackbot system messages in Addie handlers

### DIFF
--- a/.changeset/hungry-feet-jump.md
+++ b/.changeset/hungry-feet-jump.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ignore Slackbot system messages in Addie handlers (no protocol changes)

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -75,6 +75,12 @@ import {
 } from './services/community-articles.js';
 
 /**
+ * Slack's built-in system bot user ID.
+ * Slackbot sends system notifications (e.g., "added you to #channel") that should be ignored.
+ */
+const SLACKBOT_USER_ID = 'USLACKBOT';
+
+/**
  * Slack attachment type for forwarded messages
  */
 interface SlackAttachment {
@@ -586,6 +592,12 @@ async function handleUserMessage({
   // Skip if not a user message
   if (!userId || !messageText) {
     logger.debug('Addie Bolt: Ignoring message event without user or text');
+    return;
+  }
+
+  // Skip Slackbot system messages (e.g., "added you to #channel")
+  if (userId === SLACKBOT_USER_ID) {
+    logger.debug({ messageText: messageText?.substring(0, 50) }, 'Addie Bolt: Ignoring Slackbot system message');
     return;
   }
 
@@ -1398,6 +1410,13 @@ async function handleDirectMessage(
   }
 
   const userId = event.user;
+
+  // Skip Slackbot system messages (e.g., "added you to #channel")
+  if (userId === SLACKBOT_USER_ID) {
+    logger.debug({ messageText: event.text?.substring(0, 50) }, 'Addie Bolt: Ignoring Slackbot system message in DM');
+    return;
+  }
+
   const channelId = event.channel;
   const threadTs = event.thread_ts || event.ts;
 

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -57,6 +57,12 @@ import type {
   SuggestedPrompt,
 } from './types.js';
 
+/**
+ * Slack's built-in system bot user ID.
+ * Slackbot sends system notifications (e.g., "added you to #channel") that should be ignored.
+ */
+const SLACKBOT_USER_ID = 'USLACKBOT';
+
 let claudeClient: AddieClaudeClient | null = null;
 let addieDb: AddieDatabase | null = null;
 let initialized = false;
@@ -272,6 +278,12 @@ export async function handleAssistantMessage(
 ): Promise<void> {
   if (!initialized || !claudeClient) {
     logger.warn('Addie: Not initialized, ignoring message');
+    return;
+  }
+
+  // Skip Slackbot system messages (e.g., "added you to #channel")
+  if (event.user === SLACKBOT_USER_ID) {
+    logger.debug({ messageText: event.text?.substring(0, 50) }, 'Addie: Ignoring Slackbot system message');
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add filtering to ignore Slackbot system messages (user ID `USLACKBOT`) in Addie's message handlers
- Prevents Addie from responding to Slack notifications like "added you to #channel"
- Extract `SLACKBOT_USER_ID` constant for maintainability

## Changes
- `server/src/addie/bolt-app.ts`: Add filtering in `handleUserMessage()` and `handleDirectMessage()`
- `server/src/addie/handler.ts`: Add filtering in `handleAssistantMessage()`

## Context
Production feedback showed Addie was responding to Slackbot system notifications when being added to channels. Other feedback issues (prospect lookup, payment tier hallucination, GitHub links, working group names) were already addressed via database rules.

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Code review completed
- [ ] Deploy to staging and verify Slackbot messages are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)