### PR TITLE
feat: item-level attribution macros and multi-catalog creative manifests

### DIFF
--- a/.changeset/catalog-item-macros.md
+++ b/.changeset/catalog-item-macros.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add catalog item macros for item-level attribution: SKU, GTIN, OFFERING_ID, JOB_ID, HOTEL_ID, FLIGHT_ID, VEHICLE_ID, LISTING_ID, STORE_ID, PROGRAM_ID, and DESTINATION_ID (mirroring the content_id_type enum), plus CATALOG_ID for catalog-level attribution and CREATIVE_VARIANT_ID for seller-assigned creative variant tracking. Enables closed-loop attribution from impression tracking through conversion events.

--- a/.changeset/creative-manifest-multi-catalog.md
+++ b/.changeset/creative-manifest-multi-catalog.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": major
+---
+
+**BREAKING**: Rename `catalog` to `catalogs` (array) on creative manifest. Formats can declare multiple catalog_requirements (e.g., product + inventory + store); the manifest now supports multiple catalogs to match. Each catalog's `type` maps to the corresponding catalog_requirements entry.

--- a/.changeset/fix-build-creative-catalog-examples.md
+++ b/.changeset/fix-build-creative-catalog-examples.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix build_creative doc examples: remove catalog_id from inline catalogs, add missing offering_id to inline offering items.

--- a/docs/building/integration/account-state.mdx
+++ b/docs/building/integration/account-state.mdx
@@ -105,7 +105,7 @@ The platform fetches and validates each feed. Items may be approved, rejected, o
 
 ### 4. Sync creatives
 
-`sync_creatives` submits creative assets that reference the catalogs synced in step 2. For catalog-driven formats, the creative's `catalog` field references synced catalogs by `catalog_id` instead of embedding items inline.
+`sync_creatives` submits creative assets that reference the catalogs synced in step 2. For catalog-driven formats, the creative's `catalogs` field references synced catalogs by `catalog_id` instead of embedding items inline.
 
 ```json
 {
@@ -116,11 +116,11 @@ The platform fetches and validates each feed. Items may be approved, rejected, o
       "agent_url": "https://creative.retailer.com/adcp",
       "id": "product_carousel_with_inventory"
     },
-    "catalog": {
+    "catalogs": [{
       "catalog_id": "product-feed",
       "type": "product",
       "tags": ["summer"]
-    },
+    }],
     "assets": {
       "banner_image": {
         "url": "https://cdn.acmecorp.com/carousel-hero.jpg",

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -71,7 +71,7 @@ Not every workflow requires `sync_catalogs`. Use it when:
 - **Multiple creatives share the same feed** — sync once, reference by `catalog_id` from many creatives
 - **The seller may already have the data** — use discovery mode to see what's already on the account
 
-For simple campaigns with a few items, inline catalogs on the creative's `catalog` field work fine — no sync step needed.
+For simple campaigns with a few items, inline catalogs on the creative's `catalogs` field work fine — no sync step needed.
 
 ## Catalog types
 
@@ -190,12 +190,12 @@ Any catalog type can embed items directly via the `items` array. The item schema
 
 ```json
 {
-  "catalog": {
+  "catalogs": [{
     "type": "offering",
     "items": [
       {"offering_id": "summer-sale", "name": "Summer Sale", "landing_url": "https://acme.com/summer"}
     ]
-  }
+  }]
 }
 ```
 
@@ -203,7 +203,7 @@ Vertical types use their industry-specific item schema:
 
 ```json
 {
-  "catalog": {
+  "catalogs": [{
     "type": "hotel",
     "items": [
       {
@@ -215,7 +215,7 @@ Vertical types use their industry-specific item schema:
         "amenities": ["spa", "pool", "restaurant", "wifi"]
       }
     ]
-  }
+  }]
 }
 ```
 
@@ -225,13 +225,13 @@ For feeds managed outside AdCP, point to a URL and let the platform fetch:
 
 ```json
 {
-  "catalog": {
+  "catalogs": [{
     "catalog_id": "product-feed",
     "type": "product",
     "url": "https://feeds.acmecorp.com/products.xml",
     "feed_format": "google_merchant_center",
     "update_frequency": "daily"
-  }
+  }]
 }
 ```
 
@@ -241,11 +241,11 @@ For catalogs already on the account via `sync_catalogs`, reference by `catalog_i
 
 ```json
 {
-  "catalog": {
+  "catalogs": [{
     "catalog_id": "gmc-primary",
     "type": "product",
     "ids": ["SKU-123", "SKU-456"]
-  }
+  }]
 }
 ```
 
@@ -376,9 +376,9 @@ Buying agents check `catalog_requirements` after discovering formats, sync the r
 
 ## Catalogs in creatives
 
-Creatives reference catalogs via the `catalog` field on the creative object. This is a data reference — it tells the creative what items to render (products for a carousel, locations for a store locator). It is not a campaign expansion directive; campaign structure and budget allocation are handled by `create_media_buy` packages.
+Creatives reference catalogs via the `catalogs` field on the creative object. This is a data reference — it tells the creative what items to render (products for a carousel, locations for a store locator). It is not a campaign expansion directive; campaign structure and budget allocation are handled by `create_media_buy` packages.
 
-When a format declares `catalog_requirements`, the buying agent syncs the required catalogs to the account, then sets the `catalog` field on the creative to reference the synced data.
+When a format declares `catalog_requirements`, the buying agent syncs the required catalogs to the account, then sets the `catalogs` field on the creative to reference the synced data.
 
 ### Workflow
 
@@ -386,7 +386,7 @@ When a format declares `catalog_requirements`, the buying agent syncs the requir
 
 2. **Sync catalogs** — Use `sync_catalogs` to push the required feeds to the account. Wait for approval.
 
-3. **Submit the creative** — Reference the synced catalog by `catalog_id` on the creative's `catalog` field:
+3. **Submit the creative** — Reference the synced catalog by `catalog_id` in the creative's `catalogs` array:
 
 ```json
 {
@@ -397,11 +397,11 @@ When a format declares `catalog_requirements`, the buying agent syncs the requir
         "agent_url": "https://creative.retailer.com/adcp",
         "id": "product_carousel_with_inventory"
       },
-      "catalog": {
+      "catalogs": [{
         "catalog_id": "product-feed",
         "type": "product",
         "tags": ["summer"]
-      },
+      }],
       "assets": {
         "banner_image": {
           "url": "https://cdn.acmecorp.com/carousel-hero.jpg",
@@ -744,7 +744,7 @@ The buyer provides multiple offerings, each with their own creative asset pool. 
 ```json
 {
   "brand": { "domain": "acme.com" },
-  "catalog": {
+  "catalogs": [{
     "type": "offering",
     "items": [
       {
@@ -776,7 +776,7 @@ The buyer provides multiple offerings, each with their own creative asset pool. 
         ]
       }
     ]
-  }
+  }]
 }
 ```
 
@@ -787,11 +787,11 @@ For retail media, sync product and inventory feeds, then reference them in creat
 ```json
 {
   "brand": { "domain": "acmecorp.com" },
-  "catalog": {
+  "catalogs": [{
     "catalog_id": "product-feed",
     "type": "product",
     "tags": ["summer"]
-  }
+  }]
 }
 ```
 
@@ -804,7 +804,7 @@ No pre-built creatives — just offerings available for SI conversations. The br
 ```json
 {
   "brand": { "domain": "saas-company.com" },
-  "catalog": {
+  "catalogs": [{
     "type": "offering",
     "items": [
       {
@@ -820,7 +820,7 @@ No pre-built creatives — just offerings available for SI conversations. The br
         "keywords": ["trial", "free", "signup"]
       }
     ]
-  }
+  }]
 }
 ```
 
@@ -831,7 +831,7 @@ For brands with multiple physical locations — restaurants, retail chains, job 
 ```json
 {
   "brand": { "domain": "acme-restaurants.com" },
-  "catalog": {
+  "catalogs": [{
     "type": "offering",
     "items": [
       {
@@ -850,7 +850,7 @@ For brands with multiple physical locations — restaurants, retail chains, job 
         ]
       }
     ]
-  }
+  }]
 }
 ```
 
@@ -879,6 +879,39 @@ For catalog-driven packages, each catalog item rendered as a distinct ad executi
 ### Conversion attribution
 
 Conversion events carry `content_ids` that identify which catalog items were involved. The catalog's `content_id_type` declares the identifier type. Attribution is broad — a user might click item A but convert on item B. The event fires with the actual `content_id`. See [conversion tracking](/docs/media-buy/conversion-tracking).
+
+### Item-level tracking via macros
+
+For impression-level attribution (which item was clicked, which was viewed), use [catalog item macros](/docs/creative/universal-macros#catalog-item-macros) in your creative's tracker pixel URLs. The macros mirror the `content_id_type` enum — the same identifiers used at serve time that appear in conversion events:
+
+```json
+{
+  "impression_pixel": {
+    "url": "https://track.brand.com/imp?catalog={CATALOG_ID}&item={OFFERING_ID}&creative={CREATIVE_ID}&cb={CACHEBUSTER}",
+    "url_type": "tracker_pixel"
+  }
+}
+```
+
+At serve time, the platform substitutes `{OFFERING_ID}` with the specific offering being rendered. For a carousel showing 5 offerings, each item's impression fires with that item's identifier.
+
+Use the macro matching your catalog's `content_id_type`:
+
+| `content_id_type` | Macro |
+|---|---|
+| `sku` | `{SKU}` |
+| `gtin` | `{GTIN}` |
+| `offering_id` | `{OFFERING_ID}` |
+| `job_id` | `{JOB_ID}` |
+| `hotel_id` | `{HOTEL_ID}` |
+| `flight_id` | `{FLIGHT_ID}` |
+| `vehicle_id` | `{VEHICLE_ID}` |
+| `listing_id` | `{LISTING_ID}` |
+| `store_id` | `{STORE_ID}` |
+| `program_id` | `{PROGRAM_ID}` |
+| `destination_id` | `{DESTINATION_ID}` |
+
+This creates a closed attribution loop: the same identifiers appear in impression trackers (via macros at serve time), click trackers, and conversion events (via `content_ids` at event time).
 
 ## Best practices
 

--- a/docs/creative/creative-manifests.mdx
+++ b/docs/creative/creative-manifests.mdx
@@ -371,10 +371,10 @@ Manifests are submitted to the creative library using `sync_creatives`, then ref
             "agent_url": "https://creative.adcontextprotocol.org",
             "id": "native_responsive"
           },
-          "catalog": {
+          "catalogs": [{
             "catalog_id": "salmon-products",
             "type": "product"
-          },
+          }],
           "assets": {
             "headline": {
               "content": "Fresh Pacific Salmon - 20% Off Today"
@@ -431,7 +431,7 @@ See [Universal Macros](/docs/creative/universal-macros) for complete documentati
 
 ### Catalogs
 
-Manifests for catalog-driven formats (product carousels, dynamic product ads) reference their catalog via the `catalog` field on the creative object, not within the manifest's `assets`. See [Catalogs in Creatives](/docs/creative/catalogs#catalogs-in-creatives) for the workflow.
+Manifests for catalog-driven formats (product carousels, dynamic product ads) reference their catalogs via the `catalogs` field on the creative object, not within the manifest's `assets`. See [Catalogs in Creatives](/docs/creative/catalogs#catalogs-in-creatives) for the workflow.
 
 ### Repeatable Asset Groups
 

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -19,7 +19,7 @@ For information about format IDs and how to reference formats, see [Creative For
 | `brand` | object | No | Brand reference with `domain` field. Resolves brand identity via `/.well-known/brand.json`. Provides brand-level context (colors, logos, tone). |
 | `creative_brief` | object \| string | No | Campaign-level creative brief. Inline [Creative Brief](https://adcontextprotocol.org/schemas/v2/core/creative-brief.json) object or URL to a hosted brief. Provides objective, audience, messaging, and reference assets. |
 
-**Important**: Required input assets should be included in the `creative_manifest.assets` object, not as separate task parameters. The format definition specifies what assets it requires. Catalog context for dynamic creatives should be provided via the `creative_manifest.catalog` field.
+**Important**: Required input assets should be included in the `creative_manifest.assets` object, not as separate task parameters. The format definition specifies what assets it requires. Catalog context for dynamic creatives should be provided via the `creative_manifest.catalogs` field.
 
 ## Use Cases
 
@@ -43,9 +43,8 @@ For pure generation, provide a minimal source manifest with the required input a
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250_generative"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
-      "catalog_id": "winter-sale",
       "items": [
         {
           "offering_id": "winter-sale",
@@ -53,7 +52,7 @@ For pure generation, provide a minimal source manifest with the required input a
           "description": "50% off all winter items"
         }
       ]
-    },
+    }],
     "assets": {}
   }
 }
@@ -124,10 +123,10 @@ The response contains the transformed or generated creative manifest:
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
       "catalog_id": "winter-sale"
-    },
+    }],
     "assets": {
       "banner_image": {
         "asset_type": "image",
@@ -152,7 +151,7 @@ The response contains the transformed or generated creative manifest:
 
 - **creative_manifest**: The complete creative manifest ready for use with `sync_creatives` or `preview_creative`
 - **format_id**: The target format (matches `target_format_id` from request)
-- **catalog**: Catalog of items this creative promotes (optional, for dynamic product ads)
+- **catalogs**: Catalogs this creative renders (optional, for dynamic product ads)
 - **assets**: Map of asset IDs to actual asset content, matching the format's `assets` specification
 
 ## Workflow Integration
@@ -171,10 +170,10 @@ The response contains the transformed or generated creative manifest:
   "brand": { "domain": "mybrand.com" },
   "creative_manifest": {
     "format_id": {"agent_url": "...", "id": "display_300x250_generative"},
-    "catalog": {
+    "catalogs": [{
       "type": "product",
       "catalog_id": "winter-products"
-    }
+    }]
   }
 }
 
@@ -193,7 +192,7 @@ The response contains the transformed or generated creative manifest:
 }
 ```
 
-**Key insight**: The manifest carries everything. The `catalog` field (if the format renders catalog items) flows through from input to output, and is available for preview. No need to pass it separately at each step.
+**Key insight**: The manifest carries everything. The `catalogs` field (if the format renders catalog items) flows through from input to output, and is available for preview. No need to pass it separately at each step.
 
 ## Examples
 
@@ -217,16 +216,16 @@ Generate a creative from scratch using a generative format:
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250_generative"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
-      "catalog_id": "winter-sale",
       "items": [
         {
+          "offering_id": "winter-sale",
           "name": "Winter Sale Collection",
           "description": "50% off all winter items"
         }
       ]
-    },
+    }],
     "assets": {}
   }
 }
@@ -241,10 +240,10 @@ Generate a creative from scratch using a generative format:
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
       "catalog_id": "winter-sale"
-    },
+    }],
     "assets": {
       "banner_image": {
         "asset_type": "image",
@@ -438,16 +437,16 @@ Generate a creative using structured campaign context via `brand` and `creative_
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250_generative"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
-      "catalog_id": "holiday-sale",
       "items": [
         {
+          "offering_id": "holiday-sale",
           "name": "Holiday Sale Collection",
           "description": "Up to 50% off select holiday items"
         }
       ]
-    },
+    }],
     "assets": {}
   }
 }
@@ -474,16 +473,16 @@ When reusing the same brief across multiple creatives, reference it by URL:
       "agent_url": "https://creative.adcontextprotocol.org",
       "id": "display_300x250_generative"
     },
-    "catalog": {
+    "catalogs": [{
       "type": "offering",
-      "catalog_id": "brunch-menu",
       "items": [
         {
+          "offering_id": "brunch-menu",
           "name": "Weekend Brunch Menu",
           "description": "Fresh brunch items every Saturday and Sunday"
         }
       ]
-    },
+    }],
     "assets": {}
   }
 }
@@ -515,7 +514,7 @@ Both are optional. `brand` provides stable brand identity (colors, logos, tone) 
 
 ### Pure Generation vs Transformation
 
-- **Pure Generation**: Provide minimal `creative_manifest` with just the format_id, a `catalog` reference (if the format renders catalog items), and any required seed assets. The creative agent generates output assets from scratch using `message` as guidance.
+- **Pure Generation**: Provide minimal `creative_manifest` with just the format_id, a `catalogs` reference (if the format renders catalog items), and any required seed assets. The creative agent generates output assets from scratch using `message` as guidance.
 - **Transformation**: Provide complete `creative_manifest` with all existing assets. The creative agent adapts existing assets to the target format, optionally following guidance in `message`.
 
 ### Integration with Other Tasks

--- a/docs/creative/universal-macros.mdx
+++ b/docs/creative/universal-macros.mdx
@@ -168,6 +168,33 @@ For audio formats with content context:
 |-------|-------------|---------------|
 | `{AXEM}` | AXE contextual metadata (encoded blob) | `eyJjb250ZXh0IjoiLi4uIn0=` |
 
+### Catalog Item Macros
+
+For catalog-driven creatives (carousels, dynamic product ads, job boards, store locators). These macros resolve to the identifier of the specific catalog item being rendered at serve time — the same identifiers used in conversion event `content_ids` via the [`content_id_type`](/docs/creative/catalogs#conversion-events) field.
+
+| Macro | Description | Example Value |
+|-------|-------------|---------------|
+| `{CATALOG_ID}` | Buyer-defined catalog identifier | `gmc-primary`, `job-feed` |
+| `{SKU}` | Product SKU identifier | `SKU-12345` |
+| `{GTIN}` | Global Trade Item Number | `00013000006040` |
+| `{OFFERING_ID}` | AdCP offering identifier | `summer-sale` |
+| `{JOB_ID}` | Job posting identifier | `vacancy-amsterdam-chef-42` |
+| `{HOTEL_ID}` | Hotel property identifier | `grand-amsterdam` |
+| `{FLIGHT_ID}` | Flight route identifier | `AMS-BCN-2025-06` |
+| `{VEHICLE_ID}` | Vehicle listing identifier | `VIN-1234` |
+| `{LISTING_ID}` | Real estate listing identifier | `prop-amsterdam-01` |
+| `{STORE_ID}` | Store location identifier | `amsterdam-flagship` |
+| `{PROGRAM_ID}` | Education program identifier | `mba-2025` |
+| `{DESTINATION_ID}` | Travel destination identifier | `barcelona` |
+
+Use the macro that matches your catalog's `content_id_type`. For example, a product catalog with `content_id_type: "gtin"` uses `{GTIN}` in tracker URLs; a job catalog uses `{JOB_ID}`.
+
+### Creative Variant Macros
+
+| Macro | Description | Example Value |
+|-------|-------------|---------------|
+| `{CREATIVE_VARIANT_ID}` | Seller-assigned creative variant identifier | `variant_a`, `v2_mobile` |
+
 > **Note**: Publisher-specific custom macros may be defined in individual creative format specifications as `extra supported macros`.
 
 ## Usage Examples
@@ -243,6 +270,36 @@ For audio formats with content context:
   }
 }
 ```
+
+### Catalog-Driven Creative with Item Tracking
+
+```json
+{
+  "creative_id": "cr_product_carousel",
+  "format_id": {
+    "agent_url": "https://creative.retailer.com/adcp",
+    "id": "product_carousel"
+  },
+  "catalogs": [{
+    "catalog_id": "gmc-primary",
+    "type": "product",
+    "content_id_type": "gtin",
+    "tags": ["summer"]
+  }],
+  "assets": {
+    "impression_pixel": {
+      "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&catalog={CATALOG_ID}&item={GTIN}&cb={CACHEBUSTER}",
+      "url_type": "tracker_pixel"
+    },
+    "click_tracker": {
+      "url": "https://track.brand.com/click?buy={MEDIA_BUY_ID}&catalog={CATALOG_ID}&item={GTIN}",
+      "url_type": "tracker_pixel"
+    }
+  }
+}
+```
+
+**Key point**: `{GTIN}` resolves to the specific product's GTIN at serve time. For a carousel showing 5 products, each product impression/click fires with that product's identifier — enabling per-item attribution.
 
 ## Macro Availability by Inventory Type
 

--- a/docs/media-buy/task-reference/sync_creatives.mdx
+++ b/docs/media-buy/task-reference/sync_creatives.mdx
@@ -115,7 +115,7 @@ asyncio.run(main())
 | `name`        | string   | Yes      | Human-readable name                                                |
 | `format_id`   | FormatId | Yes      | Format specification (structured object with `agent_url` and `id`) |
 | `assets`      | object   | Yes      | Assets keyed by role (e.g., `{video: {...}, thumbnail: {...}}`)    |
-| `catalog`     | Catalog  | No       | Catalog reference for catalog-driven creatives (e.g., product carousels, job listings). Reference a synced catalog by `catalog_id` or provide inline items. See [Catalogs](/docs/creative/catalogs). |
+| `catalogs`    | Catalog[]| No       | Catalogs this creative renders. Each entry satisfies one of the format's `catalog_requirements`, matched by type. Reference a synced catalog by `catalog_id` or provide inline items. See [Catalogs](/docs/creative/catalogs). |
 | `tags`        | string[] | No       | Searchable tags for creative organization                          |
 
 ### Asset Structure

--- a/docs/reference/implementor-faq.mdx
+++ b/docs/reference/implementor-faq.mdx
@@ -159,10 +159,10 @@ For catalog-driven creatives, reference a synced catalog:
 {
   "creative_id": "product-carousel",
   "format_id": { "agent_url": "...", "id": "product_carousel" },
-  "catalog": {
+  "catalogs": [{
     "catalog_id": "product-feed",
     "type": "product"
-  }
+  }]
 }
 ```
 

--- a/docs/reference/migration/catalogs.mdx
+++ b/docs/reference/migration/catalogs.mdx
@@ -11,9 +11,9 @@ AdCP v3 removes the `promoted_offerings` creative asset type and the `promoted_o
 
 | v2 field | v3 field | Change type |
 |----------|----------|-------------|
-| `promoted_offerings` (creative asset type) | `catalog` field on creative manifest | Replaced |
+| `promoted_offerings` (creative asset type) | `catalogs` field on creative manifest | Replaced |
 | `promoted_offering` (string on media-buy) | Removed | Removed |
-| `promoted_offering` (string on creative-manifest) | `catalog` field | Replaced |
+| `promoted_offering` (string on creative-manifest) | `catalogs` field | Replaced |
 | No catalog sync | `sync_catalogs` task | New |
 | No format catalog requirements | `catalog_requirements` on Format | New |
 | No catalog-event linking | `conversion_events` on Catalog | New |
@@ -63,10 +63,10 @@ In v3, brand identity is a first-class parameter on tasks (`build_creative`, `sy
     "agent_url": "https://creatives.example.com",
     "id": "product_carousel"
   },
-  "catalog": {
+  "catalogs": [{
     "type": "product",
     "catalog_id": "winter-products"
-  },
+  }],
   "assets": {}
 }
 ```
@@ -74,7 +74,7 @@ In v3, brand identity is a first-class parameter on tasks (`build_creative`, `sy
 Key differences:
 
 - **Brand identity** comes from the `brand` parameter on the task, not embedded in creative assets
-- **Catalog** is a direct field on the manifest, not nested inside `assets`
+- **Catalogs** is a direct field on the manifest, not nested inside `assets`
 - **Catalog references synced data** by `catalog_id` instead of inlining items (though inline items are still supported for simple cases)
 
 ---
@@ -117,7 +117,7 @@ The `promoted_offering` string field is removed from media buy objects. What's b
 If you were using `promoted_offering` for reporting or display purposes, that context now comes from:
 - The `brief` field on `get_products` and `create_media_buy`
 - The `brand` parameter on tasks
-- The `catalog` field on creative manifests
+- The `catalogs` field on creative manifests
 
 ---
 
@@ -290,8 +290,8 @@ Packages now accept a `catalog` field for catalog-driven campaigns. One budget e
   <Step title="Remove promoted_offerings from creative assets">
     Remove `promoted_offerings` objects from `creative_manifest.assets`. Brand identity is now provided via the `brand` task parameter.
   </Step>
-  <Step title="Add catalog field to creative manifests">
-    For creatives that render catalog items (product carousels, store locators, etc.), add the `catalog` field to the creative manifest with at minimum `type` and `catalog_id`.
+  <Step title="Add catalogs field to creative manifests">
+    For creatives that render catalog items (product carousels, store locators, etc.), add the `catalogs` field to the creative manifest with at minimum `type` and `catalog_id`.
   </Step>
   <Step title="Remove promoted_offering from media buys">
     Remove the `promoted_offering` string from `create_media_buy` requests. Use the `brief` field to describe what's being promoted.

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -288,9 +288,9 @@ The `promoted_offerings` creative asset type and `promoted_offering` string fiel
 
 | v2 field | v3 replacement |
 |----------|---------------|
-| `promoted_offerings` (creative asset) | `catalog` field on creative manifest |
+| `promoted_offerings` (creative asset) | `catalogs` field on creative manifest |
 | `promoted_offering` (string on media-buy) | Removed — use `brand` + `brief` |
-| `promoted_offering` (string on creative-manifest) | Removed — use `catalog` field |
+| `promoted_offering` (string on creative-manifest) | Removed — use `catalogs` field |
 
 <Card title="Catalogs deep dive" icon="arrow-right" href="/docs/reference/migration/catalogs">
   Before/after examples, sync_catalogs workflow, catalog_requirements discovery, and migration checklist.
@@ -316,9 +316,9 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
 | `geo_postal_codes` | `geo_postal_areas` |
 | `fixed_rate` in pricing | `fixed_price` |
 | `price_guidance.floor` | `floor_price` (top-level) |
-| `promoted_offerings` asset type | `catalog` field on creative manifest |
+| `promoted_offerings` asset type | `catalogs` field on creative manifest |
 | `promoted_offering` on media-buy | Removed — use `brand` + `brief` |
-| `promoted_offering` on creative-manifest | `catalog` field |
+| `promoted_offering` on creative-manifest | `catalogs` field |
 
 ---
 
@@ -338,7 +338,7 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
     - [ ] Update format parsing to use [`assets` array](/docs/reference/migration/creatives#asset-discovery)
     - [ ] Replace `preview_image` reads with [`format_card`](/docs/reference/migration/creatives#format-cards-replacing-preview_image) rendering
     - [ ] Replace `list_authorized_properties` calls with `get_adcp_capabilities` portfolio
-    - [ ] Remove `promoted_offerings` from creative manifest assets and replace with [`catalog` field](/docs/reference/migration/catalogs)
+    - [ ] Remove `promoted_offerings` from creative manifest assets and replace with [`catalogs` field](/docs/reference/migration/catalogs)
     - [ ] Remove `promoted_offering` string from media buy and creative manifest objects
     - [ ] Validate all requests/responses against v3 schemas
   </Accordion>

--- a/static/schemas/source/core/creative-asset.json
+++ b/static/schemas/source/core/creative-asset.json
@@ -17,9 +17,13 @@
       "$ref": "/schemas/core/format-id.json",
       "description": "Format identifier specifying which format this creative conforms to. Can be: (1) concrete format_id referencing a format with fixed dimensions, (2) template format_id referencing a template format, or (3) parameterized format_id with dimensions/duration parameters for template formats."
     },
-    "catalog": {
-      "$ref": "/schemas/core/catalog.json",
-      "description": "Catalog of items this creative promotes. Used for dynamic product ads, carousels, and any format that renders catalog items. The catalog can be inline (with items), a reference to a synced catalog (by catalog_id), or a URL to an external feed."
+    "catalogs": {
+      "type": "array",
+      "description": "Catalogs this creative renders. Each entry satisfies one of the format's catalog_requirements, matched by type. Each catalog can be inline (with items), a reference to a synced catalog (by catalog_id), or a URL to an external feed.",
+      "items": {
+        "$ref": "/schemas/core/catalog.json"
+      },
+      "minItems": 1
     },
     "assets": {
       "type": "object",

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -9,9 +9,13 @@
       "$ref": "/schemas/core/format-id.json",
       "description": "Format identifier this manifest is for. Can be a template format (id only) or a deterministic format (id + dimensions/duration). For dimension-specific creatives, include width/height/unit in the format_id to create a unique identifier (e.g., {id: 'display_static', width: 300, height: 250, unit: 'px'})."
     },
-    "catalog": {
-      "$ref": "/schemas/core/catalog.json",
-      "description": "Catalog of items this creative renders. Tells the creative what data to display — product listings for a carousel, job vacancies for a recruitment ad, store locations for a locator. This is a data reference, not a campaign expansion directive; campaign structure and budget allocation are handled by create_media_buy packages. The catalog can be inline (with items), a reference to a synced catalog (by catalog_id), or a URL to an external feed."
+    "catalogs": {
+      "type": "array",
+      "description": "Catalogs this creative renders. Each entry satisfies one of the format's catalog_requirements, matched by type. Tells the creative what data to display — product listings for a carousel, job vacancies for a recruitment ad, store locations for a locator. This is a data reference, not a campaign expansion directive; campaign structure and budget allocation are handled by create_media_buy packages. Each catalog can be inline (with items), a reference to a synced catalog (by catalog_id), or a URL to an external feed.",
+      "items": {
+        "$ref": "/schemas/core/catalog.json"
+      },
+      "minItems": 1
     },
     "assets": {
       "type": "object",

--- a/static/schemas/source/enums/universal-macro.json
+++ b/static/schemas/source/enums/universal-macro.json
@@ -58,7 +58,20 @@
     "SHOW_NAME",
     "EPISODE_ID",
     "AUDIO_DURATION",
-    "AXEM"
+    "AXEM",
+    "CATALOG_ID",
+    "SKU",
+    "GTIN",
+    "OFFERING_ID",
+    "JOB_ID",
+    "HOTEL_ID",
+    "FLIGHT_ID",
+    "VEHICLE_ID",
+    "LISTING_ID",
+    "STORE_ID",
+    "PROGRAM_ID",
+    "DESTINATION_ID",
+    "CREATIVE_VARIANT_ID"
   ],
   "enumDescriptions": {
     "MEDIA_BUY_ID": "AdCP media buy identifier",
@@ -114,6 +127,19 @@
     "SHOW_NAME": "Program or show name",
     "EPISODE_ID": "Podcast episode identifier",
     "AUDIO_DURATION": "Audio content duration in seconds",
-    "AXEM": "AXE contextual metadata (encoded blob)"
+    "AXEM": "AXE contextual metadata (encoded blob)",
+    "CATALOG_ID": "Buyer-defined catalog identifier from the catalog's catalog_id field",
+    "SKU": "Product SKU identifier for the catalog item being rendered",
+    "GTIN": "Global Trade Item Number for the catalog item being rendered",
+    "OFFERING_ID": "AdCP offering identifier for the catalog item being rendered",
+    "JOB_ID": "Job posting identifier for the catalog item being rendered",
+    "HOTEL_ID": "Hotel property identifier for the catalog item being rendered",
+    "FLIGHT_ID": "Flight route identifier for the catalog item being rendered",
+    "VEHICLE_ID": "Vehicle listing identifier for the catalog item being rendered",
+    "LISTING_ID": "Real estate listing identifier for the catalog item being rendered",
+    "STORE_ID": "Store location identifier for the catalog item being rendered",
+    "PROGRAM_ID": "Education program identifier for the catalog item being rendered",
+    "DESTINATION_ID": "Travel destination identifier for the catalog item being rendered",
+    "CREATIVE_VARIANT_ID": "Seller-assigned creative variant identifier, passed through at serve time"
   }
 }

--- a/static/schemas/source/media-buy/list-creatives-response.json
+++ b/static/schemas/source/media-buy/list-creatives-response.json
@@ -81,9 +81,13 @@
             "format": "date-time",
             "description": "When the creative was last modified"
           },
-          "catalog": {
-            "$ref": "/schemas/core/catalog.json",
-            "description": "Catalog referenced by this creative, if any"
+          "catalogs": {
+            "type": "array",
+            "description": "Catalogs this creative renders, if any",
+            "items": {
+              "$ref": "/schemas/core/catalog.json"
+            },
+            "minItems": 1
           },
           "assets": {
             "type": "object",

--- a/static/schemas/source/media-buy/sync-creatives-request.json
+++ b/static/schemas/source/media-buy/sync-creatives-request.json
@@ -116,10 +116,10 @@
               "agent_url": "https://publisher.com/.well-known/adcp/sales",
               "id": "premium_bespoke_display"
             },
-            "catalog": {
+            "catalogs": [{
               "type": "product",
               "catalog_id": "winter-products"
-            },
+            }],
             "assets": {
               "generation_prompt": {
                 "content": "Create a warm, festive holiday campaign featuring winter products"


### PR DESCRIPTION
## Summary

- **Item-level attribution macros**: Add 13 new universal macros mirroring the `content_id_type` enum (SKU, GTIN, OFFERING_ID, JOB_ID, HOTEL_ID, FLIGHT_ID, VEHICLE_ID, LISTING_ID, STORE_ID, PROGRAM_ID, DESTINATION_ID) plus CATALOG_ID and CREATIVE_VARIANT_ID. Enables closed-loop attribution from impression tracking through conversion events.
- **BREAKING — Multi-catalog creative manifests**: Rename `catalog` (single object) to `catalogs` (array) on creative-manifest, creative-asset, list-creatives-response, and sync-creatives-request schemas. Formats can declare multiple `catalog_requirements` (e.g., product + inventory + store); the manifest now supports multiple catalogs matched by type.
- **Doc nits**: Fix confusing `catalog_id` on inline catalog examples in build_creative, add missing `offering_id` on inline offering items.

## Test plan

- [x] All 304 tests pass (`npm test`)
- [x] Schema cross-ref validation passes (316 schemas)
- [x] Doc example JSON validation passes (`test:json-schema`)
- [x] OpenAPI spec up to date
- [x] Typecheck passes
- [x] Pre-push hooks pass (version sync, broken links, accessibility)
- [x] Verified `catalog→catalogs` rename scoped to creative-level fields only (get_products request catalog, create_media_buy package catalog left unchanged)


🤖 Generated with [Claude Code](https://claude.com/claude-code)