### PR TITLE
fix: exclude RSS/email from research section perspectives

### DIFF
--- a/.changeset/loud-hairs-repeat.md
+++ b/.changeset/loud-hairs-repeat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Filter RSS and email content from research section to show only member perspectives.


### PR DESCRIPTION
## Summary
- Fixed research section at `/latest/research` showing random RSS news instead of member perspectives
- The previous fix (#740) queried perspectives where `working_group_id IS NULL`, but this included RSS/email content since those are also stored in the perspectives table with `source_type='rss'` or `source_type='email'`
- Added filter to only show member perspectives where `source_type IS NULL OR source_type NOT IN ('rss', 'email')`

## Changes
- Added `source_type` filter to `getResearchArticleCount()` function
- Added `source_type` filter to the research section articles query
- Made query aliasing consistent (using `p.` prefix in both queries)
- Added empty changeset with description

## Test plan
- [x] Tested locally with Vibium browser - research section now shows member perspectives (48 articles) instead of RSS content (was 552)
- [ ] Deploy to production
- [ ] Verify `/api/latest/sections/research/articles` returns member perspectives, not RSS content

🤖 Generated with [Claude Code](https://claude.com/claude-code)