### PR TITLE
fix: Remove invalid display_name column reference in member insights query

### DIFF
--- a/.changeset/fix-member-insights-query.md
+++ b/.changeset/fix-member-insights-query.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix member insights 500 error by removing invalid column reference

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -938,8 +938,7 @@ export function setupOrganizationRoutes(
             mi.confidence,
             mi.source_type,
             mi.created_at,
-            mit.name as insight_type,
-            mit.display_name as insight_type_display
+            mit.name as insight_type
           FROM member_insights mi
           JOIN member_insight_types mit ON mi.insight_type_id = mit.id
           WHERE mi.slack_user_id = ANY($1)
@@ -952,7 +951,7 @@ export function setupOrganizationRoutes(
         const insights = insightsResult.rows.map((row) => ({
           slack_user_id: row.slack_user_id,
           member_name: slackUserMap.get(row.slack_user_id) || row.slack_user_id,
-          insight_type: row.insight_type_display || row.insight_type,
+          insight_type: row.insight_type,
           value: row.value,
           confidence: row.confidence,
           source_type: row.source_type,


### PR DESCRIPTION
## Summary
- Fix 500 error on `/api/admin/organizations/:orgId/member-insights` endpoint
- The SQL query was referencing `mit.display_name`, a column that doesn't exist in the `member_insight_types` table
- The table only has `name` (as defined in migration `072_member_insights.sql`)

## Test plan
- [x] Tests pass (241 tests)
- [x] TypeScript compiles
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)