### PR TITLE
fix: set CORS headers on MCP 401 responses so OAuth flow can start

### DIFF
--- a/.changeset/fix-mcp-cors-on-401.md
+++ b/.changeset/fix-mcp-cors-on-401.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+fix: set CORS headers on MCP 401 responses so OAuth flow can start


### PR DESCRIPTION
## Summary

- `setCORSHeaders` was only called inside the final POST handler, but `requireBearerAuth` short-circuits the middleware chain before reaching it
- Browser-based MCP clients (Claude.ai) make cross-origin requests to `/mcp` — without CORS headers on 401 responses, the browser blocks the response entirely, so Claude.ai can't read `WWW-Authenticate` or discover the OAuth server
- Move CORS setup to the first middleware in the chain so **all** `/mcp` responses — including 401s — include `Access-Control-Allow-Origin: *` and `Access-Control-Expose-Headers: WWW-Authenticate`

## Test plan

- [ ] Add Addie as MCP server in Claude.ai — OAuth flow should now start (shows "Connect" button) instead of "Error connecting to the MCP server"
- [ ] Verify authenticated MCP requests still work after OAuth completes
- [ ] Verify `OPTIONS /mcp` preflight still returns 204 with CORS headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)