### PR TITLE
Add creative protocol to get_adcp_capabilities

### DIFF
--- a/.changeset/add-creative-protocol.md
+++ b/.changeset/add-creative-protocol.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add "creative" to supported_protocols enum in get_adcp_capabilities. Creative agents indicate protocol support via presence in supported_protocols array.

--- a/docs/media-buy/quick-reference.mdx
+++ b/docs/media-buy/quick-reference.mdx
@@ -72,7 +72,7 @@ No parameters required.
 
 **Response contains:**
 - `adcp.major_versions`: Supported AdCP versions
-- `supported_protocols`: Which protocols the agent implements (media_buy, signals, governance)
+- `supported_protocols`: Which protocols the agent implements (media_buy, signals, governance, sponsored_intelligence, creative)
 - `media_buy.portfolio`: Publisher domains, primary channels, and countries
 - `media_buy.execution`: Geo targeting capabilities and AXE integrations
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -9,7 +9,7 @@ Discover a seller's protocol support and capabilities across all AdCP protocols.
 
 **Purpose**:
 - **AdCP discovery** - Does this agent support AdCP? Which versions?
-- **Protocol support** - Which domain protocols (media_buy, signals)?
+- **Protocol support** - Which domain protocols (media_buy, signals, governance, sponsored_intelligence, creative)?
 - **Detailed capabilities** - Features, AXE integrations, geo targeting, portfolio
 
 **Request Schema**: [`/schemas/v1/protocol/get-adcp-capabilities-request.json`](https://adcontextprotocol.org/schemas/v1/protocol/get-adcp-capabilities-request.json)
@@ -40,7 +40,7 @@ The agent card extension (`adcp-extension.json`) has been removed in v3. Use too
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `protocols` | string[] | Optional. Filter to specific protocols (`media_buy`, `signals`). If omitted, returns all supported protocols. |
+| `protocols` | string[] | Optional. Filter to specific protocols (`media_buy`, `signals`, `governance`, `sponsored_intelligence`, `creative`). If omitted, returns all supported protocols. |
 
 ## Response Structure
 

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -281,7 +281,7 @@
         },
         "adcp-domain": {
           "$ref": "/schemas/enums/adcp-domain.json",
-          "description": "AdCP protocol domains (media-buy, signals, governance)"
+          "description": "AdCP protocol domains (media-buy, signals, governance, creative)"
         },
         "http-method": {
           "$ref": "/schemas/enums/http-method.json",

--- a/static/schemas/source/protocol/get-adcp-capabilities-request.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-request.json
@@ -10,7 +10,7 @@
       "description": "Specific protocols to query capabilities for. If omitted, returns capabilities for all supported protocols.",
       "items": {
         "type": "string",
-        "enum": ["media_buy", "signals", "sponsored_intelligence"]
+        "enum": ["media_buy", "signals", "governance", "sponsored_intelligence", "creative"]
       }
     },
     "context": {

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -26,7 +26,7 @@
       "description": "Which AdCP domain protocols this seller supports",
       "items": {
         "type": "string",
-        "enum": ["media_buy", "signals", "governance", "sponsored_intelligence"]
+        "enum": ["media_buy", "signals", "governance", "sponsored_intelligence", "creative"]
       },
       "minItems": 1
     },


### PR DESCRIPTION
Adds "creative" to supported_protocols enum so creative agents can indicate AdCP support. Updates documentation and schemas to reflect all supported protocols (media_buy, signals, governance, sponsored_intelligence, creative).

Creative agents indicate protocol support by including "creative" in their supported_protocols response array.

🤖 Generated with Claude Code