### PR TITLE
fix: link Slack users in bulk prospect creation

### DIFF
--- a/.changeset/strict-lamps-turn.md
+++ b/.changeset/strict-lamps-turn.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Slack user linking in bulk prospect creation from domain discovery.

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -434,6 +434,17 @@ export function setupDomainRoutes(
               logger.warn({ err, domain: normalizedDomain, orgId: workosOrg.id }, "Background enrichment failed");
             });
 
+            // Link unmapped Slack users to this new prospect (same as single-create)
+            if (source === 'slack') {
+              const linkResult = await slackDb.linkSlackUsersByDomain(normalizedDomain, workosOrg.id);
+              if (linkResult.usersLinked > 0) {
+                logger.info(
+                  { orgId: workosOrg.id, domain: normalizedDomain, usersLinked: linkResult.usersLinked },
+                  "Linked Slack users to new prospect from bulk creation"
+                );
+              }
+            }
+
             logger.info(
               { orgId: workosOrg.id, name: orgName, domain: normalizedDomain, source },
               "Created prospect from bulk domain creation"


### PR DESCRIPTION
## Summary
- The bulk-create-prospects endpoint was missing the `linkSlackUsersByDomain` call that the single-prospect creation endpoint has
- This caused Slack users to not be linked to their pending organization when prospects were created in bulk from domain discovery
- Added the missing call with appropriate source guard (only for slack-sourced domains)

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Code review completed
- [ ] After merge, run backfill on production: `POST /api/admin/slack/backfill-pending-orgs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)