### PR TITLE
fix: improve industry news page sorting, deduplication, and HTML entity parsing

### DIFF
--- a/.changeset/soft-rooms-spend.md
+++ b/.changeset/soft-rooms-spend.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal improvements to industry news page: HTML entity parsing, article sorting by publication date, and URL deduplication.

--- a/server/src/addie/services/content-curator.ts
+++ b/server/src/addie/services/content-curator.ts
@@ -475,10 +475,12 @@ async function createOrUpdateRssKnowledge(
       title, category, content, source_url, fetch_url, source_type,
       fetch_status, last_fetched_at, summary, key_insights, addie_notes,
       relevance_tags, quality_score, mentions_agentic, mentions_adcp,
-      notification_channel_ids, discovery_source, discovery_context, created_by
+      notification_channel_ids, discovery_source, discovery_context, created_by,
+      published_at
     ) VALUES (
       $1, $2, $3, $4, $4, 'rss', 'success', NOW(), $5, $6, $7,
-      $8, $9, $10, $11, $12, 'rss_feed', $13, 'system'
+      $8, $9, $10, $11, $12, 'rss_feed', $13, 'system',
+      $14
     )
     ON CONFLICT (source_url) DO UPDATE SET
       content = EXCLUDED.content,
@@ -492,7 +494,8 @@ async function createOrUpdateRssKnowledge(
       notification_channel_ids = EXCLUDED.notification_channel_ids,
       fetch_status = 'success',
       last_fetched_at = NOW(),
-      updated_at = NOW()`,
+      updated_at = NOW(),
+      published_at = COALESCE(EXCLUDED.published_at, addie_knowledge.published_at)`,
     [
       perspective.title,
       perspective.category || 'Industry News',
@@ -507,6 +510,7 @@ async function createOrUpdateRssKnowledge(
       checkMentionsAdcp(data.content, data.summary || ''),
       data.notification_channel_ids || [],
       JSON.stringify({ perspective_id: perspective.id, feed_id: perspective.feed_id }),
+      perspective.published_at || null,
     ]
   );
 }

--- a/server/src/db/migrations/145_backfill_knowledge_published_at.sql
+++ b/server/src/db/migrations/145_backfill_knowledge_published_at.sql
@@ -1,0 +1,51 @@
+-- Backfill published_at in addie_knowledge from perspectives table
+-- This ensures RSS articles sort by their original publication date
+
+UPDATE addie_knowledge k
+SET published_at = p.published_at
+FROM perspectives p
+WHERE k.source_url = p.external_url
+  AND k.published_at IS NULL
+  AND p.published_at IS NOT NULL;
+
+-- Deduplicate entries that might have been created with different URLs
+-- (e.g., with/without tracking params, www vs non-www) but same content.
+-- We keep the entry with the most recent updated_at (most complete analysis).
+--
+-- Note: This is a one-time cleanup migration. The normalization logic here
+-- approximates the TypeScript normalizeUrl() function. Going forward, URLs
+-- are normalized before storage to prevent duplicates from being created.
+
+WITH normalized AS (
+  SELECT
+    id,
+    source_url,
+    updated_at,
+    -- Normalize: lowercase hostname, remove www, strip query params and trailing slash
+    -- This approximates the TypeScript normalizeUrl() function
+    lower(
+      regexp_replace(
+        regexp_replace(
+          regexp_replace(source_url, '\?.*$', ''),  -- Remove query params
+          '/$', ''                                   -- Remove trailing slash
+        ),
+        '^(https?://)www\.', '\1'                   -- Remove www prefix
+      )
+    ) as normalized_url
+  FROM addie_knowledge
+  WHERE source_url IS NOT NULL
+    AND source_type = 'rss'
+),
+-- For each normalized URL group, find duplicates (keeping the most recently updated)
+duplicates AS (
+  SELECT n1.id
+  FROM normalized n1
+  WHERE EXISTS (
+    SELECT 1 FROM normalized n2
+    WHERE n2.normalized_url = n1.normalized_url
+      AND n2.id != n1.id
+      AND (n2.updated_at > n1.updated_at OR (n2.updated_at = n1.updated_at AND n2.id < n1.id))
+  )
+)
+DELETE FROM addie_knowledge
+WHERE id IN (SELECT id FROM duplicates);


### PR DESCRIPTION
## Summary

- **HTML Entity Parsing**: Added generic numeric HTML entity decoding using `String.fromCodePoint` to properly handle entities like `&#8217;` (curly apostrophe) and `&#128640;` (emoji)
- **Article Sorting**: Populate `published_at` field in `addie_knowledge` from RSS feed data so articles sort by their original publication date (newest first)
- **URL Deduplication**: Normalize article URLs before storage (remove query params, www prefix, trailing slashes) to prevent duplicates across overlapping feeds
- **Migration**: Backfill `published_at` for existing records and clean up existing duplicates (keeping the most recently updated entry)

## Test plan

- [x] TypeScript builds without errors
- [x] All tests pass
- [x] Verified page loads in browser via Docker
- [x] Migration runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)