### PR TITLE
Update @adcp/client to 3.5.2

### DIFF
--- a/.changeset/floppy-apples-live.md
+++ b/.changeset/floppy-apples-live.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update @adcp/client to 3.5.2 to fix schema validation for empty publisher_domains arrays.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "2.5.1",
       "dependencies": {
-        "@adcp/client": "^3.5.0",
+        "@adcp/client": "^3.5.2",
         "@anthropic-ai/sdk": "^0.71.2",
         "@modelcontextprotocol/sdk": "^1.24.3",
         "@mozilla/readability": "^0.6.0",
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-3.5.0.tgz",
-      "integrity": "sha512-pcCUMIztHY3tVlTOecw6rh8vUmKUyZ1VJ0DNDX17LuvqnGhhFvwmoTbUlhvn47pWlSFu5vhK7TBGFVeO0p0drQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-3.5.2.tgz",
+      "integrity": "sha512-xuK78l29o0wY5mR5MdBrqWPGYtQX+f/xf2ja+e0jXcrnIETyHRW4RLKO6DnAOFooxEGIPxhNpOGeqiO/18p1eg==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "verify-version-sync": "node scripts/verify-version-sync.cjs"
   },
   "dependencies": {
-    "@adcp/client": "^3.5.0",
+    "@adcp/client": "^3.5.2",
     "@anthropic-ai/sdk": "^0.71.2",
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@mozilla/readability": "^0.6.0",


### PR DESCRIPTION
## Summary
- Update @adcp/client from 3.5.0 to 3.5.2
- Fixes schema validation error for empty `publisher_domains` arrays in `list_authorized_properties` response

## Test plan
- [x] Verified discovery tests pass with empty publisher_domains array
- [x] All unit tests pass
- [x] Server starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)