### PR TITLE
fix: correct Addie GitHub issue drafting repo and add confidentiality guidelines

### DIFF
--- a/.changeset/bright-kids-say.md
+++ b/.changeset/bright-kids-say.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: correct GitHub issue drafting repo and add confidentiality guidelines for Addie

--- a/docs/reference/adcp-ecosystem.mdx
+++ b/docs/reference/adcp-ecosystem.mdx
@@ -23,10 +23,9 @@ All repos are under the `adcontextprotocol` GitHub organization.
 
 | Repo | Purpose | Key Contents |
 |------|---------|--------------|
-| **adcp** | Core protocol specification | JSON schemas, TypeScript SDK (`@adcp/client`), Python SDK (`adcp`), protocol docs |
+| **adcp** | Protocol and AgenticAdvertising.org | JSON schemas, TypeScript/Python SDKs, protocol docs, AgenticAdvertising.org server (Addie AI, membership, profiles) |
 | **salesagent** | Reference sales agent implementation | Sales agent code, salesagent docs, deployment configs |
 | **creative-agent** | Reference creative agent | Creative workflows, standard formats, format validation |
-| **aao-server** | AgenticAdvertising.org website | Community features, membership, Addie AI assistant, member profiles |
 
 ## Channel-to-Repo Mapping
 
@@ -37,7 +36,7 @@ For Slack channels → GitHub issues:
 | `#salesagent-*` | salesagent | Sales agent implementation and docs |
 | `#creative-*` | creative-agent | Creative agent and formats |
 | `#adcp-dev`, `#protocol-*` | adcp | Core protocol and schemas |
-| `#general`, `#community`, `#membership` | aao-server | Community and website |
+| `#general`, `#community`, `#membership` | adcp | AgenticAdvertising.org server and community features |
 
 ## SDK Packages
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -725,7 +725,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'draft_github_issue',
     description:
-      'Draft a GitHub issue and generate a pre-filled URL for the user to create it. Use this when users report bugs, request features, or ask you to create a GitHub issue. CRITICAL: Users CANNOT see tool outputs - you MUST copy this tool\'s entire output (the GitHub link, title, body preview) into your response. Never say "click the link above" without including the actual link. The user will click the link to create the issue from their own GitHub account. Infer the appropriate repo from context (channel name, conversation topic) - use "adcp" for protocol/docs issues, "aao-server" for website/community issues.',
+      'Draft a GitHub issue and generate a pre-filled URL for the user to create it. Use this when users report bugs, request features, or ask you to create a GitHub issue. CRITICAL: Users CANNOT see tool outputs - you MUST copy this tool\'s entire output (the GitHub link, title, body preview) into your response. Never say "click the link above" without including the actual link. The user will click the link to create the issue from their own GitHub account. All issues go to the "adcp" repository which contains the protocol, schemas, AgenticAdvertising.org server, and documentation.',
     usage_hints: 'use when user wants to report a bug or request a feature - MUST include full output in response',
     input_schema: {
       type: 'object',
@@ -737,12 +737,12 @@ export const MEMBER_TOOLS: AddieTool[] = [
         body: {
           type: 'string',
           description:
-            'Issue body in markdown format. Include context, steps to reproduce (for bugs), or detailed description (for features). Reference the Slack conversation if relevant.',
+            'Issue body in markdown format. CRITICAL: Never include customer names, emails, org IDs, or any PII - GitHub issues are public. Use generic placeholders like [Customer] or [Organization]. For bugs, ALWAYS include the exact error message. Include anonymized steps to reproduce.',
         },
         repo: {
           type: 'string',
           description:
-            'Repository name within adcontextprotocol org (e.g., "adcp" for protocol/docs, "aao-server" for website/community). Default: "adcp"',
+            'Repository name within adcontextprotocol org. Always use "adcp" - it contains the protocol, schemas, server, and docs. Default: "adcp"',
         },
         labels: {
           type: 'array',

--- a/server/src/db/migrations/155_fix_github_issue_repo.sql
+++ b/server/src/db/migrations/155_fix_github_issue_repo.sql
@@ -1,0 +1,64 @@
+-- Fix GitHub Issue Drafting rule
+--
+-- Problems:
+-- 1. The rule tells Addie to create issues in the "aao-server" repo, but that
+--    repository doesn't exist. All code is in the main "adcp" repository.
+-- 2. Addie includes confidential customer information in issue bodies
+-- 3. Addie doesn't include the actual error messages
+--
+-- Solution: Update the rule with correct repo and privacy guidelines.
+
+-- Update the existing GitHub Issue Drafting rule
+UPDATE addie_rules
+SET content = 'You have a draft_github_issue tool to help users create GitHub issues for bugs or feature requests. When users:
+- Report a bug or broken link
+- Request a feature or enhancement
+- Ask you to create a GitHub issue
+- Discuss something that should be tracked
+
+Use draft_github_issue to generate a pre-filled GitHub URL.
+
+**CRITICAL - CONFIDENTIALITY**: GitHub issues are PUBLIC. NEVER include:
+- Customer/company names (use "[Customer]" or "[Organization]" instead)
+- Email addresses or contact information
+- Organization IDs, user IDs, or other identifiers
+- Billing amounts, discounts, or financial details
+- Any personally identifiable information (PII)
+
+**CRITICAL - ERROR DETAILS**: For bug reports, ALWAYS include:
+- The exact error message (if any was returned)
+- The tool name and parameters that caused the error (sanitized of PII)
+- What the expected behavior was vs what actually happened
+
+**CRITICAL - TOOL OUTPUT VISIBILITY**: Users CANNOT see tool outputs directly. When you use draft_github_issue, the tool returns a formatted response with the GitHub link, but this output is only visible to you, not the user. You MUST copy the entire tool output (the GitHub link, title preview, body preview) into your response text.
+
+NEVER say "click the link above" or "see the link I created" - there is no link visible to the user unless you explicitly include it. Always format your response like:
+
+"I''ve drafted a GitHub issue for you:
+
+**[Create Issue on GitHub](https://github.com/...)**
+
+**Title:** [the title]
+**Body preview:** [summary of the body]"
+
+**adcontextprotocol organization repos:**
+- "adcp" - Main repository containing: protocol specification, JSON schemas, TypeScript/Python SDKs, AgenticAdvertising.org server (Addie AI, membership, community features)
+- "salesagent" - Reference sales agent implementation, salesagent docs
+- "creative-agent" - Reference creative agent, standard formats, creative workflow
+
+**Channel → Repo hints:**
+- #salesagent-users, #salesagent-dev → salesagent repo
+- #creative-agent, #creative-formats → creative-agent repo
+- All other channels → adcp repo (protocol, website, community features, Addie bugs)
+
+Draft clear, actionable issues with:
+- Descriptive title summarizing the issue (no customer names)
+- Generic description of the scenario (anonymized)
+- The exact error message or unexpected behavior
+- Steps to reproduce (with sanitized/generic data)
+- Appropriate labels (bug, enhancement, documentation, etc.)
+
+You can proactively offer to draft issues when you notice problems being discussed.',
+    updated_at = NOW()
+WHERE name = 'GitHub Issue Drafting'
+  AND rule_type = 'behavior';

--- a/v2.6-rc/docs/reference/adcp-ecosystem.mdx
+++ b/v2.6-rc/docs/reference/adcp-ecosystem.mdx
@@ -23,10 +23,9 @@ All repos are under the `adcontextprotocol` GitHub organization.
 
 | Repo | Purpose | Key Contents |
 |------|---------|--------------|
-| **adcp** | Core protocol specification | JSON schemas, TypeScript SDK (`@adcp/client`), Python SDK (`adcp`), protocol docs |
+| **adcp** | Protocol and AgenticAdvertising.org | JSON schemas, TypeScript/Python SDKs, protocol docs, AgenticAdvertising.org server (Addie AI, membership, profiles) |
 | **salesagent** | Reference sales agent implementation | Sales agent code, salesagent docs, deployment configs |
 | **creative-agent** | Reference creative agent | Creative workflows, standard formats, format validation |
-| **aao-server** | AgenticAdvertising.org website | Community features, membership, Addie AI assistant, member profiles |
 
 ## Channel-to-Repo Mapping
 
@@ -37,7 +36,7 @@ For Slack channels → GitHub issues:
 | `#salesagent-*` | salesagent | Sales agent implementation and docs |
 | `#creative-*` | creative-agent | Creative agent and formats |
 | `#adcp-dev`, `#protocol-*` | adcp | Core protocol and schemas |
-| `#general`, `#community`, `#membership` | aao-server | Community and website |
+| `#general`, `#community`, `#membership` | adcp | AgenticAdvertising.org server and community features |
 
 ## SDK Packages
 


### PR DESCRIPTION
## Summary

- Remove references to non-existent `aao-server` repo, direct all GitHub issues to `adcp`
- Add CRITICAL confidentiality rules to prevent PII in public GitHub issues
- Add requirement to always include actual error messages in bug reports
- Update ecosystem docs to reflect consolidated repository structure

## Problem

When Addie created GitHub issues:
1. They were directed to `aao-server` repo which doesn't exist (404)
2. Confidential customer information (names, emails, org IDs) was included in public issue bodies
3. Actual error messages were often missing from bug reports

## Solution

Updated the `draft_github_issue` tool and Addie's operating rules to:
- Always use `adcp` repo (which contains all code including the server)
- Explicitly prohibit PII in issue bodies (customer names, emails, org IDs, billing details)
- Require actual error messages in bug reports

## Test plan

- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Migration is syntactically valid SQL
- [ ] Deploy and verify Addie creates issues with correct repo URL
- [ ] Verify issues no longer contain customer PII

🤖 Generated with [Claude Code](https://claude.com/claude-code)