### PR TITLE
feat: Add channel fields to property and product schemas

### DIFF
--- a/.changeset/add-channel-fields.md
+++ b/.changeset/add-channel-fields.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add channel fields to property and product schemas. Properties can now declare `supported_channels` and products can declare `channels` to indicate which advertising channels they align with. Both fields reference the Media Channel Taxonomy enum and are optional.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -67,6 +67,7 @@ The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
   - **`privacy_policy_url`** *(optional)*: URL to entity's privacy policy for consumer consent flows
 
 **`properties`** *(optional)*: Array of properties covered by this file (canonical property definitions)
+  - **`supported_channels`** *(optional)*: Advertising channels this property supports (e.g., `["display", "olv", "social"]`). See [Media Channel Taxonomy](/docs/reference/media-channel-taxonomy).
 
 **`tags`** *(optional)*: Tag metadata providing human-readable context and enabling efficient grouping
 

--- a/docs/governance/property/specification.mdx
+++ b/docs/governance/property/specification.mdx
@@ -69,11 +69,12 @@ Properties are identified using the standard AdCP property model:
   "name": "Example News",
   "identifiers": [
     { "type": "domain", "value": "example.com" }
-  ]
+  ],
+  "supported_channels": ["display", "olv"]
 }
 ```
 
-Property types include: `website`, `mobile_app`, `ctv_app`, `dooh`, `podcast`, `radio`, `streaming_audio`.
+Property types include: `website`, `mobile_app`, `ctv_app`, `dooh`, `podcast`, `radio`, `streaming_audio`. Properties may also declare `supported_channels` to indicate which advertising channels their inventory aligns with.
 
 ### Property List References
 

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -15,6 +15,7 @@ Products declare which pricing models they support. Buyers select a specific pri
 - `product_id` (string, required)
 - `name` (string, required)
 - `description` (string, required)
+- `channels` (list[string], optional): Advertising channels this product is sold as (e.g., `["retail_media"]`, `["display", "olv"]`). Sellers SHOULD declare `channels` on products that span non-obvious channels, particularly retail media, CTV/OLV, and multi-channel bundles. Product channels SHOULD be a subset of the union of their properties' `supported_channels`. See [Media Channel Taxonomy](/docs/reference/media-channel-taxonomy).
 - `formats` (list[Format], required): See [Creative Formats](/docs/creative/formats).
 - `placements` (list[Placement], optional): Specific ad placements within this product. When provided, buyers can target individual placements when assigning creatives. See [Placements](#placements).
 - `delivery_type` (string, required): Either `"guaranteed"` or `"non_guaranteed"`.

--- a/docs/reference/media-channel-taxonomy.mdx
+++ b/docs/reference/media-channel-taxonomy.mdx
@@ -618,6 +618,27 @@ Properties in `adagents.json` declare which channels they support:
 }
 ```
 
+### Usage in Product Definitions
+
+Products declare which channels they are sold as. This typically inherits from properties but may be more specific:
+
+```json
+{
+  "product_id": "youtube_ctv_premium",
+  "name": "YouTube CTV Premium",
+  "channels": ["ctv"],
+  "publisher_properties": [
+    {
+      "publisher_domain": "youtube.com",
+      "selection_type": "by_tag",
+      "property_tags": ["ctv_apps"]
+    }
+  ]
+}
+```
+
+Even though YouTube properties support `["olv", "social", "ctv"]`, this product is specifically sold as CTV inventory.
+
 ### Extensibility
 
 Implementations MAY support additional channels beyond this specification using the `ext` field pattern:
@@ -694,7 +715,7 @@ Retail media may eventually warrant sub-channels:
 | Display on retailer site | `retail_media` | `retail_media_display` |
 | Off-site using retailer data | `retail_media` | `retail_media_offsite` |
 
-For now, use `retail_media` with format filters to distinguish.
+With `channels` on products and `format_types` in filters, buyers can distinguish retail media product types (sponsored products vs display vs offsite) without sub-channels. Use `channels: ["retail_media"]` combined with format filters to narrow results. The two-axis approach (channel + format) is preferred over channel proliferation.
 
 ### Gaming vs Display/OLV
 

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -482,6 +482,7 @@
             "meta_network",
             "social_media"
           ],
+          "supported_channels": ["social", "display", "olv"],
           "publisher_domain": "instagram.com"
         },
         {
@@ -501,6 +502,7 @@
             "meta_network",
             "social_media"
           ],
+          "supported_channels": ["social", "display", "olv"],
           "publisher_domain": "facebook.com"
         },
         {
@@ -520,6 +522,7 @@
             "meta_network",
             "messaging"
           ],
+          "supported_channels": ["social", "display"],
           "publisher_domain": "whatsapp.com"
         }
       ],

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -119,7 +119,7 @@
     },
     "channels": {
       "type": "array",
-      "description": "Filter by advertising channels (e.g., ['display', 'video', 'dooh'])",
+      "description": "Filter by advertising channels (e.g., ['display', 'ctv', 'dooh'])",
       "items": {
         "$ref": "/schemas/enums/channels.json"
       }

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -25,6 +25,14 @@
       },
       "minItems": 1
     },
+    "channels": {
+      "type": "array",
+      "description": "Advertising channels this product is sold as. Products inherit from their properties' supported_channels but may narrow the scope. For example, a product covering YouTube properties might be sold as ['ctv'] even though those properties support ['olv', 'social', 'ctv'].",
+      "items": {
+        "$ref": "/schemas/enums/channels.json"
+      },
+      "uniqueItems": true
+    },
     "format_ids": {
       "type": "array",
       "description": "Array of supported creative format IDs - structured format_id objects with agent_url and id",

--- a/static/schemas/source/core/property.json
+++ b/static/schemas/source/core/property.json
@@ -48,6 +48,14 @@
       },
       "uniqueItems": true
     },
+    "supported_channels": {
+      "type": "array",
+      "description": "Advertising channels this property supports (e.g., ['display', 'olv', 'social']). Publishers declare which channels their inventory aligns with. Properties may support multiple channels. See the Media Channel Taxonomy for definitions.",
+      "items": {
+        "$ref": "/schemas/enums/channels.json"
+      },
+      "uniqueItems": true
+    },
     "publisher_domain": {
       "type": "string",
       "description": "Domain where adagents.json should be checked for authorization validation. Optional in adagents.json (file location implies domain)."


### PR DESCRIPTION
## Summary

- Adds `supported_channels` to `property.json` — publishers declare which channels their property supports
- Adds `channels` to `product.json` — sellers declare which channels a product is sold as
- Fixes stale `video` channel value in `product-filters.json` description (should be `ctv`/`olv`)
- Updates retail media guidance to recommend channel + format filtering over sub-channels

Both fields are optional arrays referencing the existing Media Channel Taxonomy enum. This is a non-breaking minor change.

**Resolves** adcontextprotocol/adcp-client#225

## Context

Channel filters existed on `product-filters.json` and `property-list-filters.json`, but the objects being filtered (`property.json`, `product.json`) had no channel data. The taxonomy doc even showed `supported_channels` in a property example without the field existing in the schema.

The design: properties declare channel **eligibility** (what the publisher says this property can be used for), products declare channel **intent** (what the seller says this product is sold as). Products inherit from properties but may narrow — e.g., YouTube supports `["olv", "social", "ctv"]` but a CTV product is sold as `["ctv"]` only.

## Test plan

- [x] All 274 tests pass (`npm test`)
- [x] TypeScript typecheck passes
- [x] Schema validation passes (257 schemas, all `$ref` paths resolve)
- [x] Example validation passes (adagents.json examples validate against updated schemas)
- [x] Pre-push hooks pass (version sync, broken links, accessibility)
- [ ] Review schema changes in `property.json` and `product.json`
- [ ] Review doc updates for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)