### PR TITLE
fix: resolve missing column references in admin stats queries

### DIFF
--- a/.changeset/afraid-ends-mate.md
+++ b/.changeset/afraid-ends-mate.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix missing column references in admin stats queries (engagement_reasons, next_step, subscription_status)

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -5051,14 +5051,13 @@ Use add_committee_leader to assign a leader.`;
           o.prospect_status,
           o.interest_level,
           o.company_type,
-          (SELECT array_agg(r) FROM (SELECT unnest(engagement_reasons) ORDER BY 1) AS dt(r)) as engagement_reasons,
           (SELECT MAX(activity_date) FROM org_activities WHERE organization_id = o.workos_organization_id) as last_activity
         FROM organizations o
         JOIN org_stakeholders os ON os.organization_id = o.workos_organization_id
         WHERE os.user_id = $1
           AND os.role = 'owner'
           AND o.is_personal IS NOT TRUE
-          AND (o.stripe_subscription_status IS NULL OR o.stripe_subscription_status != 'active')
+          AND (o.subscription_status IS NULL OR o.subscription_status != 'active')
       `;
 
       if (hotOnly) {
@@ -5090,9 +5089,6 @@ Use add_committee_leader to assign a leader.`;
         if (row.prospect_status) response += ` | Status: ${row.prospect_status}`;
         if (row.interest_level) response += ` | Interest: ${row.interest_level}`;
         response += `\n`;
-        if (row.engagement_reasons?.length > 0) {
-          response += `   Signals: ${row.engagement_reasons.join(', ')}\n`;
-        }
         if (row.last_activity) {
           response += `   Last activity: ${new Date(row.last_activity).toLocaleDateString()}\n`;
         }
@@ -5149,7 +5145,7 @@ Use add_committee_leader to assign a leader.`;
           WHERE os.user_id = $1
             AND os.role = 'owner'
             AND o.is_personal IS NOT TRUE
-            AND (o.stripe_subscription_status IS NULL OR o.stripe_subscription_status != 'active')
+            AND (o.subscription_status IS NULL OR o.subscription_status != 'active')
         )
         SELECT *,
           CASE
@@ -5221,11 +5217,10 @@ Use add_committee_leader to assign a leader.`;
           o.email_domain,
           o.engagement_score,
           o.prospect_status,
-          o.company_type,
-          (SELECT array_agg(r) FROM (SELECT unnest(engagement_reasons) ORDER BY 1) AS dt(r)) as engagement_reasons
+          o.company_type
         FROM organizations o
         WHERE o.is_personal IS NOT TRUE
-          AND (o.stripe_subscription_status IS NULL OR o.stripe_subscription_status != 'active')
+          AND (o.subscription_status IS NULL OR o.subscription_status != 'active')
           AND o.engagement_score >= $1
           AND NOT EXISTS (
             SELECT 1 FROM org_stakeholders os
@@ -5253,9 +5248,6 @@ Use add_committee_leader to assign a leader.`;
         response += `   Score: ${row.engagement_score || 0}`;
         if (row.company_type) response += ` | Type: ${row.company_type}`;
         response += `\n`;
-        if (row.engagement_reasons?.length > 0) {
-          response += `   Signals: ${row.engagement_reasons.join(', ')}\n`;
-        }
         response += `   ID: ${row.org_id}\n`;
         response += `\n`;
       }


### PR DESCRIPTION
## Summary
- Remove `engagement_reasons` column from queries (computed dynamically, not stored)
- Fix `next_step`/`next_step_due_date` references to use `org_activities` table via LATERAL join
- Fix `stripe_subscription_status` to use correct `subscription_status` column

## Root Cause
The production error `column "engagement_reasons" does not exist` in `/api/admin/my-prospects` was caused by queries referencing columns that either:
1. Don't exist (`engagement_reasons` is computed in functions, not stored)
2. Are on a different table (`next_step` fields are on `org_activities`, not `organizations`)
3. Have a different name (`subscription_status` not `stripe_subscription_status`)

## Test plan
- [x] Build passes (`npm run build`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All tests pass (`npm test`)
- [ ] Verify admin dashboard loads on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)