### PR TITLE
fix: Make resend_invoice self-sufficient with company_name lookup

### DIFF
--- a/.changeset/empty-gifts-go.md
+++ b/.changeset/empty-gifts-go.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix resend_invoice workflow: add company_name lookup, include billing tools in billing toolset

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -347,7 +347,7 @@ IMPORTANT: Select tool SETS based on the user's INTENT:
 - Testing/validating AdCP agent implementations → ["agent_testing"]
 - Actually executing AdCP operations (media buys, creatives, signals) → ["adcp_operations"]
 - Content workflows, GitHub issues, proposals → ["content"]
-- Billing, invoices, payment links → ["billing"]
+- Billing, invoices, payment links, resending invoices → ["billing"]
 - Scheduling meetings, calendar → ["meetings"]
 - Escalations, pending requests, user role changes, merging orgs → ["admin"]
 - Multiple intents? Include multiple sets: ["knowledge", "agent_testing"]

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -189,7 +189,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   billing: {
     name: 'billing',
-    description: 'Handle billing and payment operations - create payment links, send invoices, manage discounts and promotions',
+    description: 'Handle billing and payment operations - create payment links, send invoices, manage discounts and promotions, look up pending invoices',
     tools: [
       'find_membership_products',
       'create_payment_link',
@@ -201,6 +201,8 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'create_promotion_code',
       'resend_invoice',
       'update_billing_email',
+      'list_pending_invoices',
+      'get_account',
     ],
     requiresPrecision: true,
   },


### PR DESCRIPTION
## Summary
- Added `list_pending_invoices` and `get_account` to the `billing` toolset so Addie can discover invoice IDs when handling billing requests (previously only in `admin` toolset)
- Made `resend_invoice` accept an optional `company_name` parameter to look up org → Stripe customer → pending invoices in a single tool call
- Auto-resends if exactly one open invoice found; lists choices if multiple; reports draft invoices that need finalizing

## Context
Addie couldn't resend invoices because the router selected the `billing` toolset for invoice requests, which had `resend_invoice` but not `get_account` or `list_pending_invoices` to find the invoice ID. Even with #1052 adding invoice IDs to `get_account`, the multi-step workflow (call `get_account`, extract ID, call `resend_invoice`) was fragile.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 297 tests pass
- [x] Pre-commit hooks pass (schema validation, docs, type checking)
- [x] App builds and starts correctly in Docker
- [ ] Verify in production: ask Addie to "resend the invoice for [company]" and confirm single-step completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)