### PR TITLE
feat: Consolidate individual profiles and show contributions

### DIFF
--- a/.changeset/shiny-nails-battle.md
+++ b/.changeset/shiny-nails-battle.md
@@ -1,0 +1,4 @@
+---
+---
+
+Consolidate individual profiles: redirect member-profile to community profile edit, add member directory fields, sync to member_profiles, show published content and registry contributions on profiles.

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -336,6 +336,66 @@
       color: var(--color-text-heading);
     }
 
+    .perspective-list {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+    }
+
+    .perspective-item {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-3);
+      padding: var(--space-3) var(--space-4);
+      background: var(--color-gray-50);
+      border-radius: var(--radius-lg);
+      text-decoration: none;
+      color: inherit;
+      transition: var(--transition-colors);
+    }
+
+    .perspective-item:hover {
+      background: var(--color-gray-100);
+    }
+
+    .perspective-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .perspective-icon.article {
+      background: var(--color-primary-100);
+      color: var(--color-brand);
+    }
+
+    .perspective-icon.link {
+      background: var(--color-success-100);
+      color: var(--color-success-700);
+    }
+
+    .perspective-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .perspective-title {
+      font-size: var(--text-sm);
+      font-weight: var(--font-medium);
+      color: var(--color-text-heading);
+      line-height: 1.4;
+    }
+
+    .perspective-meta {
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+      margin-top: 2px;
+    }
+
     /* =========================================================================
        Sidebar
        ========================================================================= */
@@ -993,6 +1053,104 @@
                     <span class="wg-item-name">${escapeHtml(wg.name)}</span>
                   </a>
                 `).join('')}
+              </div>
+            </div>
+          </div>
+        `;
+      }
+
+      // Published content
+      if (data.perspectives && data.perspectives.length > 0) {
+        html += `
+          <div class="profile-card">
+            <div class="profile-section" style="border-top: none;">
+              <h2 class="profile-section-title">Published content</h2>
+              <div class="perspective-list">
+                ${data.perspectives.map(p => {
+                  const isArticle = p.content_type === 'article';
+                  const href = isArticle
+                    ? '/perspectives/' + encodeURIComponent(p.slug)
+                    : escapeHtml(p.external_url || '#');
+                  const target = isArticle ? '' : ' target="_blank" rel="noopener noreferrer"';
+                  const date = new Date(p.published_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                  const meta = [p.category, !isArticle && p.external_site_name].filter(Boolean).join(' · ');
+                  const icon = isArticle
+                    ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line></svg>'
+                    : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>';
+                  return `
+                    <a href="${href}" class="perspective-item"${target}>
+                      <div class="perspective-icon ${isArticle ? 'article' : 'link'}">${icon}</div>
+                      <div class="perspective-info">
+                        <div class="perspective-title">${escapeHtml(p.title)}</div>
+                        <div class="perspective-meta">${escapeHtml(date)}${meta ? ' · ' + escapeHtml(meta) : ''}</div>
+                      </div>
+                    </a>
+                  `;
+                }).join('')}
+              </div>
+            </div>
+          </div>
+        `;
+      }
+
+      // Registry contributions
+      if (data.registry_contributions && data.registry_contributions.length > 0) {
+        html += `
+          <div class="profile-card">
+            <div class="profile-section" style="border-top: none;">
+              <h2 class="profile-section-title">Registry contributions</h2>
+              <div class="perspective-list">
+                ${data.registry_contributions.map(c => {
+                  const date = new Date(c.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                  const isBrand = c.contribution_type.startsWith('brand');
+                  const isCreate = c.contribution_type.endsWith('create');
+                  const href = isBrand ? '/brands/' + encodeURIComponent(c.domain) : '/properties/' + encodeURIComponent(c.domain);
+                  const icon = isBrand
+                    ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>'
+                    : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>';
+                  const typeLabel = isBrand ? 'Brand' : 'Property';
+                  return `
+                    <a href="${href}" class="perspective-item">
+                      <div class="perspective-icon ${isBrand ? 'article' : 'link'}">${icon}</div>
+                      <div class="perspective-info">
+                        <div class="perspective-title">${escapeHtml(c.domain)}</div>
+                        <div class="perspective-meta">${escapeHtml(date)} · ${typeLabel} ${isCreate ? 'created' : 'edited'}${!isCreate && c.summary ? ' · ' + escapeHtml(c.summary) : ''}</div>
+                      </div>
+                    </a>
+                  `;
+                }).join('')}
+              </div>
+            </div>
+          </div>
+        `;
+      }
+
+      // GitHub activity
+      if (data.github_username) {
+        const ghUser = escapeHtml(data.github_username);
+        html += `
+          <div class="profile-card">
+            <div class="profile-section" style="border-top: none;">
+              <h2 class="profile-section-title">GitHub activity</h2>
+              <div class="perspective-list">
+                <a href="https://github.com/adcontextprotocol/adcp/issues?q=author:${ghUser}" target="_blank" rel="noopener noreferrer" class="perspective-item">
+                  <div class="perspective-icon article">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+                  </div>
+                  <div class="perspective-info">
+                    <div class="perspective-title">Issues</div>
+                    <div class="perspective-meta">adcontextprotocol/adcp</div>
+                  </div>
+                </a>
+                <a href="https://github.com/adcontextprotocol/adcp/pulls?q=author:${ghUser}" target="_blank" rel="noopener noreferrer" class="perspective-item">
+                  <div class="perspective-icon link">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M13 6h3a2 2 0 0 1 2 2v7"></path><line x1="6" y1="9" x2="6" y2="21"></line></svg>
+                  </div>
+                  <div class="perspective-info">
+                    <div class="perspective-title">Pull requests</div>
+                    <div class="perspective-meta">adcontextprotocol/adcp</div>
+                  </div>
+                </a>
               </div>
             </div>
           </div>

--- a/server/public/community/profile-edit.html
+++ b/server/public/community/profile-edit.html
@@ -451,13 +451,13 @@
       <h1 class="edit-title">Edit profile</h1>
 
       <form id="profile-form" novalidate>
-        <!-- Profile visibility -->
+        <!-- Community visibility -->
         <div class="edit-section">
-          <h2 class="edit-section-title">Profile visibility</h2>
+          <h2 class="edit-section-title">Community visibility</h2>
           <div class="toggle-row">
             <div class="toggle-content">
               <div class="toggle-label">Public profile</div>
-              <div class="toggle-description">Make your profile visible in the community directory. Only logged-in members can see it.</div>
+              <div class="toggle-description">Make your profile visible in the <a href="/community/people" style="color: var(--color-brand);">community directory</a>. Only logged-in members can see it.</div>
             </div>
             <label class="toggle-switch">
               <input type="checkbox" id="field-is-public" aria-label="Public profile">
@@ -559,6 +559,43 @@
           </div>
         </div>
 
+        <!-- Member directory (individual accounts only) -->
+        <div class="edit-section" id="member-directory-section" style="display: none;">
+          <h2 class="edit-section-title">Member directory</h2>
+          <p style="font-size: var(--text-sm); color: var(--color-text-muted); margin-bottom: var(--space-4);">
+            Get listed in the <a href="/members" style="color: var(--color-brand);">member directory</a> so companies and peers can discover your expertise in agentic advertising.
+          </p>
+
+          <div id="member-directory-status" style="display: none; padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); margin-bottom: var(--space-4); font-size: var(--text-sm);"></div>
+
+          <div class="form-group">
+            <label class="form-label">What do you do?</label>
+            <div class="checkbox-row">
+              <input type="checkbox" id="offering-consulting" class="checkbox-input" value="consulting">
+              <label class="checkbox-label" for="offering-consulting">Consulting</label>
+            </div>
+            <div class="checkbox-row">
+              <input type="checkbox" id="offering-other" class="checkbox-input" value="other">
+              <label class="checkbox-label" for="offering-other">Other</label>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="field-contact-email">Contact email</label>
+            <input type="email" id="field-contact-email" class="form-input" placeholder="you@example.com">
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="field-contact-phone">Contact phone</label>
+            <input type="tel" id="field-contact-phone" class="form-input" placeholder="+1 (555) 123-4567">
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="field-contact-website">Website</label>
+            <input type="url" id="field-contact-website" class="form-input" placeholder="https://example.com">
+          </div>
+        </div>
+
         <!-- Save -->
         <div class="save-bar">
           <a href="/community" class="btn btn-ghost">Cancel</a>
@@ -582,6 +619,9 @@
 
     // State
     let profileData = null;
+    let memberProfileData = null;
+    let memberBillingData = null;
+    let isPersonalAccount = false;
     let expertiseTags = [];
     let interestsTags = [];
 
@@ -597,18 +637,48 @@
     // Data fetching
     async function loadProfile() {
       try {
-        const response = await fetch('/api/me/community/hub');
-        if (!response.ok) {
-          if (response.status === 401) {
+        const [hubResponse, memberResponse] = await Promise.all([
+          fetch('/api/me/community/hub'),
+          fetch('/api/me/member-profile').catch(() => null),
+        ]);
+
+        if (!hubResponse.ok) {
+          if (hubResponse.status === 401) {
             window.location.href = '/auth/login?return_to=/community/profile/edit';
             return;
           }
           throw new Error('Failed to load profile');
         }
 
-        const data = await response.json();
+        const data = await hubResponse.json();
         profileData = data.profile || {};
+
+        // Detect individual account and load member profile data
+        if (memberResponse && memberResponse.ok) {
+          const memberData = await memberResponse.json();
+          memberProfileData = memberData.profile || null;
+
+          // Check if org is personal via billing endpoint
+          if (memberData.organization_id) {
+            try {
+              const billingResp = await fetch(`/api/organizations/${memberData.organization_id}/billing`);
+              if (billingResp.ok) {
+                memberBillingData = await billingResp.json();
+                isPersonalAccount = memberBillingData.is_personal || false;
+              }
+            } catch (e) {
+              console.warn('Could not load billing info:', e);
+            }
+          }
+        }
+
         populateForm(profileData);
+
+        // Show member directory section for individual accounts
+        if (isPersonalAccount) {
+          document.getElementById('member-directory-section').style.display = 'block';
+          populateMemberFields(memberProfileData, memberBillingData);
+        }
 
         document.getElementById('edit-loading').style.display = 'none';
         document.getElementById('edit-content').style.display = 'block';
@@ -616,6 +686,41 @@
         console.error('Load profile error:', error);
         document.getElementById('edit-loading').innerHTML =
           '<p>Failed to load profile. <a href="/community/profile/edit">Try again</a></p>';
+      }
+    }
+
+    function populateMemberFields(memberProfile, billingData) {
+      if (!memberProfile) {
+        // No member profile yet — show informational status
+        const statusEl = document.getElementById('member-directory-status');
+        statusEl.style.display = 'block';
+        statusEl.style.background = 'var(--color-gray-50)';
+        statusEl.style.color = 'var(--color-text-secondary)';
+        statusEl.style.border = 'var(--border-1) solid var(--color-gray-200)';
+        statusEl.innerHTML = 'You don\'t have a member directory listing yet. <a href="/dashboard/settings" style="color: var(--color-brand); font-weight: var(--font-medium);">Subscribe</a> to create one and appear in the directory.';
+        return;
+      }
+      const offerings = memberProfile.offerings || [];
+      document.getElementById('offering-consulting').checked = offerings.includes('consulting');
+      document.getElementById('offering-other').checked = offerings.includes('other');
+      document.getElementById('field-contact-email').value = memberProfile.contact_email || '';
+      document.getElementById('field-contact-phone').value = memberProfile.contact_phone || '';
+      document.getElementById('field-contact-website').value = memberProfile.contact_website || '';
+
+      // Show visibility status
+      const statusEl = document.getElementById('member-directory-status');
+      statusEl.style.display = 'block';
+      const isSubscribed = billingData?.subscription?.status === 'active';
+      if (memberProfile.is_public && isSubscribed) {
+        statusEl.style.background = 'var(--color-success-50)';
+        statusEl.style.color = 'var(--color-success-700)';
+        statusEl.style.border = 'var(--border-1) solid var(--color-success-200)';
+        statusEl.innerHTML = 'Your listing is live at <a href="/members/' + encodeURIComponent(memberProfile.slug) + '" style="color: var(--color-success-700); font-weight: var(--font-medium);">/members/' + escapeHtml(memberProfile.slug) + '</a>';
+      } else {
+        statusEl.style.background = 'var(--color-warning-50)';
+        statusEl.style.color = 'var(--color-warning-700)';
+        statusEl.style.border = 'var(--border-1) solid var(--color-warning-200)';
+        statusEl.innerHTML = 'Your listing is not yet visible in the member directory. <a href="/dashboard/settings" style="color: var(--color-warning-700); font-weight: var(--font-medium);">Manage subscription</a>';
       }
     }
 
@@ -752,6 +857,17 @@
         open_to_coffee_chat: document.getElementById('field-coffee-chat').checked,
         open_to_intros: document.getElementById('field-intros').checked,
       };
+
+      // Include member directory fields for individual accounts
+      if (isPersonalAccount) {
+        const offerings = [];
+        if (document.getElementById('offering-consulting').checked) offerings.push('consulting');
+        if (document.getElementById('offering-other').checked) offerings.push('other');
+        payload.offerings = offerings;
+        payload.contact_email = document.getElementById('field-contact-email').value.trim() || undefined;
+        payload.contact_phone = document.getElementById('field-contact-phone').value.trim() || undefined;
+        payload.contact_website = document.getElementById('field-contact-website').value.trim() || undefined;
+      }
 
       try {
         const response = await fetch('/api/me/community-profile', {

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1225,6 +1225,12 @@
           console.warn('Could not load billing info for sidebar:', e);
         }
 
+        // Individual accounts use the community profile as their single profile
+        if (isPersonal) {
+          window.location.href = '/community/profile/edit';
+          return;
+        }
+
         // Initialize dashboard sidebar
         if (typeof DashboardNav !== 'undefined') {
           DashboardNav.init({
@@ -1239,9 +1245,7 @@
         document.getElementById('loading').style.display = 'none';
 
         // Update page title/subtitle based on account type
-        if (isPersonal) {
-          document.querySelector('.subtitle').textContent = 'Customize how you appear in the AdCP member directory';
-        } else if (currentOrgName) {
+        if (currentOrgName) {
           document.querySelector('.subtitle').textContent = `Customize how ${currentOrgName} appears in the AdCP member directory`;
         }
 

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -1402,7 +1402,7 @@
         }
 
         const data = await response.json();
-        renderMemberDetail(data.member);
+        renderMemberDetail(data.member, data.perspectives, data.registry_contributions, data.github_username);
       } catch (error) {
         console.error('Load member error:', error);
         document.getElementById('detail-content').innerHTML = `
@@ -1414,7 +1414,7 @@
       }
     }
 
-    function renderMemberDetail(member) {
+    function renderMemberDetail(member, perspectives, registryContributions, githubUsername) {
       const content = document.getElementById('detail-content');
 
       const foundingBadgeHtml = member.is_founding_member
@@ -1536,6 +1536,96 @@
               ` : ''}
             </div>
           </div>
+
+          ${perspectives && perspectives.length > 0 ? `
+            <div class="detail-section">
+              <h2>Published content</h2>
+              <div style="display: flex; flex-direction: column; gap: 12px;">
+                ${perspectives.map(p => {
+                  const isArticle = p.content_type === 'article';
+                  const href = isArticle ? '/perspectives/' + encodeURIComponent(p.slug) : escapeHtml(p.external_url || '#');
+                  const target = isArticle ? '' : ' target="_blank" rel="noopener noreferrer"';
+                  const date = new Date(p.published_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                  const meta = [p.category, !isArticle && p.external_site_name].filter(Boolean).join(' · ');
+                  return `
+                    <a href="${href}" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 16px; background: var(--color-gray-50); border-radius: 8px; text-decoration: none; color: inherit; transition: background 0.15s;"${target}
+                       onmouseover="this.style.background='var(--color-gray-100)'" onmouseout="this.style.background='var(--color-gray-50)'">
+                      <div style="width: 36px; height: 36px; border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; background: ${isArticle ? 'var(--color-primary-100)' : 'var(--color-success-100)'}; color: ${isArticle ? 'var(--color-brand)' : 'var(--color-success-700)'};">
+                        ${isArticle
+                          ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line></svg>'
+                          : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>'
+                        }
+                      </div>
+                      <div style="flex: 1; min-width: 0;">
+                        <div style="font-size: 14px; font-weight: 500; color: var(--color-text-heading); line-height: 1.4;">${escapeHtml(p.title)}</div>
+                        <div style="font-size: 12px; color: var(--color-text-muted); margin-top: 2px;">${escapeHtml(date)}${meta ? ' · ' + escapeHtml(meta) : ''}</div>
+                      </div>
+                    </a>
+                  `;
+                }).join('')}
+              </div>
+            </div>
+          ` : ''}
+
+          ${registryContributions && registryContributions.length > 0 ? `
+            <div class="detail-section">
+              <h2>Registry contributions</h2>
+              <div style="display: flex; flex-direction: column; gap: 12px;">
+                ${registryContributions.map(c => {
+                  const date = new Date(c.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                  const isBrand = c.contribution_type.startsWith('brand');
+                  const isCreate = c.contribution_type.endsWith('create');
+                  const href = isBrand ? '/brands/' + encodeURIComponent(c.domain) : '/properties/' + encodeURIComponent(c.domain);
+                  const typeLabel = isBrand ? 'Brand' : 'Property';
+                  return `
+                    <a href="${href}" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 16px; background: var(--color-gray-50); border-radius: 8px; text-decoration: none; color: inherit; transition: background 0.15s;"
+                       onmouseover="this.style.background='var(--color-gray-100)'" onmouseout="this.style.background='var(--color-gray-50)'">
+                      <div style="width: 36px; height: 36px; border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; background: ${isBrand ? 'var(--color-primary-100)' : 'var(--color-success-100)'}; color: ${isBrand ? 'var(--color-brand)' : 'var(--color-success-700)'};">
+                        ${isBrand
+                          ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>'
+                          : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>'
+                        }
+                      </div>
+                      <div style="flex: 1; min-width: 0;">
+                        <div style="font-size: 14px; font-weight: 500; color: var(--color-text-heading); line-height: 1.4;">${escapeHtml(c.domain)}</div>
+                        <div style="font-size: 12px; color: var(--color-text-muted); margin-top: 2px;">${escapeHtml(date)} · ${typeLabel} ${isCreate ? 'created' : 'edited'}${!isCreate && c.summary ? ' · ' + escapeHtml(c.summary) : ''}</div>
+                      </div>
+                    </a>
+                  `;
+                }).join('')}
+              </div>
+            </div>
+          ` : ''}
+
+          ${githubUsername ? `
+            <div class="detail-section">
+              <h2>GitHub activity</h2>
+              <div style="display: flex; flex-direction: column; gap: 12px;">
+                <a href="https://github.com/adcontextprotocol/adcp/issues?q=author:${escapeHtml(githubUsername)}" target="_blank" rel="noopener noreferrer"
+                   style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 16px; background: var(--color-gray-50); border-radius: 8px; text-decoration: none; color: inherit; transition: background 0.15s;"
+                   onmouseover="this.style.background='var(--color-gray-100)'" onmouseout="this.style.background='var(--color-gray-50)'">
+                  <div style="width: 36px; height: 36px; border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; background: var(--color-primary-100); color: var(--color-brand);">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+                  </div>
+                  <div style="flex: 1; min-width: 0;">
+                    <div style="font-size: 14px; font-weight: 500; color: var(--color-text-heading); line-height: 1.4;">Issues</div>
+                    <div style="font-size: 12px; color: var(--color-text-muted); margin-top: 2px;">adcontextprotocol/adcp</div>
+                  </div>
+                </a>
+                <a href="https://github.com/adcontextprotocol/adcp/pulls?q=author:${escapeHtml(githubUsername)}" target="_blank" rel="noopener noreferrer"
+                   style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 16px; background: var(--color-gray-50); border-radius: 8px; text-decoration: none; color: inherit; transition: background 0.15s;"
+                   onmouseover="this.style.background='var(--color-gray-100)'" onmouseout="this.style.background='var(--color-gray-50)'">
+                  <div style="width: 36px; height: 36px; border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; background: var(--color-success-100); color: var(--color-success-700);">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M13 6h3a2 2 0 0 1 2 2v7"></path><line x1="6" y1="9" x2="6" y2="21"></line></svg>
+                  </div>
+                  <div style="flex: 1; min-width: 0;">
+                    <div style="font-size: 14px; font-weight: 500; color: var(--color-text-heading); line-height: 1.4;">Pull requests</div>
+                    <div style="font-size: 12px; color: var(--color-text-muted); margin-top: 2px;">adcontextprotocol/adcp</div>
+                  </div>
+                </a>
+              </div>
+            </div>
+          ` : ''}
 
           ${member.tags && member.tags.length > 0 ? `
             <div class="detail-section">


### PR DESCRIPTION
## Summary

- For individual accounts, redirect `/member-profile` to `/community/profile/edit` to eliminate the redundant profile form
- Add "Member directory" section to community profile edit (offerings, contact email/phone/website) that appears only for personal accounts
- Sync community profile data to `member_profiles` table on save (update-only, no auto-creation)
- Display published content (articles/links) on both community person profile and member directory listing pages
- Display registry contributions (brand/property edits and creations) on both profile pages
- Display GitHub activity links (issues/PRs on adcontextprotocol/adcp) when user has a `github_username`
- Update UX copy: "Profile visibility" -> "Community visibility" with clearer description
- Add visibility status indicator for member directory listings

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (297/297)
- [x] Vibium browser test: community profile edit loads correctly for company accounts (member directory section hidden)
- [x] Vibium browser test: member-profile page shows company form (no redirect for non-personal accounts)
- [x] Code review: 3 CRITICAL fixes applied (XSS escaping for external_url and slug, contact_phone validation)
- [ ] Manual test with personal account: verify redirect from `/member-profile` to `/community/profile/edit`
- [ ] Manual test with personal account: verify member directory section appears and fields save correctly
- [ ] Manual test: verify published content renders on community person profile
- [ ] Manual test: verify registry contributions render on community person profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)