### PR TITLE
feat: Add governance and SI agent types with full AdCP tool coverage

### DIFF
--- a/.changeset/metal-cows-tickle.md
+++ b/.changeset/metal-cows-tickle.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add governance and SI agent types to Addie with complete AdCP protocol tool coverage. Adds 21 new tools for update_media_buy, list_creatives, provide_performance_feedback, property lists, content standards, sponsored intelligence, and get_adcp_capabilities.

--- a/server/src/addie/mcp/directory-tools.ts
+++ b/server/src/addie/mcp/directory-tools.ts
@@ -69,14 +69,14 @@ export const DIRECTORY_TOOLS: AddieTool[] = [
   },
   {
     name: 'list_agents',
-    description: 'List all public AdCP agents from member organizations. Can filter by type: creative (asset generation), signals (audience data), or sales (media buying).',
+    description: 'List all public AdCP agents from member organizations. Can filter by type: creative (asset generation), signals (audience data), sales (media buying), governance (property lists and content standards), or si (sponsored intelligence/conversational commerce).',
     usage_hints: 'Use when asked about registered agents, what agents are available, or agents of a specific type.',
     input_schema: {
       type: 'object',
       properties: {
         type: {
           type: 'string',
-          enum: ['creative', 'signals', 'sales'],
+          enum: ['creative', 'signals', 'sales', 'governance', 'si'],
           description: 'Filter by agent type',
         },
       },

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -113,21 +113,46 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   adcp_operations: {
     name: 'adcp_operations',
-    description: 'Execute AdCP protocol operations - discover products, create media buys, manage creatives, work with signals, and interact with sales/creative/signal agents',
+    description: 'Execute AdCP protocol operations - discover products, create/update media buys, manage creatives, work with signals, governance (property lists, content standards), sponsored intelligence (SI), and interact with sales/creative/signals/governance/si agents',
     tools: [
       // Media Buy tools
       'get_products',
       'create_media_buy',
+      'update_media_buy',
       'sync_creatives',
+      'list_creatives',
       'list_creative_formats',
       'list_authorized_properties',
       'get_media_buy_delivery',
+      'provide_performance_feedback',
       // Creative tools
       'build_creative',
       'preview_creative',
       // Signals tools
       'get_signals',
       'activate_signal',
+      // Governance - Property Lists
+      'create_property_list',
+      'update_property_list',
+      'get_property_list',
+      'list_property_lists',
+      'delete_property_list',
+      // Governance - Content Standards
+      'create_content_standards',
+      'get_content_standards',
+      'update_content_standards',
+      'list_content_standards',
+      'delete_content_standards',
+      'calibrate_content',
+      'get_media_buy_artifacts',
+      'validate_content_delivery',
+      // Sponsored Intelligence (SI)
+      'si_initiate_session',
+      'si_send_message',
+      'si_get_offering',
+      'si_terminate_session',
+      // Protocol
+      'get_adcp_capabilities',
       // Agent management
       'save_agent',
       'list_saved_agents',

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,9 +1,9 @@
-export type AgentType = "creative" | "signals" | "sales" | "unknown";
+export type AgentType = "creative" | "signals" | "sales" | "governance" | "si" | "unknown";
 
 /**
  * Valid agent type values for runtime validation
  */
-export const VALID_AGENT_TYPES: readonly AgentType[] = ["creative", "signals", "sales", "unknown"] as const;
+export const VALID_AGENT_TYPES: readonly AgentType[] = ["creative", "signals", "sales", "governance", "si", "unknown"] as const;
 
 /**
  * Type guard to check if a string is a valid AgentType
@@ -259,7 +259,7 @@ export interface AgentConfig {
   is_public: boolean;
   // Cached info from discovery (optional, refreshed periodically)
   name?: string;
-  type?: 'sales' | 'creative' | 'signals' | 'buyer' | 'unknown';
+  type?: AgentType | 'buyer';
 }
 
 /**
@@ -621,7 +621,7 @@ export interface CommitteeDocumentActivity {
 export interface FederatedAgent {
   url: string;
   name?: string;
-  type?: AgentType | 'buyer' | 'unknown';
+  type?: AgentType | 'buyer';
   protocol?: 'mcp' | 'a2a';
   source: 'registered' | 'discovered';
   // For registered agents


### PR DESCRIPTION
## Summary
- Add `governance` and `si` to the `AgentType` union and `VALID_AGENT_TYPES` array
- Implement 21 new AdCP protocol tools for Addie, enabling full protocol coverage:
  - **Media Buy**: `update_media_buy`, `list_creatives`, `provide_performance_feedback`
  - **Governance - Property Lists**: `create_property_list`, `update_property_list`, `get_property_list`, `list_property_lists`, `delete_property_list`
  - **Governance - Content Standards**: `create_content_standards`, `get_content_standards`, `update_content_standards`, `list_content_standards`, `delete_content_standards`, `calibrate_content`, `get_media_buy_artifacts`, `validate_content_delivery`
  - **SI (Sponsored Intelligence)**: `si_initiate_session`, `si_send_message`, `si_get_offering`, `si_terminate_session`
  - **Protocol**: `get_adcp_capabilities`
- Add input validation for tools requiring at least one of multiple optional parameters

## Test plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All tests pass (`npm test`)
- [x] Pre-commit hooks pass
- [x] Docker build and run successful
- [x] Manual verification: app loads and Addie dashboard accessible

🤖 Generated with [Claude Code](https://claude.ai/code)