### PR TITLE
refactor(members): Replace pricing table with CTA banner and add URL filters

### DIFF
--- a/.changeset/members-page-refactor.md
+++ b/.changeset/members-page-refactor.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Refactor members page to remove pricing table and add URL filter support
+
+- Replace full pricing grid with compact "Become a Member" banner linking to /membership
+- Add URL query parameter support for filtering (e.g., /members?type=sales_agent)
+- URL updates as users interact with filters for shareable/bookmarkable views

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -154,103 +154,6 @@
       margin-bottom: var(--space-2);
     }
 
-    /* Membership Intro Section */
-    .membership-intro {
-      background: var(--color-bg-card);
-      border-radius: var(--card-radius);
-      padding: var(--space-10);
-      margin-bottom: var(--space-8);
-      box-shadow: var(--shadow-md);
-    }
-    .membership-intro h2 {
-      font-size: var(--text-2xl);
-      color: var(--color-brand);
-      margin-bottom: var(--space-4);
-      padding-bottom: var(--space-3);
-      border-bottom: 3px solid var(--color-brand);
-    }
-    .membership-intro > p {
-      font-size: var(--text-lg);
-      color: var(--color-text-body);
-      line-height: var(--leading-relaxed);
-      margin-bottom: var(--space-8);
-    }
-    .membership-benefits {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: var(--space-6);
-      margin-bottom: var(--space-8);
-    }
-    .benefit-item {
-      display: flex;
-      gap: var(--space-4);
-      align-items: flex-start;
-    }
-    .benefit-icon {
-      width: 48px;
-      height: 48px;
-      background: var(--color-primary-100);
-      border-radius: var(--radius-lg);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-shrink: 0;
-      color: var(--color-brand);
-    }
-    .benefit-content h3 {
-      font-size: var(--text-lg);
-      font-weight: var(--font-semibold);
-      color: var(--color-text-heading);
-      margin-bottom: var(--space-1);
-    }
-    .benefit-content p {
-      font-size: var(--text-sm);
-      color: var(--color-text-muted);
-      line-height: var(--leading-normal);
-    }
-    .membership-cta-btn {
-      display: inline-block;
-      padding: var(--space-4) var(--space-8);
-      background: var(--color-brand);
-      color: white;
-      text-decoration: none;
-      border-radius: var(--radius-lg);
-      font-weight: var(--font-semibold);
-      font-size: var(--text-lg);
-      transition: var(--transition-all);
-      box-shadow: var(--shadow-md);
-    }
-    .membership-cta-btn:hover {
-      background: var(--color-brand-hover);
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-lg);
-    }
-    .coming-soon-teaser {
-      display: flex;
-      align-items: center;
-      gap: var(--space-3);
-      padding: var(--space-4) var(--space-5);
-      background: var(--color-primary-50);
-      border: 1px dashed var(--color-primary-300);
-      border-radius: var(--radius-lg);
-      margin-bottom: var(--space-6);
-    }
-    .coming-soon-badge {
-      font-size: var(--text-xs);
-      font-weight: var(--font-bold);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      padding: var(--space-1) var(--space-2);
-      background: var(--color-brand);
-      color: white;
-      border-radius: var(--radius-sm);
-      flex-shrink: 0;
-    }
-    .coming-soon-text {
-      font-size: var(--text-sm);
-      color: var(--color-primary-800);
-    }
-
     /* Join CTA Banner */
     .join-cta {
       background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-hover) 100%);
@@ -1215,7 +1118,6 @@
   <div id="adcp-nav"></div>
   <script src="/nav.js"></script>
   <script src="/member-card.js"></script>
-  <script src="/join-cta.js"></script>
 
   <!-- List View -->
   <div id="list-view">
@@ -1225,11 +1127,16 @@
     </div>
 
     <div class="container">
-      <!-- Membership Introduction -->
-      <section class="membership-intro" id="join">
-        <h2>Become a Member</h2>
-        <div id="join-cta-container"></div>
-      </section>
+      <!-- Join CTA Banner -->
+      <div class="join-cta">
+        <div class="join-cta-content">
+          <div class="join-cta-text">
+            <h2>Join AgenticAdvertising.org</h2>
+            <p>Become a founding member and help shape the future of agentic advertising</p>
+          </div>
+          <a href="/membership" class="join-cta-btn">Become a Member</a>
+        </div>
+      </div>
 
       <div class="search-section">
         <div class="search-bar">
@@ -1358,19 +1265,43 @@
       injectAgentCardStyles();
       injectPublisherCardStyles();
 
-      // Initialize join CTA component
-      renderJoinCta({
-        containerId: 'join-cta-container',
-        showFoundingNote: true,
-        showContactLine: true
-      });
-
       // Check if we're viewing a specific member
       const path = window.location.pathname;
       const match = path.match(/^\/members\/([^/]+)$/);
       if (match) {
         loadMemberBySlug(match[1]);
       } else {
+        // Check for URL query parameters
+        const urlParams = new URLSearchParams(window.location.search);
+        const typeParam = urlParams.get('type');
+        const searchParam = urlParams.get('search');
+        const marketParam = urlParams.get('market');
+
+        // Apply URL params to filters (validate against known values)
+        const validFilters = ['buyer_agent', 'sales_agent', 'creative_agent', 'signals_agent', 'consulting'];
+        if (typeParam && validFilters.includes(typeParam)) {
+          currentFilter = typeParam;
+          // Update filter button UI
+          document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.classList.remove('active');
+            if (btn.getAttribute('data-filter') === typeParam) {
+              btn.classList.add('active');
+            }
+          });
+        }
+        if (searchParam) {
+          currentSearch = searchParam;
+          document.getElementById('search-input').value = searchParam;
+        }
+        if (marketParam) {
+          const marketSelect = document.getElementById('market-filter');
+          const validMarkets = Array.from(marketSelect.options).map(o => o.value);
+          if (validMarkets.includes(marketParam)) {
+            currentMarket = marketParam;
+            marketSelect.value = marketParam;
+          }
+        }
+
         loadMembers();
       }
     });
@@ -1422,6 +1353,7 @@
       currentSearch = document.getElementById('search-input').value.trim();
       document.getElementById('loading').style.display = 'block';
       document.getElementById('members-grid').innerHTML = '';
+      updateUrlParams();
       loadMembers();
     }
 
@@ -1433,13 +1365,30 @@
       currentFilter = filter;
       document.getElementById('loading').style.display = 'block';
       document.getElementById('members-grid').innerHTML = '';
+
+      // Update URL with filter params
+      updateUrlParams();
+
       loadMembers();
+    }
+
+    function updateUrlParams() {
+      const params = new URLSearchParams();
+      if (currentFilter) params.set('type', currentFilter);
+      if (currentSearch) params.set('search', currentSearch);
+      if (currentMarket) params.set('market', currentMarket);
+
+      const newUrl = params.toString()
+        ? `${window.location.pathname}?${params.toString()}`
+        : window.location.pathname;
+      history.replaceState({}, '', newUrl);
     }
 
     function setMarketFilter(market) {
       currentMarket = market;
       document.getElementById('loading').style.display = 'block';
       document.getElementById('members-grid').innerHTML = '';
+      updateUrlParams();
       loadMembers();
     }
 


### PR DESCRIPTION
## Summary

- Remove full pricing grid from the members page, replacing with a compact "Become a Member" banner that links to `/membership`
- Add URL query parameter support for filtering members directory
- URL updates as users interact with filters for shareable/bookmarkable views

## URL Filter Support

Now you can link directly to filtered views:
- `/members?type=sales_agent` - Shows only Sales Agents
- `/members?type=buyer_agent` - Shows only Buyer Agents  
- `/members?type=creative_agent` - Shows only Creative Agents
- `/members?type=signals_agent` - Shows only Signals Agents
- `/members?type=consulting` - Shows only Consulting members
- `/members?search=acme` - Pre-fills search
- `/members?market=EMEA` - Pre-selects market filter

Parameters can be combined: `/members?type=sales_agent&market=EMEA`

## Test plan
- [ ] Visit /members and verify compact CTA banner appears instead of pricing table
- [ ] Click "Become a Member" button and verify it goes to /membership
- [ ] Test `/members?type=sales_agent` - filter button should be active
- [ ] Test `/members?market=EMEA` - market dropdown should be selected
- [ ] Test `/members?search=test` - search input should be pre-filled
- [ ] Click filter buttons and verify URL updates
- [ ] Verify invalid params are ignored gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)