### PR TITLE
chore: reduce log noise from periodic background jobs

### DIFF
--- a/server/src/addie/jobs/committee-summary-generator.ts
+++ b/server/src/addie/jobs/committee-summary-generator.ts
@@ -208,7 +208,7 @@ async function generateCommitteeSummary(
     'addie'
   );
 
-  logger.info({
+  logger.debug({
     workingGroupId,
     groupName: group.name,
     summaryType,
@@ -225,7 +225,7 @@ export async function runSummaryGeneratorJob(options: {
 } = {}): Promise<SummaryGeneratorResult> {
   const { batchSize = 10, summaryType = 'activity' } = options;
 
-  logger.info({ batchSize, summaryType }, 'Running committee summary generator job');
+  logger.debug({ batchSize, summaryType }, 'Running committee summary generator job');
 
   const result: SummaryGeneratorResult = {
     committeesProcessed: 0,
@@ -243,7 +243,7 @@ export async function runSummaryGeneratorJob(options: {
       return result;
     }
 
-    logger.info({ count: committeeIds.length }, 'Processing committees for summary generation');
+    logger.debug({ count: committeeIds.length }, 'Processing committees for summary generation');
 
     // Process each committee
     for (const workingGroupId of committeeIds) {

--- a/server/src/addie/jobs/goal-follow-up.ts
+++ b/server/src/addie/jobs/goal-follow-up.ts
@@ -355,7 +355,7 @@ export async function runGoalFollowUpJob(options: {
   skipFollowUps?: boolean;
   skipReconciliation?: boolean;
 } = {}): Promise<FollowUpJobResult> {
-  logger.info({ options }, 'Running goal follow-up job');
+  logger.debug({ options }, 'Running goal follow-up job');
 
   let followUpsSent = 0;
   let followUpsSkipped = 0;
@@ -365,7 +365,7 @@ export async function runGoalFollowUpJob(options: {
   // Part 1: Send follow-up messages
   if (!options.skipFollowUps) {
     const pendingFollowUps = await getGoalsNeedingFollowUp();
-    logger.info({ count: pendingFollowUps.length }, 'Found goals needing follow-up');
+    logger.debug({ count: pendingFollowUps.length }, 'Found goals needing follow-up');
 
     for (const pending of pendingFollowUps) {
       if (options.dryRun) {
@@ -393,7 +393,7 @@ export async function runGoalFollowUpJob(options: {
   // Part 2: Reconcile goal outcomes
   if (!options.skipReconciliation) {
     const goalsToReconcile = await getGoalsToReconcile();
-    logger.info({ count: goalsToReconcile.length }, 'Found goals to reconcile');
+    logger.debug({ count: goalsToReconcile.length }, 'Found goals to reconcile');
 
     for (const goal of goalsToReconcile) {
       if (options.dryRun) {
@@ -414,7 +414,9 @@ export async function runGoalFollowUpJob(options: {
     }
   }
 
-  logger.info({
+  // Only log at info level if work was done
+  const logLevel = (followUpsSent > 0 || goalsReconciled > 0) ? 'info' : 'debug';
+  logger[logLevel]({
     followUpsSent,
     followUpsSkipped,
     goalsReconciled,

--- a/server/src/addie/services/outbound-planner.ts
+++ b/server/src/addie/services/outbound-planner.ts
@@ -90,7 +90,7 @@ export class OutboundPlanner {
     const quickMatch = this.quickMatch(available, ctx);
     if (quickMatch) {
       quickMatch.decision_method = 'rule_match';
-      logger.info({
+      logger.debug({
         slack_user_id: ctx.user.slack_user_id,
         goal: quickMatch.goal.name,
         reason: quickMatch.reason,
@@ -101,7 +101,7 @@ export class OutboundPlanner {
 
     // STAGE 4: LLM-based selection among candidates (nuanced)
     const llmResult = await this.llmSelect(available, ctx, startTime);
-    logger.info({
+    logger.debug({
       slack_user_id: ctx.user.slack_user_id,
       goal: llmResult.goal.name,
       reason: llmResult.reason,

--- a/server/src/addie/services/proactive-outreach.ts
+++ b/server/src/addie/services/proactive-outreach.ts
@@ -475,7 +475,7 @@ async function initiateOutreachWithPlanner(candidate: OutreachCandidate): Promis
   // Update user's last_outreach_at
   await updateLastOutreach(candidate.slack_user_id);
 
-  logger.info({
+  logger.debug({
     outreachId: outreach.id,
     slackUserId: candidate.slack_user_id,
     goalId: plannedAction.goal.id,
@@ -579,17 +579,17 @@ export async function runOutreachScheduler(options: {
     return { processed: 0, sent: 0, skipped: 0, errors: 0 };
   }
 
-  logger.info({ limit, usePlanner }, 'Running outreach scheduler');
+  logger.debug({ limit, usePlanner }, 'Running outreach scheduler');
 
   // Get candidates (we'll check business hours per-user based on their timezone)
   const candidates = await getEligibleCandidates(limit * 3); // Fetch more since some may be outside business hours
 
   if (candidates.length === 0) {
-    logger.info('Outreach scheduler: No eligible candidates');
+    logger.debug('Outreach scheduler: No eligible candidates');
     return { processed: 0, sent: 0, skipped: 0, errors: 0 };
   }
 
-  logger.info({ count: candidates.length }, 'Found outreach candidates');
+  logger.debug({ count: candidates.length }, 'Found outreach candidates');
 
   let sent = 0;
   let skipped = 0;
@@ -634,7 +634,9 @@ export async function runOutreachScheduler(options: {
     }
   }
 
-  logger.info({ sent, skipped, errors }, 'Outreach scheduler completed');
+  // Only log at info level if messages were actually sent
+  const logLevel = sent > 0 ? 'info' : 'debug';
+  logger[logLevel]({ sent, skipped, errors }, 'Outreach scheduler completed');
   return { processed: candidates.length, sent, skipped, errors };
 }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7017,7 +7017,7 @@ Disallow: /api/admin/
       this.feedFetcherInitialTimeoutId = null;
       try {
         const result = await processFeedsToFetch();
-        if (result.feedsProcessed > 0) {
+        if (result.newPerspectives > 0 || result.errors > 0) {
           logger.info(result, 'Industry monitor: fetched RSS feeds');
         }
       } catch (err) {
@@ -7028,7 +7028,7 @@ Disallow: /api/admin/
     this.feedFetcherIntervalId = setInterval(async () => {
       try {
         const result = await processFeedsToFetch();
-        if (result.feedsProcessed > 0) {
+        if (result.newPerspectives > 0 || result.errors > 0) {
           logger.info(result, 'Industry monitor: fetched RSS feeds');
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Change per-item and routine "nothing to do" logs from info to debug level across periodic background jobs
- Only log at info level when meaningful work occurs (e.g., content created, errors encountered)

## Changes
- **Committee summary generator**: Per-committee logs changed to debug
- **Goal follow-up job**: Only info log when follow-ups sent or goals reconciled
- **Outreach scheduler/planner**: Per-outreach logs changed to debug, only info when messages sent
- **RSS feed processor**: Only log when new perspectives created or errors occur

## Test plan
- [ ] Deploy to staging and verify logs are quieter
- [ ] Confirm meaningful events still appear in logs
- [ ] Verify debug logs available when LOG_LEVEL=debug

🤖 Generated with [Claude Code](https://claude.com/claude-code)