### PR TITLE
fix: exclude free email providers from related domains in domain health

### DIFF
--- a/.changeset/block-gmail-corp-domain.md
+++ b/.changeset/block-gmail-corp-domain.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix domain health page to exclude free email providers (gmail.com, etc.) from "Related Organizations" section

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -1439,6 +1439,8 @@ export function setupDomainRoutes(
               SUBSTRING(domain FROM '([^.]+\\.[^.]+)$') as root_domain
             FROM org_domains
             WHERE domain IS NOT NULL
+              -- Exclude personal email domains (gmail.com, yahoo.com, admin-managed domains, etc.)
+              AND LOWER(SUBSTRING(domain FROM '([^.]+\\.[^.]+)$')) NOT IN (${freeEmailPlaceholders})
           ),
           root_groups AS (
             -- Group by root domain, only keep groups with multiple orgs
@@ -1461,8 +1463,8 @@ export function setupDomainRoutes(
           )
           SELECT * FROM root_groups
           ORDER BY org_count DESC
-          LIMIT $1
-        `, [limit]);
+          LIMIT $${allExcludedDomains.length + 1}
+        `, [...allExcludedDomains, limit]);
 
         // 7. Similar organization names - find orgs with similar names that might be duplicates
         // Uses trigram similarity (requires pg_trgm extension) or simple word matching


### PR DESCRIPTION
## Summary
- Fixed gmail.com and other free email providers appearing in the "Related Organizations" section of the domain health dashboard
- Organizations with users having personal email addresses (gmail, yahoo, etc.) were being incorrectly grouped together as "related"

## Changes
- Added exclusion filter to the `relatedDomainsResult` query in `server/src/routes/admin/domains.ts`
- The filter excludes both hardcoded free email domains (gmail.com, yahoo.com, etc.) and admin-managed personal domains

## Test plan
- [ ] Visit Domain Health admin page
- [ ] Verify gmail.com no longer appears in "Related Organizations" section
- [ ] Verify legitimate related domains (e.g., yahooinc.com and advertising.yahoo.com) still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)