### PR TITLE
fix: Rename Terms of Service to Terms of Use

### DIFF
--- a/.changeset/sunny-coats-punch.md
+++ b/.changeset/sunny-coats-punch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Rename "Terms of Service" to "Terms of Use" across website UI (no protocol changes)

--- a/docs.json
+++ b/docs.json
@@ -415,7 +415,7 @@
             "href": "https://agenticadvertising.org/api/agreement?type=privacy_policy"
           },
           {
-            "label": "Terms of Service",
+            "label": "Terms of Use",
             "href": "https://agenticadvertising.org/api/agreement?type=terms_of_service"
           }
         ]

--- a/server/public/admin-agreements.html
+++ b/server/public/admin-agreements.html
@@ -224,7 +224,7 @@
         <label>Agreement Type</label>
         <select id="agreementType">
           <option value="membership">Membership Agreement</option>
-          <option value="terms_of_service">Terms of Service</option>
+          <option value="terms_of_service">Terms of Use</option>
           <option value="privacy_policy">Privacy Policy</option>
           <option value="bylaws">Bylaws</option>
           <option value="ip_policy">IP Rights Policy</option>
@@ -332,7 +332,7 @@
 
       const formatType = (type) => {
         const types = {
-          'terms_of_service': 'Terms of Service',
+          'terms_of_service': 'Terms of Use',
           'privacy_policy': 'Privacy Policy',
           'membership': 'Membership Agreement',
           'bylaws': 'Bylaws',

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1656,7 +1656,7 @@
     function formatAgreementType(type) {
       const map = {
         'membership_agreement': 'Membership Agreement',
-        'terms_of_service': 'Terms of Service',
+        'terms_of_service': 'Terms of Use',
         'privacy_policy': 'Privacy Policy',
         'bylaws': 'Bylaws',
         'ip_policy': 'IP Policy',

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -3071,7 +3071,7 @@
     // Format agreement type for display
     function formatAgreementType(type) {
       const types = {
-        'terms_of_service': 'Terms of Service',
+        'terms_of_service': 'Terms of Use',
         'privacy_policy': 'Privacy Policy',
         'membership': 'Membership Agreement'
       };
@@ -3323,7 +3323,7 @@
             }
           });
         } else {
-          // Terms of Service & Privacy Policy - just acknowledgment
+          // Terms of Use & Privacy Policy - just acknowledgment
           buttonsDiv.innerHTML = `
             <div style="display: flex; gap: 10px; width: 100%; justify-content: flex-end;">
               <button class="btn btn-primary" onclick="acceptAgreement('${type}', '${version}')">I Understand</button>

--- a/server/public/legal/terms.html
+++ b/server/public/legal/terms.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Terms of Service - AdCP Registry</title>
+  <title>Terms of Use - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -63,16 +63,16 @@
 </head>
 <body>
   <div class="container">
-    <h1>Terms of Service</h1>
+    <h1>Terms of Use</h1>
     <div class="meta">
-      Version 1.0<br>
-      Last Updated: <span id="date"></span>
+      Terms of Use Agreement<br>
+      Effective: December 11, 2025
     </div>
 
-    <p><strong>[Placeholder: Full Terms of Service content will be added here]</strong></p>
+    <p><strong>[Placeholder: Full Terms of Use content will be added here]</strong></p>
 
     <h2>1. Acceptance of Terms</h2>
-    <p>By accessing and using the AdCP Registry, you accept and agree to be bound by these Terms of Service.</p>
+    <p>By accessing and using the AdCP Registry, you accept and agree to be bound by these Terms of Use.</p>
 
     <h2>2. Use of Service</h2>
     <p>The AdCP Registry provides a platform for managing advertising agents and protocols. You agree to use this service in compliance with all applicable laws and regulations.</p>
@@ -115,12 +115,5 @@
     <a href="/" class="back-link">← Back to Home</a>
   </div>
 
-  <script>
-    document.getElementById('date').textContent = new Date().toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
-  </script>
 </body>
 </html>

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -988,7 +988,7 @@
               <div class="aao-footer__title">Legal</div>
               <ul class="aao-footer__list">
                 <li><a href="/api/agreement?type=privacy_policy">Privacy Policy</a></li>
-                <li><a href="/api/agreement?type=terms_of_service">Terms of Service</a></li>
+                <li><a href="/api/agreement?type=terms_of_service">Terms of Use</a></li>
                 <li><a href="/api/agreement?type=bylaws">Bylaws</a></li>
                 <li><a href="/api/agreement?type=ip_policy">IP Policy</a></li>
               </ul>

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -689,7 +689,7 @@
           <div class="agreements-checkbox" onclick="document.getElementById('tosAgree').click(); event.stopPropagation();">
             <input type="checkbox" id="tosAgree" required onclick="event.stopPropagation();">
             <label for="tosAgree" onclick="event.stopPropagation();">
-              I agree to the <a href="/api/agreement?type=terms_of_service" target="_blank" onclick="event.stopPropagation();">Terms of Service</a> and <a href="/api/agreement?type=privacy_policy" target="_blank" onclick="event.stopPropagation();">Privacy Policy</a>
+              I agree to the <a href="/api/agreement?type=terms_of_service" target="_blank" onclick="event.stopPropagation();">Terms of Use</a> and <a href="/api/agreement?type=privacy_policy" target="_blank" onclick="event.stopPropagation();">Privacy Policy</a>
             </label>
           </div>
           <button type="submit" class="btn" id="createBtn">Register Company</button>
@@ -724,7 +724,7 @@
         <div class="agreements-checkbox" onclick="document.getElementById('tosAgreeIndividual').click(); event.stopPropagation();">
           <input type="checkbox" id="tosAgreeIndividual" onclick="event.stopPropagation();">
           <label for="tosAgreeIndividual" onclick="event.stopPropagation();">
-            I agree to the <a href="/api/agreement?type=terms_of_service" target="_blank" onclick="event.stopPropagation();">Terms of Service</a> and <a href="/api/agreement?type=privacy_policy" target="_blank" onclick="event.stopPropagation();">Privacy Policy</a>
+            I agree to the <a href="/api/agreement?type=terms_of_service" target="_blank" onclick="event.stopPropagation();">Terms of Use</a> and <a href="/api/agreement?type=privacy_policy" target="_blank" onclick="event.stopPropagation();">Privacy Policy</a>
           </label>
         </div>
         <button class="btn" id="individualBtn" onclick="createIndividualWorkspace()">Join as Individual</button>
@@ -1186,7 +1186,7 @@
       }
 
       if (!tosAgree) {
-        showError('Please agree to the Terms of Service and Privacy Policy');
+        showError('Please agree to the Terms of Use and Privacy Policy');
         return;
       }
 
@@ -1228,7 +1228,7 @@
       var btn = document.getElementById('individualBtn');
 
       if (!tosAgree) {
-        showError('Please agree to the Terms of Service and Privacy Policy');
+        showError('Please agree to the Terms of Use and Privacy Policy');
         return;
       }
 

--- a/server/public/registry.html
+++ b/server/public/registry.html
@@ -516,7 +516,7 @@
         </div>
         <div class="footer-links">
             <a href="/api/agreement?type=privacy_policy">Privacy Policy</a> |
-            <a href="/api/agreement?type=terms_of_service">Terms of Service</a> |
+            <a href="/api/agreement?type=terms_of_service">Terms of Use</a> |
             Powered by <a href="https://adcontextprotocol.org" target="_blank">Ad Context Protocol</a>
         </div>
     </footer>

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -5210,7 +5210,7 @@ Disallow: /api/admin/
         const htmlContent = await marked(agreement.text);
 
         const typeLabels: Record<string, string> = {
-          terms_of_service: 'Terms of Service',
+          terms_of_service: 'Terms of Use',
           privacy_policy: 'Privacy Policy',
           membership: 'Membership Agreement'
         };

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -601,7 +601,7 @@ export async function requireSignedAgreement(req: Request, res: Response, next: 
   if (!company.agreement_signed_at) {
     return res.status(403).json({
       error: 'Agreement not signed',
-      message: 'Please review and sign the AdCP Terms of Service before continuing',
+      message: 'Please review and sign the AdCP Terms of Use before continuing',
       agreement_url: '/api/agreement/current',
     });
   }


### PR DESCRIPTION
## Summary
- Renames all user-facing display labels from "Terms of Service" to "Terms of Use"
- Updates the terms.html document header to show "Terms of Use Agreement" with "Effective: December 11, 2025"
- Preserves the internal API identifier `terms_of_service` (no database/API changes)

## Files Changed
- `server/public/legal/terms.html` - Main document title, header, and effective date
- `server/public/onboarding.html` - Checkbox labels and error messages
- `server/public/nav.js`, `registry.html` - Footer links
- `server/src/http.ts`, `middleware/auth.ts` - Display labels and messages
- `dashboard*.html`, `admin-agreements.html` - Format functions
- `docs.json` - Footer navigation

## Test plan
- [x] Verified terms.html displays "Terms of Use" with correct date via Vibium browser
- [x] Verified registry.html footer shows "Terms of Use"
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)