### PR TITLE
Add functional restriction overlays: age, device platform, language

### DIFF
--- a/.changeset/targeting-restrictions.md
+++ b/.changeset/targeting-restrictions.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add functional restriction overlays: age_restriction (with verification methods for compliance), device_platform (technical compatibility using Sec-CH-UA-Platform values), and language (localization). These are compliance/technical restrictions, not audience targeting - demographic preferences should be expressed in briefs.

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -154,6 +154,66 @@ Use geo fields **only** for:
 
 **Note**: Not all geographic granularities are supported by all publishers. Country and region are most widely supported.
 
+### Age Restrictions (Compliance)
+Use for **legal compliance** requirements:
+- **Alcohol advertising**: Require verified 21+ in the US
+- **Gambling/Gaming**: Require verified 18+ or 21+ depending on jurisdiction
+- **Cannabis**: Require verified age per local regulations
+
+```json
+{
+  "targeting_overlay": {
+    "age_restriction": {
+      "min": 21,
+      "verification_required": true,
+      "accepted_methods": ["facial_age_estimation", "id_document", "world_id"]
+    }
+  }
+}
+```
+
+**Verification methods** (defined in [`age-verification-method.json`](https://adcontextprotocol.org/schemas/v2/enums/age-verification-method.json), based on ISO/IEC 27566-1 age assurance standards):
+- `facial_age_estimation` - AI-based age estimation (Yoti, etc.)
+- `id_document` - Government ID scan
+- `digital_id` - Verified digital identity credentials
+- `credit_card` - Payment card age gate
+- `world_id` - World ID orb verification
+
+**Note**: "Inferred" age (guessing from behavior/profile) is **not** accepted for regulatory compliance. Platforms declare their supported verification methods in `get_adcp_capabilities`.
+
+### Device Platform (Technical Compatibility)
+Use for **technical requirements**:
+- **App install campaigns**: iOS-only app requires `device_platform: ["ios"]`
+- **CTV campaigns**: Target specific TV operating systems
+
+```json
+{
+  "targeting_overlay": {
+    "device_platform": ["ios", "android"]
+  }
+}
+```
+
+**Available platforms** (defined in [`device-platform.json`](https://adcontextprotocol.org/schemas/v2/enums/device-platform.json), based on Sec-CH-UA-Platform standard extended for CTV):
+- Browser: `ios`, `android`, `windows`, `macos`, `linux`, `chromeos`
+- CTV: `tvos`, `tizen`, `webos`, `fire_os`, `roku_os`
+- Other: `unknown`
+
+### Language (Localization)
+Use for **localization requirements**:
+- Creative is in a specific language
+- Campaign targets specific language speakers
+
+```json
+{
+  "targeting_overlay": {
+    "language": ["es", "en"]
+  }
+}
+```
+
+**Format**: ISO 639-1 two-letter language codes (e.g., `en`, `es`, `fr`, `de`, `zh`).
+
 ### Frequency Capping
 Basic impression suppression controls:
 ```json
@@ -191,16 +251,23 @@ Basic impression suppression controls:
 ## What NOT to Use Targeting Overlays For
 
 **Express these in briefs instead:**
-- **Demographics** (age, gender) - "Target adults 25-54" in brief text
-- **Device types** - "Mobile users" or "CTV viewers" in brief text
-- **Browser/OS** - Rarely relevant; mention in brief if truly needed
+- **Demographic preferences** (age, gender, income) - "Target millennials" or "high-income households" in brief text
+- **Device preferences** - "Mobile users" or "CTV viewers" in brief text (use `device_platform` overlay only for technical compatibility)
 - **Content categories** - "Sports content" or "News sites" in brief text
 - **Audience segments** - "Auto intenders" or "Luxury shoppers" in brief text
-- **Operating systems and browsers** - Mention in brief if needed
-- **Language preferences** - "Spanish language content" in brief text
 - **Daypart preferences** - "Morning commute hours" or "prime time evening" in brief text
 
-**Why briefs work better:**
+**Overlays vs Briefs:**
+| Use Case | Overlay | Brief |
+|----------|---------|-------|
+| Age for compliance (alcohol, gambling) | ✅ `age_restriction` | |
+| Age for audience targeting | | ✅ "Target millennials" |
+| Device for app compatibility | ✅ `device_platform` | |
+| Device for audience preference | | ✅ "Mobile users" |
+| Language for creative localization | ✅ `language` | |
+| Language for audience preference | | ✅ "Spanish-speaking audiences" |
+
+**Why briefs work better for preferences:**
 - Natural language captures intent more clearly
 - Publishers know their inventory and can target effectively
 - Avoids channel-specific complexity (DOOH has no browsers)
@@ -256,6 +323,26 @@ All targeting parameters use the `any_of` operator pattern for inclusive targeti
 - **Format**: Frequency cap object with impressions, duration, and scope
 - **Use cases**: Brand safety, user experience management
 - **Example**: `{"impressions": 5, "duration_seconds": 86400, "scope": "creative"}`
+
+### age_restriction
+- **Description**: Require minimum age for compliance
+- **Format**: Object with `min` (required), `verification_required`, and `accepted_methods`
+- **Examples**: `{"min": 21, "verification_required": true}`, `{"min": 18, "accepted_methods": ["world_id"]}`
+- **Use cases**: Alcohol (21+), gambling (18+), cannabis regulations
+- **Note**: Platforms declare supported verification methods in `get_adcp_capabilities`
+
+### device_platform
+- **Description**: Restrict to specific operating system platforms
+- **Format**: Array of platform identifiers from Sec-CH-UA-Platform standard
+- **Examples**: `["ios"]`, `["ios", "android"]`, `["tvos", "fire_os"]`
+- **Use cases**: App install campaigns (iOS-only app), CTV-specific campaigns
+- **Values**: `ios`, `android`, `windows`, `macos`, `linux`, `chromeos`, `tvos`, `tizen`, `webos`, `fire_os`, `roku_os`
+
+### language
+- **Description**: Restrict to users with specific language preferences
+- **Format**: Array of ISO 639-1 two-letter language codes
+- **Examples**: `["en"]`, `["es", "en"]`, `["zh", "ja", "ko"]`
+- **Use cases**: Localized creative, language-specific campaigns
 
 ## Benefits for Different Stakeholders
 

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/targeting.json",
   "title": "Targeting Overlay",
-  "description": "Optional geographic refinements for media buys. Most targeting should be expressed in the brief and handled by the publisher. These fields are primarily for geographic restrictions (RCT testing, regulatory compliance).",
+  "description": "Optional restriction overlays for media buys. Most targeting should be expressed in the brief and handled by the publisher. These fields are for functional restrictions: geographic (RCT testing, regulatory compliance), age verification (alcohol, gambling), device platform (app compatibility), and language (localization).",
   "type": "object",
   "properties": {
     "geo_countries": {
@@ -81,6 +81,49 @@
     "property_list": {
       "$ref": "/schemas/core/property-list-ref.json",
       "description": "Reference to a property list for targeting specific properties within this product. The package runs on the intersection of the product's publisher_properties and this list. Sellers SHOULD return a validation error if the product has property_targeting_allowed: false."
+    },
+    "age_restriction": {
+      "type": "object",
+      "description": "Age restriction for compliance. Use for legal requirements (alcohol, gambling), not audience targeting.",
+      "properties": {
+        "min": {
+          "type": "integer",
+          "minimum": 13,
+          "maximum": 99,
+          "description": "Minimum age required"
+        },
+        "verification_required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether verified age (not inferred) is required for compliance"
+        },
+        "accepted_methods": {
+          "type": "array",
+          "description": "Accepted verification methods. If omitted, any method the platform supports is acceptable.",
+          "items": {
+            "$ref": "/schemas/enums/age-verification-method.json"
+          }
+        }
+      },
+      "required": ["min"],
+      "additionalProperties": false
+    },
+    "device_platform": {
+      "type": "array",
+      "description": "Restrict to specific platforms. Use for technical compatibility (app only works on iOS). Values from Sec-CH-UA-Platform standard, extended for CTV.",
+      "items": {
+        "$ref": "/schemas/enums/device-platform.json"
+      },
+      "minItems": 1
+    },
+    "language": {
+      "type": "array",
+      "description": "Restrict to users with specific language preferences. ISO 639-1 codes (e.g., 'en', 'es', 'fr').",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z]{2}$"
+      },
+      "minItems": 1
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/enums/age-verification-method.json
+++ b/static/schemas/source/enums/age-verification-method.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/age-verification-method.json",
+  "title": "Age Verification Method",
+  "description": "Methods for verifying user age for compliance. Does not include 'inferred' as it is not accepted for regulatory compliance.",
+  "type": "string",
+  "enum": [
+    "facial_age_estimation",
+    "id_document",
+    "digital_id",
+    "credit_card",
+    "world_id"
+  ]
+}

--- a/static/schemas/source/enums/device-platform.json
+++ b/static/schemas/source/enums/device-platform.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/device-platform.json",
+  "title": "Device Platform",
+  "description": "Operating system platforms for device targeting. Browser values from Sec-CH-UA-Platform standard, extended for CTV.",
+  "type": "string",
+  "enum": [
+    "ios",
+    "android",
+    "windows",
+    "macos",
+    "linux",
+    "chromeos",
+    "tvos",
+    "tizen",
+    "webos",
+    "fire_os",
+    "roku_os",
+    "unknown"
+  ]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -370,6 +370,14 @@
         "postal-system": {
           "$ref": "/schemas/enums/postal-system.json",
           "description": "Postal code systems for geographic targeting. System names encode country and precision (us_zip, gb_outward, ca_fsa, etc.)"
+        },
+        "age-verification-method": {
+          "$ref": "/schemas/enums/age-verification-method.json",
+          "description": "Methods for verifying user age for compliance (facial_age_estimation, id_document, digital_id, credit_card, world_id)"
+        },
+        "device-platform": {
+          "$ref": "/schemas/enums/device-platform.json",
+          "description": "Operating system platforms for device targeting. Browser values from Sec-CH-UA-Platform standard, extended for CTV"
         }
       }
     },

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -154,6 +154,31 @@
                       "description": "Australian postcode, 4 digits (e.g., '2000')"
                     }
                   }
+                },
+                "age_restriction": {
+                  "type": "object",
+                  "description": "Age restriction capabilities for compliance (alcohol, gambling)",
+                  "properties": {
+                    "supported": {
+                      "type": "boolean",
+                      "description": "Whether platform supports age restrictions"
+                    },
+                    "verification_methods": {
+                      "type": "array",
+                      "description": "Age verification methods this platform supports",
+                      "items": {
+                        "$ref": "/schemas/enums/age-verification-method.json"
+                      }
+                    }
+                  }
+                },
+                "device_platform": {
+                  "type": "boolean",
+                  "description": "Whether platform supports device platform targeting (Sec-CH-UA-Platform values)"
+                },
+                "language": {
+                  "type": "boolean",
+                  "description": "Whether platform supports language targeting (ISO 639-1 codes)"
                 }
               }
             }


### PR DESCRIPTION
Add three new targeting overlay types for compliance, technical compatibility, and localization requirements.

**New Fields:**
- `age_restriction`: Age verification for regulatory compliance (alcohol, gambling, cannabis)
- `device_platform`: Device platform restrictions for technical compatibility (app-only, CTV-specific)
- `language`: Language restrictions using ISO 639-1 codes for localization

**Changes:**
- Added enum definitions: `age-verification-method.json`, `device-platform.json`
- Updated `targeting.json` schema with new overlay properties
- Enhanced capabilities response in `get-adcp-capabilities-response.json`
- Comprehensive documentation distinguishing overlays (compliance/technical) from briefs (preferences)

The distinction helps buyers express intent correctly: restrictions go in overlays, preferences go in briefs.