### PR TITLE
fix(addie): Pass conversation history in emoji reaction handler

### DIFF
--- a/.changeset/calm-deserts-share.md
+++ b/.changeset/calm-deserts-share.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix emoji reaction handler to include conversation history when processing confirmations.


### PR DESCRIPTION
## Summary
- The `handleReactionAdded` handler was calling `processMessage` with `undefined` for conversation history, while every other handler (DM, mention, thread) passes the full history
- Without context, Claude didn't know what the user was confirming via emoji, leading to unrelated responses (e.g. CES 2026 info when confirming a membership update)
- Adds the same conversation history loading pattern used by all other handlers

## Test plan
- [ ] Add emoji reaction to an Addie confirmation prompt — verify Addie responds in context
- [ ] Add emoji reaction to a non-confirmation Addie message — verify feedback-only behavior unchanged
- [ ] Verify no regressions in DM, mention, and thread handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)