### PR TITLE
fix(addie): Remove duplicate validate_adagents tool causing API 400 errors

### DIFF
--- a/.changeset/fair-feet-shop.md
+++ b/.changeset/fair-feet-shop.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(addie): Remove duplicate validate_adagents tool definition that caused Claude API 400 errors

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -337,9 +337,10 @@ export class AddieClaudeClient {
       logger.info({ model: effectiveModel, defaultModel: this.model }, 'Addie: Using precision model for billing/financial query');
     }
 
-    // Combine global tools with per-request tools
+    // Combine global tools with per-request tools, deduplicating by name (last wins)
     // Calculate tool count first to inform token budget for conversation history
-    const allTools = [...this.tools, ...(requestTools?.tools || [])];
+    const allToolsRaw = [...this.tools, ...(requestTools?.tools || [])];
+    const allTools = [...new Map(allToolsRaw.map(t => [t.name, t])).values()];
     const allHandlers = new Map([...this.toolHandlers, ...(requestTools?.handlers || [])]);
     const toolCount = allTools.length + (this.webSearchEnabled ? 1 : 0);
 
@@ -820,9 +821,10 @@ export class AddieClaudeClient {
       logger.info({ model: effectiveModel, defaultModel: this.model }, 'Addie Stream: Using precision model for billing/financial query');
     }
 
-    // Combine global tools with per-request tools
+    // Combine global tools with per-request tools, deduplicating by name (last wins)
     // Calculate tool count first to inform token budget for conversation history
-    const allTools = [...this.tools, ...(requestTools?.tools || [])];
+    const allToolsRaw = [...this.tools, ...(requestTools?.tools || [])];
+    const allTools = [...new Map(allToolsRaw.map(t => [t.name, t])).values()];
     const allHandlers = new Map([...this.toolHandlers, ...(requestTools?.handlers || [])]);
     const toolCount = allTools.length; // Note: streaming doesn't use web search
 

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -29,12 +29,9 @@ describe('MEMBER_TOOLS definitions', () => {
     }
   });
 
-  it('has validate_adagents tool', () => {
+  it('does not have validate_adagents tool (moved to property-tools)', () => {
     const tool = MEMBER_TOOLS.find(t => t.name === 'validate_adagents');
-    expect(tool).toBeDefined();
-    expect(tool?.input_schema.properties).toHaveProperty('domain');
-    expect(tool?.input_schema.properties).toHaveProperty('validate_cards');
-    expect(tool?.input_schema.required).toContain('domain');
+    expect(tool).toBeUndefined();
   });
 
   it('has list_working_groups tool with limit parameter', () => {


### PR DESCRIPTION
## Summary

- Removed duplicate `validate_adagents` tool definition from `member-tools.ts` (canonical version stays in `property-tools.ts`)
- Added tool name deduplication in `claude-client.ts` to prevent future duplicates from reaching the API

## Context

Production logs showed repeated 400 errors from the Anthropic API:
```
"tools: Tool names must be unique."
```

`validate_adagents` was defined in both `MEMBER_TOOLS` and `PROPERTY_TOOLS`. When `bolt-app.ts` combined them into `allTools`, the duplicate caused the API to reject every request. The member-tools handler was already dead code — the property-tools handler overwrote it in the `allHandlers` Map.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All tests pass (292/293 — 1 pre-existing failure in organization-db unrelated to this change)
- [x] Verified only one `validate_adagents` definition remains across all tool files
- [x] No other duplicate tool names in the codebase


🤖 Generated with [Claude Code](https://claude.com/claude-code)