### PR TITLE
fix: Use absolute URLs for OAuth authorization links

### DIFF
--- a/.changeset/fix-oauth-urls.md
+++ b/.changeset/fix-oauth-urls.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix OAuth authorization URLs to use absolute paths for Slack compatibility

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -15,6 +15,18 @@ import { AuthenticationRequiredError } from '@adcp/client';
 // Tool handler type (matches claude-client.ts internal type)
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
+/**
+ * Base URL for OAuth redirect URLs
+ * Uses BASE_URL env var in production, falls back to localhost for development
+ */
+function getBaseUrl(): string {
+  if (process.env.BASE_URL) {
+    return process.env.BASE_URL;
+  }
+  const port = process.env.PORT || process.env.CONDUCTOR_PORT || '3000';
+  return `http://localhost:${port}`;
+}
+
 // ============================================
 // MEDIA BUY TOOLS
 // ============================================
@@ -1423,7 +1435,7 @@ export function createAdcpToolHandlers(
               pending_task: task,
               pending_params: JSON.stringify(params),
             });
-            const authUrl = `/api/oauth/agent/start?${authParams.toString()}`;
+            const authUrl = `${getBaseUrl()}/api/oauth/agent/start?${authParams.toString()}`;
 
             return (
               `**Task failed:** \`${task}\`\n\n` +

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -1918,7 +1918,7 @@ export function createMemberToolHandlers(
           const authParams = new URLSearchParams({
             agent_context_id: agentContext.id,
           });
-          const authUrl = `/api/oauth/agent/start?${authParams.toString()}`;
+          const authUrl = `${getBaseUrl()}/api/oauth/agent/start?${authParams.toString()}`;
 
           let response = `## Agent Probe: ${agent?.name || agentUrl}\n\n`;
           response += `### Connectivity\n`;


### PR DESCRIPTION
## Summary
- Fixed OAuth authorization URLs being generated as relative paths (`/api/oauth/agent/start?...`) which don't work in Slack messages
- Slack requires absolute URLs for clickable links; web interface worked because browsers resolve relative URLs against the current page
- Added `getBaseUrl()` helper to `adcp-tools.ts` and used existing one in `member-tools.ts`

## Test plan
- [ ] Deploy to staging
- [ ] Test via Slack: ask Addie to probe an OAuth-protected agent (e.g., `https://snapadcp.scope3.com/mcp`)
- [ ] Verify the authorization link is a full URL (starts with `https://agenticadvertising.org/`)
- [ ] Test via web chat to ensure it still works there

🤖 Generated with [Claude Code](https://claude.com/claude-code)