### PR TITLE
fix: remove insight_goal_id references after column drop

### DIFF
--- a/.changeset/tender-experts-repeat.md
+++ b/.changeset/tender-experts-repeat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove insight_goal_id references following migration 166 column drop.

--- a/server/src/addie/services/proactive-outreach.ts
+++ b/server/src/addie/services/proactive-outreach.ts
@@ -530,7 +530,6 @@ async function initiateOutreach(candidate: OutreachCandidate): Promise<OutreachR
   const outreach = await insightsDb.recordOutreach({
     slack_user_id: candidate.slack_user_id,
     outreach_type: outreachType,
-    insight_goal_id: goal?.id,
     dm_channel_id: channelId,
     initial_message: message,
     variant_id: variant.id,

--- a/server/src/db/insights-db.ts
+++ b/server/src/db/insights-db.ts
@@ -82,7 +82,6 @@ export interface MemberOutreach {
   id: number;
   slack_user_id: string;
   outreach_type: OutreachType;
-  insight_goal_id: number | null;
   thread_id: string | null;
   dm_channel_id: string | null;
   initial_message: string | null;
@@ -149,7 +148,6 @@ export interface CreateVariantInput {
 export interface CreateOutreachInput {
   slack_user_id: string;
   outreach_type: OutreachType;
-  insight_goal_id?: number;
   thread_id?: string;
   dm_channel_id?: string;
   initial_message?: string;
@@ -808,14 +806,13 @@ export class InsightsDatabase {
   async recordOutreach(input: CreateOutreachInput): Promise<MemberOutreach> {
     const result = await query<MemberOutreach>(
       `INSERT INTO member_outreach (
-        slack_user_id, outreach_type, insight_goal_id, thread_id, dm_channel_id,
+        slack_user_id, outreach_type, thread_id, dm_channel_id,
         initial_message, variant_id, tone, approach
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING *`,
       [
         input.slack_user_id,
         input.outreach_type,
-        input.insight_goal_id || null,
         input.thread_id || null,
         input.dm_channel_id || null,
         input.initial_message || null,


### PR DESCRIPTION
## Summary
- Fixes production database errors in outreach scheduler caused by code referencing a dropped column
- Migration 166 dropped `insight_goal_id` from `member_outreach` but code still referenced it
- Removed references from TypeScript interfaces and SQL queries

## Test plan
- [x] Build passes (`npm run build`)
- [x] TypeCheck passes (`npm run typecheck`)
- [x] All tests pass (pre-commit hook)
- [x] App starts and runs in Docker
- [x] Dev login and member profile page load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)