### PR TITLE
fix: detect untracked files in sync-versioned-docs workflow

### DIFF
--- a/.github/workflows/sync-versioned-docs.yml
+++ b/.github/workflows/sync-versioned-docs.yml
@@ -38,8 +38,9 @@ jobs:
           # Extract docs folder from 2.6.x branch
           git archive origin/2.6.x -- docs | tar -x -C v2.6-rc/
 
-          # Check if there are changes
-          if git diff --quiet v2.6-rc/; then
+          # Check if there are changes (including untracked files)
+          git add v2.6-rc/
+          if git diff --cached --quiet; then
             echo "No changes to sync"
             echo "CHANGES_DETECTED=false" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Problem
The sync workflow was always skipping commits on first run because git diff only detects changes to tracked files. When v2.6-rc/ doesn't exist yet (first sync), the extracted docs are untracked and invisible to git diff.
## Solution
Stage files before checking for changes:
```
- if git diff --quiet v2.6-rc/; then
+ git add v2.6-rc/
+ if git diff --cached --quiet; then
```