### PR TITLE
improve Zoom recording diagnostic logging

### DIFF
--- a/.changeset/famous-adults-cross.md
+++ b/.changeset/famous-adults-cross.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improve Zoom recording diagnostic logging to distinguish between cloud recording not enabled (404), audio transcription not enabled (recording exists but no transcript file), and successful transcript/summary retrieval.


### PR DESCRIPTION
## Summary

- Distinguish between three failure modes when processing Zoom recording webhooks: cloud recording not configured (404), audio transcription not enabled (recording exists but no TRANSCRIPT file type present), and successful retrieval
- Each webhook now logs a single `Recording processing completed` entry with `hadTranscript` and `hadSummary` flags for easy filtering
- Tightened 404 detection from loose `.includes('404')` to a format-specific regex matching `zoomRequest`'s error format
- Removed asymmetric try/catch around `getMeetingSummary` — both zoom functions handle errors internally and return null, so the outer wrap was misleading

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] After a meeting ends, search Fly logs for `Recording processing completed` and verify `meetingTitle`, `hadTranscript`, `hadSummary` are present
- [ ] If cloud recording is off, confirm warn log `Recording not found (404)` appears instead of a generic error
- [ ] If transcription is off, confirm warn log with `fileTypes` array appears showing which file types were present (e.g. `["MP4","M4A"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)