### PR TITLE
fix: Addie quality improvements from thread review

### DIFF
--- a/.changeset/addie-thread-review.md
+++ b/.changeset/addie-thread-review.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Addie quality improvements from thread review: accurate spec claims, fictional example names, ads.txt knowledge, shorter deflections, agent type awareness, and session-level web feedback prompt.

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -770,6 +770,85 @@
       padding: 4px 0;
     }
 
+    /* Session-level feedback prompt */
+    .session-feedback {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      padding: 12px 16px;
+      margin: 16px 24px;
+      background: var(--color-bg-subtle);
+      border: 1px solid var(--color-border);
+      border-radius: 10px;
+      font-size: 13px;
+      color: var(--color-text-secondary);
+      animation: fadeInUp 0.3s ease-out;
+    }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .session-feedback-label {
+      color: var(--color-text-secondary);
+    }
+
+    .session-feedback-buttons {
+      display: flex;
+      gap: 6px;
+    }
+
+    .session-feedback-btn {
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
+      border-radius: 6px;
+      padding: 6px 14px;
+      cursor: pointer;
+      font-size: 13px;
+      color: var(--color-text-secondary);
+      transition: all 0.2s;
+    }
+
+    .session-feedback-btn:hover {
+      border-color: var(--color-brand);
+      background: var(--color-bg-subtle);
+    }
+
+    .session-feedback-btn.positive:hover {
+      background: var(--color-success-500);
+      border-color: var(--color-success-500);
+      color: white;
+    }
+
+    .session-feedback-btn.negative:hover {
+      background: var(--color-error-500);
+      border-color: var(--color-error-500);
+      color: white;
+    }
+
+    .session-feedback-dismiss {
+      background: none;
+      border: none;
+      color: var(--color-text-muted);
+      cursor: pointer;
+      font-size: 16px;
+      padding: 0 4px;
+      line-height: 1;
+    }
+
+    .session-feedback-dismiss:hover {
+      color: var(--color-text-secondary);
+    }
+
+    .session-feedback--success {
+      justify-content: center;
+      color: var(--color-success-600);
+      border-color: var(--color-success-500);
+      background: var(--color-success-50, var(--color-bg-subtle));
+    }
+
     /* SI Agent CTA Buttons */
     .si-cta-container {
       display: flex;
@@ -2423,7 +2502,7 @@
 
       // Clear only chat messages from the container (preserves static elements like home/welcome)
       function clearChatMessages() {
-        const messages = messagesContainer.querySelectorAll('.message');
+        const messages = messagesContainer.querySelectorAll('.message, .session-feedback');
         messages.forEach(msg => msg.remove());
       }
 
@@ -2633,6 +2712,8 @@
         currentTabId = 'home';
         conversationId = null;
         currentChannel = 'web';
+        lastAssistantMessageId = null;
+        clearSessionFeedbackTimer();
 
         // Update UI
         homeTab.classList.add('active');
@@ -2765,9 +2846,14 @@
 
           const data = await response.json();
 
-          // Render messages
+          // Render messages and track last assistant message
+          lastAssistantMessageId = null;
+          clearSessionFeedbackTimer();
           data.messages.forEach(msg => {
             addMessage(msg.content, msg.role, msg.message_id);
+            if (msg.role === 'assistant' && msg.message_id) {
+              lastAssistantMessageId = msg.message_id;
+            }
           });
 
           // Handle read-only mode for Slack threads
@@ -2805,6 +2891,8 @@
         conversationId = null;
         currentChannel = 'web';
         currentTabId = 'home'; // New chat starts from home
+        lastAssistantMessageId = null;
+        clearSessionFeedbackTimer();
 
         // Clear messages and show home
         clearChatMessages();
@@ -3320,6 +3408,80 @@
         }
       }
 
+      // === Session-level feedback ===
+      let sessionFeedbackTimer = null;
+      let lastAssistantMessageId = null;
+      const sessionFeedbackShown = new Set(); // Track per conversation
+
+      function scheduleSessionFeedback() {
+        clearSessionFeedbackTimer();
+        if (!conversationId || sessionFeedbackShown.has(conversationId)) return;
+        if (!lastAssistantMessageId) return;
+
+        // Count assistant messages in current view
+        const assistantMessages = messagesContainer.querySelectorAll('.message--assistant');
+        if (assistantMessages.length < 3) return;
+
+        sessionFeedbackTimer = setTimeout(() => {
+          showSessionFeedback();
+        }, 45000); // 45 seconds of idle
+      }
+
+      function clearSessionFeedbackTimer() {
+        if (sessionFeedbackTimer) {
+          clearTimeout(sessionFeedbackTimer);
+          sessionFeedbackTimer = null;
+        }
+      }
+
+      function showSessionFeedback() {
+        if (!conversationId || sessionFeedbackShown.has(conversationId)) return;
+        sessionFeedbackShown.add(conversationId);
+
+        const prompt = document.createElement('div');
+        prompt.className = 'session-feedback';
+        prompt.innerHTML = `
+          <span class="session-feedback-label">How was this conversation?</span>
+          <div class="session-feedback-buttons">
+            <button class="session-feedback-btn positive" data-rating="5">&#128077; Helpful</button>
+            <button class="session-feedback-btn negative" data-rating="1">&#128078; Not helpful</button>
+          </div>
+          <button class="session-feedback-dismiss" title="Dismiss">&times;</button>
+        `;
+
+        prompt.querySelector('.session-feedback-dismiss').addEventListener('click', () => {
+          prompt.remove();
+        });
+
+        const feedbackMessageId = lastAssistantMessageId;
+        prompt.querySelectorAll('.session-feedback-btn').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const rating = parseInt(btn.dataset.rating);
+            try {
+              await authFetch(`/api/addie/chat/${conversationId}/feedback`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  message_id: feedbackMessageId,
+                  rating: rating,
+                  rating_category: 'session',
+                  feedback_tags: null,
+                  improvement_suggestion: null
+                })
+              });
+            } catch (e) {
+              console.error('Session feedback failed:', e);
+            }
+            prompt.innerHTML = '<span>Thanks for the feedback!</span>';
+            prompt.className = 'session-feedback session-feedback--success';
+            setTimeout(() => prompt.remove(), 3000);
+          });
+        });
+
+        messagesContainer.appendChild(prompt);
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+      }
+
       // Add typing indicator
       function addTypingIndicator() {
         const messageDiv = document.createElement('div');
@@ -3580,6 +3742,11 @@
 
         isLoading = true;
         updateSendButton();
+        clearSessionFeedbackTimer();
+
+        // Remove any visible session feedback prompt
+        const existingPrompt = messagesContainer.querySelector('.session-feedback');
+        if (existingPrompt) existingPrompt.remove();
 
         // Request notification permission on first message
         requestNotificationPermission();
@@ -3705,6 +3872,7 @@
 
           // Finalize the message with feedback UI
           finalizeStreamingMessage(messageDiv, contentDiv, fullContent, messageId);
+          if (messageId) lastAssistantMessageId = messageId;
 
           // Open SI modal if a brand agent session was created
           // This must happen AFTER the stream is completely done to avoid race conditions
@@ -3743,6 +3911,9 @@
             }
           }
 
+          // Schedule session-level feedback prompt after idle
+          scheduleSessionFeedback();
+
           // Refresh thread list to show new/updated conversation (debounced)
           scheduleLoadThreads();
 
@@ -3768,6 +3939,7 @@
       chatInput.addEventListener('input', () => {
         autoResize();
         updateSendButton();
+        clearSessionFeedbackTimer(); // Reset idle timer when user types
       });
 
       chatInput.addEventListener('keydown', (e) => {

--- a/server/src/db/migrations/215_addie_thread_review_improvements.sql
+++ b/server/src/db/migrations/215_addie_thread_review_improvements.sql
@@ -1,0 +1,108 @@
+-- Addie improvements from Feb 2026 thread review
+-- Addresses: speculative feature claims, real brand names in examples, ads.txt accuracy, verbose deflections
+
+-- 1. Don't speculate about unimplemented protocol features
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'constraint',
+  'Current Spec Only',
+  'Distinguish between what AdCP currently specifies vs aspirational features',
+  'When discussing AdCP capabilities, only describe features that exist in the current specification. Do NOT present aspirational or future features as current reality.
+
+Specific examples:
+- AdCP does NOT currently have cryptographic verification, ads.cert integration, or blockchain-based trust
+- AdCP does NOT have "agent reputation networks" or formal trust scoring between agents
+- adagents.json is a discovery mechanism, not a cryptographic chain of trust
+
+When discussing what AdCP COULD support in the future, clearly mark it as aspirational:
+- "This isn''t part of AdCP today, but the architecture could support..."
+- "The community is exploring..."
+
+The protocol is young. Accurately representing its current state builds more credibility than overclaiming.',
+  215,
+  'system'
+);
+
+-- 2. Use fictional names in examples
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'constraint',
+  'Fictional Names in Examples',
+  'Use fictional company names when creating illustrative examples',
+  'When creating hypothetical examples or scenarios, use fictional company names instead of real brands, agencies, or publishers.
+
+Use names like: Acme Corp, Pinnacle Media, Nova Brands, Summit Publishing, Apex Athletic, Horizon DSP, etc.
+
+Exceptions:
+- When a user asks specifically about a real company (e.g., "what do we have for Fanta in the registry?")
+- When referencing industry players in factual context (e.g., "The Trade Desk supports UID2")
+- When discussing AdCP member organizations by name
+- Enum values that reference industry standards (e.g., "groupm" viewability standard)
+
+The rule applies to INVENTED scenarios and examples, not factual references.',
+  112,
+  'system'
+);
+
+-- 3. Accurate ads.txt/sellers.json knowledge
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'knowledge',
+  'Ads.txt and Sellers.json Accuracy',
+  'Correct understanding of supply chain authorization mechanisms',
+  'When discussing ads.txt and sellers.json, be precise about how they work:
+
+ads.txt:
+- Published at domain.com/ads.txt by publishers
+- Lists authorized seller account IDs and relationship type (DIRECT or RESELLER)
+- DSPs check ads.txt BEFORE bidding (pre-bid), not post-facto
+- Verification is cached/scraped periodically, not checked per-impression
+
+sellers.json:
+- Published by SSPs/exchanges at their domain
+- Maps seller_id to business entity (name, domain, seller_type)
+- seller_type: PUBLISHER, INTERMEDIARY, or BOTH
+- Enables supply chain object (schain) validation
+
+Supply chain object (schain):
+- Passed in bid requests per OpenRTB
+- Lists each node in the supply path
+- Buyers verify the complete chain against ads.txt + sellers.json
+
+Common issues to understand:
+- DIRECT means the publisher has a direct business relationship with the advertising system
+- RESELLER means the publisher has authorized another entity to sell on their behalf
+- A seller claiming DIRECT when the relationship is through an intermediary is a misrepresentation',
+  162,
+  'system'
+);
+
+-- 4. Shorten off-topic deflection template
+UPDATE addie_rules SET content = 'CRITICAL: You are an ad tech expert, NOT a general assistant. Your knowledge domain is:
+
+TOPICS YOU KNOW ABOUT:
+- AdCP (Ad Context Protocol) and agentic advertising
+- AgenticAdvertising.org community, working groups, membership
+- Ad tech industry: programmatic, RTB, SSPs, DSPs, ad servers, Prebid, header bidding
+- AI and agents in advertising contexts
+- Industry players in factual context
+- Sustainability in advertising (GMSF, carbon impact)
+- Privacy and identity in advertising
+- Publisher monetization and buyer/seller dynamics
+
+TOPICS OUTSIDE YOUR DOMAIN:
+- General news, sports, entertainment, weather
+- Topics unrelated to advertising, marketing, or media
+- General technology not related to ad tech or AI agents
+- Personal advice, health, legal matters
+- Questions about your own implementation or source code
+
+When asked about off-topic subjects, keep the deflection SHORT (1-2 sentences max):
+"I specialize in ad tech and agentic advertising — that''s outside my area. Happy to help with anything AdCP or advertising related though!"
+
+Do NOT list out everything you can help with when deflecting. Just redirect briefly and let the user ask.
+
+When asked "what''s the latest news" or similar, interpret as ad tech news and use tools to search for recent updates.',
+  version = version + 1,
+  updated_at = NOW()
+WHERE name = 'Domain Focus - CRITICAL' AND rule_type = 'constraint';

--- a/server/src/db/migrations/216_addie_agent_types.sql
+++ b/server/src/db/migrations/216_addie_agent_types.sql
@@ -1,0 +1,21 @@
+-- Keep Addie current on formal AdCP agent types
+-- These change over time and her training data lags
+
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'knowledge',
+  'AdCP Agent Types',
+  'Current list of formal AdCP agent types',
+  'The formal AdCP agent types are:
+- **Sales** — publisher-side inventory discovery and media buying
+- **Creative** — creative asset generation, format listing, preview rendering
+- **Signals** — audience signals discovery and activation
+- **Governance** — property lists (where ads run) and content standards (brand suitability)
+- **SI (Sponsored Intelligence)** — commerce-oriented sponsored placements
+
+All of these are first-class agent types with their own tools and documentation in docs/. Use search_docs to look up details rather than answering from memory, especially for newer agent types.
+
+Do NOT describe any of these as "not formally defined" or "conceptual" — they are all part of the current AdCP specification.',
+  170,
+  'system'
+);


### PR DESCRIPTION
## Summary
- Reviewed ~50 recent production Addie threads to identify behavioral gaps
- Added 4 new Addie rules: accurate spec claims, fictional example names, ads.txt knowledge, agent type awareness
- Shortened off-topic deflection template (was generating walls of text)
- Added session-level web feedback prompt (appears after 45s idle on 3+ message conversations)

## Context
Current per-message feedback gets <1% engagement (22 ratings across 3,216 responses in 30 days). The session-level prompt gives users a second chance to rate the overall conversation quality.

Thread review findings that drove the rule changes:
- Addie claimed "cryptographic verification" and "ads.cert" as current AdCP features (they're not)
- Used real brand names (Nike, Apple, etc.) in hypothetical examples
- Told a user ads.txt verification happens "post-facto" (it's pre-bid)
- Said governance agents are "not a formally defined agent type" (they are)
- Gave 2-paragraph deflections for off-topic questions

## Test plan
- [x] All 297 tests pass
- [x] TypeCheck passes
- [x] Migration 215 applies cleanly (verified in Docker)
- [x] Migration 216 applies cleanly (verified in Docker)
- [x] Web chat page loads with session feedback CSS/JS
- [x] Per-message feedback UI renders correctly (verified in browser)
- [ ] Verify session feedback prompt appears after idle in production
- [ ] Monitor Addie responses for spec accuracy improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)