### PR TITLE
fix: Add SSR meta tags for social sharing previews

### DIFF
--- a/.changeset/shiny-donuts-guess.md
+++ b/.changeset/shiny-donuts-guess.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix SSR meta tags for social sharing previews on perspectives pages

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1632,7 +1632,16 @@ export class HTTPServer {
       const { slug } = req.params;
 
       // Fetch article data for meta tags (social crawlers don't execute JS)
-      let article: { title: string; excerpt?: string; subtitle?: string; featured_image_url?: string; author_name?: string; published_at?: string; updated_at?: string } | null = null;
+      interface ArticleMetaData {
+        title: string;
+        excerpt?: string;
+        subtitle?: string;
+        featured_image_url?: string;
+        author_name?: string;
+        published_at?: string;
+        updated_at?: string;
+      }
+      let article: ArticleMetaData | null = null;
       try {
         const pool = getPool();
         const result = await pool.query(

--- a/server/src/utils/html-config.ts
+++ b/server/src/utils/html-config.ts
@@ -181,7 +181,7 @@ function escapeHtmlAttr(str: string): string {
 export function injectMetaTagsIntoHtml(html: string, metaTags: MetaTagData): string {
   const safeTitle = escapeHtmlAttr(metaTags.title);
   const safeDesc = escapeHtmlAttr(metaTags.description);
-  const safeImage = metaTags.image || 'https://agenticadvertising.org/AAo-social.png';
+  const safeImage = escapeHtmlAttr(metaTags.image || 'https://agenticadvertising.org/AAo-social.png');
   const safeUrl = escapeHtmlAttr(metaTags.url);
 
   let result = html;
@@ -273,9 +273,11 @@ export function injectMetaTagsIntoHtml(html: string, metaTags: MetaTagData): str
       }
     };
 
+    // Escape </script> sequences in JSON to prevent XSS
+    const jsonString = JSON.stringify(jsonLd, null, 2).replace(/<\//g, '<\\/');
     result = result.replace(
       /<script type="application\/ld\+json" id="articleJsonLd">[\s\S]*?<\/script>/,
-      `<script type="application/ld+json" id="articleJsonLd">\n${JSON.stringify(jsonLd, null, 2)}\n</script>`
+      `<script type="application/ld+json" id="articleJsonLd">\n${jsonString}\n</script>`
     );
   }
 


### PR DESCRIPTION
## Summary

- Fixes broken Slack link previews that showed "Loading..." instead of article content
- Adds server-side meta tag injection for `/perspectives/:slug` pages
- Social crawlers (Slack, Twitter, LinkedIn, Facebook) now see proper title, description, and image

## Problem

The perspectives article pages are client-side rendered SPAs. Social platform crawlers don't execute JavaScript, so they were seeing placeholder HTML:

```html
<title>Loading... | AgenticAdvertising.org</title>
<meta property="og:title" content="">
<meta property="og:description" content="">
```

## Solution

Added `serveHtmlWithMetaTags()` utility that:
1. Fetches article data from database on server
2. Injects actual content into Open Graph, Twitter Card, and JSON-LD meta tags
3. Serves the modified HTML to crawlers

Now crawlers see:
```html
<title>The Article Title | AgenticAdvertising.org</title>
<meta property="og:title" content="The Article Title">
<meta property="og:description" content="Article description...">
```

## Test plan

- [x] TypeScript compiles without errors
- [x] All 262 tests pass
- [x] Verified locally with Docker + curl
- [ ] After deploy: Test with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
- [ ] After deploy: Test with [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] After deploy: Re-share link in Slack to verify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)