### PR TITLE
fix: display Slack profile name for chapter leaders without WorkOS accounts

### DIFF
--- a/.changeset/fix-slack-leader-display.md
+++ b/.changeset/fix-slack-leader-display.md
@@ -1,0 +1,12 @@
+---
+"adcontextprotocol": patch
+---
+
+fix: display Slack profile name for chapter leaders without WorkOS accounts
+
+Leaders added via Slack ID that haven't linked their WorkOS account now display
+their Slack profile name (real_name or display_name) instead of the raw Slack
+user ID (e.g., U09BEKNJ3GB).
+
+The getLeaders and getLeadersBatch queries now include slack_user_mappings as an
+additional name source in the COALESCE chain.


### PR DESCRIPTION
## Summary

- Leaders added via Slack ID that haven't linked their WorkOS account were showing raw Slack user IDs (e.g., `U09BEKNJ3GB`) instead of their names
- Updated `getLeaders` and `getLeadersBatch` queries to include `slack_user_mappings.slack_real_name` and `slack_display_name` as fallback name sources
- Added clarifying comments explaining why the same table is joined twice (for ID resolution vs profile name)

## Test plan

- [ ] Verify London chapter page shows proper leader names instead of Slack IDs
- [ ] Confirm leaders with linked WorkOS accounts still display correctly
- [ ] Verify chapters list page shows correct leader names

🤖 Generated with [Claude Code](https://claude.com/claude-code)