### PR TITLE
feat: add unified user counts to accounts list and Addie tools

### DIFF
--- a/.changeset/fiery-actors-show.md
+++ b/.changeset/fiery-actors-show.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add unified user counts (members + Slack-only) to accounts list and detail pages. Add Addie tools for listing organizations by user count and listing Slack users by organization.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -808,34 +808,34 @@
             </div>
           </div>
 
-          <!-- Members -->
+          <!-- Users (Members + Slack-only) -->
           <div class="card">
             <div style="display: flex; justify-content: space-between; align-items: center;">
               <h2 class="collapsible collapsed" onclick="toggleSection(this)" style="margin-bottom: 0;">
-                Members <span id="memberCount" style="font-weight: normal; color: var(--color-text-muted);"></span>
+                Users <span id="memberCount" style="font-weight: normal; color: var(--color-text-muted);"></span>
               </h2>
               <button id="migrateMembersBtn" class="btn btn-sm btn-secondary" onclick="openMigrateMembersModal()" style="display: none;">Migrate Members</button>
             </div>
             <div class="collapsible-content collapsed" id="membersContent" style="margin-top: var(--space-4);">
-              <ul id="membersList" class="members-list">
-                <li class="empty-state">No members yet</li>
-              </ul>
-            </div>
-          </div>
-
-          <!-- Pending Slack Users (only shown if there are any) -->
-          <div class="card" id="pendingSlackCard" style="display: none;">
-            <h2 class="collapsible" onclick="toggleSection(this)" style="margin-bottom: 0;">
-              Pending Slack Users
-              <span id="pendingSlackCount" style="font-weight: normal; color: var(--color-text-muted);"></span>
-            </h2>
-            <div class="collapsible-content" id="pendingSlackContent" style="margin-top: var(--space-4);">
-              <p style="font-size: var(--text-sm); color: var(--color-text-muted); margin-bottom: var(--space-3);">
-                These users have email addresses matching this account's domain but haven't signed up yet.
-              </p>
-              <ul id="pendingSlackList" class="members-list">
-                <li class="empty-state">No pending users</li>
-              </ul>
+              <!-- Website Members -->
+              <div id="membersSectionWrapper">
+                <h3 style="font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-2); font-weight: 600;">Website Members</h3>
+                <ul id="membersList" class="members-list">
+                  <li class="empty-state">No members yet</li>
+                </ul>
+              </div>
+              <!-- Slack-only Users -->
+              <div id="pendingSlackCard" style="display: none; margin-top: var(--space-4); padding-top: var(--space-4); border-top: var(--border-1) solid var(--color-gray-200);">
+                <h3 style="font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-2); font-weight: 600;">
+                  Slack Only <span id="pendingSlackCount" style="font-weight: normal; color: var(--color-text-muted);"></span>
+                </h3>
+                <p style="font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-3);">
+                  Users in Slack with this account's domain who haven't signed up yet.
+                </p>
+                <ul id="pendingSlackList" class="members-list">
+                  <li class="empty-state">No pending users</li>
+                </ul>
+              </div>
             </div>
           </div>
 
@@ -1532,9 +1532,16 @@
       // Account type badge
       renderAccountTypeBadge();
 
-      // Members
+      // Users (Members + Slack-only)
+      const memberCount = (a.members && a.members.length) || 0;
+      const slackOnlyCount = (a.pending_slack_users && a.pending_slack_users.length) || 0;
+      const totalUserCount = memberCount + slackOnlyCount;
+
+      // Set total user count in header
+      document.getElementById('memberCount').textContent = totalUserCount > 0 ? `(${totalUserCount})` : '';
+
+      // Website members
       if (a.members && a.members.length > 0) {
-        document.getElementById('memberCount').textContent = `(${a.members.length})`;
         // Show migrate button if there are members
         document.getElementById('migrateMembersBtn').style.display = 'inline-flex';
         let membersHtml = '';
@@ -1549,7 +1556,7 @@
         document.getElementById('membersList').innerHTML = membersHtml;
       }
 
-      // Pending Slack users (discovered via domain but not yet members)
+      // Slack-only users (discovered via domain but not yet members)
       if (a.pending_slack_users && a.pending_slack_users.length > 0) {
         document.getElementById('pendingSlackCard').style.display = 'block';
         document.getElementById('pendingSlackCount').textContent = `(${a.pending_slack_users.length})`;

--- a/server/public/admin-accounts.html
+++ b/server/public/admin-accounts.html
@@ -577,6 +577,9 @@
       <button class="view-tab" data-view="members">
         Members <span class="badge" id="count-members">-</span>
       </button>
+      <button class="view-tab" data-view="most_users">
+        Most Users
+      </button>
       <button class="view-tab" data-view="all">
         All
       </button>
@@ -599,6 +602,7 @@
           <tr>
             <th>Account</th>
             <th>Status</th>
+            <th>Users</th>
             <th style="width: 60px;">🔥</th>
             <th>Interest</th>
             <th>Last Activity</th>
@@ -607,7 +611,7 @@
           </tr>
         </thead>
         <tbody id="accountsTable">
-          <tr><td colspan="7" class="loading">Loading accounts...</td></tr>
+          <tr><td colspan="8" class="loading">Loading accounts...</td></tr>
         </tbody>
       </table>
     </div>
@@ -753,13 +757,13 @@
         renderAccounts();
       } catch (e) {
         console.error('Error loading accounts:', e);
-        document.getElementById('accountsTable').innerHTML = '<tr><td colspan="7" class="empty-state">Error loading accounts</td></tr>';
+        document.getElementById('accountsTable').innerHTML = '<tr><td colspan="8" class="empty-state">Error loading accounts</td></tr>';
       }
     }
 
     function renderAccounts() {
       if (accounts.length === 0) {
-        document.getElementById('accountsTable').innerHTML = '<tr><td colspan="7" class="empty-state">No accounts found</td></tr>';
+        document.getElementById('accountsTable').innerHTML = '<tr><td colspan="8" class="empty-state">No accounts found</td></tr>';
         return;
       }
 
@@ -808,12 +812,17 @@
           extraColumnHtml = '<td>-</td>';
         }
 
+        // User count (members + slack-only users)
+        const userCount = account.user_count || account.member_count || 0;
+        const userCountHtml = userCount > 0 ? userCount : '<span style="color: var(--color-text-muted);">0</span>';
+
         html += `<tr>
           <td>
             <a href="/admin/accounts/${account.id}" class="account-name">${escapeHtml(account.name)}</a>
             ${account.domain ? `<div class="account-domain">${escapeHtml(account.domain)}</div>` : ''}
           </td>
           <td><span class="status-badge status-${statusClass}">${statusLabel}</span></td>
+          <td>${userCountHtml}</td>
           <td class="engagement-fires">${firesDisplay}</td>
           <td>${interestHtml || '-'}</td>
           <td>${activityHtml}</td>


### PR DESCRIPTION
## Summary
- Add combined user count (website members + Slack-only users) to accounts list and detail pages
- Add "Users" column to accounts table with "Most Users" tab for sorting
- Add `list_organizations_by_users` Addie tool for ranking organizations by total user count
- Add `list_slack_users_by_org` Addie tool for viewing Slack users by organization
- Include Slack-only count breakdown in `get_account` Addie response

## Test plan
- [ ] Verify accounts list shows correct user counts (member_count + slack_only_count)
- [ ] Verify "Most Users" tab sorts accounts by combined user count
- [ ] Verify account detail page shows unified Users section
- [ ] Test Addie: "which companies have the most users?"
- [ ] Test Addie: "who from [company] is in Slack?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)