### PR TITLE
Add industry gathering management for Addie

### DIFF
--- a/.changeset/old-geese-dress.md
+++ b/.changeset/old-geese-dress.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add industry gathering management for Addie admin and improve admin form UX.

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -416,11 +416,6 @@
 
           <div class="form-row">
             <div class="form-group">
-              <label>Slug</label>
-              <input type="text" id="slug" required placeholder="e.g., protocol-development" pattern="[a-z0-9-]+">
-              <small>URL path: /working-groups/{slug}</small>
-            </div>
-            <div class="form-group">
               <label>Committee Type</label>
               <select id="committeeType" onchange="updateRegionVisibility()">
                 <option value="working_group">Working Group</option>
@@ -429,6 +424,11 @@
                 <option value="governance">Governance</option>
                 <option value="industry_gathering">Industry Gathering</option>
               </select>
+            </div>
+            <div class="form-group">
+              <label>Slug</label>
+              <input type="text" id="slug" required placeholder="e.g., protocol-development" pattern="[a-z0-9-]+">
+              <small>URL path: /working-groups/{slug}</small>
             </div>
           </div>
 
@@ -1043,7 +1043,7 @@
 
       // Update slug help text based on type
       if (committeeType === 'industry_gathering') {
-        slugHelp.textContent = 'URL path: /working-groups/industry-gatherings/{year}/{name}';
+        slugHelp.textContent = 'URL path: /industry-gatherings/{year}/{name}';
         // Auto-update slug if name is set
         updateGatheringSlug();
       } else {


### PR DESCRIPTION
## Summary

- Add `create_industry_gathering` and `list_industry_gatherings` tools for Addie admin
- Add `createIndustryGathering` and `getIndustryGatherings` database methods
- Fix admin form to show Committee Type before Slug field (better UX)
- Fix URL path preview to show `/industry-gatherings/{year}/{name}` instead of `/working-groups/industry-gatherings/{year}/{name}`

This allows admins to create industry gatherings (temporary committees for conferences like CES, Cannes Lions, etc.) directly through Addie in Slack.

## Test plan

- [x] TypeScript type check passes
- [x] All unit tests pass
- [ ] Manual test: Create an industry gathering via Addie in Slack
- [ ] Manual test: Verify admin form shows correct URL path when Industry Gathering is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)