### PR TITLE
feat(addie): Infer membership tier and add list_paying_members tool

### DIFF
--- a/.changeset/slimy-paths-beam.md
+++ b/.changeset/slimy-paths-beam.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add list_paying_members admin tool and infer membership tier from subscription amount in get_account.

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -271,6 +271,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'get_member_search_analytics',
       'list_organizations_by_users',
       'list_slack_users_by_org',
+      'list_paying_members',
       'tag_insight',
       'list_pending_insights',
       'run_synthesis',


### PR DESCRIPTION
## Summary
- **Infer tier from amount**: `get_account` now shows membership tier for members who joined before the `membership_tier` column existed, by mapping `subscription_amount` to tier (with "inferred from amount" annotation)
- **New `list_paying_members` admin tool**: Returns all active members grouped by subscription level ($50K ICL / $10K corporate / $2.5K SMB) in a single query, replacing the need to call `get_account` per-org for tier reports

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (274 tests, 15 suites)
- [x] Pre-commit hooks pass
- [ ] Test Addie: ask "list all corporate members by tier" — should get grouped output
- [ ] Test Addie: `get_account` for a member with NULL `membership_tier` — should show inferred tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)