### PR TITLE
feat: display user names in proactive outreach history

### DIFF
--- a/.changeset/activity-user-names.md
+++ b/.changeset/activity-user-names.md
@@ -1,0 +1,4 @@
+---
+---
+
+Display user names instead of Slack IDs in proactive outreach history

--- a/server/public/admin-outreach.html
+++ b/server/public/admin-outreach.html
@@ -663,10 +663,12 @@
 
     function renderHistory() {
       const tbody = document.getElementById('history-body');
-      tbody.innerHTML = history.map(item => `
+      tbody.innerHTML = history.map(item => {
+        const userName = item.slack_display_name || item.slack_real_name || item.slack_user_id;
+        return `
         <tr>
           <td>${formatDate(item.sent_at)}</td>
-          <td>${escapeHtml(item.slack_user_id)}</td>
+          <td>${escapeHtml(userName)}</td>
           <td><span class="badge badge-info">${item.outreach_type}</span></td>
           <td>${item.tone ? `${item.tone} / ${item.approach}` : '—'}</td>
           <td>
@@ -680,7 +682,7 @@
             </span>
           </td>
         </tr>
-      `).join('');
+      `}).join('');
     }
 
     async function loadVariants() {

--- a/server/src/db/insights-db.ts
+++ b/server/src/db/insights-db.ts
@@ -117,6 +117,11 @@ export interface ResponseAnalysis {
   analysisNote: string;
 }
 
+export interface MemberOutreachWithUser extends MemberOutreach {
+  slack_display_name: string | null;
+  slack_real_name: string | null;
+}
+
 // Input types
 export interface CreateInsightTypeInput {
   name: string;
@@ -1295,9 +1300,13 @@ export class InsightsDatabase {
   /**
    * Get recent outreach history for admin dashboard
    */
-  async getRecentOutreach(limit = 50): Promise<MemberOutreach[]> {
-    const result = await query<MemberOutreach>(
-      'SELECT * FROM member_outreach ORDER BY sent_at DESC LIMIT $1',
+  async getRecentOutreach(limit = 50): Promise<MemberOutreachWithUser[]> {
+    const result = await query<MemberOutreachWithUser>(
+      `SELECT mo.*, sm.slack_display_name, sm.slack_real_name
+       FROM member_outreach mo
+       LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = mo.slack_user_id
+       ORDER BY mo.sent_at DESC
+       LIMIT $1`,
       [limit]
     );
     return result.rows;


### PR DESCRIPTION
## Summary
- Display actual user names instead of raw Slack user IDs in the admin outreach history table
- Join `member_outreach` with `slack_user_mappings` to fetch `slack_display_name`/`slack_real_name`
- Falls back to `slack_user_id` if no name is available

## Test plan
- [ ] Load `/admin/outreach` page and verify History tab shows user names
- [ ] Verify users without names still display their Slack ID as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)