### PR TITLE
fix: resolve Slack/WorkOS leader IDs for chapter event management

### DIFF
--- a/.changeset/david-event-mgmt-fix.md
+++ b/.changeset/david-event-mgmt-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix chapter leader event management permission checks for users added via Slack

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -38,7 +38,7 @@ async function getPendingContentForUser(
   const leaderResult = await pool.query(
     `SELECT wg.id, wg.name, wg.slug
      FROM working_group_leaders wgl
-     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id
+     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
      JOIN working_groups wg ON wg.id = wgl.working_group_id
      WHERE wgl.user_id = $1 OR sm.workos_user_id = $1`,
     [workosUserId]

--- a/server/src/db/outbound-db.ts
+++ b/server/src/db/outbound-db.ts
@@ -746,7 +746,7 @@ export async function getMemberCapabilities(
          AND (
            EXISTS(SELECT 1 FROM working_group_memberships wgm WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1)
            OR EXISTS(SELECT 1 FROM working_group_leaders wgl
-                     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id
+                     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
                      WHERE wgl.working_group_id = wg.id AND (wgl.user_id = $1 OR sm.workos_user_id = $1))
          )) as wg_count,
         (SELECT COUNT(DISTINCT wg.id) FROM working_groups wg
@@ -754,7 +754,7 @@ export async function getMemberCapabilities(
          AND (
            EXISTS(SELECT 1 FROM working_group_memberships wgm WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1)
            OR EXISTS(SELECT 1 FROM working_group_leaders wgl
-                     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id
+                     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
                      WHERE wgl.working_group_id = wg.id AND (wgl.user_id = $1 OR sm.workos_user_id = $1))
          )) as council_count`,
       [workosUserId]

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -109,7 +109,7 @@ export function createContentRouter(): Router {
         `SELECT wg.id, wg.slug, wg.name, wg.description,
                 EXISTS(
                   SELECT 1 FROM working_group_leaders wgl
-                  LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id
+                  LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
                   WHERE wgl.working_group_id = wg.id AND (wgl.user_id = $1 OR sm.workos_user_id = $1)
                 ) as is_leader
          FROM working_group_memberships wgm
@@ -329,7 +329,7 @@ export function createContentRouter(): Router {
       const leaderResult = await pool.query(
         `SELECT wg.id, wg.name, wg.slug
          FROM working_group_leaders wgl
-         LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id
+         LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
          JOIN working_groups wg ON wg.id = wgl.working_group_id
          WHERE wgl.user_id = $1 OR sm.workos_user_id = $1`,
         [user.id]


### PR DESCRIPTION
## Summary

- Fix chapter leader permission checks for users added via Slack ID before linking WorkOS
- David (Germany Chapter leader) couldn't manage events because his leader record stored his Slack user ID, but login uses WorkOS ID
- Now resolves user IDs at read time via `slack_user_mappings` table JOIN

## Changes

- `getLeaders` / `getLeadersBatch`: Use `COALESCE(sm.workos_user_id, wgl.user_id)` to resolve canonical ID
- `isLeader`: Check both `wgl.user_id = $1 OR sm.workos_user_id = $1`
- `getCommitteesLedByUser`: Same bidirectional check
- `content.ts`: Fix is_leader subqueries in collections and pending content
- `member-context.ts`: Fix leader query for pending content
- `outbound-db.ts`: Fix capability count queries

## Test plan

- [x] All 187 tests pass
- [x] TypeScript type checking passes
- [ ] Verify David can manage events on Germany Chapter page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)