### PR TITLE
feat(creative): Add typed asset requirements schemas

### DIFF
--- a/.changeset/typed-asset-requirements.md
+++ b/.changeset/typed-asset-requirements.md
@@ -1,0 +1,23 @@
+---
+"adcontextprotocol": minor
+---
+
+Add typed asset requirements schemas for creative formats
+
+Introduces explicit requirement schemas for every asset type with proper discriminated unions. In `format.json`, assets use `oneOf` with `asset_type` as the discriminator - each variant pairs a specific `asset_type` const with its typed requirements schema. This produces clean discriminated union types for code generation.
+
+- **image-asset-requirements**: `min_width`, `max_width`, `min_height`, `max_height`, `formats`, `max_file_size_kb`, `animation_allowed`, etc.
+- **video-asset-requirements**: dimensions, duration, `containers`, `codecs`, `max_bitrate_kbps`, etc.
+- **audio-asset-requirements**: `min_duration_ms`, `max_duration_ms`, `formats`, `sample_rates`, `channels`, bitrate constraints
+- **text-asset-requirements**: `min_length`, `max_length`, `min_lines`, `max_lines`, `character_pattern`, `prohibited_terms`
+- **markdown-asset-requirements**: `max_length`
+- **html-asset-requirements**: `sandbox` (none/iframe/safeframe/fencedframe), `external_resources_allowed`, `allowed_external_domains`, `max_file_size_kb`
+- **css-asset-requirements**: `max_file_size_kb`
+- **javascript-asset-requirements**: `module_type`, `external_resources_allowed`, `max_file_size_kb`
+- **vast-asset-requirements**: `vast_version`
+- **daast-asset-requirements**: `daast_version`
+- **promoted-offerings-asset-requirements**: (extensible)
+- **url-asset-requirements**: `protocols`, `allowed_domains`, `macro_support`, `role`
+- **webhook-asset-requirements**: `methods`
+
+This allows sales agents to declare execution environment constraints for HTML creatives (e.g., "must work in SafeFrame with no external JS") as part of the format definition.

--- a/docs/creative/channels/display.mdx
+++ b/docs/creative/channels/display.mdx
@@ -25,17 +25,32 @@ Display formats in AdCP include:
     "id": "display_300x250"
   },
   "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 300,
+        "height": 250,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
   "assets": [
     {
+      "item_type": "individual",
       "asset_id": "banner_image",
       "asset_type": "image",
       "asset_role": "hero_image",
       "required": true,
       "requirements": {
-        "width": 300,
-        "height": 250,
-        "file_types": ["jpg", "png", "webp", "gif"],
-        "max_file_size_kb": 200
+        "min_width": 300,
+        "max_width": 300,
+        "min_height": 250,
+        "max_height": 250,
+        "formats": ["jpg", "png", "webp", "gif"],
+        "max_file_size_kb": 200,
+        "animation_allowed": true,
+        "max_animation_duration_ms": 15000
       }
     }
   ]
@@ -229,6 +244,155 @@ Display formats in AdCP include:
 }
 ```
 
+## HTML Display Formats with Execution Context
+
+HTML display creatives run as executable code, not static media. Different publisher environments have different execution constraints - some allow full DOM access, others run in SafeFrame containers with restricted JavaScript capabilities.
+
+AdCP defines explicit **HTML asset requirements** that specify the execution environment the HTML must be compatible with:
+
+- **`sandbox`**: Execution environment (`none`, `iframe`, `safeframe`, `fencedframe`)
+- **`external_resources_allowed`**: Whether the creative can load external scripts, images, or fonts
+- **`allowed_external_domains`**: Permitted domains for external resources (when allowed)
+- **`max_file_size_kb`**: Maximum file size for the HTML asset
+
+### SafeFrame-Compatible HTML Banner
+
+SafeFrame is an IAB standard that provides secure isolation between ad creatives and publisher pages. SafeFrame-compatible creatives cannot use `document.write()`, must use SafeFrame expansion APIs, and cannot make arbitrary cross-origin requests.
+
+```json
+{
+  "format_id": {
+    "agent_url": "https://creative.adcontextprotocol.org",
+    "id": "display_300x250_html_safeframe"
+  },
+  "name": "SafeFrame HTML Banner 300x250",
+  "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 300,
+        "height": 250,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "item_type": "individual",
+      "asset_id": "banner_html",
+      "asset_type": "html",
+      "asset_role": "creative",
+      "required": true,
+      "requirements": {
+        "max_file_size_kb": 150,
+        "sandbox": "safeframe",
+        "external_resources_allowed": false
+      }
+    },
+    {
+      "item_type": "individual",
+      "asset_id": "landing_url",
+      "asset_type": "url",
+      "asset_role": "clickthrough",
+      "required": true,
+      "requirements": {
+        "protocols": ["https"]
+      }
+    }
+  ]
+}
+```
+
+### Native DOM HTML Banner
+
+Some publishers allow full DOM access for trusted creatives. These formats can use standard JavaScript APIs and load external resources.
+
+```json
+{
+  "format_id": {
+    "agent_url": "https://creative.adcontextprotocol.org",
+    "id": "display_300x250_html_native"
+  },
+  "name": "Native HTML Banner 300x250",
+  "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 300,
+        "height": 250,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "item_type": "individual",
+      "asset_id": "banner_html",
+      "asset_type": "html",
+      "asset_role": "creative",
+      "required": true,
+      "requirements": {
+        "max_file_size_kb": 200,
+        "sandbox": "none",
+        "external_resources_allowed": true,
+        "allowed_external_domains": ["cdn.brand.com", "fonts.googleapis.com"]
+      }
+    },
+    {
+      "item_type": "individual",
+      "asset_id": "landing_url",
+      "asset_type": "url",
+      "asset_role": "clickthrough",
+      "required": true,
+      "requirements": {
+        "protocols": ["https"]
+      }
+    }
+  ]
+}
+```
+
+### Fenced Frame HTML Banner (Privacy Sandbox)
+
+Chrome's Privacy Sandbox introduces Fenced Frames for privacy-preserving ad rendering. These have the most restrictive execution environment.
+
+```json
+{
+  "format_id": {
+    "agent_url": "https://creative.adcontextprotocol.org",
+    "id": "display_300x250_html_fencedframe"
+  },
+  "name": "Fenced Frame HTML Banner 300x250",
+  "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 300,
+        "height": 250,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "item_type": "individual",
+      "asset_id": "banner_html",
+      "asset_type": "html",
+      "asset_role": "creative",
+      "required": true,
+      "requirements": {
+        "max_file_size_kb": 100,
+        "sandbox": "fencedframe",
+        "external_resources_allowed": false
+      }
+    }
+  ]
+}
+```
+
 ## Third-Party Tag Formats
 
 ### JavaScript Tag Format
@@ -240,17 +404,27 @@ Display formats in AdCP include:
     "id": "display_300x250_3p"
   },
   "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 300,
+        "height": 250,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
   "assets": [
     {
+      "item_type": "individual",
       "asset_id": "tag",
       "asset_type": "javascript",
       "asset_role": "third_party_tag",
       "required": true,
       "requirements": {
-        "width": 300,
-        "height": 250,
         "max_file_size_kb": 200,
-        "https_required": true
+        "external_resources_allowed": true,
+        "strict_mode_required": false
       }
     }
   ]
@@ -283,17 +457,27 @@ JavaScript tag manifest:
     "id": "display_728x90_html"
   },
   "type": "display",
+  "renders": [
+    {
+      "role": "primary",
+      "dimensions": {
+        "width": 728,
+        "height": 90,
+        "responsive": { "width": false, "height": false }
+      }
+    }
+  ],
   "assets": [
     {
+      "item_type": "individual",
       "asset_id": "tag",
       "asset_type": "html",
       "asset_role": "third_party_tag",
       "required": true,
       "requirements": {
-        "width": 728,
-        "height": 90,
         "max_file_size_kb": 200,
-        "https_required": true
+        "sandbox": "iframe",
+        "external_resources_allowed": true
       }
     }
   ]

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -306,6 +306,78 @@ The `assets` array enables comprehensive asset discovery. Each asset has a `requ
 
 This unified approach helps creative tools and AI agents understand the full capabilities of a format, enabling richer creative experiences when optional assets are available while clearly indicating minimum requirements.
 
+### Typed Asset Requirements
+
+Each asset type has its own requirements schema that defines what constraints apply to that asset. The `requirements` object is typed based on the `asset_type`:
+
+**Image assets** (`asset_type: "image"`):
+- `min_width`, `max_width`, `min_height`, `max_height` - Dimension constraints (set min=max for exact)
+- `aspect_ratio` - Required aspect ratio (e.g., '1:1')
+- `formats` - Accepted file formats (jpg, jpeg, png, webp, gif, svg, avif)
+- `max_file_size_kb` - Maximum file size
+- `animation_allowed` - Whether animated images are accepted
+- `max_animation_duration_ms` - Maximum animation duration
+
+**Video assets** (`asset_type: "video"`):
+- `min_width`, `max_width`, `min_height`, `max_height` - Dimension constraints
+- `aspect_ratio` - Required aspect ratio (e.g., '16:9')
+- `min_duration_ms`, `max_duration_ms` - Duration constraints
+- `containers` - Accepted container formats (mp4, webm, mov)
+- `codecs` - Accepted codecs (h264, h265, vp9, av1)
+- `frame_rates` - Accepted frame rates (e.g., [24, 30, 60])
+- `max_file_size_kb`, `max_bitrate_kbps` - Size constraints
+
+**HTML assets** (`asset_type: "html"`):
+- `max_file_size_kb` - Maximum file size
+- `sandbox` - Execution environment (`none`, `iframe`, `safeframe`, `fencedframe`)
+- `external_resources_allowed` - Whether external scripts/images can be loaded
+- `allowed_external_domains` - Permitted domains for external resources
+
+**JavaScript assets** (`asset_type: "javascript"`):
+- `max_file_size_kb` - Maximum file size
+- `module_type` - Module format (`script`, `module`, `iife`)
+- `external_resources_allowed` - Whether dynamic resource loading is allowed
+- `allowed_external_domains` - Permitted domains for dynamic loading
+
+**Audio assets** (`asset_type: "audio"`):
+- `min_duration_ms`, `max_duration_ms` - Duration constraints
+- `formats` - Accepted audio formats (mp3, aac, wav, ogg, flac)
+- `sample_rates` - Accepted sample rates in Hz (e.g., [44100, 48000])
+- `channels` - Accepted channel configurations (mono, stereo)
+- `min_bitrate_kbps`, `max_bitrate_kbps` - Bitrate constraints
+- `max_file_size_kb` - Maximum file size
+
+**Text assets** (`asset_type: "text"`):
+- `min_length`, `max_length` - Character limits
+- `min_lines`, `max_lines` - Line count limits
+- `character_pattern` - Regex for allowed characters
+- `prohibited_terms` - Words/phrases not allowed
+
+**URL assets** (`asset_type: "url"`):
+- `role` - Standard purpose (clickthrough, impression_tracker, click_tracker, etc.)
+- `protocols` - Allowed protocols (https, http)
+- `allowed_domains` - Permitted destination domains
+- `macro_support` - Whether macro substitution is supported
+
+**Example with HTML execution context:**
+
+```json
+{
+  "asset_id": "banner_html",
+  "asset_type": "html",
+  "required": true,
+  "requirements": {
+    "max_file_size_kb": 150,
+    "sandbox": "safeframe",
+    "external_resources_allowed": false
+  }
+}
+```
+
+This tells creative agents: "Build HTML that works in a SafeFrame container with no external resource loading."
+
+See [Display Ads - HTML Display Formats](/docs/creative/channels/display#html-display-formats-with-execution-context) for complete examples.
+
 ### Rendered Outputs and Dimensions
 
 Formats describe one or more rendered outputs, each with defined dimensions and semantic roles.

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -4,6 +4,50 @@
   "title": "Format",
   "description": "Represents a creative format with its requirements",
   "type": "object",
+  "$defs": {
+    "baseIndividualAsset": {
+      "type": "object",
+      "properties": {
+        "item_type": {
+          "type": "string",
+          "const": "individual",
+          "description": "Discriminator indicating this is an individual asset"
+        },
+        "asset_id": {
+          "type": "string",
+          "description": "Unique identifier for this asset. Creative manifests MUST use this exact value as the key in the assets object."
+        },
+        "asset_role": {
+          "type": "string",
+          "description": "Optional descriptive label for this asset's purpose (e.g., 'hero_image', 'logo', 'third_party_tracking'). Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this asset is required (true) or optional (false). Required assets must be provided for a valid creative. Optional assets enhance the creative but are not mandatory."
+        }
+      },
+      "required": ["item_type", "asset_id", "asset_type", "required"]
+    },
+    "baseGroupAsset": {
+      "type": "object",
+      "properties": {
+        "asset_id": {
+          "type": "string",
+          "description": "Identifier for this asset within the group"
+        },
+        "asset_role": {
+          "type": "string",
+          "description": "Optional descriptive label for this asset's purpose. Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this asset is required within each repetition of the group",
+          "default": false
+        }
+      },
+      "required": ["asset_id", "asset_type", "required"]
+    }
+  },
   "properties": {
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
@@ -145,37 +189,121 @@
       "items": {
         "oneOf": [
           {
-            "description": "Individual asset specification",
-            "type": "object",
+            "description": "Image asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
-              "item_type": {
-                "type": "string",
-                "const": "individual",
-                "description": "Discriminator indicating this is an individual asset"
-              },
-              "asset_id": {
-                "type": "string",
-                "description": "Unique identifier for this asset. Creative manifests MUST use this exact value as the key in the assets object."
-              },
-              "asset_type": {
-                "$ref": "/schemas/enums/asset-content-type.json",
-                "description": "Type of asset"
-              },
-              "asset_role": {
-                "type": "string",
-                "description": "Optional descriptive label for this asset's purpose (e.g., 'hero_image', 'logo', 'third_party_tracking'). Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
-              },
-              "required": {
-                "type": "boolean",
-                "description": "Whether this asset is required (true) or optional (false). Required assets must be provided for a valid creative. Optional assets enhance the creative but are not mandatory."
-              },
-              "requirements": {
-                "type": "object",
-                "description": "Technical requirements for this asset (dimensions, file size, duration, etc.). For template formats, use parameters_from_format_id: true to indicate asset parameters must match the format_id parameters (width/height/unit and/or duration_ms).",
-                "additionalProperties": true
-              }
-            },
-            "required": ["item_type", "asset_id", "asset_type", "required"]
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "image" },
+              "requirements": { "$ref": "/schemas/core/requirements/image-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Video asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "video" },
+              "requirements": { "$ref": "/schemas/core/requirements/video-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Audio asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "audio" },
+              "requirements": { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Text asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "text" },
+              "requirements": { "$ref": "/schemas/core/requirements/text-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Markdown asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "markdown" },
+              "requirements": { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "HTML asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "html" },
+              "requirements": { "$ref": "/schemas/core/requirements/html-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "CSS asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "css" },
+              "requirements": { "$ref": "/schemas/core/requirements/css-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "JavaScript asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "javascript" },
+              "requirements": { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "VAST asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "vast" },
+              "requirements": { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "DAAST asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "daast" },
+              "requirements": { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Promoted offerings asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "promoted_offerings" },
+              "requirements": { "$ref": "/schemas/core/requirements/promoted-offerings-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "URL asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "url" },
+              "requirements": { "$ref": "/schemas/core/requirements/url-asset-requirements.json" }
+            }
+          },
+          {
+            "description": "Webhook asset",
+            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "properties": {
+              "item_type": { "const": "individual" },
+              "asset_type": { "const": "webhook" },
+              "requirements": { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
+            }
           },
           {
             "description": "Repeatable asset group (for carousels, slideshows, playlists, etc.)",
@@ -208,32 +336,112 @@
                 "type": "array",
                 "description": "Assets within each repetition of this group",
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "asset_id": {
-                      "type": "string",
-                      "description": "Identifier for this asset within the group"
+                  "oneOf": [
+                    {
+                      "description": "Image asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "image" },
+                        "requirements": { "$ref": "/schemas/core/requirements/image-asset-requirements.json" }
+                      }
                     },
-                    "asset_type": {
-                      "$ref": "/schemas/enums/asset-content-type.json",
-                      "description": "Type of asset"
+                    {
+                      "description": "Video asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "video" },
+                        "requirements": { "$ref": "/schemas/core/requirements/video-asset-requirements.json" }
+                      }
                     },
-                    "asset_role": {
-                      "type": "string",
-                      "description": "Optional descriptive label for this asset's purpose. Not used for referencing assets in manifests—use asset_id instead. This field is for human-readable documentation and UI display only."
+                    {
+                      "description": "Audio asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "audio" },
+                        "requirements": { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" }
+                      }
                     },
-                    "required": {
-                      "type": "boolean",
-                      "description": "Whether this asset is required within each repetition of the group",
-                      "default": false
+                    {
+                      "description": "Text asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "text" },
+                        "requirements": { "$ref": "/schemas/core/requirements/text-asset-requirements.json" }
+                      }
                     },
-                    "requirements": {
-                      "type": "object",
-                      "description": "Technical requirements for this asset. For template formats, use parameters_from_format_id: true to indicate asset parameters must match the format_id parameters (width/height/unit and/or duration_ms).",
-                      "additionalProperties": true
+                    {
+                      "description": "Markdown asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "markdown" },
+                        "requirements": { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "HTML asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "html" },
+                        "requirements": { "$ref": "/schemas/core/requirements/html-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "CSS asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "css" },
+                        "requirements": { "$ref": "/schemas/core/requirements/css-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "JavaScript asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "javascript" },
+                        "requirements": { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "VAST asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "vast" },
+                        "requirements": { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "DAAST asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "daast" },
+                        "requirements": { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "Promoted offerings asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "promoted_offerings" },
+                        "requirements": { "$ref": "/schemas/core/requirements/promoted-offerings-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "URL asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "url" },
+                        "requirements": { "$ref": "/schemas/core/requirements/url-asset-requirements.json" }
+                      }
+                    },
+                    {
+                      "description": "Webhook asset in group",
+                      "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
+                      "properties": {
+                        "asset_type": { "const": "webhook" },
+                        "requirements": { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
+                      }
                     }
-                  },
-                  "required": ["asset_id", "asset_type", "required"]
+                  ]
                 }
               }
             },

--- a/static/schemas/source/core/requirements/asset-requirements.json
+++ b/static/schemas/source/core/requirements/asset-requirements.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/asset-requirements.json",
+  "title": "Asset Requirements",
+  "description": "Technical requirements for creative assets. The applicable schema is determined by the sibling asset_type field.",
+  "oneOf": [
+    { "$ref": "/schemas/core/requirements/image-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/video-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/text-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/html-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/css-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/promoted-offerings-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/url-asset-requirements.json" },
+    { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
+  ]
+}

--- a/static/schemas/source/core/requirements/audio-asset-requirements.json
+++ b/static/schemas/source/core/requirements/audio-asset-requirements.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/audio-asset-requirements.json",
+  "title": "Audio Asset Requirements",
+  "description": "Requirements for audio creative assets.",
+  "type": "object",
+  "properties": {
+    "min_duration_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum duration in milliseconds"
+    },
+    "max_duration_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum duration in milliseconds"
+    },
+    "formats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["mp3", "aac", "wav", "ogg", "flac"]
+      },
+      "description": "Accepted audio file formats"
+    },
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes"
+    },
+    "sample_rates": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "description": "Accepted sample rates in Hz (e.g., [44100, 48000])"
+    },
+    "channels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["mono", "stereo"]
+      },
+      "description": "Accepted audio channel configurations"
+    },
+    "min_bitrate_kbps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum audio bitrate in kilobits per second"
+    },
+    "max_bitrate_kbps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum audio bitrate in kilobits per second"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/css-asset-requirements.json
+++ b/static/schemas/source/core/requirements/css-asset-requirements.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/css-asset-requirements.json",
+  "title": "CSS Asset Requirements",
+  "description": "Requirements for CSS creative assets.",
+  "type": "object",
+  "properties": {
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/daast-asset-requirements.json
+++ b/static/schemas/source/core/requirements/daast-asset-requirements.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/daast-asset-requirements.json",
+  "title": "DAAST Asset Requirements",
+  "description": "Requirements for DAAST (Digital Audio Ad Serving Template) creative assets.",
+  "type": "object",
+  "properties": {
+    "daast_version": {
+      "type": "string",
+      "enum": ["1.0"],
+      "description": "Required DAAST version. DAAST 1.0 is the current IAB standard."
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/html-asset-requirements.json
+++ b/static/schemas/source/core/requirements/html-asset-requirements.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/html-asset-requirements.json",
+  "title": "HTML Asset Requirements",
+  "description": "Requirements for HTML creative assets. These define the execution environment constraints that the HTML must be compatible with.",
+  "type": "object",
+  "properties": {
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes for the HTML asset"
+    },
+    "sandbox": {
+      "type": "string",
+      "enum": ["none", "iframe", "safeframe", "fencedframe"],
+      "default": "none",
+      "description": "Sandbox environment the HTML must be compatible with. 'none' = direct DOM access, 'iframe' = standard iframe isolation, 'safeframe' = IAB SafeFrame container, 'fencedframe' = Privacy Sandbox fenced frame"
+    },
+    "external_resources_allowed": {
+      "type": "boolean",
+      "description": "Whether the HTML creative can load external resources (scripts, images, fonts, etc.). When false, all resources must be inlined or bundled."
+    },
+    "allowed_external_domains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "hostname"
+      },
+      "description": "List of domains the HTML creative may reference for external resources. Only applicable when external_resources_allowed is true."
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/image-asset-requirements.json
+++ b/static/schemas/source/core/requirements/image-asset-requirements.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/image-asset-requirements.json",
+  "title": "Image Asset Requirements",
+  "description": "Requirements for image creative assets. These define the technical constraints for image files.",
+  "type": "object",
+  "properties": {
+    "min_width": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum width in pixels. For exact dimensions, set min_width = max_width."
+    },
+    "max_width": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum width in pixels. For exact dimensions, set min_width = max_width."
+    },
+    "min_height": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum height in pixels. For exact dimensions, set min_height = max_height."
+    },
+    "max_height": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum height in pixels. For exact dimensions, set min_height = max_height."
+    },
+    "aspect_ratio": {
+      "type": "string",
+      "pattern": "^\\d+:\\d+$",
+      "description": "Required aspect ratio (e.g., '16:9', '1:1')"
+    },
+    "formats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["jpg", "jpeg", "png", "gif", "webp", "svg", "avif"]
+      },
+      "description": "Accepted image file formats"
+    },
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes"
+    },
+    "transparency_required": {
+      "type": "boolean",
+      "description": "Whether the image must support transparency (requires PNG, WebP, or GIF)"
+    },
+    "animation_allowed": {
+      "type": "boolean",
+      "description": "Whether animated images (GIF, animated WebP) are accepted"
+    },
+    "max_animation_duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Maximum animation duration in milliseconds (if animation_allowed is true)"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/javascript-asset-requirements.json
+++ b/static/schemas/source/core/requirements/javascript-asset-requirements.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/javascript-asset-requirements.json",
+  "title": "JavaScript Asset Requirements",
+  "description": "Requirements for JavaScript creative assets. These define the execution environment constraints that the JavaScript must be compatible with.",
+  "type": "object",
+  "properties": {
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes for the JavaScript asset"
+    },
+    "module_type": {
+      "type": "string",
+      "enum": ["script", "module", "iife"],
+      "description": "Required JavaScript module format. 'script' = classic script, 'module' = ES modules, 'iife' = immediately invoked function expression"
+    },
+    "strict_mode_required": {
+      "type": "boolean",
+      "description": "Whether the JavaScript must use strict mode"
+    },
+    "external_resources_allowed": {
+      "type": "boolean",
+      "description": "Whether the JavaScript can load external resources dynamically"
+    },
+    "allowed_external_domains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "hostname"
+      },
+      "description": "List of domains the JavaScript may reference for external resources. Only applicable when external_resources_allowed is true."
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/markdown-asset-requirements.json
+++ b/static/schemas/source/core/requirements/markdown-asset-requirements.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/markdown-asset-requirements.json",
+  "title": "Markdown Asset Requirements",
+  "description": "Requirements for markdown creative assets.",
+  "type": "object",
+  "properties": {
+    "max_length": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum character length"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/promoted-offerings-asset-requirements.json
+++ b/static/schemas/source/core/requirements/promoted-offerings-asset-requirements.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/promoted-offerings-asset-requirements.json",
+  "title": "Promoted Offerings Asset Requirements",
+  "description": "Requirements for promoted offerings creative assets.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/text-asset-requirements.json
+++ b/static/schemas/source/core/requirements/text-asset-requirements.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/text-asset-requirements.json",
+  "title": "Text Asset Requirements",
+  "description": "Requirements for text creative assets such as headlines, body copy, and CTAs.",
+  "type": "object",
+  "properties": {
+    "min_length": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Minimum character length"
+    },
+    "max_length": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum character length"
+    },
+    "min_lines": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum number of lines"
+    },
+    "max_lines": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum number of lines"
+    },
+    "character_pattern": {
+      "type": "string",
+      "description": "Regex pattern defining allowed characters (e.g., '^[a-zA-Z0-9 .,!?-]+$')"
+    },
+    "prohibited_terms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of prohibited words or phrases"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/url-asset-requirements.json
+++ b/static/schemas/source/core/requirements/url-asset-requirements.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/url-asset-requirements.json",
+  "title": "URL Asset Requirements",
+  "description": "Requirements for URL assets such as click-through URLs, tracking pixels, and landing pages.",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "enum": ["clickthrough", "landing_page", "impression_tracker", "click_tracker", "viewability_tracker", "third_party_tracker"],
+      "description": "Standard role for this URL asset. Use this to constrain which purposes are valid for this URL slot. Complements asset_role (which is a human-readable label) by providing a machine-readable enum."
+    },
+    "protocols": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["https", "http"]
+      },
+      "description": "Allowed URL protocols. HTTPS is recommended for all ad URLs."
+    },
+    "allowed_domains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "hostname"
+      },
+      "description": "List of allowed domains for the URL"
+    },
+    "max_length": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum URL length in characters"
+    },
+    "macro_support": {
+      "type": "boolean",
+      "description": "Whether the URL supports macro substitution (e.g., ${CACHEBUSTER})"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/vast-asset-requirements.json
+++ b/static/schemas/source/core/requirements/vast-asset-requirements.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/vast-asset-requirements.json",
+  "title": "VAST Asset Requirements",
+  "description": "Requirements for VAST (Video Ad Serving Template) creative assets.",
+  "type": "object",
+  "properties": {
+    "vast_version": {
+      "type": "string",
+      "enum": ["2.0", "3.0", "4.0", "4.1", "4.2"],
+      "description": "Required VAST version"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/video-asset-requirements.json
+++ b/static/schemas/source/core/requirements/video-asset-requirements.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/video-asset-requirements.json",
+  "title": "Video Asset Requirements",
+  "description": "Requirements for video creative assets. These define the technical constraints for video files.",
+  "type": "object",
+  "properties": {
+    "min_width": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum width in pixels"
+    },
+    "max_width": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum width in pixels"
+    },
+    "min_height": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum height in pixels"
+    },
+    "max_height": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum height in pixels"
+    },
+    "aspect_ratio": {
+      "type": "string",
+      "pattern": "^\\d+:\\d+$",
+      "description": "Required aspect ratio (e.g., '16:9', '9:16')"
+    },
+    "min_duration_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum duration in milliseconds"
+    },
+    "max_duration_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum duration in milliseconds"
+    },
+    "containers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["mp4", "webm", "mov", "avi", "mkv"]
+      },
+      "description": "Accepted video container formats"
+    },
+    "codecs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["h264", "h265", "vp8", "vp9", "av1"]
+      },
+      "description": "Accepted video codecs"
+    },
+    "max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum file size in kilobytes"
+    },
+    "min_bitrate_kbps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum video bitrate in kilobits per second"
+    },
+    "max_bitrate_kbps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum video bitrate in kilobits per second"
+    },
+    "frame_rates": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minimum": 1
+      },
+      "description": "Accepted frame rates in frames per second (e.g., [24, 30, 60])"
+    },
+    "audio_required": {
+      "type": "boolean",
+      "description": "Whether the video must include an audio track"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/requirements/webhook-asset-requirements.json
+++ b/static/schemas/source/core/requirements/webhook-asset-requirements.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/webhook-asset-requirements.json",
+  "title": "Webhook Asset Requirements",
+  "description": "Requirements for webhook creative assets.",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["GET", "POST"]
+      },
+      "description": "Allowed HTTP methods"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -178,6 +178,67 @@
           "$ref": "/schemas/core/media-buy-features.json",
           "description": "Optional media-buy protocol features for capability declarations and product filters"
         }
+      },
+      "requirements": {
+        "description": "Typed requirement schemas for creative assets in format definitions",
+        "schemas": {
+          "asset-requirements": {
+            "$ref": "/schemas/core/requirements/asset-requirements.json",
+            "description": "Combined schema that allows any typed asset requirements"
+          },
+          "html-asset-requirements": {
+            "$ref": "/schemas/core/requirements/html-asset-requirements.json",
+            "description": "Requirements for HTML creative assets - sandbox compatibility, external resources, allowed domains"
+          },
+          "image-asset-requirements": {
+            "$ref": "/schemas/core/requirements/image-asset-requirements.json",
+            "description": "Requirements for image creative assets - dimensions, formats, file size, animation"
+          },
+          "video-asset-requirements": {
+            "$ref": "/schemas/core/requirements/video-asset-requirements.json",
+            "description": "Requirements for video creative assets - dimensions, duration, codecs, bitrate"
+          },
+          "audio-asset-requirements": {
+            "$ref": "/schemas/core/requirements/audio-asset-requirements.json",
+            "description": "Requirements for audio creative assets - duration, formats, sample rate, channels"
+          },
+          "javascript-asset-requirements": {
+            "$ref": "/schemas/core/requirements/javascript-asset-requirements.json",
+            "description": "Requirements for JavaScript creative assets - module type, external resources"
+          },
+          "text-asset-requirements": {
+            "$ref": "/schemas/core/requirements/text-asset-requirements.json",
+            "description": "Requirements for text creative assets - character limits, line counts"
+          },
+          "url-asset-requirements": {
+            "$ref": "/schemas/core/requirements/url-asset-requirements.json",
+            "description": "Requirements for URL assets - protocols, allowed domains, macro support"
+          },
+          "markdown-asset-requirements": {
+            "$ref": "/schemas/core/requirements/markdown-asset-requirements.json",
+            "description": "Requirements for markdown creative assets"
+          },
+          "css-asset-requirements": {
+            "$ref": "/schemas/core/requirements/css-asset-requirements.json",
+            "description": "Requirements for CSS creative assets"
+          },
+          "vast-asset-requirements": {
+            "$ref": "/schemas/core/requirements/vast-asset-requirements.json",
+            "description": "Requirements for VAST creative assets - version requirements"
+          },
+          "daast-asset-requirements": {
+            "$ref": "/schemas/core/requirements/daast-asset-requirements.json",
+            "description": "Requirements for DAAST creative assets"
+          },
+          "promoted-offerings-asset-requirements": {
+            "$ref": "/schemas/core/requirements/promoted-offerings-asset-requirements.json",
+            "description": "Requirements for promoted offerings creative assets"
+          },
+          "webhook-asset-requirements": {
+            "$ref": "/schemas/core/requirements/webhook-asset-requirements.json",
+            "description": "Requirements for webhook creative assets"
+          }
+        }
       }
     },
     "enums": {


### PR DESCRIPTION
## Summary

- Introduces explicit requirement schemas for every asset type with proper discriminated unions
- In `format.json`, assets use `oneOf` with `asset_type` as the discriminator - each variant pairs a specific `asset_type` const with its typed requirements schema
- Produces clean discriminated union types for code generation

### Asset requirement schemas added:

| Asset Type | Key Requirements |
|------------|------------------|
| `image` | dimensions, formats, animation constraints |
| `video` | dimensions, duration, codecs, bitrate |
| `audio` | duration, formats, sample rates, channels |
| `html` | sandbox environment, external resources, allowed domains |
| `javascript` | module type, external resources |
| `text` | character/line limits, patterns, prohibited terms |
| `url` | protocols, domains, macro support |
| `markdown`, `css`, `vast`, `daast`, `webhook` | type-specific constraints |

### HTML execution context

Enables sales agents to declare execution environment constraints for HTML creatives as part of the format definition:

```json
{
  "asset_type": "html",
  "requirements": {
    "sandbox": "safeframe",
    "external_resources_allowed": false
  }
}
```

This tells creative agents: "Build HTML that works in a SafeFrame container with no external resource loading."

## Test plan

- [x] All existing tests pass (273 tests)
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass (schema validation, broken link check)
- [ ] Verify generated TypeScript types produce proper discriminated unions

🤖 Generated with [Claude Code](https://claude.ai/code)