### PR TITLE
feat: Replace custom MCP auth with SDK's ProxyOAuthServerProvider

### DIFF
--- a/.changeset/spotty-nights-happen.md
+++ b/.changeset/spotty-nights-happen.md
@@ -1,2 +1,4 @@
 ---
 ---
+
+Replace custom MCP auth middleware with SDK's ProxyOAuthServerProvider to proxy all OAuth endpoints to WorkOS AuthKit.

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -6,17 +6,16 @@
  * - Directory lookup (members, agents, publishers)
  * - Billing operations (membership products, payment links)
  *
- * Authentication required via OAuth 2.1 (WorkOS AuthKit).
- * Unauthenticated requests receive 401 with OAuth discovery metadata.
+ * Authentication via OAuth 2.1 (WorkOS AuthKit), proxied through
+ * the MCP SDK's ProxyOAuthServerProvider.
  */
 
 export { createUnifiedMCPServer, initializeMCPServer, isMCPServerReady, getAllTools } from './server.js';
 export { configureMCPRoutes } from './routes.js';
+export { createOAuthProvider, AUTHKIT_ISSUER, MCP_AUTH_ENABLED } from './oauth-provider.js';
 export {
-  mcpAuthMiddleware,
-  getOAuthProtectedResourceMetadata,
-  MCP_AUTH_ENABLED,
-  AUTHKIT_ISSUER,
+  authInfoToMCPAuthContext,
+  anonymousAuthContext,
   type MCPAuthContext,
   type MCPAuthenticatedRequest,
 } from './auth.js';

--- a/server/src/mcp/oauth-provider.ts
+++ b/server/src/mcp/oauth-provider.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP OAuth Provider
+ *
+ * Configures ProxyOAuthServerProvider to proxy OAuth 2.1 to WorkOS AuthKit.
+ * All OAuth endpoints (authorize, token, register) are proxied to AuthKit.
+ * JWT validation uses AuthKit's JWKS endpoint.
+ */
+
+import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('mcp-oauth');
+
+/**
+ * WorkOS AuthKit configuration
+ */
+export const AUTHKIT_ISSUER =
+  process.env.AUTHKIT_ISSUER || 'https://clean-gradient-46.authkit.app';
+
+const WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID;
+
+/**
+ * Whether MCP auth is enabled.
+ * Disable via MCP_AUTH_DISABLED=true for local development.
+ */
+export const MCP_AUTH_ENABLED = process.env.MCP_AUTH_DISABLED !== 'true';
+
+/**
+ * JWKS for token verification (cached and auto-refreshed by jose)
+ */
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJWKS() {
+  if (!jwks) {
+    if (!WORKOS_CLIENT_ID) {
+      logger.warn('MCP OAuth: WORKOS_CLIENT_ID not set — audience validation disabled');
+    }
+    const jwksUrl = new URL(`${AUTHKIT_ISSUER}/oauth2/jwks`);
+    jwks = createRemoteJWKSet(jwksUrl);
+    logger.info(
+      { jwksUrl: jwksUrl.toString(), audienceValidation: !!WORKOS_CLIENT_ID },
+      'MCP OAuth: JWKS configured'
+    );
+  }
+  return jwks;
+}
+
+/**
+ * Validate a JWT access token and return AuthInfo for the MCP SDK.
+ *
+ * Checks signature via JWKS, issuer, audience (if configured), and expiry.
+ * Stashes user claims in `extra` for the MCPAuthContext bridge.
+ */
+async function verifyAccessToken(token: string): Promise<AuthInfo> {
+  const jwksInstance = getJWKS();
+
+  const verifyOptions: { issuer: string; audience?: string } = {
+    issuer: AUTHKIT_ISSUER,
+  };
+  if (WORKOS_CLIENT_ID) {
+    verifyOptions.audience = WORKOS_CLIENT_ID;
+  }
+
+  const { payload } = await jwtVerify(token, jwksInstance, verifyOptions);
+
+  const isM2M =
+    payload.grant_type === 'client_credentials' ||
+    (typeof payload.sub === 'string' && payload.sub.startsWith('client_'));
+
+  // Derive clientId from azp (authorized party) or audience
+  const clientId =
+    (payload.azp as string) ||
+    (typeof payload.aud === 'string' ? payload.aud : payload.aud?.[0]) ||
+    'unknown';
+
+  // Parse scopes from space-delimited scope claim
+  const scopes =
+    typeof payload.scope === 'string'
+      ? payload.scope.split(' ').filter(Boolean)
+      : [];
+
+  // WorkOS AuthKit JWTs always include exp. jose's jwtVerify rejects
+  // tokens without exp by default, so payload.exp is guaranteed here.
+  return {
+    token,
+    clientId,
+    scopes,
+    expiresAt: payload.exp,
+    extra: {
+      sub: payload.sub,
+      orgId: payload.org_id,
+      isM2M,
+      email: payload.email,
+      payload,
+    },
+  };
+}
+
+/**
+ * Return a minimal client record for any clientId.
+ *
+ * AuthKit is the source of truth for client registration.
+ * The SDK's authenticateClient middleware requires a non-null return,
+ * but since MCP clients are public (no client_secret), no secret
+ * checking occurs. AuthKit validates the client_id during token exchange.
+ */
+async function getClient(
+  clientId: string
+): Promise<OAuthClientInformationFull | undefined> {
+  return { client_id: clientId, redirect_uris: [] } as OAuthClientInformationFull;
+}
+
+/**
+ * Create the OAuth provider that proxies all OAuth requests to AuthKit.
+ */
+export function createOAuthProvider(): ProxyOAuthServerProvider {
+  const provider = new ProxyOAuthServerProvider({
+    endpoints: {
+      authorizationUrl: `${AUTHKIT_ISSUER}/oauth2/authorize`,
+      tokenUrl: `${AUTHKIT_ISSUER}/oauth2/token`,
+      registrationUrl: `${AUTHKIT_ISSUER}/oauth2/register`,
+    },
+    verifyAccessToken,
+    getClient,
+  });
+
+  logger.info(
+    { issuer: AUTHKIT_ISSUER, authEnabled: MCP_AUTH_ENABLED },
+    'MCP OAuth: Provider configured'
+  );
+
+  return provider;
+}

--- a/server/src/mcp/routes.ts
+++ b/server/src/mcp/routes.ts
@@ -1,32 +1,45 @@
 /**
  * MCP Route Handlers
  *
- * Configures Express routes for the unified MCP server:
+ * Configures Express routes for the MCP server:
  * - POST /mcp - MCP JSON-RPC endpoint (auth required, rate limited)
- * - GET /.well-known/oauth-protected-resource - OAuth resource metadata (RFC 9728)
+ * - OAuth endpoints via SDK's mcpAuthRouter (authorize, token, register, metadata)
  * - OPTIONS /mcp - CORS preflight
  *
- * Authentication via OAuth 2.1 (WorkOS AuthKit).
- * WorkOS handles dynamic client registration (RFC 7591), authorization,
- * and token issuance. This server validates bearer tokens via JWKS.
- *
- * Clients discover the authorization server via the Protected Resource Metadata
- * endpoint (RFC 9728), which points them to AuthKit directly.
+ * OAuth 2.1 is proxied to WorkOS AuthKit via ProxyOAuthServerProvider.
+ * The SDK's mcpAuthRouter handles all discovery and proxy endpoints:
+ * - /.well-known/oauth-authorization-server
+ * - /.well-known/oauth-protected-resource/mcp
+ * - /authorize, /token, /register
  */
 
-import type { Router, Request, Response } from 'express';
+import type { Router, Request, Response, NextFunction } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import rateLimit from 'express-rate-limit';
 import { createLogger } from '../logger.js';
 import { createUnifiedMCPServer } from './server.js';
+import { createOAuthProvider, MCP_AUTH_ENABLED } from './oauth-provider.js';
 import {
-  mcpAuthMiddleware,
-  getOAuthProtectedResourceMetadata,
-  MCP_AUTH_ENABLED,
+  authInfoToMCPAuthContext,
+  anonymousAuthContext,
   type MCPAuthenticatedRequest,
 } from './auth.js';
 
 const logger = createLogger('mcp-routes');
+
+/**
+ * Externally-reachable URL of this server.
+ * Used as the OAuth issuer URL and for resource metadata.
+ *
+ * In production, BASE_URL defaults to https://agenticadvertising.org.
+ * In development, defaults to http://localhost:{PORT}.
+ */
+const MCP_SERVER_URL = (
+  process.env.BASE_URL ||
+  `http://localhost:${process.env.PORT || process.env.CONDUCTOR_PORT || '3000'}`
+).replace(/\/$/, '');
 
 /**
  * Rate limiter for MCP endpoint
@@ -40,7 +53,7 @@ const mcpRateLimiter = rateLimit({
   keyGenerator: (req: MCPAuthenticatedRequest) => {
     return `user:${req.mcpAuth?.sub || 'anonymous'}`;
   },
-  handler: (req, res) => {
+  handler: (_req, res) => {
     res.status(429).json({
       jsonrpc: '2.0',
       id: null,
@@ -56,46 +69,70 @@ const mcpRateLimiter = rateLimit({
  * Configure MCP routes on an Express router
  */
 export function configureMCPRoutes(router: Router): void {
-  // OAuth Protected Resource Metadata (RFC 9728)
-  // MCP clients use this to discover where to authenticate
-  const servePRM = (req: Request, res: Response) => {
-    const metadata = getOAuthProtectedResourceMetadata(req);
-    res.setHeader('Cache-Control', 'public, max-age=3600');
-    res.json(metadata);
-  };
+  const provider = createOAuthProvider();
 
-  router.get('/.well-known/oauth-protected-resource', servePRM);
-  // Path-specific PRM per RFC 9728 (for /mcp resource path)
-  router.get('/.well-known/oauth-protected-resource/mcp', servePRM);
+  // Mount SDK's OAuth router (handles metadata, authorize, token, register)
+  router.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl: new URL(MCP_SERVER_URL),
+      resourceServerUrl: new URL(`${MCP_SERVER_URL}/mcp`),
+      scopesSupported: ['openid', 'profile', 'email'],
+    })
+  );
 
   // CORS preflight for MCP endpoint
-  router.options('/mcp', (req: Request, res: Response) => {
+  router.options('/mcp', (_req: Request, res: Response) => {
     setCORSHeaders(res);
     res.status(204).end();
   });
 
-  // MCP POST handler - main endpoint
-  // Auth required: returns 401 with OAuth discovery metadata for unauthenticated requests
-  // Rate limited: 10/min per user
+  // Build the MCP POST middleware chain
+  const mcpMiddleware: Array<(req: MCPAuthenticatedRequest, res: Response, next: NextFunction) => void> = [];
+
+  if (MCP_AUTH_ENABLED) {
+    // Bearer token validation via SDK
+    mcpMiddleware.push(requireBearerAuth({ verifier: provider }) as (
+      req: MCPAuthenticatedRequest,
+      res: Response,
+      next: NextFunction,
+    ) => void);
+
+    // Bridge: convert SDK's req.auth (AuthInfo) → req.mcpAuth (MCPAuthContext)
+    mcpMiddleware.push((req: MCPAuthenticatedRequest, _res: Response, next: NextFunction) => {
+      if (req.auth) {
+        req.mcpAuth = authInfoToMCPAuthContext(req.auth);
+      } else {
+        logger.warn('MCP: requireBearerAuth passed but req.auth is missing');
+        req.mcpAuth = anonymousAuthContext();
+      }
+      next();
+    });
+  } else {
+    // Dev mode: attach anonymous auth context
+    mcpMiddleware.push((req: MCPAuthenticatedRequest, _res: Response, next: NextFunction) => {
+      req.mcpAuth = anonymousAuthContext();
+      next();
+    });
+  }
+
+  // MCP POST handler
   router.post(
     '/mcp',
-    mcpAuthMiddleware,
+    ...mcpMiddleware,
     mcpRateLimiter,
     async (req: MCPAuthenticatedRequest, res: Response) => {
       setCORSHeaders(res);
 
       let server: ReturnType<typeof createUnifiedMCPServer> | null = null;
       try {
-        // Create a new MCP server and transport for each request (stateless mode)
         server = createUnifiedMCPServer(req.mcpAuth);
         const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined, // Stateless mode - no sessions
+          sessionIdGenerator: undefined, // Stateless mode
         });
 
-        // Connect server to transport
         await server.connect(transport);
 
-        // Log request with auth context
         const isAuthenticated = req.mcpAuth?.sub && req.mcpAuth.sub !== 'anonymous';
         logger.debug({
           authenticated: isAuthenticated,
@@ -104,7 +141,6 @@ export function configureMCPRoutes(router: Router): void {
           ip: req.ip,
         }, 'MCP: Handling request');
 
-        // Handle the request
         await transport.handleRequest(req, res, req.body);
       } catch (error) {
         logger.error({ error }, 'MCP: Request handling error');
@@ -120,14 +156,13 @@ export function configureMCPRoutes(router: Router): void {
           });
         }
       } finally {
-        // Clean up per-request server to avoid event listener leaks
         await server?.close().catch(() => {});
       }
     }
   );
 
   // MCP GET handler - not supported in stateless mode
-  router.get('/mcp', (req: Request, res: Response) => {
+  router.get('/mcp', (_req: Request, res: Response) => {
     setCORSHeaders(res);
     res.setHeader('Allow', 'POST, OPTIONS');
     res.status(405).json({
@@ -141,7 +176,7 @@ export function configureMCPRoutes(router: Router): void {
   });
 
   // MCP DELETE handler - not needed in stateless mode
-  router.delete('/mcp', (req: Request, res: Response) => {
+  router.delete('/mcp', (_req: Request, res: Response) => {
     setCORSHeaders(res);
     res.setHeader('Allow', 'POST, OPTIONS');
     res.status(405).json({
@@ -154,7 +189,7 @@ export function configureMCPRoutes(router: Router): void {
     });
   });
 
-  logger.info({ authEnabled: MCP_AUTH_ENABLED }, 'MCP: Routes configured');
+  logger.info({ authEnabled: MCP_AUTH_ENABLED, serverUrl: MCP_SERVER_URL }, 'MCP: Routes configured');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaces hand-rolled OAuth middleware with the MCP SDK's built-in `ProxyOAuthServerProvider` and `mcpAuthRouter`
- All OAuth endpoints (authorize, token, register, discovery metadata) are now proxied to WorkOS AuthKit via the SDK
- ChatGPT, Claude Desktop, and other MCP clients should all work regardless of which OAuth discovery path they follow

## Changes
- **New**: `server/src/mcp/oauth-provider.ts` — `ProxyOAuthServerProvider` configured with AuthKit endpoints, JWT verification via JWKS
- **Rewritten**: `server/src/mcp/auth.ts` — Stripped to `MCPAuthContext` interface + `authInfoToMCPAuthContext` bridge
- **Rewritten**: `server/src/mcp/routes.ts` — Uses SDK's `mcpAuthRouter` + `requireBearerAuth` instead of custom middleware
- **Updated**: `server/src/mcp/index.ts` — Barrel exports adjusted

## How it works
The SDK's `mcpAuthRouter` auto-creates these endpoints:
- `GET /.well-known/oauth-authorization-server` — AS metadata (issuer = our URL, endpoints = our proxy routes)
- `GET /.well-known/oauth-protected-resource/mcp` — PRM metadata
- `GET/POST /authorize` — Redirects to AuthKit
- `POST /token` — Proxies to AuthKit
- `POST /register` — Proxies to AuthKit (RFC 7591 dynamic client registration)

The SDK's `requireBearerAuth` validates bearer tokens, and a bridge middleware converts the SDK's `AuthInfo` to our `MCPAuthContext` for tool handlers.

## Test plan
- [x] TypeScript builds without errors
- [x] All 297 tests pass
- [x] Vibium verified endpoints return correct metadata locally
- [ ] Deploy and test ChatGPT connector
- [ ] Verify Claude Desktop MCP connection still works
- [ ] Run `scripts/mcp-auth-test.mjs` against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)