### PR TITLE
fix: Replace proxy OAuth provider with broker for MCP auth

### DIFF
--- a/.changeset/fix-mcp-oauth-redirect.md
+++ b/.changeset/fix-mcp-oauth-redirect.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix MCP OAuth authentication by replacing the proxy-based OAuth provider with a broker that handles client registration and PKCE locally while delegating user authentication to AuthKit.

--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -150,3 +150,45 @@ export async function refreshToken(refreshToken: string): Promise<{
     refreshToken: response.refreshToken,
   };
 }
+
+/**
+ * Exchange authorization code for tokens without sealed session.
+ * Used by MCP OAuth flow where we need raw tokens, not cookies.
+ */
+export async function authenticateWithCodeForTokens(code: string): Promise<{
+  accessToken: string;
+  refreshToken: string;
+}> {
+  logger.debug('Authenticating with code for tokens (MCP flow)');
+
+  const result = await workos.userManagement.authenticateWithCode({
+    clientId,
+    code,
+  });
+
+  logger.info({ userId: result.user.id }, 'MCP: User authenticated for tokens');
+
+  return {
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+  };
+}
+
+/**
+ * Refresh tokens without sealed session.
+ * Used by MCP OAuth flow.
+ */
+export async function refreshTokenRaw(refreshTokenValue: string): Promise<{
+  accessToken: string;
+  refreshToken: string;
+}> {
+  const response = await workos.userManagement.authenticateWithRefreshToken({
+    clientId,
+    refreshToken: refreshTokenValue,
+  });
+
+  return {
+    accessToken: response.accessToken,
+    refreshToken: response.refreshToken,
+  };
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4873,6 +4873,17 @@ Disallow: /api/admin/
         });
       }
 
+      // MCP OAuth flow: detect mcp_pending_id in state and delegate
+      if (state) {
+        let parsedState: Record<string, unknown> | undefined;
+        try { parsedState = JSON.parse(state); } catch { /* not JSON */ }
+
+        if (typeof parsedState?.mcp_pending_id === 'string') {
+          const { handleMCPOAuthCallback } = await import('./mcp/oauth-provider.js');
+          return handleMCPOAuthCallback(req, res, code, parsedState.mcp_pending_id);
+        }
+      }
+
       try {
         // Exchange code for sealed session and user info
         const { user, sealedSession } = await workos!.userManagement.authenticateWithCode({

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -6,13 +6,13 @@
  * - Directory lookup (members, agents, publishers)
  * - Billing operations (membership products, payment links)
  *
- * Authentication via OAuth 2.1 (WorkOS AuthKit), proxied through
- * the MCP SDK's ProxyOAuthServerProvider.
+ * Authentication via OAuth 2.1 (WorkOS AuthKit), brokered through
+ * MCPOAuthProvider which handles registration and PKCE locally.
  */
 
 export { createUnifiedMCPServer, initializeMCPServer, isMCPServerReady, getAllTools } from './server.js';
 export { configureMCPRoutes } from './routes.js';
-export { createOAuthProvider, AUTHKIT_ISSUER, MCP_AUTH_ENABLED } from './oauth-provider.js';
+export { createOAuthProvider, handleMCPOAuthCallback, AUTHKIT_ISSUER, MCP_AUTH_ENABLED } from './oauth-provider.js';
 export {
   authInfoToMCPAuthContext,
   anonymousAuthContext,

--- a/server/src/mcp/routes.ts
+++ b/server/src/mcp/routes.ts
@@ -6,8 +6,9 @@
  * - OAuth endpoints via SDK's mcpAuthRouter (authorize, token, register, metadata)
  * - OPTIONS /mcp - CORS preflight
  *
- * OAuth 2.1 is proxied to WorkOS AuthKit via ProxyOAuthServerProvider.
- * The SDK's mcpAuthRouter handles all discovery and proxy endpoints:
+ * OAuth 2.1 is brokered via MCPOAuthProvider: registration and PKCE
+ * are handled locally, user authentication delegates to AuthKit.
+ * The SDK's mcpAuthRouter handles all discovery and OAuth endpoints:
  * - /.well-known/oauth-authorization-server
  * - /.well-known/oauth-protected-resource/mcp
  * - /authorize, /token, /register


### PR DESCRIPTION
## Summary

- Replaces `ProxyOAuthServerProvider` with custom `MCPOAuthProvider` that acts as an OAuth broker
- Handles client registration (RFC 7591) and PKCE locally using in-memory TTL stores
- Delegates user authentication to WorkOS AuthKit via existing `/auth/callback` route
- Adds `mcp_pending_id` detection in the auth callback to route MCP flows separately from web auth

## Why

MCP clients (ChatGPT, Claude) could authenticate at AuthKit but the redirect back to their callback URLs failed because the proxy approach forwarded everything to AuthKit, which doesn't redirect to arbitrary MCP client URLs.

## How it works

```
MCP Client → POST /register → Server stores client locally
MCP Client → GET /authorize → Server stores pending auth, redirects to AuthKit
User → Logs in at AuthKit → Redirects to /auth/callback?state={mcp_pending_id}
Server → Exchanges WorkOS code for tokens → Generates local auth code
Server → Redirects to MCP client's callback with code
MCP Client → POST /token → SDK validates PKCE, server returns tokens
```

## Test plan

- [x] `npm run build` compiles
- [x] `npm test` — all 297 tests pass
- [x] `npm run typecheck` — clean
- [x] Code review — no critical issues
- [ ] Manual test with `scripts/mcp-auth-test.mjs` against deployed server
- [ ] Test with ChatGPT or Claude MCP client


🤖 Generated with [Claude Code](https://claude.com/claude-code)