### PR TITLE
Add attribution window metadata to delivery response

### DIFF
--- a/.changeset/attribution-window.md
+++ b/.changeset/attribution-window.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add attribution window metadata to delivery response. The response root now includes an optional `attribution_window` object describing `click_window_days`, `view_window_days`, and attribution `model` (last_touch, first_touch, linear, time_decay, data_driven). Placed at response level since all media buys from a single seller share the same attribution methodology. Enables cross-platform comparison of conversion metrics.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -32,6 +32,7 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 |-------|-------------|
 | `reporting_period` | Date range for report (start/end timestamps) |
 | `currency` | ISO 4217 currency code (USD, EUR, GBP, etc.) |
+| `attribution_window` | Attribution methodology: `click_window_days`, `view_window_days`, and `model` (last_touch, first_touch, linear, time_decay, data_driven) |
 | `aggregated_totals` | Combined metrics across all media buys (impressions, spend, clicks, video_completions, conversions, conversion_value, roas, new_to_brand_rate, cost_per_acquisition, media_buy_count) |
 | `media_buy_deliveries` | Array of delivery data per media buy |
 
@@ -508,6 +509,7 @@ asyncio.run(main())
 - **Universal**: Impressions, spend (available on all platforms)
 - **Format-dependent**: Clicks, video completions (depends on inventory type and platform capabilities)
 - **Commerce attribution**: Conversions, conversion_value, roas, new_to_brand_rate (available on commerce media platforms)
+- **Attribution window**: `attribution_window` describes the lookback windows and model used for conversion attribution (e.g., 14-day click, 1-day view, last_touch)
 - **Package-level**: All metrics broken down by package with pacing_index
 
 ## Data Freshness

--- a/static/schemas/source/core/attribution-window.json
+++ b/static/schemas/source/core/attribution-window.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/attribution-window.json",
+  "title": "Attribution Window",
+  "description": "Describes the attribution methodology and lookback windows used for conversion measurement. Enables cross-platform comparison by making attribution methodology transparent.",
+  "type": "object",
+  "properties": {
+    "click_window_days": {
+      "type": "integer",
+      "description": "Click-through attribution window in days. Conversions occurring within this many days after a click are attributed to the ad.",
+      "minimum": 0
+    },
+    "view_window_days": {
+      "type": "integer",
+      "description": "View-through attribution window in days. Conversions occurring within this many days after an ad impression (without click) are attributed to the ad.",
+      "minimum": 0
+    },
+    "model": {
+      "$ref": "/schemas/enums/attribution-model.json",
+      "description": "Attribution model used to assign credit when multiple touchpoints exist"
+    }
+  },
+  "required": ["model"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/enums/attribution-model.json
+++ b/static/schemas/source/enums/attribution-model.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/attribution-model.json",
+  "title": "Attribution Model",
+  "description": "Attribution model used for conversion measurement",
+  "type": "string",
+  "enum": [
+    "last_touch",
+    "first_touch",
+    "linear",
+    "time_decay",
+    "data_driven"
+  ]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -225,6 +225,10 @@
         "event-custom-data": {
           "$ref": "/schemas/core/event-custom-data.json",
           "description": "Event-specific data for attribution and reporting"
+        },
+        "attribution-window": {
+          "$ref": "/schemas/core/attribution-window.json",
+          "description": "Attribution methodology and lookback windows for conversion measurement"
         }
       },
       "requirements": {
@@ -511,6 +515,10 @@
         "action-source": {
           "$ref": "/schemas/enums/action-source.json",
           "description": "Where the conversion event originated (website, app, offline, etc.)"
+        },
+        "attribution-model": {
+          "$ref": "/schemas/enums/attribution-model.json",
+          "description": "Attribution model used for conversion measurement"
         },
         "wcag-level": {
           "$ref": "/schemas/enums/wcag-level.json",

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -60,6 +60,10 @@
       "description": "ISO 4217 currency code",
       "pattern": "^[A-Z]{3}$"
     },
+    "attribution_window": {
+      "$ref": "/schemas/core/attribution-window.json",
+      "description": "Attribution methodology and lookback windows used for conversion metrics in this response. All media buys from a single seller share the same attribution methodology. Enables cross-platform comparison (e.g., Amazon 14-day click vs. Criteo 30-day click)."
+    },
     "aggregated_totals": {
       "type": "object",
       "description": "Combined metrics across all returned media buys. Only included in API responses (get_media_buy_delivery), not in webhook notifications.",


### PR DESCRIPTION
## Summary

Add optional `attribution_window` object to the `get_media_buy_delivery` response. Placed at response root level (sibling to `currency`), describing how conversions were attributed across all media buys. Includes `click_window_days`, `view_window_days`, and attribution `model` (last_touch, first_touch, linear, time_decay, data_driven).

## Problem

When comparing conversion metrics across platforms, agents cannot programmatically determine the attribution methodology behind the numbers. A ROAS of 4.2 on Amazon (14-day click) is not directly comparable to 2.8 on Criteo (30-day click, 1-day view).

## Solution

Declares attribution metadata alongside metrics so agents can contextualize cross-platform comparisons.

## Implementation

- New enum schema: `attribution-model` 
- New core schema: `attribution-window` with integer day fields and required model field
- Updated delivery response to include optional `attribution_window` at root
- Updated documentation with examples

Fixes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)