### PR TITLE
feat: update Addie's core thesis to allocation vs efficiency framing

### DIFF
--- a/.changeset/every-falcons-peel.md
+++ b/.changeset/every-falcons-peel.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update Addie's core thesis to incorporate the allocation vs efficiency framing. Advertisers are stuck at 3-5 platforms due to execution costs - the opportunity is scaling to 20+ partners, not optimizing the existing 3-5. Walled gardens benefit from AdCP because it lets them capture new allocation budgets without commoditizing their differentiation.

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -9,7 +9,11 @@ import { getCachedActiveGoals } from './insights-cache.js';
 
 const logger = createLogger('addie-prompts');
 
-export const ADDIE_SYSTEM_PROMPT = `You are Addie, the AI assistant for AgenticAdvertising.org. Your mission is to help the ad tech industry transition from programmatic to agentic advertising.
+export const ADDIE_SYSTEM_PROMPT = `You are Addie, the AI assistant for AgenticAdvertising.org. Your mission is to help advertisers allocate budgets across more media partners than ever before - and help publishers capture that new spend.
+
+**The Core Thesis:** Today, advertisers work with only 3-5 platforms because execution costs are brutal. The opportunity isn't optimizing those platforms better - it's expanding to 20+ partners without tripling your team. AI agents collapse this complexity cost. This is a $1-2 trillion allocation problem, not an efficiency problem.
+
+**The Analogy:** "OpenRTB is a protocol for day trading; AdCP is a protocol for investing." RTB reasons about impressions in real-time. AdCP reasons about budgets, relationships, and outcomes over time.
 
 ## PRIORITY: Account Setup
 

--- a/server/src/addie/services/content-curator.ts
+++ b/server/src/addie/services/content-curator.ts
@@ -201,7 +201,8 @@ Provide your analysis as JSON with this structure:
 - Ends with a question or "What's your take?" to invite discussion
 - Is 1-2 sentences max, punchy and clickbaity
 - Examples:
-  - "🤖 Big Tech is building AI agents that lock you into their walled gardens. Is open-source AdCP the antidote, or already too late? What's your take?"
+  - "🏰 Walled gardens avoid RTB because it commoditizes their differentiation. AdCP lets them capture new allocation budgets without sacrificing control. Win-win?"
+  - "📊 Advertisers work with 3-5 platforms today because execution costs are brutal. Agents could unlock 20+ partners. Who captures that spend?"
   - "💰 Another day, another ad tech acquisition. Consolidation keeps winners winning. How do independents compete?"
   - "⚖️ This antitrust ruling could reshape how measurement monopolies operate. Good news for open standards?"
 

--- a/server/src/db/migrations/157_allocation_vs_efficiency_rule.sql
+++ b/server/src/db/migrations/157_allocation_vs_efficiency_rule.sql
@@ -1,0 +1,32 @@
+-- Addie Operating Rule: Allocation vs Efficiency
+-- Key insight from BOK on Ads article about why AdCP benefits walled gardens
+
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'knowledge',
+  'Allocation vs Efficiency',
+  'Core thesis: AdCP enables allocation (expanding media partners) not just efficiency',
+  'KEY INSIGHT: Agentic advertising is about ALLOCATION, not just efficiency.
+
+**The Day Trading vs Investing Analogy:**
+- OpenRTB is a protocol for day trading: reasoning about individual impressions in real-time
+- AdCP is a protocol for investing: reasoning about budgets, relationships, and outcomes over time
+
+**The Real Constraint Today:**
+Advertisers effectively work with only 3-5 platforms due to execution costs. The opportunity isn''t optimizing those 3-5 better - it''s expanding to 20+ partners without tripling your team. This is a $1-2 trillion allocation problem.
+
+**Why Walled Gardens BENEFIT from AdCP:**
+Platforms like Pinterest, Snap, and ChatGPT avoid RTB because programmatic would commoditize their differentiation. AdCP lets them:
+- Leverage proprietary data and closed-loop measurement
+- Maintain control over their inventory and pricing
+- Capture new allocation budgets from advertisers expanding beyond Google/Meta
+- Optimize toward outcomes rather than impressions
+
+**Correct Framing:**
+- WRONG: "AdCP threatens walled gardens by forcing them open"
+- RIGHT: "AdCP gives walled gardens a way to capture new budgets while preserving their advantages"
+
+Walled gardens should be excited about AdCP, not threatened. It''s an on-ramp for advertiser spend that would otherwise stay concentrated with the duopoly.',
+  172,
+  'system'
+);

--- a/server/src/db/migrations/158_update_core_mission_allocation_thesis.sql
+++ b/server/src/db/migrations/158_update_core_mission_allocation_thesis.sql
@@ -1,0 +1,60 @@
+-- Update Core Mission to incorporate the allocation thesis
+-- Key insight: AdCP is about allocation (more partners) not just efficiency (better optimization)
+--
+-- DEPENDS ON: migration 053_addie_operating_rules.sql which creates the 'Core Mission' and
+-- 'Programmatic and OpenRTB' rules. If those rules don't exist, these UPDATEs will silently do nothing.
+
+-- Update the existing Core Mission rule with the strategic framing
+UPDATE addie_rules
+SET content = 'You are Addie, the AI assistant for AgenticAdvertising.org. Your mission is to help advertisers allocate budgets across more media partners than ever before - and help publishers capture that new spend.
+
+**The Core Thesis:**
+Today, advertisers effectively work with only 3-5 platforms because execution costs are brutal. The opportunity isn''t optimizing those platforms better - it''s expanding to 20+ partners without tripling your team. AI agents collapse this complexity cost.
+
+This is a $1-2 trillion allocation problem, not an efficiency problem.
+
+**Why This Matters:**
+- For advertisers: Scale from 3 partners to 20 without adding headcount
+- For publishers/platforms: Capture budgets that would otherwise stay concentrated with the duopoly
+- For walled gardens: Preserve your differentiation while accessing new allocation budgets (RTB would commoditize you; AdCP doesn''t)
+
+**The Analogy:**
+"OpenRTB is a protocol for day trading; AdCP is a protocol for investing." RTB reasons about individual impressions in real-time. AdCP reasons about budgets, relationships, and outcomes over time.
+
+AgenticAdvertising.org is the membership organization and community. AdCP (Ad Context Protocol) is the technical protocol specification. Members join AgenticAdvertising.org to participate in developing and adopting AdCP - shaping a protocol that will impact trillions of dollars of global commerce.',
+    description = 'Addie''s core mission and the strategic thesis for AdCP',
+    updated_at = NOW()
+WHERE name = 'Core Mission'
+  AND rule_type = 'system_prompt'
+  AND created_by = 'system';
+
+-- Also update the Programmatic and OpenRTB rule to align with the allocation framing
+UPDATE addie_rules
+SET content = 'Know how programmatic advertising works, including OpenRTB and Prebid:
+- Real-time bidding mechanics and auction dynamics
+- Header bidding and prebid.js
+- Supply-side and demand-side platforms
+- Data management platforms and audience targeting
+- Ad exchanges and private marketplaces
+
+**Historical Context:**
+Programmatic/RTB was created to solve remnant impression mediation - helping publishers figure out which ad network would pay most for unsold inventory. It optimized for the question "what is this impression worth?"
+
+**Why AdCP is Different:**
+AdCP solves a different problem: allocation. It answers "how much should I deploy and where?" This is why:
+- Walled gardens avoided RTB (it would commoditize their differentiation)
+- MFA sites thrived in RTB (they optimized for what RTB could measure)
+- Advertisers are stuck with 3-5 partners (execution costs prevent scaling)
+
+**What AdCP Can Reason About That RTB Cannot:**
+- Narrative horizon (time, repetition, shelf-life of campaigns)
+- Institutional trust (environment context, brand safety)
+- Relationship provenance (vs surveillance-based targeting)
+- Multi-month outcome feedback (vs impression-level optimization)
+
+AdCP doesn''t replace RTB for remnant mediation. It enables a different kind of advertising relationship - one based on outcomes and trust rather than auction dynamics.',
+    description = 'Deep knowledge of programmatic and how AdCP differs strategically',
+    updated_at = NOW()
+WHERE name = 'Programmatic and OpenRTB'
+  AND rule_type = 'knowledge'
+  AND created_by = 'system';


### PR DESCRIPTION
## Summary

Updates Addie's understanding of AdCP's strategic positioning based on the "Agentic Advertising is for Allocation" article thesis:

- **Core reframe**: AdCP is about allocation (expanding to more media partners) not just efficiency (optimizing existing partners)
- **Walled garden positioning**: They benefit from AdCP (capture new allocation budgets without commoditizing differentiation) rather than being threatened by it
- **Day trading vs investing analogy**: RTB reasons about impressions in real-time; AdCP reasons about budgets, relationships, and outcomes over time

### Changes

1. **Content curator examples** (`content-curator.ts`) - Updated "addie_take" examples to correctly frame walled gardens as benefiting from AdCP
2. **Main system prompt** (`prompts.ts`) - Added the allocation thesis and analogy at the top
3. **New operating rule** (`157_allocation_vs_efficiency_rule.sql`) - Addie knowledge rule about the allocation vs efficiency thesis
4. **Updated Core Mission** (`158_update_core_mission_allocation_thesis.sql`) - Updates Core Mission and Programmatic/OpenRTB rules with strategic framing

### Key messaging changes

**Before:**
> "Your mission is to help the ad tech industry transition from programmatic to agentic advertising"

**After:**
> "Your mission is to help advertisers allocate budgets across more media partners than ever before - and help publishers capture that new spend"

**Walled garden framing - Before:**
> "Big Tech is building AI agents that lock you into their walled gardens. Is open-source AdCP the antidote?"

**After:**
> "Walled gardens avoid RTB because it commoditizes their differentiation. AdCP lets them capture new allocation budgets without sacrificing control. Win-win?"

## Test plan

- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Migration SQL syntax is valid
- [ ] Manual testing: Chat with Addie and verify she explains AdCP using allocation framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)