### PR TITLE
Upgrade test_adcp_agent to @adcp/client 3.20.0 suite API

### DIFF
--- a/.changeset/addie-testing-suite.md
+++ b/.changeset/addie-testing-suite.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update Addie's test_adcp_agent tool to use @adcp/client 3.20.0 suite API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-beta.3",
       "dependencies": {
-        "@adcp/client": "^3.11.2",
+        "@adcp/client": "^3.20.0",
         "@anthropic-ai/sdk": "^0.71.2",
         "@asteasolutions/zod-to-openapi": "^8.4.0",
         "@modelcontextprotocol/sdk": "^1.24.3",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-3.11.2.tgz",
-      "integrity": "sha512-wnZ6P1VAJM11S2/Xflj7rUDnIlH2+c6B9p9vb0zgT/YCVzjlOVZ03IF6lmryNBmr2nL0Y2a74+8IN2kNtkviCw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-3.20.0.tgz",
+      "integrity": "sha512-iarAAsiT4l42KWL9NBvxNZqiuBkCJVotqSNk13qF3VACBCMomIQPbKUQqUBIyu1zodPvlhv2pDDtZ75OkGVU1g==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "verify-version-sync": "node scripts/verify-version-sync.cjs"
   },
   "dependencies": {
-    "@adcp/client": "^3.11.2",
+    "@adcp/client": "^3.20.0",
     "@anthropic-ai/sdk": "^0.71.2",
     "@asteasolutions/zod-to-openapi": "^8.4.0",
     "@modelcontextprotocol/sdk": "^1.24.3",


### PR DESCRIPTION
## Summary

- Bumps `@adcp/client` from `^3.11.2` to `^3.20.0`
- Replaces single-scenario `runAgentTests` with `testAllScenarios`, which auto-discovers the agent's capabilities and runs all applicable scenarios in one call
- Updates `test_adcp_agent` tool schema: `scenario` (single enum) → `scenarios` (optional array filter)
- DB history records one entry per scenario; suite-level `update()` runs after the loop so `last_test_*` fields reflect the aggregate result, not the last individual scenario
- Removes unused import (`createTestClient`)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` (304 unit tests) — all pass
- [x] Direct API call to `POST /api/addie/chat` with the public test agent URL — ran 13 scenarios, returned `formatSuiteResults` markdown
- [x] Vibium browser test against `/chat` — suite results rendered correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)