### PR TITLE
fix: persist agent type from discovery; fix registry MCP URL

### DIFF
--- a/.changeset/fix-registry-agent-type-mcp-url.md
+++ b/.changeset/fix-registry-agent-type-mcp-url.md
@@ -1,0 +1,4 @@
+---
+"adcontextprotocol": patch
+---
+

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -2155,6 +2155,11 @@
         } else {
           const data = await response.json();
           agentInfo[url] = data;
+          // Write discovered type back so it gets persisted when the profile is saved
+          const agent = agents.find(a => a.url === url);
+          if (agent && data.type && data.type !== 'unknown' && (!agent.type || agent.type === 'unknown')) {
+            agent.type = data.type;
+          }
         }
       } catch (error) {
         agentInfo[url] = { error: 'Failed to connect to agent' };

--- a/server/public/registry.html
+++ b/server/public/registry.html
@@ -503,7 +503,7 @@
                 <h3>🤖 Use in Your AI Assistant</h3>
                 <div class="mcp-box">
                     <p>Add this MCP server to Claude Desktop or ChatGPT:</p>
-                    <div class="mcp-url">https://adcp-registry.fly.dev/mcp</div>
+                    <div class="mcp-url">https://agenticadvertising.org/mcp</div>
                     <p class="property-section-small">Exposes 4 tools: <code>list_agents</code>, <code>get_agent</code>, <code>find_agents_for_property</code>, <code>get_properties_for_agent</code></p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Sales agents not appearing in registry**: When members register agents in their profile, `discoverAgentInfo` fetched the type from `/api/discover-agent` (correctly detecting `'sales'`, `'creative'`, etc.) but stored it only in a UI-only cache — never writing it back to the `agents` array that gets persisted. All agents were saved as `{ url, is_public: true }` with no type, defaulting to `'unknown'` in the registry and making all tabs appear empty.
- **Stale MCP URL**: `registry.html` footer showed `https://adcp-registry.fly.dev/mcp` — that app doesn't exist (Fly.io app is `adcp-docs`). Fixed to `https://agenticadvertising.org/mcp`.

## Test plan

- [ ] Existing members: visit profile page, wait for agent discovery to complete (type badge appears), save — agents should now appear in correct registry tab
- [ ] New agent registration: add an agent URL, wait for discovery, save — type persists
- [ ] Registry footer shows `https://agenticadvertising.org/mcp`
- [ ] `/registry?type=sales` tab populates after members re-save their profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)