### PR TITLE
feat: Add Addie code version tracking and shorter performance timeframes

### DIFF
--- a/.changeset/addie-code-version.md
+++ b/.changeset/addie-code-version.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add Addie code version tracking and shorter performance timeframes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,19 @@ Types: `patch` (fixes), `minor` (new features), `major` (breaking), `--empty` (n
 - **MINOR**: Add optional fields, new enum values, new tasks
 - **MAJOR**: Remove/rename fields, change types, remove enum values
 
+### Addie Code Version
+When making significant changes to Addie's core logic, bump `CODE_VERSION` in `server/src/addie/config-version.ts`.
+
+**When to bump:**
+- Claude client behavior (`claude-client.ts`)
+- Tool implementations (`mcp/*.ts`)
+- Message processing logic (`thread-service.ts`, `bolt-app.ts`)
+- Router logic beyond `ROUTING_RULES` (`router.ts`)
+
+**Format:** `YYYY.MM.N` (e.g., `2025.01.1`, `2025.01.2`, `2025.02.1`)
+
+This creates a new Addie config version, allowing performance comparison before/after code changes.
+
 ## Deployment
 
 Production deploys to **Fly.io** (not Vercel). Migrations run automatically on startup.

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -1240,9 +1240,11 @@
     <!-- Config Version Banner -->
     <div class="card" id="config-version-banner" style="display: flex; justify-content: space-between; align-items: center; background: var(--color-bg-muted); padding: var(--space-4) var(--space-5);">
       <div>
-        <span style="font-weight: var(--font-semibold); color: var(--color-text-heading);">Config Version:</span>
+        <span style="font-weight: var(--font-semibold); color: var(--color-text-heading);">Addie Version:</span>
         <span id="config-version-id" style="font-family: var(--font-mono); color: var(--color-brand);">-</span>
-        <span style="color: var(--color-text-secondary); margin-left: var(--space-2);">(<span id="config-rule-count">-</span> rules)</span>
+        <span style="color: var(--color-text-secondary); margin-left: var(--space-2);">
+          (code <span id="config-code-version">-</span>, <span id="config-rule-count">-</span> rules)
+        </span>
       </div>
       <div style="display: flex; gap: var(--space-4); align-items: center;">
         <span style="font-size: var(--text-sm); color: var(--color-text-secondary);">
@@ -1464,15 +1466,16 @@
 
     <!-- Config Version History Modal -->
     <div class="modal-overlay" id="config-history-modal" style="display: none;">
-      <div class="modal" style="max-width: 800px; max-height: 90vh; overflow-y: auto;">
-        <h2>Config Version History</h2>
+      <div class="modal" style="max-width: 900px; max-height: 90vh; overflow-y: auto;">
+        <h2>Addie Version History</h2>
         <p style="color: var(--color-text-secondary); margin-bottom: var(--space-4);">
-          Each config version represents a unique combination of active rules. Performance metrics are tracked per version.
+          Each version represents a unique combination of code version and active rules. Performance metrics are tracked per version.
         </p>
         <table style="width: 100%; border-collapse: collapse;">
           <thead>
             <tr style="border-bottom: var(--border-1) solid var(--color-gray-200);">
               <th style="text-align: left; padding: var(--space-2);">Version</th>
+              <th style="text-align: left; padding: var(--space-2);">Code</th>
               <th style="text-align: left; padding: var(--space-2);">Created</th>
               <th style="text-align: center; padding: var(--space-2);">Rules</th>
               <th style="text-align: center; padding: var(--space-2);">Messages</th>
@@ -1700,10 +1703,15 @@
             <h2 style="margin: 0;">Performance Metrics</h2>
             <p style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-top: var(--space-1);">
               Latency, token usage, and tool performance analysis
+              <span style="margin-left: var(--space-2); padding: 2px 8px; background: var(--color-bg-muted); border-radius: var(--radius-sm); font-family: var(--font-mono);">
+                Addie <span id="perf-addie-version">v?</span> (code <span id="perf-code-version">-</span>)
+              </span>
             </p>
           </div>
           <div class="filter-row">
             <select id="perf-days-filter" onchange="loadPerformance()">
+              <option value="0.125">Last 3 hours</option>
+              <option value="0.5">Last 12 hours</option>
               <option value="1">Last 24 hours</option>
               <option value="7" selected>Last 7 days</option>
               <option value="30">Last 30 days</option>
@@ -2146,11 +2154,15 @@
         if (config.config_version) {
           const cv = config.config_version;
           document.getElementById('config-version-id').textContent = `v${cv.version_id}`;
+          document.getElementById('config-code-version').textContent = cv.code_version || '-';
           document.getElementById('config-rule-count').textContent = cv.rule_count || 0;
           document.getElementById('config-message-count').textContent = cv.message_count || 0;
           document.getElementById('config-rating').textContent = cv.avg_rating
             ? `${parseFloat(cv.avg_rating).toFixed(1)}/5`
             : 'N/A';
+          // Also update performance page version display
+          document.getElementById('perf-addie-version').textContent = `v${cv.version_id}`;
+          document.getElementById('perf-code-version').textContent = cv.code_version || '-';
         }
       } catch (error) {
         console.error('Error loading stats:', error);
@@ -2168,7 +2180,7 @@
 
         const listEl = document.getElementById('config-history-list');
         if (!data.versions || data.versions.length === 0) {
-          listEl.innerHTML = '<tr><td colspan="6" style="text-align: center; padding: var(--space-4); color: var(--color-text-secondary);">No config versions found</td></tr>';
+          listEl.innerHTML = '<tr><td colspan="7" style="text-align: center; padding: var(--space-4); color: var(--color-text-secondary);">No config versions found</td></tr>';
           return;
         }
 
@@ -2178,6 +2190,9 @@
               <span style="font-family: var(--font-mono); font-weight: var(--font-semibold);">v${v.version_id}</span>
               <br>
               <span style="font-size: var(--text-xs); color: var(--color-text-muted); font-family: var(--font-mono);">${v.config_hash?.substring(0, 8) || '-'}</span>
+            </td>
+            <td style="padding: var(--space-2); font-size: var(--text-sm); font-family: var(--font-mono);">
+              ${v.code_version || '-'}
             </td>
             <td style="padding: var(--space-2); font-size: var(--text-sm);">
               ${new Date(v.created_at).toLocaleDateString()}<br>
@@ -2197,7 +2212,7 @@
       } catch (error) {
         console.error('Error loading config history:', error);
         document.getElementById('config-history-list').innerHTML =
-          '<tr><td colspan="6" style="text-align: center; padding: var(--space-4); color: var(--color-error);">Error loading history</td></tr>';
+          '<tr><td colspan="7" style="text-align: center; padding: var(--space-4); color: var(--color-error);">Error loading history</td></tr>';
       }
     }
 

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -3191,6 +3191,7 @@ export class AddieDatabase {
       `SELECT
          cv.version_id,
          cv.config_hash,
+         cv.code_version,
          cv.created_at,
          array_length(cv.active_rule_ids, 1) as rule_count,
          cv.message_count,
@@ -3213,6 +3214,7 @@ export class AddieDatabase {
       `SELECT
          cv.version_id,
          cv.config_hash,
+         cv.code_version,
          cv.created_at,
          array_length(cv.active_rule_ids, 1) as rule_count,
          cv.message_count,
@@ -3233,6 +3235,7 @@ export class AddieDatabase {
 export interface ConfigVersionInfo {
   version_id: number;
   config_hash: string;
+  code_version: string | null;
   created_at: Date;
   rule_count: number;
   message_count: number;

--- a/server/src/db/migrations/184_addie_code_version.sql
+++ b/server/src/db/migrations/184_addie_code_version.sql
@@ -1,0 +1,12 @@
+-- Add code_version column to track Addie code changes
+-- This is a manually-bumped version string for significant code logic changes
+
+ALTER TABLE addie_config_versions
+  ADD COLUMN IF NOT EXISTS code_version VARCHAR(32);
+
+-- Index for filtering by code version
+CREATE INDEX IF NOT EXISTS idx_addie_config_versions_code_version
+  ON addie_config_versions(code_version)
+  WHERE code_version IS NOT NULL;
+
+COMMENT ON COLUMN addie_config_versions.code_version IS 'Manually-bumped version string tracking significant code logic changes';


### PR DESCRIPTION
## Summary
- Add `CODE_VERSION` constant to track significant code logic changes separately from rule changes
- Add shorter time filter options (3hr, 12hr) for post-release performance analysis
- Display code version in admin performance page banner
- Add migration for `code_version` column on `addie_config_versions` table

## Test plan
- [x] Verified migration applies cleanly via Docker
- [x] Tested UI shows version banner and time filters work
- [x] Code review completed, critical bug fixed (cleanupAnonymousThreads time unit)
- [x] TypeScript compiles successfully
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)