### PR TITLE
Fix table name in getMemberCapabilities: email_preferences → user_email_preferences

### DIFF
--- a/.changeset/fix-email-preferences-table.md
+++ b/.changeset/fix-email-preferences-table.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix table name in getMemberCapabilities: email_preferences → user_email_preferences

--- a/server/src/db/outbound-db.ts
+++ b/server/src/db/outbound-db.ts
@@ -776,7 +776,7 @@ export async function getMemberCapabilities(
 
     // Email preferences
     query<{ configured: boolean }>(
-      `SELECT EXISTS(SELECT 1 FROM email_preferences WHERE workos_user_id = $1) as configured`,
+      `SELECT EXISTS(SELECT 1 FROM user_email_preferences WHERE workos_user_id = $1) as configured`,
       [workosUserId]
     ),
 


### PR DESCRIPTION
## Summary
- Fixes another database error preventing the planner recommendation from showing
- Query was using `email_preferences` but the actual table is `user_email_preferences`

## Related
- Follow-up to #596 which fixed `messages_sent` → `message_count`

## Test plan
- [x] Build passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)