### PR TITLE
fix: Set BASE_URL in Fly.io env for MCP OAuth

### DIFF
--- a/.changeset/fix-mcp-oauth-base-url.md
+++ b/.changeset/fix-mcp-oauth-base-url.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix MCP OAuth metadata returning localhost:8080 URLs in production by setting BASE_URL in Fly.io environment.

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,7 @@ primary_region = 'iad'
 
 [env]
   PORT = "8080"
+  BASE_URL = "https://agenticadvertising.org"
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
 


### PR DESCRIPTION
## Summary
- MCP OAuth metadata endpoints were returning `http://localhost:8080` URLs in production because `BASE_URL` was never set in Fly.io environment
- Claude (and other MCP clients) couldn't complete OAuth discovery since the metadata pointed them to unreachable localhost URLs
- Adds `BASE_URL = "https://agenticadvertising.org"` to `fly.toml` `[env]` section

## Test plan
- [ ] Deploy to Fly.io
- [ ] Verify `/.well-known/oauth-protected-resource/mcp` returns `https://agenticadvertising.org` URLs
- [ ] Verify `/.well-known/oauth-authorization-server` returns `https://agenticadvertising.org` URLs  
- [ ] Test MCP connection from Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)