### PR TITLE
feat: add campaign_ref for cross-operation campaign grouping

### DIFF
--- a/.changeset/campaign-ref.md
+++ b/.changeset/campaign-ref.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `campaign_ref` field to `get_products` and `create_media_buy` for grouping related operations under a buyer-defined campaign label. Echoed in media buy responses for CRM and ad server correlation.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -162,6 +162,7 @@ npx adcp \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `buyer_ref` | string | Yes | Your reference identifier for this media buy |
+| `campaign_ref` | string | No | Buyer's campaign label for CRM and ad server correlation (e.g., `"NovaDrink_Meals_Q2"`). Groups related discovery and buy operations. |
 | `account_id` | string | No | Account to bill. Required when the agent has access to multiple accounts; the seller infers the account when only one exists. |
 | `proposal_id` | string | No* | ID of a proposal from `get_products` to execute. Alternative to providing packages. |
 | `total_budget` | TotalBudget | No* | Total budget when executing a proposal. Publisher applies allocation percentages. |
@@ -207,6 +208,7 @@ npx adcp \
 |-------|-------------|
 | `media_buy_id` | Publisher's unique identifier |
 | `buyer_ref` | Your reference identifier |
+| `campaign_ref` | Buyer's campaign label (echoed from request) |
 | `creative_deadline` | ISO 8601 timestamp for creative upload deadline |
 | `packages` | Array of created packages with complete state |
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -123,6 +123,7 @@ asyncio.run(discover_with_filters())
 |-----------|------|----------|-------------|
 | `brief` | string | No | Natural language description of campaign requirements. |
 | `brand` | BrandRef | No | Brand reference (domain + optional brand_id). Resolved to full identity at execution time. |
+| `campaign_ref` | string | No | Buyer's campaign label for CRM and ad server correlation (e.g., `"NovaDrink_Meals_Q2"`). Groups related discovery and buy operations. |
 | `product_selectors` | ProductSelectors | No | Selectors to filter the brand's product catalog. Requires `brand`. See [Product Selectors](#product-selectors) below. |
 | `filters` | Filters | No | Structured filters (see below) |
 | `property_list` | PropertyListRef | No | [AdCP 3.0] Reference to a property list for filtering. See [Property Lists](/docs/governance/property/tasks/property_lists) |

--- a/static/schemas/source/core/media-buy.json
+++ b/static/schemas/source/core/media-buy.json
@@ -13,6 +13,10 @@
       "type": "string",
       "description": "Buyer's reference identifier for this media buy"
     },
+    "campaign_ref": {
+      "type": "string",
+      "description": "Buyer's campaign reference label. Groups related operations under a single campaign for CRM and ad server correlation."
+    },
     "account": {
       "$ref": "/schemas/core/account.json",
       "description": "Account billed for this media buy"

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "Buyer's reference identifier for this media buy"
     },
+    "campaign_ref": {
+      "type": "string",
+      "description": "Buyer's campaign reference label. Groups related discovery and buy operations under a single campaign for CRM and ad server correlation (e.g., 'NovaDrink_Meals_Q2')."
+    },
     "account_id": {
       "type": "string",
       "description": "Account to bill for this media buy. Required when the agent has access to multiple accounts; when omitted, the seller uses the agent's sole account. The seller maps the agent's brand + operator to an account during sync_accounts; the agent passes that account_id here."

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -18,6 +18,10 @@
           "type": "string",
           "description": "Buyer's reference identifier for this media buy"
         },
+        "campaign_ref": {
+          "type": "string",
+          "description": "Buyer's campaign reference label, echoed from the request"
+        },
         "account": {
           "$ref": "/schemas/core/account.json",
           "description": "Account billed for this media buy. Includes advertiser, billing proxy (if any), and rate card applied."

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -141,6 +141,10 @@
             "type": "string",
             "description": "Buyer's reference identifier for this media buy"
           },
+          "campaign_ref": {
+            "type": "string",
+            "description": "Buyer's campaign reference label. Groups related operations under a single campaign for CRM and ad server correlation."
+          },
           "status": {
             "type": "string",
             "description": "Current media buy status. In webhook context, reporting_delayed indicates data temporarily unavailable.",

--- a/static/schemas/source/media-buy/get-products-request.json
+++ b/static/schemas/source/media-buy/get-products-request.json
@@ -21,6 +21,10 @@
       "type": "string",
       "description": "Account ID for product lookup. Required when the seller declares account.required_for_products = true in capabilities. Returns products with pricing specific to this account's rate card."
     },
+    "campaign_ref": {
+      "type": "string",
+      "description": "Buyer's campaign reference label. Groups related discovery and buy operations under a single campaign for CRM and ad server correlation (e.g., 'NovaDrink_Meals_Q2')."
+    },
     "filters": {
       "$ref": "/schemas/core/product-filters.json"
     },


### PR DESCRIPTION
## Summary

- Adds optional `campaign_ref` string field to `get_products` request, `create_media_buy` request/response, delivery responses, and core media buy object
- Allows buyers to label related operations under a shared campaign identifier (e.g., "NovaDrink_Meals_Q2") for CRM and ad server correlation
- Distinct from `buyer_ref` (per-transaction) — `campaign_ref` is a non-unique grouping label that can repeat across many buys

## Test plan

- [ ] `npm run build` — schemas compile to `dist/schemas/latest/` with `campaign_ref` in all 9 built files
- [ ] `npm test` — all 304 tests pass (field is optional, schemas allow additionalProperties)
- [ ] Verify field appears in: get-products-request, create-media-buy-request, create-media-buy-response (success variant), core/media-buy, get-media-buy-delivery-response

🤖 Generated with [Claude Code](https://claude.com/claude-code)