### PR TITLE
chore: Ignore generated dist/schemas/registry.* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ server/node_modules
 !/dist/docs
 /dist/schemas/latest
 /dist/schemas/v*
+/dist/schemas/registry.*
 
 # Generated files
 .docusaurus


### PR DESCRIPTION
## Summary
- Build artifacts (`registry.js`, `registry.d.ts`, and their source maps) were showing up as untracked files after every `npm run build`
- The `!/dist/schemas` un-ignore rule in `.gitignore` was letting them through
- Added `/dist/schemas/registry.*` to re-ignore them alongside the existing `latest/` and `v*` rules

## Test plan
- [x] `git status` is clean after `npm run build` (no more untracked registry files)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)