### PR TITLE
fix: Handle pending invitations in auto-add domain users feature

### DIFF
--- a/.changeset/fix-auto-add-members.md
+++ b/.changeset/fix-auto-add-members.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix auto-add domain users feature to properly handle pending invitations

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -2195,9 +2195,27 @@ export function setupDomainRoutes(
               after = memberships.listMetadata?.after;
             } while (after);
 
-            // Filter to users who aren't already members
+            // Also get pending invitations (can't add users who have pending invites)
+            const pendingInvitationEmails = new Set<string>();
+            after = undefined;
+            do {
+              const invitations = await config.workos!.userManagement.listInvitations({
+                organizationId: orgId,
+                limit: 100,
+                after,
+              });
+              for (const inv of invitations.data) {
+                if (inv.state === 'pending') {
+                  pendingInvitationEmails.add(inv.email.toLowerCase());
+                }
+              }
+              after = invitations.listMetadata?.after;
+            } while (after);
+
+            // Filter to users who aren't already members and don't have pending invitations
             const usersToAdd = (row.users as Array<{ email: string; name: string | null; workos_user_id: string }>)
-              .filter(u => !existingMemberUserIds.has(u.workos_user_id));
+              .filter(u => !existingMemberUserIds.has(u.workos_user_id) &&
+                          !pendingInvitationEmails.has(u.email.toLowerCase()));
 
             if (usersToAdd.length > 0) {
               orgUsersToAdd.push({
@@ -2351,9 +2369,10 @@ export function setupDomainRoutes(
                 userId: user.workos_user_id,
                 addedBy: adminUser.id,
               }, 'Domain user auto-added to organization via backfill');
-            } catch (err) {
-              const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-              if (errorMessage.includes('already a member')) {
+            } catch (err: any) {
+              if (err?.code === 'organization_membership_already_exists' ||
+                  err?.code === 'cannot_reactivate_pending_organization_membership') {
+                // User is already a member or has a pending invitation
                 orgSkipped++;
               } else {
                 logger.warn({ err, orgId, email: user.email }, 'Failed to add domain user');

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -423,24 +423,24 @@ export function createOrganizationsRouter(): Router {
         success: true,
         message: `Invitation sent to ${request.user_email}`,
       });
-    } catch (error) {
+    } catch (error: any) {
       logger.error({ err: error }, 'Approve join request error:');
 
       // Check for specific WorkOS errors
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      if (errorMessage.includes('already a member')) {
+      if (error?.code === 'organization_membership_already_exists') {
         return res.status(400).json({
           error: 'User already a member',
           message: 'This user is already a member of the organization',
         });
       }
-      if (errorMessage.includes('pending invitation')) {
+      if (error?.code === 'invitation_already_exists') {
         return res.status(400).json({
           error: 'Invitation exists',
           message: 'There is already a pending invitation for this user',
         });
       }
 
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       res.status(500).json({
         error: 'Failed to approve join request',
         message: errorMessage,
@@ -937,17 +937,17 @@ export function createOrganizationsRouter(): Router {
           role: membership.role?.slug || roleToAssign,
         },
       });
-    } catch (error) {
+    } catch (error: any) {
       logger.error({ err: error }, 'Add domain user error');
 
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      if (errorMessage.includes('already a member')) {
+      if (error?.code === 'organization_membership_already_exists') {
         return res.status(400).json({
           error: 'Already a member',
           message: 'This user is already a member of the organization.',
         });
       }
 
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       res.status(500).json({
         error: 'Failed to add domain user',
         message: errorMessage,
@@ -2002,24 +2002,24 @@ export function createOrganizationsRouter(): Router {
           accept_invitation_url: invitation.acceptInvitationUrl,
         },
       });
-    } catch (error) {
+    } catch (error: any) {
       logger.error({ err: error }, 'Send invitation error');
 
       // Check for specific WorkOS errors
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      if (errorMessage.includes('already a member')) {
+      if (error?.code === 'organization_membership_already_exists') {
         return res.status(400).json({
           error: 'User already a member',
           message: 'This user is already a member of the organization',
         });
       }
-      if (errorMessage.includes('pending invitation')) {
+      if (error?.code === 'invitation_already_exists') {
         return res.status(400).json({
           error: 'Invitation already exists',
           message: 'An invitation has already been sent to this email address',
         });
       }
 
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       res.status(500).json({
         error: 'Failed to send invitation',
         message: errorMessage,


### PR DESCRIPTION
## Summary
- Fixed auto-add domain users feature showing users as "can be added" when they have pending invitations
- Fixed WorkOS error code checking (was checking error message strings instead of error codes)

## Root Cause
WorkOS's `listOrganizationMemberships` only returns **active** memberships, not pending invitations. When the backfill tried to add users with pending invitations, WorkOS returned `cannot_reactivate_pending_organization_membership` error, which was being counted as an error instead of a skip.

## Changes
- **Status endpoint**: Now checks pending invitations and excludes those users from the "can be added" list
- **Backfill endpoint**: Handles both `organization_membership_already_exists` and `cannot_reactivate_pending_organization_membership` as skip conditions
- **organizations.ts**: Fixed error code checking pattern in 3 places (was checking `errorMessage.includes()` instead of `err?.code`)

## Test plan
- [x] Build passes
- [x] All 241 tests pass
- [x] Verified UI loads correctly on local dev server
- [x] Code review completed - no critical issues

🤖 Generated with [Claude Code](https://claude.ai/code)