### PR TITLE
fix: preserve roles in org merge and block domains on personal orgs

### DIFF
--- a/.changeset/fix-org-merge-roles-and-personal-domains.md
+++ b/.changeset/fix-org-merge-roles-and-personal-domains.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Empty changeset — no protocol impact.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -4563,7 +4563,7 @@ Use add_committee_leader to assign a leader.`;
     try {
       // Verify org exists
       const orgResult = await pool.query(
-        `SELECT name, email_domain FROM organizations WHERE workos_organization_id = $1`,
+        `SELECT name, email_domain, is_personal FROM organizations WHERE workos_organization_id = $1`,
         [organizationId]
       );
 
@@ -4572,6 +4572,7 @@ Use add_committee_leader to assign a leader.`;
       }
 
       const orgName = orgResult.rows[0].name;
+      const isPersonal = orgResult.rows[0].is_personal;
 
       switch (action) {
         case 'list': {
@@ -4603,6 +4604,10 @@ Use add_committee_leader to assign a leader.`;
         case 'add': {
           if (!domain) {
             return '❌ domain is required for the "add" action. Example: "acme.com"';
+          }
+
+          if (isPersonal) {
+            return `❌ Domains cannot be added to individual (personal) organizations like **${orgName}**.`;
           }
 
           const normalizedDomain = domain.toLowerCase().trim();

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -1180,12 +1180,19 @@ export function setupDomainRoutes(
 
         // Verify org exists
         const orgResult = await pool.query(
-          `SELECT name FROM organizations WHERE workos_organization_id = $1`,
+          `SELECT name, is_personal FROM organizations WHERE workos_organization_id = $1`,
           [orgId]
         );
 
         if (orgResult.rows.length === 0) {
           return res.status(404).json({ error: "Organization not found" });
+        }
+
+        if (orgResult.rows[0].is_personal) {
+          return res.status(400).json({
+            error: "Invalid operation",
+            message: "Domains cannot be added to individual (personal) organizations",
+          });
         }
 
         // Check if domain is already claimed by another org locally


### PR DESCRIPTION
## Summary

- **Org merge loses owner role**: The member migration endpoint (`POST /api/admin/accounts/migrate-members`) was calling `createOrganizationMembership` without a `roleSlug`, so WorkOS defaulted everyone to `member`. Owners being migrated lost their status, leaving the destination org without an admin.
- **Personal orgs could get verified domains**: Four domain-write paths lacked an `is_personal` guard — the admin domain endpoint, both WorkOS webhook handlers (`organization.updated` via `syncOrganizationDomains` and `organization_domain.*` via `upsertOrganizationDomain`), and the Addie `manage_organization_domains` tool.

## Changes

- `admin/accounts.ts`: Select `role` from source memberships, pass it as `roleSlug` on create, include it in the local cache insert; log a warning when role is missing from cache
- `admin/domains.ts`: Reject domain adds for personal orgs with 400
- `workos-webhooks.ts`: Skip domain sync in both `syncOrganizationDomains` and `upsertOrganizationDomain` for personal orgs
- `admin-tools.ts`: Return an error from the Addie `add` domain action for personal orgs

## Test plan

- [ ] Migrate members from an org where one member is `owner` — verify they land in the target org as `owner` in WorkOS
- [ ] Attempt to add a domain to a personal org via admin UI — should get 400
- [ ] Trigger a WorkOS `organization_domain.created` event for a personal org — verify no row appears in `organization_domains`
- [ ] Normal org merge with all `member` roles continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)