### PR TITLE
fix(oauth): Auto-recover when redirect_uri changes

### DIFF
--- a/.changeset/fine-loops-design.md
+++ b/.changeset/fine-loops-design.md
@@ -1,0 +1,4 @@
+---
+---
+
+OAuth client registration resilience: auto-detect redirect_uri changes and re-register

--- a/server/src/db/migrations/198_oauth_redirect_uri_tracking.sql
+++ b/server/src/db/migrations/198_oauth_redirect_uri_tracking.sql
@@ -1,0 +1,10 @@
+-- Migration: 198_oauth_redirect_uri_tracking.sql
+-- Track the redirect_uri used during OAuth client registration
+--
+-- This enables automatic recovery when redirect_uri changes (e.g., environment change)
+-- by detecting mismatches and re-registering the OAuth client.
+
+ALTER TABLE agent_contexts
+ADD COLUMN IF NOT EXISTS oauth_registered_redirect_uri TEXT;
+
+COMMENT ON COLUMN agent_contexts.oauth_registered_redirect_uri IS 'The redirect_uri used when registering the OAuth client - used to detect mismatches';


### PR DESCRIPTION
## Summary
- OAuth client registration now tracks the redirect_uri used during registration
- Automatically detects when redirect_uri changes (e.g., localhost → production)
- Clears stale OAuth client and re-registers with the correct redirect_uri
- Adds UUID validation on route parameters for security
- Sanitizes error messages to prevent XSS in redirect URLs

## Test plan
- [x] Typecheck passes
- [x] Unit tests pass
- [x] Migration applies correctly (verified with Docker)
- [x] Code review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)