### PR TITLE
fix: Paginate through all organization members in domain user backfill

### DIFF
--- a/.changeset/fix-auto-add-pagination.md
+++ b/.changeset/fix-auto-add-pagination.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix pagination in auto-add domain users feature to fetch all organization members


### PR DESCRIPTION
## Summary
- Fixed auto-add domain users feature to paginate through all WorkOS organization members
- Previously only checked first page (max 100 members), causing users to incorrectly appear as "available to add" when they were already members

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Verified admin-domain-health page loads correctly in dev mode
- [ ] Test in production with organization that has 100+ members - "55 users" count should drop to actual non-members

🤖 Generated with [Claude Code](https://claude.com/claude-code)