### PR TITLE
Fix column name mismatch in getMemberCapabilities query

### DIFF
--- a/.changeset/fix-planner-column-names.md
+++ b/.changeset/fix-planner-column-names.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix column name mismatch in getMemberCapabilities query (messages_sent → message_count, date → activity_date)

--- a/server/src/db/outbound-db.ts
+++ b/server/src/db/outbound-db.ts
@@ -768,9 +768,9 @@ export async function getMemberCapabilities(
           (SELECT last_slack_activity_at FROM slack_user_mappings WHERE workos_user_id = $1),
           (SELECT created_at FROM slack_user_mappings WHERE workos_user_id = $1)
         )) as last_active_days,
-        COALESCE((SELECT SUM(messages_sent) FROM slack_activity_daily
+        COALESCE((SELECT SUM(message_count) FROM slack_activity_daily
                   WHERE slack_user_id = (SELECT slack_user_id FROM slack_user_mappings WHERE workos_user_id = $1)
-                  AND date > NOW() - INTERVAL '30 days'), 0) as slack_messages_30d`,
+                  AND activity_date > NOW() - INTERVAL '30 days'), 0) as slack_messages_30d`,
       [workosUserId]
     ),
 


### PR DESCRIPTION
## Summary
- Fixes database error when loading planner recommendation in admin user context modal
- Query was using incorrect column names from the `slack_activity_daily` table:
  - `messages_sent` → `message_count`
  - `date` → `activity_date`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Verified planner recommendation displays correctly in admin users page (Vibium browser test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)