### PR TITLE
fix: Get meeting attendee emails from users table

### DIFF
--- a/.changeset/fix-meeting-attendee-emails.md
+++ b/.changeset/fix-meeting-attendee-emails.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix: Get meeting attendee emails from users table
+
+The working_group_memberships.user_email field is often NULL because it's not
+always populated when members are added. Updated the query to join with the
+users table to get the actual email, falling back to the cached value if needed.
+
+This fixes calendar invites not being sent because attendeeCount was 0.


### PR DESCRIPTION
## Summary
- Fixed calendar invites not being sent for scheduled meetings
- The `working_group_memberships.user_email` field is often NULL because it's not always populated when members are added
- Updated the query to join with the `users` table to get the actual email, with fallback to cached value

## Problem
When Addie scheduled a meeting:
- ✅ Meeting created in database
- ✅ 5 members invited
- ❌ Calendar event created with `attendeeCount: 0`

The query was using `working_group_memberships.user_email` which was NULL for all members.

## Solution
Changed the query to:
```sql
SELECT
  wgm.workos_user_id,
  COALESCE(u.email, wgm.user_email) as email,
  COALESCE(u.first_name || ' ' || u.last_name, wgm.user_name) as name
FROM working_group_memberships wgm
LEFT JOIN users u ON u.workos_user_id = wgm.workos_user_id
WHERE ...
```

## Test plan
- [ ] Schedule a meeting with Addie
- [ ] Verify attendees have emails in the log output
- [ ] Verify calendar invites are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)