### PR TITLE
fix: Make documentation flowcharts readable with responsive sizing

### DIFF
--- a/.changeset/early-grapes-find.md
+++ b/.changeset/early-grapes-find.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: Make documentation flowcharts readable by using responsive image sizing

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -40,7 +40,7 @@ All tasks and data models are defined with JSON schemas for validation and clien
 
 AdCP operates at multiple layers, providing a clean separation between the business roles, orchestration layer, and technical execution:
 
-![Layers of the Stack](./layers-of-the-stack.png)
+<img src="./layers-of-the-stack.png" alt="Layers of the AdCP Stack showing Business Principals, Orchestration, and Technical Execution layers" style={{ width: '100%', maxWidth: '900px', display: 'block', margin: '0 auto' }} />
 
 ## The AdCP Ecosystem Layers
 
@@ -105,7 +105,7 @@ The technical infrastructure that:
 
 The AdCP ecosystem extends beyond media transactions to include creative production and delivery. This expanded view shows how creative agents integrate with the core AdCP components:
 
-![AdCP Flows with Creative Agents](./adcp_flows.png)
+<img src="./adcp_flows.png" alt="AdCP ecosystem diagram showing Creative, Business, and Technical flows with agent integration" style={{ width: '100%', maxWidth: '900px', display: 'block', margin: '0 auto' }} />
 
 ### Three Interconnected Flows
 

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -195,7 +195,7 @@ This accountability framework transforms the advertising marketplace from a seri
 
 The following diagram illustrates the complete lifecycle of a media buy in AdCP:
 
-![Media Buying Lifecycle](./media-buying-lifecycle.png)
+<img src="./media-buying-lifecycle.png" alt="Media buying lifecycle diagram showing discovery, creation, delivery, and optimization stages" style={{ width: '100%', maxWidth: '900px', display: 'block', margin: '0 auto' }} />
 
 ## Documentation Structure
 

--- a/docs/protocols/context-management.mdx
+++ b/docs/protocols/context-management.mdx
@@ -169,9 +169,9 @@ Response (application-level context is repeated inside the payload):
 }
 ```
 
-![Application Context Lifecycle 01](./initator-context-lifecycle-01.png)
+<img src="./initator-context-lifecycle-01.png" alt="Application context lifecycle diagram showing initiator request flow" style={{ width: '100%', maxWidth: '900px', display: 'block', margin: '0 auto' }} />
 
-![Application Context Lifecycle 02](./initator-context-lifecycle-02.png)
+<img src="./initator-context-lifecycle-02.png" alt="Application context lifecycle diagram showing webhook response flow" style={{ width: '100%', maxWidth: '900px', display: 'block', margin: '0 auto' }} />
 
 Webhook updates include the same application-level `context` inside the webhook `result` payload.
 


### PR DESCRIPTION
## Summary
- Convert markdown image syntax to HTML img tags with responsive styling
- Add `width: 100%`, `maxWidth: 900px` for responsive sizing
- Add `display: block` and `margin: 0 auto` for centering
- Improve alt text for better accessibility

## Files Changed
- `docs/intro.mdx` - 2 images (Layers of the Stack, AdCP Flows)
- `docs/media-buy/index.mdx` - 1 image (Media Buying Lifecycle)
- `docs/protocols/context-management.mdx` - 2 images (Context Lifecycle diagrams)

## Test plan
- [x] Verified images render at readable sizes with Vibium browser
- [x] Confirmed responsive behavior with maxWidth constraint
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)