### PR TITLE
Add unified account lifecycle stage to admin tools

### DIFF
--- a/.changeset/account-lifecycle-stage.md
+++ b/.changeset/account-lifecycle-stage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal tooling: Add unified account lifecycle stage to admin tools


### PR DESCRIPTION
## Summary

- Add `get_account` as the primary tool for looking up any organization
- Introduce `computeLifecycleStage()` function that combines `subscription_status` and `prospect_status` into a unified view
- Mark `lookup_organization` and `find_prospect` as deprecated (still functional for backwards compatibility)

### Lifecycle Stages
```
prospect → contacted → responded → interested → negotiating → member
                                                            ↘ declined
                                                            ↘ churned
```

### Problem Solved
Previously, `find_prospect` would show paying members (like Mediaocean) as "prospect" because it only checked `prospect_status` and ignored `subscription_status`. Now all tools show the correct lifecycle stage.

### Subscription Status Handling
- `active`, `trialing` → **member**
- `canceled`, `past_due`, `unpaid`, `incomplete_expired` → **churned**
- `incomplete` → **negotiating** (started payment but didn't complete)

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Code review completed and suggestions addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)