### PR TITLE
fix: Set founding member status for new profiles before cutoff date

### DIFF
--- a/.changeset/itchy-gifts-go.md
+++ b/.changeset/itchy-gifts-go.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix founding member badge not displaying for members who joined after initial migration ran.
+
+The original migration 147 only set `is_founding_member = TRUE` for profiles that existed at migration time. Profiles created afterward were not automatically flagged, even though they joined before the April 2026 cutoff.
+
+Changes:
+- Update `createProfile` to set founding member status based on cutoff date
+- Add migration 180 to backfill existing profiles that should have the flag

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -34,8 +34,8 @@ export class MemberDatabase {
         contact_email, contact_website, contact_phone,
         linkedin_url, twitter_url,
         offerings, agents, publishers, headquarters, markets, metadata, tags,
-        is_public, show_in_carousel
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+        is_public, show_in_carousel, is_founding_member
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, NOW() < '2026-04-01'::timestamptz)
       RETURNING *`,
       [
         input.workos_organization_id,

--- a/server/src/db/migrations/180_fix_founding_member_status.sql
+++ b/server/src/db/migrations/180_fix_founding_member_status.sql
@@ -1,0 +1,8 @@
+-- Fix founding member status for profiles created before cutoff
+-- The original migration 147 only ran once, so profiles created afterwards
+-- were not automatically flagged as founding members
+
+UPDATE member_profiles
+SET is_founding_member = TRUE
+WHERE created_at < '2026-04-01'::timestamptz
+  AND is_founding_member = FALSE;


### PR DESCRIPTION
## Summary
- Fix founding member badge not displaying for members who joined after initial migration ran
- The original migration 147 only set `is_founding_member = TRUE` for profiles that existed at migration time
- Profiles created afterward were not automatically flagged, even though they joined before the April 2026 cutoff

## Changes
- Update `createProfile` in `member-db.ts` to set founding member status based on cutoff date
- Add migration 180 to backfill existing profiles that should have the flag

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Migration applies correctly (verified in docker compose)
- [x] Schema has `is_founding_member` column with correct index

🤖 Generated with [Claude Code](https://claude.com/claude-code)