### PR TITLE
feat: Add commerce attribution metrics to delivery response

### DIFF
--- a/.changeset/commerce-attribution-metrics.md
+++ b/.changeset/commerce-attribution-metrics.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add commerce attribution metrics to delivery response schema. Adds `new_to_brand_rate` as a first-class field in DeliveryMetrics. Adds `roas` and `new_to_brand_rate` to `aggregated_totals` and `daily_breakdown` in the delivery response. Updates documentation to reflect commerce metric availability.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -32,7 +32,7 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 |-------|-------------|
 | `reporting_period` | Date range for report (start/end timestamps) |
 | `currency` | ISO 4217 currency code (USD, EUR, GBP, etc.) |
-| `aggregated_totals` | Combined metrics across all media buys (impressions, spend, clicks, video_completions, media_buy_count) |
+| `aggregated_totals` | Combined metrics across all media buys (impressions, spend, clicks, video_completions, conversions, conversion_value, roas, new_to_brand_rate, cost_per_acquisition, media_buy_count) |
 | `media_buy_deliveries` | Array of delivery data per media buy |
 
 ### Media Buy Delivery Object
@@ -42,9 +42,9 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 | `media_buy_id` | Media buy identifier |
 | `buyer_ref` | Buyer's reference identifier |
 | `status` | Current status (`pending`, `active`, `paused`, `completed`, `failed`) |
-| `totals` | Aggregate metrics (impressions, spend, clicks, ctr, video_completions, completion_rate) |
+| `totals` | Aggregate metrics (impressions, spend, clicks, ctr, conversions, conversion_value, roas, new_to_brand_rate) |
 | `by_package` | Package-level breakdowns with delivery_status, paused state, and pacing_index |
-| `daily_breakdown` | Day-by-day delivery (date, impressions, spend) |
+| `daily_breakdown` | Day-by-day delivery (date, impressions, spend, conversions, conversion_value, roas, new_to_brand_rate) |
 
 See [schema](https://adcontextprotocol.org/schemas/v2/media-buy/get-media-buy-delivery-response.json) for complete field list.
 
@@ -476,6 +476,11 @@ asyncio.run(main())
 | **CTR** | Click-through rate (clicks/impressions) |
 | **Video Completions** | Videos watched to completion |
 | **Completion Rate** | Video completions/video impressions |
+| **Conversions** | Attributed conversions/orders |
+| **Conversion Value** | Total monetary value of attributed conversions |
+| **ROAS** | Return on ad spend (conversion_value / spend) |
+| **New-to-Brand Rate** | Fraction of conversions from first-time brand buyers (0-1) |
+| **Cost per Acquisition** | Cost per conversion (spend / conversions) |
 | **Pacing Index** | Actual vs. expected delivery rate (1.0 = on track, &lt;1.0 = behind, &gt;1.0 = ahead) |
 | **CPM** | Cost per thousand impressions (spend/impressions * 1000) |
 
@@ -502,6 +507,7 @@ asyncio.run(main())
 ### Metric Availability
 - **Universal**: Impressions, spend (available on all platforms)
 - **Format-dependent**: Clicks, video completions (depends on inventory type and platform capabilities)
+- **Commerce attribution**: Conversions, conversion_value, roas, new_to_brand_rate (available on commerce media platforms)
 - **Package-level**: All metrics broken down by package with pacing_index
 
 ## Data Freshness

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -62,6 +62,12 @@
       "description": "Cost per conversion (spend / conversions)",
       "minimum": 0
     },
+    "new_to_brand_rate": {
+      "type": "number",
+      "description": "Fraction of conversions from first-time brand buyers (0 = none, 1 = all)",
+      "minimum": 0,
+      "maximum": 1
+    },
     "leads": {
       "type": "number",
       "description": "Leads generated (convenience alias for by_event_type where event_type='lead')",

--- a/static/schemas/source/enums/available-metric.json
+++ b/static/schemas/source/enums/available-metric.json
@@ -15,6 +15,7 @@
     "conversion_value",
     "roas",
     "cost_per_acquisition",
+    "new_to_brand_rate",
     "viewability",
     "engagement_rate"
   ]

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -94,6 +94,22 @@
           "description": "Total conversion value across all media buys (if applicable)",
           "minimum": 0
         },
+        "roas": {
+          "type": "number",
+          "description": "Aggregate return on ad spend across all media buys (total conversion_value / total spend)",
+          "minimum": 0
+        },
+        "new_to_brand_rate": {
+          "type": "number",
+          "description": "Fraction of total conversions across all media buys from first-time brand buyers (weighted by conversion volume, not a simple average of per-buy rates)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "cost_per_acquisition": {
+          "type": "number",
+          "description": "Aggregate cost per conversion across all media buys (total spend / total conversions)",
+          "minimum": 0
+        },
         "media_buy_count": {
           "type": "integer",
           "description": "Number of media buys included in the response",
@@ -262,6 +278,17 @@
                   "type": "number",
                   "description": "Daily conversion value",
                   "minimum": 0
+                },
+                "roas": {
+                  "type": "number",
+                  "description": "Daily return on ad spend (conversion_value / spend)",
+                  "minimum": 0
+                },
+                "new_to_brand_rate": {
+                  "type": "number",
+                  "description": "Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)",
+                  "minimum": 0,
+                  "maximum": 1
                 }
               },
               "required": [


### PR DESCRIPTION
## Summary

- Adds `new_to_brand_rate` to `DeliveryMetrics` schema and `available-metric` enum
- Surfaces `roas` and `new_to_brand_rate` in `aggregated_totals` and `daily_breakdown` of the delivery response
- Updates delivery documentation with commerce attribution metric definitions and availability

Closes #1008

## Context

The delivery schema already had `conversions`, `conversion_value`, `roas`, and `cost_per_acquisition` as first-class fields in `DeliveryMetrics`. The missing piece was `new_to_brand_rate` — a universal commerce metric reported by Amazon, Walmart, Moloco, and others. Additionally, `roas` and the commerce metrics weren't surfaced in `aggregated_totals` or `daily_breakdown`, making cross-platform comparison harder.

## Test plan

- [x] Schema validation tests pass (269 schemas)
- [x] Example validation tests pass
- [x] TypeScript typecheck passes
- [x] All 293 unit tests pass
- [x] Pre-commit hooks pass (includes full test suite + Mintlify link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)