### PR TITLE
fix: Include invoice IDs in get_account for resend_invoice

### DIFF
--- a/.changeset/yellow-lizards-mix.md
+++ b/.changeset/yellow-lizards-mix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Include invoice IDs and billing details in get_account response (no protocol schema impact).


### PR DESCRIPTION
## Summary
- `get_account` now shows invoice IDs, billing email, and Stripe customer ID so the agent can use `resend_invoice` without manual escalation
- Extracted `renderPendingInvoiceSection()` helper to deduplicate invoice display logic across member and prospect sections
- Updated `resend_invoice` tool description to point agents to `get_account` as the primary lookup path
- Added typed `FormattedInvoice` interface for compile-time safety on invoice formatting

## Context
When asked to resend an invoice for Postindustria, the agent found the customer via `get_account` and saw a pending invoice, but the response only showed amount and status (e.g., "$2,500.00 (open)") — not the invoice ID needed by `resend_invoice`. The agent had to escalate to a human to resend from the Stripe dashboard.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All tests pass (schemas, examples, unit, typecheck)
- [ ] Verify `get_account` response shows invoice IDs in format `` `in_xxx` — $2,500.00 (open) → billing@example.com ``
- [ ] Verify `resend_invoice` works end-to-end when given an ID from `get_account`

🤖 Generated with [Claude Code](https://claude.com/claude-code)