### PR TITLE
Fix first DM to Addie not getting a response

### DIFF
--- a/.changeset/addie-first-dm-fix.md
+++ b/.changeset/addie-first-dm-fix.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix first DM to Addie not getting a response


### PR DESCRIPTION
## Summary

- Adds middleware workaround for Bolt's Assistant middleware failing on DMs without `thread_ts`
- When a user sends their first DM to Addie, the message may not have `thread_ts` set
- Bolt's `isAssistantMessage()` check passes if `thread_ts` exists in the payload (even if undefined), but then `extractThreadInfo()` throws `AssistantMissingPropertyError`, causing the event to be lost
- The new middleware intercepts these DMs before they reach the Assistant middleware and routes them directly to `handleDirectMessage`

## Test plan

- [ ] Send first DM to Addie in production - verify response is received
- [ ] Send subsequent DMs - verify they continue to work
- [ ] Check logs for diagnostic messages about first DM handling
- [ ] Verify no duplicate processing occurs

## Related

- https://github.com/slackapi/bolt-js/issues/642
- https://github.com/slackapi/bolt-js/issues/963

🤖 Generated with [Claude Code](https://claude.com/claude-code)