### PR TITLE
fix: skip JSON body parser for Zoom webhook endpoint

### DIFF
--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -435,11 +435,13 @@ export class HTTPServer {
       // - Stripe webhooks: need raw body for webhook signature verification
       // - Resend inbound webhooks: need raw body for Svix signature verification
       // - WorkOS webhooks: need raw body for WorkOS signature verification
+      // - Zoom webhooks: need raw body for Zoom signature verification
       // - Slack routes: need raw body for Slack signature verification
       //   (both JSON for events and URL-encoded for commands)
       if (req.path === '/api/webhooks/stripe' ||
           req.path === '/api/webhooks/resend-inbound' ||
           req.path === '/api/webhooks/workos' ||
+          req.path === '/api/webhooks/zoom' ||
           req.path.startsWith('/api/slack/')) {
         next();
       } else {


### PR DESCRIPTION
## Summary
The Zoom webhook validation was failing because `express.json()` middleware was consuming the request body before our custom raw body middleware could capture it for signature verification.

This adds `/api/webhooks/zoom` to the skip list for the JSON body parser, matching how Stripe, Resend, and WorkOS webhooks are handled.

## Test plan
- [x] TypeScript compilation passes
- [x] All tests pass
- [ ] After deploy, retry Zoom webhook URL validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)