### PR TITLE
feat: add token-aware context limiting for Addie

### DIFF
--- a/.changeset/thirty-snails-kneel.md
+++ b/.changeset/thirty-snails-kneel.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add token-aware context limiting for Addie to prevent prompt overflow errors in long conversations.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -8,12 +8,13 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { logger } from '../logger.js';
 import type { AddieTool } from './types.js';
-import { ADDIE_SYSTEM_PROMPT, buildMessageTurns } from './prompts.js';
+import { ADDIE_SYSTEM_PROMPT, buildMessageTurnsWithMetadata } from './prompts.js';
 import { AddieDatabase, type AddieRule } from '../db/addie-db.js';
 import { AddieModelConfig, ModelConfig } from '../config/models.js';
 import { getCurrentConfigVersionId, type RuleSnapshot } from './config-version.js';
 import { isMultimodalContent, extractMultimodalContent, isAllowedImageType, type FileReadResult } from './mcp/url-tools.js';
 import { withRetry, isRetryableError, RetriesExhaustedError, type RetryConfig } from '../utils/anthropic-retry.js';
+import { formatTokenCount, getConversationTokenLimit } from '../utils/token-limiter.js';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
@@ -319,16 +320,31 @@ export class AddieClaudeClient {
     // Get config version ID for this interaction (skip for eval mode)
     const configVersionId = rulesOverride ? undefined : await getCurrentConfigVersionId(ruleIds, rulesSnapshot);
 
+    const maxIterations = options?.maxIterations ?? 10;
+    const effectiveModel = options?.modelOverride ?? this.model;
+
     // Build proper message turns from thread context
     // This sends conversation history as actual user/assistant turns, not flattened text
-    const messageTurns = buildMessageTurns(userMessage, threadContext);
-    const messages: Anthropic.MessageParam[] = messageTurns.map(turn => ({
+    // Token-aware: automatically trims older messages if conversation exceeds limits
+    const messageTurnsResult = buildMessageTurnsWithMetadata(userMessage, threadContext, {
+      model: effectiveModel,
+    });
+
+    if (messageTurnsResult.wasTrimmed) {
+      logger.info(
+        {
+          messagesRemoved: messageTurnsResult.messagesRemoved,
+          estimatedTokens: formatTokenCount(messageTurnsResult.estimatedTokens),
+          tokenLimit: formatTokenCount(getConversationTokenLimit(effectiveModel)),
+        },
+        'Addie: Trimmed conversation history to fit context limit'
+      );
+    }
+
+    const messages: Anthropic.MessageParam[] = messageTurnsResult.messages.map(turn => ({
       role: turn.role,
       content: turn.content,
     }));
-
-    const maxIterations = options?.maxIterations ?? 10;
-    const effectiveModel = options?.modelOverride ?? this.model;
     let iteration = 0;
 
     // Log if using precision model
@@ -777,8 +793,23 @@ export class AddieClaudeClient {
 
     // Build proper message turns from thread context
     // This sends conversation history as actual user/assistant turns, not flattened text
-    const messageTurns = buildMessageTurns(userMessage, threadContext);
-    const messages: Anthropic.MessageParam[] = messageTurns.map(turn => ({
+    // Token-aware: automatically trims older messages if conversation exceeds limits
+    const messageTurnsResult = buildMessageTurnsWithMetadata(userMessage, threadContext, {
+      model: this.model,
+    });
+
+    if (messageTurnsResult.wasTrimmed) {
+      logger.info(
+        {
+          messagesRemoved: messageTurnsResult.messagesRemoved,
+          estimatedTokens: formatTokenCount(messageTurnsResult.estimatedTokens),
+          tokenLimit: formatTokenCount(getConversationTokenLimit(this.model)),
+        },
+        'Addie Stream: Trimmed conversation history to fit context limit'
+      );
+    }
+
+    const messages: Anthropic.MessageParam[] = messageTurnsResult.messages.map(turn => ({
       role: turn.role,
       content: turn.content,
     }));

--- a/server/src/utils/token-limiter.ts
+++ b/server/src/utils/token-limiter.ts
@@ -1,0 +1,240 @@
+/**
+ * Token limiting utilities for Anthropic API calls
+ *
+ * Provides functions to estimate token counts and trim conversation
+ * history to stay within Claude's context limits.
+ *
+ * Uses a conservative character-based estimate for fast local calculations.
+ * For exact counts, use Anthropic's messages.countTokens API.
+ */
+
+import { logger } from '../logger.js';
+
+/**
+ * Model context limits (input tokens)
+ * These are the maximum input tokens allowed before the API rejects the request.
+ * Reserve buffer space for system prompt, tools, and response generation.
+ */
+export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  'claude-sonnet-4-20250514': 200000,
+  'claude-3-5-sonnet-20241022': 200000,
+  'claude-3-opus-20240229': 200000,
+  'claude-3-haiku-20240307': 200000,
+  // Default for unknown models
+  default: 200000,
+};
+
+/**
+ * Buffer sizes for different components that contribute to context
+ * These are conservative estimates to prevent hitting limits
+ */
+export const TOKEN_BUFFERS = {
+  /** System prompt typically 8-15K tokens */
+  systemPrompt: 20000,
+  /** Tool definitions can be significant */
+  toolDefinitions: 15000,
+  /** Reserve space for response generation */
+  responseBuffer: 5000,
+  /** Safety margin for any miscalculation */
+  safetyMargin: 10000,
+};
+
+/**
+ * Total reserved tokens (not available for conversation history)
+ */
+export const RESERVED_TOKENS =
+  TOKEN_BUFFERS.systemPrompt +
+  TOKEN_BUFFERS.toolDefinitions +
+  TOKEN_BUFFERS.responseBuffer +
+  TOKEN_BUFFERS.safetyMargin;
+
+/**
+ * Get the effective limit for conversation history
+ */
+export function getConversationTokenLimit(model?: string): number {
+  const limit = MODEL_CONTEXT_LIMITS[model ?? 'default'] ?? MODEL_CONTEXT_LIMITS.default;
+  return limit - RESERVED_TOKENS;
+}
+
+/**
+ * Estimate token count from text using a character-based heuristic.
+ *
+ * Claude uses a BPE tokenizer where:
+ * - English text averages ~4 characters per token
+ * - Code and structured data can be 3-5 chars per token
+ * - We use 3.5 to be conservative (overestimate slightly)
+ *
+ * This is NOT exact but is fast for local estimation.
+ * Use Anthropic's API for precise counts when needed.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  // Conservative estimate: ~3.5 characters per token
+  // This slightly overestimates which is safer than underestimating
+  return Math.ceil(text.length / 3.5);
+}
+
+/**
+ * Message turn structure (matches prompts.ts)
+ */
+export interface MessageTurn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Result of trimming conversation history
+ */
+export interface TrimResult {
+  /** Trimmed messages that fit within limit */
+  messages: MessageTurn[];
+  /** Estimated token count of trimmed messages */
+  estimatedTokens: number;
+  /** Number of messages removed */
+  messagesRemoved: number;
+  /** Whether any trimming occurred */
+  wasTrimmed: boolean;
+}
+
+/**
+ * Trim conversation history to fit within token limit.
+ *
+ * Strategy:
+ * 1. Always keep the most recent message (current turn)
+ * 2. Remove oldest messages first until we fit
+ * 3. If even one message exceeds limit, truncate it
+ *
+ * @param messages - Conversation history (newest last)
+ * @param tokenLimit - Maximum tokens allowed for messages
+ * @returns Trimmed messages and metadata
+ */
+export function trimConversationHistory(
+  messages: MessageTurn[],
+  tokenLimit: number
+): TrimResult {
+  if (messages.length === 0) {
+    return {
+      messages: [],
+      estimatedTokens: 0,
+      messagesRemoved: 0,
+      wasTrimmed: false,
+    };
+  }
+
+  const originalCount = messages.length;
+
+  // Estimate tokens for each message
+  const messagesWithTokens = messages.map(msg => ({
+    message: msg,
+    tokens: estimateTokens(msg.content),
+  }));
+
+  // Start from the end (most recent) and work backwards
+  let totalTokens = 0;
+  const includedMessages: MessageTurn[] = [];
+
+  // Always try to include the most recent message (current user turn)
+  // Work backwards from the end
+  for (let i = messagesWithTokens.length - 1; i >= 0; i--) {
+    const { message, tokens } = messagesWithTokens[i];
+
+    if (totalTokens + tokens <= tokenLimit) {
+      // Fits within limit - add to front (to maintain order)
+      includedMessages.unshift(message);
+      totalTokens += tokens;
+    } else if (includedMessages.length === 0) {
+      // Even the most recent message doesn't fit - truncate it
+      const availableChars = Math.floor(tokenLimit * 3.5);
+      const truncateAt = Math.max(0, availableChars - 100);
+      const truncatedContent = message.content.substring(0, truncateAt) +
+        '\n\n[Message truncated due to length]';
+
+      logger.warn(
+        {
+          originalTokens: tokens,
+          truncatedTo: estimateTokens(truncatedContent),
+          tokenLimit,
+        },
+        'Token limiter: Truncated single message that exceeded limit'
+      );
+
+      includedMessages.unshift({
+        role: message.role,
+        content: truncatedContent,
+      });
+      totalTokens = estimateTokens(truncatedContent);
+      break; // Can't include any more
+    } else {
+      // Message doesn't fit and we have some messages - stop here
+      break;
+    }
+  }
+
+  const messagesRemoved = originalCount - includedMessages.length;
+  const wasTrimmed = messagesRemoved > 0;
+
+  if (wasTrimmed) {
+    logger.info(
+      {
+        originalMessages: originalCount,
+        keptMessages: includedMessages.length,
+        messagesRemoved,
+        estimatedTokens: totalTokens,
+        tokenLimit,
+      },
+      'Token limiter: Trimmed conversation history to fit context limit'
+    );
+  }
+
+  return {
+    messages: includedMessages,
+    estimatedTokens: totalTokens,
+    messagesRemoved,
+    wasTrimmed,
+  };
+}
+
+/**
+ * Check if a request is likely to exceed context limits.
+ *
+ * This is a fast local check using estimates. For critical operations,
+ * use Anthropic's messages.countTokens API.
+ *
+ * @param systemPromptTokens - Estimated tokens in system prompt
+ * @param messagesTokens - Estimated tokens in conversation messages
+ * @param toolsTokens - Estimated tokens in tool definitions
+ * @param model - Model name (for looking up context limit)
+ * @returns Object with check result and details
+ */
+export function checkContextLimit(
+  systemPromptTokens: number,
+  messagesTokens: number,
+  toolsTokens: number = 0,
+  model?: string
+): {
+  withinLimit: boolean;
+  estimatedTotal: number;
+  modelLimit: number;
+  headroom: number;
+} {
+  const modelLimit = MODEL_CONTEXT_LIMITS[model ?? 'default'] ?? MODEL_CONTEXT_LIMITS.default;
+  const estimatedTotal = systemPromptTokens + messagesTokens + toolsTokens + TOKEN_BUFFERS.responseBuffer;
+  const headroom = modelLimit - estimatedTotal;
+
+  return {
+    withinLimit: headroom > TOKEN_BUFFERS.safetyMargin,
+    estimatedTotal,
+    modelLimit,
+    headroom,
+  };
+}
+
+/**
+ * Format a token count for logging (e.g., "150K")
+ */
+export function formatTokenCount(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${Math.round(tokens / 1000)}K`;
+  }
+  return String(tokens);
+}

--- a/tests/utils/token-limiter.test.ts
+++ b/tests/utils/token-limiter.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for token-limiter utilities
+ *
+ * These tests verify the token estimation and conversation trimming logic
+ * that prevents context limit errors when calling the Anthropic API.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  estimateTokens,
+  trimConversationHistory,
+  getConversationTokenLimit,
+  checkContextLimit,
+  formatTokenCount,
+  MODEL_CONTEXT_LIMITS,
+  RESERVED_TOKENS,
+  type MessageTurn,
+} from '../../server/src/utils/token-limiter.js';
+
+describe('estimateTokens', () => {
+  it('should return 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('should return 0 for undefined/null', () => {
+    // @ts-expect-error - testing edge case
+    expect(estimateTokens(undefined)).toBe(0);
+    // @ts-expect-error - testing edge case
+    expect(estimateTokens(null)).toBe(0);
+  });
+
+  it('should estimate tokens for short text', () => {
+    // "Hello world" = 11 chars, ~3 tokens at 3.5 chars/token
+    const result = estimateTokens('Hello world');
+    expect(result).toBe(Math.ceil(11 / 3.5)); // 4
+  });
+
+  it('should estimate tokens for longer text', () => {
+    const text = 'This is a longer piece of text that should have more tokens.';
+    const result = estimateTokens(text);
+    expect(result).toBe(Math.ceil(text.length / 3.5));
+  });
+
+  it('should round up token estimates', () => {
+    // 10 chars / 3.5 = 2.857... should round up to 3
+    expect(estimateTokens('1234567890')).toBe(3);
+  });
+});
+
+describe('trimConversationHistory', () => {
+  it('should return empty result for empty messages', () => {
+    const result = trimConversationHistory([], 10000);
+    expect(result.messages).toEqual([]);
+    expect(result.estimatedTokens).toBe(0);
+    expect(result.messagesRemoved).toBe(0);
+    expect(result.wasTrimmed).toBe(false);
+  });
+
+  it('should keep all messages when within limit', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const result = trimConversationHistory(messages, 100000);
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messagesRemoved).toBe(0);
+    expect(result.wasTrimmed).toBe(false);
+  });
+
+  it('should remove oldest messages when over limit', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'A'.repeat(1000) }, // ~286 tokens
+      { role: 'assistant', content: 'B'.repeat(1000) }, // ~286 tokens
+      { role: 'user', content: 'C'.repeat(100) }, // ~29 tokens
+    ];
+
+    // Set limit to only fit the last message
+    const result = trimConversationHistory(messages, 50);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toContain('C');
+    expect(result.messagesRemoved).toBe(2);
+    expect(result.wasTrimmed).toBe(true);
+  });
+
+  it('should always try to include the most recent message', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'First message that is very long ' + 'x'.repeat(500) },
+      { role: 'assistant', content: 'Second message' },
+      { role: 'user', content: 'Most recent message' },
+    ];
+
+    // Very small limit - should prioritize most recent messages
+    const result = trimConversationHistory(messages, 10);
+
+    // Should include at least the most recent message
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+    // Most recent message should be preserved
+    expect(result.messages[result.messages.length - 1].content).toBe('Most recent message');
+    // First long message should be trimmed
+    expect(result.wasTrimmed).toBe(true);
+  });
+
+  it('should handle zero or very small token limit gracefully', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'Hello world' },
+    ];
+
+    const result = trimConversationHistory(messages, 0);
+
+    // Should still return a message (truncated)
+    expect(result.messages).toHaveLength(1);
+    // Content should include truncation notice (message content was truncated)
+    expect(result.messages[0].content).toContain('[Message truncated due to length]');
+    // No messages were removed, but content was truncated
+    expect(result.messagesRemoved).toBe(0);
+  });
+
+  it('should truncate single message if it exceeds limit', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'A'.repeat(10000) }, // Very long message
+    ];
+
+    // Very small limit
+    const result = trimConversationHistory(messages, 50);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toContain('[Message truncated due to length]');
+    expect(result.messages[0].content.length).toBeLessThan(10000);
+  });
+
+  it('should preserve message order', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'First' },
+      { role: 'assistant', content: 'Second' },
+      { role: 'user', content: 'Third' },
+      { role: 'assistant', content: 'Fourth' },
+    ];
+
+    const result = trimConversationHistory(messages, 100000);
+
+    expect(result.messages[0].content).toBe('First');
+    expect(result.messages[1].content).toBe('Second');
+    expect(result.messages[2].content).toBe('Third');
+    expect(result.messages[3].content).toBe('Fourth');
+  });
+
+  it('should track estimated tokens correctly', () => {
+    const messages: MessageTurn[] = [
+      { role: 'user', content: 'Hello' }, // 5 chars ~2 tokens
+      { role: 'assistant', content: 'World' }, // 5 chars ~2 tokens
+    ];
+
+    const result = trimConversationHistory(messages, 100000);
+
+    expect(result.estimatedTokens).toBeGreaterThan(0);
+    expect(result.estimatedTokens).toBe(
+      estimateTokens('Hello') + estimateTokens('World')
+    );
+  });
+});
+
+describe('getConversationTokenLimit', () => {
+  it('should return default limit minus reserved tokens', () => {
+    const limit = getConversationTokenLimit();
+    expect(limit).toBe(MODEL_CONTEXT_LIMITS.default - RESERVED_TOKENS);
+  });
+
+  it('should return model-specific limit minus reserved tokens', () => {
+    const limit = getConversationTokenLimit('claude-sonnet-4-20250514');
+    expect(limit).toBe(MODEL_CONTEXT_LIMITS['claude-sonnet-4-20250514'] - RESERVED_TOKENS);
+  });
+
+  it('should use default for unknown models', () => {
+    const limit = getConversationTokenLimit('unknown-model');
+    expect(limit).toBe(MODEL_CONTEXT_LIMITS.default - RESERVED_TOKENS);
+  });
+});
+
+describe('checkContextLimit', () => {
+  it('should return within limit for small request', () => {
+    const result = checkContextLimit(5000, 10000, 5000);
+
+    expect(result.withinLimit).toBe(true);
+    expect(result.headroom).toBeGreaterThan(0);
+  });
+
+  it('should return not within limit for large request', () => {
+    // System + messages + tools close to limit
+    const result = checkContextLimit(100000, 80000, 20000);
+
+    expect(result.withinLimit).toBe(false);
+  });
+
+  it('should calculate correct totals', () => {
+    const result = checkContextLimit(10000, 20000, 5000);
+
+    // Total should include response buffer
+    expect(result.estimatedTotal).toBe(10000 + 20000 + 5000 + 5000);
+    expect(result.modelLimit).toBe(MODEL_CONTEXT_LIMITS.default);
+  });
+});
+
+describe('formatTokenCount', () => {
+  it('should format small numbers as-is', () => {
+    expect(formatTokenCount(500)).toBe('500');
+    expect(formatTokenCount(999)).toBe('999');
+  });
+
+  it('should format thousands with K suffix', () => {
+    expect(formatTokenCount(1000)).toBe('1K');
+    expect(formatTokenCount(5000)).toBe('5K');
+    expect(formatTokenCount(10000)).toBe('10K');
+  });
+
+  it('should round to nearest K', () => {
+    expect(formatTokenCount(1500)).toBe('2K');
+    expect(formatTokenCount(1499)).toBe('1K');
+    expect(formatTokenCount(150000)).toBe('150K');
+  });
+});


### PR DESCRIPTION
## Summary
- Prevents "prompt is too long" errors when Addie conversation history exceeds Claude's 200K token limit
- Estimates token counts locally using a conservative character-based heuristic (~3.5 chars/token)
- Reserves ~50K tokens for system prompt, tools, and safety buffer
- Trims oldest messages when conversation exceeds ~150K tokens
- Truncates single messages that exceed the limit with a notice
- Logs when trimming occurs for debugging

## Test plan
- [x] Unit tests for token-limiter.ts pass
- [x] Unit tests for buildMessageTurnsWithMetadata pass
- [x] TypeScript compiles without errors
- [x] Docker app starts and health check passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)