### PR TITLE
fix: Dedupe alerts by URL to prevent spam from existing duplicates

### DIFF
--- a/.changeset/alert-dedupe-url.md
+++ b/.changeset/alert-dedupe-url.md
@@ -2,11 +2,13 @@
 "adcontextprotocol": patch
 ---
 
-Fix alert deduplication to check external_url across all perspectives
+Fix Addie alert spam and improve content relevance
 
-The previous fix prevented new duplicate perspectives from being created,
-but the alert query still matched existing duplicates and posted the same
-article multiple times (once per perspective).
+**Alert deduplication fix:**
+The alert query now checks if ANY perspective with the same external_url
+has been alerted to a channel, preventing spam from cross-feed duplicates.
 
-Now the alert query checks if ANY perspective with the same external_url
-has been alerted to a channel, preventing spam from pre-existing duplicates.
+**Content relevance improvement:**
+Tightened `mentions_agentic` detection to require BOTH agentic AI terms
+AND advertising context. This prevents general AI news (e.g., ChatGPT updates)
+from being flagged as relevant to our agentic advertising community.

--- a/server/src/addie/services/industry-alerts.ts
+++ b/server/src/addie/services/industry-alerts.ts
@@ -238,6 +238,8 @@ async function getNextArticleForChannel(
          OR k.notification_channel_ids IS NULL
          OR array_length(k.notification_channel_ids, 1) = 0
        )
+       -- Dedupe by URL: check if ANY perspective with the same article URL
+       -- has been alerted to this channel (prevents spam from cross-feed duplicates)
        AND NOT EXISTS (
          SELECT 1 FROM industry_alerts ia
          JOIN perspectives p2 ON ia.perspective_id = p2.id

--- a/server/src/db/migrations/179_index_industry_alerts_channel.sql
+++ b/server/src/db/migrations/179_index_industry_alerts_channel.sql
@@ -1,0 +1,5 @@
+-- Add composite index on industry_alerts for channel-based deduplication queries
+-- This supports the NOT EXISTS subquery that checks if any perspective with
+-- the same external_url has been alerted to a specific channel
+CREATE INDEX IF NOT EXISTS idx_industry_alerts_channel_perspective
+  ON industry_alerts(channel_id, perspective_id);


### PR DESCRIPTION
## Summary
- Fix alert deduplication to check `external_url` across all perspectives
- Tighten `mentions_agentic` detection to require advertising context
- Add composite index on `industry_alerts(channel_id, perspective_id)` for query performance

## Problem
1. **Spam from duplicates**: The same Adweek article was being posted 5+ times because it appeared in multiple RSS feeds. Each feed created a duplicate perspective before the cross-feed deduplication fix.

2. **Irrelevant content**: Articles about general AI (ChatGPT updates, OpenAI agents) were being flagged as relevant because they mentioned "AI agent" even without any advertising context.

## Solution

### Alert deduplication
Changed the NOT EXISTS subquery from checking `perspective_id` to checking if ANY perspective with the same `external_url` has been alerted to that channel.

### Content relevance
Tightened `checkMentionsAgentic()` to require BOTH:
- Agentic terms: `agentic`, `ai agent`, `autonomous agent`, etc.
- Advertising context: `advertising`, `programmatic`, `media buy`, `dsp`, `campaign`, etc.

**Before**: Article about "OpenAI's new AI agent" → `mentions_agentic = true`
**After**: Same article → `mentions_agentic = false` (no advertising context)

## Test plan
- [x] TypeScript compiles
- [x] All tests pass
- [x] Verified app loads via Vibium browser testing
- [x] Admin feeds page displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)