### PR TITLE
docs: clarify AdCP/MCP relationship - MCP is transport, not base

### DIFF
--- a/.changeset/orange-bottles-reply.md
+++ b/.changeset/orange-bottles-reply.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify AdCP/MCP relationship in docs: AdCP works *over* MCP and A2A as transports, not "built on" MCP.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AdCP - Open Standard for Advertising Automation
 
-**Unified advertising automation protocol built on Model Context Protocol (MCP)**
+**Open standard for advertising automation over MCP and A2A protocols**
 
 [![GitHub stars](https://img.shields.io/github/stars/adcontextprotocol/adcp?style=social)](https://github.com/adcontextprotocol/adcp)
 [![Documentation](https://img.shields.io/badge/docs-adcontextprotocol.org-blue)](https://adcontextprotocol.org)
@@ -15,7 +15,7 @@ Visit [adcontextprotocol.org](https://adcontextprotocol.org) for full documentat
 
 ## What is AdCP?
 
-Ad Context Protocol (AdCP) is an **open standard for advertising automation** that enables AI assistants to interact with advertising platforms through natural language. Built on the Model Context Protocol (MCP), AdCP provides:
+Ad Context Protocol (AdCP) is an **open standard for advertising automation** that enables AI assistants to interact with advertising platforms through natural language. AdCP defines domain-specific tasks and schemas that work over MCP and A2A as transports:
 
 - 🔌 **Unified Advertising API** - Single interface for all advertising platforms
 - 🤖 **AI-Powered Automation** - Built for natural language campaign management

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Getting Started
-description: AdCP is an open standard for advertising automation built on Model Context Protocol (MCP). Learn how to integrate AI-powered advertising workflows.
+description: AdCP is an open standard for advertising automation that works over MCP and A2A protocols. Learn how to integrate AI-powered advertising workflows.
 keywords: [advertising automation protocol, programmatic advertising API, MCP advertising integration, AI advertising workflows, unified advertising platform API]
 ---
 
@@ -19,8 +19,8 @@ Welcome to the Ad Context Protocol (AdCP) documentation. AdCP is an **open stand
 Ad Context Protocol (AdCP) is an **open standard for advertising automation** that enables AI-powered programmatic advertising workflows through:
 
 - **Unified Advertising API**: Single interface for all advertising platforms
-- **AI-Powered Automation**: Built on Model Context Protocol (MCP) for seamless AI integration
-- **Multi-Protocol Support**: Access through MCP, A2A, or future protocols
+- **AI-Powered Automation**: Works over MCP and A2A protocols for seamless AI integration
+- **Multi-Protocol Support**: Access through MCP, A2A, or future transports
 - **Platform Agnostic**: Works with any compatible advertising platform
 - **Programmatic Advertising Made Simple**: Standardized workflows across all ad tech
 

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -12,8 +12,8 @@ Classification of MCP session credentials as either "platform" (aggregator) or "
 **Activation**  
 The process of making a signal available for targeting on a specific platform and seat.
 
-**Ad Context Protocol (AdCP)**  
-An open standard based on Model Context Protocol (MCP) that enables AI-powered advertising workflows through natural language interfaces.
+**Ad Context Protocol (AdCP)**
+An open standard for AI-powered advertising workflows. AdCP defines domain-specific tasks and schemas that work over MCP and A2A as transports, enabling natural language interfaces for advertising operations.
 
 **Agentic eXecution Engine (AXE)**  
 The real-time execution layer that sits between orchestrators and decisioning platforms, handling dynamic audience targeting, brand safety enforcement, frequency management, and first-party data activation at impression time. See [AXE documentation](/docs/media-buy/advanced-topics/agentic-execution-engine) for details.

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -31,7 +31,7 @@
       "@id": "https://adcontextprotocol.org/#software",
       "name": "Ad Context Protocol",
       "alternateName": "AdCP",
-      "description": "Unified advertising automation protocol built on Model Context Protocol (MCP). Enables AI-powered workflows across advertising platforms including media buying, creative generation, and first-party data signals.",
+      "description": "Open standard for advertising automation that works over MCP and A2A protocols. Enables AI-powered workflows across advertising platforms including media buying, creative generation, and first-party data signals.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any",
       "offers": {
@@ -85,7 +85,7 @@
           "name": "What protocols does AdCP support?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "AdCP is built on the Model Context Protocol (MCP) and supports Agent-to-Agent (A2A) protocol. This enables seamless integration with AI assistants like Claude, ChatGPT, and custom AI agents."
+            "text": "AdCP works over MCP (Model Context Protocol) and A2A (Agent-to-Agent) as transports. This enables seamless integration with AI assistants like Claude, ChatGPT, and custom AI agents."
           }
         },
         {
@@ -108,7 +108,7 @@
     }
   ]
 }
-</script><meta name="description" content="AdCP (Ad Context Protocol) is an open standard that unifies advertising platforms through AI-powered workflows. Built on MCP for seamless programmatic advertising automation.">
+</script><meta name="description" content="AdCP (Ad Context Protocol) is an open standard that unifies advertising platforms through AI-powered workflows. Works over MCP and A2A for seamless programmatic advertising automation.">
 <meta name="keywords" content="advertising automation protocol, programmatic advertising API, MCP advertising integration, AI advertising workflows, unified advertising platform API, advertising technology, agent-to-agent, A2A protocol, AI agents, agentic advertising">
 <meta name="author" content="Ad Context Protocol Contributors">
 <meta name="publisher" content="Ad Context Protocol">
@@ -577,7 +577,7 @@
           <div class="row">
             <div class="col col--10 col--offset-1">
               <h2 class="sectionTitle_Ut5p">How AdCP works</h2>
-              <p class="sectionSubtitle_AZuW">Built on the Model Context Protocol (MCP), AdCP provides a unified interface for advertising operations across any platform.</p>
+              <p class="sectionSubtitle_AZuW">AdCP works over MCP and A2A protocols, providing a unified interface for advertising operations across any platform.</p>
               <div class="workflowSteps_gwt9">
                 <div class="step_BHwS">
                   <div class="stepNumber_rxuX">1</div>


### PR DESCRIPTION
## Summary

- Updates documentation to clarify that AdCP works *over* MCP and A2A as transports, rather than being "built on" MCP
- Addresses confusion where people thought AdCP was a fork or outdated branch of the MCP protocol

**The actual relationship:**
- MCP and A2A are transports (like HTTP)
- AdCP defines domain-specific tasks and schemas for advertising
- AdCP uses the latest MCP SDK (1.25.2) as a dependency, not a fork

## Changes

| Before | After |
|--------|-------|
| "Built on Model Context Protocol (MCP)" | "Works over MCP and A2A protocols" |
| "Based on Model Context Protocol (MCP)" | "Defines domain-specific tasks and schemas that work over MCP and A2A as transports" |

## Files Changed

- `docs/intro.mdx` - Description and feature bullets
- `docs/reference/glossary.mdx` - AdCP definition
- `README.md` - Tagline and description  
- `server/public/index.html` - Schema.org data, meta description, FAQ, "How it works" section

## Test plan

- [x] All tests pass
- [x] Docs build successfully
- [ ] Review updated language for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)