### PR TITLE
fix: broken working group post links

### DIFF
--- a/.changeset/fix-perspectives-link.md
+++ b/.changeset/fix-perspectives-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix broken working group post links in Slack notifications and frontend

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1029,7 +1029,7 @@
           <div class="form-group">
             <label>Slug</label>
             <input type="text" id="postSlug" required placeholder="url-friendly-slug" pattern="[a-z0-9-]+">
-            <small>URL path: /perspectives/{slug}</small>
+            <small>Post identifier for linking</small>
           </div>
           <div class="form-group">
             <label>Category</label>
@@ -1290,7 +1290,7 @@
         }
 
         postsList.innerHTML = posts.map(post => `
-          <a href="/perspectives/${escapeHtml(post.slug)}" class="post-card">
+          <a href="/working-groups/${currentSlug}#post-${escapeHtml(post.slug)}" class="post-card">
             <div class="post-title">${escapeHtml(post.title)}</div>
             <div class="post-meta">
               <span>${formatDate(post.published_at)}</span>

--- a/server/public/working-groups/manage.html
+++ b/server/public/working-groups/manage.html
@@ -625,7 +625,7 @@
           <div class="form-group">
             <label>Slug</label>
             <input type="text" id="slug" required placeholder="url-friendly-slug" pattern="[a-z0-9-]+">
-            <small>URL path: /perspectives/{slug}</small>
+            <small>Post identifier for linking</small>
           </div>
           <div class="form-group">
             <label>Category</label>
@@ -1079,7 +1079,7 @@
               </div>
             </div>
             <div class="post-actions">
-              ${post.status === 'published' ? `<a href="/perspectives/${post.slug}" target="_blank" class="btn btn-secondary btn-small">View</a>` : ''}
+              ${post.status === 'published' ? `<a href="/working-groups/${currentSlug}#post-${post.slug}" target="_blank" class="btn btn-secondary btn-small">View</a>` : ''}
               <button class="btn btn-primary btn-small" onclick="editPost('${post.id}')">Edit</button>
               <button class="btn btn-danger btn-small" onclick="showDeleteModal('${post.id}', '${escapeHtml(post.title).replace(/'/g, "\\'")}')">Delete</button>
             </div>

--- a/server/src/notifications/slack.ts
+++ b/server/src/notifications/slack.ts
@@ -343,7 +343,7 @@ export async function notifyWorkingGroupPost(data: {
 }): Promise<boolean> {
   const emoji = data.contentType === 'link' ? '🔗' : '📝';
   const typeLabel = data.contentType === 'link' ? 'Link' : 'Article';
-  const postUrl = `https://agenticadvertising.org/perspectives/${data.postSlug}`;
+  const postUrl = `https://agenticadvertising.org/working-groups/${data.workingGroupSlug}#post-${data.postSlug}`;
   const groupUrl = `https://agenticadvertising.org/working-groups/${data.workingGroupSlug}`;
 
   return sendSlackMessage({


### PR DESCRIPTION
## Summary
- Fixed broken working group post links that were incorrectly pointing to `/perspectives/:slug` (which redirects to `/latest/research`)
- Slack notifications now link directly to the working group page with anchor fragment
- Post links on detail and manage pages now use correct URL structure

## Test plan
- [x] Verified bug in production: clicking post link on Germany Chapter redirects to "Research & Ideas"
- [x] TypeScript type check passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)