### PR TITLE
docs: Document save endpoints for brands and properties

### DIFF
--- a/.changeset/doc-save-endpoints.md
+++ b/.changeset/doc-save-endpoints.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Document save endpoints for brands and properties in registry API docs.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -60,9 +60,10 @@ print(brand["brand_name"], brand["canonical_domain"])
 | Endpoint | Limit |
 |----------|-------|
 | Bulk resolve (`/api/brands/resolve/bulk`, `/api/properties/resolve/bulk`) | 20 requests/minute per IP |
+| Save endpoints (`/api/brands/save`, `/api/properties/save`) | 60 requests/hour per user |
 | All other endpoints | No limit |
 
-Bulk endpoints return `429 Too Many Requests` when the limit is exceeded.
+Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded.
 
 ## Endpoint Groups
 
@@ -90,6 +91,7 @@ Bulk endpoints return `429 Too Many Requests` when the limit is exceeded.
 | GET | `/api/brands/brand-json` | Fetch raw brand.json for a domain |
 | GET | `/api/brands/registry` | List all brands (search, pagination) |
 | GET | `/api/brands/enrich` | Enrich brand data via Brandfetch |
+| POST | `/api/brands/save` | Save or update a community brand (auth required) |
 
 ### Property Resolution
 
@@ -99,6 +101,7 @@ Bulk endpoints return `429 Too Many Requests` when the limit is exceeded.
 | POST | `/api/properties/resolve/bulk` | Resolve up to 100 domains at once |
 | GET | `/api/properties/registry` | List all properties (search, pagination) |
 | GET | `/api/properties/validate` | Validate a domain's adagents.json |
+| POST | `/api/properties/save` | Save or update a hosted property (auth required) |
 
 ### Agent Discovery
 
@@ -159,15 +162,15 @@ Pass the key in the `Authorization` header:
 Authorization: Bearer wos_api_key_...
 ```
 
-### Authenticated Endpoints
+### Authenticated endpoints
 
-These endpoints require a valid API key.
+These endpoints require a valid API key. Rate-limited to 60 requests per hour per user.
 
-#### Brand Write
+#### Save brand
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/brands/discovered/community` | Submit a brand to the registry (pending review) |
+`POST /api/brands/save`
+
+Save or update a community brand in the registry. For existing brands, creates a revision-tracked edit. Cannot edit authoritative brands managed via `brand.json` — those return `409 Conflict`.
 
 **Request body:**
 
@@ -175,8 +178,6 @@ These endpoints require a valid API key.
 {
   "domain": "acmecorp.com",
   "brand_name": "Acme Corp",
-  "house_domain": "acmecorp.com",
-  "keller_type": "master",
   "brand_manifest": {
     "name": "Acme Corp",
     "description": "A fictional company",
@@ -186,14 +187,12 @@ These endpoints require a valid API key.
 }
 ```
 
-Only `domain` is required. Submitted brands go through review before appearing in the registry.
-
-**Example:**
+`domain` and `brand_name` are required. `brand_manifest` is optional. The brand's `source` is set to `"community"` by the server. Domains are normalized (protocol stripped, lowercased).
 
 <CodeGroup>
 
 ```bash cURL
-curl -X POST "https://agenticadvertising.org/api/brands/discovered/community" \
+curl -X POST "https://agenticadvertising.org/api/brands/save" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"domain":"acmecorp.com","brand_name":"Acme Corp"}'
@@ -201,7 +200,7 @@ curl -X POST "https://agenticadvertising.org/api/brands/discovered/community" \
 
 ```javascript JavaScript
 const res = await fetch(
-  "https://agenticadvertising.org/api/brands/discovered/community",
+  "https://agenticadvertising.org/api/brands/save",
   {
     method: "POST",
     headers: {
@@ -221,7 +220,7 @@ const result = await res.json();
 import requests
 
 result = requests.post(
-    "https://agenticadvertising.org/api/brands/discovered/community",
+    "https://agenticadvertising.org/api/brands/save",
     headers={"Authorization": "Bearer YOUR_API_KEY"},
     json={"domain": "acmecorp.com", "brand_name": "Acme Corp"},
 ).json()
@@ -229,24 +228,130 @@ result = requests.post(
 
 </CodeGroup>
 
-```json Response
+```json Response (create)
 {
-  "brand": {
-    "domain": "acmecorp.com",
-    "brand_name": "Acme Corp",
-    "source_type": "community"
-  },
-  "review_status": "pending"
+  "success": true,
+  "message": "Brand \"Acme Corp\" saved to registry",
+  "domain": "acmecorp.com",
+  "id": "br_abc123"
 }
 ```
 
-### Error Responses
+```json Response (update)
+{
+  "success": true,
+  "message": "Brand \"Acme Corp\" updated in registry (revision 2)",
+  "domain": "acmecorp.com",
+  "id": "br_abc123",
+  "revision_number": 2
+}
+```
 
-| Status | Code | Description |
-|--------|------|-------------|
-| 401 | Unauthorized | Missing or invalid API key |
-| 403 | Forbidden | Valid key but insufficient permissions (e.g., not a member) |
-| 409 | Conflict | Brand already exists for this domain |
+#### Save property
+
+`POST /api/properties/save`
+
+Save or update a hosted property in the registry. For existing properties, creates a revision-tracked edit. Cannot edit authoritative properties managed via `adagents.json` — those return `409 Conflict`.
+
+**Request body:**
+
+```json
+{
+  "publisher_domain": "examplepub.com",
+  "authorized_agents": [
+    { "url": "https://agent.example.com", "authorized_for": "sell" }
+  ],
+  "properties": [
+    { "type": "website", "name": "Example Publisher" }
+  ],
+  "contact": {
+    "name": "Ad Ops",
+    "email": "adops@examplepub.com"
+  }
+}
+```
+
+`publisher_domain` and `authorized_agents` (each with a required `url` and optional `authorized_for`) are required. `properties` (each requiring `type` and `name`) and `contact` are optional. Domains are normalized (protocol stripped, lowercased).
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST "https://agenticadvertising.org/api/properties/save" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "publisher_domain": "examplepub.com",
+    "authorized_agents": [{"url": "https://agent.example.com", "authorized_for": "sell"}],
+    "properties": [{"type": "website", "name": "Example Publisher"}]
+  }'
+```
+
+```javascript JavaScript
+const res = await fetch(
+  "https://agenticadvertising.org/api/properties/save",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer YOUR_API_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      publisher_domain: "examplepub.com",
+      authorized_agents: [{ url: "https://agent.example.com", authorized_for: "sell" }],
+      properties: [{ type: "website", name: "Example Publisher" }],
+    }),
+  }
+);
+const result = await res.json();
+```
+
+```python Python
+import requests
+
+result = requests.post(
+    "https://agenticadvertising.org/api/properties/save",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    json={
+        "publisher_domain": "examplepub.com",
+        "authorized_agents": [{"url": "https://agent.example.com", "authorized_for": "sell"}],
+        "properties": [{"type": "website", "name": "Example Publisher"}],
+    },
+).json()
+```
+
+</CodeGroup>
+
+```json Response (create)
+{
+  "success": true,
+  "message": "Hosted property created for examplepub.com",
+  "id": "prop_xyz789"
+}
+```
+
+```json Response (update)
+{
+  "success": true,
+  "message": "Property 'examplepub.com' updated (revision 2)",
+  "id": "prop_xyz789",
+  "revision_number": 2
+}
+```
+
+#### Submit brand (legacy)
+
+`POST /api/brands/discovered/community`
+
+Submit a brand for review. This endpoint predates `/api/brands/save` — prefer the save endpoint for new integrations.
+
+### Error responses
+
+| Status | Description |
+|--------|-------------|
+| 400 | Missing required fields or invalid domain |
+| 401 | Missing or invalid API key |
+| 409 | Cannot edit an authoritative brand/property (managed via `brand.json` or `adagents.json`) |
+| 429 | Rate limit exceeded (60 requests/hour) |
 
 ## Protocol vs REST API
 


### PR DESCRIPTION
## Summary

- Documents `POST /api/brands/save` and `POST /api/properties/save` in the registry API docs
- These endpoints were implemented in #1101 but were missing from the Mintlify documentation
- Adds rate limits, auth requirements, request/response examples (create and update paths), and error codes

## Test plan

- [x] All tests pass (schema validation, examples, OpenAPI, typecheck)
- [x] No broken links in docs
- [x] Reviewed by docs expert and code reviewer
- [ ] Visual check in `mintlify dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)