### PR TITLE
feat: Add partner discovery as primary homepage CTA

### DIFF
--- a/.changeset/three-streets-warn.md
+++ b/.changeset/three-streets-warn.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add "Find a partner" as primary homepage CTA and rebrand member directory as partner directory with Addie chat integration for introductions.

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -518,7 +518,7 @@
             <p class="heroSubtitle_jFu1">One protocol for AI agents to buy media, build creatives, and activate audiences across any platform.</p>
             <div class="buttons_AeoN">
               <a href="https://docs.adcontextprotocol.org" target="_blank" rel="noopener noreferrer" class="button button--primary button--lg margin-right--md">Read the Docs</a>
-              <a href="/chat.html" class="button button--secondary button--lg margin-right--md">Talk to Addie</a>
+              <a href="/members" class="button button--secondary button--lg margin-right--md">Find a partner</a>
               <a href="https://github.com/adcontextprotocol/adcp" target="_blank" rel="noopener noreferrer" class="button button--outline button--secondary button--lg">GitHub</a>
             </div>
           </div>
@@ -765,15 +765,15 @@
                   </div>
                 </div>
                 <div class="audienceCard_fWZI">
-                  <h3>Join the community</h3>
-                  <p class="audienceDescription_DkBw">Shape the future of agentic advertising.</p>
+                  <h3>Find a partner</h3>
+                  <p class="audienceDescription_DkBw">Connect with companies who can help you implement AdCP.</p>
                   <ul class="audienceList_msXI">
-                    <li>Working groups and governance</li>
-                    <li>Slack community</li>
-                    <li>GitHub discussions</li>
+                    <li>Search by capability and geography</li>
+                    <li>Browse live agent implementations</li>
+                    <li>Request introductions via Addie</li>
                   </ul>
                   <div class="audienceAction_gTR6">
-                    <a href="/membership" class="button button--primary button--lg">Become a Member</a>
+                    <a href="/members" class="button button--primary button--lg">Browse partners</a>
                   </div>
                 </div>
               </div>

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Member Directory - AgenticAdvertising.org</title>
+  <title>Partner Directory - AgenticAdvertising.org</title>
   <link rel="icon" href="/AAo.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
@@ -1106,16 +1106,16 @@
   <!-- List View -->
   <div id="list-view">
     <div class="header">
-      <h1>Member Directory</h1>
-      <p class="subtitle">Organizations building the future of agentic advertising</p>
+      <h1>Partner directory</h1>
+      <p class="subtitle">Find companies who can help you implement AdCP</p>
     </div>
 
     <div class="container">
       <!-- Join CTA Card -->
       <div class="join-cta">
-        <h3>Ready to Join?</h3>
-        <p>Become a founding member today and help shape the future of agentic advertising. Join before March 31, 2026 to participate in the initial board selection process.</p>
-        <a href="/membership#pricing" class="join-cta-btn">View Membership Options</a>
+        <h3>Looking for implementation help?</h3>
+        <p>Browse partners below, or ask Addie to help you find the right match and make an introduction.</p>
+        <a href="/chat?prompt=Help%20me%20find%20a%20partner%20who%20can%20help%20me%20implement%20AdCP" class="join-cta-btn">Ask Addie to help</a>
       </div>
 
       <div class="search-section">
@@ -1148,6 +1148,11 @@
         <p>Try adjusting your search or filter criteria</p>
       </div>
       <div id="members-grid" class="members-grid"></div>
+      <div class="join-cta" id="general-inquiry" style="display: none;">
+        <h3>Not finding the right fit?</h3>
+        <p>Tell Addie what you're looking for and get matched with the right partner.</p>
+        <a href="/chat?prompt=I%27m%20looking%20for%20a%20partner%20who%20can%20help%20me%20with%20AdCP%20implementation" class="join-cta-btn">Ask Addie</a>
+      </div>
     </div>
   </div>
 
@@ -1158,6 +1163,12 @@
         <button class="back-btn" onclick="showListView()" style="margin-bottom: 0;">
           <span>&larr;</span> Back to Directory
         </button>
+        <a class="share-btn" id="intro-btn" href="#" style="background: var(--color-brand); color: white; text-decoration: none;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+          </svg>
+          Request introduction
+        </a>
         <div style="position: relative;">
           <button class="share-btn" id="share-btn" onclick="toggleShareDropdown(event)">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1313,14 +1324,17 @@
     function renderMembers(members) {
       const grid = document.getElementById('members-grid');
       const noResults = document.getElementById('no-results');
+      const generalInquiry = document.getElementById('general-inquiry');
 
       if (members.length === 0) {
         grid.innerHTML = '';
         noResults.style.display = 'block';
+        generalInquiry.style.display = 'none';
         return;
       }
 
       noResults.style.display = 'none';
+      generalInquiry.style.display = 'block';
 
       // renderMemberCard is now in member-card.js
       grid.innerHTML = members.map(member => renderMemberCard(member)).join('');
@@ -1549,7 +1563,7 @@
       `;
 
       // Update page title
-      document.title = `${member.display_name} - AgenticAdvertising.org Member Directory`;
+      document.title = `${member.display_name} - AgenticAdvertising.org Partner Directory`;
 
       // Update share links with member info
       updateShareLinks(member);
@@ -1776,6 +1790,10 @@
       currentMemberForShare = member;
       const profileUrl = window.location.href;
       const shareText = `Check out ${member.display_name} on AgenticAdvertising.org`;
+
+      // Introduction request link
+      const introPrompt = `I'd like an introduction to ${member.display_name}`;
+      document.getElementById('intro-btn').href = `/chat?prompt=${encodeURIComponent(introPrompt)}`;
 
       // LinkedIn share
       const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(profileUrl)}`;

--- a/server/public/org-index.html
+++ b/server/public/org-index.html
@@ -410,14 +410,9 @@
         We steward open standards like AdCP and bring together platforms, brands, agencies, and builders shaping the future of AI-powered advertising.
       </p>
       <div class="hero-buttons">
-        <a href="/membership" class="btn btn-primary">Become a Founding Member</a>
+        <a href="/members" class="btn btn-primary">Find a partner</a>
+        <a href="/membership" class="btn btn-secondary">Become a Founding Member</a>
         <a href="/about" class="btn btn-secondary">Learn More</a>
-        <a href="https://www.youtube.com/watch?v=QWmxvVS1RA8" class="btn btn-secondary" target="_blank" rel="noopener">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 0.5rem;">
-            <path d="M8 5v14l11-7z"/>
-          </svg>
-          Watch Launch Video
-        </a>
       </div>
       <p style="font-size: 0.9rem; color: rgba(255,255,255,0.85); margin-top: 1.5rem;"><strong>Limited time:</strong> Founding member pricing ends March 31, 2026</p>
     </div>
@@ -535,12 +530,12 @@
   <!-- CTA Section -->
   <section class="cta">
     <div class="cta-container">
-      <h2>Shape the Future of Advertising</h2>
+      <h2>Find a partner who can help you implement AdCP today</h2>
       <p>
-        Join the organizations building open standards for AI-powered advertising.
+        Browse our partner directory or ask Addie to match you with the right company.
       </p>
-      <a href="/membership" class="btn btn-primary">Become a Founding Member</a>
-      <p style="font-size: 0.85rem; color: rgba(255,255,255,0.8); margin-top: 1rem;"><strong>Limited time:</strong> Founding member pricing ends March 31, 2026</p>
+      <a href="/members" class="btn btn-primary">Browse partners</a>
+      <a href="/chat?prompt=Help%20me%20find%20a%20partner%20who%20can%20help%20me%20implement%20AdCP" class="btn btn-secondary" style="margin-left: 0.5rem;">Ask Addie</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Adds "Find a partner" as the primary CTA on both homepages (org + protocol site), shifting from membership-first to discovery-first messaging
- Rebrands the member directory as "Partner directory" with updated header, subtitle, and CTA card pointing visitors to Addie for partner matching
- Adds "Request introduction" button on member detail views and a "Not finding the right fit?" general inquiry card, both leveraging the existing Addie chat `request_introduction` flow
- No backend changes — all partner inquiry/introduction functionality already exists in Addie

## Test plan
- [x] Homepage hero shows "Find a partner" as primary CTA linking to `/members`
- [x] Homepage Get Started section updated with partner discovery card
- [x] Bottom CTA section updated with "Browse partners" + "Ask Addie" buttons
- [x] Partner directory page header reads "Partner directory"
- [x] "Ask Addie to help" CTA opens chat with pre-filled partner search prompt
- [x] Chat URLs use clean `/chat` path (not `/chat.html`) matching existing patterns
- [x] All button labels use sentence case per design system guidelines
- [x] URL-encoded apostrophe in prompt link
- [x] All tests pass, typecheck clean
- [x] Tested locally with Vibium browser automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)