### PR TITLE
Make user names clickable in admin users list

### DIFF
--- a/.changeset/clickable-user-name.md
+++ b/.changeset/clickable-user-name.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Make user names clickable in admin users list to open context modal

--- a/server/public/admin-users.html
+++ b/server/public/admin-users.html
@@ -145,6 +145,14 @@
       font-weight: var(--font-medium);
       color: var(--color-text-heading);
     }
+    .user-name-link {
+      color: var(--color-brand);
+      text-decoration: none;
+      cursor: pointer;
+    }
+    .user-name-link:hover {
+      text-decoration: underline;
+    }
     .user-email {
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
@@ -1385,10 +1393,15 @@
         const displayEmail = user.email || user.slack_email || '';
         const displayOrg = user.org_name || '';
 
+        // Make name clickable if user has context (reuse contextUserId/contextType from above)
+        const nameHtml = contextUserId
+          ? `<a href="#" class="user-name-link" onclick="showUserContext('${escapeHtml(contextUserId)}', '${contextType}', '${escapeHtml(displayName)}', event); return false;">${escapeHtml(displayName)}</a>`
+          : escapeHtml(displayName);
+
         return `
           <tr>
             <td>
-              <div class="user-name">${escapeHtml(displayName)} ${sourceIcon} ${aaoIcon}</div>
+              <div class="user-name">${nameHtml} ${sourceIcon} ${aaoIcon}</div>
               <div class="user-email">${escapeHtml(displayEmail)}</div>
             </td>
             <td>


### PR DESCRIPTION
## Summary
- User names in the admin users list are now clickable links that open the context modal
- Previously admins had to click the "View" button on the right side of each row
- This is a small UX improvement for faster navigation

## Test plan
- [ ] Navigate to /admin-users.html
- [ ] Verify user names appear as links (brand color, underline on hover)
- [ ] Click a user name and verify the context modal opens
- [ ] Verify the "View" button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)