### PR TITLE
fix: accept WorkOS sk_ prefix API keys in auth middleware

### DIFF
--- a/.changeset/fix-sk-api-key-auth.md
+++ b/.changeset/fix-sk-api-key-auth.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix API key authentication for WorkOS keys using the new `sk_` prefix. WorkOS changed their key format from `wos_api_key_` to `sk_`, which caused all newer API keys to be rejected by the auth middleware before reaching validation.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -169,7 +169,7 @@ Public endpoints (resolution, discovery, search) require no authentication. Writ
 Pass the key in the `Authorization` header:
 
 ```
-Authorization: Bearer wos_api_key_...
+Authorization: Bearer sk_...
 ```
 
 ### Authenticated endpoints

--- a/server/src/middleware/api-key-format.ts
+++ b/server/src/middleware/api-key-format.ts
@@ -1,0 +1,7 @@
+/**
+ * Check if a token looks like a WorkOS API key.
+ * WorkOS has used multiple key prefixes over time: 'wos_api_key_' (legacy) and 'sk_' (current).
+ */
+export function isWorkOSApiKeyFormat(token: string): boolean {
+  return token.startsWith('wos_api_key_') || token.startsWith('sk_');
+}

--- a/server/tests/unit/auth-api-key-format.test.ts
+++ b/server/tests/unit/auth-api-key-format.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isWorkOSApiKeyFormat } from '../../src/middleware/api-key-format.js';
+
+describe('isWorkOSApiKeyFormat', () => {
+  it('accepts current sk_ prefix keys', () => {
+    expect(isWorkOSApiKeyFormat('sk_fake_example_key_for_testing_only')).toBe(true);
+    expect(isWorkOSApiKeyFormat('sk_test_abc123')).toBe(true);
+    expect(isWorkOSApiKeyFormat('sk_')).toBe(true);
+  });
+
+  it('accepts legacy wos_api_key_ prefix keys', () => {
+    expect(isWorkOSApiKeyFormat('wos_api_key_abc123def456')).toBe(true);
+    expect(isWorkOSApiKeyFormat('wos_api_key_')).toBe(true);
+  });
+
+  it('rejects tokens that are not WorkOS API keys', () => {
+    expect(isWorkOSApiKeyFormat('some-random-token')).toBe(false);
+    expect(isWorkOSApiKeyFormat('admin_key_123')).toBe(false);
+    expect(isWorkOSApiKeyFormat('')).toBe(false);
+    expect(isWorkOSApiKeyFormat('bearer_token_xyz')).toBe(false);
+  });
+
+  it('rejects tokens with similar but incorrect prefixes', () => {
+    expect(isWorkOSApiKeyFormat('wos_api_')).toBe(false);
+    expect(isWorkOSApiKeyFormat('wos_')).toBe(false);
+    expect(isWorkOSApiKeyFormat('s_key')).toBe(false);
+    expect(isWorkOSApiKeyFormat('SK_uppercase')).toBe(false);
+  });
+
+  it('does not match sealed session tokens', () => {
+    expect(isWorkOSApiKeyFormat('eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- WorkOS changed their API key format from `wos_api_key_` to `sk_` prefix
- The auth middleware was rejecting the new `sk_` format before even sending it to WorkOS for validation, causing 401 errors for all users with new-format API keys
- Added `isWorkOSApiKeyFormat()` helper that recognizes both legacy and current prefixes, updated all 3 check sites in `auth.ts`
- Updated docs to show the current `sk_` key format

## Test plan
- [x] TypeScript typecheck passes
- [x] All 304 tests pass
- [x] Build succeeds
- [ ] Verify `sk_` prefixed API keys authenticate successfully against `/api/brands/save`
- [ ] Verify `wos_api_key_` prefixed keys still work (backward compat)
- [ ] Verify static admin API key still works
- [ ] Verify sealed session auth (native apps) still works