### PR TITLE
feat: Add account_id to delivery and artifact requests

### DIFF
--- a/.changeset/account-id-delivery.md
+++ b/.changeset/account-id-delivery.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional account_id parameter to get_media_buy_delivery and get_media_buy_artifacts requests, allowing buyers to scope queries to a specific account.

--- a/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
+++ b/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
@@ -30,6 +30,7 @@ The buyer requests artifacts from the seller using the same media buy parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `account_id` | string | No | Filter to a specific account. Only returns artifacts for media buys belonging to this account. When omitted, returns artifacts across all accessible accounts. Optional if the agent has a single account. |
 | `media_buy_id` | string | Yes | Media buy to get artifacts from |
 | `package_ids` | array | No | Filter to specific packages |
 | `sampling` | object | No | Sampling parameters (defaults to media buy agreement) |

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -15,6 +15,7 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `account_id` | string | No | Filter to a specific account. Only returns media buys belonging to this account. When omitted, returns data across all accessible accounts. Optional if the agent has a single account. |
 | `media_buy_ids` | string[] | No* | Array of media buy IDs to retrieve |
 | `buyer_refs` | string[] | No* | Array of buyer reference IDs |
 | `status_filter` | string \| string[] | No | Status filter: `"active"`, `"pending"`, `"paused"`, `"completed"`, `"failed"`, `"all"`. Defaults to `["active"]` |
@@ -402,6 +403,63 @@ async def main():
         if delivery.totals.impressions > 0:
             cpm = (delivery.totals.spend / delivery.totals.impressions) * 1000
             print(f"{delivery.buyer_ref}: CPM ${cpm:.2f}, CTR {delivery.totals.ctr * 100:.2f}%")
+
+asyncio.run(main())
+```
+
+</CodeGroup>
+
+### Account-Scoped Query
+
+<CodeGroup>
+
+```javascript JavaScript
+import { testAgent } from '@adcp/client/testing';
+import { GetMediaBuyDeliveryResponseSchema } from '@adcp/client';
+
+// Get delivery for a specific advertiser account
+const result = await testAgent.getMediaBuyDelivery({
+  account_id: 'acc_coke_publicis',
+  status_filter: 'active',
+  start_date: '2024-02-01',
+  end_date: '2024-02-07'
+});
+
+if (!result.success) {
+  throw new Error(`Request failed: ${result.error}`);
+}
+
+const validated = GetMediaBuyDeliveryResponseSchema.parse(result.data);
+
+if ('errors' in validated && validated.errors) {
+  throw new Error(`Query failed: ${JSON.stringify(validated.errors)}`);
+}
+
+console.log(`${validated.aggregated_totals.media_buy_count} campaigns for account`);
+console.log(`Total spend: $${validated.aggregated_totals.spend.toFixed(2)}`);
+```
+
+```python Python
+import asyncio
+from adcp.testing import test_agent
+from adcp.types import GetMediaBuyDeliveryRequest
+
+async def main():
+    # Get delivery for a specific advertiser account
+    result = await test_agent.get_media_buy_delivery(
+        GetMediaBuyDeliveryRequest(
+            account_id='acc_coke_publicis',
+            status_filter='active',
+            start_date='2024-02-01',
+            end_date='2024-02-07'
+        )
+    )
+
+    if hasattr(result, 'errors') and result.errors:
+        raise Exception(f"Query failed: {result.errors}")
+
+    print(f"{result.aggregated_totals.media_buy_count} campaigns for account")
+    print(f"Total spend: ${result.aggregated_totals.spend:.2f}")
 
 asyncio.run(main())
 ```

--- a/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
+++ b/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
@@ -5,6 +5,10 @@
   "description": "Request parameters for retrieving content artifacts from a media buy for validation",
   "type": "object",
   "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Filter artifacts to a specific account. When provided, only returns artifacts for media buys belonging to this account. When omitted, returns artifacts across all accessible accounts. Optional if the agent has a single account."
+    },
     "media_buy_id": {
       "type": "string",
       "description": "Media buy to get artifacts from"

--- a/static/schemas/source/media-buy/get-media-buy-delivery-request.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-request.json
@@ -5,6 +5,10 @@
   "description": "Request parameters for retrieving comprehensive delivery metrics",
   "type": "object",
   "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Filter delivery data to a specific account. When provided, only returns media buys belonging to this account. When omitted, returns data across all accessible accounts. Optional if the agent has a single account."
+    },
     "media_buy_ids": {
       "type": "array",
       "description": "Array of publisher media buy IDs to get delivery data for",


### PR DESCRIPTION
## Summary

- Add optional `account_id` parameter to `get_media_buy_delivery` and `get_media_buy_artifacts` request schemas
- Allows multi-account buyers to scope queries to a specific account for per-account webhook routing and vendor-specific reporting
- When omitted, returns data across all accessible accounts (no behavioral change for existing consumers)

## Test plan

- [x] All 273 tests pass (`npm test`)
- [x] Schema validation passes
- [x] TypeScript typecheck passes
- [x] No broken links in docs
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)