### PR TITLE
fix: Register account domain in schema index

### DIFF
--- a/.changeset/fix-account-index.md
+++ b/.changeset/fix-account-index.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Register account domain with list_accounts task in schema index

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -406,6 +406,21 @@
         }
       }
     },
+    "account": {
+      "description": "Account management task request/response schemas",
+      "tasks": {
+        "list-accounts": {
+          "request": {
+            "$ref": "/schemas/account/list-accounts-request.json",
+            "description": "Request parameters for listing accounts accessible to the authenticated agent"
+          },
+          "response": {
+            "$ref": "/schemas/account/list-accounts-response.json",
+            "description": "Response payload for list_accounts task"
+          }
+        }
+      }
+    },
     "media-buy": {
       "description": "Media buy task request/response schemas",
       "supporting-schemas": {


### PR DESCRIPTION
## Summary
- Registers the `account` domain with `list_accounts` task in the schema index
- The account task schemas existed but weren't discoverable via the index

## Test plan
- [x] Schema validation tests pass
- [x] All 273 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)