### PR TITLE
refactor: Extract package update schema and add reporting_webhook support

### DIFF
--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -149,10 +149,24 @@ asyncio.run(create_and_pause_campaign())
 | `end_time` | string | No | Updated campaign end time |
 | `paused` | boolean | No | Pause/resume entire media buy (`true` = paused, `false` = active) |
 | `packages` | PackageUpdate[] | No | Package-level updates (see below) |
-| `creatives` | CreativeAsset[] | No | Upload and assign new creative assets inline |
-| `creative_assignments` | CreativeAssignment[] | No | Update creative rotation weights and placement targeting |
+| `reporting_webhook` | object | No | Update reporting webhook configuration (see below) |
+| `push_notification_config` | object | No | Webhook for async operation notifications |
 
 *Either `media_buy_id` OR `buyer_ref` is required (not both)
+
+### Reporting Webhook Object
+
+Configure automated delivery reporting for this media buy:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | Yes | Webhook endpoint URL |
+| `authentication` | object | Yes | Auth config with `schemes` and `credentials` |
+| `reporting_frequency` | string | Yes | `hourly`, `daily`, or `monthly` |
+| `requested_metrics` | string[] | No | Specific metrics to include (defaults to all) |
+| `token` | string | No | Client token for validation (min 16 chars) |
+
+**Note**: `reporting_webhook` configures ongoing campaign reporting. `push_notification_config` is for async operation notifications (e.g., "notify me when this update completes").
 
 ### Package Update Object
 
@@ -166,7 +180,9 @@ asyncio.run(create_and_pause_campaign())
 | `pacing` | string | Updated pacing strategy |
 | `bid_price` | number | Updated bid price (auction products only) |
 | `targeting_overlay` | TargetingOverlay | Updated targeting restrictions |
-| `creative_ids` | string[] | Replace assigned creatives |
+| `creative_ids` | string[] | Replace assigned creatives (by library ID) |
+| `creatives` | CreativeAsset[] | Upload and assign new creatives inline |
+| `creative_assignments` | CreativeAssignment[] | Assignments with weights and placement targeting |
 
 *Either `package_id` OR `buyer_ref` is required for each package update
 
@@ -513,6 +529,7 @@ asyncio.run(update_multiple_packages())
 ✅ **Can update:**
 - Start/end times (subject to seller approval)
 - Campaign status (active/paused)
+- Reporting webhook configuration (URL, frequency, metrics)
 
 ❌ **Cannot update:**
 - Media buy ID

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -403,6 +403,10 @@
         "package-request": {
           "$ref": "/schemas/media-buy/package-request.json",
           "description": "Package configuration for media buy creation - used within create_media_buy request"
+        },
+        "package-update": {
+          "$ref": "/schemas/media-buy/package-update.json",
+          "description": "Package update configuration for update_media_buy - identifies package and specifies fields to modify"
         }
       },
       "tasks": {

--- a/static/schemas/source/media-buy/package-update.json
+++ b/static/schemas/source/media-buy/package-update.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/media-buy/package-update.json",
+  "title": "Package Update",
+  "description": "Package update configuration for update_media_buy. Identifies package by package_id or buyer_ref and specifies fields to modify. Fields not present are left unchanged. Note: product_id, format_ids, and pricing_option_id cannot be changed after creation.",
+  "type": "object",
+  "properties": {
+    "package_id": {
+      "type": "string",
+      "description": "Publisher's ID of package to update"
+    },
+    "buyer_ref": {
+      "type": "string",
+      "description": "Buyer's reference for the package to update"
+    },
+    "budget": {
+      "type": "number",
+      "description": "Updated budget allocation for this package in the currency specified by the pricing option",
+      "minimum": 0
+    },
+    "pacing": {
+      "$ref": "/schemas/enums/pacing.json"
+    },
+    "bid_price": {
+      "type": "number",
+      "description": "Updated bid price for auction-based pricing options (only applies when pricing_option is auction-based)",
+      "minimum": 0
+    },
+    "impressions": {
+      "type": "number",
+      "description": "Updated impression goal for this package",
+      "minimum": 0
+    },
+    "paused": {
+      "type": "boolean",
+      "description": "Pause/resume specific package (true = paused, false = active)"
+    },
+    "targeting_overlay": {
+      "$ref": "/schemas/core/targeting.json"
+    },
+    "creative_ids": {
+      "type": "array",
+      "description": "Update creative assignments (references existing library creatives)",
+      "items": {
+        "type": "string"
+      }
+    },
+    "creatives": {
+      "type": "array",
+      "description": "Full creative objects to upload and assign to this package (alternative to creative_ids - creatives will be added to library). Supports both static and generative creatives.",
+      "items": {
+        "$ref": "/schemas/core/creative-asset.json"
+      },
+      "maxItems": 100
+    },
+    "creative_assignments": {
+      "type": "array",
+      "description": "Full creative assignment objects with weights and placement targeting (alternative to creative_ids - provides granular control over weights and placement targeting). Uses replacement semantics like creative_ids.",
+      "items": {
+        "$ref": "/schemas/core/creative-assignment.json"
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "oneOf": [
+    {
+      "required": [
+        "package_id"
+      ]
+    },
+    {
+      "required": [
+        "buyer_ref"
+      ]
+    }
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -29,82 +29,88 @@
       "type": "array",
       "description": "Package-specific updates",
       "items": {
-        "type": "object",
-        "properties": {
-          "package_id": {
-            "type": "string",
-            "description": "Publisher's ID of package to update"
-          },
-          "buyer_ref": {
-            "type": "string",
-            "description": "Buyer's reference for the package to update"
-          },
-          "budget": {
-            "type": "number",
-            "description": "Updated budget allocation for this package in the currency specified by the pricing option",
-            "minimum": 0
-          },
-          "pacing": {
-            "$ref": "/schemas/enums/pacing.json"
-          },
-          "bid_price": {
-            "type": "number",
-            "description": "Updated bid price for auction-based pricing options (only applies when pricing_option is auction-based)",
-            "minimum": 0
-          },
-          "impressions": {
-            "type": "number",
-            "description": "Updated impression goal for this package",
-            "minimum": 0
-          },
-          "paused": {
-            "type": "boolean",
-            "description": "Pause/resume specific package (true = paused, false = active)"
-          },
-          "targeting_overlay": {
-            "$ref": "/schemas/core/targeting.json"
-          },
-          "creative_ids": {
-            "type": "array",
-            "description": "Update creative assignments (references existing library creatives)",
-            "items": {
-              "type": "string"
-            }
-          },
-          "creatives": {
-            "type": "array",
-            "description": "Full creative objects to upload and assign to this package (alternative to creative_ids - creatives will be added to library). Supports both static and generative creatives.",
-            "items": {
-              "$ref": "/schemas/core/creative-asset.json"
-            },
-            "maxItems": 100
-          },
-          "creative_assignments": {
-            "type": "array",
-            "description": "Full creative assignment objects with weights and placement targeting (alternative to creative_ids - provides granular control over weights and placement targeting). Uses replacement semantics like creative_ids.",
-            "items": {
-              "$ref": "/schemas/core/creative-assignment.json"
-            }
-          }
-        },
-        "oneOf": [
-          {
-            "required": [
-              "package_id"
-            ]
-          },
-          {
-            "required": [
-              "buyer_ref"
-            ]
-          }
-        ],
-        "additionalProperties": true
+        "$ref": "/schemas/media-buy/package-update.json"
       }
+    },
+    "reporting_webhook": {
+      "$comment": "Fields url, token, and authentication mirror push-notification-config.json. Inlined here because allOf + additionalProperties:false doesn't work in JSON Schema (additionalProperties can't see $ref properties). See CLAUDE.md 'Avoiding allOf with additionalProperties'.",
+      "type": "object",
+      "description": "Optional webhook configuration for automated reporting delivery. Updates the reporting configuration for this media buy. Combines push_notification_config structure with reporting-specific fields.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Webhook endpoint URL for reporting notifications"
+        },
+        "token": {
+          "type": "string",
+          "description": "Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.",
+          "minLength": 16
+        },
+        "authentication": {
+          "type": "object",
+          "description": "Authentication configuration for webhook delivery (A2A-compatible)",
+          "properties": {
+            "schemes": {
+              "type": "array",
+              "description": "Array of authentication schemes. Supported: ['Bearer'] for simple token auth, ['HMAC-SHA256'] for signature verification (recommended for production)",
+              "items": {
+                "$ref": "/schemas/enums/auth-scheme.json"
+              },
+              "minItems": 1,
+              "maxItems": 1
+            },
+            "credentials": {
+              "type": "string",
+              "description": "Credentials for authentication. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.",
+              "minLength": 32
+            }
+          },
+          "required": [
+            "schemes",
+            "credentials"
+          ],
+          "additionalProperties": false
+        },
+        "reporting_frequency": {
+          "type": "string",
+          "enum": [
+            "hourly",
+            "daily",
+            "monthly"
+          ],
+          "description": "Frequency for automated reporting delivery. Must be supported by all products in the media buy."
+        },
+        "requested_metrics": {
+          "type": "array",
+          "description": "Optional list of metrics to include in webhook notifications. If omitted, all available metrics are included. Must be subset of product's available_metrics.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "impressions",
+              "spend",
+              "clicks",
+              "ctr",
+              "video_completions",
+              "completion_rate",
+              "conversions",
+              "viewability",
+              "engagement_rate"
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "url",
+        "authentication",
+        "reporting_frequency"
+      ],
+      "additionalProperties": true
     },
     "push_notification_config": {
       "$ref": "/schemas/core/push-notification-config.json",
-      "description": "Optional webhook configuration for async update notifications. Publisher will send webhook when update completes if operation takes longer than immediate response time."
+      "description": "Optional webhook configuration for async update notifications. Publisher will send webhook when update completes if operation takes longer than immediate response time. This is separate from reporting_webhook which configures ongoing campaign reporting."
     },
     "context": {
       "$ref": "/schemas/core/context.json"


### PR DESCRIPTION
## Summary
Split package schema into three clear variants: package-request.json for creation, package-update.json for updates, and package.json for responses. Added reporting_webhook to update_media_buy, enabling modification of reporting configuration after campaign creation.

## Changes
- Created package-update.json schema documenting only updatable fields
- Added reporting_webhook field to update-media-buy-request.json  
- Unified schema definitions to eliminate duplication
- Updated documentation with complete webhook and package configuration details

## Resolves
Fixes issue where reporting configuration could not be updated post-launch without recreating the media buy.