### PR TITLE
fix: Correct admin role update route path

### DIFF
--- a/.changeset/fix-admin-role-update.md
+++ b/.changeset/fix-admin-role-update.md
@@ -1,0 +1,5 @@
+---
+---
+
+Fix admin role update route returning 404 due to path duplication.
+

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -1823,7 +1823,7 @@ export function setupAccountRoutes(
    * unlike /members/:orgId/memberships/:membershipId which uses membershipId.
    */
   apiRouter.put(
-    "/api/admin/accounts/:orgId/members/:userId/role",
+    "/accounts/:orgId/members/:userId/role",
     requireAuth,
     requireAdmin,
     async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- Fixed 404 error when changing user roles on admin account detail page
- The route was registered with full path `/api/admin/accounts/:orgId/members/:userId/role`, but apiRouter is mounted at `/api/admin`, causing path duplication

## Test plan
- [ ] Start local dev server
- [ ] Navigate to Admin > Accounts > [any account with members]
- [ ] Change a member's role using the dropdown
- [ ] Verify the role change succeeds (no 404 error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)