### PR TITLE
feat: Add property_targeting_allowed flag to Product schema

### DIFF
--- a/.changeset/property-targeting-allowed.md
+++ b/.changeset/property-targeting-allowed.md
@@ -1,0 +1,14 @@
+---
+"adcontextprotocol": minor
+---
+
+Add property targeting for products and packages
+
+**Product schema**: Add `property_targeting_allowed` flag to declare whether buyers can filter a product to a subset of its `publisher_properties`:
+
+- `property_targeting_allowed: false` (default): Product is "all or nothing" - excluded from `get_products` results unless buyer's list contains all properties
+- `property_targeting_allowed: true`: Product included if any properties intersect with buyer's list
+
+**Targeting overlay schema**: Add `property_list` field to specify which properties to target when purchasing products with `property_targeting_allowed: true`. The package runs on the intersection of the product's properties and the buyer's list.
+
+This enables publishers to offer run-of-network products that can't be cherry-picked alongside flexible inventory where buyers can target specific properties.

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -75,9 +75,9 @@ A media buy contains:
 
 ### Package Model
 Packages are the building blocks of media buys:
-- **Single product** selection from discovery results - when you buy a product, you buy the entire product
+- **Single product** selection from discovery results - when you buy a product, you buy the entire product (unless using property targeting)
 - **Creative formats** to be provided for this package
-- **Targeting overlays** for audience refinement beyond product defaults
+- **Targeting overlays** for refinements including geo restrictions, frequency caps, and property targeting
 - **Budget allocation** as portion of overall media buy budget
 - **Pricing option** selection from product's available pricing models
 - **Pacing strategy** for budget delivery (even, asap, or front_loaded)
@@ -150,6 +150,31 @@ When a product defines multiple placements, buyers can assign different creative
 - **Dayparting**: Different creatives for morning vs evening placements
 
 See [Media Products - Placements](/docs/media-buy/product-discovery/media-products.mdx#placements) for complete placement documentation.
+
+### Property Targeting
+
+For products with `property_targeting_allowed: true`, buyers can specify which properties to target using `property_list` in the `targeting_overlay`:
+
+```json
+{
+  "product_id": "flexible_news_network",
+  "targeting_overlay": {
+    "property_list": {
+      "agent_url": "https://governance.example.com",
+      "list_id": "pl_brand_safe_2024"
+    }
+  },
+  "budget": 50000
+}
+```
+
+**Key Points:**
+- Only valid for products with `property_targeting_allowed: true`
+- The package runs on the intersection of the product's `publisher_properties` and the `property_list`
+- If omitted, the package runs on all of the product's properties
+- If provided for a product with `property_targeting_allowed: false`, the seller SHOULD return a validation error
+
+See [Media Products - Property Targeting](/docs/media-buy/product-discovery/media-products#property-targeting) for more on how products declare targeting flexibility.
 
 ### Lifecycle States
 Media buys progress through predictable states:

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -23,6 +23,7 @@ Products declare which pricing models they support. Buyers select a specific pri
 - `creative_policy` (CreativePolicy, optional): Creative requirements and restrictions.
 - `is_custom` (bool, optional): `true` if the product was generated for a specific brief.
 - `expires_at` (datetime, optional): If `is_custom`, the time the product is no longer valid.
+- `property_targeting_allowed` (bool, optional, default: false): Whether buyers can filter this product to a subset of its `publisher_properties`. When `false` (default), the product is "all or nothing" - buyers must accept all properties or the product is excluded from `property_list` filtering results. See [Property Targeting](#property-targeting).
 - `product_card` (object, optional): Visual card definition for displaying this product in user interfaces. See [Product Cards](#product-cards).
 
 ### Pricing Models
@@ -192,6 +193,54 @@ When creating a media buy, buyers can assign different creatives to different pl
 ```
 
 See [Creative Assignment and Placement Targeting](/docs/media-buy/media-buys/index.mdx#creative-assignment-and-placement-targeting) for more details.
+
+### Property Targeting
+
+The `property_targeting_allowed` flag indicates whether buyers can filter a product to a subset of its `publisher_properties` when using property list filtering via `get_products`.
+
+#### Behavior
+
+- **`property_targeting_allowed: false` (default)**: The product is "all or nothing." If the buyer's `property_list` doesn't include all of the product's properties, the product is excluded from results entirely.
+
+- **`property_targeting_allowed: true`**: Buyers can filter the product to properties matching their `property_list`. The product is included in results if there is any intersection between its properties and the buyer's list.
+
+#### Use Cases
+
+| Use Case | `property_targeting_allowed` | Why |
+|----------|------------------------------|-----|
+| Run of Network | `false` | Buyers must accept the entire network |
+| Premium Bundles | `false` | Sports + News bundle sold together |
+| Flexible Inventory | `true` | Buyers can target specific sites within a category |
+
+#### Examples
+
+**All-or-nothing product** (`property_targeting_allowed: false`):
+```json
+{
+  "product_id": "premium_news_bundle",
+  "name": "Premium News Bundle",
+  "publisher_properties": [
+    { "publisher_domain": "news.example.com", "property_ids": ["site_a", "site_b", "site_c"] }
+  ],
+  "property_targeting_allowed": false
+}
+```
+
+When a buyer calls `get_products` with a `property_list` containing only `site_a` and `site_b`, this product is **excluded** because the buyer's list doesn't include all properties (`site_c` is missing).
+
+**Flexible product** (`property_targeting_allowed: true`):
+```json
+{
+  "product_id": "news_category_flexible",
+  "name": "News Category - Flexible Targeting",
+  "publisher_properties": [
+    { "publisher_domain": "news.example.com", "property_ids": ["tech", "sports", "finance", "politics"] }
+  ],
+  "property_targeting_allowed": true
+}
+```
+
+When a buyer calls `get_products` with a `property_list` containing only `tech` and `sports`, this product is **included** because there is an intersection. The buyer can then purchase this product and target only the matching properties via `targeting_overlay.property_list` in the package.
 
 ### Custom & Principal-Specific Products
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -572,7 +572,16 @@ asyncio.run(discover_with_property_list())
 - The agent couldn't access the property list
 - The property list had no effect on the available inventory
 
-See [Property Governance](/docs/governance/property/specification) for more on property lists.
+#### Property Targeting Behavior
+
+Products have a `property_targeting_allowed` flag that affects filtering:
+
+- **`property_targeting_allowed: false` (default)**: Product is "all or nothing" - excluded unless your list contains all of its properties
+- **`property_targeting_allowed: true`**: Product is included if there's any intersection between its properties and your list
+
+This allows publishers to offer run-of-network products that can't be cherry-picked alongside flexible inventory that buyers can filter.
+
+See [Property Targeting](/docs/media-buy/product-discovery/media-products#property-targeting) for more details and [Property Governance](/docs/governance/property/specification) for more on property lists.
 
 ## Error Handling
 

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -86,6 +86,11 @@
       "type": "boolean",
       "description": "Whether this is a custom product"
     },
+    "property_targeting_allowed": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether buyers can filter this product to a subset of its publisher_properties. When false (default), the product is 'all or nothing' - buyers must accept all properties or the product is excluded from property_list filtering results."
+    },
     "brief_relevance": {
       "type": "string",
       "description": "Explanation of why this product matches the brief (only included when brief is provided)"

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -77,6 +77,10 @@
     },
     "frequency_cap": {
       "$ref": "/schemas/core/frequency-cap.json"
+    },
+    "property_list": {
+      "$ref": "/schemas/core/property-list-ref.json",
+      "description": "Reference to a property list for targeting specific properties within this product. The package runs on the intersection of the product's publisher_properties and this list. Sellers SHOULD return a validation error if the product has property_targeting_allowed: false."
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
## Summary

- Add `property_targeting_allowed` boolean flag to Product schema (default: `false`)
- Add `property_list` field to targeting overlay for package-level property targeting
- Document property targeting behavior in discovery and purchase flows

## Changes

**Schema:**
- `product.json`: Added `property_targeting_allowed` field
- `targeting.json`: Added `property_list` field

**Documentation:**
- `media-products.mdx`: New Property Targeting section with examples
- `get_products.mdx`: Property Targeting Behavior subsection
- `media-buys/index.mdx`: Property Targeting section for packages

## Behavior

**Discovery (`get_products`):**
- `property_targeting_allowed: false` (default): Product excluded unless buyer's list contains ALL properties
- `property_targeting_allowed: true`: Product included if ANY properties intersect

**Purchase (`create_media_buy`):**
- Buyers can specify `targeting_overlay.property_list` to target specific properties
- Seller SHOULD return validation error if provided for products with `property_targeting_allowed: false`

## Test plan

- [x] Schema validation tests pass
- [x] Example validation tests pass
- [x] All existing tests pass
- [ ] Manual review of documentation

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)