### PR TITLE
chore: Reduce log noise in scheduled jobs

### DIFF
--- a/.changeset/reduce-log-noise.md
+++ b/.changeset/reduce-log-noise.md
@@ -1,0 +1,4 @@
+---
+---
+
+Reduce log noise by changing per-item logs to debug level and making job summaries conditional

--- a/server/src/addie/jobs/scheduler.ts
+++ b/server/src/addie/jobs/scheduler.ts
@@ -86,10 +86,7 @@ class JobScheduler {
     // Run after a delay on startup
     job.initialTimeoutId = setTimeout(async () => {
       try {
-        const result = await runOutreachScheduler({ limit: 5 });
-        if (result.sent > 0) {
-          logger.info(result, 'Proactive outreach: initial run completed');
-        }
+        await runOutreachScheduler({ limit: 5 });
       } catch (err) {
         logger.error({ err }, 'Proactive outreach: initial run failed');
       }
@@ -98,10 +95,7 @@ class JobScheduler {
     // Then run periodically
     job.intervalId = setInterval(async () => {
       try {
-        const result = await runOutreachScheduler({ limit: 5 });
-        if (result.sent > 0) {
-          logger.info(result, 'Proactive outreach: job completed');
-        }
+        await runOutreachScheduler({ limit: 5 });
       } catch (err) {
         logger.error({ err }, 'Proactive outreach: job failed');
       }

--- a/server/src/addie/services/outbound-planner.ts
+++ b/server/src/addie/services/outbound-planner.ts
@@ -90,7 +90,7 @@ export class OutboundPlanner {
     const quickMatch = this.quickMatch(available, ctx);
     if (quickMatch) {
       quickMatch.decision_method = 'rule_match';
-      logger.info({
+      logger.debug({
         slack_user_id: ctx.user.slack_user_id,
         goal: quickMatch.goal.name,
         reason: quickMatch.reason,
@@ -101,7 +101,7 @@ export class OutboundPlanner {
 
     // STAGE 4: LLM-based selection among candidates (nuanced)
     const llmResult = await this.llmSelect(available, ctx, startTime);
-    logger.info({
+    logger.debug({
       slack_user_id: ctx.user.slack_user_id,
       goal: llmResult.goal.name,
       reason: llmResult.reason,

--- a/server/src/addie/services/proactive-outreach.ts
+++ b/server/src/addie/services/proactive-outreach.ts
@@ -475,7 +475,7 @@ async function initiateOutreachWithPlanner(candidate: OutreachCandidate): Promis
   // Update user's last_outreach_at
   await updateLastOutreach(candidate.slack_user_id);
 
-  logger.info({
+  logger.debug({
     outreachId: outreach.id,
     slackUserId: candidate.slack_user_id,
     goalId: plannedAction.goal.id,
@@ -579,17 +579,17 @@ export async function runOutreachScheduler(options: {
     return { processed: 0, sent: 0, skipped: 0, errors: 0 };
   }
 
-  logger.info({ limit, usePlanner }, 'Running outreach scheduler');
+  logger.debug({ limit, usePlanner }, 'Running outreach scheduler');
 
   // Get candidates (we'll check business hours per-user based on their timezone)
   const candidates = await getEligibleCandidates(limit * 3); // Fetch more since some may be outside business hours
 
   if (candidates.length === 0) {
-    logger.info('Outreach scheduler: No eligible candidates');
+    logger.debug('Outreach scheduler: No eligible candidates');
     return { processed: 0, sent: 0, skipped: 0, errors: 0 };
   }
 
-  logger.info({ count: candidates.length }, 'Found outreach candidates');
+  logger.debug({ count: candidates.length }, 'Found outreach candidates');
 
   let sent = 0;
   let skipped = 0;
@@ -634,7 +634,9 @@ export async function runOutreachScheduler(options: {
     }
   }
 
-  logger.info({ sent, skipped, errors }, 'Outreach scheduler completed');
+  if (sent > 0 || errors > 0) {
+    logger.info({ sent, skipped, errors }, 'Outreach scheduler completed');
+  }
   return { processed: candidates.length, sent, skipped, errors };
 }
 

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -1,5 +1,8 @@
 import type { Agent } from "./types.js";
 import { FormatsService } from "./formats.js";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger('capabilities');
 
 export interface ToolCapability {
   name: string;
@@ -113,7 +116,7 @@ export class CapabilityDiscovery {
       const client = multiClient.agent("discovery");
 
       const agentInfo = await client.getAgentInfo();
-      console.log(`MCP discovery for ${url}: found ${agentInfo.tools.length} tools`);
+      logger.debug({ url, toolCount: agentInfo.tools.length }, 'MCP discovery completed');
 
       return agentInfo.tools.map((tool: any) => ({
         name: tool.name,
@@ -122,7 +125,7 @@ export class CapabilityDiscovery {
         verified_at: new Date().toISOString(),
       }));
     } catch (error: any) {
-      console.error(`MCP discovery failed for ${url}:`, error.message);
+      logger.warn({ url, error: error.message }, 'MCP discovery failed');
       return [];
     }
   }
@@ -140,7 +143,7 @@ export class CapabilityDiscovery {
       const client = multiClient.agent("discovery");
 
       const agentInfo = await client.getAgentInfo();
-      console.log(`A2A discovery for ${url}: found ${agentInfo.tools.length} tools`);
+      logger.debug({ url, toolCount: agentInfo.tools.length }, 'A2A discovery completed');
 
       return agentInfo.tools.map((tool: any) => ({
         name: tool.name,
@@ -149,7 +152,7 @@ export class CapabilityDiscovery {
         verified_at: new Date().toISOString(),
       }));
     } catch (error: any) {
-      console.error(`A2A discovery failed for ${url}:`, error.message);
+      logger.warn({ url, error: error.message }, 'A2A discovery failed');
       return [];
     }
   }
@@ -177,9 +180,8 @@ export class CapabilityDiscovery {
       try {
         const formatsProfile = await this.formatsService.getFormatsForAgent(agent);
         formats = formatsProfile.formats.map(f => f.name);
-      } catch (error) {
-        // If format discovery fails, continue with empty array
-        console.error(`Format discovery failed for ${agent.url}:`, error);
+      } catch (error: any) {
+        logger.warn({ url: agent.url, error: error.message }, 'Format discovery failed');
       }
     }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7152,10 +7152,7 @@ Disallow: /api/admin/
     // Run after a delay on startup
     setTimeout(async () => {
       try {
-        const result = await runGoalFollowUpJob();
-        if (result.followUpsSent > 0 || result.goalsReconciled > 0) {
-          logger.info(result, 'Goal follow-up: initial run completed');
-        }
+        await runGoalFollowUpJob();
       } catch (err) {
         logger.error({ err }, 'Goal follow-up: initial run failed');
       }
@@ -7182,10 +7179,7 @@ Disallow: /api/admin/
           return;
         }
 
-        const result = await runGoalFollowUpJob();
-        if (result.followUpsSent > 0 || result.goalsReconciled > 0) {
-          logger.info(result, 'Goal follow-up: job completed');
-        }
+        await runGoalFollowUpJob();
       } catch (err) {
         logger.error({ err }, 'Goal follow-up: job failed');
       }


### PR DESCRIPTION
## Summary
- Change per-item logs to debug level (planner decisions, outreach sends, goal reconciliations)
- Make job summary logs conditional (only when there's activity)
- Remove duplicate wrapper logs from scheduler.ts and http.ts
- Convert console.log to logger.debug for MCP/A2A discovery
- Make "Running job" and "Found candidates" logs debug level

## Test plan
- [x] TypeScript compiles
- [x] All tests pass
- [x] Verified app starts and logs are quieter

---
Generated with [Claude Code](https://claude.com/claude-code)