### PR TITLE
docs: Expand bundled schemas and document GitHub access

### DIFF
--- a/.changeset/document-github-bundled-schemas.md
+++ b/.changeset/document-github-bundled-schemas.md
@@ -1,0 +1,7 @@
+---
+---
+
+Expand bundled schemas to all task categories and document GitHub access
+
+- Updated build-schemas.cjs to bundle all task request/response schemas, not just media-buy and signals. Now bundles: creative, property, content-standards, sponsored-intelligence, protocol, and core tasks (71 schemas total, up from ~25).
+- Updated schemas-and-sdks.mdx to document GitHub as a source for bundled schemas, including raw URLs, directory structure, and all bundled schema categories.

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -8,11 +8,14 @@ Get started integrating with AdCP using our schemas and official SDKs.
 
 ## Schema Access
 
-All AdCP schemas are available at:
+AdCP schemas are available from two sources:
 
-```
-https://adcontextprotocol.org/schemas/v2/
-```
+| Source | URL | Best For |
+|--------|-----|----------|
+| Website | `https://adcontextprotocol.org/schemas/v2/` | Runtime fetching, version aliases |
+| GitHub | `https://github.com/adcontextprotocol/adcp/tree/main/dist/schemas` | Offline access, CI/CD pipelines |
+
+Both sources contain identical schemas. The GitHub repository includes all released versions with bundled schemas committed directly to the codebase.
 
 ### Common Schemas
 
@@ -152,11 +155,59 @@ datamodel-codegen \
 
 ## Bundled Schemas
 
-For tools that don't support `$ref` resolution, use bundled schemas with all references resolved inline:
+For tools that don't support `$ref` resolution, use bundled schemas with all references resolved inline. Bundled schemas are available from both the website and GitHub:
+
+### Website Access
 
 ```
 https://adcontextprotocol.org/schemas/2.6.0/bundled/media-buy/create-media-buy-request.json
 ```
+
+### GitHub Access
+
+Bundled schemas are committed to the repository at `dist/schemas/{VERSION}/bundled/`:
+
+```bash
+# Clone and access locally
+git clone https://github.com/adcontextprotocol/adcp.git
+ls adcp/dist/schemas/2.5.3/bundled/media-buy/
+
+# Or fetch directly via GitHub raw
+curl https://raw.githubusercontent.com/adcontextprotocol/adcp/main/dist/schemas/2.5.3/bundled/media-buy/get-products-request.json
+```
+
+### Directory Structure
+
+```
+dist/schemas/{VERSION}/
+├── bundled/                      # Fully dereferenced schemas
+│   ├── media-buy/                # Media buying tasks
+│   ├── creative/                 # Creative tasks
+│   ├── signals/                  # Signal protocol tasks
+│   ├── property/                 # Property/governance tasks
+│   ├── content-standards/        # Content standards tasks
+│   ├── sponsored-intelligence/   # Sponsored intelligence tasks
+│   ├── protocol/                 # Protocol tasks
+│   └── core/                     # Core task schemas
+├── core/                         # Modular schemas with $ref
+├── media-buy/
+└── index.json                    # Schema registry
+```
+
+### Bundled Schema Categories
+
+All request/response task schemas are bundled:
+
+| Category | Tasks |
+|----------|-------|
+| `bundled/media-buy/` | get-products, create-media-buy, update-media-buy, list-creative-formats, sync-creatives, build-creative, list-creatives, get-media-buy-delivery, list-authorized-properties, provide-performance-feedback |
+| `bundled/creative/` | list-creative-formats, preview-creative |
+| `bundled/signals/` | get-signals, activate-signal |
+| `bundled/property/` | create-property-list, get-property-list, list-property-lists, update-property-list, delete-property-list, get-property-features, validate-property-delivery |
+| `bundled/content-standards/` | create-content-standards, get-content-standards, list-content-standards, update-content-standards, calibrate-content, validate-content-delivery, get-media-buy-artifacts |
+| `bundled/sponsored-intelligence/` | si-get-offering, si-initiate-session, si-send-message, si-terminate-session |
+| `bundled/protocol/` | get-adcp-capabilities |
+| `bundled/core/` | tasks-get, tasks-list |
 
 See the [schema registry](https://adcontextprotocol.org/schemas/v2/index.json) for all available schemas.
 

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -486,6 +486,18 @@ async function generateBundledSchemas(sourceDir, bundledDir, version) {
     /media-buy\/.*-response\.json$/,
     /signals\/.*-request\.json$/,
     /signals\/.*-response\.json$/,
+    /creative\/.*-request\.json$/,
+    /creative\/.*-response\.json$/,
+    /property\/.*-request\.json$/,
+    /property\/.*-response\.json$/,
+    /content-standards\/.*-request\.json$/,
+    /content-standards\/.*-response\.json$/,
+    /sponsored-intelligence\/.*-request\.json$/,
+    /sponsored-intelligence\/.*-response\.json$/,
+    /protocol\/.*-request\.json$/,
+    /protocol\/.*-response\.json$/,
+    /core\/tasks-.*-request\.json$/,
+    /core\/tasks-.*-response\.json$/,
   ];
 
   for (const schemaPath of schemaFiles) {


### PR DESCRIPTION
Expand schema bundling to all task categories and add GitHub access documentation.

**Changes:**
- Build script now bundles request/response schemas for all task categories (creative, property, content-standards, sponsored-intelligence, protocol, core) in addition to existing media-buy and signals
- Documentation updated to show GitHub as an alternative source for bundled schemas with examples for offline access and CI/CD pipelines
- Total bundled schemas increased from ~25 to 71

Both the website (`adcontextprotocol.org/schemas/`) and GitHub repository now provide identical bundled schemas for maximum accessibility.