### PR TITLE
feat: Add privacy_policy_url to brand manifest and adagents.json

### DIFF
--- a/.changeset/hip-numbers-train.md
+++ b/.changeset/hip-numbers-train.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add privacy_policy_url field to brand manifest and adagents.json schemas
+
+Enables consumer consent flows by providing a link to advertiser/publisher privacy policies. AI platforms can use this to present explicit privacy choices to users before data handoff. Works alongside MyTerms/IEEE P7012 discovery for machine-readable privacy terms.

--- a/docs/creative/brand-manifest.mdx
+++ b/docs/creative/brand-manifest.mdx
@@ -22,6 +22,7 @@ Brand manifests solve a key problem: how to efficiently identify advertisers and
 ### Key Benefits
 
 - **Know Your Customer**: Publishers can verify advertisers meet their standards
+- **Privacy Transparency**: Link to privacy policy for consumer consent flows
 - **Minimal Friction**: Start with just a name or URL, expand as needed
 - **Cacheable**: Same brand manifest reused across all requests
 - **Standardized**: Consistent format across all AdCP implementations
@@ -243,6 +244,7 @@ The structure of the brand manifest object itself (whether provided inline or ho
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | Brand or business name |
+| `privacy_policy_url` | string (uri) | URL to the brand's privacy policy for consumer consent flows |
 | `logos` | Logo[] | Brand logo assets with semantic tags |
 | `colors` | Colors | Brand color palette (hex format) |
 | `fonts` | Fonts | Brand typography guidelines |
@@ -491,6 +493,33 @@ Enterprise brands with large asset libraries should provide explicit assets:
   ]
 }
 ```
+
+## Privacy Integration
+
+Brand manifests support privacy transparency through the `privacy_policy_url` field. This enables AI platforms to present explicit privacy choices to users before sharing personal data with advertisers.
+
+### Consumer Consent Flow
+
+When an AI assistant helps a user engage with an advertiser (booking a flight, making a purchase, etc.), the platform can use the brand manifest's privacy policy URL to:
+
+1. **Present explicit consent**: "May I share your details with Delta? [View their privacy policy]"
+2. **Enable informed decisions**: Users can review data practices before data handoff
+3. **Support machine-readable terms**: Works alongside [MyTerms/IEEE P7012](https://myterms.info) for automated privacy negotiation
+
+### Example with Privacy Policy
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v2/core/brand-manifest.json",
+  "name": "Delta Airlines",
+  "url": "https://delta.com",
+  "privacy_policy_url": "https://delta.com/privacy"
+}
+```
+
+### MyTerms Discovery
+
+For advertisers implementing [IEEE P7012 (MyTerms)](https://myterms.info), AI platforms can discover machine-readable privacy terms from the advertiser's domain (e.g., `/.well-known/myterms`). The brand manifest's `privacy_policy_url` serves as the human-readable fallback and explicit consent path.
 
 ## Evolution and Versioning
 

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -70,6 +70,11 @@
               "description": "TAG Certified Against Fraud ID for verification (if applicable)",
               "minLength": 1,
               "maxLength": 100
+            },
+            "privacy_policy_url": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to the entity's privacy policy. Used for consumer consent flows when interacting with this sales agent."
             }
           },
           "required": [
@@ -350,7 +355,8 @@
         "email": "adops@meta.com",
         "domain": "meta.com",
         "seller_id": "pub-meta-12345",
-        "tag_id": "12345"
+        "tag_id": "12345",
+        "privacy_policy_url": "https://www.meta.com/privacy/policy"
       },
       "properties": [
         {

--- a/static/schemas/source/core/brand-manifest.json
+++ b/static/schemas/source/core/brand-manifest.json
@@ -10,6 +10,11 @@
       "format": "uri",
       "description": "Primary brand URL for context and asset discovery. Creative agents can infer brand information from this URL."
     },
+    "privacy_policy_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the brand's privacy policy. Used for consumer consent flows when personal data may be shared with the advertiser. AI platforms can use this to present explicit privacy choices to users before data handoff."
+    },
     "name": {
       "type": "string",
       "description": "Brand or business name"
@@ -318,6 +323,7 @@
       "description": "Full brand manifest with all fields",
       "data": {
         "url": "https://acmecorp.com",
+        "privacy_policy_url": "https://acmecorp.com/privacy",
         "name": "ACME Corporation",
         "logos": [
           {

--- a/v2.6-rc/docs/media-buy/capability-discovery/adagents.mdx
+++ b/v2.6-rc/docs/media-buy/capability-discovery/adagents.mdx
@@ -65,6 +65,7 @@ The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
   - **`domain`** *(optional)*: Primary domain of managing entity
   - **`seller_id`** *(optional)*: Seller ID from IAB Tech Lab sellers.json
   - **`tag_id`** *(optional)*: TAG Certified Against Fraud ID
+  - **`privacy_policy_url`** *(optional)*: URL to entity's privacy policy for consumer consent flows
 
 **`properties`** *(optional)*: Array of properties covered by this file (canonical property definitions)
 
@@ -357,7 +358,8 @@ Large network using tags for grouping efficiency:
     "email": "adops@meta.com",
     "domain": "meta.com",
     "seller_id": "pub-meta-12345",
-    "tag_id": "12345"
+    "tag_id": "12345",
+    "privacy_policy_url": "https://www.meta.com/privacy/policy"
   },
   "properties": [
     {


### PR DESCRIPTION
## Summary

- Add `privacy_policy_url` field to brand manifest schema for advertiser privacy policies
- Add `privacy_policy_url` field to adagents.json contact object for publisher/agent privacy policies
- Add documentation for privacy integration including MyTerms/IEEE P7012 context

## Context

This enables consumer consent flows in AI advertising platforms. When an AI assistant helps a user engage with an advertiser (booking a flight, making a purchase, etc.), the platform can use the privacy policy URL to present explicit privacy choices before data handoff.

Works alongside [MyTerms/IEEE P7012](https://myterms.info) discovery for machine-readable privacy terms - the `privacy_policy_url` serves as the human-readable fallback and explicit consent path.

## Test plan

- [x] Build passes
- [x] All unit tests pass
- [x] Schema validation tests pass
- [x] Example validation tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)