### PR TITLE
fix: Consolidate subscription checking for invoice-based memberships

### DIFF
--- a/.changeset/optable-publish-fix.md
+++ b/.changeset/optable-publish-fix.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix profile visibility check for invoice-based memberships (Founding Members)

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -298,9 +298,11 @@ export async function getPriceByLookupKey(lookupKey: string): Promise<string | n
 }
 
 /**
- * Get subscription info from Stripe for an organization
+ * Get subscription info directly from Stripe for a customer.
+ * NOTE: For most use cases, use OrganizationDatabase.getSubscriptionInfo() instead,
+ * which checks both Stripe AND local DB (handles invoice-based memberships).
  */
-export async function getSubscriptionInfo(
+export async function getStripeSubscriptionInfo(
   stripeCustomerId: string
 ): Promise<{
   status: 'active' | 'trialing' | 'past_due' | 'canceled' | 'unpaid' | 'none';

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1,5 +1,5 @@
 import { getPool } from './client.js';
-import { getSubscriptionInfo, listCustomersWithOrgIds } from '../billing/stripe-client.js';
+import { getStripeSubscriptionInfo, listCustomersWithOrgIds } from '../billing/stripe-client.js';
 import { WorkOS } from '@workos-inc/node';
 import { createLogger } from '../logger.js';
 import { CompanyTypeValue } from '../config/company-types.js';
@@ -609,7 +609,7 @@ export class OrganizationDatabase {
 
     // If we have a Stripe customer ID, check for active subscription
     if (org.stripe_customer_id) {
-      const stripeInfo = await getSubscriptionInfo(org.stripe_customer_id);
+      const stripeInfo = await getStripeSubscriptionInfo(org.stripe_customer_id);
 
       // If Stripe has an active subscription, use that
       if (stripeInfo && stripeInfo.status !== 'none') {
@@ -630,6 +630,15 @@ export class OrganizationDatabase {
 
     // No Stripe customer - use local DB or return 'none'
     return localInfo || { status: 'none' };
+  }
+
+  /**
+   * Check if an organization has an active subscription.
+   * Simple boolean helper that checks both Stripe and local DB.
+   */
+  async hasActiveSubscription(workos_organization_id: string): Promise<boolean> {
+    const info = await this.getSubscriptionInfo(workos_organization_id);
+    return info?.status === 'active' || info?.status === 'trialing';
   }
 
   // Agreement Methods

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -19,7 +19,7 @@ import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
 import type { Agent, AgentType, AgentWithStats, Company } from "./types.js";
 import { isValidAgentType, VALID_MEMBER_OFFERINGS, VALID_LEGAL_DOCUMENT_TYPES } from "./types.js";
 import type { Server } from "http";
-import { stripe, STRIPE_WEBHOOK_SECRET, createStripeCustomer, createCustomerPortalSession, createCustomerSession, getSubscriptionInfo, fetchAllPaidInvoices, fetchAllRefunds, getPendingInvoices, type RevenueEvent } from "./billing/stripe-client.js";
+import { stripe, STRIPE_WEBHOOK_SECRET, createStripeCustomer, createCustomerPortalSession, createCustomerSession, fetchAllPaidInvoices, fetchAllRefunds, getPendingInvoices, type RevenueEvent } from "./billing/stripe-client.js";
 import Stripe from "stripe";
 import { OrganizationDatabase, CompanyType, RevenueTier } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";

--- a/server/src/routes/admin/members.ts
+++ b/server/src/routes/admin/members.ts
@@ -16,7 +16,7 @@ import { getPool } from "../../db/client.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { OrganizationDatabase } from "../../db/organization-db.js";
-import { stripe, getSubscriptionInfo } from "../../billing/stripe-client.js";
+import { stripe } from "../../billing/stripe-client.js";
 
 const logger = createLogger("admin-members");
 
@@ -530,24 +530,21 @@ export function setupMembersRoutes(
           });
         }
 
-        // Check for active Stripe subscription
-        if (org.stripe_customer_id) {
-          const subscriptionInfo = await getSubscriptionInfo(
-            org.stripe_customer_id
-          );
-          if (
-            subscriptionInfo &&
-            (subscriptionInfo.status === "active" ||
-              subscriptionInfo.status === "past_due")
-          ) {
-            return res.status(400).json({
-              error: "Cannot delete workspace with active subscription",
-              message:
-                "This workspace has an active subscription. Please cancel the subscription first before deleting the workspace.",
-              has_active_subscription: true,
-              subscription_status: subscriptionInfo.status,
-            });
-          }
+        // Check for active subscription (checks both Stripe and local DB)
+        const orgDb = new OrganizationDatabase();
+        const subscriptionInfo = await orgDb.getSubscriptionInfo(orgId);
+        if (
+          subscriptionInfo &&
+          (subscriptionInfo.status === "active" ||
+            subscriptionInfo.status === "past_due")
+        ) {
+          return res.status(400).json({
+            error: "Cannot delete workspace with active subscription",
+            message:
+              "This workspace has an active subscription. Please cancel the subscription first before deleting the workspace.",
+            has_active_subscription: true,
+            subscription_status: subscriptionInfo.status,
+          });
         }
 
         // Require confirmation by typing the organization name
@@ -561,7 +558,6 @@ export function setupMembersRoutes(
         }
 
         // Record audit log before deletion (while org still exists)
-        const orgDb = new OrganizationDatabase();
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: req.user!.id,

--- a/tests/billing/organization-db.test.ts
+++ b/tests/billing/organization-db.test.ts
@@ -7,12 +7,12 @@ jest.mock('../../server/src/db/client.js', () => ({
 
 // Mock the Stripe client
 jest.mock('../../server/src/billing/stripe-client.js', () => ({
-  getSubscriptionInfo: jest.fn(),
+  getStripeSubscriptionInfo: jest.fn(),
 }));
 
 describe('organization-db', () => {
   let mockPool: any;
-  let mockGetSubscriptionInfo: any;
+  let mockGetStripeSubscriptionInfo: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,7 +25,7 @@ describe('organization-db', () => {
 
     // Setup mocks
     const { getPool } = require('../../server/src/db/client.js');
-    mockGetSubscriptionInfo = require('../../server/src/billing/stripe-client.js').getSubscriptionInfo;
+    mockGetStripeSubscriptionInfo = require('../../server/src/billing/stripe-client.js').getStripeSubscriptionInfo;
     getPool.mockReturnValue(mockPool);
   });
 
@@ -168,7 +168,7 @@ describe('organization-db', () => {
       const result = await orgDb.getSubscriptionInfo('org_123');
 
       expect(result).toEqual({ status: 'none' });
-      expect(mockGetSubscriptionInfo).not.toHaveBeenCalled();
+      expect(mockGetStripeSubscriptionInfo).not.toHaveBeenCalled();
     });
 
     test('returns status "none" when organization does not exist', async () => {
@@ -182,10 +182,10 @@ describe('organization-db', () => {
       const result = await orgDb.getSubscriptionInfo('org_notfound');
 
       expect(result).toEqual({ status: 'none' });
-      expect(mockGetSubscriptionInfo).not.toHaveBeenCalled();
+      expect(mockGetStripeSubscriptionInfo).not.toHaveBeenCalled();
     });
 
-    test('calls Stripe getSubscriptionInfo when stripe_customer_id exists', async () => {
+    test('calls getStripeSubscriptionInfo when stripe_customer_id exists', async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [{
           workos_organization_id: 'org_123',
@@ -193,7 +193,7 @@ describe('organization-db', () => {
         }],
       });
 
-      mockGetSubscriptionInfo.mockResolvedValueOnce({
+      mockGetStripeSubscriptionInfo.mockResolvedValueOnce({
         status: 'active',
         product_name: 'Test Product',
         current_period_end: 1234567890,
@@ -204,7 +204,7 @@ describe('organization-db', () => {
 
       const result = await orgDb.getSubscriptionInfo('org_123');
 
-      expect(mockGetSubscriptionInfo).toHaveBeenCalledWith('cus_123');
+      expect(mockGetStripeSubscriptionInfo).toHaveBeenCalledWith('cus_123');
       expect(result).toEqual({
         status: 'active',
         product_name: 'Test Product',
@@ -221,7 +221,7 @@ describe('organization-db', () => {
         }],
       });
 
-      mockGetSubscriptionInfo.mockResolvedValueOnce(null);
+      mockGetStripeSubscriptionInfo.mockResolvedValueOnce(null);
 
       const { OrganizationDatabase } = await import('../../server/src/db/organization-db.js');
       const orgDb = new OrganizationDatabase();
@@ -244,7 +244,7 @@ describe('organization-db', () => {
         }],
       });
 
-      mockGetSubscriptionInfo.mockResolvedValueOnce(null);
+      mockGetStripeSubscriptionInfo.mockResolvedValueOnce(null);
 
       const { OrganizationDatabase } = await import('../../server/src/db/organization-db.js');
       const orgDb = new OrganizationDatabase();

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -12,16 +12,16 @@ describe('stripe-client', () => {
     jest.resetModules();
   });
 
-  describe('getSubscriptionInfo', () => {
+  describe('getStripeSubscriptionInfo', () => {
     test('returns null when Stripe is not initialized', async () => {
       // Set environment variable to undefined to disable Stripe
       const originalEnv = process.env.STRIPE_SECRET_KEY;
       delete process.env.STRIPE_SECRET_KEY;
 
       // Re-import module after changing env var
-      const { getSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
+      const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
 
-      const result = await getSubscriptionInfo('cus_test123');
+      const result = await getStripeSubscriptionInfo('cus_test123');
 
       expect(result).toBeNull();
 
@@ -47,9 +47,9 @@ describe('stripe-client', () => {
       StripeMock.mockImplementation(() => mockStripeInstance as any);
 
       // Re-import module to get mocked version
-      const { getSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
+      const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
 
-      const result = await getSubscriptionInfo('cus_deleted');
+      const result = await getStripeSubscriptionInfo('cus_deleted');
 
       expect(result).toEqual({ status: 'none' });
       expect(mockStripeInstance.customers.retrieve).toHaveBeenCalledWith(
@@ -74,9 +74,9 @@ describe('stripe-client', () => {
       };
       StripeMock.mockImplementation(() => mockStripeInstance as any);
 
-      const { getSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
+      const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
 
-      const result = await getSubscriptionInfo('cus_nosubs');
+      const result = await getStripeSubscriptionInfo('cus_nosubs');
 
       expect(result).toEqual({ status: 'none' });
     });
@@ -120,9 +120,9 @@ describe('stripe-client', () => {
       };
       StripeMock.mockImplementation(() => mockStripeInstance as any);
 
-      const { getSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
+      const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
 
-      const result = await getSubscriptionInfo('cus_active');
+      const result = await getStripeSubscriptionInfo('cus_active');
 
       expect(result).toEqual({
         status: 'active',
@@ -144,9 +144,9 @@ describe('stripe-client', () => {
       };
       StripeMock.mockImplementation(() => mockStripeInstance as any);
 
-      const { getSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
+      const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
 
-      const result = await getSubscriptionInfo('cus_error');
+      const result = await getStripeSubscriptionInfo('cus_error');
 
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Summary

- Fixes Optable's inability to publish their profile despite having an active Founding Member subscription
- Consolidates subscription checking to use `OrganizationDatabase.getSubscriptionInfo()` which checks both Stripe AND local DB
- Renames the Stripe-only function to `getStripeSubscriptionInfo()` to prevent future confusion

## Problem

The profile visibility endpoint was using `getSubscriptionInfo()` from `stripe-client.ts` which only checks Stripe subscriptions. Founding Members who paid via invoice have their subscription status stored in the **local database** (`subscription_status = 'active'`), not as a recurring Stripe subscription.

## Solution

1. **Renamed** `getSubscriptionInfo` → `getStripeSubscriptionInfo` in stripe-client.ts
2. **Added** `hasActiveSubscription()` helper to OrganizationDatabase  
3. **Updated** visibility check and delete workspace checks to use the unified method
4. **Updated tests** to use the new function names

## Test plan

- [ ] All 241 tests pass
- [ ] Type check passes
- [ ] Verify Optable can now publish their profile on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)