### PR TITLE
fix: Addie chat home button now properly shows dashboard

### DIFF
--- a/.changeset/addie-home-nav-fix.md
+++ b/.changeset/addie-home-nav-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Addie chat home button navigation - clicking Home now properly shows the dashboard

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -1511,6 +1511,12 @@
 
       // === Tab Management Functions ===
 
+      // Clear only chat messages from the container (preserves static elements like home/welcome)
+      function clearChatMessages() {
+        const messages = messagesContainer.querySelectorAll('.message');
+        messages.forEach(msg => msg.remove());
+      }
+
       // Debounced thread refresh (avoids excessive API calls when sending multiple messages)
       let loadThreadsTimer = null;
       function scheduleLoadThreads() {
@@ -1681,11 +1687,13 @@
         renderActiveTabs();
 
         // Show home content
-        messagesContainer.innerHTML = '';
+        clearChatMessages();
         if (isAuthenticated) {
           addieHomeContainer.classList.add('visible');
+          welcomeMessage.style.display = 'none';
           loadAddieHome();
         } else {
+          addieHomeContainer.classList.remove('visible');
           welcomeMessage.style.display = 'block';
         }
 
@@ -1767,8 +1775,8 @@
         // Update active tabs UI
         renderActiveTabs();
 
-        // Clear current messages
-        messagesContainer.innerHTML = '';
+        // Clear current messages and hide static content
+        clearChatMessages();
         welcomeMessage.style.display = 'none';
         addieHomeContainer.classList.remove('visible');
 
@@ -1822,13 +1830,15 @@
         currentTabId = 'home'; // New chat starts from home
 
         // Clear messages and show home
-        messagesContainer.innerHTML = '';
+        clearChatMessages();
 
         // Show welcome or Addie Home based on auth
         if (isAuthenticated) {
           addieHomeContainer.classList.add('visible');
+          welcomeMessage.style.display = 'none';
           loadAddieHome();
         } else {
+          addieHomeContainer.classList.remove('visible');
           welcomeMessage.style.display = 'block';
         }
 
@@ -2187,10 +2197,11 @@
 
       // Add message to chat
       function addMessage(content, role, messageId = null) {
-        // Hide welcome message
+        // Hide welcome/home content when showing messages
         if (welcomeMessage) {
           welcomeMessage.style.display = 'none';
         }
+        addieHomeContainer.classList.remove('visible');
 
         const messageDiv = document.createElement('div');
         messageDiv.className = `message message--${role}`;
@@ -2363,10 +2374,11 @@
 
       // Create a streaming message element that can be updated
       function createStreamingMessage() {
-        // Hide welcome message
+        // Hide welcome/home content when showing messages
         if (welcomeMessage) {
           welcomeMessage.style.display = 'none';
         }
+        addieHomeContainer.classList.remove('visible');
 
         const messageDiv = document.createElement('div');
         messageDiv.className = 'message message--assistant';


### PR DESCRIPTION
## Summary

- Fix bug where clicking Home button in Addie chat sidebar cleared the dashboard content
- Add `clearChatMessages()` helper to selectively remove chat messages without destroying static elements
- Ensure home dashboard hides properly when starting a chat

## Root Cause

The code was using `messagesContainer.innerHTML = ''` which destroyed the `addieHomeContainer` element (a child of `messagesContainer`). When trying to show home content, the elements no longer existed.

## Test plan

- [x] Click "Ask Addie" → dashboard shows
- [x] Click "Home" in sidebar → dashboard remains visible
- [x] Send a message → dashboard hides, chat shows
- [x] Click "Home" after chatting → dashboard returns
- [x] Click "New Chat" → dashboard returns
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)