### PR TITLE
fix: outreach stats header shows correct values

### DIFF
--- a/.changeset/fix-outreach-stats.md
+++ b/.changeset/fix-outreach-stats.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: align frontend outreach stats field names with backend API response

--- a/server/public/admin-outreach.html
+++ b/server/public/admin-outreach.html
@@ -613,7 +613,7 @@
         if (response.ok) {
           const stats = await response.json();
           document.getElementById('stat-today').textContent = stats.sent_today || 0;
-          document.getElementById('stat-week').textContent = stats.sent_week || 0;
+          document.getElementById('stat-week').textContent = stats.sent_this_week || 0;
           const responseRate = stats.total_sent > 0
             ? Math.round(100 * stats.total_responded / stats.total_sent)
             : 0;

--- a/server/src/db/insights-db.ts
+++ b/server/src/db/insights-db.ts
@@ -287,6 +287,7 @@ export interface OutreachStats {
   sent_today: number;
   sent_this_week: number;
   total_responded: number;
+  total_sent: number;
   response_rate: number;
   insights_gathered: number;
 }
@@ -1238,6 +1239,7 @@ export class InsightsDatabase {
       sent_today: parseInt(row.sent_today, 10),
       sent_this_week: parseInt(row.sent_this_week, 10),
       total_responded: totalResponded,
+      total_sent: totalSent,
       response_rate: totalSent > 0 ? Math.round((100 * totalResponded) / totalSent) : 0,
       insights_gathered: parseInt(row.insights_gathered, 10),
     };


### PR DESCRIPTION
## Summary
- Fixed SENT THIS WEEK showing 0: frontend used `stats.sent_week` but backend returned `sent_this_week`
- Fixed RESPONSE RATE showing X/0: frontend expected `stats.total_sent` but backend didn't return it

## Test plan
- [x] TypeScript typecheck passes
- [x] All tests pass
- [x] Verified page loads correctly in browser

🤖 Generated with [Claude Code](https://claude.ai/code)