### PR TITLE
Add product_selectors to get_products for commerce media discovery

### DIFF
--- a/.changeset/product-selectors.md
+++ b/.changeset/product-selectors.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add product_selectors to get_products for commerce product discovery. Add manifest_gtins to promoted-products schema for cross-retailer GTIN matching.

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -128,6 +128,7 @@ asyncio.run(discover_with_filters())
 | `brief` | string | No | Natural language description of campaign requirements. When refining a proposal, can include instructions like "focus more on German speakers". |
 | `proposal_id` | string | No | Proposal ID to refine. When provided with a brief, the publisher uses the brief as refinement instructions and returns an updated proposal. |
 | `brand_manifest` | BrandManifest \| string | No | Brand information (inline object or URL). See [Brand Manifest](/docs/creative/brand-manifest) |
+| `product_selectors` | ProductSelectors | No | Selectors to filter the brand manifest product catalog. Requires `brand_manifest`. See [Product Selectors](#product-selectors) below. |
 | `filters` | Filters | No | Structured filters (see below) |
 | `property_list` | PropertyListRef | No | [AdCP 3.0] Reference to a property list for filtering. See [Property Lists](/docs/governance/property/tasks/property_lists) |
 | `pagination` | PaginationRequest | No | Cursor-based pagination for large product catalogs (see below) |
@@ -157,6 +158,18 @@ asyncio.run(discover_with_filters())
 | `max` | number | No* | Maximum budget amount |
 
 *At least one of `min` or `max` must be specified.
+
+### Product Selectors
+
+Filter which items from the brand manifest product catalog to evaluate for product discovery. When provided, sellers should only return advertising products where the selected catalog items have matches (e.g., a retailer carries the specified GTINs). Selectors combine with OR logic — items matching any criteria are included.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `manifest_gtins` | string[] | GTIN identifiers for cross-retailer catalog matching (GTIN-8, UPC-A/GTIN-12, EAN-13/GTIN-13, GTIN-14) |
+| `manifest_skus` | string[] | Direct SKU references from the brand manifest |
+| `manifest_tags` | string[] | Select by tags (e.g., `["organic", "ketchup"]`) |
+| `manifest_category` | string | Select from a specific category (e.g., `"food/condiments"`) |
+| `manifest_query` | string | Natural language query (e.g., `"all pasta sauces under $5"`) |
 
 ## Response
 
@@ -211,6 +224,7 @@ Pagination is optional. When omitted, the server returns all results (or a serve
 | Field | Type | Description |
 |-------|------|-------------|
 | `property_list_applied` | boolean | [AdCP 3.0] `true` if the agent filtered products based on the provided `property_list`. Absent or `false` if not provided or not supported. |
+| `product_selectors_applied` | boolean | `true` if the seller filtered results based on the provided `product_selectors`. Absent or `false` if not provided or not supported. |
 
 **See schema for complete field list**: [`get-products-response.json`](https://adcontextprotocol.org/schemas/v2/media-buy/get-products-response.json)
 
@@ -517,6 +531,94 @@ asyncio.run(discover_standard_formats())
 ```
 
 </CodeGroup>
+
+### Commerce Product Discovery
+
+Use `product_selectors` with a brand manifest to discover advertising products where your catalog items have matches at specific retailers:
+
+<CodeGroup>
+
+```javascript JavaScript
+import { testAgent } from '@adcp/client/testing';
+
+// Discover retail media products for specific catalog items
+const result = await testAgent.getProducts({
+  brand_manifest: {
+    name: 'Kraft Heinz',
+    url: 'https://kraftheinz.com',
+    product_catalog: {
+      feed_url: 'https://kraftheinz.com/products.xml',
+      feed_format: 'google_merchant_center'
+    }
+  },
+  product_selectors: {
+    manifest_tags: ['ketchup', 'organic'],
+    manifest_category: 'food/condiments'
+  },
+  filters: {
+    channels: ['retail_media']
+  }
+});
+
+if (result.success && result.data) {
+  if (result.data.product_selectors_applied) {
+    console.log(`Found ${result.data.products.length} products with catalog matches`);
+  } else {
+    console.log('Seller does not support product selectors');
+  }
+}
+```
+
+```python Python
+import asyncio
+from adcp.testing import test_agent
+
+async def discover_commerce_products():
+    # Discover retail media products for specific catalog items
+    result = await test_agent.simple.get_products(
+        brand_manifest={
+            'name': 'Kraft Heinz',
+            'url': 'https://kraftheinz.com',
+            'product_catalog': {
+                'feed_url': 'https://kraftheinz.com/products.xml',
+                'feed_format': 'google_merchant_center'
+            }
+        },
+        product_selectors={
+            'manifest_tags': ['ketchup', 'organic'],
+            'manifest_category': 'food/condiments'
+        },
+        filters={
+            'channels': ['retail_media']
+        }
+    )
+    if result.get('product_selectors_applied'):
+        print(f"Found {len(result.products)} products with catalog matches")
+    else:
+        print("Seller does not support product selectors")
+
+asyncio.run(discover_commerce_products())
+```
+
+```bash CLI
+uvx adcp \
+  https://test-agent.adcontextprotocol.org/mcp \
+  get_products \
+  '{"brand_manifest":{"name":"Kraft Heinz","url":"https://kraftheinz.com","product_catalog":{"feed_url":"https://kraftheinz.com/products.xml","feed_format":"google_merchant_center"}},"product_selectors":{"manifest_tags":["ketchup","organic"],"manifest_category":"food/condiments"},"filters":{"channels":["retail_media"]}}' \
+  --auth 1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ
+```
+
+</CodeGroup>
+
+You can also select catalog items by GTIN for precise cross-retailer matching:
+
+```json
+{
+  "product_selectors": {
+    "manifest_gtins": ["00013000006040", "00013000006057"]
+  }
+}
+```
 
 ### Property List Filtering
 

--- a/static/schemas/source/core/promoted-products.json
+++ b/static/schemas/source/core/promoted-products.json
@@ -5,6 +5,14 @@
   "description": "Specification of products or offerings being promoted in a campaign. Supports multiple selection methods from the brand manifest that can be combined using UNION (OR) logic. When multiple selection methods are provided, products matching ANY of the criteria are selected (logical OR, not AND).",
   "type": "object",
   "properties": {
+    "manifest_gtins": {
+      "type": "array",
+      "description": "GTIN product identifiers for cross-retailer catalog matching. Accepts standard GTIN formats (GTIN-8, UPC-A/GTIN-12, EAN-13/GTIN-13, GTIN-14).",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9]{8,14}$"
+      }
+    },
     "manifest_skus": {
       "type": "array",
       "description": "Direct product SKU references from the brand manifest product catalog",
@@ -28,8 +36,18 @@
       "description": "Natural language query to select products from the brand manifest (e.g., 'all Kraft Heinz pasta sauces', 'organic products under $20')"
     }
   },
+  "minProperties": 1,
   "additionalProperties": true,
   "examples": [
+    {
+      "description": "Cross-retailer GTIN matching for commerce media product discovery",
+      "data": {
+        "manifest_gtins": [
+          "00013000006040",
+          "00013000006057"
+        ]
+      }
+    },
     {
       "description": "Direct SKU selection for specific products from brand manifest",
       "data": {

--- a/static/schemas/source/media-buy/get-products-request.json
+++ b/static/schemas/source/media-buy/get-products-request.json
@@ -17,6 +17,10 @@
       "$ref": "/schemas/core/brand-manifest-ref.json",
       "description": "Brand information manifest providing brand context, assets, and product catalog. Can be provided inline or as a URL reference to a hosted manifest."
     },
+    "product_selectors": {
+      "$ref": "/schemas/core/promoted-products.json",
+      "description": "Selectors to filter the brand manifest product catalog for product discovery. When provided, sellers should only return advertising products where the selected catalog items have matches. Uses the same selection methods as promoted-offerings."
+    },
     "account_id": {
       "type": "string",
       "description": "Account context for product lookup. When provided, returns products with pricing specific to this account's rate card. Optional if the agent has a single account."
@@ -39,5 +43,8 @@
     }
   },
   "required": [],
+  "dependencies": {
+    "product_selectors": ["brand_manifest"]
+  },
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/get-products-response.json
+++ b/static/schemas/source/media-buy/get-products-response.json
@@ -30,6 +30,10 @@
       "type": "boolean",
       "description": "[AdCP 3.0] Indicates whether property_list filtering was applied. True if the agent filtered products based on the provided property_list. Absent or false if property_list was not provided or not supported by this agent."
     },
+    "product_selectors_applied": {
+      "type": "boolean",
+      "description": "Indicates whether product_selectors filtering was applied. True if the seller filtered results based on the provided product_selectors. Absent or false if product_selectors was not provided or not supported by this agent."
+    },
     "pagination": {
       "$ref": "/schemas/core/pagination-response.json"
     },


### PR DESCRIPTION
## Summary

- Add `product_selectors` to `get_products` request, reusing the existing `promoted-products.json` schema, so commerce media buyers can specify which catalog items to evaluate by GTIN, SKU, tag, category, or query
- Add `manifest_gtins` to `promoted-products.json` for cross-retailer GTIN/UPC matching (the universal identifier in commerce media)
- Add `product_selectors_applied` boolean to the response (following the `property_list_applied` pattern)
- Add `minProperties: 1` and GTIN pattern validation (`^[0-9]{8,14}$`)
- Add documentation: Product Selectors reference table, Commerce Product Discovery scenario with JS/Python/CLI examples

## Test plan

- [x] `npm run build` — schema builds successfully
- [x] `npm run test:schemas` — all 269 schemas validate (7/7 tests)
- [x] `npm run test:snippets -- --file docs/media-buy/task-reference/get_products.mdx` — all 23/23 doc snippets pass
- [x] `npm test` — full test suite passes (293 tests, 16 suites)
- [x] Pre-commit hook runs full suite
- [x] Pre-push hook validates version sync, broken links, accessibility

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)