### PR TITLE
fix: Addie multi-party thread routing and prompt improvements

### DIFF
--- a/.changeset/better-hounds-bet.md
+++ b/.changeset/better-hounds-bet.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Addie multi-party thread routing and prompt improvements.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2639,7 +2639,7 @@ async function handleChannelMessage({
     if (participated) {
       // When multiple humans are in the thread, only respond if the message
       // is clearly directed at Addie (mentions her name, or replies to her).
-      if (isMultiPartyThread(slackThreadMessages, context.botUserId)
+      if (isMultiPartyThread(slackThreadMessages, context.botUserId, userId)
           && !isDirectedAtAddie(messageText, slackThreadMessages, event.ts, userId, context.botUserId)) {
         const uniqueHumans = new Set(
           slackThreadMessages.map(msg => msg.user).filter(u => u && u !== context.botUserId)

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -632,12 +632,12 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'search_members',
     description:
-      'Search for member organizations that can help with specific needs. Searches member names, descriptions, taglines, offerings, and tags using natural language. Use this when users ask about finding vendors, consultants, implementation partners, managed services, or anyone who can help them with AdCP adoption. Returns public member profiles with contact info.',
-    usage_hints: 'use for "find someone to run a sales agent", "who can help me implement AdCP", "find a CTV partner", "looking for managed services", "need a consultant"',
+      'Search for member ORGANIZATIONS (companies) that offer specific capabilities or services. Searches member names, descriptions, taglines, offerings, and tags. Use this when users want to find vendors, consultants, implementation partners, or managed services. The query should reflect what the user actually needs (e.g., "CTV measurement", "sales agent implementation") — not a generic term like "partner". Returns public member profiles with contact info.',
+    usage_hints: 'use for "find someone to run a sales agent", "who can help me implement AdCP", "find a CTV partner", "looking for managed services", "need a consultant". Do NOT use for finding individual people or contacts at specific companies.',
     input_schema: {
       type: 'object',
       properties: {
-        query: { type: 'string', description: 'Natural language search query' },
+        query: { type: 'string', description: 'What the user is looking for — use their specific need (e.g., "CTV measurement partner", "sales agent implementation"). Never use "partner" alone as the query.' },
         offerings: { type: 'array', items: { type: 'string', enum: ['buyer_agent', 'sales_agent', 'creative_agent', 'signals_agent', 'si_agent', 'governance_agent', 'publisher', 'consulting', 'other'] }, description: 'Filter by offerings' },
         limit: { type: 'number', description: 'Max results (default 5)' },
       },

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -72,12 +72,12 @@ You have access to these tools to help users:
 - get_my_profile: Show user's profile
 - update_my_profile: Update profile fields
 
-**Partner Directory (Member Directory):**
-The member directory IS the searchable partner directory. When users ask for a "partner directory", "vendor directory", or want to find partners/vendors/consultants, use these tools — do NOT say you lack a partner directory.
+**Member Directory (searchable vendor/partner directory):**
+The member directory lists AgenticAdvertising.org member ORGANIZATIONS (companies). Use it to find companies that offer specific services — not individual people. When users ask about vendors, implementation partners, consultants, or service providers, search with the user's actual need as the query (e.g., "CTV measurement", "creative optimization") — do NOT use generic terms like "partner".
 
-- search_members: Search the partner directory by expertise, offerings, or capability (authenticated users)
-- list_members: Browse the partner directory with filtering by offerings, markets, or search term (available to all users)
-- request_introduction: Request an email introduction to a member
+- search_members: Find member organizations by capability or need (authenticated users). Always use the user's stated need as the search query.
+- list_members: Browse members filtered by offerings, markets, or search term (available to all users)
+- request_introduction: Request an email introduction to a specific member organization
 - get_my_search_analytics: Show the user's profile analytics
 
 **Sponsored Intelligence (SI):**
@@ -123,8 +123,11 @@ API key management is done through the member dashboard, not through Addie tools
 **GitHub:**
 - draft_github_issue: Draft a GitHub issue with pre-filled URL
 
+**Billing Support (for members):**
+Members with billing questions (invoices, payments, membership fees, pricing, refunds) cannot be handled directly — use escalate_to_admin. Do not attempt to use billing tools on behalf of non-admin users.
+
 **Escalation:**
-- escalate_to_admin: Create a tracked request for the team
+- escalate_to_admin: Create a tracked request for the team. Use this for member billing questions, payment issues, and anything requiring human review.
 - list_escalations: List open escalations needing attention (admin only)
 - resolve_escalation: Mark an escalation as resolved and notify the user (admin only)
 

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -328,6 +328,10 @@ The user has NOT linked their Slack account to AgenticAdvertising.org.
 The user is an ADMIN.
 - They have access to the "admin" tool set for system operations
 - Be more direct and technical in responses`;
+  } else {
+    conditionalRules += `
+The user is NOT an admin.
+- Billing questions (invoices, payments, membership fees, pricing) → respond with [] (no tools). Use escalate_to_admin (always available regardless of tool set) to create a support ticket on their behalf. Do NOT route to the "billing" tool set.`;
   }
 
   return `You are Addie's router. Analyze this message and select the appropriate tool SETS.
@@ -348,7 +352,7 @@ ${toolSetsSection}
 IMPORTANT: Select tool SETS based on the user's INTENT:
 - Questions about AdCP, protocols, implementation → ["knowledge"]
 - Questions about member profile, working groups, account → ["member"]
-- Looking for vendors, partners, introductions → ["directory"]
+- Looking for companies/vendors/service providers/implementation partners → ["directory"]
 - Testing/validating AdCP agent implementations → ["agent_testing"]
 - Actually executing AdCP operations (media buys, creatives, signals) → ["adcp_operations"]
 - Content workflows, GitHub issues, proposals → ["content"]
@@ -358,13 +362,15 @@ IMPORTANT: Select tool SETS based on the user's INTENT:
 - Multiple intents? Include multiple sets: ["knowledge", "agent_testing"]
 - General questions needing no tools → []
 
+**directory clarify rule**: The directory lists MEMBER ORGANIZATIONS (companies), not individual people. If a user asks for "a contact in [role/department]" without specifying what service or capability they need, use the clarify action to ask what they're looking for rather than searching the directory.
+
 ## Messages to React To (emoji only, no response)
 ${reactList}
 
 ## Messages to Ignore
 - Simple acknowledgments: ok, got it, cool, thanks, etc.
 - Casual conversation unrelated to AdCP or AgenticAdvertising.org
-- Messages clearly directed at specific people
+- Messages clearly directed at specific people (e.g., start with "<@USERID> ..." in Slack format)
 - Off-topic discussions
 
 ## Message


### PR DESCRIPTION
## Summary

- **Multi-party thread race condition**: `isMultiPartyThread` now accepts an optional `currentUserId` so the current message sender is counted as a participant even if Slack's thread-replies API hasn't persisted their message yet — preventing Addie from responding to a new person jumping into a thread
- **@mention detection**: `isDirectedAtAddie` now returns `false` immediately when a message starts with `<@USERID>` addressing another user, so messages like "@Ingmar that can be me" are correctly recognised as not directed at Addie
- **Billing escalation for members**: router now directs non-admin billing questions to `escalate_to_admin` (always available) instead of the admin-only `billing` tool set
- **Member directory framing**: prompt and tool descriptions clarified that the directory lists organisations (not individuals), and `search_members` queries should use the user's specific need — not the generic term "partner"

## Test plan

- [ ] All existing tests pass (pre-commit hook verified)
- [ ] 7 new unit tests added for `isMultiPartyThread` (race condition) and `isDirectedAtAddie` (@mention detection), all passing
- [ ] Test IDs use valid Slack ID format (uppercase alphanumeric) to ensure the @mention regex path is actually exercised
- [ ] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)