### PR TITLE
Make format_id optional in preview_creative

### DIFF
--- a/.changeset/preview-format-id-optional.md
+++ b/.changeset/preview-format-id-optional.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Make top-level format_id optional in preview_creative request. The field was redundant with creative_manifest.format_id (which is always required). Callers who omit it fall back to creative_manifest.format_id. Existing callers who send both still work.

--- a/docs/creative/creative-manifests.mdx
+++ b/docs/creative/creative-manifests.mdx
@@ -327,10 +327,6 @@ Use the `preview_creative` task to see how a manifest will render:
 
 ```json
 {
-  "format_id": {
-    "agent_url": "https://creative.adcontextprotocol.org",
-    "id": "native_responsive"
-  },
   "creative_manifest": {
     "format_id": {
       "agent_url": "https://creative.adcontextprotocol.org",

--- a/docs/creative/quick-reference.mdx
+++ b/docs/creative/quick-reference.mdx
@@ -132,10 +132,6 @@ Generate visual previews of creative manifests.
 ```json
 {
   "request_type": "single",
-  "format_id": {
-    "agent_url": "https://creative.adcontextprotocol.org",
-    "id": "display_300x250"
-  },
   "creative_manifest": {
     "format_id": {
       "agent_url": "https://creative.adcontextprotocol.org",
@@ -157,8 +153,7 @@ Generate visual previews of creative manifests.
 ```json
 {
   "request_type": "single",
-  "format_id": { "agent_url": "...", "id": "native_responsive" },
-  "creative_manifest": { },
+  "creative_manifest": { /* includes format_id, assets */ },
   "inputs": [
     { "name": "Desktop", "macros": { "DEVICE_TYPE": "desktop" } },
     { "name": "Mobile", "macros": { "DEVICE_TYPE": "mobile" } }
@@ -171,15 +166,15 @@ Generate visual previews of creative manifests.
 {
   "request_type": "batch",
   "requests": [
-    { "format_id": {}, "creative_manifest": { } },
-    { "format_id": {}, "creative_manifest": { } }
+    { "creative_manifest": { /* creative 1 */ } },
+    { "creative_manifest": { /* creative 2 */ } }
   ]
 }
 ```
 
 **Key fields:**
 - `request_type` (string, required): `"single"` or `"batch"`
-- `format_id` (object, required for single): Format identifier
+- `format_id` (object, optional): Format identifier. Defaults to `creative_manifest.format_id` if omitted.
 - `creative_manifest` (object, required): Complete creative manifest
 - `inputs` (array, optional): Generate variants with different macros/contexts
 - `output_format` (string, optional): `"url"` (default) or `"html"`

--- a/docs/creative/task-reference/preview_creative-advanced.mdx
+++ b/docs/creative/task-reference/preview_creative-advanced.mdx
@@ -212,7 +212,6 @@ previews = []
 for format in formats:
     preview = await client.preview_creative(
         request_type="single",
-        format_id=format.format_id,
         creative_manifest=format.format_card.manifest
     )
     previews.append(preview)
@@ -225,10 +224,7 @@ response = await client.preview_creative(
     request_type="batch",
     output_format="html",
     requests=[
-        {
-            "format_id": fmt.format_id,
-            "creative_manifest": fmt.format_card.manifest
-        }
+        {"creative_manifest": fmt.format_card.manifest}
         for fmt in formats
     ]
 )

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -12,11 +12,7 @@ Generate preview renderings of creative manifests. Supports both single creative
 ```json
 {
   "request_type": "single",
-  "format_id": {
-    "agent_url": "https://creative.adcontextprotocol.org",
-    "id": "native_responsive"
-  },
-  "creative_manifest": { /* your creative */ }
+  "creative_manifest": { /* includes format_id, assets */ }
 }
 ```
 
@@ -49,8 +45,7 @@ For faster rendering without iframe overhead, request HTML directly:
 ```json
 {
   "request_type": "single",
-  "format_id": { "agent_url": "...", "id": "native_responsive" },
-  "creative_manifest": { /* your creative */ },
+  "creative_manifest": { /* includes format_id, assets */ },
   "output_format": "html"
 }
 ```
@@ -81,8 +76,8 @@ Preview multiple creatives in one API call (5-10x faster):
 {
   "request_type": "batch",
   "requests": [
-    { "format_id": {...}, "creative_manifest": { /* creative 1 */ } },
-    { "format_id": {...}, "creative_manifest": { /* creative 2 */ } }
+    { "creative_manifest": { /* creative 1 */ } },
+    { "creative_manifest": { /* creative 2 */ } }
   ]
 }
 ```
@@ -106,7 +101,7 @@ Response contains results in order:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `request_type` | string | Yes | `"single"` |
-| `format_id` | FormatID | Yes | Format identifier (agent_url + id) |
+| `format_id` | FormatID | No | Format identifier (agent_url + id). Defaults to `creative_manifest.format_id` if omitted. |
 | `creative_manifest` | object | Yes | Complete creative manifest |
 | `inputs` | array | No | Array of input sets for multiple preview variants |
 | `output_format` | string | No | `"url"` (default) or `"html"` |
@@ -193,7 +188,6 @@ Generate multiple preview variants by providing different contexts:
 ```json
 {
   "request_type": "single",
-  "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "native_responsive" },
   "creative_manifest": {
     "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "native_responsive" },
     "assets": {
@@ -217,14 +211,8 @@ Preview multiple creatives for a grid layout:
   "request_type": "batch",
   "output_format": "html",
   "requests": [
-    {
-      "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250" },
-      "creative_manifest": { /* creative 1 */ }
-    },
-    {
-      "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "display_728x90" },
-      "creative_manifest": { /* creative 2 */ }
-    }
+    { "creative_manifest": { /* creative 1 */ } },
+    { "creative_manifest": { /* creative 2 */ } }
   ]
 }
 ```
@@ -234,7 +222,6 @@ Preview multiple creatives for a grid layout:
 ```json
 {
   "request_type": "single",
-  "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "audio_host_read_30s" },
   "creative_manifest": {
     "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "audio_host_read_30s" },
     "assets": {

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -553,7 +553,7 @@ export const ADCP_CREATIVE_TOOLS: AddieTool[] = [
         },
         requests: {
           type: 'array',
-          description: 'For batch preview - array of { format_id, creative_manifest }',
+          description: 'For batch preview - array of { creative_manifest } objects',
         },
         output_format: {
           type: 'string',

--- a/skills/adcp-creative/SKILL.md
+++ b/skills/adcp-creative/SKILL.md
@@ -137,10 +137,6 @@ Generate visual previews of creative manifests.
 ```json
 {
   "request_type": "single",
-  "format_id": {
-    "agent_url": "https://creative.adcontextprotocol.org",
-    "id": "display_300x250"
-  },
   "creative_manifest": {
     "format_id": {
       "agent_url": "https://creative.adcontextprotocol.org",
@@ -162,8 +158,7 @@ Generate visual previews of creative manifests.
 ```json
 {
   "request_type": "single",
-  "format_id": { "agent_url": "...", "id": "native_responsive" },
-  "creative_manifest": { /* ... */ },
+  "creative_manifest": { /* includes format_id, assets */ },
   "inputs": [
     { "name": "Desktop", "macros": { "DEVICE_TYPE": "desktop" } },
     { "name": "Mobile", "macros": { "DEVICE_TYPE": "mobile" } }
@@ -176,15 +171,15 @@ Generate visual previews of creative manifests.
 {
   "request_type": "batch",
   "requests": [
-    { "format_id": {...}, "creative_manifest": { /* creative 1 */ } },
-    { "format_id": {...}, "creative_manifest": { /* creative 2 */ } }
+    { "creative_manifest": { /* creative 1 */ } },
+    { "creative_manifest": { /* creative 2 */ } }
   ]
 }
 ```
 
 **Key fields:**
 - `request_type` (string, required): `"single"` or `"batch"`
-- `format_id` (object, required for single): Format identifier
+- `format_id` (object, optional): Format identifier. Defaults to `creative_manifest.format_id` if omitted.
 - `creative_manifest` (object, required): Complete creative manifest
 - `inputs` (array, optional): Generate variants with different macros/contexts
 - `output_format` (string, optional): `"url"` (default) or `"html"`

--- a/static/schemas/source/creative/preview-creative-request.json
+++ b/static/schemas/source/creative/preview-creative-request.json
@@ -15,7 +15,7 @@
         },
         "format_id": {
           "$ref": "/schemas/core/format-id.json",
-          "description": "Format identifier for rendering the preview"
+          "description": "Format identifier for rendering the preview. Optional — defaults to creative_manifest.format_id if omitted."
         },
         "creative_manifest": {
           "$ref": "/schemas/core/creative-manifest.json",
@@ -67,7 +67,6 @@
       },
       "required": [
         "request_type",
-        "format_id",
         "creative_manifest"
       ],
       "additionalProperties": true
@@ -89,7 +88,7 @@
             "properties": {
               "format_id": {
                 "$ref": "/schemas/core/format-id.json",
-                "description": "Format identifier for rendering the preview"
+                "description": "Format identifier for rendering the preview. Optional — defaults to creative_manifest.format_id if omitted."
               },
               "creative_manifest": {
                 "$ref": "/schemas/core/creative-manifest.json",
@@ -134,7 +133,6 @@
               }
             },
             "required": [
-              "format_id",
               "creative_manifest"
             ],
             "additionalProperties": true


### PR DESCRIPTION
## Summary

- Remove `format_id` from `required` in the `preview_creative` request schema (both single and batch item variants)
- The field was always redundant with `creative_manifest.format_id`, which is required
- Callers who omit it fall back to `creative_manifest.format_id`; callers who send both still work

## Test plan

- [x] All 274 unit tests pass
- [x] Schema validation tests pass (7/7)
- [x] Example validation tests pass
- [x] TypeScript typecheck clean
- [x] Mintlify link checker passes
- [ ] Verify creative agents handle missing top-level `format_id` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)