### PR TITLE
chore: Move scheduled job logs to debug level

### DIFF
--- a/.changeset/shiny-dots-act.md
+++ b/.changeset/shiny-dots-act.md
@@ -1,0 +1,4 @@
+---
+---
+
+Reduce log noise from scheduled jobs by moving routine success logs to debug level while keeping error logs at info level.

--- a/server/src/addie/services/feed-fetcher.ts
+++ b/server/src/addie/services/feed-fetcher.ts
@@ -228,8 +228,13 @@ export async function processFeedsToFetch(): Promise<{
   }
 
   // Only log when there's something notable
-  if (totalNewPerspectives > 0 || errorCount > 0) {
+  if (errorCount > 0) {
     logger.info(
+      { feedsProcessed: feeds.length, newPerspectives: totalNewPerspectives, errors: errorCount },
+      'RSS feed processing complete with errors'
+    );
+  } else if (totalNewPerspectives > 0) {
+    logger.debug(
       { feedsProcessed: feeds.length, newPerspectives: totalNewPerspectives, errors: errorCount },
       'RSS feed processing complete'
     );

--- a/server/src/addie/services/proactive-outreach.ts
+++ b/server/src/addie/services/proactive-outreach.ts
@@ -634,8 +634,10 @@ export async function runOutreachScheduler(options: {
     }
   }
 
-  if (sent > 0 || errors > 0) {
-    logger.info({ sent, skipped, errors }, 'Outreach scheduler completed');
+  if (errors > 0) {
+    logger.info({ sent, skipped, errors }, 'Outreach scheduler completed with errors');
+  } else if (sent > 0) {
+    logger.debug({ sent, skipped, errors }, 'Outreach scheduler completed');
   }
   return { processed: candidates.length, sent, skipped, errors };
 }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6953,17 +6953,17 @@ Disallow: /api/admin/
         // Process manually queued resources
         const result = await processPendingResources({ limit: 5 });
         if (result.processed > 0) {
-          logger.info(result, 'Content curator: processed pending resources');
+          logger.debug(result, 'Content curator: processed pending resources');
         }
         // Process RSS perspectives
         const rssResult = await processRssPerspectives({ limit: 5 });
         if (rssResult.processed > 0) {
-          logger.info(rssResult, 'Content curator: processed RSS perspectives');
+          logger.debug(rssResult, 'Content curator: processed RSS perspectives');
         }
         // Process community articles
         const communityResult = await processCommunityArticles({ limit: 5 });
         if (communityResult.processed > 0) {
-          logger.info(communityResult, 'Content curator: processed community articles');
+          logger.debug(communityResult, 'Content curator: processed community articles');
         }
         // Send replies to processed community articles
         const replyResult = await sendCommunityReplies(async (channelId, threadTs, text) => {
@@ -6971,7 +6971,7 @@ Disallow: /api/admin/
           return result.ok;
         });
         if (replyResult.sent > 0) {
-          logger.info(replyResult, 'Content curator: sent community article replies');
+          logger.debug(replyResult, 'Content curator: sent community article replies');
         }
       } catch (err) {
         logger.error({ err }, 'Content curator: initial processing failed');
@@ -6984,17 +6984,17 @@ Disallow: /api/admin/
         // Process manually queued resources
         const result = await processPendingResources({ limit: 5 });
         if (result.processed > 0) {
-          logger.info(result, 'Content curator: processed pending resources');
+          logger.debug(result, 'Content curator: processed pending resources');
         }
         // Process RSS perspectives
         const rssResult = await processRssPerspectives({ limit: 5 });
         if (rssResult.processed > 0) {
-          logger.info(rssResult, 'Content curator: processed RSS perspectives');
+          logger.debug(rssResult, 'Content curator: processed RSS perspectives');
         }
         // Process community articles
         const communityResult = await processCommunityArticles({ limit: 5 });
         if (communityResult.processed > 0) {
-          logger.info(communityResult, 'Content curator: processed community articles');
+          logger.debug(communityResult, 'Content curator: processed community articles');
         }
         // Send replies to processed community articles
         const replyResult = await sendCommunityReplies(async (channelId, threadTs, text) => {
@@ -7002,7 +7002,7 @@ Disallow: /api/admin/
           return result.ok;
         });
         if (replyResult.sent > 0) {
-          logger.info(replyResult, 'Content curator: sent community article replies');
+          logger.debug(replyResult, 'Content curator: sent community article replies');
         }
       } catch (err) {
         logger.error({ err }, 'Content curator: periodic processing failed');
@@ -7028,7 +7028,7 @@ Disallow: /api/admin/
       try {
         const result = await processFeedsToFetch();
         if (result.feedsProcessed > 0) {
-          logger.info(result, 'Industry monitor: fetched RSS feeds');
+          logger.debug(result, 'Industry monitor: fetched RSS feeds');
         }
       } catch (err) {
         logger.error({ err }, 'Industry monitor: initial feed fetch failed');
@@ -7039,7 +7039,7 @@ Disallow: /api/admin/
       try {
         const result = await processFeedsToFetch();
         if (result.feedsProcessed > 0) {
-          logger.info(result, 'Industry monitor: fetched RSS feeds');
+          logger.debug(result, 'Industry monitor: fetched RSS feeds');
         }
       } catch (err) {
         logger.error({ err }, 'Industry monitor: periodic feed fetch failed');


### PR DESCRIPTION
## Summary
- Move routine scheduled job success logs from info to debug level
- Keep error logs at info level with "with errors" suffix for visibility
- Reduce production log noise while preserving error visibility

## Affected jobs
- Industry monitor: RSS feed fetching
- Content curator: RSS perspectives, community articles, pending resources
- Outreach scheduler: Proactive outreach

## Test plan
- [x] Type check passes
- [x] All tests pass
- [x] Docker compose builds and runs successfully
- [x] Verified error case logs at info level (tested with RSS feed timeout error)

🤖 Generated with [Claude Code](https://claude.ai/code)