### PR TITLE
feat: Add OpenAI Commerce integration to brand manifest

### DIFF
--- a/.changeset/openai-product-feed.md
+++ b/.changeset/openai-product-feed.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Add OpenAI Commerce integration to brand manifest
+
+- Add `openai_product_feed` as a supported feed format for product catalogs
+- Add `agentic_checkout` object to enable AI agents to complete purchases via structured checkout APIs
+- Document field mapping from Google Merchant Center to OpenAI Product Feed spec

--- a/docs/creative/brand-manifest.mdx
+++ b/docs/creative/brand-manifest.mdx
@@ -327,10 +327,21 @@ The structure of the brand manifest object itself (whether provided inline or ho
 ```typescript
 {
   feed_url: string;                  // URL to product catalog feed
-  feed_format?: string;              // Format of the product feed (default: "google_merchant_center")
+  feed_format?: string;              // Format: "google_merchant_center" | "facebook_catalog" | "openai_product_feed" | "custom"
   categories?: string[];             // Product categories available in the catalog
   last_updated?: string;             // When the product catalog was last updated (ISO 8601)
   update_frequency?: string;         // How frequently the catalog is updated
+  agentic_checkout?: AgenticCheckout; // Optional checkout endpoint configuration
+}
+```
+
+### AgenticCheckout Object
+
+```typescript
+{
+  endpoint: string;                  // Base URL for checkout session API
+  spec: string;                      // Checkout API specification (e.g., "openai_agentic_checkout_v1")
+  supported_payment_providers?: string[]; // Payment providers (e.g., ["stripe", "adyen"])
 }
 ```
 
@@ -461,7 +472,7 @@ Large retailers should provide product feeds:
 }
 ```
 
-**Supported Feed Formats**: RSS, JSON Feed, Product CSV
+**Supported Feed Formats**: Google Merchant Center, Facebook Catalog, [OpenAI Product Feed](https://developers.openai.com/commerce/specs/feed), Custom
 
 ### 5. Asset Libraries for Enterprise
 
@@ -520,6 +531,58 @@ When an AI assistant helps a user engage with an advertiser (booking a flight, m
 ### MyTerms Discovery
 
 For advertisers implementing [IEEE P7012 (MyTerms)](https://myterms.info), AI platforms can discover machine-readable privacy terms from the advertiser's domain (e.g., `/.well-known/myterms`). The brand manifest's `privacy_policy_url` serves as the human-readable fallback and explicit consent path.
+
+## Agentic Commerce Integration
+
+Brand manifests support integration with AI commerce platforms through the `product_catalog` field. This enables AI agents to discover products and complete purchases on behalf of users.
+
+### OpenAI Commerce
+
+For merchants implementing [OpenAI's Commerce specifications](https://developers.openai.com/commerce), the brand manifest provides a bridge:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v2/core/brand-manifest.json",
+  "name": "Shop Example",
+  "url": "https://shopexample.com",
+  "privacy_policy_url": "https://shopexample.com/privacy",
+  "product_catalog": {
+    "feed_url": "https://shopexample.com/products.jsonl.gz",
+    "feed_format": "openai_product_feed",
+    "update_frequency": "daily",
+    "agentic_checkout": {
+      "endpoint": "https://api.shopexample.com/checkout_sessions",
+      "spec": "openai_agentic_checkout_v1",
+      "supported_payment_providers": ["stripe", "adyen"]
+    }
+  }
+}
+```
+
+**Key fields for OpenAI Commerce:**
+
+| Field | Description |
+|-------|-------------|
+| `feed_format: "openai_product_feed"` | Indicates the feed conforms to [OpenAI's Product Feed spec](https://developers.openai.com/commerce/specs/feed) |
+| `agentic_checkout.endpoint` | Base URL for [OpenAI's Agentic Checkout API](https://developers.openai.com/commerce/specs/checkout) |
+| `agentic_checkout.spec` | Version identifier for the checkout spec |
+
+### Feed Format Mapping
+
+If you have an existing Google Merchant Center feed, here's how key fields map to OpenAI's spec:
+
+| OpenAI Field | Google Merchant Center | Notes |
+|--------------|----------------------|-------|
+| `item_id` | `id` | Direct mapping |
+| `title` | `title` | Direct mapping |
+| `description` | `description` | Direct mapping |
+| `url` | `link` | Direct mapping |
+| `brand` | `brand` | Direct mapping |
+| `price` | `price` | OpenAI uses number + currency code |
+| `availability` | `availability` | Same enum values |
+| `image_url` | `image_link` | Direct mapping |
+| `is_eligible_search` | N/A | OpenAI-specific flag |
+| `is_eligible_checkout` | N/A | OpenAI-specific flag |
 
 ## Evolution and Versioning
 

--- a/static/schemas/source/core/brand-manifest.json
+++ b/static/schemas/source/core/brand-manifest.json
@@ -194,10 +194,11 @@
           "enum": [
             "google_merchant_center",
             "facebook_catalog",
+            "openai_product_feed",
             "custom"
           ],
           "default": "google_merchant_center",
-          "description": "Format of the product feed"
+          "description": "Format of the product feed. Use 'openai_product_feed' for feeds conforming to the OpenAI Commerce Product Feed specification."
         },
         "categories": {
           "type": "array",
@@ -220,6 +221,35 @@
             "weekly"
           ],
           "description": "How frequently the product catalog is updated"
+        },
+        "agentic_checkout": {
+          "type": "object",
+          "description": "Agentic checkout endpoint configuration. Enables AI agents to complete purchases on behalf of users through a structured checkout API.",
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "format": "uri",
+              "description": "Base URL for checkout session API (e.g., https://merchant.com/api/checkout_sessions)"
+            },
+            "spec": {
+              "type": "string",
+              "enum": [
+                "openai_agentic_checkout_v1"
+              ],
+              "description": "Checkout API specification implemented by the endpoint"
+            },
+            "supported_payment_providers": {
+              "type": "array",
+              "description": "Payment providers supported by this checkout endpoint",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "endpoint",
+            "spec"
+          ]
         }
       },
       "required": [
@@ -409,6 +439,27 @@
         ],
         "industry": "technology",
         "target_audience": "business decision-makers aged 35-55"
+      }
+    },
+    {
+      "description": "E-commerce brand with OpenAI product feed and agentic checkout",
+      "data": {
+        "url": "https://shopexample.com",
+        "privacy_policy_url": "https://shopexample.com/privacy",
+        "name": "Shop Example",
+        "product_catalog": {
+          "feed_url": "https://shopexample.com/products.jsonl.gz",
+          "feed_format": "openai_product_feed",
+          "update_frequency": "daily",
+          "agentic_checkout": {
+            "endpoint": "https://api.shopexample.com/checkout_sessions",
+            "spec": "openai_agentic_checkout_v1",
+            "supported_payment_providers": [
+              "stripe",
+              "adyen"
+            ]
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
Adds support for OpenAI's product feed format and agentic checkout specification in brand manifests, enabling AI agents to discover products and complete purchases through a structured API.

This includes the new `openai_product_feed` feed format option and the optional `agentic_checkout` object for specifying checkout endpoints. Documentation includes a helpful field mapping table for merchants migrating from Google Merchant Center feeds.