### PR TITLE
fix: reorder migration 151 to delete duplicates before update

### DIFF
--- a/.changeset/fix-migration-151.md
+++ b/.changeset/fix-migration-151.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix migration 151 to delete duplicates before updating Slack IDs to WorkOS IDs


### PR DESCRIPTION
## Summary
- Fix migration 151 that was blocking deployments due to unique constraint violation
- Reorder SQL operations to delete duplicate records before updating Slack IDs to WorkOS IDs

## Problem
Migration 151 (`consolidate_slack_workos_ids.sql`) was failing with:
```
duplicate key value violates unique constraint "idx_wg_membership_unique"
Key (working_group_id, workos_user_id)=(29c61a7a-..., user_01KEF3D9...) already exists.
```

The migration tried to UPDATE Slack IDs to WorkOS IDs before deleting duplicates, causing the unique constraint to fail when both records already existed.

## Solution
Reordered operations to:
1. DELETE Slack-ID-based records where a WorkOS-ID-based record already exists
2. UPDATE remaining Slack IDs to WorkOS IDs (now safe - no duplicates possible)
3. Same pattern for `working_group_leaders` table

## Test plan
- [x] All tests pass
- [x] Migration logic reviewed for data integrity
- [x] Migration runner wraps each migration in a transaction (rollback on failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)