### PR TITLE
Fix engagement scores showing as 0 for all users

### DIFF
--- a/.changeset/engagement-scoring-job.md
+++ b/.changeset/engagement-scoring-job.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Add scheduled job to compute user engagement scores
+
+User engagement scores were always showing as 0 because the scoring functions existed in the database but were never called. Added a periodic job that runs hourly to update stale user and organization engagement scores.

--- a/server/src/addie/jobs/engagement-scoring.ts
+++ b/server/src/addie/jobs/engagement-scoring.ts
@@ -1,0 +1,76 @@
+/**
+ * Engagement Scoring Job
+ *
+ * Periodically updates engagement and excitement scores for users and organizations.
+ * Scores are computed from activity data (Slack, email, conversations, community).
+ *
+ * User scoring (0-100):
+ * - Slack activity: up to 30 points
+ * - Email engagement: up to 20 points
+ * - Addie conversations: up to 25 points
+ * - Community participation: up to 25 points
+ *
+ * Organization scoring (0-100):
+ * - Slack users: up to 20 points
+ * - Team members: up to 15 points
+ * - Working groups: up to 15 points
+ * - Recent activity: up to 15 points
+ * - Email engagement: up to 15 points
+ * - Event interest: up to 10 points
+ * - Interest level: up to 10 points
+ */
+
+import { logger } from '../../logger.js';
+import { query } from '../../db/client.js';
+
+export interface EngagementScoringResult {
+  usersUpdated: number;
+  orgsUpdated: number;
+}
+
+/**
+ * Run the engagement scoring job
+ * Updates stale scores (older than 1 day) for users and organizations
+ */
+export async function runEngagementScoringJob(options: {
+  usersPerBatch?: number;
+  orgsPerBatch?: number;
+} = {}): Promise<EngagementScoringResult> {
+  const { usersPerBatch = 100, orgsPerBatch = 100 } = options;
+
+  logger.info({ usersPerBatch, orgsPerBatch }, 'Running engagement scoring job');
+
+  // Update stale user scores
+  const userResult = await query<{ update_stale_user_scores: number }>(
+    `SELECT update_stale_user_scores($1) as update_stale_user_scores`,
+    [usersPerBatch]
+  );
+  const usersUpdated = userResult.rows[0]?.update_stale_user_scores || 0;
+
+  // Update stale org scores
+  const orgResult = await query<{ update_stale_org_engagement_scores: number }>(
+    `SELECT update_stale_org_engagement_scores($1) as update_stale_org_engagement_scores`,
+    [orgsPerBatch]
+  );
+  const orgsUpdated = orgResult.rows[0]?.update_stale_org_engagement_scores || 0;
+
+  logger.info({ usersUpdated, orgsUpdated }, 'Engagement scoring job completed');
+
+  return { usersUpdated, orgsUpdated };
+}
+
+/**
+ * Force update scores for a specific user
+ */
+export async function updateUserScores(workosUserId: string): Promise<void> {
+  await query(`SELECT update_user_scores($1)`, [workosUserId]);
+  logger.debug({ workosUserId }, 'Updated user scores');
+}
+
+/**
+ * Force update scores for a specific organization
+ */
+export async function updateOrgScores(workosOrgId: string): Promise<void> {
+  await query(`SELECT update_org_engagement($1)`, [workosOrgId]);
+  logger.debug({ workosOrgId }, 'Updated org scores');
+}


### PR DESCRIPTION
## Summary
- User engagement scores were always showing as 0 because the database scoring functions existed but were never called from application code
- Added a periodic job that runs on startup and hourly to update stale user and org engagement scores
- Follows the same pattern as `task-reminder.ts` - job logic in separate file, orchestration in http.ts

## Changes
- **New file**: `server/src/addie/jobs/engagement-scoring.ts` - Job that calls database functions to update stale scores
- **Modified**: `server/src/http.ts` - Added scheduled job that runs on startup (after 10s) and hourly

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify tests pass (`npm test`)
- [ ] Deploy and check logs for "Running engagement scoring job" and "Engagement scoring job completed"
- [ ] Verify engagement scores update from 0 after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)