### PR TITLE
feat: Make Addie a Prebid expert

### DIFF
--- a/.changeset/famous-coins-follow.md
+++ b/.changeset/famous-coins-follow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Prebid documentation expertise to Addie knowledge base.

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN git clone --depth=1 --branch main https://github.com/IABTechLab/adscert.git 
 # Prebid Ecosystem
 RUN git clone --depth=1 --branch master https://github.com/prebid/Prebid.js.git prebid-js || true
 RUN git clone --depth=1 --branch master https://github.com/prebid/prebid-server.git prebid-server || true
+RUN git clone --depth=1 --branch master https://github.com/prebid/prebid.github.io.git prebid-docs || true
 
 # Agent Frameworks
 RUN git clone --depth=1 --branch main https://github.com/langchain-ai/langgraph.git langgraph || true

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -27,7 +27,7 @@ import { ROUTING_RULES } from './router.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.02.2';
+export const CODE_VERSION = '2026.02.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/external-repos.ts
+++ b/server/src/addie/mcp/external-repos.ts
@@ -291,7 +291,7 @@ const EXTERNAL_REPOS: ExternalRepo[] = [
     url: 'https://github.com/prebid/Prebid.js',
     name: 'Prebid.js',
     description: 'Client-side header bidding library with 200+ bid adapters',
-    indexPatterns: ['README.md', 'CONTRIBUTING.md'],
+    indexPatterns: ['README.md', 'CONTRIBUTING.md', 'modules/**/*.md'],
     branch: 'master',
   },
   {
@@ -300,6 +300,14 @@ const EXTERNAL_REPOS: ExternalRepo[] = [
     name: 'Prebid Server',
     description: 'Server-side header bidding for mobile, AMP, CTV, DOOH',
     indexPatterns: ['README.md', 'docs/**/*.md'],
+    branch: 'master',
+  },
+  {
+    id: 'prebid-docs',
+    url: 'https://github.com/prebid/prebid.github.io',
+    name: 'Prebid Documentation',
+    description: 'Official Prebid documentation site - configuration guides, bidder adapters, ad ops workflows, GAM integration, troubleshooting, Prebid Server, Prebid Mobile, and video',
+    indexPatterns: ['**/*.md'],
     branch: 'master',
   },
 
@@ -786,6 +794,22 @@ const SEARCH_SYNONYMS: Record<string, string[]> = {
   deploy: ['deployment', 'hosting', 'cloud', 'production'],
   config: ['configure', 'configuration', 'environment', 'settings'],
   run: ['start', 'execute', 'launch'],
+  // Prebid ecosystem
+  prebid: ['header bidding', 'prebid.js', 'prebid server', 'pbs', 'pbjs'],
+  'header bidding': ['prebid', 'prebid.js'],
+  bidder: ['adapter', 'bid adapter', 'demand partner'],
+  adapter: ['bidder', 'bid adapter'],
+  gam: ['google ad manager', 'dfp', 'ad server'],
+  dfp: ['gam', 'google ad manager'],
+  gdpr: ['tcf', 'consent', 'cmp'],
+  consent: ['gdpr', 'tcf', 'cmp', 'gpp'],
+  floors: ['price floors', 'floor price', 'bid floor'],
+  'price floors': ['floors', 'floor price', 'bid floor'],
+  currency: ['currency conversion', 'currency module'],
+  'user id': ['identity', 'userid', 'uid2', 'id module'],
+  video: ['video ads', 'outstream', 'instream', 'vast'],
+  pbjs: ['prebid.js', 'prebid'],
+  pbs: ['prebid server', 'server-side bidding'],
 };
 
 /**

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -203,10 +203,11 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
       'A2A (Google Agent-to-Agent protocol and samples), ' +
       'MCP (Model Context Protocol spec, TypeScript/Python SDKs, reference servers), ' +
       'IAB Tech Lab specs (OpenRTB 2.x/3.0, AdCOM, OpenDirect, ARTF, UCP, GPP, TCF, US Privacy, UID2, VAST, ads.cert), ' +
-      'Prebid (Prebid.js, Prebid Server), and LangGraph. ' +
+      'Prebid (full documentation site with configuration guides, bidder adapter docs, ad ops workflows, GAM integration, troubleshooting, Prebid Mobile, and video; plus Prebid.js source with module docs, and Prebid Server source), ' +
+      'and LangGraph. ' +
       'Use this for protocol details, spec comparisons, implementation examples, and SDK usage.',
     usage_hints:
-      'use for: OpenRTB questions, A2A protocol, MCP implementation, IAB specs, Prebid, TCF/GPP consent, UID2, salesagent setup, SDK usage',
+      'use for: OpenRTB questions, A2A protocol, MCP implementation, IAB specs, Prebid configuration/adapters/troubleshooting/GAM, TCF/GPP consent, UID2, salesagent setup, SDK usage',
     input_schema: {
       type: 'object',
       properties: {
@@ -217,7 +218,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
         repo_id: {
           type: 'string',
           description:
-            'Optional filter to search only a specific repo: adcp, salesagent, signals-agent, adcp-client, adcp-client-python, a2a, a2a-samples, mcp-spec, mcp-typescript-sdk, mcp-python-sdk, mcp-servers, iab-artf, iab-ucp, iab-openrtb2, iab-openrtb3, iab-adcom, iab-opendirect, iab-gpp, iab-tcf, iab-usprivacy, iab-uid2-docs, iab-vast, iab-adscert, prebid-js, prebid-server, langgraph',
+            'Optional filter to search only a specific repo: adcp, salesagent, signals-agent, adcp-client, adcp-client-python, a2a, a2a-samples, mcp-spec, mcp-typescript-sdk, mcp-python-sdk, mcp-servers, iab-artf, iab-ucp, iab-openrtb2, iab-openrtb3, iab-adcom, iab-opendirect, iab-gpp, iab-tcf, iab-usprivacy, iab-uid2-docs, iab-vast, iab-adscert, prebid-js, prebid-server, prebid-docs, langgraph',
         },
         limit: {
           type: 'number',

--- a/server/src/db/migrations/218_addie_prebid_knowledge.sql
+++ b/server/src/db/migrations/218_addie_prebid_knowledge.sql
@@ -1,0 +1,76 @@
+-- Add Prebid domain expertise to Addie's knowledge base.
+-- Covers Prebid.js, Prebid Server, header bidding concepts,
+-- AdCP Sales Agent + Prebid/AXE integration, and common troubleshooting.
+
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'knowledge',
+  'Prebid Expertise',
+  'Deep knowledge of Prebid.js, Prebid Server, header bidding, and how AdCP Sales Agents integrate with Prebid via AXE',
+  'You have comprehensive Prebid documentation indexed. Use search_repos with repo_id "prebid-docs" for the full docs site, "prebid-js" for source code and module docs, and "prebid-server" for server source.
+
+## Prebid.js
+
+Client-side header bidding library that runs in the browser:
+- Collects bids from 200+ demand partners (SSPs/exchanges) in parallel before the ad server call
+- Passes winning bid info to the ad server (typically Google Ad Manager) via key-value targeting
+- Modular architecture: core wrapper + bidder adapters + optional modules (consent, currency, floors, identity, analytics, etc.)
+- Configured via pbjs.setConfig() and adUnits array defining placements, media types (banner, video, native), and bidder params
+- Each bidder adapter has its own required params (documented per-adapter)
+
+## Prebid Server
+
+Server-side header bidding that handles bid requests on the server:
+- Reduces client-side latency and battery drain, essential for mobile apps
+- Supports AMP, CTV, DOOH, and mobile app environments where client-side JS can''t run
+- Has its own bidder adapters (Go-based, separate from Prebid.js adapters)
+- Works alongside Prebid.js via s2sConfig (hybrid client+server) or standalone
+- Two implementations: prebid-server (Go) and prebid-server-java
+
+## Key Concepts
+
+- **Bid adapters**: Each SSP/exchange has an adapter with bidder-specific params. Configured per ad unit.
+- **Modules**: Optional add-ons for consent management (GDPR/TCF, USP/CCPA, GPP), currency conversion, price floors, user identity (UID2, SharedID, etc.), real-time data (RTD), and analytics.
+- **Price granularity**: Controls how bid prices are bucketed for key-value targeting. Options: low, medium, high, auto, dense, or custom buckets.
+- **Ad server integration**: Prebid sets targeting keys (hb_bidder, hb_adid, hb_pb, hb_size, hb_format) on the ad server request. Line items in GAM compete with other demand based on hb_pb value.
+- **First-party data**: Bidders and ad units receive first-party data via ortb2 config (site, user, imp level).
+- **Auction mechanics**: First-price auction. sendAllBids sends keys for every bidder; targetingControls.allowTargetingKeys controls which keys are set.
+
+## AdCP Sales Agent + Prebid Integration
+
+The AdCP Sales Agent (reference implementation: salesagent repo) integrates with Prebid through the AXE (Agentic eXecution Engine) in a two-phase workflow:
+
+**Phase 1 - Offline Setup:**
+1. Buyer Agent creates campaigns with targeting and budgets via AdCP
+2. Signal Agents attach audiences, brand suitability rules, contextual signals
+3. Orchestrator maps campaigns to opaque AXE segment IDs and syncs data to the RTD module
+4. Sales Agent creates ad server line items (in GAM/Kevel) targeting AXE key-values (axei for include, axex for exclude, axem for creative macros)
+
+**Phase 2 - Real-Time Serving (via Prebid):**
+1. User visits publisher page, triggering ad request
+2. Ad server initiates request; Prebid''s RTD module sends OpenRTB request to AXE
+3. AXE evaluates user/context against segment rules and returns segment decisions
+4. Segment values (axei/axex/axem) are passed as key-values to the ad server
+5. Ad server matches line items to segments and serves the appropriate ad
+
+Publishers support this by integrating Prebid''s RTD module, accepting AXE key-value targeting, and declaring AXE support in their adagents.json.
+
+## Common Troubleshooting
+
+- **No bids returning**: Check bidder params match adapter docs, verify ad unit config (sizes, mediaTypes), check consent/privacy settings aren''t blocking, inspect network tab for bid request/response.
+- **Bids not winning in GAM**: Verify line item setup matches price granularity buckets, check key-value targeting is set correctly (hb_pb, hb_bidder), ensure line items have correct priority.
+- **Latency issues**: Check bidderTimeout setting, consider moving slow bidders to server-side (s2sConfig), reduce number of bidders per ad unit.
+- **GDPR/consent problems**: Ensure CMP loads before Prebid, verify consentManagement module config (gdpr.cmpApi, usp.cmpApi), check that consent string is being passed to bidders.
+- **Currency mismatch**: Load the currency module if bidders respond in different currencies, configure adServerCurrency.
+- **Price floors not working**: Verify the priceFloors module is loaded, check floor data format, ensure floors are set before auction.
+
+## Prebid vs AdCP
+
+Prebid and AdCP are complementary:
+- Prebid optimizes yield per impression (real-time auction for individual ad slots)
+- AdCP enables budget allocation across many partners over time (campaign-level)
+- A publisher can use both: Prebid for programmatic demand, AdCP for direct/agentic campaigns
+- The Sales Agent bridges them: it creates ad server line items from AdCP campaigns, and Prebid''s RTD module handles real-time execution via AXE',
+  162,
+  'system'
+);


### PR DESCRIPTION
## Summary

- Index the full Prebid documentation site (`prebid/prebid.github.io`) with 1,300+ pages of configuration guides, bidder adapter docs, ad ops workflows, GAM integration, troubleshooting, Prebid Mobile, and video
- Expand Prebid.js source indexing to include `modules/**/*.md` (654 adapter/module docs with exact parameter specs)
- Add Prebid-specific search synonyms (bidder/adapter, gam/dfp, floors, consent, etc.)
- Add knowledge rule covering Prebid ecosystem, Sales Agent + Prebid/AXE two-phase integration, and common troubleshooting patterns

Prompted by Erin's feedback: "Using a robot has been super super helpful with troubleshooting prebid, however, it definitely makes a lot of mistakes so background knowledge with prebid is a must."

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (all suites)
- [x] Pre-commit hooks pass (full test suite + version sync + Mintlify validation)
- [ ] Deploy to staging and verify Addie can answer Prebid questions with citations from prebid-docs repo
- [ ] Test search_repos with `repo_id: "prebid-docs"` returns relevant results
- [ ] Verify migration applies cleanly (knowledge rule appears in addie_rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)