### PR TITLE
fix: Add access control for private Slack channel search

### DIFF
--- a/.changeset/yellow-deer-brush.md
+++ b/.changeset/yellow-deer-brush.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal changes only - no protocol impact

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -709,6 +709,19 @@ async function createUserScopedTools(
     allHandlers.set('bookmark_resource', createUserScopedBookmarkHandler(slackUserId));
   }
 
+  // Override Slack search handlers with user-scoped versions (for private channel access control)
+  if (slackUserId) {
+    const userScopedKnowledgeHandlers = createKnowledgeToolHandlers(slackUserId);
+    const searchSlackHandler = userScopedKnowledgeHandlers.get('search_slack');
+    const getChannelActivityHandler = userScopedKnowledgeHandlers.get('get_channel_activity');
+    if (searchSlackHandler) {
+      allHandlers.set('search_slack', searchSlackHandler);
+    }
+    if (getChannelActivityHandler) {
+      allHandlers.set('get_channel_activity', getChannelActivityHandler);
+    }
+  }
+
   return {
     tools: {
       tools: allTools,

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -300,6 +300,19 @@ async function createUserScopedTools(
     allHandlers.set('bookmark_resource', createUserScopedBookmarkHandler(slackUserId));
   }
 
+  // Override Slack search handlers with user-scoped versions (for private channel access control)
+  if (slackUserId) {
+    const userScopedKnowledgeHandlers = createKnowledgeToolHandlers(slackUserId);
+    const searchSlackHandler = userScopedKnowledgeHandlers.get('search_slack');
+    const getChannelActivityHandler = userScopedKnowledgeHandlers.get('get_channel_activity');
+    if (searchSlackHandler) {
+      allHandlers.set('search_slack', searchSlackHandler);
+    }
+    if (getChannelActivityHandler) {
+      allHandlers.set('get_channel_activity', getChannelActivityHandler);
+    }
+  }
+
   return {
     tools: {
       tools: allTools,

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -717,21 +717,55 @@ export class AddieDatabase {
 
   /**
    * Search Slack messages stored locally using PostgreSQL full-text search
+   *
+   * @param accessiblePrivateChannelIds - List of private channel IDs the user has access to.
+   *   If provided, results will only include public channels OR private channels in this list.
+   *   If not provided (undefined), no access filtering is applied (use for internal/admin queries).
    */
   async searchSlackMessages(searchQuery: string, options: {
     limit?: number;
     channel?: string;
+    accessiblePrivateChannelIds?: string[];
   } = {}): Promise<SlackSearchResult[]> {
     const limit = options.limit ?? 10;
     const channel = options.channel;
+    const accessiblePrivateChannelIds = options.accessiblePrivateChannelIds;
 
-    // Build query with optional channel filter
-    const channelFilter = channel
-      ? `AND LOWER(slack_channel_name) LIKE LOWER($3)`
-      : '';
-    const params: (string | number)[] = [searchQuery, limit];
+    // Build dynamic query with optional filters
+    const params: (string | number | string[])[] = [searchQuery, limit];
+    let paramIndex = 3;
+
+    // Channel name filter
+    let channelFilter = '';
     if (channel) {
+      channelFilter = `AND LOWER(slack_channel_name) LIKE LOWER($${paramIndex})`;
       params.push(`%${channel}%`);
+      paramIndex++;
+    }
+
+    // Access control filter for private channels
+    // Only include messages from:
+    // 1. Public channels (those without a working group - tracked via slack_channel_id)
+    // 2. Private channels the user has access to (in accessiblePrivateChannelIds)
+    let accessFilter = '';
+    if (accessiblePrivateChannelIds !== undefined) {
+      if (accessiblePrivateChannelIds.length > 0) {
+        // Include public channels (not in any working group) OR accessible private channels
+        accessFilter = `AND (
+          NOT EXISTS (
+            SELECT 1 FROM working_groups wg
+            WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
+          )
+          OR slack_channel_id = ANY($${paramIndex}::text[])
+        )`;
+        params.push(accessiblePrivateChannelIds);
+      } else {
+        // User has no private channel access - only show public channels
+        accessFilter = `AND NOT EXISTS (
+          SELECT 1 FROM working_groups wg
+          WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
+        )`;
+      }
     }
 
     const result = await query<SlackSearchResult>(
@@ -749,6 +783,7 @@ export class AddieDatabase {
          AND source_type = 'slack'
          AND search_vector @@ websearch_to_tsquery('english', $1)
          ${channelFilter}
+         ${accessFilter}
        ORDER BY rank DESC
        LIMIT $2`,
       params
@@ -768,6 +803,7 @@ export class AddieDatabase {
 
   /**
    * Get recent messages from a channel (no keyword search, just by recency)
+   * Uses the actual Slack message timestamp (slack_ts) for filtering, not the DB record creation time
    */
   async getChannelActivity(channel: string, options: {
     days?: number;
@@ -794,13 +830,14 @@ export class AddieDatabase {
         slack_channel_name as channel_name,
         slack_username as username,
         slack_permalink as permalink,
-        created_at
+        TO_TIMESTAMP(slack_ts::numeric) as created_at
        FROM addie_knowledge
        WHERE is_active = TRUE
          AND source_type = 'slack'
          AND LOWER(slack_channel_name) LIKE LOWER($1)
-         AND created_at >= NOW() - INTERVAL '1 day' * $2
-       ORDER BY created_at DESC
+         AND slack_ts IS NOT NULL
+         AND TO_TIMESTAMP(slack_ts::numeric) >= NOW() - INTERVAL '1 day' * $2
+       ORDER BY slack_ts::numeric DESC
        LIMIT $3`,
       [`%${channel}%`, days, limit]
     );

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -511,6 +511,19 @@ export class WorkingGroupDatabase {
   }
 
   /**
+   * Get all working group IDs a user is a member of
+   */
+  async getWorkingGroupIdsByUser(userId: string): Promise<string[]> {
+    const canonicalUserId = await this.resolveToCanonicalUserId(userId);
+    const result = await query<{ working_group_id: string }>(
+      `SELECT working_group_id FROM working_group_memberships
+       WHERE workos_user_id = $1 AND status = 'active'`,
+      [canonicalUserId]
+    );
+    return result.rows.map(r => r.working_group_id);
+  }
+
+  /**
    * Get all memberships for a working group
    */
   async getMembershipsByWorkingGroup(workingGroupId: string): Promise<WorkingGroupMembership[]> {


### PR DESCRIPTION
## Summary
- Fix Addie's channel activity query to use actual Slack timestamps (`slack_ts`) instead of database record creation time (`created_at`)
- Remove `aao-admin` from the exclusion list so it can be indexed
- Add access control for private Slack channels based on working group membership
- Only index private channels that have linked working groups (simplifies access control)
- Filter search results to only show channels the user has access to

## Security
This PR addresses a potential information leak where users could search for keywords and receive results from private channels they don't have access to.

Private channel access is now determined by:
1. **Working group membership** - only private channels with linked working groups are indexed
2. **Local database lookup** - fast membership checks without Slack API calls

## Test plan
- [x] TypeScript compiles
- [x] All unit tests pass
- [x] Homepage loads in browser (Vibium test)
- [ ] Manual test: search for content in a private channel as a non-member (should not return results)
- [ ] Manual test: search for content in a private channel as a member (should return results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)