### PR TITLE
docs: Update release notes and homepage for beta.3

### DIFF
--- a/.changeset/empty-ducks-press.md
+++ b/.changeset/empty-ducks-press.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update beta.3 release notes, homepage version, roadmap, and intro banner for beta.3 release.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -8,7 +8,7 @@ keywords: [advertising automation protocol, programmatic advertising API, MCP ad
 <Warning>
 **AdCP 3.0 Beta**
 
-You're viewing the v3 beta documentation. The API is stable for testing, but breaking changes may occur before final release. See [what's new in 3.0](/docs/reference/release-notes#version-300-beta2) and the [v3 migration guide](/docs/reference/migrating-to-v3). For production use, switch to version 2.5 using the version selector above.
+You're viewing the v3 beta documentation. The API is stable for testing, but breaking changes may occur before final release. See [what's new in 3.0](/docs/reference/release-notes#version-300-beta3) and the [v3 migration guide](/docs/reference/migrating-to-v3). For production use, switch to version 2.5 using the version selector above.
 </Warning>
 
 # Introduction to AdCP

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -11,25 +11,37 @@ High-level summaries of major AdCP releases with migration guidance. For detaile
 
 ## Version 3.0.0-beta.3
 
-**Status:** Upcoming | [Migration Guide](/docs/reference/migrating-to-v3)
+**Status:** Beta | [Migration Guide](/docs/reference/migrating-to-v3)
 
 ### What's New
 
-1. **Brand Protocol** - Brand discovery and identity resolution via `brand.json`. Four manifest variants (authoritative redirect, house redirect, brand agent, house portfolio) with builder tools, registry, and admin UI.
+1. **Delivery Forecasting** - Predict campaign performance before committing budget. New `DeliveryForecast` type with budget curves, forecast methods (estimate, modeled, guaranteed), daypart targeting windows, and GRP demographic notation. Forecasts attach to product allocations and proposals, enabling budget curve analysis across spend levels.
 
-2. **Conversion Tracking** - New events protocol with `sync_event_sources` and `log_event` tasks for attribution and measurement.
+2. **Brand Protocol** - Brand discovery and identity resolution via `brand.json`. Four manifest variants (authoritative redirect, house redirect, brand agent, house portfolio) with builder tools, registry, and admin UI. Brands declare `authorized_operators` to control which agents can represent them.
 
-3. **Signal Catalog** - Data providers become first-class members with signal definitions, categories, targeting schemas, and value types. New schemas for signal discovery and integration into products.
+3. **Account Management** - `sync_accounts` task lets agents declare brand portfolios to sellers with upsert semantics. Account capabilities in `get_adcp_capabilities` describe billing requirements and operator authorization. Three-party billing model (brand, operator, agent) with account lifecycle (active, pending_approval, payment_required, suspended, closed). `account_id` is optional on `create_media_buy` — single-account agents can omit it.
 
-4. **Cursor-Based Pagination** - All list operations (`list_creatives`, `tasks_list`, `list_property_lists`, `get_property_list`, `get_media_buy_artifacts`) standardized on cursor-based pagination with shared `pagination-request.json` and `pagination-response.json` schemas.
+4. **Commerce Media** - `product_selectors` on `get_products` for commerce product discovery. `manifest_gtins` on promoted products for cross-retailer GTIN matching. Commerce attribution metrics (`roas`, `new_to_brand_rate`) in delivery response aggregated totals and daily breakdown. See the [Commerce Media Guide](/docs/guides/commerce-media).
 
-5. **Targeting Restrictions** - Functional restriction overlays for age (with verification methods), device platform (Sec-CH-UA-Platform values), and language localization. Geographic exclusion fields (`geo_countries_exclude`, `geo_regions_exclude`, `geo_metros_exclude`, `geo_postal_areas_exclude`) enable RCT holdout groups and regulatory exclusions. These are compliance/technical restrictions, not audience targeting.
+5. **Creative Delivery Reporting** - Per-creative metrics breakdown within `by_package` in delivery responses. New `get_creative_delivery` task on creative agents for variant-level delivery data with manifests. Three variant tiers: standard (1:1), asset group optimization, and generative creative. Format-level `reported_metrics` declare which metrics each format can provide.
 
-6. **Typed Asset Requirements** - Discriminated union schemas for all 13 asset types (image, video, audio, text, markdown, HTML, CSS, JavaScript, VAST, DAAST, promoted offerings, URL, webhook) using `asset_type` as discriminator.
+6. **CPA & TIME Pricing Models** - Two new pricing models. CPA (Cost Per Acquisition) for outcome-based campaigns — covers CPO, CPL, CPI use cases differentiated by `event_type`. TIME for sponsorship-based advertising where price scales with duration (hour, day, week, month) with optional min/max constraints.
 
-7. **Universal Macros** - `universal-macro.json` enum defining all 54 standard ad-serving macros, including 6 new additions: `GPP_SID`, `IP_ADDRESS`, `STATION_ID`, `SHOW_NAME`, `EPISODE_ID`, `AUDIO_DURATION`.
+7. **Conversion Tracking** - New events protocol with `sync_event_sources` and `log_event` tasks for attribution and measurement.
 
-8. **Brand Manifest Improvements** - Structured tone object with `voice`, `attributes`, `dos`, `donts` fields. Logo objects gain `orientation`, `background`, `variant`, `usage` fields.
+8. **Signal Catalog** - Data providers become first-class members with signal definitions, categories, targeting schemas, and value types. New schemas for signal discovery and integration into products.
+
+9. **Cursor-Based Pagination** - All list operations (`list_creatives`, `tasks_list`, `list_property_lists`, `get_property_list`, `get_media_buy_artifacts`) standardized on cursor-based pagination with shared `pagination-request.json` and `pagination-response.json` schemas.
+
+10. **Accessibility in Creative Formats** - Two-layer accessibility model. Format-level `wcag_level` (A/AA/AAA) and `requires_accessible_assets` flag. Asset-level metadata for inspectable assets (alt text, captions, transcripts) and self-declared properties for opaque assets (keyboard navigable, motion control). Buyers can filter by `wcag_level` in `list_creative_formats`.
+
+11. **Targeting Restrictions & Geo Exclusion** - Functional restriction overlays for age (with verification methods), device platform (Sec-CH-UA-Platform values), and language localization. Geographic exclusion fields (`geo_countries_exclude`, `geo_regions_exclude`, `geo_metros_exclude`, `geo_postal_areas_exclude`) enable RCT holdout groups and regulatory exclusions.
+
+12. **Typed Asset Requirements** - Discriminated union schemas for all 13 asset types (image, video, audio, text, markdown, HTML, CSS, JavaScript, VAST, DAAST, promoted offerings, URL, webhook) using `asset_type` as discriminator.
+
+13. **Universal Macros** - `universal-macro.json` enum defining all 54 standard ad-serving macros, including 6 new additions: `GPP_SID`, `IP_ADDRESS`, `STATION_ID`, `SHOW_NAME`, `EPISODE_ID`, `AUDIO_DURATION`.
+
+14. **Brand Manifest Improvements** - Structured tone object with `voice`, `attributes`, `dos`, `donts` fields. Logo objects gain `orientation`, `background`, `variant`, `usage` fields.
 
 ### Breaking Changes
 
@@ -40,9 +52,15 @@ High-level summaries of major AdCP releases with migration guidance. For detaile
 
 ### Other Changes
 
+- `optimization_goal` on package requests — buyers can specify conversion goals when creating or updating media buys
+- Attribution window metadata on delivery response: `click_window_days`, `view_window_days`, and attribution `model` (last_touch, first_touch, linear, time_decay, data_driven)
+- Channel fields on property and product schemas: `supported_channels` and `channels` referencing Media Channel Taxonomy enum
 - `account_id` added to `get_media_buy_delivery` and `get_media_buy_artifacts` requests
+- `date_range_support` in reporting capabilities
+- `minItems: 1` on request-side arrays for stricter validation
 - `FormatCategory` enum deprecated; `type` field on Format objects now optional
 - `format_id` optional in `preview_creative` (falls back to `creative_manifest.format_id`)
+- `selection_mode` on repeatable asset groups to distinguish sequential (carousel) from optimize (asset pool) behavior
 - Session ID fallback recommendation for MCP agent `context_id`
 
 ---

--- a/docs/reference/roadmap.mdx
+++ b/docs/reference/roadmap.mdx
@@ -17,7 +17,7 @@ Version 2.5.0 delivered developer experience and API refinement improvements inc
 - **Type Safety & Code Generation** - Discriminator fields throughout for excellent TypeScript/Python type inference
 - **Batch Creative Previews** - Preview up to 50 creatives in a single call (5-10x faster)
 - **Schema Infrastructure** - Build-time versioning with semantic paths (`/schemas/v2.5/`)
-- **Agent Cards** - ADCP extension schema for capability discovery
+- **Agent Cards** - AdCP extension schema for capability discovery
 - **Brand Manifest** - Standardized brand information for creative generation
 - **Template Formats** - Dynamic creative sizing via `accepts_parameters` (dimensions, duration, etc.)
 - **Inline Creative Updates** - `sync_creatives` task for updating creatives in existing campaigns
@@ -35,32 +35,27 @@ From December 2025 through year end:
 
 ## Version 3.0.0 - Major Update
 
-**Target Release:** January 15, 2026
+**Current Status:** beta.3 released | [View Release Notes](./release-notes#version-300-beta3)
 
-Version 3.0 represents a significant evolution of the protocol with several major new capabilities.
+Version 3.0 is a major evolution of the protocol. Three beta releases have shipped:
 
-### Confirmed Features
+- **beta.1** - Media Channel Taxonomy (19 channels), Governance Protocol, Sponsored Intelligence, `get_adcp_capabilities`, creative assignment weighting, global geo targeting
+- **beta.2** - Accounts & Agents, property targeting, A2UI for Sponsored Intelligence, CTV/streaming constraints, creative protocol discovery
+- **beta.3** - Delivery forecasting, brand protocol, account management, commerce media, creative delivery reporting, CPA & TIME pricing, conversion tracking, signal catalog, cursor-based pagination, accessibility, targeting restrictions
 
-#### Creative Agent Protocol Enhancements
-- **Hosted Creative Sets** - New protocol for managing collections of related creatives
+### Remaining for GA
 
-#### Registry & Discovery
+- **Creative Governance** - Creative guidelines, approval workflows, and brand compliance controls for creative agents
+- **Hosted Creative Sets** - Protocol for managing collections of related creatives
 - **Property Registry** - Centralized registry for publisher property definitions
-
-### Under Consideration
-
-These features are in active development but may not make the 3.0 release:
-- Better namespace management for custom capabilities
+- Namespace management for custom capabilities
+- Final migration guide review
 
 ---
 
 ## Future Work (No Target Date)
 
 The following features are in the working group planning stages:
-
-### Governance Protocol [3.0]
-
-Property governance (property lists, filters, adagents.json authorization), brand standards (brand manifests, creative guidelines), and compliance controls. See the [Governance Protocol](/docs/governance/overview) for current specification.
 
 ### Private Marketplace (PMP) Support
 - Deal ID integration

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -43,8 +43,8 @@
         "@type": "Organization",
         "@id": "https://adcontextprotocol.org/#organization"
       },
-      "softwareVersion": "2.5.0",
-      "releaseNotes": "Developer experience and API refinement release featuring type safety improvements, batch creative previews (5-10x faster), schema versioning with minor version aliases, template formats with dynamic sizing, enhanced product filtering, and inline creative updates",
+      "softwareVersion": "3.0.0-beta.3",
+      "releaseNotes": "Major protocol expansion with delivery forecasting, commerce media discovery, CPA and TIME pricing models, creative delivery reporting, account management, accessibility support, and cursor-based pagination across all list operations",
       "programmingLanguage": ["TypeScript", "JavaScript"],
       "keywords": "advertising automation, programmatic advertising, MCP protocol, AI advertising workflows, unified advertising API, agent-to-agent, A2A protocol, media buying automation, creative generation",
       "url": "https://adcontextprotocol.org",
@@ -590,8 +590,8 @@
       <div class="releaseBanner_qgG2">
         <div class="container">
           <div class="releaseBannerContent_dZLA">
-            <span class="releaseTag_YUts">v2.5.0</span>
-            <span class="releaseText_vBj7">Type safety, batch previews, schema versioning</span>
+            <span class="releaseTag_YUts">v3.0.0-beta.3</span>
+            <span class="releaseText_vBj7">Delivery forecasting, commerce media, creative reporting, new pricing models</span>
             <a href="https://docs.adcontextprotocol.org/docs/reference/release-notes" target="_blank" rel="noopener noreferrer" class="releaseLink_cLn6">Release notes →</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Expand beta.3 release notes from 8 to 14 "What's New" items and from 4 to 10 "Other Changes" — adds delivery forecasting, account management, commerce media, creative delivery reporting, CPA & TIME pricing, accessibility
- Update homepage version and release banner from v2.5.0 to v3.0.0-beta.3
- Update roadmap with beta progression, add creative governance to remaining GA items, remove stale Jan 2026 target date
- Fix intro banner link to point to beta.3 instead of beta.2
- Fix pre-existing ADCP→AdCP casing in roadmap

## Test plan

- [x] All schema/example/unit tests pass
- [x] Mintlify link checker passes (no broken links)
- [x] Accessibility check passes
- [ ] Visual check of homepage release banner
- [ ] Verify release notes anchor link from intro page

🤖 Generated with [Claude Code](https://claude.com/claude-code)