### PR TITLE
feat!: Replace estimated_exposures with forecast on Product

### DIFF
--- a/.changeset/remove-estimated-exposures.md
+++ b/.changeset/remove-estimated-exposures.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": major
+---
+
+Remove `estimated_exposures` from Product, replace with optional `forecast`
+
+- Remove the unitless `estimated_exposures` integer field from the Product schema
+- Add optional `forecast` field using the existing `DeliveryForecast` type, giving buyers structured delivery estimates with time periods, metric ranges, and methodology context during product discovery

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -59,10 +59,9 @@
       },
       "minItems": 1
     },
-    "estimated_exposures": {
-      "type": "integer",
-      "description": "Estimated exposures/impressions for guaranteed products",
-      "minimum": 0
+    "forecast": {
+      "$ref": "/schemas/core/delivery-forecast.json",
+      "description": "Forecasted delivery metrics for this product. Gives buyers an estimate of expected performance before requesting a proposal."
     },
     "measurement": {
       "$ref": "/schemas/core/measurement.json"


### PR DESCRIPTION
## Summary
- Remove the unitless `estimated_exposures` integer from the Product schema
- Add optional `forecast` field using the existing `DeliveryForecast` type, so buyers get structured delivery estimates (time periods, metric ranges, methodology) during product discovery
- Consistent with how `forecast` already works on `Proposal` and `ProductAllocation`

## Test plan
- [x] `npm test` passes (all 297 tests)
- [x] Schema validation confirms `$ref` resolves correctly
- [x] Bundled schemas include full inlined DeliveryForecast
- [x] No stale `estimated_exposures` references remain outside `dist/` history

🤖 Generated with [Claude Code](https://claude.com/claude-code)