### PR TITLE
feat(addie): Add committee leadership tools for committee leaders

### DIFF
--- a/.changeset/committee-leader-tools.md
+++ b/.changeset/committee-leader-tools.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add committee leadership tools for Addie - allows committee leaders to add/remove co-leaders for their own committees (working groups, councils, chapters, industry gatherings) without requiring admin access

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -62,6 +62,11 @@ import {
   SCHEMA_TOOLS,
   createSchemaToolHandlers,
 } from './mcp/schema-tools.js';
+import {
+  COMMITTEE_LEADER_TOOLS,
+  createCommitteeLeaderToolHandlers,
+  isCommitteeLeader,
+} from './mcp/committee-leader-tools.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SUGGESTED_PROMPTS, STATUS_MESSAGES, buildDynamicSuggestedPrompts } from './prompts.js';
 import { AddieModelConfig } from '../config/models.js';
@@ -318,6 +323,17 @@ async function createUserScopedTools(
       allHandlers.set(name, handler);
     }
     logger.debug('Addie: Meeting tools enabled for this user');
+  }
+
+  // Add committee leadership tools if user leads any committees
+  const isLeader = slackUserId ? await isCommitteeLeader(slackUserId) : false;
+  if (isLeader) {
+    const committeeHandlers = createCommitteeLeaderToolHandlers(memberContext, slackUserId);
+    allTools.push(...COMMITTEE_LEADER_TOOLS);
+    for (const [name, handler] of committeeHandlers) {
+      allHandlers.set(name, handler);
+    }
+    logger.debug('Addie: Committee leadership tools enabled for this user');
   }
 
   // Override bookmark_resource handler with user-scoped version (for attribution)

--- a/server/src/addie/mcp/committee-leader-tools.ts
+++ b/server/src/addie/mcp/committee-leader-tools.ts
@@ -1,0 +1,409 @@
+/**
+ * Committee Leader Tools
+ *
+ * Tools for committee leaders to manage co-leaders of their own committees.
+ * Works for all committee types: working groups, councils, chapters, and industry gatherings.
+ *
+ * Permission model:
+ * - Leaders can add/remove co-leaders to committees they lead
+ * - Leaders can list leaders of committees they lead
+ * - Leaders cannot manage committees they don't lead
+ * - Leaders cannot remove themselves (must contact admin)
+ */
+
+import { createLogger } from '../../logger.js';
+import type { AddieTool } from '../types.js';
+import type { MemberContext } from '../member-context.js';
+import { WorkingGroupDatabase } from '../../db/working-group-db.js';
+import { SlackDatabase } from '../../db/slack-db.js';
+import { getPool } from '../../db/client.js';
+import { invalidateWebAdminStatusCache } from './admin-tools.js';
+
+const logger = createLogger('committee-leader-tools');
+const wgDb = new WorkingGroupDatabase();
+const slackDb = new SlackDatabase();
+
+/**
+ * Committee Leader Tool Definitions
+ */
+export const COMMITTEE_LEADER_TOOLS: AddieTool[] = [
+  {
+    name: 'add_committee_co_leader',
+    description: `Add a co-leader to a committee you lead. Use this when a committee leader wants to add another person to help lead their committee.
+
+Works for working groups, councils, chapters, and industry gatherings.
+
+IMPORTANT: You can only add co-leaders to committees where you are already a leader.
+
+Example uses:
+- "Add Sarah as a co-leader for the India Chapter"
+- "I want to add John to help lead the Creative Working Group"
+- "Add Maria to the CTV Council leadership"`,
+    usage_hints: 'Committee leaders adding co-leaders to their own committees',
+    input_schema: {
+      type: 'object',
+      properties: {
+        committee_slug: {
+          type: 'string',
+          description: 'Committee slug (e.g., "india-chapter", "creative-wg", "ctv-council")',
+        },
+        user_id: {
+          type: 'string',
+          description: 'WorkOS user ID or Slack user ID of the person to add',
+        },
+        user_email: {
+          type: 'string',
+          description: 'Email address of the person to add (optional, helps identify them)',
+        },
+      },
+      required: ['committee_slug', 'user_id'],
+    },
+  },
+  {
+    name: 'remove_committee_co_leader',
+    description: `Remove a co-leader from a committee you lead. The person will remain a member but lose leadership access.
+
+Works for working groups, councils, chapters, and industry gatherings.
+
+IMPORTANT: You can only remove co-leaders from committees where you are a leader.
+You cannot remove yourself as a leader (contact admin for that).`,
+    usage_hints: 'Committee leaders removing co-leaders from their own committees',
+    input_schema: {
+      type: 'object',
+      properties: {
+        committee_slug: {
+          type: 'string',
+          description: 'Committee slug (e.g., "india-chapter", "creative-wg", "ctv-council")',
+        },
+        user_id: {
+          type: 'string',
+          description: 'WorkOS user ID or Slack user ID of the person to remove',
+        },
+      },
+      required: ['committee_slug', 'user_id'],
+    },
+  },
+  {
+    name: 'list_committee_co_leaders',
+    description: `List all current leaders of a committee you lead. Shows who has leadership access.
+
+Works for working groups, councils, chapters, and industry gatherings.`,
+    usage_hints: 'View co-leaders of committees you lead',
+    input_schema: {
+      type: 'object',
+      properties: {
+        committee_slug: {
+          type: 'string',
+          description: 'Committee slug (e.g., "india-chapter", "creative-wg", "ctv-council")',
+        },
+      },
+      required: ['committee_slug'],
+    },
+  },
+];
+
+/**
+ * Check if a user leads any committees
+ */
+export async function isCommitteeLeader(slackUserId: string): Promise<boolean> {
+  try {
+    // Get the user's WorkOS ID
+    const slackMapping = await slackDb.getBySlackUserId(slackUserId);
+    if (!slackMapping?.workos_user_id) {
+      return false;
+    }
+
+    const pool = getPool();
+    // Check if user leads any committee
+    const result = await pool.query(
+      `SELECT 1 FROM working_group_leaders wgl
+       JOIN working_groups wg ON wg.id = wgl.working_group_id
+       LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
+       WHERE (wgl.user_id = $1 OR sm.workos_user_id = $1)
+       LIMIT 1`,
+      [slackMapping.workos_user_id]
+    );
+    return result.rows.length > 0;
+  } catch (error) {
+    logger.error({ error, slackUserId }, 'Error checking if user is committee leader');
+    return false;
+  }
+}
+
+/**
+ * Get the committees a user leads
+ */
+async function getCommitteesLedByUser(workosUserId: string): Promise<Array<{ id: string; slug: string; name: string; committee_type: string }>> {
+  const pool = getPool();
+  const result = await pool.query<{ id: string; slug: string; name: string; committee_type: string }>(
+    `SELECT wg.id, wg.slug, wg.name, wg.committee_type
+     FROM working_group_leaders wgl
+     JOIN working_groups wg ON wg.id = wgl.working_group_id
+     LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
+     WHERE (wgl.user_id = $1 OR sm.workos_user_id = $1)`,
+    [workosUserId]
+  );
+  return result.rows;
+}
+
+/**
+ * Format committee type for display
+ */
+function formatCommitteeType(type: string): string {
+  const typeMap: Record<string, string> = {
+    working_group: 'working group',
+    council: 'council',
+    chapter: 'chapter',
+    governance: 'governance committee',
+    industry_gathering: 'industry gathering',
+  };
+  return typeMap[type] || type;
+}
+
+/**
+ * Create committee leader tool handlers
+ *
+ * These handlers check that the user is a leader of the specified committee
+ * before allowing them to modify leadership.
+ */
+export function createCommitteeLeaderToolHandlers(
+  memberContext?: MemberContext | null,
+  slackUserId?: string
+): Map<string, (input: Record<string, unknown>) => Promise<string>> {
+  const handlers = new Map<string, (input: Record<string, unknown>) => Promise<string>>();
+
+  /**
+   * Get the current user's WorkOS ID from context or Slack mapping
+   */
+  const getCurrentUserWorkosId = async (): Promise<string | null> => {
+    // Try to get from member context first
+    if (memberContext?.workos_user?.workos_user_id) {
+      return memberContext.workos_user.workos_user_id;
+    }
+
+    // Fall back to Slack mapping
+    if (slackUserId) {
+      const mapping = await slackDb.getBySlackUserId(slackUserId);
+      return mapping?.workos_user_id || null;
+    }
+
+    return null;
+  };
+
+  /**
+   * Check if the current user leads the specified committee
+   */
+  const checkUserLeadsCommittee = async (committeeSlug: string): Promise<{ allowed: boolean; error?: string; committee?: { id: string; name: string; committee_type: string } }> => {
+    const workosUserId = await getCurrentUserWorkosId();
+    if (!workosUserId) {
+      return {
+        allowed: false,
+        error: 'You need to link your Slack account to your AgenticAdvertising.org account to manage committee leadership.',
+      };
+    }
+
+    // Get the committee
+    const committee = await wgDb.getWorkingGroupBySlug(committeeSlug);
+    if (!committee) {
+      return {
+        allowed: false,
+        error: `Committee "${committeeSlug}" not found. Check the slug and try again.`,
+      };
+    }
+
+    // Check if user is a leader
+    const isLeader = await wgDb.isLeader(committee.id, workosUserId);
+    if (!isLeader) {
+      // Get committees they do lead to give helpful context
+      const ledCommittees = await getCommitteesLedByUser(workosUserId);
+      if (ledCommittees.length > 0) {
+        const committeeNames = ledCommittees.map(c => c.name).join(', ');
+        return {
+          allowed: false,
+          error: `You are not a leader of ${committee.name}. You can manage leadership for: ${committeeNames}.`,
+        };
+      }
+      return {
+        allowed: false,
+        error: `You are not a leader of ${committee.name}. Only committee leaders can add or remove co-leaders.`,
+      };
+    }
+
+    return { allowed: true, committee: { id: committee.id, name: committee.name, committee_type: committee.committee_type } };
+  };
+
+  // ============================================
+  // ADD COMMITTEE CO-LEADER
+  // ============================================
+  handlers.set('add_committee_co_leader', async (input) => {
+    const committeeSlug = (input.committee_slug as string)?.trim();
+    let userId = (input.user_id as string)?.trim();
+    const userEmail = input.user_email as string | undefined;
+
+    if (!committeeSlug) {
+      return '❌ Please provide a committee_slug (e.g., "india-chapter", "creative-wg").';
+    }
+
+    if (!userId) {
+      return '❌ Please provide a user_id (WorkOS user ID or Slack user ID).';
+    }
+
+    // Check permission
+    const permCheck = await checkUserLeadsCommittee(committeeSlug);
+    if (!permCheck.allowed) {
+      return `⚠️ ${permCheck.error}`;
+    }
+    const committee = permCheck.committee!;
+
+    try {
+      // Resolve to canonical ID for consistent comparison
+      // The DB methods also resolve, but we need the canonical ID for the "already a leader" check
+      const canonicalUserId = await wgDb.resolveToCanonicalUserId(userId);
+
+      // Check if already a leader
+      const leaders = await wgDb.getLeaders(committee.id);
+      if (leaders.some((l) => l.canonical_user_id === canonicalUserId)) {
+        return `ℹ️ This person is already a leader of ${committee.name}.`;
+      }
+
+      // Add as leader (DB method also resolves IDs, but we pass canonical for consistency)
+      await wgDb.addLeader(committee.id, canonicalUserId);
+
+      // Invalidate cache after adding as leader (leadership affects permissions)
+      invalidateWebAdminStatusCache(canonicalUserId);
+
+      // Also ensure they're a member
+      const memberships = await wgDb.getMembershipsByWorkingGroup(committee.id);
+      if (!memberships.some(m => m.workos_user_id === canonicalUserId)) {
+        await wgDb.addMembership({
+          working_group_id: committee.id,
+          workos_user_id: canonicalUserId,
+          user_email: userEmail,
+        });
+      }
+
+      logger.info({ committeeSlug, committeeName: committee.name, userId: canonicalUserId, userEmail, addedBy: slackUserId }, 'Added committee co-leader');
+
+      const emailInfo = userEmail ? ` (${userEmail})` : '';
+      const typeLabel = formatCommitteeType(committee.committee_type);
+      return `✅ Successfully added ${userId}${emailInfo} as a co-leader of **${committee.name}**.
+
+They now have management access to:
+- Create and manage ${typeLabel} events
+- Create and manage ${typeLabel} posts
+- Add or remove other co-leaders
+
+Management page: https://agenticadvertising.org/working-groups/${committeeSlug}/manage`;
+    } catch (error) {
+      logger.error({ error, committeeSlug, userId }, 'Error adding committee co-leader');
+      return '❌ Failed to add committee co-leader. Please try again.';
+    }
+  });
+
+  // ============================================
+  // REMOVE COMMITTEE CO-LEADER
+  // ============================================
+  handlers.set('remove_committee_co_leader', async (input) => {
+    const committeeSlug = (input.committee_slug as string)?.trim();
+    let userId = (input.user_id as string)?.trim();
+
+    if (!committeeSlug) {
+      return '❌ Please provide a committee_slug (e.g., "india-chapter", "creative-wg").';
+    }
+
+    if (!userId) {
+      return '❌ Please provide a user_id (WorkOS user ID or Slack user ID).';
+    }
+
+    // Check permission
+    const permCheck = await checkUserLeadsCommittee(committeeSlug);
+    if (!permCheck.allowed) {
+      return `⚠️ ${permCheck.error}`;
+    }
+    const committee = permCheck.committee!;
+
+    try {
+      // Resolve to canonical ID for consistent comparison
+      const canonicalUserId = await wgDb.resolveToCanonicalUserId(userId);
+
+      // Get current user's WorkOS ID
+      const currentUserWorkosId = await getCurrentUserWorkosId();
+
+      // Prevent removing yourself - compare canonical IDs to prevent bypass
+      if (canonicalUserId === currentUserWorkosId) {
+        return `⚠️ You cannot remove yourself as a leader. If you want to step down from leading ${committee.name}, please contact an admin.`;
+      }
+
+      // Check if they are a leader
+      const leaders = await wgDb.getLeaders(committee.id);
+      if (!leaders.some((l) => l.canonical_user_id === canonicalUserId)) {
+        return `ℹ️ This person is not a leader of ${committee.name}.`;
+      }
+
+      await wgDb.removeLeader(committee.id, canonicalUserId);
+      invalidateWebAdminStatusCache(canonicalUserId);
+
+      logger.info({ committeeSlug, committeeName: committee.name, userId: canonicalUserId, removedBy: slackUserId }, 'Removed committee co-leader');
+
+      return `✅ Successfully removed as a leader of **${committee.name}**.
+
+They are still a member but no longer have management access.`;
+    } catch (error) {
+      logger.error({ error, committeeSlug, userId }, 'Error removing committee co-leader');
+      return '❌ Failed to remove committee co-leader. Please try again.';
+    }
+  });
+
+  // ============================================
+  // LIST COMMITTEE CO-LEADERS
+  // ============================================
+  handlers.set('list_committee_co_leaders', async (input) => {
+    const committeeSlug = (input.committee_slug as string)?.trim();
+
+    if (!committeeSlug) {
+      return '❌ Please provide a committee_slug (e.g., "india-chapter", "creative-wg").';
+    }
+
+    // Check permission
+    const permCheck = await checkUserLeadsCommittee(committeeSlug);
+    if (!permCheck.allowed) {
+      return `⚠️ ${permCheck.error}`;
+    }
+    const committee = permCheck.committee!;
+
+    try {
+      const leaders = await wgDb.getLeaders(committee.id);
+
+      if (leaders.length === 0) {
+        return `ℹ️ **${committee.name}** has no assigned leaders.
+
+Use add_committee_co_leader to add a co-leader.`;
+      }
+
+      const typeLabel = formatCommitteeType(committee.committee_type);
+      let response = `## Leaders of ${committee.name}\n\n`;
+      response += `**Type:** ${typeLabel}\n`;
+      response += `**Slug:** ${committeeSlug}\n\n`;
+
+      for (const leader of leaders) {
+        response += `- **User ID:** ${leader.user_id}\n`;
+        if (leader.name) {
+          response += `  **Name:** ${leader.name}\n`;
+        }
+        if (leader.org_name) {
+          response += `  **Org:** ${leader.org_name}\n`;
+        }
+        if (leader.created_at) {
+          response += `  Added: ${new Date(leader.created_at).toLocaleDateString()}\n`;
+        }
+      }
+
+      return response;
+    } catch (error) {
+      logger.error({ error, committeeSlug }, 'Error listing committee leaders');
+      return '❌ Failed to list committee leaders. Please try again.';
+    }
+  });
+
+  return handlers;
+}

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -177,6 +177,16 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     ],
   },
 
+  committee_leadership: {
+    name: 'committee_leadership',
+    description: 'Manage committee co-leaders - add or remove co-leaders for committees you lead (working groups, councils, chapters, industry gatherings)',
+    tools: [
+      'add_committee_co_leader',
+      'remove_committee_co_leader',
+      'list_committee_co_leaders',
+    ],
+  },
+
   admin: {
     name: 'admin',
     description: 'Administrative operations - manage prospects, organizations, feeds, flagged conversations, insights (admin only)',


### PR DESCRIPTION
## Summary
- Allow committee leaders to manage co-leaders for their own committees without requiring admin access
- Works for all committee types: working groups, councils, chapters, and industry gatherings
- Addresses the issue where Addie couldn't help chapter leaders add co-leaders (see attached screenshot in original conversation)

## New Tools
- `add_committee_co_leader`: Add a co-leader to committees you lead
- `remove_committee_co_leader`: Remove a co-leader (can't remove yourself)
- `list_committee_co_leaders`: List current leaders of your committees

## Permission Model
- Must be a leader of the specific committee
- Can only manage committees where you're already a leader
- Cannot remove yourself (must contact admin for that)
- Helpful error messages tell you which committees you *can* manage

## Test plan
- [ ] Verify type checks pass (`npm run typecheck`)
- [ ] Verify tests pass (`npm test`)
- [ ] Test with a chapter leader user in Slack:
  - Ask to add a co-leader to their chapter
  - Ask to list leaders of their chapter
  - Ask to remove a co-leader (not themselves)
  - Verify permission errors when trying to manage committees they don't lead

🤖 Generated with [Claude Code](https://claude.ai/code)