### PR TITLE
Replace Coke/Publicis examples with fictional brands

### DIFF
--- a/.changeset/replace-brand-examples.md
+++ b/.changeset/replace-brand-examples.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Replace Coke/Publicis examples with fictional brands (Acme Corp, Pinnacle Media, Nova Brands) and add CLAUDE.md rule against using real brand names in examples.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ This project uses **Mintlify** for documentation:
 - ✅ **AdCP** - the protocol specification
 - ❌ Never "Alliance for Agentic Advertising", "AAO", or "ADCP"
 
+### Examples: No Real Brands or Agencies
+- ❌ Never use real company names (brands, agencies, holding companies) in new examples
+- ✅ Use fictional names: Acme Corp, Pinnacle Media, Nova Brands, etc.
+- The brand seed data in migrations may list real domains for discovery purposes
+- Enum values that reference industry standards (e.g., `"groupm"` viewability standard) are protocol terms, not examples
+
 ### Schema Compliance
 All documentation and examples MUST match JSON schemas in `static/schemas/v1/`:
 - Verify fields exist in schema before documenting

--- a/dist/schemas/3.0.0-beta.2/account/list-accounts-response.json
+++ b/dist/schemas/3.0.0-beta.2/account/list-accounts-response.json
@@ -34,23 +34,23 @@
       "data": {
         "accounts": [
           {
-            "account_id": "acc_coke_publicis",
-            "name": "Coke c/o Publicis",
-            "advertiser": "The Coca-Cola Company",
-            "billing_proxy": "Publicis Media",
+            "account_id": "acc_acme_pinnacle",
+            "name": "Acme c/o Pinnacle",
+            "advertiser": "Acme Corp",
+            "billing_proxy": "Pinnacle Media",
             "status": "active"
           },
           {
-            "account_id": "acc_pepsi_publicis",
-            "name": "Pepsi c/o Publicis",
-            "advertiser": "PepsiCo",
-            "billing_proxy": "Publicis Media",
+            "account_id": "acc_nova_pinnacle",
+            "name": "Nova c/o Pinnacle",
+            "advertiser": "Nova Brands",
+            "billing_proxy": "Pinnacle Media",
             "status": "active"
           },
           {
-            "account_id": "acc_publicis",
-            "name": "Publicis",
-            "advertiser": "Publicis Media",
+            "account_id": "acc_pinnacle",
+            "name": "Pinnacle",
+            "advertiser": "Pinnacle Media",
             "status": "active"
           }
         ]
@@ -61,11 +61,11 @@
       "data": {
         "accounts": [
           {
-            "account_id": "acc_coke_direct",
-            "name": "Coke",
-            "advertiser": "The Coca-Cola Company",
+            "account_id": "acc_acme_direct",
+            "name": "Acme",
+            "advertiser": "Acme Corp",
             "status": "active",
-            "rate_card": "coke_vip_2024"
+            "rate_card": "acme_vip_2024"
           }
         ]
       }

--- a/dist/schemas/3.0.0-beta.2/bundled/media-buy/create-media-buy-response.json
+++ b/dist/schemas/3.0.0-beta.2/bundled/media-buy/create-media-buy-response.json
@@ -29,7 +29,7 @@
             },
             "name": {
               "type": "string",
-              "description": "Human-readable account name (e.g., 'Coke', 'Coke c/o Publicis')"
+              "description": "Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')"
             },
             "advertiser": {
               "type": "string",
@@ -91,32 +91,32 @@
             {
               "description": "Direct advertiser account",
               "data": {
-                "account_id": "acc_coke_direct",
-                "name": "Coke",
-                "advertiser": "The Coca-Cola Company",
+                "account_id": "acc_acme_direct",
+                "name": "Acme",
+                "advertiser": "Acme Corp",
                 "status": "active",
-                "rate_card": "coke_vip_2024",
+                "rate_card": "acme_vip_2024",
                 "payment_terms": "net_30"
               }
             },
             {
               "description": "Advertiser account with agency billing proxy",
               "data": {
-                "account_id": "acc_coke_publicis",
-                "name": "Coke c/o Publicis",
-                "advertiser": "The Coca-Cola Company",
-                "billing_proxy": "Publicis Media",
+                "account_id": "acc_acme_pinnacle",
+                "name": "Acme c/o Pinnacle",
+                "advertiser": "Acme Corp",
+                "billing_proxy": "Pinnacle Media",
                 "status": "active",
-                "rate_card": "coke_vip_2024",
+                "rate_card": "acme_vip_2024",
                 "payment_terms": "net_60"
               }
             },
             {
               "description": "Agency as direct buyer",
               "data": {
-                "account_id": "acc_publicis",
-                "name": "Publicis",
-                "advertiser": "Publicis Media",
+                "account_id": "acc_pinnacle",
+                "name": "Pinnacle",
+                "advertiser": "Pinnacle Media",
                 "status": "active",
                 "rate_card": "agency_standard",
                 "payment_terms": "net_45"

--- a/dist/schemas/3.0.0-beta.2/bundled/media-buy/list-creatives-response.json
+++ b/dist/schemas/3.0.0-beta.2/bundled/media-buy/list-creatives-response.json
@@ -108,7 +108,7 @@
               },
               "name": {
                 "type": "string",
-                "description": "Human-readable account name (e.g., 'Coke', 'Coke c/o Publicis')"
+                "description": "Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')"
               },
               "advertiser": {
                 "type": "string",
@@ -170,32 +170,32 @@
               {
                 "description": "Direct advertiser account",
                 "data": {
-                  "account_id": "acc_coke_direct",
-                  "name": "Coke",
-                  "advertiser": "The Coca-Cola Company",
+                  "account_id": "acc_acme_direct",
+                  "name": "Acme",
+                  "advertiser": "Acme Corp",
                   "status": "active",
-                  "rate_card": "coke_vip_2024",
+                  "rate_card": "acme_vip_2024",
                   "payment_terms": "net_30"
                 }
               },
               {
                 "description": "Advertiser account with agency billing proxy",
                 "data": {
-                  "account_id": "acc_coke_publicis",
-                  "name": "Coke c/o Publicis",
-                  "advertiser": "The Coca-Cola Company",
-                  "billing_proxy": "Publicis Media",
+                  "account_id": "acc_acme_pinnacle",
+                  "name": "Acme c/o Pinnacle",
+                  "advertiser": "Acme Corp",
+                  "billing_proxy": "Pinnacle Media",
                   "status": "active",
-                  "rate_card": "coke_vip_2024",
+                  "rate_card": "acme_vip_2024",
                   "payment_terms": "net_60"
                 }
               },
               {
                 "description": "Agency as direct buyer",
                 "data": {
-                  "account_id": "acc_publicis",
-                  "name": "Publicis",
-                  "advertiser": "Publicis Media",
+                  "account_id": "acc_pinnacle",
+                  "name": "Pinnacle",
+                  "advertiser": "Pinnacle Media",
                   "status": "active",
                   "rate_card": "agency_standard",
                   "payment_terms": "net_45"

--- a/dist/schemas/3.0.0-beta.2/bundled/media-buy/sync-creatives-response.json
+++ b/dist/schemas/3.0.0-beta.2/bundled/media-buy/sync-creatives-response.json
@@ -35,7 +35,7 @@
                   },
                   "name": {
                     "type": "string",
-                    "description": "Human-readable account name (e.g., 'Coke', 'Coke c/o Publicis')"
+                    "description": "Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')"
                   },
                   "advertiser": {
                     "type": "string",
@@ -97,32 +97,32 @@
                   {
                     "description": "Direct advertiser account",
                     "data": {
-                      "account_id": "acc_coke_direct",
-                      "name": "Coke",
-                      "advertiser": "The Coca-Cola Company",
+                      "account_id": "acc_acme_direct",
+                      "name": "Acme",
+                      "advertiser": "Acme Corp",
                       "status": "active",
-                      "rate_card": "coke_vip_2024",
+                      "rate_card": "acme_vip_2024",
                       "payment_terms": "net_30"
                     }
                   },
                   {
                     "description": "Advertiser account with agency billing proxy",
                     "data": {
-                      "account_id": "acc_coke_publicis",
-                      "name": "Coke c/o Publicis",
-                      "advertiser": "The Coca-Cola Company",
-                      "billing_proxy": "Publicis Media",
+                      "account_id": "acc_acme_pinnacle",
+                      "name": "Acme c/o Pinnacle",
+                      "advertiser": "Acme Corp",
+                      "billing_proxy": "Pinnacle Media",
                       "status": "active",
-                      "rate_card": "coke_vip_2024",
+                      "rate_card": "acme_vip_2024",
                       "payment_terms": "net_60"
                     }
                   },
                   {
                     "description": "Agency as direct buyer",
                     "data": {
-                      "account_id": "acc_publicis",
-                      "name": "Publicis",
-                      "advertiser": "Publicis Media",
+                      "account_id": "acc_pinnacle",
+                      "name": "Pinnacle",
+                      "advertiser": "Pinnacle Media",
                       "status": "active",
                       "rate_card": "agency_standard",
                       "payment_terms": "net_45"

--- a/dist/schemas/3.0.0-beta.2/core/account.json
+++ b/dist/schemas/3.0.0-beta.2/core/account.json
@@ -11,7 +11,7 @@
     },
     "name": {
       "type": "string",
-      "description": "Human-readable account name (e.g., 'Coke', 'Coke c/o Publicis')"
+      "description": "Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')"
     },
     "advertiser": {
       "type": "string",
@@ -59,32 +59,32 @@
     {
       "description": "Direct advertiser account",
       "data": {
-        "account_id": "acc_coke_direct",
-        "name": "Coke",
-        "advertiser": "The Coca-Cola Company",
+        "account_id": "acc_acme_direct",
+        "name": "Acme",
+        "advertiser": "Acme Corp",
         "status": "active",
-        "rate_card": "coke_vip_2024",
+        "rate_card": "acme_vip_2024",
         "payment_terms": "net_30"
       }
     },
     {
       "description": "Advertiser account with agency billing proxy",
       "data": {
-        "account_id": "acc_coke_publicis",
-        "name": "Coke c/o Publicis",
-        "advertiser": "The Coca-Cola Company",
-        "billing_proxy": "Publicis Media",
+        "account_id": "acc_acme_pinnacle",
+        "name": "Acme c/o Pinnacle",
+        "advertiser": "Acme Corp",
+        "billing_proxy": "Pinnacle Media",
         "status": "active",
-        "rate_card": "coke_vip_2024",
+        "rate_card": "acme_vip_2024",
         "payment_terms": "net_60"
       }
     },
     {
       "description": "Agency as direct buyer",
       "data": {
-        "account_id": "acc_publicis",
-        "name": "Publicis",
-        "advertiser": "Publicis Media",
+        "account_id": "acc_pinnacle",
+        "name": "Pinnacle",
+        "advertiser": "Pinnacle Media",
         "status": "active",
         "rate_card": "agency_standard",
         "payment_terms": "net_45"

--- a/docs/building/integration/accounts-and-agents.mdx
+++ b/docs/building/integration/accounts-and-agents.mdx
@@ -20,7 +20,7 @@ The **brand** is the advertiser whose products or services are being promoted. B
 
 For example, Dove is identified as `house: "unilever.com"` + `brand_id: "dove"`. Any party can resolve `unilever.com/.well-known/brand.json` to verify Dove's identity, assets, and authorized operators.
 
-For single-brand houses like Coca-Cola, the house domain alone (`house: "coca-cola.com"`) identifies the brand — no `brand_id` is needed.
+For single-brand houses like Acme Corp, the house domain alone (`house: "acme-corp.com"`) identifies the brand — no `brand_id` is needed.
 
 Every billable operation requires a [brand manifest](/docs/creative/brand-manifest) that identifies the brand and provides context for ad serving.
 
@@ -53,11 +53,11 @@ Every account has a billing model that determines who gets invoiced:
 
 ### Examples
 
-**Brand buys direct** — Coca-Cola has their own account on the seller:
+**Brand buys direct** — Acme Corp has their own account on the seller:
 ```
 Billing: brand
-Invoice: Seller → Coca-Cola
-Rates: Coca-Cola's negotiated rates
+Invoice: Seller → Acme Corp
+Rates: Acme Corp's negotiated rates
 ```
 
 **Agency buys for brand, brand pays** — GroupM buys on Unilever's account:
@@ -160,7 +160,7 @@ Each account entry identifies the brand by house domain + brand_id, the operator
       "billing": "agent"
     },
     {
-      "house": "coca-cola.com",
+      "house": "acme-corp.com",
       "billing": "brand"
     }
   ]
@@ -174,7 +174,7 @@ Each account entry identifies the brand by house domain + brand_id, the operator
 | `operator` | No | Domain of the entity operating the seat. Omit if the brand operates its own seat. |
 | `billing` | No | Who should be invoiced: `brand`, `operator`, or `agent`. Omit to accept the seller's default. The seller returns the actual billing model in the sync_accounts response, so the agent always knows what was applied. |
 
-**Natural key:** The tuple `(house, brand_id, operator)` uniquely identifies an account relationship. Missing fields are distinct from present fields — `{house: "coca-cola.com"}` (brand buying direct) is a different account from `{house: "coca-cola.com", operator: "groupm.com"}` (brand via agency). The seller uses this natural key for upsert matching across sync calls.
+**Natural key:** The tuple `(house, brand_id, operator)` uniquely identifies an account relationship. Missing fields are distinct from present fields — `{house: "acme-corp.com"}` (brand buying direct) is a different account from `{house: "acme-corp.com", operator: "groupm.com"}` (brand via agency). The seller uses this natural key for upsert matching across sync calls.
 
 ### Response
 
@@ -195,14 +195,14 @@ The seller responds with per-account results. Each account has an action (what h
       "parent_account_id": "acc_agent_house"
     },
     {
-      "account_id": "acc_coke_pending",
-      "house": "coca-cola.com",
-      "name": "Coca-Cola",
+      "account_id": "acc_acme_pending",
+      "house": "acme-corp.com",
+      "name": "Acme Corp",
       "action": "created",
       "status": "pending_approval",
       "billing": "brand",
       "setup": {
-        "url": "https://seller.com/credit-app/coca-cola",
+        "url": "https://seller.com/credit-app/acme-corp",
         "message": "Credit application required for direct billing"
       }
     }
@@ -236,7 +236,7 @@ The seller may return a different `billing` value than the agent requested. For 
 ```json
 {
   "account_id": "acc_agent_house",
-  "house": "coca-cola.com",
+  "house": "acme-corp.com",
   "action": "created",
   "status": "active",
   "billing": "agent",
@@ -333,12 +333,12 @@ Returns accounts the authenticated agent can operate.
 {
   "accounts": [
     {
-      "account_id": "acc_coke_publicis",
-      "name": "Coke c/o Publicis",
-      "advertiser": "The Coca-Cola Company",
-      "billing_proxy": "Publicis Media",
+      "account_id": "acc_acme_pinnacle",
+      "name": "Acme c/o Pinnacle",
+      "advertiser": "Acme Corp",
+      "billing_proxy": "Pinnacle Media",
       "status": "active",
-      "house": "coca-cola.com",
+      "house": "acme-corp.com",
       "billing": "brand"
     },
     {
@@ -368,8 +368,8 @@ Every billable operation must include the brand manifest, either inline or as a 
 ```json
 {
   "brand_manifest": {
-    "url": "https://coca-cola.com",
-    "name": "Coca-Cola",
+    "url": "https://acme-corp.com",
+    "name": "Acme Corp",
     "colors": { "primary": "#F40009" }
   }
 }
@@ -379,7 +379,7 @@ Or as a URL to a hosted manifest:
 
 ```json
 {
-  "brand_manifest": "https://cdn.coca-cola.com/brand-manifest.json"
+  "brand_manifest": "https://cdn.acme-corp.com/brand-manifest.json"
 }
 ```
 
@@ -389,8 +389,8 @@ Every billable operation requires `account_id`. The agent gets this from `sync_a
 
 ```json
 {
-  "account_id": "acc_coke_publicis",
-  "brand_manifest": "https://cdn.coca-cola.com/brand-manifest.json"
+  "account_id": "acc_acme_pinnacle",
+  "brand_manifest": "https://cdn.acme-corp.com/brand-manifest.json"
 }
 ```
 
@@ -412,8 +412,8 @@ Returned when the seller cannot determine which account to use:
       "message": "Multiple accounts available. Please specify account_id.",
       "details": {
         "available_accounts": [
-          { "account_id": "acc_coke_publicis", "name": "Coke c/o Publicis" },
-          { "account_id": "acc_publicis", "name": "Publicis" }
+          { "account_id": "acc_acme_pinnacle", "name": "Acme c/o Pinnacle" },
+          { "account_id": "acc_pinnacle", "name": "Pinnacle" }
         ]
       }
     }
@@ -445,7 +445,7 @@ The account has reached its credit limit or run out of funds:
   "errors": [
     {
       "code": "PAYMENT_REQUIRED",
-      "message": "Account 'acc_coke_publicis' has reached its credit limit"
+      "message": "Account 'acc_acme_pinnacle' has reached its credit limit"
     }
   ]
 }
@@ -460,7 +460,7 @@ The account exists but is not in good standing:
   "errors": [
     {
       "code": "ACCOUNT_SUSPENDED",
-      "message": "Account 'acc_coke_publicis' is suspended"
+      "message": "Account 'acc_acme_pinnacle' is suspended"
     }
   ]
 }
@@ -485,14 +485,14 @@ Billable operation attempted without brand manifest:
 
 ### Scenario 1: Brand buying direct on a publisher
 
-Coca-Cola wants to buy inventory on a premium publisher. Their in-house team operates the seat directly.
+Acme Corp wants to buy inventory on a premium publisher. Their in-house team operates the seat directly.
 
 **Step 1**: Agent syncs the account:
 ```json
 {
   "task": "sync_accounts",
   "accounts": [{
-    "house": "coca-cola.com",
+    "house": "acme-corp.com",
     "billing": "brand"
   }]
 }
@@ -502,8 +502,8 @@ Coca-Cola wants to buy inventory on a premium publisher. Their in-house team ope
 ```json
 {
   "accounts": [{
-    "account_id": "acc_coke_001",
-    "house": "coca-cola.com",
+    "account_id": "acc_acme_001",
+    "house": "acme-corp.com",
     "action": "created",
     "status": "pending_approval",
     "billing": "brand",
@@ -515,12 +515,12 @@ Coca-Cola wants to buy inventory on a premium publisher. Their in-house team ope
 }
 ```
 
-**Step 3**: Human at Coca-Cola completes the setup at the URL. Agent polls `list_accounts` until the account becomes `active`.
+**Step 3**: Human at Acme Corp completes the setup at the URL. Agent polls `list_accounts` until the account becomes `active`.
 
 **Step 4**: Agent places buys using the account:
 ```json
 {
-  "account_id": "acc_coke_001",
+  "account_id": "acc_acme_001",
   "brand_manifest": { "..." : "..." },
   "campaign": { "..." : "..." }
 }
@@ -634,7 +634,7 @@ An agent requests direct billing for an advertiser, but the seller only supports
 {
   "task": "sync_accounts",
   "accounts": [{
-    "house": "coca-cola.com",
+    "house": "acme-corp.com",
     "billing": "brand"
   }]
 }
@@ -645,7 +645,7 @@ An agent requests direct billing for an advertiser, but the seller only supports
 {
   "accounts": [{
     "account_id": "acc_agent_house",
-    "house": "coca-cola.com",
+    "house": "acme-corp.com",
     "action": "created",
     "status": "active",
     "billing": "agent",

--- a/docs/media-buy/advanced-topics/accounts-and-security.mdx
+++ b/docs/media-buy/advanced-topics/accounts-and-security.mdx
@@ -21,10 +21,10 @@ See [Authentication](/docs/building/integration/authentication) for details on o
 
 AdCP distinguishes between:
 
-- **Agent**: The authenticated entity making API calls (e.g., `"publicis_trading_desk"`)
-- **Account**: The billing relationship for a media buy (e.g., `"coke_c/o_publicis"`)
+- **Agent**: The authenticated entity making API calls (e.g., `"pinnacle_trading_desk"`)
+- **Account**: The billing relationship for a media buy (e.g., `"acme_c/o_pinnacle"`)
 
-An agent may operate on multiple accounts. For example, an agency trading desk might manage accounts for Coke, Pepsi, and their own house account. See [Accounts and Agents](/docs/building/integration/accounts-and-agents) for details.
+An agent may operate on multiple accounts. For example, an agency trading desk might manage accounts for multiple advertisers and their own house account. See [Accounts and Agents](/docs/building/integration/accounts-and-agents) for details.
 
 ## Data Isolation
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -420,7 +420,7 @@ import { GetMediaBuyDeliveryResponseSchema } from '@adcp/client';
 
 // Get delivery for a specific advertiser account
 const result = await testAgent.getMediaBuyDelivery({
-  account_id: 'acc_coke_publicis',
+  account_id: 'acc_acme_pinnacle',
   status_filter: 'active',
   start_date: '2024-02-01',
   end_date: '2024-02-07'
@@ -449,7 +449,7 @@ async def main():
     # Get delivery for a specific advertiser account
     result = await test_agent.get_media_buy_delivery(
         GetMediaBuyDeliveryRequest(
-            account_id='acc_coke_publicis',
+            account_id='acc_acme_pinnacle',
             status_filter='active',
             start_date='2024-02-01',
             end_date='2024-02-07'

--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -27,7 +27,7 @@ export const BRAND_TOOLS: AddieTool[] = [
       properties: {
         domain: {
           type: 'string',
-          description: 'Domain to research (e.g., "nike.com", "coca-cola.com")',
+          description: 'Domain to research (e.g., "acme-corp.com", "example.com")',
         },
       },
       required: ['domain'],
@@ -42,7 +42,7 @@ export const BRAND_TOOLS: AddieTool[] = [
       properties: {
         domain: {
           type: 'string',
-          description: 'Domain to resolve (e.g., "jumpman23.com", "nike.com")',
+          description: 'Domain to resolve (e.g., "acme-corp.com", "example.com")',
         },
       },
       required: ['domain'],

--- a/server/src/db/slack-db.ts
+++ b/server/src/db/slack-db.ts
@@ -723,7 +723,7 @@ export class SlackDatabase {
    * Link unmapped Slack users with a specific email domain to an organization.
    * Sets the pending_organization_id field so they're associated with the prospect.
    *
-   * @param domain The email domain to match (e.g., "publicis.com")
+   * @param domain The email domain to match (e.g., "example.com")
    * @param organizationId The WorkOS organization ID to link users to
    * @returns Number of users linked and their details
    */

--- a/static/schemas/source/account/list-accounts-response.json
+++ b/static/schemas/source/account/list-accounts-response.json
@@ -37,23 +37,23 @@
       "data": {
         "accounts": [
           {
-            "account_id": "acc_coke_publicis",
-            "name": "Coke c/o Publicis",
-            "advertiser": "The Coca-Cola Company",
-            "billing_proxy": "Publicis Media",
+            "account_id": "acc_acme_pinnacle",
+            "name": "Acme c/o Pinnacle",
+            "advertiser": "Acme Corp",
+            "billing_proxy": "Pinnacle Media",
             "status": "active"
           },
           {
-            "account_id": "acc_pepsi_publicis",
-            "name": "Pepsi c/o Publicis",
-            "advertiser": "PepsiCo",
-            "billing_proxy": "Publicis Media",
+            "account_id": "acc_nova_pinnacle",
+            "name": "Nova c/o Pinnacle",
+            "advertiser": "Nova Brands",
+            "billing_proxy": "Pinnacle Media",
             "status": "active"
           },
           {
-            "account_id": "acc_publicis",
-            "name": "Publicis",
-            "advertiser": "Publicis Media",
+            "account_id": "acc_pinnacle",
+            "name": "Pinnacle",
+            "advertiser": "Pinnacle Media",
             "status": "active"
           }
         ],
@@ -68,11 +68,11 @@
       "data": {
         "accounts": [
           {
-            "account_id": "acc_coke_direct",
-            "name": "Coke",
-            "advertiser": "The Coca-Cola Company",
+            "account_id": "acc_acme_direct",
+            "name": "Acme",
+            "advertiser": "Acme Corp",
             "status": "active",
-            "rate_card": "coke_vip_2024"
+            "rate_card": "acme_vip_2024"
           }
         ]
       }

--- a/static/schemas/source/account/sync-accounts-request.json
+++ b/static/schemas/source/account/sync-accounts-request.json
@@ -14,7 +14,7 @@
         "properties": {
           "house": {
             "type": "string",
-            "description": "House domain where brand.json is hosted (e.g., 'unilever.com', 'coca-cola.com'). This is the canonical identity anchor for the brand, resolved via /.well-known/brand.json. For single-brand houses, this alone identifies the brand.",
+            "description": "House domain where brand.json is hosted (e.g., 'unilever.com', 'acme-corp.com'). This is the canonical identity anchor for the brand, resolved via /.well-known/brand.json. For single-brand houses, this alone identifies the brand.",
             "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
           },
           "brand_id": {
@@ -86,7 +86,7 @@
       "data": {
         "accounts": [
           {
-            "house": "coca-cola.com",
+            "house": "acme-corp.com",
             "billing": "brand"
           }
         ]

--- a/static/schemas/source/account/sync-accounts-response.json
+++ b/static/schemas/source/account/sync-accounts-response.json
@@ -197,8 +197,8 @@
         "accounts": [
           {
             "account_id": "acc_agent_house",
-            "house": "coca-cola.com",
-            "name": "Coca-Cola (via agent)",
+            "house": "acme-corp.com",
+            "name": "Acme Corp (via agent)",
             "action": "created",
             "status": "active",
             "billing": "agent",

--- a/static/schemas/source/core/account.json
+++ b/static/schemas/source/core/account.json
@@ -11,7 +11,7 @@
     },
     "name": {
       "type": "string",
-      "description": "Human-readable account name (e.g., 'Coke', 'Coke c/o Publicis')"
+      "description": "Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')"
     },
     "advertiser": {
       "type": "string",
@@ -79,32 +79,32 @@
     {
       "description": "Direct advertiser account",
       "data": {
-        "account_id": "acc_coke_direct",
-        "name": "Coke",
-        "advertiser": "The Coca-Cola Company",
+        "account_id": "acc_acme_direct",
+        "name": "Acme",
+        "advertiser": "Acme Corp",
         "status": "active",
-        "rate_card": "coke_vip_2024",
+        "rate_card": "acme_vip_2024",
         "payment_terms": "net_30"
       }
     },
     {
       "description": "Advertiser account with agency billing proxy",
       "data": {
-        "account_id": "acc_coke_publicis",
-        "name": "Coke c/o Publicis",
-        "advertiser": "The Coca-Cola Company",
-        "billing_proxy": "Publicis Media",
+        "account_id": "acc_acme_pinnacle",
+        "name": "Acme c/o Pinnacle",
+        "advertiser": "Acme Corp",
+        "billing_proxy": "Pinnacle Media",
         "status": "active",
-        "rate_card": "coke_vip_2024",
+        "rate_card": "acme_vip_2024",
         "payment_terms": "net_60"
       }
     },
     {
       "description": "Agency as direct buyer",
       "data": {
-        "account_id": "acc_publicis",
-        "name": "Publicis",
-        "advertiser": "Publicis Media",
+        "account_id": "acc_pinnacle",
+        "name": "Pinnacle",
+        "advertiser": "Pinnacle Media",
         "status": "active",
         "rate_card": "agency_standard",
         "payment_terms": "net_45"


### PR DESCRIPTION
## Summary

- Replace all Coca-Cola/Coke + Publicis brand/agency examples with fictional alternatives (Acme Corp, Pinnacle Media, Nova Brands) across schemas, docs, and server code
- Add CLAUDE.md rule: do not use real brand/agency names in new examples
- Clean up real brand references in tool descriptions (`brand-tools.ts`)

Triggered by Publicis requesting removal from protocol examples.

## Scope

This PR targets Coke + Publicis references specifically. Other real brands (Nike, Unilever, GroupM, etc.) remain in the codebase and can be addressed in follow-up PRs as needed.

## Files changed (16)

**Source schemas:** `list-accounts-response.json`, `sync-accounts-request.json`, `sync-accounts-response.json`, `core/account.json`
**Docs:** `accounts-and-agents.mdx`, `accounts-and-security.mdx`, `get_media_buy_delivery.mdx`  
**Server:** `brand-tools.ts`, `slack-db.ts`
**Dist schemas:** 5 bundled/versioned files
**Config:** `CLAUDE.md`, `.changeset/replace-brand-examples.md`

## Test plan

- [x] All 293 unit tests pass
- [x] Schema validation passes (examples validate against schemas)
- [x] TypeScript typecheck passes
- [x] No broken links in docs
- [x] Grep confirms zero remaining Publicis/Coke references (except brand seed data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)