### PR TITLE
Add industry gatherings page and external event support

### DIFF
--- a/.changeset/frank-pets-tan.md
+++ b/.changeset/frank-pets-tan.md
@@ -1,0 +1,4 @@
+---
+---
+
+No protocol changes - website improvements only.

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -679,15 +679,18 @@
 
       document.getElementById('eventsList').innerHTML = filtered.map(event => {
         const startDate = new Date(event.start_time);
+        const eventTimezone = event.timezone || 'America/New_York';
         const dateStr = startDate.toLocaleDateString('en-US', {
           weekday: 'short',
           month: 'short',
           day: 'numeric',
-          year: 'numeric'
+          year: 'numeric',
+          timeZone: eventTimezone
         });
         const timeStr = startDate.toLocaleTimeString('en-US', {
           hour: 'numeric',
-          minute: '2-digit'
+          minute: '2-digit',
+          timeZone: eventTimezone
         });
 
         return `

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -87,6 +87,7 @@
     .badge-virtual { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-hybrid { background: var(--color-success-100); color: var(--color-success-700); }
     .badge-type { background: var(--color-gray-100); color: var(--color-gray-700); }
+    .badge-external { background: var(--color-warning-100); color: var(--color-warning-700); }
 
     .event-title {
       font-size: 2rem;
@@ -583,23 +584,27 @@
     function renderEvent(event, sponsors, registrationCount, industryGathering) {
       const startDate = new Date(event.start_time);
       const endDate = event.end_time ? new Date(event.end_time) : null;
+      const eventTimezone = event.timezone || 'America/New_York';
 
       const dateStr = startDate.toLocaleDateString('en-US', {
         weekday: 'long',
         month: 'long',
         day: 'numeric',
-        year: 'numeric'
+        year: 'numeric',
+        timeZone: eventTimezone
       });
 
       const timeStr = startDate.toLocaleTimeString('en-US', {
         hour: 'numeric',
-        minute: '2-digit'
+        minute: '2-digit',
+        timeZone: eventTimezone
       });
 
       const endTimeStr = endDate ? endDate.toLocaleTimeString('en-US', {
         hour: 'numeric',
         minute: '2-digit',
-        timeZoneName: 'short'
+        timeZoneName: 'short',
+        timeZone: eventTimezone
       }) : '';
 
       const formatLabel = {
@@ -631,6 +636,7 @@
             <div class="event-badges">
               <span class="event-badge badge-${event.event_format}">${formatLabel}</span>
               <span class="event-badge badge-type">${typeLabel}</span>
+              ${event.is_external_event ? '<span class="event-badge badge-external">Industry Event</span>' : ''}
             </div>
             <h1 class="event-title">${escapeHtml(event.title)}</h1>
 
@@ -675,13 +681,22 @@
             <div class="event-actions">
               ${isPast ? `
                 <span class="btn btn-outline" style="cursor: default;">Event Has Ended</span>
+              ` : event.external_registration_url ? `
+                <a href="${escapeHtml(event.external_registration_url)}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
+                  Register on Event Site
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 1l7 7-7 7-1.4-1.4L11.2 9H1V7h10.2L6.6 2.4z"/>
+                  </svg>
+                </a>
               ` : event.luma_url ? `
-                <a href="${escapeHtml(event.luma_url)}" class="btn btn-primary" target="_blank" rel="noopener">
+                <a href="${escapeHtml(event.luma_url)}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                   Register Now
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M8 1l7 7-7 7-1.4-1.4L11.2 9H1V7h10.2L6.6 2.4z"/>
                   </svg>
                 </a>
+              ` : event.is_external_event ? `
+                <span class="btn btn-outline" style="cursor: default;">External Event</span>
               ` : `
                 <button class="btn btn-primary" onclick="handleRegister()">
                   Register Now
@@ -723,7 +738,7 @@
               </div>
               <div class="attendee-group-actions">
                 ${industryGathering.slack_channel_url ? `
-                  <a href="${escapeHtml(industryGathering.slack_channel_url)}" class="btn btn-primary" target="_blank" rel="noopener">
+                  <a href="${escapeHtml(industryGathering.slack_channel_url)}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 0.25rem;">
                       <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
                     </svg>
@@ -746,7 +761,7 @@
               ${sponsors.map(sponsor => `
                 <a href="${sponsor.organization_website ? escapeHtml(sponsor.organization_website) : '#'}"
                    class="sponsor-card"
-                   ${sponsor.organization_website ? 'target="_blank" rel="noopener"' : ''}>
+                   ${sponsor.organization_website ? 'target="_blank" rel="noopener noreferrer"' : ''}>
                   ${sponsor.display_logo_url
                     ? `<img src="${escapeHtml(sponsor.display_logo_url)}" alt="${escapeHtml(sponsor.organization_name)}" class="sponsor-logo">`
                     : `<div class="sponsor-logo" style="background: var(--color-gray-200); border-radius: 8px;"></div>`

--- a/server/public/events.html
+++ b/server/public/events.html
@@ -402,16 +402,19 @@
 
       container.innerHTML = events.map(event => {
         const startDate = new Date(event.start_time);
+        const eventTimezone = event.timezone || 'America/New_York';
         const dateStr = startDate.toLocaleDateString('en-US', {
           weekday: 'long',
           month: 'long',
           day: 'numeric',
-          year: 'numeric'
+          year: 'numeric',
+          timeZone: eventTimezone
         });
         const timeStr = startDate.toLocaleTimeString('en-US', {
           hour: 'numeric',
           minute: '2-digit',
-          timeZoneName: 'short'
+          timeZoneName: 'short',
+          timeZone: eventTimezone
         });
 
         const formatLabel = {

--- a/server/public/industry-gatherings.html
+++ b/server/public/industry-gatherings.html
@@ -1,0 +1,623 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Industry Gatherings | AgenticAdvertising.org</title>
+  <meta name="description" content="Connect with AgenticAdvertising.org members at industry conferences and events. Join attendee groups to network before, during, and after major advertising events.">
+  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="canonical" href="https://agenticadvertising.org/industry-gatherings">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://agenticadvertising.org/industry-gatherings">
+  <meta property="og:title" content="Industry Gatherings | AgenticAdvertising.org">
+  <meta property="og:description" content="Connect with AgenticAdvertising.org members at industry conferences and events.">
+  <meta property="og:image" content="https://agenticadvertising.org/AAo-social.png">
+  <meta property="og:site_name" content="AgenticAdvertising.org">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://agenticadvertising.org/industry-gatherings">
+  <meta name="twitter:title" content="Industry Gatherings | AgenticAdvertising.org">
+  <meta name="twitter:description" content="Connect with AgenticAdvertising.org members at industry conferences and events.">
+  <meta name="twitter:image" content="https://agenticadvertising.org/AAo-social.png">
+
+  <link rel="stylesheet" href="/design-system.css">
+  <style>
+    body {
+      background: var(--color-bg-page);
+      padding-top: var(--nav-height);
+    }
+
+    .header {
+      background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-hover) 100%);
+      color: white;
+      padding: var(--space-12) 0;
+      text-align: center;
+    }
+
+    .header h1 {
+      font-size: var(--text-4xl);
+      margin-bottom: var(--space-2);
+    }
+
+    .header .subtitle {
+      font-size: var(--text-lg);
+      color: rgba(255, 255, 255, 0.9);
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    .container {
+      max-width: var(--container-xl);
+      margin: 0 auto;
+      padding: var(--space-8) var(--space-4);
+    }
+
+    /* Section Headers */
+    .section-header {
+      margin-bottom: var(--space-6);
+    }
+
+    .section-header h2 {
+      font-size: var(--text-2xl);
+      color: var(--color-text-heading);
+      margin-bottom: var(--space-2);
+    }
+
+    .section-header p {
+      font-size: var(--text-base);
+      color: var(--color-text-muted);
+    }
+
+    /* Gatherings Grid */
+    .gatherings-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+      gap: var(--space-6);
+    }
+
+    .gathering-card {
+      background: var(--color-bg-card);
+      border-radius: var(--card-radius);
+      overflow: hidden;
+      box-shadow: var(--shadow-sm);
+      transition: var(--transition-all);
+      border: var(--border-1) solid var(--color-border);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .gathering-card:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-lg);
+      border-color: var(--color-brand);
+    }
+
+    .gathering-event-banner {
+      background: linear-gradient(135deg, var(--color-primary-500), var(--color-primary-700));
+      padding: var(--space-4);
+      display: flex;
+      align-items: center;
+      gap: var(--space-4);
+      min-height: 100px;
+    }
+
+    .gathering-event-banner img {
+      width: 80px;
+      height: 80px;
+      object-fit: cover;
+      border-radius: var(--radius-md);
+      background: white;
+    }
+
+    .gathering-event-banner .placeholder-icon {
+      width: 80px;
+      height: 80px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(255, 255, 255, 0.2);
+      border-radius: var(--radius-md);
+      color: white;
+      font-size: var(--text-2xl);
+    }
+
+    .gathering-event-info {
+      flex: 1;
+      color: white;
+    }
+
+    .gathering-event-date {
+      font-size: var(--text-sm);
+      opacity: 0.9;
+      margin-bottom: var(--space-1);
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+    }
+
+    .gathering-event-title {
+      font-size: var(--text-lg);
+      font-weight: var(--font-semibold);
+      margin-bottom: var(--space-1);
+    }
+
+    .gathering-event-location {
+      font-size: var(--text-sm);
+      opacity: 0.85;
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+    }
+
+    .gathering-content {
+      padding: var(--space-6);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .gathering-group-title {
+      font-size: var(--text-base);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-heading);
+      margin-bottom: var(--space-2);
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+
+    .gathering-group-title svg {
+      width: 20px;
+      height: 20px;
+      color: var(--color-brand);
+    }
+
+    .gathering-description {
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+      line-height: var(--leading-relaxed);
+      margin-bottom: var(--space-4);
+      flex: 1;
+    }
+
+    .gathering-stats {
+      display: flex;
+      align-items: center;
+      gap: var(--space-4);
+      margin-bottom: var(--space-4);
+    }
+
+    .gathering-stat {
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+      font-size: var(--text-sm);
+      color: var(--color-text-secondary);
+    }
+
+    .gathering-stat svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .gathering-actions {
+      display: flex;
+      gap: var(--space-3);
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-2) var(--space-4);
+      border-radius: var(--radius-lg);
+      font-size: var(--text-sm);
+      font-weight: var(--font-medium);
+      text-decoration: none;
+      transition: var(--transition-all);
+      cursor: pointer;
+      border: none;
+    }
+
+    .btn svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .btn-primary {
+      background: var(--color-brand);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background: var(--color-brand-hover);
+    }
+
+    .btn-outline {
+      background: transparent;
+      color: var(--color-brand);
+      border: var(--border-1) solid var(--color-brand);
+    }
+
+    .btn-outline:hover {
+      background: var(--color-primary-50);
+    }
+
+    .btn-slack {
+      background: #4A154B;
+      color: white;
+    }
+
+    .btn-slack:hover {
+      background: #611f69;
+    }
+
+    /* Loading & Empty States */
+    .loading-state,
+    .empty-state {
+      text-align: center;
+      padding: var(--space-16);
+      color: var(--color-text-muted);
+    }
+
+    .empty-state h3 {
+      color: var(--color-text-heading);
+      margin-bottom: var(--space-2);
+    }
+
+    /* Sections */
+    .gatherings-section {
+      margin-bottom: var(--space-12);
+    }
+
+    .gatherings-section:last-child {
+      margin-bottom: 0;
+    }
+
+    /* Past Events Badge */
+    .past-badge {
+      font-size: var(--text-xs);
+      padding: var(--space-1) var(--space-2);
+      background: var(--color-gray-200);
+      color: var(--color-gray-700);
+      border-radius: var(--radius-md);
+      margin-left: var(--space-2);
+    }
+
+    /* Join CTA */
+    .join-cta {
+      background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-hover) 100%);
+      border-radius: var(--card-radius);
+      padding: var(--space-8);
+      text-align: center;
+      margin-top: var(--space-8);
+      color: white;
+    }
+
+    .join-cta h2 {
+      font-size: var(--text-2xl);
+      margin-bottom: var(--space-2);
+    }
+
+    .join-cta p {
+      font-size: var(--text-lg);
+      opacity: 0.9;
+      margin-bottom: var(--space-6);
+    }
+
+    .join-cta-btn {
+      display: inline-block;
+      padding: var(--space-3) var(--space-8);
+      background: white;
+      color: var(--color-brand);
+      text-decoration: none;
+      border-radius: var(--radius-lg);
+      font-weight: var(--font-semibold);
+      transition: var(--transition-all);
+    }
+
+    .join-cta-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-lg);
+    }
+
+    @media (max-width: 768px) {
+      .gatherings-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .gathering-event-banner {
+        flex-direction: column;
+        text-align: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <div id="adcp-nav"></div>
+  <script src="/nav.js"></script>
+
+  <!-- Header -->
+  <div class="header">
+    <h1>Industry Gatherings</h1>
+    <p class="subtitle">Connect with AgenticAdvertising.org members at industry conferences and events</p>
+  </div>
+
+  <div class="container">
+    <!-- Loading State -->
+    <div id="loading" class="loading-state">
+      Loading industry gatherings...
+    </div>
+
+    <!-- Empty State -->
+    <div id="empty-state" class="empty-state" style="display: none;">
+      <h3>No Industry Gatherings Yet</h3>
+      <p>Check back soon for upcoming events where you can connect with AAO members!</p>
+      <a href="/events" class="btn btn-primary" style="margin-top: var(--space-4);">View All Events</a>
+    </div>
+
+    <!-- Upcoming Gatherings Section -->
+    <section id="upcoming-section" class="gatherings-section" style="display: none;">
+      <div class="section-header">
+        <h2>Upcoming Gatherings</h2>
+        <p>Join attendee groups for upcoming industry events to network with AAO members before, during, and after.</p>
+      </div>
+      <div id="upcoming-grid" class="gatherings-grid"></div>
+    </section>
+
+    <!-- Past Gatherings Section -->
+    <section id="past-section" class="gatherings-section" style="display: none;">
+      <div class="section-header">
+        <h2>Past Gatherings</h2>
+        <p>Archives of previous industry event attendee groups.</p>
+      </div>
+      <div id="past-grid" class="gatherings-grid"></div>
+    </section>
+
+    <!-- Join CTA (for non-members) -->
+    <div id="join-cta" class="join-cta" style="display: none;">
+      <h2>Want to Join Our Community?</h2>
+      <p>Become an AAO member to connect with peers at industry events and access exclusive Slack channels.</p>
+      <a href="/membership" class="join-cta-btn">Learn About Membership</a>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="footer footer--centered">
+    <div class="footer-links">
+      <a href="/">Home</a>
+      <a href="/events">Events</a>
+      <a href="/committees">Committees</a>
+      <a href="/members">Members</a>
+    </div>
+    <div class="footer-copyright">
+      &copy; 2025 AgenticAdvertising.org
+    </div>
+  </footer>
+
+  <script>
+    let currentUser = null;
+
+    async function init() {
+      await checkAuth();
+      await loadGatherings();
+    }
+
+    async function checkAuth() {
+      try {
+        const response = await fetch('/api/config', { credentials: 'include' });
+        if (response.ok) {
+          const config = await response.json();
+          currentUser = config.user || null;
+        }
+      } catch (err) {
+        console.debug('Auth check failed:', err);
+      }
+    }
+
+    async function loadGatherings() {
+      const loadingEl = document.getElementById('loading');
+      const emptyEl = document.getElementById('empty-state');
+      const upcomingSection = document.getElementById('upcoming-section');
+      const pastSection = document.getElementById('past-section');
+      const upcomingGrid = document.getElementById('upcoming-grid');
+      const pastGrid = document.getElementById('past-grid');
+      const joinCtaEl = document.getElementById('join-cta');
+
+      try {
+        const response = await fetch('/api/working-groups/industry-gatherings');
+        if (!response.ok) throw new Error('Failed to load gatherings');
+
+        const data = await response.json();
+        const gatherings = data.industry_gatherings || [];
+
+        loadingEl.style.display = 'none';
+
+        if (gatherings.length === 0) {
+          emptyEl.style.display = 'block';
+          return;
+        }
+
+        // Split into upcoming and past based on event end date
+        const now = new Date();
+        const upcoming = [];
+        const past = [];
+
+        for (const g of gatherings) {
+          const endDate = g.event_end_date ? new Date(g.event_end_date) :
+                          g.linked_event?.end_time ? new Date(g.linked_event.end_time) :
+                          g.event_start_date ? new Date(g.event_start_date) : null;
+
+          if (!endDate || endDate >= now) {
+            upcoming.push(g);
+          } else {
+            past.push(g);
+          }
+        }
+
+        // Sort upcoming by start date ascending
+        upcoming.sort((a, b) => {
+          const aDate = a.event_start_date || a.linked_event?.start_time || '';
+          const bDate = b.event_start_date || b.linked_event?.start_time || '';
+          return new Date(aDate) - new Date(bDate);
+        });
+
+        // Sort past by end date descending
+        past.sort((a, b) => {
+          const aDate = a.event_end_date || a.linked_event?.end_time || a.event_start_date || '';
+          const bDate = b.event_end_date || b.linked_event?.end_time || b.event_start_date || '';
+          return new Date(bDate) - new Date(aDate);
+        });
+
+        if (upcoming.length > 0) {
+          upcomingSection.style.display = 'block';
+          upcomingGrid.innerHTML = upcoming.map(g => renderGatheringCard(g, false)).join('');
+        }
+
+        if (past.length > 0) {
+          pastSection.style.display = 'block';
+          pastGrid.innerHTML = past.map(g => renderGatheringCard(g, true)).join('');
+        }
+
+        if (!currentUser) {
+          joinCtaEl.style.display = 'block';
+        }
+
+      } catch (error) {
+        console.error('Error loading gatherings:', error);
+        loadingEl.innerHTML = '<p style="color: var(--color-error-600);">Failed to load gatherings. Please refresh the page.</p>';
+      }
+    }
+
+    function renderGatheringCard(gathering, isPast) {
+      const event = gathering.linked_event;
+
+      // Format date - use event timezone if available
+      const startDate = gathering.event_start_date || event?.start_time;
+      const eventTimezone = event?.timezone || 'America/New_York';
+      const dateStr = startDate ? formatEventDate(new Date(startDate), eventTimezone) : 'Date TBD';
+
+      // Location
+      const location = gathering.event_location ||
+        (event?.venue_city ? `${event.venue_city}${event.venue_state ? ', ' + event.venue_state : ''}` : '') ||
+        'Location TBD';
+
+      // Event title
+      const eventTitle = event?.title || gathering.name.replace(' Attendees', '');
+
+      // Image
+      const imageUrl = gathering.logo_url || event?.featured_image_url;
+
+      // Detail page URL - use event slug if available, otherwise working group slug
+      const detailUrl = event?.slug ? `/events/${escapeHtml(event.slug)}` : `/working-groups/${escapeHtml(gathering.slug)}`;
+
+      return `
+        <article class="gathering-card">
+          <div class="gathering-event-banner">
+            ${imageUrl
+              ? `<img src="${escapeHtml(imageUrl)}" alt="${escapeHtml(eventTitle)}">`
+              : `<div class="placeholder-icon">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                  </svg>
+                </div>`
+            }
+            <div class="gathering-event-info">
+              <div class="gathering-event-date">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                  <line x1="16" y1="2" x2="16" y2="6"></line>
+                  <line x1="8" y1="2" x2="8" y2="6"></line>
+                  <line x1="3" y1="10" x2="21" y2="10"></line>
+                </svg>
+                ${dateStr}
+                ${isPast ? '<span class="past-badge">Past</span>' : ''}
+              </div>
+              <div class="gathering-event-title">${escapeHtml(eventTitle)}</div>
+              <div class="gathering-event-location">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
+                  <circle cx="12" cy="10" r="3"></circle>
+                </svg>
+                ${escapeHtml(location)}
+              </div>
+            </div>
+          </div>
+
+          <div class="gathering-content">
+            <div class="gathering-group-title">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                <circle cx="9" cy="7" r="4"></circle>
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+              </svg>
+              AAO Attendee Group
+            </div>
+
+            <p class="gathering-description">
+              ${escapeHtml(gathering.description || `Connect with AgenticAdvertising.org members attending ${eventTitle}.`)}
+            </p>
+
+            <div class="gathering-stats">
+              <span class="gathering-stat">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="9" cy="7" r="4"></circle>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>
+                ${gathering.member_count || 0} member${gathering.member_count !== 1 ? 's' : ''}
+              </span>
+            </div>
+
+            <div class="gathering-actions">
+              ${gathering.slack_channel_url
+                ? `<a href="${escapeHtml(gathering.slack_channel_url)}" target="_blank" rel="noopener noreferrer" class="btn btn-slack">
+                    <svg viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
+                    </svg>
+                    Join Slack Channel
+                  </a>`
+                : ''
+              }
+              <a href="${detailUrl}" class="btn btn-outline">
+                View Details
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M9 18l6-6-6-6"/>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </article>
+      `;
+    }
+
+    function formatEventDate(date, timezone = 'America/New_York') {
+      return date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: timezone
+      });
+    }
+
+    function escapeHtml(str) {
+      if (!str) return '';
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -187,8 +187,8 @@
 
     // Build Events dropdown
     const eventsUrl = isLocal ? '/events' : `${aaoBaseUrl}/events`;
-    const industryGatheringsUrl = isLocal ? '/committees?type=industry_gathering' : `${aaoBaseUrl}/committees?type=industry_gathering`;
-    const isEventsActive = currentPath.startsWith('/events');
+    const industryGatheringsUrl = isLocal ? '/industry-gatherings' : `${aaoBaseUrl}/industry-gatherings`;
+    const isEventsActive = currentPath.startsWith('/events') || currentPath === '/industry-gatherings';
     const eventsDropdown = membershipEnabled
       ? `<div class="navbar__dropdown-wrapper">
           <button class="navbar__link navbar__dropdown-trigger ${isEventsActive ? 'active' : ''}">
@@ -199,7 +199,7 @@
           </button>
           <div class="navbar__dropdown navbar__dropdown--nav">
             <a href="${eventsUrl}" class="navbar__dropdown-item ${currentPath === '/events' ? 'active' : ''}">All Events</a>
-            <a href="${industryGatheringsUrl}" class="navbar__dropdown-item">Industry Gatherings</a>
+            <a href="${industryGatheringsUrl}" class="navbar__dropdown-item ${currentPath === '/industry-gatherings' ? 'active' : ''}">Industry Gatherings</a>
           </div>
         </div>`
       : '';
@@ -297,7 +297,7 @@
           <a href="${propertiesUrl}" class="navbar__link navbar__link--indent ${currentPath === '/properties' ? 'active' : ''}">Properties</a>
           ${membershipEnabled ? `<span class="navbar__link navbar__link--header">Events</span>` : ''}
           ${membershipEnabled ? `<a href="${eventsUrl}" class="navbar__link navbar__link--indent ${currentPath === '/events' ? 'active' : ''}">All Events</a>` : ''}
-          ${membershipEnabled ? `<a href="${industryGatheringsUrl}" class="navbar__link navbar__link--indent">Industry Gatherings</a>` : ''}
+          ${membershipEnabled ? `<a href="${industryGatheringsUrl}" class="navbar__link navbar__link--indent ${currentPath === '/industry-gatherings' ? 'active' : ''}">Industry Gatherings</a>` : ''}
           ${membershipEnabled ? `<span class="navbar__link navbar__link--header">The Latest</span>` : ''}
           ${membershipEnabled ? `<a href="${latestBaseUrl}/research" class="navbar__link navbar__link--indent ${currentPath === '/latest/research' ? 'active' : ''}">Research & Ideas</a>` : ''}
           ${membershipEnabled ? `<a href="${latestBaseUrl}/industry-news" class="navbar__link navbar__link--indent ${currentPath === '/latest/industry-news' ? 'active' : ''}">Industry News</a>` : ''}

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1273,9 +1273,10 @@
 
     function renderEventCard(event, isPast) {
       const eventDate = new Date(event.start_time);
-      const month = eventDate.toLocaleDateString('en-US', { month: 'short' });
-      const day = eventDate.getDate();
-      const time = eventDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+      const eventTimezone = event.timezone || 'America/New_York';
+      const month = eventDate.toLocaleDateString('en-US', { month: 'short', timeZone: eventTimezone });
+      const day = eventDate.toLocaleDateString('en-US', { day: 'numeric', timeZone: eventTimezone });
+      const time = eventDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: eventTimezone });
 
       return `
         <a href="/events/${escapeHtml(event.slug)}" class="event-card">

--- a/server/public/working-groups/manage.html
+++ b/server/public/working-groups/manage.html
@@ -669,6 +669,24 @@
           </div>
         </div>
 
+        <div class="form-group" style="border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-4); background: var(--color-bg-subtle);">
+          <label style="display: flex; align-items: center; gap: var(--space-2); cursor: pointer;">
+            <input type="checkbox" id="eventIsExternal" onchange="updateExternalEventFields()">
+            <span>This is a third-party event (CES, Cannes Lions, etc.)</span>
+          </label>
+          <small style="display: block; margin-top: var(--space-2); color: var(--color-text-muted);">
+            Check this if the event is hosted elsewhere and you just want to list it for AAO members.
+          </small>
+        </div>
+
+        <div id="externalEventFields" style="display: none;">
+          <div class="form-group">
+            <label>External Registration URL</label>
+            <input type="url" id="eventExternalUrl" placeholder="https://ces.tech/registration">
+            <small>Link to the event's official registration page</small>
+          </div>
+        </div>
+
         <div class="form-row">
           <div class="form-group">
             <label>URL Slug *</label>
@@ -1186,11 +1204,12 @@
       listDiv.innerHTML = events.map(event => {
         const statusBadge = `<span class="badge badge-${event.status}">${event.status}</span>`;
         const formatBadge = event.event_format ? `<span class="badge badge-${event.event_format}">${event.event_format.replace('_', ' ')}</span>` : '';
+        const eventTimezone = event.timezone || 'America/New_York';
         const date = event.start_time
-          ? new Date(event.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+          ? new Date(event.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: eventTimezone })
           : '';
         const time = event.start_time
-          ? new Date(event.start_time).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+          ? new Date(event.start_time).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: eventTimezone })
           : '';
 
         return `
@@ -1227,6 +1246,7 @@
       }
 
       updateEventFormatFields();
+      updateExternalEventFields();
       document.getElementById('eventModal').style.display = 'flex';
     }
 
@@ -1254,6 +1274,8 @@
         document.getElementById('eventVenueState').value = editingEvent.venue_state || '';
         document.getElementById('eventVirtualUrl').value = editingEvent.virtual_url || '';
         document.getElementById('eventMaxAttendees').value = editingEvent.max_attendees || '';
+        document.getElementById('eventIsExternal').checked = editingEvent.is_external_event || false;
+        document.getElementById('eventExternalUrl').value = editingEvent.external_registration_url || '';
 
         // Format datetime-local values
         if (editingEvent.start_time) {
@@ -1264,6 +1286,7 @@
         }
 
         updateEventFormatFields();
+        updateExternalEventFields();
         document.getElementById('eventModal').style.display = 'flex';
       } catch (error) {
         console.error('Error loading event:', error);
@@ -1298,10 +1321,17 @@
       }
     }
 
+    function updateExternalEventFields() {
+      const isExternal = document.getElementById('eventIsExternal').checked;
+      const externalFields = document.getElementById('externalEventFields');
+      externalFields.style.display = isExternal ? 'block' : 'none';
+    }
+
     async function saveEvent(e) {
       e.preventDefault();
 
       const id = document.getElementById('eventId').value;
+      const isExternal = document.getElementById('eventIsExternal').checked;
       const data = {
         title: document.getElementById('eventTitle').value.trim(),
         description: document.getElementById('eventDescription').value.trim() || null,
@@ -1317,6 +1347,8 @@
         venue_state: document.getElementById('eventVenueState').value.trim() || null,
         virtual_meeting_url: document.getElementById('eventVirtualUrl').value.trim() || null,
         max_attendees: document.getElementById('eventMaxAttendees').value ? parseInt(document.getElementById('eventMaxAttendees').value) : null,
+        is_external_event: isExternal,
+        external_registration_url: isExternal ? document.getElementById('eventExternalUrl').value.trim() || null : null,
       };
 
       const saveBtn = document.getElementById('saveEventBtn');

--- a/server/src/db/events-db.ts
+++ b/server/src/db/events-db.ts
@@ -42,6 +42,7 @@ export class EventsDatabase {
         venue_lat, venue_lng,
         virtual_url, virtual_platform,
         luma_event_id, luma_url,
+        external_registration_url, is_external_event,
         featured_image_url,
         sponsorship_enabled, sponsorship_tiers, stripe_product_id,
         status, max_attendees,
@@ -49,7 +50,7 @@ export class EventsDatabase {
       ) VALUES (
         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
         $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-        $21, $22, $23, $24, $25, $26, $27, $28, $29
+        $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31
       )
       RETURNING *`,
       [
@@ -73,6 +74,8 @@ export class EventsDatabase {
         input.virtual_platform || null,
         input.luma_event_id || null,
         input.luma_url || null,
+        input.external_registration_url || null,
+        input.is_external_event ?? false,
         input.featured_image_url || null,
         input.sponsorship_enabled ?? false,
         JSON.stringify(input.sponsorship_tiers || []),
@@ -136,6 +139,8 @@ export class EventsDatabase {
       virtual_platform: 'virtual_platform',
       luma_event_id: 'luma_event_id',
       luma_url: 'luma_url',
+      external_registration_url: 'external_registration_url',
+      is_external_event: 'is_external_event',
       featured_image_url: 'featured_image_url',
       sponsorship_enabled: 'sponsorship_enabled',
       sponsorship_tiers: 'sponsorship_tiers',

--- a/server/src/db/migrations/133_external_event_registration.sql
+++ b/server/src/db/migrations/133_external_event_registration.sql
@@ -1,0 +1,12 @@
+-- Migration: 133_external_event_registration.sql
+-- Add support for external event registration URLs (for third-party events like CES, Cannes Lions, etc.)
+
+-- Add external registration URL field to events
+ALTER TABLE events ADD COLUMN IF NOT EXISTS external_registration_url TEXT;
+
+-- Add a flag to indicate this is an external/third-party event (not managed by AAO)
+ALTER TABLE events ADD COLUMN IF NOT EXISTS is_external_event BOOLEAN DEFAULT FALSE;
+
+-- Comments
+COMMENT ON COLUMN events.external_registration_url IS 'External registration URL for third-party events (CES, Cannes Lions, etc.)';
+COMMENT ON COLUMN events.is_external_event IS 'True if this is a third-party event not managed by AAO';

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1516,6 +1516,11 @@ export class HTTPServer {
       res.redirect(301, '/committees?type=chapter');
     });
 
+    // Industry Gatherings page (events with attendee groups)
+    this.app.get("/industry-gatherings", async (req, res) => {
+      await this.serveHtmlWithConfig(req, res, 'industry-gatherings.html');
+    });
+
     this.app.get("/working-groups/:slug", async (req, res) => {
       await this.serveHtmlWithConfig(req, res, 'working-groups/detail.html');
     });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -576,6 +576,8 @@ export interface Event {
   virtual_platform?: string;
   luma_event_id?: string;
   luma_url?: string;
+  external_registration_url?: string;
+  is_external_event?: boolean;
   featured_image_url?: string;
   sponsorship_enabled: boolean;
   sponsorship_tiers: SponsorshipTier[];
@@ -611,6 +613,8 @@ export interface CreateEventInput {
   virtual_platform?: string;
   luma_event_id?: string;
   luma_url?: string;
+  external_registration_url?: string;
+  is_external_event?: boolean;
   featured_image_url?: string;
   sponsorship_enabled?: boolean;
   sponsorship_tiers?: SponsorshipTier[];
@@ -642,6 +646,8 @@ export interface UpdateEventInput {
   virtual_platform?: string;
   luma_event_id?: string;
   luma_url?: string;
+  external_registration_url?: string;
+  is_external_event?: boolean;
   featured_image_url?: string;
   sponsorship_enabled?: boolean;
   sponsorship_tiers?: SponsorshipTier[];


### PR DESCRIPTION
## Summary
- Create dedicated `/industry-gatherings` page with API endpoint for browsing industry event attendee groups
- Update nav to link to `/industry-gatherings` instead of `/committees?type=industry_gathering` filter
- Fix event timezone display - use event's timezone instead of viewer's local timezone
- Add external event support for third-party events (CES, Cannes Lions, etc.)

## Changes

### Industry Gatherings Page
- New `/industry-gatherings` route and HTML page
- New `/api/working-groups/industry-gatherings` endpoint that returns gatherings with linked event info
- Separates upcoming vs past gatherings
- Shows event banner with date, location, and image
- Links to Slack channels and event detail pages

### Event Timezone Fix
- All event datetime displays now use the event's stored timezone instead of the viewer's local timezone
- Affects: events.html, event-detail.html, admin-events.html, working-groups/manage.html, working-groups/detail.html, industry-gatherings.html

### External Event Support
- New `external_registration_url` and `is_external_event` fields in events table
- Committee admins can mark events as third-party when creating/editing
- Event detail page shows "Register on Event Site" button for external events
- "Industry Event" badge displayed for external events

## Test plan
- [ ] Navigate to `/industry-gatherings` - page should load with any existing industry gatherings
- [ ] Click Events → Industry Gatherings in nav - should link to new page (not committees)
- [ ] Create an event with PT timezone, view on events page - should display in PT not local timezone
- [ ] Create an external event via working group manage page - should show external registration URL field when checkbox is checked
- [ ] View external event detail page - should show "Register on Event Site" button and "Industry Event" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)