### PR TITLE
feat(schema): Add minItems: 1 to request-side arrays

### DIFF
--- a/.changeset/long-melons-rush.md
+++ b/.changeset/long-melons-rush.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add minItems: 1 to request-side arrays where empty arrays are semantically invalid. Formalizes the rule that if you include an optional array field, provide at least one value. Response arrays and replacement-semantic arrays (where [] means "clear all") are unchanged.

--- a/static/schemas/source/content-standards/content-standards.json
+++ b/static/schemas/source/content-standards/content-standards.json
@@ -16,11 +16,13 @@
     "countries_all": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "ISO 3166-1 alpha-2 country codes. Standards apply in ALL listed countries (AND logic)."
     },
     "channels_any": {
       "type": "array",
       "items": { "$ref": "/schemas/enums/channels.json" },
+      "minItems": 1,
       "description": "Advertising channels. Standards apply to ANY of the listed channels (OR logic)."
     },
     "languages_any": {

--- a/static/schemas/source/content-standards/create-content-standards-request.json
+++ b/static/schemas/source/content-standards/create-content-standards-request.json
@@ -12,11 +12,13 @@
         "countries_all": {
           "type": "array",
           "items": { "type": "string" },
+          "minItems": 1,
           "description": "ISO 3166-1 alpha-2 country codes. Standards apply in ALL listed countries (AND logic)."
         },
         "channels_any": {
           "type": "array",
           "items": { "$ref": "/schemas/enums/channels.json" },
+          "minItems": 1,
           "description": "Advertising channels. Standards apply to ANY of the listed channels (OR logic)."
         },
         "languages_any": {

--- a/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
+++ b/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
@@ -16,6 +16,7 @@
     "package_ids": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "Filter to specific packages within the media buy"
     },
     "sampling": {

--- a/static/schemas/source/content-standards/list-content-standards-request.json
+++ b/static/schemas/source/content-standards/list-content-standards-request.json
@@ -8,16 +8,19 @@
     "channels": {
       "type": "array",
       "items": { "$ref": "/schemas/enums/channels.json" },
+      "minItems": 1,
       "description": "Filter by channel"
     },
     "languages": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "Filter by BCP 47 language tags"
     },
     "countries": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "Filter by ISO 3166-1 alpha-2 country codes"
     },
     "pagination": {

--- a/static/schemas/source/content-standards/update-content-standards-request.json
+++ b/static/schemas/source/content-standards/update-content-standards-request.json
@@ -16,11 +16,13 @@
         "countries_all": {
           "type": "array",
           "items": { "type": "string" },
+          "minItems": 1,
           "description": "ISO 3166-1 alpha-2 country codes. Standards apply in ALL listed countries (AND logic)."
         },
         "channels_any": {
           "type": "array",
           "items": { "$ref": "/schemas/enums/channels.json" },
+          "minItems": 1,
           "description": "Advertising channels. Standards apply to ANY of the listed channels (OR logic)."
         },
         "languages_any": {

--- a/static/schemas/source/content-standards/validate-content-delivery-request.json
+++ b/static/schemas/source/content-standards/validate-content-delivery-request.json
@@ -12,6 +12,7 @@
     "records": {
       "type": "array",
       "description": "Delivery records to validate (max 10,000)",
+      "minItems": 1,
       "maxItems": 10000,
       "items": {
         "type": "object",
@@ -62,6 +63,7 @@
     "feature_ids": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "Specific features to evaluate (defaults to all)"
     },
     "include_passed": {

--- a/static/schemas/source/core/creative-filters.json
+++ b/static/schemas/source/core/creative-filters.json
@@ -10,35 +10,40 @@
       "description": "Filter creatives by owning accounts. Useful for agencies managing multiple client accounts.",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "formats": {
       "type": "array",
       "description": "Filter by creative format types (e.g., video, audio, display)",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "statuses": {
       "type": "array",
       "description": "Filter by creative approval statuses",
       "items": {
         "$ref": "/schemas/enums/creative-status.json"
-      }
+      },
+      "minItems": 1
     },
     "tags": {
       "type": "array",
       "description": "Filter by creative tags (all tags must match)",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "tags_any": {
       "type": "array",
       "description": "Filter by creative tags (any tag must match)",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "name_contains": {
       "type": "string",
@@ -50,6 +55,7 @@
       "items": {
         "type": "string"
       },
+      "minItems": 1,
       "maxItems": 100
     },
     "created_after": {
@@ -77,21 +83,24 @@
       "description": "Filter creatives assigned to any of these packages",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "media_buy_ids": {
       "type": "array",
       "description": "Filter creatives assigned to any of these media buys",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "buyer_refs": {
       "type": "array",
       "description": "Filter creatives assigned to media buys with any of these buyer references",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "unassigned": {
       "type": "boolean",

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -17,14 +17,16 @@
       "description": "Filter by format types",
       "items": {
         "$ref": "/schemas/enums/format-category.json"
-      }
+      },
+      "minItems": 1
     },
     "format_ids": {
       "type": "array",
       "description": "Filter by specific format IDs",
       "items": {
         "$ref": "/schemas/core/format-id.json"
-      }
+      },
+      "minItems": 1
     },
     "standard_formats_only": {
       "type": "boolean",
@@ -88,7 +90,8 @@
       "items": {
         "type": "string",
         "pattern": "^[A-Z]{2}$"
-      }
+      },
+      "minItems": 1
     },
     "regions": {
       "type": "array",
@@ -96,7 +99,8 @@
       "items": {
         "type": "string",
         "pattern": "^[A-Z]{2}-[A-Z0-9]+$"
-      }
+      },
+      "minItems": 1
     },
     "metros": {
       "type": "array",
@@ -115,14 +119,16 @@
         },
         "required": ["system", "code"],
         "additionalProperties": false
-      }
+      },
+      "minItems": 1
     },
     "channels": {
       "type": "array",
       "description": "Filter by advertising channels (e.g., ['display', 'ctv', 'dooh'])",
       "items": {
         "$ref": "/schemas/enums/channels.json"
-      }
+      },
+      "minItems": 1
     },
     "required_axe_integrations": {
       "type": "array",
@@ -130,7 +136,8 @@
       "items": {
         "type": "string",
         "format": "uri"
-      }
+      },
+      "minItems": 1
     },
     "required_features": {
       "$ref": "/schemas/core/media-buy-features.json",
@@ -153,14 +160,16 @@
         },
         "required": ["level"],
         "additionalProperties": false
-      }
+      },
+      "minItems": 1
     },
     "signal_targeting": {
       "type": "array",
       "description": "Filter to products supporting specific signals from data provider catalogs. Products must have the requested signals in their data_provider_signals and signal_targeting_allowed must be true (or all signals requested).",
       "items": {
         "$ref": "/schemas/core/signal-targeting.json"
-      }
+      },
+      "minItems": 1
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/core/signal-filters.json
+++ b/static/schemas/source/core/signal-filters.json
@@ -10,14 +10,16 @@
       "description": "Filter by catalog type",
       "items": {
         "$ref": "/schemas/enums/signal-catalog-type.json"
-      }
+      },
+      "minItems": 1
     },
     "data_providers": {
       "type": "array",
       "description": "Filter by specific data providers",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "max_cpm": {
       "type": "number",

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -172,7 +172,8 @@
           "description": "Accepted verification methods. If omitted, any method the platform supports is acceptable.",
           "items": {
             "$ref": "/schemas/enums/age-verification-method.json"
-          }
+          },
+          "minItems": 1
         }
       },
       "required": ["min"],

--- a/static/schemas/source/core/tasks-list-request.json
+++ b/static/schemas/source/core/tasks-list-request.json
@@ -18,7 +18,8 @@
           "description": "Filter by multiple AdCP domains",
           "items": {
             "$ref": "/schemas/enums/adcp-domain.json"
-          }
+          },
+          "minItems": 1
         },
         "status": {
           "$ref": "/schemas/enums/task-status.json",
@@ -29,7 +30,8 @@
           "description": "Filter by multiple task statuses",
           "items": {
             "$ref": "/schemas/enums/task-status.json"
-          }
+          },
+          "minItems": 1
         },
         "task_type": {
           "$ref": "/schemas/enums/task-type.json",
@@ -40,7 +42,8 @@
           "description": "Filter by multiple task types",
           "items": {
             "$ref": "/schemas/enums/task-type.json"
-          }
+          },
+          "minItems": 1
         },
         "created_after": {
           "type": "string",
@@ -68,6 +71,7 @@
           "items": {
             "type": "string"
           },
+          "minItems": 1,
           "maxItems": 100
         },
         "context_contains": {

--- a/static/schemas/source/creative/list-creative-formats-request.json
+++ b/static/schemas/source/creative/list-creative-formats-request.json
@@ -10,7 +10,8 @@
       "description": "Return only these specific format IDs",
       "items": {
         "$ref": "/schemas/core/format-id.json"
-      }
+      },
+      "minItems": 1
     },
     "type": {
       "type": "string",
@@ -36,7 +37,8 @@
           "javascript",
           "url"
         ]
-      }
+      },
+      "minItems": 1
     },
     "max_width": {
       "type": "integer",

--- a/static/schemas/source/creative/preview-creative-request.json
+++ b/static/schemas/source/creative/preview-creative-request.json
@@ -47,7 +47,8 @@
               "name"
             ],
             "additionalProperties": true
-          }
+          },
+          "minItems": 1
         },
         "template_id": {
           "type": "string",
@@ -120,7 +121,8 @@
                     "name"
                   ],
                   "additionalProperties": true
-                }
+                },
+                "minItems": 1
               },
               "template_id": {
                 "type": "string",

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -42,7 +42,8 @@
       "description": "Array of package configurations. Required when not using proposal_id. When executing a proposal, this can be omitted and packages will be derived from the proposal's allocations.",
       "items": {
         "$ref": "/schemas/media-buy/package-request.json"
-      }
+      },
+      "minItems": 1
     },
     "brand_manifest": {
       "$ref": "/schemas/core/brand-manifest-ref.json",

--- a/static/schemas/source/media-buy/get-media-buy-delivery-request.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-request.json
@@ -14,14 +14,16 @@
       "description": "Array of publisher media buy IDs to get delivery data for",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "buyer_refs": {
       "type": "array",
       "description": "Array of buyer reference IDs to get delivery data for",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "status_filter": {
       "oneOf": [
@@ -32,7 +34,8 @@
           "type": "array",
           "items": {
             "$ref": "/schemas/enums/media-buy-status.json"
-          }
+          },
+          "minItems": 1
         }
       ],
       "description": "Filter by status. Can be a single status or array of statuses"

--- a/static/schemas/source/media-buy/list-creative-formats-request.json
+++ b/static/schemas/source/media-buy/list-creative-formats-request.json
@@ -10,7 +10,8 @@
       "description": "Return only these specific format IDs (e.g., from get_products response)",
       "items": {
         "$ref": "/schemas/core/format-id.json"
-      }
+      },
+      "minItems": 1
     },
     "type": {
       "$ref": "/schemas/enums/format-category.json",
@@ -21,7 +22,8 @@
       "description": "Filter to formats that include these asset types. For third-party tags, search for 'html' or 'javascript'. E.g., ['image', 'text'] returns formats with images and text, ['javascript'] returns formats accepting JavaScript tags.",
       "items": {
         "$ref": "/schemas/enums/asset-content-type.json"
-      }
+      },
+      "minItems": 1
     },
     "max_width": {
       "type": "integer",

--- a/static/schemas/source/media-buy/list-creatives-request.json
+++ b/static/schemas/source/media-buy/list-creatives-request.json
@@ -46,6 +46,7 @@
     "fields": {
       "type": "array",
       "description": "Specific fields to include in response (omit for all fields)",
+      "minItems": 1,
       "items": {
         "type": "string",
         "enum": [

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -56,7 +56,8 @@
       "description": "Assign existing library creatives to this package with optional weights and placement targeting",
       "items": {
         "$ref": "/schemas/core/creative-assignment.json"
-      }
+      },
+      "minItems": 1
     },
     "creatives": {
       "type": "array",
@@ -64,6 +65,7 @@
       "items": {
         "$ref": "/schemas/core/creative-asset.json"
       },
+      "minItems": 1,
       "maxItems": 100
     },
     "ext": {

--- a/static/schemas/source/media-buy/package-update.json
+++ b/static/schemas/source/media-buy/package-update.json
@@ -51,6 +51,7 @@
       "items": {
         "$ref": "/schemas/core/creative-asset.json"
       },
+      "minItems": 1,
       "maxItems": 100
     },
     "ext": {

--- a/static/schemas/source/media-buy/sync-creatives-request.json
+++ b/static/schemas/source/media-buy/sync-creatives-request.json
@@ -15,6 +15,7 @@
       "items": {
         "$ref": "/schemas/core/creative-asset.json"
       },
+      "minItems": 1,
       "maxItems": 100
     },
     "creative_ids": {
@@ -23,6 +24,7 @@
       "items": {
         "type": "string"
       },
+      "minItems": 1,
       "maxItems": 100
     },
     "assignments": {

--- a/static/schemas/source/media-buy/sync-event-sources-request.json
+++ b/static/schemas/source/media-buy/sync-event-sources-request.json
@@ -12,6 +12,7 @@
     "event_sources": {
       "type": "array",
       "description": "Event sources to sync (create or update). When omitted, the call is discovery-only and returns all existing event sources on the account without modification.",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
@@ -28,14 +29,16 @@
             "description": "Event types this source handles (e.g. purchase, lead). If omitted, accepts all event types.",
             "items": {
               "$ref": "/schemas/enums/event-type.json"
-            }
+            },
+            "minItems": 1
           },
           "allowed_domains": {
             "type": "array",
             "description": "Domains authorized to send events for this event source",
             "items": {
               "type": "string"
-            }
+            },
+            "minItems": 1
           }
         },
         "required": [

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -30,7 +30,8 @@
       "description": "Package-specific updates",
       "items": {
         "$ref": "/schemas/media-buy/package-update.json"
-      }
+      },
+      "minItems": 1
     },
     "reporting_webhook": {
       "$ref": "/schemas/core/reporting-webhook.json",

--- a/static/schemas/source/property/create-property-list-request.json
+++ b/static/schemas/source/property/create-property-list-request.json
@@ -18,7 +18,8 @@
       "description": "Array of property sources to evaluate. Each entry is a discriminated union: publisher_tags (publisher_domain + tags), publisher_ids (publisher_domain + property_ids), or identifiers (direct identifiers). If omitted, queries the agent's entire property database.",
       "items": {
         "$ref": "/schemas/property/base-property-source.json"
-      }
+      },
+      "minItems": 1
     },
     "filters": {
       "$ref": "/schemas/property/property-list-filters.json",

--- a/static/schemas/source/property/feature-requirement.json
+++ b/static/schemas/source/property/feature-requirement.json
@@ -20,7 +20,8 @@
     "allowed_values": {
       "type": "array",
       "description": "Values that pass the requirement (for binary/categorical features)",
-      "items": {}
+      "items": {},
+      "minItems": 1
     },
     "if_not_covered": {
       "type": "string",

--- a/static/schemas/source/property/get-property-features-request.json
+++ b/static/schemas/source/property/get-property-features-request.json
@@ -31,21 +31,24 @@
       "description": "Filter to specific property types (e.g., 'website', 'mobile_app', 'ctv_app'). Only applies when using publisher_domain.",
       "items": {
         "$ref": "/schemas/enums/property-type.json"
-      }
+      },
+      "minItems": 1
     },
     "property_tags": {
       "type": "array",
       "description": "Filter to properties with these tags. Only applies when using publisher_domain.",
       "items": {
         "$ref": "/schemas/core/property-tag.json"
-      }
+      },
+      "minItems": 1
     },
     "feature_ids": {
       "type": "array",
       "description": "Optional filter to specific features. If omitted, returns all available features.",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "context": {
       "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/property/property-list-filters.json
+++ b/static/schemas/source/property/property-list-filters.json
@@ -11,35 +11,40 @@
       "items": {
         "type": "string",
         "pattern": "^[A-Z]{2}$"
-      }
+      },
+      "minItems": 1
     },
     "channels_any": {
       "type": "array",
       "description": "Property must support ANY of the listed channels. Required.",
       "items": {
         "$ref": "/schemas/enums/channels.json"
-      }
+      },
+      "minItems": 1
     },
     "property_types": {
       "type": "array",
       "description": "Filter to these property types",
       "items": {
         "$ref": "/schemas/enums/property-type.json"
-      }
+      },
+      "minItems": 1
     },
     "feature_requirements": {
       "type": "array",
       "description": "Feature-based requirements. Property must pass ALL requirements (AND logic).",
       "items": {
         "$ref": "/schemas/property/feature-requirement.json"
-      }
+      },
+      "minItems": 1
     },
     "exclude_identifiers": {
       "type": "array",
       "description": "Identifiers to always exclude from results",
       "items": {
         "$ref": "/schemas/core/identifier.json"
-      }
+      },
+      "minItems": 1
     }
   },
   "required": ["countries_all", "channels_any"],

--- a/static/schemas/source/protocol/get-adcp-capabilities-request.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-request.json
@@ -11,7 +11,8 @@
       "items": {
         "type": "string",
         "enum": ["media_buy", "signals", "governance", "sponsored_intelligence", "creative"]
-      }
+      },
+      "minItems": 1
     },
     "context": {
       "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/signals/get-signals-request.json
+++ b/static/schemas/source/signals/get-signals-request.json
@@ -35,7 +35,8 @@
           "items": {
             "type": "string",
             "pattern": "^[A-Z]{2}$"
-          }
+          },
+          "minItems": 1
         }
       },
       "required": [

--- a/tests/extension-fields.test.cjs
+++ b/tests/extension-fields.test.cjs
@@ -376,7 +376,7 @@ async function runTests() {
 
     const request = {
       buyer_ref: 'buyer_ref_123',
-      packages: [],
+      packages: [{ buyer_ref: 'pkg_1', product_id: 'prod_1', budget: 1000, pricing_option_id: 'cpm_fixed' }],
       brand_manifest: {
         name: 'Test Brand'
       },
@@ -465,7 +465,7 @@ async function runTests() {
 
     const request = {
       buyer_ref: 'buyer_ref_123',
-      packages: [],
+      packages: [{ buyer_ref: 'pkg_1', product_id: 'prod_1', budget: 1000, pricing_option_id: 'cpm_fixed' }],
       brand_manifest: {
         name: 'Test Brand'
       },
@@ -494,7 +494,7 @@ async function runTests() {
 
     const request = {
       buyer_ref: 'buyer_ref_123',
-      packages: [],
+      packages: [{ buyer_ref: 'pkg_1', product_id: 'prod_1', budget: 1000, pricing_option_id: 'cpm_fixed' }],
       brand_manifest: {
         name: 'Test Brand'
       },
@@ -522,7 +522,7 @@ async function runTests() {
 
     const request = {
       buyer_ref: 'buyer_ref_123',
-      packages: [],
+      packages: [{ buyer_ref: 'pkg_1', product_id: 'prod_1', budget: 1000, pricing_option_id: 'cpm_fixed' }],
       brand_manifest: {
         name: 'Test Brand'
       },


### PR DESCRIPTION
## Summary
- Adds `minItems: 1` to ~65 request-side arrays across 28 schema files where empty arrays are semantically invalid
- Formalizes the rule: if you include an optional array field, provide at least one value
- Replacement-semantic arrays (where `[]` means "clear all"), calibration exemplars, and response arrays are unchanged

Closes #1018

## Rule

| Array type | `minItems: 1`? | Rationale |
|---|---|---|
| Filter arrays | Yes | `[]` is meaningless — omit the field to not filter |
| Input/payload arrays | Yes | If you include the field, provide at least one value |
| Replacement-semantic arrays | No | `[]` means "clear all" — a valid operation |
| Calibration exemplars | No | Empty = "no examples" is valid |
| Response arrays | No | Empty results are valid |

## Files changed

- **Filter schemas** (4 files): `creative-filters`, `product-filters`, `signal-filters`, `property-list-filters`
- **Content standards** (6 files): `content-standards`, `create/update/list-content-standards-request`, `get-media-buy-artifacts-request`, `validate-content-delivery-request`
- **Creative** (2 files): `list-creative-formats-request`, `preview-creative-request`
- **Media buy** (8 files): `create/update-media-buy-request`, `get-media-buy-delivery-request`, `list-creative-formats-request`, `list-creatives-request`, `package-request`, `package-update`, `sync-creatives-request`, `sync-event-sources-request`
- **Property** (3 files): `create-property-list-request`, `feature-requirement`, `get-property-features-request`
- **Core** (2 files): `targeting`, `tasks-list-request`
- **Protocol** (1 file): `get-adcp-capabilities-request`
- **Signals** (1 file): `get-signals-request`
- **Tests** (1 file): Updated `extension-fields.test.cjs` fixtures to use valid non-empty package arrays

## Explicitly skipped
- `package-update.json` → `creative_assignments` (replacement semantics)
- `update-property-list-request.json` → `base_properties` (replacement semantics)
- `content-standards` → `calibration_exemplars.pass/fail` (empty exemplar list is valid)

## Test plan
- [x] All 293 tests pass
- [x] Schema build succeeds
- [x] TypeScript typecheck passes
- [x] Pre-push hooks pass (broken links, accessibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)