### PR TITLE
fix: Extract shared PriceGuidance schema to fix duplicate type generation

### DIFF
--- a/.changeset/price-guidance-shared-schema.md
+++ b/.changeset/price-guidance-shared-schema.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+Extract shared PriceGuidance schema to fix duplicate type generation
+
+**Schema Changes:**
+- Create new `/schemas/pricing-options/price-guidance.json` shared schema
+- Update all 7 pricing option schemas to use `$ref` instead of inline definitions
+
+**Issue Fixed:**
+- Fixes #884 (Issue 1): Duplicate `PriceGuidance` classes causing mypy arg-type errors
+- When Python types are generated, there will now be a single `PriceGuidance` class instead of 7 identical copies
+
+**Note:** Issue 2 (RootModel wrappers) requires Python library changes to export type aliases for union types.

--- a/static/schemas/source/pricing-options/cpc-option.json
+++ b/static/schemas/source/pricing-options/cpc-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "min_spend_per_package": {
       "type": "number",

--- a/static/schemas/source/pricing-options/cpcv-option.json
+++ b/static/schemas/source/pricing-options/cpcv-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "min_spend_per_package": {
       "type": "number",

--- a/static/schemas/source/pricing-options/cpm-option.json
+++ b/static/schemas/source/pricing-options/cpm-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile winning price",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median winning price",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile winning price",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile winning price",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "min_spend_per_package": {
       "type": "number",

--- a/static/schemas/source/pricing-options/cpp-option.json
+++ b/static/schemas/source/pricing-options/cpp-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "parameters": {
       "type": "object",

--- a/static/schemas/source/pricing-options/cpv-option.json
+++ b/static/schemas/source/pricing-options/cpv-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "parameters": {
       "type": "object",

--- a/static/schemas/source/pricing-options/flat-rate-option.json
+++ b/static/schemas/source/pricing-options/flat-rate-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "parameters": {
       "type": "object",

--- a/static/schemas/source/pricing-options/price-guidance.json
+++ b/static/schemas/source/pricing-options/price-guidance.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/pricing-options/price-guidance.json",
+  "title": "Price Guidance",
+  "description": "Pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
+  "type": "object",
+  "properties": {
+    "p25": {
+      "type": "number",
+      "description": "25th percentile of recent winning bids",
+      "minimum": 0
+    },
+    "p50": {
+      "type": "number",
+      "description": "Median of recent winning bids",
+      "minimum": 0
+    },
+    "p75": {
+      "type": "number",
+      "description": "75th percentile of recent winning bids",
+      "minimum": 0
+    },
+    "p90": {
+      "type": "number",
+      "description": "90th percentile of recent winning bids",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/pricing-options/vcpm-option.json
+++ b/static/schemas/source/pricing-options/vcpm-option.json
@@ -31,30 +31,8 @@
       "minimum": 0
     },
     "price_guidance": {
-      "type": "object",
-      "description": "Optional pricing guidance for auction-based bidding. Helps buyers calibrate bids with historical percentiles.",
-      "properties": {
-        "p25": {
-          "type": "number",
-          "description": "25th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p50": {
-          "type": "number",
-          "description": "Median of recent winning bids",
-          "minimum": 0
-        },
-        "p75": {
-          "type": "number",
-          "description": "75th percentile of recent winning bids",
-          "minimum": 0
-        },
-        "p90": {
-          "type": "number",
-          "description": "90th percentile of recent winning bids",
-          "minimum": 0
-        }
-      }
+      "description": "Optional pricing guidance for auction-based bidding",
+      "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "min_spend_per_package": {
       "type": "number",


### PR DESCRIPTION
## Summary

- Create shared `price-guidance.json` schema with p25, p50, p75, p90 percentile fields
- Update all 7 pricing option schemas to use `$ref` instead of inline definitions
- Fixes duplicate `PriceGuidance` class generation causing mypy `arg-type` errors

## Changes

| File | Change |
|------|--------|
| `price-guidance.json` | **New** - Shared schema for price guidance percentiles |
| `cpm-option.json` | Updated to use `$ref` |
| `vcpm-option.json` | Updated to use `$ref` |
| `cpc-option.json` | Updated to use `$ref` |
| `cpcv-option.json` | Updated to use `$ref` |
| `cpv-option.json` | Updated to use `$ref` |
| `cpp-option.json` | Updated to use `$ref` |
| `flat-rate-option.json` | Updated to use `$ref` |

## Issue Fixed

Fixes #884 (Issue 1): When Python types are generated from these schemas, there will now be a single `PriceGuidance` class instead of 7 identical copies with different module paths.

## Issue 2 (RootModel wrappers)

Issue 2 from #884 requires Python library changes, not schema changes. Created follow-up issue: https://github.com/adcontextprotocol/adcp-client-python/issues/120

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 262 tests pass (`npm test`)
- [x] Schema validation passes
- [x] Example validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)