### PR TITLE
feat(catalog): typed assets, field bindings, and feed field mappings

### DIFF
--- a/.changeset/catalog-typed-assets.md
+++ b/.changeset/catalog-typed-assets.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Add typed catalog assets, field bindings, and feed field mappings.
+
+**Typed assets on vertical catalog items**: `hotel`, `flight`, `job`, `vehicle`, `real_estate`, `education`, `destination`, and `app` item schemas now support an `assets` array using `OfferingAssetGroup` structure. Enables buyers to provide typed image pools (`images_landscape`, `images_vertical`, `logo`, etc.) alongside existing scalar fields, so formats can declare which asset group to use for each platform-specific slot rather than relying on a single `image_url`.
+
+**Field bindings on format catalog requirements**: `catalog_requirements` entries now support `field_bindings` — explicit mappings from format template slots (`asset_id`) to catalog item fields (dot-notation path) or typed asset pools (`asset_group_id`). Supports scalar field binding, asset pool binding, and repeatable group iteration over catalog items. Optional — agents can still infer without bindings.
+
+**Feed field mappings on catalog**: The `Catalog` object now accepts `feed_field_mappings` for normalizing external feeds during `sync_catalogs` ingestion. Supports field renames, named transforms (`date`, `divide`, `boolean`, `split`) with per-transform parameters, static literal injection, and placement of image URLs into typed asset pools. Eliminates the need to preprocess every non-AdCP feed before syncing.

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -102,6 +102,48 @@ Each vertical type has a defined AdCP item schema, so formats can declare `catal
 | `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/v1/core/destination-item.json) | Meta destination catalogs, Google travel ads |
 | `app` | [AppItem](https://adcontextprotocol.org/schemas/v1/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
 
+## Typed catalog assets
+
+Vertical catalog items support an `assets` array using the same `OfferingAssetGroup` structure as offering-type catalogs. This solves a concrete problem: standard catalog feeds have a single `image_url` field, but a hotel ad on Snap needs a 1080×1920 vertical image, a display banner needs a 1920×1080 landscape hero, and the advertiser's logo goes in a separate slot. Without typed pools, a creative agent has to guess which image to use for which slot.
+
+By providing assets grouped by role, each catalog item self-describes the images it carries:
+
+```json
+{
+  "hotel_id": "grand-amsterdam",
+  "name": "Grand Hotel Amsterdam",
+  "price": { "amount": 289, "currency": "EUR", "period": "night" },
+  "image_url": "https://images.acmehotels.com/grand-amsterdam/hero.jpg",
+  "assets": [
+    {
+      "asset_group_id": "images_landscape",
+      "asset_type": "image",
+      "items": [
+        { "url": "https://images.acmehotels.com/grand-amsterdam/landscape.jpg", "width": 1920, "height": 1080 }
+      ]
+    },
+    {
+      "asset_group_id": "images_vertical",
+      "asset_type": "image",
+      "items": [
+        { "url": "https://images.acmehotels.com/grand-amsterdam/vertical.jpg", "width": 1080, "height": 1920 }
+      ]
+    },
+    {
+      "asset_group_id": "logo",
+      "asset_type": "image",
+      "items": [
+        { "url": "https://images.acmehotels.com/logo.png", "width": 400, "height": 200 }
+      ]
+    }
+  ]
+}
+```
+
+The `asset_group_id` vocabulary is not standardized at the protocol level — each format defines which group IDs it uses via `offering_asset_constraints` in `catalog_requirements`. Common conventions: `images_landscape` (16:9), `images_vertical` (9:16), `images_square` (1:1), `logo`, `video`.
+
+Formats use `field_bindings` (see [Format catalog requirements](#format-catalog-requirements)) to explicitly declare which template slot maps to which asset group.
+
 ## The Catalog object
 
 **Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/v1/core/catalog.json)
@@ -129,6 +171,9 @@ interface Catalog {
   // Integration
   conversion_events?: EventType[]; // Events to attribute to catalog items
   content_id_type?: ContentIdType; // Identifier type for event attribution
+
+  // Feed normalization (for external feeds via url)
+  feed_field_mappings?: CatalogFieldMapping[]; // Map non-standard feed fields to AdCP schema
 }
 ```
 
@@ -148,6 +193,7 @@ interface Catalog {
 | `query` | string | No | Natural language filter |
 | `conversion_events` | EventType[] | No | Event types that represent conversions for items in this catalog (e.g., `submit_application` for job catalogs, `purchase` for product catalogs) |
 | `content_id_type` | ContentIdType | No | Identifier type for matching conversion event `content_ids` to catalog items. Values: `sku`, `gtin`, or vertical-specific IDs (`job_id`, `hotel_id`, etc.). Omit for custom identifier schemes. |
+| `feed_field_mappings` | CatalogFieldMapping[] | No | Normalization rules for external feeds. Maps non-standard field names, date formats, price encodings, and image URLs to the AdCP catalog item schema. See [Feed field mappings](#feed-field-mappings). |
 
 ## Conversion events
 
@@ -347,6 +393,51 @@ Omit `catalogs` to list all catalogs on the account without modification:
 
 This matters because sellers may already have brand data from other sources — a retailer might have the brand's product catalog from their commerce platform. Discovery lets the buyer build on existing state rather than re-uploading everything.
 
+## Feed field mappings
+
+External feeds rarely match the AdCP catalog item schema exactly. Field names differ, dates use platform-specific formats, prices may be encoded as integer cents, and images arrive as untyped URLs. `feed_field_mappings` provides a declarative normalization layer — included on the catalog object in the `sync_catalogs` request — so buyers can describe the translation without preprocessing every feed.
+
+```json
+{
+  "catalog_id": "hotel-feed",
+  "type": "hotel",
+  "url": "https://feeds.partner.com/hotels.xml",
+  "feed_format": "custom",
+  "feed_field_mappings": [
+    { "feed_field": "hotel_name",      "catalog_field": "name" },
+    { "feed_field": "nightly_cents",   "catalog_field": "price.amount",   "transform": "divide", "by": 100 },
+    { "catalog_field": "price.currency", "value": "USD" },
+    { "feed_field": "avail_date",      "catalog_field": "valid_from",     "transform": "date", "format": "YYYYMMDD", "timezone": "UTC" },
+    { "feed_field": "primary_photo",   "asset_group_id": "images_landscape" },
+    { "feed_field": "snap_photo",      "asset_group_id": "images_vertical" },
+    { "feed_field": "logo_url",        "asset_group_id": "logo" },
+    { "feed_field": "facility_list",   "catalog_field": "amenities",      "transform": "split", "separator": "," },
+    { "feed_field": "star_class",      "catalog_field": "star_rating",    "default": 0 }
+  ]
+}
+```
+
+Each mapping entry is one of:
+
+| Pattern | What it does |
+|---------|-------------|
+| `feed_field` + `catalog_field` | Renames a feed field to its schema equivalent (dot notation for nested fields) |
+| `feed_field` + `asset_group_id` | Places a URL into a typed asset pool on the item's `assets` array |
+| `value` + `catalog_field` | Injects a static literal — useful for fields the feed omits (e.g., currency when always USD) |
+| Any of the above + `transform` | Applies a named coercion before writing |
+| Any of the above + `default` | Fallback when the feed field is absent or null |
+
+### Supported transforms
+
+| Transform | Parameters | Example |
+|-----------|-----------|---------|
+| `date` | `format` (input date pattern), `timezone` (IANA, default UTC) | `"YYYYMMDD"` → `"2025-03-01"` |
+| `divide` | `by` (divisor, must be > 0) | `1000` ÷ `100` → `10.00` |
+| `boolean` | — | `"yes"` / `"1"` / `"true"` → `true` |
+| `split` | `separator` (default `,`) | `"spa,pool,wifi"` → `["spa", "pool", "wifi"]` |
+
+Multiple mappings can assemble a nested object. The `price.amount` and `price.currency` mappings above each write one field of the `price` object independently.
+
 ## Format catalog requirements
 
 Formats that render product listings, store locators, or promotional content declare what catalog feeds they need via `catalog_requirements`. This tells buying agents which catalogs to sync before submitting creatives.
@@ -375,6 +466,59 @@ Formats that render product listings, store locators, or promotional content dec
 ```
 
 Buying agents check `catalog_requirements` after discovering formats, sync the required catalogs via `sync_catalogs`, then submit creatives that reference those catalogs.
+
+### Field bindings
+
+Formats can declare `field_bindings` inside each `catalog_requirements` entry to explicitly map template slots to catalog item fields or asset pools. This makes the format self-describing — creative agents don't have to guess which catalog field maps to which template slot.
+
+```json
+{
+  "catalog_requirements": [
+    {
+      "catalog_type": "hotel",
+      "required": true,
+      "required_fields": ["name", "price.amount"],
+      "offering_asset_constraints": [
+        { "asset_group_id": "images_landscape", "asset_type": "image", "required": true, "min_count": 1 },
+        { "asset_group_id": "images_vertical",  "asset_type": "image", "required": true, "min_count": 1 }
+      ],
+      "field_bindings": [
+        { "asset_id": "headline",       "catalog_field": "name" },
+        { "asset_id": "price_badge",    "catalog_field": "price.amount" },
+        { "asset_id": "hero_image",     "asset_group_id": "images_landscape" },
+        { "asset_id": "snap_background","asset_group_id": "images_vertical" },
+        { "asset_id": "logo",           "asset_group_id": "logo" }
+      ]
+    }
+  ]
+}
+```
+
+For repeatable groups (carousels where each slide is one catalog item), use `format_group_id` with `catalog_item: true`:
+
+```json
+{
+  "field_bindings": [
+    {
+      "format_group_id": "slide",
+      "catalog_item": true,
+      "per_item_bindings": [
+        { "asset_id": "title",  "catalog_field": "name" },
+        { "asset_id": "price",  "catalog_field": "price.amount" },
+        { "asset_id": "image",  "asset_group_id": "images_landscape" }
+      ]
+    }
+  ]
+}
+```
+
+Field bindings are **optional** — creative agents can still infer mappings from field names and asset types when bindings are absent. Providing them removes ambiguity and enables pre-render validation.
+
+| Binding variant | Required fields | What it does |
+|----------------|----------------|-------------|
+| Scalar | `asset_id` + `catalog_field` | Maps individual template asset to catalog item field (dot notation) |
+| Asset pool | `asset_id` + `asset_group_id` | Maps individual template asset to typed asset pool on the catalog item |
+| Catalog group | `format_group_id` + `catalog_item: true` | Iterates a format repeatable_group over catalog items |
 
 ## Catalogs in creatives
 

--- a/static/schemas/source/core/app-item.json
+++ b/static/schemas/source/core/app-item.json
@@ -95,6 +95,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this app. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (promotional hero), 'images_vertical' (9:16 for Snap, Stories), 'images_square' (1:1 for display), 'video' (gameplay or demo video). Supplements icon_url and screenshots for platform-specific format requirements.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/catalog-field-mapping.json
+++ b/static/schemas/source/core/catalog-field-mapping.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/catalog-field-mapping.json",
+  "title": "Catalog Field Mapping",
+  "description": "Declares how a field in an external feed maps to the AdCP catalog item schema. Used in sync_catalogs feed_field_mappings to normalize non-AdCP feeds (Google Merchant Center, LinkedIn Jobs XML, hotel XML, etc.) to the standard catalog item schema without requiring the buyer to preprocess every feed. Multiple mappings can assemble a nested object via dot notation (e.g., separate mappings for price.amount and price.currency).",
+  "type": "object",
+  "properties": {
+    "feed_field": {
+      "type": "string",
+      "description": "Field name in the external feed record. Omit when injecting a static literal value (use the value property instead)."
+    },
+    "catalog_field": {
+      "type": "string",
+      "description": "Target field on the catalog item schema, using dot notation for nested fields (e.g., 'name', 'price.amount', 'location.city'). Mutually exclusive with asset_group_id."
+    },
+    "asset_group_id": {
+      "type": "string",
+      "description": "Places the feed field value (a URL) into a typed asset pool on the catalog item's assets array. The value is wrapped as an image or video asset in a group with this ID. Use standard group IDs: 'images_landscape', 'images_vertical', 'images_square', 'logo', 'video'. Mutually exclusive with catalog_field."
+    },
+    "value": {
+      "description": "Static literal value to inject into catalog_field for every item, regardless of what the feed contains. Mutually exclusive with feed_field. Useful for fields the feed omits (e.g., currency when price is always USD, or a constant category value)."
+    },
+    "transform": {
+      "type": "string",
+      "description": "Named transform to apply to the feed field value before writing to the catalog schema. See transform-specific parameters (format, timezone, by, separator).",
+      "enum": ["date", "divide", "boolean", "split"]
+    },
+    "format": {
+      "type": "string",
+      "description": "For transform 'date': the input date format string (e.g., 'YYYYMMDD', 'MM/DD/YYYY', 'DD-MM-YYYY'). Output is always ISO 8601 (e.g., '2025-03-01'). Uses Unicode date pattern tokens."
+    },
+    "timezone": {
+      "type": "string",
+      "description": "For transform 'date': the timezone of the input value. IANA timezone identifier (e.g., 'UTC', 'America/New_York', 'Europe/Amsterdam'). Defaults to UTC when omitted."
+    },
+    "by": {
+      "type": "number",
+      "description": "For transform 'divide': the divisor to apply (e.g., 100 to convert integer cents to decimal dollars).",
+      "exclusiveMinimum": 0
+    },
+    "separator": {
+      "type": "string",
+      "description": "For transform 'split': the separator character or string to split on. Defaults to ','.",
+      "default": ","
+    },
+    "default": {
+      "description": "Fallback value to use when feed_field is absent, null, or empty. Applied after any transform would have been applied. Allows optional feed fields to have a guaranteed baseline value."
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "allOf": [
+    { "not": { "required": ["feed_field", "value"] } },
+    { "not": { "required": ["catalog_field", "asset_group_id"] } }
+  ],
+  "additionalProperties": true,
+  "examples": [
+    {
+      "description": "Simple field rename",
+      "data": {
+        "feed_field": "hotel_name",
+        "catalog_field": "name"
+      }
+    },
+    {
+      "description": "Date format transform — YYYYMMDD to ISO 8601",
+      "data": {
+        "feed_field": "available_from",
+        "catalog_field": "valid_from",
+        "transform": "date",
+        "format": "YYYYMMDD",
+        "timezone": "UTC"
+      }
+    },
+    {
+      "description": "Divide cents to dollars",
+      "data": {
+        "feed_field": "price_cents",
+        "catalog_field": "price.amount",
+        "transform": "divide",
+        "by": 100
+      }
+    },
+    {
+      "description": "Static literal injection — currency not in feed",
+      "data": {
+        "catalog_field": "price.currency",
+        "value": "USD"
+      }
+    },
+    {
+      "description": "Image URL assigned to typed asset pool",
+      "data": {
+        "feed_field": "primary_photo_url",
+        "asset_group_id": "images_landscape"
+      }
+    },
+    {
+      "description": "Vertical photo URL assigned to vertical pool",
+      "data": {
+        "feed_field": "portrait_photo_url",
+        "asset_group_id": "images_vertical"
+      }
+    },
+    {
+      "description": "Split comma-separated tags to array",
+      "data": {
+        "feed_field": "amenity_list",
+        "catalog_field": "amenities",
+        "transform": "split",
+        "separator": ","
+      }
+    },
+    {
+      "description": "Boolean coercion with default",
+      "data": {
+        "feed_field": "is_available",
+        "catalog_field": "available",
+        "transform": "boolean",
+        "default": false
+      }
+    }
+  ]
+}

--- a/static/schemas/source/core/catalog.json
+++ b/static/schemas/source/core/catalog.json
@@ -83,6 +83,14 @@
     "content_id_type": {
       "$ref": "/schemas/enums/content-id-type.json",
       "description": "Identifier type that the event's content_ids field should be matched against for items in this catalog. For example, 'gtin' means content_ids values are Global Trade Item Numbers, 'sku' means retailer SKUs. Omit when using a custom identifier scheme not listed in the enum."
+    },
+    "feed_field_mappings": {
+      "type": "array",
+      "description": "Declarative normalization rules for external feeds. Maps non-standard feed field names, date formats, price encodings, and image URLs to the AdCP catalog item schema. Applied during sync_catalogs ingestion. Supports field renames, named transforms (date, divide, boolean, split), static literal injection, and assignment of image URLs to typed asset pools.",
+      "items": {
+        "$ref": "/schemas/core/catalog-field-mapping.json"
+      },
+      "minItems": 1
     }
   },
   "required": ["type"],

--- a/static/schemas/source/core/destination-item.json
+++ b/static/schemas/source/core/destination-item.json
@@ -83,6 +83,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this destination. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (destination hero), 'images_vertical' (9:16 for Snap, Stories), 'images_square' (1:1). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/education-item.json
+++ b/static/schemas/source/core/education-item.json
@@ -79,6 +79,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this program. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (campus/program hero), 'images_vertical' (9:16 for Stories), 'logo' (institution logo). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/flight-item.json
+++ b/static/schemas/source/core/flight-item.json
@@ -83,6 +83,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this flight. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (destination hero), 'images_vertical' (9:16 for Stories), 'images_square' (1:1). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/hotel-item.json
+++ b/static/schemas/source/core/hotel-item.json
@@ -115,6 +115,24 @@
       },
       "minItems": 1
     },
+    "valid_from": {
+      "type": "string",
+      "format": "date",
+      "description": "Date from which this item is available or this rate applies (ISO 8601, e.g., '2025-03-01'). Used for seasonal availability windows in feed imports."
+    },
+    "valid_to": {
+      "type": "string",
+      "format": "date",
+      "description": "Date until which this item is available or this rate applies (ISO 8601, e.g., '2025-09-30'). Used for seasonal availability windows in feed imports."
+    },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this hotel. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (16:9 hero images), 'images_vertical' (9:16 for Snap, Stories), 'images_square' (1:1), 'logo'. Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/job-item.json
+++ b/static/schemas/source/core/job-item.json
@@ -102,6 +102,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this job. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (company/role hero), 'images_vertical' (9:16 for Stories), 'logo' (company logo). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/real-estate-item.json
+++ b/static/schemas/source/core/real-estate-item.json
@@ -133,6 +133,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this property listing. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (exterior/interior hero), 'images_vertical' (9:16 for Stories), 'images_square' (1:1). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/requirements/catalog-field-binding.json
+++ b/static/schemas/source/core/requirements/catalog-field-binding.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/requirements/catalog-field-binding.json",
+  "title": "Catalog Field Binding",
+  "description": "Maps a format template slot to a catalog item field or typed asset pool. Allows formats to explicitly declare how their template slots map to catalog data, making the binding self-describing for creative agents rather than leaving it implicit. All bindings are optional — agents can still infer mappings without them.",
+  "type": "object",
+  "oneOf": [
+    {
+      "description": "Scalar binding — maps an individual format asset to a catalog item field via dot-notation path",
+      "required": ["asset_id", "catalog_field"],
+      "not": { "required": ["format_group_id"] }
+    },
+    {
+      "description": "Asset pool binding — maps an individual format asset to a typed asset pool on the catalog item (e.g., images_landscape, images_vertical, logo)",
+      "required": ["asset_id", "asset_group_id"],
+      "not": { "required": ["catalog_field", "format_group_id"] }
+    },
+    {
+      "description": "Catalog group binding — a format repeatable_group where each repetition corresponds to one catalog item. Iterates the group over catalog items.",
+      "required": ["format_group_id", "catalog_item"],
+      "properties": {
+        "catalog_item": { "const": true }
+      },
+      "not": { "required": ["asset_id", "catalog_field", "asset_group_id"] }
+    }
+  ],
+  "properties": {
+    "asset_id": {
+      "type": "string",
+      "description": "The asset_id from the format's assets array. Identifies which individual template slot this binding applies to."
+    },
+    "format_group_id": {
+      "type": "string",
+      "description": "The asset_group_id of a repeatable_group in the format's assets array. Used when the entire group iterates over catalog items (catalog_item: true)."
+    },
+    "catalog_field": {
+      "type": "string",
+      "description": "Dot-notation path to the field on the catalog item (e.g., 'name', 'price.amount', 'location.city'). Used for scalar bindings."
+    },
+    "asset_group_id": {
+      "type": "string",
+      "description": "The asset_group_id on the catalog item's assets array to pull from (e.g., 'images_landscape', 'images_vertical', 'logo'). Used for asset pool bindings — the format slot receives the first item in the pool."
+    },
+    "catalog_item": {
+      "type": "boolean",
+      "const": true,
+      "description": "When true on a format_group_id binding, each repetition of the format's repeatable_group maps to one item from the catalog. The group iterates in catalog item order."
+    },
+    "per_item_bindings": {
+      "type": "array",
+      "description": "For catalog_item group bindings: the scalar and asset pool bindings that apply within each repetition of the group. Only scalar and asset pool variants are allowed here — nested catalog group bindings are not permitted.",
+      "items": {
+        "allOf": [
+          { "$ref": "/schemas/core/requirements/catalog-field-binding.json" },
+          { "not": { "anyOf": [{ "required": ["catalog_item"] }, { "required": ["format_group_id"] }] } }
+        ]
+      },
+      "minItems": 1
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "additionalProperties": true,
+  "examples": [
+    {
+      "description": "Scalar binding — hotel name to headline slot",
+      "data": {
+        "asset_id": "headline",
+        "catalog_field": "name"
+      }
+    },
+    {
+      "description": "Scalar binding — nested field (nightly rate)",
+      "data": {
+        "asset_id": "price_badge",
+        "catalog_field": "price.amount"
+      }
+    },
+    {
+      "description": "Asset pool binding — hero image from landscape pool",
+      "data": {
+        "asset_id": "hero_image",
+        "asset_group_id": "images_landscape"
+      }
+    },
+    {
+      "description": "Asset pool binding — Snap vertical background from vertical pool",
+      "data": {
+        "asset_id": "snap_background",
+        "asset_group_id": "images_vertical"
+      }
+    },
+    {
+      "description": "Catalog group binding — carousel where each slide is one hotel",
+      "data": {
+        "format_group_id": "slide",
+        "catalog_item": true,
+        "per_item_bindings": [
+          { "asset_id": "title", "catalog_field": "name" },
+          { "asset_id": "price", "catalog_field": "price.amount" },
+          { "asset_id": "image", "asset_group_id": "images_landscape" }
+        ]
+      }
+    }
+  ]
+}

--- a/static/schemas/source/core/requirements/catalog-requirements.json
+++ b/static/schemas/source/core/requirements/catalog-requirements.json
@@ -39,9 +39,18 @@
     },
     "offering_asset_constraints": {
       "type": "array",
-      "description": "Per-offering creative requirements. Only applicable when catalog_type is 'offering'. Declares what asset groups (headlines, images, videos) each offering must provide, along with count bounds and per-asset technical constraints.",
+      "description": "Per-item creative asset requirements. Declares what asset groups (headlines, images, videos) each catalog item must provide in its assets array, along with count bounds and per-asset technical constraints. Applicable to 'offering' and all vertical catalog types (hotel, flight, job, etc.) whose items carry typed assets.",
       "items": {
         "$ref": "/schemas/core/requirements/offering-asset-constraint.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "field_bindings": {
+      "type": "array",
+      "description": "Explicit mappings from format template slots to catalog item fields or typed asset pools. Optional — creative agents can infer mappings without them, but bindings make the relationship self-describing and enable validation. Covers scalar fields (asset_id → catalog_field), asset pools (asset_id → asset_group_id on the catalog item), and repeatable groups that iterate over catalog items.",
+      "items": {
+        "$ref": "/schemas/core/requirements/catalog-field-binding.json"
       },
       "minItems": 1,
       "uniqueItems": true

--- a/static/schemas/source/core/vehicle-item.json
+++ b/static/schemas/source/core/vehicle-item.json
@@ -122,6 +122,14 @@
       },
       "minItems": 1
     },
+    "assets": {
+      "type": "array",
+      "description": "Typed creative asset pools for this vehicle. Uses the same OfferingAssetGroup structure as offering-type catalogs. Standard group IDs: 'images_landscape' (exterior hero), 'images_vertical' (9:16 for Stories), 'images_square' (1:1). Enables formats to declare typed image requirements that map unambiguously to the right asset regardless of platform.",
+      "items": {
+        "$ref": "/schemas/core/offering-asset-group.json"
+      },
+      "minItems": 1
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }


### PR DESCRIPTION
## Summary

- **Typed assets on vertical catalog items**: `hotel`, `flight`, `job`, `vehicle`, `real_estate`, `education`, `destination`, and `app` item schemas now support an `assets` array using `OfferingAssetGroup`. Enables typed image pools (`images_landscape`, `images_vertical`, `logo`, etc.) so formats can declare which pool to use for each platform-specific slot rather than relying on a single `image_url`.

- **Field bindings on format catalog requirements**: `catalog_requirements` entries now accept `field_bindings` — explicit mappings from format template slots (`asset_id`) to catalog item fields (dot-notation) or typed asset pools (`asset_group_id`). Supports scalar field binding, asset pool binding, and repeatable group iteration over catalog items. Optional — agents can still infer without bindings.

- **Feed field mappings on catalog**: `Catalog` now accepts `feed_field_mappings` for normalizing external feeds during `sync_catalogs` ingestion. Supports field renames, named transforms (`date`, `divide`, `boolean`, `split`) with per-transform parameters, static literal injection, and image URL assignment to typed asset pools.

## New schemas

- `static/schemas/source/core/requirements/catalog-field-binding.json` — three-variant discriminated union (scalar, asset pool, catalog group iteration)
- `static/schemas/source/core/catalog-field-mapping.json` — feed normalization with mutual exclusivity enforced via `allOf`/`not` constraints

## Test plan

- [x] `npm test` — 325 schemas valid, 304 tests pass, OpenAPI spec up to date, typecheck clean
- [x] Schema examples validate against their own schemas
- [x] No broken doc links

🤖 Generated with [Claude Code](https://claude.com/claude-code)