### PR TITLE
Fix Discover Events nudge when no events exist

### DIFF
--- a/.changeset/fix-empty-events-nudge.md
+++ b/.changeset/fix-empty-events-nudge.md
@@ -1,0 +1,5 @@
+---
+---
+
+Skip Discover Events nudge when no upcoming events exist or user is registered for all events
+


### PR DESCRIPTION
## Summary
- Skip "Discover Events" nudge when no upcoming events exist
- Skip nudge when user is already registered for all upcoming events

## Problem
The "Discover Events" nudge was being recommended to users even when:
1. There are no upcoming events in the database at all
2. The user is already registered for all available events

This led to confusing outreach like suggesting Christina discover events when there are none to discover.

## Solution
Added `filterDynamicEligibility()` to the outbound planner that checks:
1. If there are any upcoming events at all (via `eventsDb.getUpcomingEvents()`)
2. If the user is registered for all upcoming events (via `eventsDb.getUserRegistrations()`)

If either condition is true, the "Discover Events" goal is filtered out before goal selection.

## Test plan
- [ ] Verify no type errors (`npm run typecheck`)
- [ ] Verify all tests pass (`npm test`)
- [ ] Manual test: User with no upcoming events should not see "Discover Events" nudge
- [ ] Manual test: User registered for all events should not see "Discover Events" nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)