### PR TITLE
fix: remove RSS content from Editorial working group

### DIFF
--- a/.changeset/legal-islands-kick.md
+++ b/.changeset/legal-islands-kick.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix: Remove RSS and email content from Editorial working group
+
+Migration 153 incorrectly swept RSS feed articles into the Editorial working group.
+RSS content should remain unassigned (working_group_id = NULL) and display
+via The Latest sections through addie_knowledge.

--- a/server/src/db/migrations/169_remove_rss_from_editorial.sql
+++ b/server/src/db/migrations/169_remove_rss_from_editorial.sql
@@ -1,0 +1,20 @@
+-- Migration: 169_remove_rss_from_editorial.sql
+-- Fix: Remove RSS-sourced content from Editorial working group
+--
+-- Migration 153 incorrectly swept ALL perspectives with NULL working_group_id
+-- into the Editorial working group, including RSS feed articles.
+-- RSS content should remain unassigned (working_group_id = NULL) and display
+-- via The Latest sections through addie_knowledge, not on working group pages.
+
+-- =============================================================================
+-- Remove RSS and email content from any working group
+-- =============================================================================
+
+UPDATE perspectives
+SET working_group_id = NULL
+WHERE source_type IN ('rss', 'email')
+  AND working_group_id IS NOT NULL;
+
+-- =============================================================================
+-- Done
+-- =============================================================================


### PR DESCRIPTION
## Summary
- Migration 153 incorrectly swept ALL perspectives with NULL `working_group_id` into the Editorial working group, including RSS feed articles
- This fix sets `working_group_id = NULL` for all rss/email sourced content
- RSS content will now display via The Latest sections through `addie_knowledge` instead of on working group pages

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Verified migration runs correctly in local Docker environment
- [x] Editorial page still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)