### PR TITLE
Add explicit type to error.json details property

### DIFF
--- a/.changeset/error-details-type.md
+++ b/.changeset/error-details-type.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Add explicit type definition to error.json details property
+
+The `details` property in core/error.json now explicitly declares `"type": "object"` and `"additionalProperties": true`, consistent with other error details definitions in the codebase. This addresses issue #343 where the data type was unspecified.

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -27,7 +27,9 @@
       "minimum": 0
     },
     "details": {
-      "description": "Additional task-specific error details"
+      "type": "object",
+      "description": "Additional task-specific error details",
+      "additionalProperties": true
     }
   },
   "required": ["code", "message"],


### PR DESCRIPTION
## Summary
- Added explicit `"type": "object"` and `"additionalProperties": true` to the `details` property in error.json
- Makes the schema explicit about accepted types, consistent with other error details definitions in the codebase
- Fixes #343

## Test plan
- All existing tests pass
- Schema validation tests confirm the change is valid