### PR TITLE
fix: Broken links in nav and docs URLs

### DIFF
--- a/.changeset/fix-broken-links.md
+++ b/.changeset/fix-broken-links.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix broken links across codebase:
+- Sales Agent nav link now points to GitHub repo instead of non-existent /sales-agent page
+- Fix docs URLs using adcontextprotocol.org/docs/ to use docs.adcontextprotocol.org/docs/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install adcp
 
 Implement AdCP to enable AI-powered workflows for your customers:
 
-1. **Review the Specification**: [Signals Protocol](https://adcontextprotocol.org/docs/signals/specification)
+1. **Review the Specification**: [Signals Protocol](https://docs.adcontextprotocol.org/docs/signals/specification)
 2. **Implement MCP Server**: Check out the [reference implementations](#reference-implementations)
 3. **Test Your Implementation**: Use the validation test suite
 
@@ -474,9 +474,9 @@ The Ad Context Protocol specifications are licensed under [Apache 2.0](./LICENSE
 ## Links
 
 - **Website**: [adcontextprotocol.org](https://adcontextprotocol.org)
-- **API Documentation**: [Task Reference](https://adcontextprotocol.org/docs/media-buy/task-reference/index)
-- **MCP Integration**: [MCP Guide](https://adcontextprotocol.org/docs/protocols/mcp-guide)
-- **Specifications**: [Signals Protocol RFC](https://adcontextprotocol.org/docs/signals/specification)
+- **API Documentation**: [Task Reference](https://docs.adcontextprotocol.org/docs/media-buy/task-reference/index)
+- **MCP Integration**: [MCP Guide](https://docs.adcontextprotocol.org/docs/protocols/mcp-guide)
+- **Specifications**: [Signals Protocol RFC](https://docs.adcontextprotocol.org/docs/signals/specification)
 - **Discussions**: [GitHub Discussions](https://github.com/adcontextprotocol/adcp/discussions)
 - **Issues**: [Report Issues](https://github.com/adcontextprotocol/adcp/issues)
 

--- a/docs.json
+++ b/docs.json
@@ -46,7 +46,7 @@
     {
       "name": "Working Group",
       "icon": "users",
-      "url": "https://adcontextprotocol.org/docs/community/working-group"
+      "url": "https://docs.adcontextprotocol.org/docs/community/working-group"
     }
   ],
   "navigation": {

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -161,8 +161,8 @@
 
     // Build Projects dropdown
     const adagentsUrl = isLocal ? '/adagents' : `${aaoBaseUrl}/adagents`;
-    const salesAgentUrl = isLocal ? '/sales-agent' : `${aaoBaseUrl}/sales-agent`;
-    const isProjectsActive = currentPath === '/adagents' || currentPath === '/sales-agent' ||
+    const salesAgentUrl = 'https://github.com/adcontextprotocol/salesagent';
+    const isProjectsActive = currentPath === '/adagents' ||
                              currentPath === '/members' || currentPath.startsWith('/members/') ||
                              currentPath === '/registry' || currentPath === '/publishers' || currentPath === '/properties';
     const projectsDropdown = `<div class="navbar__dropdown-wrapper">
@@ -175,7 +175,7 @@
           <div class="navbar__dropdown navbar__dropdown--nav">
             <a href="https://adcontextprotocol.org" class="navbar__dropdown-item">AdCP</a>
             <a href="${adagentsUrl}" class="navbar__dropdown-item ${currentPath === '/adagents' ? 'active' : ''}">adagents.json</a>
-            <a href="${salesAgentUrl}" class="navbar__dropdown-item ${currentPath === '/sales-agent' ? 'active' : ''}">Sales Agent</a>
+            <a href="${salesAgentUrl}" target="_blank" rel="noopener noreferrer" class="navbar__dropdown-item">Sales Agent</a>
             <div class="navbar__dropdown-divider"></div>
             <span class="navbar__dropdown-header-text">Registry</span>
             <a href="${membersUrl}" class="navbar__dropdown-item ${currentPath === '/members' || currentPath.startsWith('/members/') ? 'active' : ''}">Members</a>
@@ -282,7 +282,7 @@
           <span class="navbar__link navbar__link--header">Projects</span>
           <a href="https://adcontextprotocol.org" class="navbar__link navbar__link--indent">AdCP</a>
           <a href="${adagentsUrl}" class="navbar__link navbar__link--indent ${currentPath === '/adagents' ? 'active' : ''}">adagents.json</a>
-          <a href="${salesAgentUrl}" class="navbar__link navbar__link--indent ${currentPath === '/sales-agent' ? 'active' : ''}">Sales Agent</a>
+          <a href="${salesAgentUrl}" target="_blank" rel="noopener noreferrer" class="navbar__link navbar__link--indent">Sales Agent</a>
           <span class="navbar__link navbar__link--subheader">Registry</span>
           <a href="${membersUrl}" class="navbar__link navbar__link--indent ${currentPath === '/members' || currentPath.startsWith('/members/') ? 'active' : ''}">Members</a>
           <a href="${agentsUrl}" class="navbar__link navbar__link--indent ${currentPath === '/registry' ? 'active' : ''}">Agents</a>

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -65,14 +65,14 @@ const KNOWN_OPEN_SOURCE_AGENTS: Record<string, { org: string; repo: string; name
 /**
  * Public test agent credentials.
  * These are intentionally public and documented for testing purposes.
- * See: https://adcontextprotocol.org/docs/media-buy/advanced-topics/testing
+ * See: https://docs.adcontextprotocol.org/docs/media-buy/advanced-topics/testing
  *
  * The token can be overridden via PUBLIC_TEST_AGENT_TOKEN env var if needed,
  * but defaults to the documented public token.
  */
 const PUBLIC_TEST_AGENT = {
   url: 'https://test-agent.adcontextprotocol.org/mcp',
-  // Default token is documented at https://adcontextprotocol.org/docs/quickstart
+  // Default token is documented at https://docs.adcontextprotocol.org/docs/quickstart
   token: process.env.PUBLIC_TEST_AGENT_TOKEN || '1v8tAhASaUYYp' + '4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ',
   name: 'AdCP Public Test Agent',
 };

--- a/server/src/publishers.ts
+++ b/server/src/publishers.ts
@@ -52,7 +52,7 @@ export class PublisherTracker {
         status.issues.push({
           severity: "error",
           message: `File not found (HTTP ${response.status})`,
-          fix: `Deploy a valid adagents.json file to ${url}. See: https://adcontextprotocol.org/docs/authorization`,
+          fix: `Deploy a valid adagents.json file to ${url}. See: https://docs.adcontextprotocol.org/docs/authorization`,
         });
         this.cache.set(domain, status);
         return status;

--- a/tests/extension-schemas.test.cjs
+++ b/tests/extension-schemas.test.cjs
@@ -236,7 +236,7 @@ async function runTests() {
       title: 'Sustainability Extension',
       description: 'Carbon footprint and green certification data',
       valid_from: '2.5',
-      docs_url: 'https://adcontextprotocol.org/docs/extensions/sustainability',
+      docs_url: 'https://docs.adcontextprotocol.org/docs/extensions/sustainability',
       type: 'object',
       properties: {
         carbon_kg_per_impression: { type: 'number' },


### PR DESCRIPTION
## Summary
- Sales Agent nav link now points to GitHub repo instead of non-existent `/sales-agent` page
- Fix docs URLs across codebase from `adcontextprotocol.org/docs/` to `docs.adcontextprotocol.org/docs/`

## Files Changed
- `server/public/nav.js` - Sales Agent link now opens GitHub repo in new tab
- `README.md` - 4 docs URLs fixed
- `docs.json` - Working group URL fixed
- `server/src/publishers.ts` - Authorization docs URL fixed
- `server/src/addie/mcp/member-tools.ts` - 2 docs URLs fixed
- `tests/extension-schemas.test.cjs` - Sustainability docs URL fixed

## Test plan
- [x] TypeScript type check passes
- [x] All 273 tests pass
- [x] Verified broken link in production via Vibium browser test

🤖 Generated with [Claude Code](https://claude.com/claude-code)