### PR TITLE
fix: Convert governance docs to relative links

### DIFF
--- a/docs/governance/brand-standards/index.mdx
+++ b/docs/governance/brand-standards/index.mdx
@@ -87,4 +87,4 @@ Detailed specification and task definitions for Brand Standards governance are u
 - **Creative compliance**: Validate creatives against brand guidelines
 - **Audience verification**: Ensure targeting complies with brand audience constraints
 
-See the [Governance Protocol overview](/docs/governance/index) for the broader context of how Brand Standards fits into AdCP governance.
+See the [Governance Protocol overview](../index) for the broader context of how Brand Standards fits into AdCP governance.

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -300,5 +300,5 @@ The verification agent doesn't need to understand the scheme - it's opaque. The 
 
 ## Related
 
-- [Content Standards Overview](/docs/governance/content-standards) - How artifacts fit into the content standards workflow
-- [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) - Sending artifacts for calibration
+- [Content Standards Overview](.) - How artifacts fit into the content standards workflow
+- [calibrate_content](./tasks/calibrate_content) - Sending artifacts for calibration

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -43,7 +43,7 @@ This inverts the traditional model. Instead of "send us your content, we'll eval
 
 Content standards evaluation involves four key questions that buyers and sellers negotiate:
 
-1. **What content?** - What [artifacts](/docs/governance/content-standards/artifacts) to evaluate (the ad-adjacent content)
+1. **What content?** - What [artifacts](./artifacts) to evaluate (the ad-adjacent content)
 2. **How much adjacency?** - How many artifacts around the ad slot to consider
 3. **What sampling rate?** - What percentage of traffic to evaluate
 4. **How to calibrate?** - How to align on policy interpretation before runtime
@@ -204,7 +204,7 @@ Content Standards uses **natural language prompts** rather than rigid keyword li
 
 The policy prompt enables AI-powered verification agents to understand context and nuance. **Calibration** examples provide a training/test set that helps the agent interpret the policy correctly.
 
-See [Artifacts](/docs/governance/content-standards/artifacts) for details on artifact structure and secured asset access.
+See [Artifacts](./artifacts) for details on artifact structure and secured asset access.
 
 ## Scoped Standards
 
@@ -255,7 +255,7 @@ Before running campaigns, sellers calibrate their local models against the verif
 }
 ```
 
-See [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) for the full task specification.
+See [calibrate_content](./tasks/calibrate_content) for the full task specification.
 
 ## Tasks
 
@@ -263,24 +263,24 @@ See [calibrate_content](/docs/governance/content-standards/tasks/calibrate_conte
 
 | Task | Description |
 |------|-------------|
-| [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) | List available standards configurations |
-| [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) | Retrieve a specific standards configuration |
+| [list_content_standards](./tasks/list_content_standards) | List available standards configurations |
+| [get_content_standards](./tasks/get_content_standards) | Retrieve a specific standards configuration |
 
 ### Management
 
 | Task | Description |
 |------|-------------|
-| [create_content_standards](/docs/governance/content-standards/tasks/create_content_standards) | Create a new standards configuration |
-| [update_content_standards](/docs/governance/content-standards/tasks/update_content_standards) | Update an existing standards configuration |
-| [delete_content_standards](/docs/governance/content-standards/tasks/delete_content_standards) | Delete a standards configuration |
+| [create_content_standards](./tasks/create_content_standards) | Create a new standards configuration |
+| [update_content_standards](./tasks/update_content_standards) | Update an existing standards configuration |
+| [delete_content_standards](./tasks/delete_content_standards) | Delete a standards configuration |
 
 ### Calibration & Validation
 
 | Task | Description |
 |------|-------------|
-| [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) | Collaborative dialogue to align on policy interpretation |
-| [get_media_buy_artifacts](/docs/governance/content-standards/tasks/get_media_buy_artifacts) | Retrieve content artifacts from a media buy |
-| [validate_content_delivery](/docs/governance/content-standards/tasks/validate_content_delivery) | Batch validation of content artifacts |
+| [calibrate_content](./tasks/calibrate_content) | Collaborative dialogue to align on policy interpretation |
+| [get_media_buy_artifacts](./tasks/get_media_buy_artifacts) | Retrieve content artifacts from a media buy |
+| [validate_content_delivery](./tasks/validate_content_delivery) | Batch validation of content artifacts |
 
 ## Typical Providers
 
@@ -354,5 +354,5 @@ This architecture aligns with the [IAB Tech Lab ARTF (Agentic RTB Framework)](ht
 
 ## Related
 
-- [Artifacts](/docs/governance/content-standards/artifacts) - What artifacts are and how to structure them
-- [Brand Manifest](/docs/creative/brand-manifest) - Static brand identity that can link to standards agents
+- [Artifacts](./artifacts) - What artifacts are and how to structure them
+- [Brand Manifest](../../creative/brand-manifest) - Static brand identity that can link to standards agents

--- a/docs/governance/content-standards/tasks/calibrate_content.mdx
+++ b/docs/governance/content-standards/tasks/calibrate_content.mdx
@@ -224,5 +224,5 @@ The key insight is that the dialogue happens at the **protocol layer**, not the 
 
 ## Related Tasks
 
-- [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) - Retrieve the policies being calibrated against
-- [validate_content_delivery](/docs/governance/content-standards/tasks/validate_content_delivery) - Post-campaign delivery validation
+- [get_content_standards](./get_content_standards) - Retrieve the policies being calibrated against
+- [validate_content_delivery](./validate_content_delivery) - Post-campaign delivery validation

--- a/docs/governance/content-standards/tasks/create_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/create_content_standards.mdx
@@ -79,12 +79,12 @@ Implementors MUST apply a brand safety floor regardless of what policy is define
 
 Multiple standards cannot have overlapping scopes for the same country/channel/language combination. When creating standards that would conflict:
 
-1. **Check existing standards** - Use [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) filtered by your scope
-2. **Update rather than create** - If standards already exist, use [update_content_standards](/docs/governance/content-standards/tasks/update_content_standards)
+1. **Check existing standards** - Use [list_content_standards](./list_content_standards) filtered by your scope
+2. **Update rather than create** - If standards already exist, use [update_content_standards](./update_content_standards)
 3. **Narrow the scope** - Adjust countries or channels to avoid overlap
 
 ## Related Tasks
 
-- [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) - List all configurations
-- [update_content_standards](/docs/governance/content-standards/tasks/update_content_standards) - Update a configuration
-- [delete_content_standards](/docs/governance/content-standards/tasks/delete_content_standards) - Delete a configuration
+- [list_content_standards](./list_content_standards) - List all configurations
+- [update_content_standards](./update_content_standards) - Update a configuration
+- [delete_content_standards](./delete_content_standards) - Delete a configuration

--- a/docs/governance/content-standards/tasks/delete_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/delete_content_standards.mdx
@@ -62,9 +62,9 @@ Delete a content standards configuration.
 }
 ```
 
-Standards cannot be deleted while they are referenced by active media buys. Use [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) to identify usage, or archive standards by setting an expiration date rather than deleting.
+Standards cannot be deleted while they are referenced by active media buys. Use [list_content_standards](./list_content_standards) to identify usage, or archive standards by setting an expiration date rather than deleting.
 
 ## Related Tasks
 
-- [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) - List all configurations
-- [create_content_standards](/docs/governance/content-standards/tasks/create_content_standards) - Create a new configuration
+- [list_content_standards](./list_content_standards) - List all configurations
+- [create_content_standards](./create_content_standards) - Create a new configuration

--- a/docs/governance/content-standards/tasks/get_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/get_content_standards.mdx
@@ -73,5 +73,5 @@ Implementors MUST apply a brand safety floor regardless of what policy is define
 
 ## Related Tasks
 
-- [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) - Collaborative calibration against these standards
-- [list_content_standards](/docs/governance/content-standards/tasks/list_content_standards) - List available standards configurations
+- [calibrate_content](./calibrate_content) - Collaborative calibration against these standards
+- [list_content_standards](./list_content_standards) - List available standards configurations

--- a/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
+++ b/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
@@ -200,6 +200,6 @@ print(f"False positive rate: {false_positives / len(failures['artifacts']):.1%}"
 
 ## Related Tasks
 
-- [validate_content_delivery](/docs/governance/content-standards/tasks/validate_content_delivery) - Validate the artifacts
-- [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) - Understand why artifacts pass/fail
-- [get_media_buy_delivery](/docs/media-buy/task-reference/get_media_buy_delivery) - Get performance metrics
+- [validate_content_delivery](./validate_content_delivery) - Validate the artifacts
+- [calibrate_content](./calibrate_content) - Understand why artifacts pass/fail
+- [get_media_buy_delivery](../../../media-buy/task-reference/get_media_buy_delivery) - Get performance metrics

--- a/docs/governance/content-standards/tasks/list_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/list_content_standards.mdx
@@ -23,7 +23,7 @@ List available content standards configurations.
 
 **Schema**: [list-content-standards-response.json](https://adcontextprotocol.org/schemas/v2/content-standards/list-content-standards-response.json)
 
-Returns an abbreviated list of standards configurations. Use [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) to retrieve full details including policy text and calibration data.
+Returns an abbreviated list of standards configurations. Use [get_content_standards](./get_content_standards) to retrieve full details including policy text and calibration data.
 
 ### Success Response
 
@@ -63,5 +63,5 @@ Returns an abbreviated list of standards configurations. Use [get_content_standa
 
 ## Related Tasks
 
-- [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) - Get a specific standards configuration
-- [create_content_standards](/docs/governance/content-standards/tasks/create_content_standards) - Create a new configuration
+- [get_content_standards](./get_content_standards) - Get a specific standards configuration
+- [create_content_standards](./create_content_standards) - Create a new configuration

--- a/docs/governance/content-standards/tasks/update_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/update_content_standards.mdx
@@ -67,6 +67,6 @@ Update an existing content standards configuration. Creates a new version.
 
 ## Related Tasks
 
-- [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) - Get current configuration
-- [create_content_standards](/docs/governance/content-standards/tasks/create_content_standards) - Create a new configuration
-- [delete_content_standards](/docs/governance/content-standards/tasks/delete_content_standards) - Delete a configuration
+- [get_content_standards](./get_content_standards) - Get current configuration
+- [create_content_standards](./create_content_standards) - Create a new configuration
+- [delete_content_standards](./delete_content_standards) - Delete a configuration

--- a/docs/governance/content-standards/tasks/validate_content_delivery.mdx
+++ b/docs/governance/content-standards/tasks/validate_content_delivery.mdx
@@ -178,6 +178,6 @@ for result in response["results"]:
 
 ## Related Tasks
 
-- [get_media_buy_artifacts](/docs/governance/content-standards/tasks/get_media_buy_artifacts) - Get content artifacts from seller
-- [calibrate_content](/docs/governance/content-standards/tasks/calibrate_content) - Understand why artifacts pass/fail
-- [get_content_standards](/docs/governance/content-standards/tasks/get_content_standards) - Retrieve the policies
+- [get_media_buy_artifacts](./get_media_buy_artifacts) - Get content artifacts from seller
+- [calibrate_content](./calibrate_content) - Understand why artifacts pass/fail
+- [get_content_standards](./get_content_standards) - Retrieve the policies

--- a/docs/governance/index.mdx
+++ b/docs/governance/index.mdx
@@ -19,8 +19,8 @@ The Governance Protocol covers four distinct governance domains:
 
 | Domain | What It Governs | Key Mechanisms |
 |--------|-----------------|----------------|
-| **[Property Governance](/docs/governance/property/index)** | Where ads can run | Property lists, compliance filtering, adagents.json authorization |
-| **[Brand Standards](/docs/governance/brand-standards/index)** | Brand requirements | Brand manifests, creative guidelines, audience constraints |
+| **[Property Governance](./property/index)** | Where ads can run | Property lists, compliance filtering, adagents.json authorization |
+| **[Brand Standards](./brand-standards/index)** | Brand requirements | Brand manifests, creative guidelines, audience constraints |
 | **Creative Governance** | What creatives are compliant | Format validation, content moderation, accessibility |
 | **Campaign Governance** | What can be bought | Budget controls, approval workflows, policy compliance |
 
@@ -173,7 +173,7 @@ The Media Buy Protocol consumes governance data at multiple stages:
 1. Implement feature discovery tasks (`list_property_features`, etc.)
 2. Implement stateful list management (CRUD operations)
 3. Support webhooks to notify when evaluations change
-4. See the [Property Protocol Specification](/docs/governance/property/specification) for detailed implementation guidance
+4. See the [Property Protocol Specification](./property/specification) for detailed implementation guidance
 
 ## Protocol Sections
 

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -620,14 +620,14 @@ The Python library handles validation automatically when fetching - if the adage
 
 After implementing adagents.json validation:
 
-1. **Integrate with Product Discovery**: Use [`get_products`](/docs/media-buy/task-reference/get_products) to discover inventory
-2. **Validate at Purchase**: Check authorization before calling [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy)
+1. **Integrate with Product Discovery**: Use [`get_products`](../../media-buy/task-reference/get_products) to discover inventory
+2. **Validate at Purchase**: Check authorization before calling [`create_media_buy`](../../media-buy/task-reference/create_media_buy)
 3. **Cache Property Mappings**: Store resolved properties for efficient validation
 4. **Monitor Authorization**: Track validation success rates and unauthorized attempts
 
 ## Learn More
 
 - [AdCP Basics: Authorized Properties](https://bokonads.com/p/adcp-basics-authorized-properties) - Accessible introduction to AdCP authorization
-- [list_authorized_properties](/docs/media-buy/task-reference/list_authorized_properties) - Discover publisher domains an agent represents
+- [list_authorized_properties](../../media-buy/task-reference/list_authorized_properties) - Discover publisher domains an agent represents
 - [Property Schema](https://adcontextprotocol.org/schemas/v2/core/property.json) - Property definition structure
 - [AdAgents.json Builder](https://adcontextprotocol.org/adagents) - Web-based validator and creator

--- a/docs/governance/property/authorized-properties.mdx
+++ b/docs/governance/property/authorized-properties.mdx
@@ -93,7 +93,7 @@ Publishers authorize sales agents by hosting an `adagents.json` file at `/.well-
 
 ## How Sales Agents Share Authorized Properties
 
-Sales agents use the [`list_authorized_properties`](/docs/media-buy/task-reference/list_authorized_properties) task to declare all properties they are authorized to represent. This serves multiple purposes:
+Sales agents use the [`list_authorized_properties`](../../media-buy/task-reference/list_authorized_properties) task to declare all properties they are authorized to represent. This serves multiple purposes:
 
 1. **Transparency**: Buyers can see what properties an agent represents
 2. **Validation enablement**: Provides the data buyers need to verify authorization
@@ -248,9 +248,9 @@ if (!authorized) {
 
 ## Integration with Product Discovery
 
-Authorization validation integrates seamlessly with [Product Discovery](/docs/media-buy/product-discovery/):
+Authorization validation integrates seamlessly with [Product Discovery](../../media-buy/product-discovery/):
 
-1. **Discover products** using [`get_products`](/docs/media-buy/task-reference/get_products)
+1. **Discover products** using [`get_products`](../../media-buy/task-reference/get_products)
 2. **Validate authorization** for properties referenced in products
 3. **Proceed confidently** with authorized inventory
 4. **Flag unauthorized** products for manual review
@@ -269,11 +269,11 @@ For complete technical details on implementing the `adagents.json` file format, 
 - Validation code examples and error handling
 - Security considerations and best practices
 
-See the **[adagents.json Tech Spec](/docs/governance/property/adagents)** for complete implementation guidance.
+See the **[adagents.json Tech Spec](./adagents)** for complete implementation guidance.
 
 ## Related Documentation
 
-- **[`list_authorized_properties`](/docs/media-buy/task-reference/list_authorized_properties)** - API reference for property discovery
-- **[Product Discovery](/docs/media-buy/product-discovery/)** - How authorization integrates with product discovery
+- **[`list_authorized_properties`](../../media-buy/task-reference/list_authorized_properties)** - API reference for property discovery
+- **[Product Discovery](../../media-buy/product-discovery/)** - How authorization integrates with product discovery
 - **[Properties Schema](https://adcontextprotocol.org/schemas/v2/core/property.json)** - Technical property data model
-- **[adagents.json Tech Spec](/docs/governance/property/adagents)** - Complete `adagents.json` implementation guide
+- **[adagents.json Tech Spec](./adagents)** - Complete `adagents.json` implementation guide

--- a/docs/governance/property/index.mdx
+++ b/docs/governance/property/index.mdx
@@ -48,7 +48,7 @@ Publishers declare their properties and authorize sales agents via `/.well-known
 }
 ```
 
-See the [adagents.json Tech Spec](/docs/governance/property/adagents) for complete documentation.
+See the [adagents.json Tech Spec](./adagents) for complete documentation.
 
 ## Buyer Side: Property Data and Selection
 
@@ -197,14 +197,14 @@ Both protocols operate on properties but serve different purposes:
 
 ### Discovery
 
-- **[list_property_features](/docs/governance/property/tasks/list_property_features)**: Discover what data a governance agent can provide about properties
+- **[list_property_features](./tasks/list_property_features)**: Discover what data a governance agent can provide about properties
 
 ### Property List Management
 
-- **[create_property_list](/docs/governance/property/tasks/property_lists#create_property_list)**: Create a new property list on a governance agent
-- **[get_property_list](/docs/governance/property/tasks/property_lists#get_property_list)**: Retrieve resolved properties (with caching guidance)
-- **[update_property_list](/docs/governance/property/tasks/property_lists#update_property_list)**: Modify filters or base properties
-- **[delete_property_list](/docs/governance/property/tasks/property_lists#delete_property_list)**: Remove a property list
+- **[create_property_list](./tasks/property_lists#create_property_list)**: Create a new property list on a governance agent
+- **[get_property_list](./tasks/property_lists#get_property_list)**: Retrieve resolved properties (with caching guidance)
+- **[update_property_list](./tasks/property_lists#update_property_list)**: Modify filters or base properties
+- **[delete_property_list](./tasks/property_lists#delete_property_list)**: Remove a property list
 
 ## Getting Started
 
@@ -222,6 +222,6 @@ Both protocols operate on properties but serve different purposes:
 1. Implement `list_property_features` to advertise your capabilities
 2. Implement property list CRUD operations
 3. Support webhooks to notify buyers when evaluations change
-4. See the [Protocol Specification](/docs/governance/property/specification) for implementation details
+4. See the [Protocol Specification](./specification) for implementation details
 
-See the [Protocol Specification](/docs/governance/property/specification) for detailed implementation guidance.
+See the [Protocol Specification](./specification) for detailed implementation guidance.

--- a/docs/governance/property/specification.mdx
+++ b/docs/governance/property/specification.mdx
@@ -605,7 +605,7 @@ Media buys can reference governance policies via property list references:
 
 ## Next Steps
 
-- See the [adagents.json Tech Spec](/docs/governance/property/adagents) for property declaration and authorization
-- See the [list_property_features task reference](/docs/governance/property/tasks/list_property_features) for capability discovery
-- See the [Property List Management](/docs/governance/property/tasks/property_lists) for CRUD operations and webhooks
-- See the [validate_property_delivery task reference](/docs/governance/property/tasks/validate_property_delivery) for post-campaign compliance validation
+- See the [adagents.json Tech Spec](./adagents) for property declaration and authorization
+- See the [list_property_features task reference](./tasks/list_property_features) for capability discovery
+- See the [Property List Management](./tasks/property_lists) for CRUD operations and webhooks
+- See the [validate_property_delivery task reference](./tasks/validate_property_delivery) for post-campaign compliance validation

--- a/docs/governance/property/tasks/index.mdx
+++ b/docs/governance/property/tasks/index.mdx
@@ -15,27 +15,27 @@ Property governance uses a **stateful** model where all evaluation happens throu
 
 | Task | Purpose | Response Time |
 |------|---------|---------------|
-| [list_property_features](/docs/governance/property/tasks/list_property_features) | Discover agent capabilities | ~200ms |
+| [list_property_features](./list_property_features) | Discover agent capabilities | ~200ms |
 
 ## Property List Management
 
 | Task | Purpose | Response Time |
 |------|---------|---------------|
-| [create_property_list](/docs/governance/property/tasks/property_lists#create_property_list) | Create a new property list | ~500ms |
-| [update_property_list](/docs/governance/property/tasks/property_lists#update_property_list) | Modify an existing list | ~500ms |
-| [get_property_list](/docs/governance/property/tasks/property_lists#get_property_list) | Retrieve list with resolved properties | ~2-5s |
-| [list_property_lists](/docs/governance/property/tasks/property_lists#list_property_lists) | List all property lists | ~500ms |
-| [delete_property_list](/docs/governance/property/tasks/property_lists#delete_property_list) | Delete a property list | ~200ms |
+| [create_property_list](./property_lists#create_property_list) | Create a new property list | ~500ms |
+| [update_property_list](./property_lists#update_property_list) | Modify an existing list | ~500ms |
+| [get_property_list](./property_lists#get_property_list) | Retrieve list with resolved properties | ~2-5s |
+| [list_property_lists](./property_lists#list_property_lists) | List all property lists | ~500ms |
+| [delete_property_list](./property_lists#delete_property_list) | Delete a property list | ~200ms |
 
-See [Property List Management](/docs/governance/property/tasks/property_lists) for complete CRUD documentation.
+See [Property List Management](./property_lists) for complete CRUD documentation.
 
 ## Validation
 
 | Task | Purpose | Response Time |
 |------|---------|---------------|
-| [validate_property_delivery](/docs/governance/property/tasks/validate_property_delivery) | Validate delivery records against a list | ~1-5s |
+| [validate_property_delivery](./validate_property_delivery) | Validate delivery records against a list | ~1-5s |
 
-See [validate_property_delivery](/docs/governance/property/tasks/validate_property_delivery) for post-campaign compliance validation.
+See [validate_property_delivery](./validate_property_delivery) for post-campaign compliance validation.
 
 ## Task Selection Guide
 

--- a/docs/governance/property/tasks/validate_property_delivery.mdx
+++ b/docs/governance/property/tasks/validate_property_delivery.mdx
@@ -397,6 +397,6 @@ def analyze_validation(response):
 
 ## Related Tasks
 
-- [create_property_list](/docs/governance/property/tasks/property_lists#create_property_list) - Create the list to validate against
-- [get_property_list](/docs/governance/property/tasks/property_lists#get_property_list) - Retrieve current list membership
-- [list_property_features](/docs/governance/property/tasks/list_property_features) - Discover available filter features
+- [create_property_list](./property_lists#create_property_list) - Create the list to validate against
+- [get_property_list](./property_lists#get_property_list) - Retrieve current list membership
+- [list_property_features](./list_property_features) - Discover available filter features


### PR DESCRIPTION
## Summary

Converts all absolute links (`/docs/governance/...`) in governance docs to relative links (`./artifacts`, `../property/index`, etc.).

This fixes broken links when docs are synced to `v2.6-rc/` on main - absolute links would point to the wrong version.

## Changes

- 18 files updated
- 77 absolute links converted to relative paths
- Links within governance use `./` or `../` relative paths
- Cross-section links (to media-buy, creative) also use relative paths

## Test plan

- [x] All tests pass
- [x] Mintlify broken link check passes
- [ ] Verify links work after merge and sync to main

🤖 Generated with [Claude Code](https://claude.ai/claude-code)