### PR TITLE
fix: update schema links to v3 and add prerelease symlink support

### DIFF
--- a/.changeset/fix-schema-version-sorting.md
+++ b/.changeset/fix-schema-version-sorting.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix schema version alias resolution for prereleases
+
+- Fix prerelease sorting bug in schema middleware: `/v3/` was resolving to `3.0.0-beta.1` instead of `3.0.0-beta.3` because prereleases were sorted ascending instead of descending
+- Update `sync_event_sources` and `log_event` docs to use `/v3/` schema links (these schemas were added in v3)

--- a/docs/media-buy/task-reference/log_event.mdx
+++ b/docs/media-buy/task-reference/log_event.mdx
@@ -8,8 +8,8 @@ Send conversion or marketing events for attribution and optimization. Supports b
 
 **Response Time**: ~1s (events are queued for processing)
 
-**Request Schema**: [`/schemas/v2/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v2/media-buy/log-event-request.json)
-**Response Schema**: [`/schemas/v2/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v2/media-buy/log-event-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/sync_event_sources.mdx
+++ b/docs/media-buy/task-reference/sync_event_sources.mdx
@@ -8,8 +8,8 @@ Configure event sources on a seller account for conversion tracking. Supports up
 
 **Response Time**: ~1s (synchronous configuration)
 
-**Request Schema**: [`/schemas/v2/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v2/media-buy/sync-event-sources-request.json)
-**Response Schema**: [`/schemas/v2/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v2/media-buy/sync-event-sources-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
 
 ## Quick Start
 
@@ -123,7 +123,7 @@ asyncio.run(main())
 - `setup` - Implementation details (snippet, instructions)
 - `errors` - Per-source errors (only when `action: "failed"`)
 
-**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/v2/media-buy/sync-event-sources-response.json)
+**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
 
 ## Common Scenarios
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -504,8 +504,8 @@ export class HTTPServer {
           // Stable versions come before prereleases (no prerelease = higher precedence)
           if (!av.prerelease && bv.prerelease) return -1;
           if (av.prerelease && !bv.prerelease) return 1;
-          // Both have prereleases, sort alphabetically (beta.1 < beta.2)
-          if (av.prerelease && bv.prerelease) return av.prerelease.localeCompare(bv.prerelease);
+          // Both have prereleases, sort descending (beta.3 before beta.1)
+          if (av.prerelease && bv.prerelease) return bv.prerelease.localeCompare(av.prerelease);
           return 0;
         });
 


### PR DESCRIPTION
## Summary
- Fix prerelease sorting bug in schema middleware: `/v3/` was resolving to `3.0.0-beta.1` instead of `3.0.0-beta.3` because prereleases were sorted ascending instead of descending
- Update `sync_event_sources` and `log_event` docs to use `/v3/` schema links (previously pointing to non-existent `/v2/` paths)

Issue 1: Wrong symlink version ordering 
<img width="672" height="200" alt="Screenshot 2026-02-20 at 2 38 42 PM" src="https://github.com/user-attachments/assets/1ae1333d-dbb9-4230-bed3-5aa09327d30e" />

Issue 2: Broken hyper link for sync_event_sources and log_event
<img width="704" height="166" alt="image" src="https://github.com/user-attachments/assets/53ada7be-66d1-4271-8a5d-84f8a91e695e" />

## Test plan
- [x] Verify `/schemas/v3/media-buy/log-event-request.json` resolves correctly after deploy
- [x] Confirm docs render properly with new links