### PR TITLE
fix: remove duplicate heading and expand at-a-glance table on AdCP v3 overview

### DIFF
--- a/.changeset/fix-v3-overview-heading.md
+++ b/.changeset/fix-v3-overview-heading.md
@@ -1,0 +1,4 @@
+---
+"adcontextprotocol": patch
+---
+

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -3,16 +3,16 @@ title: AdCP v3
 description: "Overview of AdCP v3: new capabilities, breaking changes, and migration guides"
 ---
 
-# AdCP v3
-
 AdCP v3 expands the protocol beyond media buying into brand identity, governance, media planning, and conversational brand experiences.
 
 ## At a glance
 
 | Area | v2.x | v3.x |
 |------|------|------|
-| **Protocol scope** | Media Buy, Signals, Creative | + Governance, Sponsored Intelligence, Brand Protocol |
+| **Protocol scope** | Media Buy, Signals, Creative | Adds Brand Protocol, Governance, Sponsored Intelligence |
 | **Brand identity** | No standard mechanism | `brand.json` + community brand registry |
+| **Governance** | No brand suitability protocol | Property lists, content standards, and brand calibration |
+| **Sponsored Intelligence** | No conversational brand protocol | Consent-first brand sessions in AI assistants |
 | **Accounts** | No formal account model | `sync_accounts` with billing models and trust levels |
 | **Media planning** | Products only | Proposals with budget allocations + delivery forecasts |
 | **Channel model** | 9 channels | 19 planning-oriented channels |


### PR DESCRIPTION
## Summary

- Removes the duplicate `# AdCP v3` H1 heading — Mintlify renders the frontmatter `title` as the page heading, so the explicit H1 was appearing twice
- Adds individual rows for **Governance** and **Sponsored Intelligence** in the at-a-glance table so they get proper visibility rather than being bundled into the protocol scope row

## Test plan

- [ ] Verify the AdCP v3 overview page shows a single heading
- [ ] Verify the at-a-glance table has rows for Governance and Sponsored Intelligence

🤖 Generated with [Claude Code](https://claude.com/claude-code)