### PR TITLE
feat: Add product bundle proposals to get_products

### DIFF
--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -452,6 +452,130 @@ When displaying products in UIs, clients should follow this fallback order:
 
 This ensures a consistent user experience regardless of what product metadata is available.
 
+## Proposals
+
+Publishers can return **proposals** alongside products - structured media plans with budget allocations that buyers can refine conversationally and execute directly.
+
+### What Are Proposals?
+
+A proposal is a recommended buying strategy that groups products with suggested budget allocations. Proposals encode publisher expertise - the kind of media planning guidance that traditionally required human sales reps.
+
+Key characteristics:
+- **Actionable**: Buyers execute proposals directly via `create_media_buy` with a `proposal_id`
+- **Refinable**: Buyers can request changes via natural language in subsequent `get_products` calls
+- **Budget-agnostic**: Allocations use percentages, allowing the same proposal to scale to any budget
+
+### Proposal Structure
+
+```json
+{
+  "proposal_id": "swiss_balanced_v1",
+  "name": "Swiss Multi-Channel Plan",
+  "description": "Balanced coverage across devices and language regions",
+  "allocations": [
+    {
+      "product_id": "ch_desktop_de",
+      "allocation_percentage": 20,
+      "pricing_option_id": "cpm_usd_fixed",
+      "rationale": "Primary desktop audience in German Switzerland",
+      "tags": ["desktop", "german"]
+    },
+    {
+      "product_id": "ch_desktop_fr",
+      "allocation_percentage": 30,
+      "tags": ["desktop", "french"]
+    },
+    {
+      "product_id": "ch_mobile_de",
+      "allocation_percentage": 8,
+      "tags": ["mobile", "german"]
+    },
+    {
+      "product_id": "ch_mobile_fr",
+      "allocation_percentage": 12,
+      "tags": ["mobile", "french"]
+    },
+    {
+      "product_id": "ch_inapp_de",
+      "allocation_percentage": 12,
+      "tags": ["in-app", "german"]
+    },
+    {
+      "product_id": "ch_inapp_fr",
+      "allocation_percentage": 18,
+      "tags": ["in-app", "french"]
+    }
+  ],
+  "total_budget_guidance": {
+    "min": 30000,
+    "recommended": 50000,
+    "currency": "USD"
+  },
+  "brief_alignment": "Achieves 50/20/30 channel split (desktop/mobile/in-app) and 40/60 language split (German/French)"
+}
+```
+
+The `tags` field enables grouping allocations by dimension:
+- **By channel**: desktop (50%) + mobile (20%) + in-app (30%) = 100%
+- **By language**: German (40%) + French (60%) = 100%
+
+### Conversational Refinement
+
+Proposals support iterative refinement through natural language:
+
+```
+// Initial request
+get_products({
+  brief: "Swiss campaign, $50k, 50% desktop/20% mobile/30% in-app, 40% German/60% French"
+})
+
+// Response includes proposal "swiss_balanced_v1"
+
+// Refinement request
+get_products({
+  proposal_id: "swiss_balanced_v1",
+  brief: "focus more on German speakers - try 60/40 instead of 40/60"
+})
+
+// Response includes updated proposal "swiss_balanced_v2" with adjusted allocations
+```
+
+The publisher interprets the natural language instructions and returns an updated proposal. This mimics the back-and-forth of traditional media planning conversations.
+
+### Executing a Proposal
+
+To execute a proposal, provide the `proposal_id` and `total_budget` in `create_media_buy`:
+
+```json
+{
+  "buyer_ref": "swiss_q1_campaign",
+  "proposal_id": "swiss_balanced_v2",
+  "total_budget": {
+    "amount": 50000,
+    "currency": "USD"
+  },
+  "brand_manifest": { ... },
+  "start_time": "2025-04-01T00:00:00Z",
+  "end_time": "2025-04-30T23:59:59Z"
+}
+```
+
+The publisher converts the proposal's allocation percentages into packages:
+- `ch_desktop_de`: 20% × $50,000 = $10,000
+- `ch_desktop_fr`: 30% × $50,000 = $15,000
+- etc.
+
+This approach simplifies complex multi-line-item campaigns to a single proposal execution.
+
+### When Publishers Return Proposals
+
+Publishers include proposals when:
+- The brief requests specific allocation strategies (channel splits, language splits, etc.)
+- The publisher can provide strategic guidance based on campaign goals
+- Multiple products work better together than individually
+
+Proposals are optional - publishers may return only products if allocation guidance isn't applicable.
+
 ## Integration with Discovery
 
 Products are discovered through the [Product Discovery](/docs/media-buy/product-discovery) process, which uses natural language to match campaign briefs with available inventory. Once products are identified, they can be purchased via `create_media_buy`.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -5,7 +5,11 @@ testable: true
 ---
 
 
-Create a media buy from selected packages. Handles validation, approval if needed, and campaign creation.
+Create a media buy from selected packages or execute a proposal. Handles validation, approval if needed, and campaign creation.
+
+Supports two modes:
+- **Manual Mode**: Provide `packages` array with explicit line item configurations
+- **Proposal Mode**: Provide `proposal_id` and `total_budget` to execute a proposal from `get_products`
 
 **Response Time**: Instant to days (returns `completed`, `working` < 120s, or `submitted` for hours/days)
 
@@ -161,12 +165,23 @@ npx adcp \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Your reference identifier for this media buy |
-| `packages` | Package[] | Yes | Array of package configurations (see below) |
+| `proposal_id` | string | No* | ID of a proposal from `get_products` to execute. Alternative to providing packages. |
+| `total_budget` | TotalBudget | No* | Total budget when executing a proposal. Publisher applies allocation percentages. |
+| `packages` | Package[] | No* | Array of package configurations (see below). Required when not using proposal_id. |
 | `brand_manifest` | BrandManifestRef | Yes | Brand identity - minimal (name/URL) acceptable for sales agents. See [Brand Manifest](/docs/creative/brand-manifest) |
 | `start_time` | string | Yes | `"asap"` or ISO 8601 date-time |
 | `end_time` | string | Yes | ISO 8601 date-time (UTC unless timezone specified) |
 | `po_number` | string | No | Purchase order number |
 | `reporting_webhook` | ReportingWebhook | No | Automated reporting delivery configuration |
+
+\* Either `packages` OR (`proposal_id` + `total_budget`) must be provided.
+
+### TotalBudget Object
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `amount` | number | Yes | Total budget amount |
+| `currency` | string | Yes | ISO 4217 currency code |
 
 ### Package Object
 
@@ -537,6 +552,95 @@ asyncio.run(create_with_reporting())
 ```
 
 </CodeGroup>
+
+### Executing a Proposal
+
+Execute a proposal from `get_products` without manually constructing packages:
+
+<CodeGroup>
+
+```javascript JavaScript
+import { testAgent } from '@adcp/client/testing';
+import { CreateMediaBuyResponseSchema } from '@adcp/client';
+
+// Calculate end date dynamically - 90 days from now
+const endDate = new Date();
+endDate.setDate(endDate.getDate() + 90);
+
+const result = await testAgent.createMediaBuy({
+  buyer_ref: 'swiss_campaign_' + Date.now(),
+  proposal_id: 'swiss_balanced_v2',  // From get_products response
+  total_budget: {
+    amount: 50000,
+    currency: 'USD'
+  },
+  brand_manifest: {
+    name: 'Swiss Brand',
+    url: 'https://example-swiss.com'
+  },
+  start_time: 'asap',
+  end_time: endDate.toISOString()
+});
+
+if (!result.success) {
+  throw new Error(`Request failed: ${result.error}`);
+}
+
+const validated = CreateMediaBuyResponseSchema.parse(result.data);
+if ('errors' in validated && validated.errors) {
+  throw new Error(`Creation failed: ${JSON.stringify(validated.errors)}`);
+}
+
+if ('media_buy_id' in validated) {
+  // Publisher converted proposal allocations to packages
+  console.log(`Created media buy ${validated.media_buy_id}`);
+  console.log(`Packages created: ${validated.packages.length}`);
+}
+```
+
+```python Python
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from adcp import test_agent
+
+async def execute_proposal():
+    # Calculate end date dynamically - 90 days from now
+    end_date = datetime.now(timezone.utc) + timedelta(days=90)
+
+    result = await test_agent.simple.create_media_buy(
+        buyer_ref=f'swiss_campaign_{int(time.time() * 1000)}',
+        proposal_id='swiss_balanced_v2',  # From get_products response
+        total_budget={
+            'amount': 50000,
+            'currency': 'USD'
+        },
+        brand_manifest={
+            'name': 'Swiss Brand',
+            'url': 'https://example-swiss.com'
+        },
+        start_time='asap',
+        end_time=end_date.isoformat().replace('+00:00', 'Z')
+    )
+
+    if hasattr(result, 'errors') and result.errors:
+        raise Exception(f"Creation failed: {result.errors}")
+
+    # Publisher converted proposal allocations to packages
+    print(f"Created media buy {result.media_buy_id}")
+    print(f"Packages created: {len(result.packages)}")
+
+asyncio.run(execute_proposal())
+```
+
+</CodeGroup>
+
+When executing a proposal:
+- The publisher converts allocation percentages to actual budgets using `total_budget`
+- Packages are created automatically based on the proposal's allocations
+- All other fields (brand_manifest, start_time, end_time, etc.) work the same as manual mode
+
+See [Proposals](/docs/media-buy/product-discovery/media-products#proposals) for the complete workflow including conversational refinement.
 
 ## Error Handling
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -126,7 +126,8 @@ asyncio.run(discover_with_filters())
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `brief` | string | No | Natural language description of campaign requirements |
+| `brief` | string | No | Natural language description of campaign requirements. When refining a proposal, can include instructions like "focus more on German speakers". |
+| `proposal_id` | string | No | Proposal ID to refine. When provided with a brief, the publisher uses the brief as refinement instructions and returns an updated proposal. |
 | `brand_manifest` | BrandManifest \| string | No | Brand information (inline object or URL). See [Brand Manifest](/docs/creative/brand-manifest) |
 | `filters` | Filters | No | Structured filters (see below) |
 | `property_list` | PropertyListRef | No | [AdCP 3.0] Reference to a property list for filtering. See [Property Lists](/docs/governance/property/tasks/property_lists) |
@@ -159,7 +160,9 @@ asyncio.run(discover_with_filters())
 
 ## Response
 
-Returns an array of `products`, each containing:
+Returns an array of `products` and optionally `proposals`.
+
+### Products Array
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -172,6 +175,19 @@ Returns an array of `products`, each containing:
 | `delivery_measurement` | DeliveryMeasurement | How delivery is measured (impressions, views, etc.) |
 | `pricing_options` | PricingOption[] | Available pricing models (CPM, CPCV, etc.) |
 | `brief_relevance` | string | Why this product matches the brief (when brief provided) |
+
+### Proposals Array (Optional)
+
+Publishers may return proposals alongside products - structured media plans with budget allocations. See [Proposals](/docs/media-buy/product-discovery/media-products#proposals) for details.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `proposal_id` | string | Unique identifier for executing or refining this proposal |
+| `name` | string | Human-readable name for the media plan |
+| `allocations` | ProductAllocation[] | Budget allocations across products (percentages must sum to 100) |
+| `total_budget_guidance` | object | Optional min/recommended/max budget guidance |
+| `brief_alignment` | string | How this proposal addresses the campaign brief |
+| `expires_at` | string | ISO 8601 timestamp when this proposal expires |
 
 ### Response Metadata
 

--- a/static/schemas/source/core/product-allocation.json
+++ b/static/schemas/source/core/product-allocation.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/product-allocation.json",
+  "title": "Product Allocation",
+  "description": "A budget allocation for a specific product within a proposal. Percentages across all allocations in a proposal should sum to 100.",
+  "type": "object",
+  "properties": {
+    "product_id": {
+      "type": "string",
+      "description": "ID of the product (must reference a product in the products array)"
+    },
+    "allocation_percentage": {
+      "type": "number",
+      "description": "Percentage of total budget allocated to this product (0-100)",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "pricing_option_id": {
+      "type": "string",
+      "description": "Recommended pricing option ID from the product's pricing_options array"
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Explanation of why this product and allocation are recommended"
+    },
+    "sequence": {
+      "type": "integer",
+      "description": "Optional ordering hint for multi-line-item plans (1-based)",
+      "minimum": 1
+    },
+    "tags": {
+      "type": "array",
+      "description": "Categorical tags for this allocation (e.g., 'desktop', 'german', 'mobile') - useful for grouping/filtering allocations by dimension",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "product_id",
+    "allocation_percentage"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/proposal.json
+++ b/static/schemas/source/core/proposal.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/proposal.json",
+  "title": "Proposal",
+  "description": "A proposed media plan with budget allocations across products. Represents the publisher's strategic recommendation for how to structure a campaign based on the brief. Proposals are actionable - buyers can execute them directly via create_media_buy by providing the proposal_id.",
+  "type": "object",
+  "properties": {
+    "proposal_id": {
+      "type": "string",
+      "description": "Unique identifier for this proposal. Used to refine the proposal in subsequent get_products calls or to execute it via create_media_buy."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for this media plan proposal"
+    },
+    "description": {
+      "type": "string",
+      "description": "Explanation of the proposal strategy and what it achieves"
+    },
+    "allocations": {
+      "type": "array",
+      "description": "Budget allocations across products. Allocation percentages MUST sum to 100. Publishers are responsible for ensuring the sum equals 100; buyers SHOULD validate this before execution.",
+      "items": {
+        "$ref": "/schemas/core/product-allocation.json"
+      },
+      "minItems": 1
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this proposal expires and can no longer be executed. After expiration, referenced products or pricing may no longer be available."
+    },
+    "total_budget_guidance": {
+      "type": "object",
+      "description": "Optional budget guidance for this proposal",
+      "properties": {
+        "min": {
+          "type": "number",
+          "description": "Minimum recommended budget",
+          "minimum": 0
+        },
+        "recommended": {
+          "type": "number",
+          "description": "Recommended budget for optimal performance",
+          "minimum": 0
+        },
+        "max": {
+          "type": "number",
+          "description": "Maximum budget before diminishing returns",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code"
+        }
+      },
+      "additionalProperties": true
+    },
+    "brief_alignment": {
+      "type": "string",
+      "description": "Explanation of how this proposal aligns with the campaign brief"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "proposal_id",
+    "name",
+    "allocations"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -117,6 +117,14 @@
           "$ref": "/schemas/core/promoted-products.json",
           "description": "Product or offering selection for campaigns with multiple selection methods"
         },
+        "proposal": {
+          "$ref": "/schemas/core/proposal.json",
+          "description": "A proposed media plan with budget allocations across products - actionable via create_media_buy"
+        },
+        "product-allocation": {
+          "$ref": "/schemas/core/product-allocation.json",
+          "description": "A budget allocation for a specific product within a proposal"
+        },
         "start-timing": {
           "$ref": "/schemas/core/start-timing.json",
           "description": "Campaign start timing: 'asap' or ISO 8601 date-time"

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -2,16 +2,40 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/create-media-buy-request.json",
   "title": "Create Media Buy Request",
-  "description": "Request parameters for creating a media buy",
+  "description": "Request parameters for creating a media buy. Supports two modes: (1) Manual mode - provide packages array with explicit line item configurations, or (2) Proposal mode - provide proposal_id and total_budget to execute a proposal from get_products. One of packages or proposal_id must be provided.",
   "type": "object",
   "properties": {
     "buyer_ref": {
       "type": "string",
       "description": "Buyer's reference identifier for this media buy"
     },
+    "proposal_id": {
+      "type": "string",
+      "description": "ID of a proposal from get_products to execute. When provided with total_budget, the publisher converts the proposal's allocation percentages into packages automatically. Alternative to providing packages array."
+    },
+    "total_budget": {
+      "type": "object",
+      "description": "Total budget for the media buy when executing a proposal. The publisher applies the proposal's allocation percentages to this amount to derive package budgets.",
+      "properties": {
+        "amount": {
+          "type": "number",
+          "description": "Total budget amount",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code"
+        }
+      },
+      "required": [
+        "amount",
+        "currency"
+      ],
+      "additionalProperties": false
+    },
     "packages": {
       "type": "array",
-      "description": "Array of package configurations",
+      "description": "Array of package configurations. Required when not using proposal_id. When executing a proposal, this can be omitted and packages will be derived from the proposal's allocations.",
       "items": {
         "$ref": "/schemas/media-buy/package-request.json"
       }
@@ -115,10 +139,12 @@
   },
   "required": [
     "buyer_ref",
-    "packages",
     "brand_manifest",
     "start_time",
     "end_time"
   ],
+  "dependencies": {
+    "proposal_id": ["total_budget"]
+  },
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/get-products-request.json
+++ b/static/schemas/source/media-buy/get-products-request.json
@@ -7,7 +7,11 @@
   "properties": {
     "brief": {
       "type": "string",
-      "description": "Natural language description of campaign requirements"
+      "description": "Natural language description of campaign requirements. When refining a proposal, can include instructions like 'focus more on German speakers' or 'increase mobile allocation'."
+    },
+    "proposal_id": {
+      "type": "string",
+      "description": "Optional proposal ID to refine. When provided with a brief, the publisher will use the brief as refinement instructions for the specified proposal and return an updated version."
     },
     "brand_manifest": {
       "$ref": "/schemas/core/brand-manifest-ref.json",

--- a/static/schemas/source/media-buy/get-products-response.json
+++ b/static/schemas/source/media-buy/get-products-response.json
@@ -12,6 +12,13 @@
         "$ref": "/schemas/core/product.json"
       }
     },
+    "proposals": {
+      "type": "array",
+      "description": "Optional array of proposed media plans with budget allocations across products. Publishers include proposals when they can provide strategic guidance based on the brief. Proposals are actionable - buyers can refine them via subsequent get_products calls or execute them directly via create_media_buy.",
+      "items": {
+        "$ref": "/schemas/core/proposal.json"
+      }
+    },
     "errors": {
       "type": "array",
       "description": "Task-specific errors and warnings (e.g., product filtering issues)",


### PR DESCRIPTION
## Summary

- Publishers can now return structured media plan proposals alongside products in `get_products` responses
- Proposals contain budget allocation percentages (must sum to 100) across products
- Buyers can refine proposals conversationally via `proposal_id` + natural language `brief`
- Buyers can execute proposals directly via `create_media_buy` with `proposal_id` + `total_budget`

### Example Flow

```
Buyer: get_products({ brief: "Swiss campaign, 50/20/30 channel split" })
Publisher: { products: [...], proposals: [{ proposal_id: "swiss_v1", allocations: [...] }] }

Buyer: get_products({ proposal_id: "swiss_v1", brief: "focus more on German speakers" })
Publisher: { products: [...], proposals: [{ proposal_id: "swiss_v2", allocations: [...updated...] }] }

Buyer: create_media_buy({ proposal_id: "swiss_v2", total_budget: { amount: 50000, currency: "USD" }, ... })
```

### New Schemas
- `core/proposal.json` - Media plan proposal with allocations and expiration
- `core/product-allocation.json` - Individual allocation within a proposal

### Updated Schemas
- `get-products-request.json` - Added `proposal_id` for refinement
- `get-products-response.json` - Added `proposals` array
- `create-media-buy-request.json` - Added `proposal_id` + `total_budget` mode with dependency constraint

## Test plan

- [x] All schema validation tests pass (241 tests)
- [x] Schema cross-references resolve correctly
- [x] Backward compatible - existing requests without proposals remain valid
- [x] Documentation updated for get_products, create_media_buy, and media-products

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)