### PR TITLE
feat: extend signals protocol with transaction support

### DIFF
--- a/.changeset/signals-transactions.md
+++ b/.changeset/signals-transactions.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Extend signals protocol with transaction support:
+
+- **Pricing models**: Signal pricing now supports `cpm` and `percent_of_media` models via the new `signal-pricing.json` discriminated union schema. Percent-of-media supports an optional `max_cpm` cap (the hybrid model used by platforms like The Trade Desk).
+- **Pricing options**: `get_signals` now returns `pricing_options[]` per signal (replacing the single `pricing` field), each with a `pricing_option_id` and pricing model. Pass `account_id` for per-account rate cards and `buyer_campaign_ref` to correlate discovery with settlement.
+- **New `max_percent` filter**: Signal discovery can filter percent-of-media signals by maximum percentage.
+- **`account_id` and `buyer_campaign_ref` on `activate_signal`**: Links custom signal activations to a vendor account and specific campaign.
+- **New generic vendor task `report_usage`**: Reports vendor service consumption (impressions, media spend, vendor cost) across protocols (signals, governance, creative). Supports batching multiple campaigns in a single request via per-record `buyer_campaign_ref`. Requires `operator_id` to characterize billing responsibility. Usage records reference `pricing_option_id` so signals agents can verify the correct rate was applied.

--- a/docs/building/integration/account-state.mdx
+++ b/docs/building/integration/account-state.mdx
@@ -219,7 +219,55 @@ Not everything requires account state. Some tasks are stateless queries:
 | `get_signals` — discover signals | `activate_signal` — activate signals |
 | `get_adcp_capabilities` — discover features | `sync_catalogs` — upload catalogs |
 
-The pattern: **discovery is stateless, execution is stateful**. You can browse a seller's inventory without an account. You need an account to buy.
+The pattern: **discovery is stateless, execution is stateful**. You can browse a seller's inventory without an account. You need an account to buy. Some discovery tasks accept an optional `account_id` to return per-account pricing or personalized results — but an account is never required for discovery.
+
+## Vendor settlement
+
+Vendor protocols — signals, governance, creative — use two shared tasks for post-campaign settlement. These tasks run between an orchestrator and a vendor agent (not a buying platform), using the `account_id` from the vendor relationship established via `sync_accounts` or `activate_signal`.
+
+### report_usage
+
+**Schema**: [`account/report-usage-request.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-request.json) / [`account/report-usage-response.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-response.json)
+
+Orchestrators call `report_usage` to inform a vendor agent how their service was used after delivery. Multiple campaigns can be batched in a single request by varying `buyer_campaign_ref` across records. The vendor agent uses this data to track earned revenue and verify billing.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `account_id` | string | Yes | The caller's account with this vendor agent |
+| `operator_id` | string | Yes | The operator (agency or buyer) on whose behalf usage is reported. Characterizes billing responsibility. |
+| `reporting_period` | object | Yes | `start` and `end` as ISO 8601 date-time in UTC |
+| `usage` | UsageRecord[] | Yes | One record per service unit consumed (see below) |
+
+Each usage record requires `kind`, `vendor_cost`, and `currency`. Signal records additionally require `signal_agent_segment_id`, `pricing_option_id`, and `impressions`; include `media_spend` for percent-of-media cost verification. Include `buyer_campaign_ref` per record to associate it with a specific campaign.
+
+```json
+{
+  "account_id": "acct_pinnacle_signals",
+  "operator_id": "pinnacle-media.com",
+  "reporting_period": {
+    "start": "2025-03-01T00:00:00Z",
+    "end": "2025-03-31T23:59:59Z"
+  },
+  "usage": [
+    {
+      "buyer_campaign_ref": "mb_spring_launch_001",
+      "kind": "signal",
+      "signal_agent_segment_id": "luxury_auto_intenders",
+      "pricing_option_id": "po_lux_auto_cpm",
+      "impressions": 4200000,
+      "media_spend": 21000.00,
+      "vendor_cost": 2100.00,
+      "currency": "USD"
+    }
+  ]
+}
+```
+
+The response confirms how many records were accepted. Partial acceptance is valid — accepted records are stored even if some records fail validation.
+
+```json
+{ "accepted": 1 }
+```
 
 ## Related documentation
 

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -25,29 +25,35 @@ The Signals Protocol provides:
 - Natural language signal discovery based on marketing objectives
 - Multi-platform signal discovery in a single request
 - Signal activation for specific platforms and accounts
-- Transparent pricing with CPM and revenue share models
-- Signal size reporting with unit types (individuals, devices, households)
+- Transparent pricing with CPM and percent-of-media models (including CPM caps)
+- Campaign usage reporting for post-delivery settlement
 
 ## Tasks
 
-| Task | Purpose |
-|------|---------|
-| [`get_signals`](/docs/signals/tasks/get_signals) | Discover signals matching campaign criteria |
-| [`activate_signal`](/docs/signals/tasks/activate_signal) | Activate a signal for use in campaigns |
+The Signals Protocol has two protocol-specific tasks. Transaction reporting uses the generic [account management tasks](/docs/building/integration/account-state) shared across all vendor protocols.
 
-## Agent Integration
+| Task | Domain | Purpose |
+|------|--------|---------|
+| [`get_signals`](/docs/signals/tasks/get_signals) | signals | Discover signals with pricing options |
+| [`activate_signal`](/docs/signals/tasks/activate_signal) | signals | Activate a custom signal for use in campaigns |
+| [`report_usage`](/docs/building/integration/account-state) | account | Report how signal data was used after delivery |
 
-The Signals Protocol operates within the broader [AdCP Ecosystem](/docs/intro#the-adcp-ecosystem-layers), enabling signal agents to integrate directly with decisioning platforms (DSPs, orchestration platforms).
+## Transaction Model
 
-### Direct Integration Model
+The standard signal transaction flow:
 
-Signal agents contract directly with decisioning platforms, eliminating intermediary reporting and usage tracking. Once signals are activated on a decisioning platform, all usage reporting, billing, and campaign metrics are handled directly by that platform.
+1. **`sync_accounts`** — Establish the commercial relationship with the signals agent, receiving an `account_id` and billing terms.
+2. **`get_signals`** — Discover signals. Pass `account_id` and `buyer_campaign_ref` to receive per-account pricing options. Each signal returns `pricing_options[]`, each with a `pricing_option_id` and rate.
+3. **Campaign runs** — Use the signals via the platform's standard targeting interface.
+4. **`report_usage`** — Report actual consumption (impressions, media spend, vendor cost) referencing the `signal_agent_segment_id` and `pricing_option_id` chosen at discovery time.
+
+`activate_signal` is for custom signals that require explicit DSP-side activation (e.g., audience lists that need to be pushed to a specific platform before use).
 
 ## Getting Started
 
-1. **Discover signals** using `get_signals` with a natural language brief
-2. **Review pricing** and signal sizes in the response
-3. **Activate signals** using `activate_signal` for your target platform
-4. **Use in campaigns** via the platform's standard targeting interface
+1. **Discover signals** using `get_signals` with a natural language brief and your `account_id`
+2. **Review pricing options** and signal sizes in the response
+3. **Use in campaigns** via the platform's standard targeting interface
+4. **Report usage** using `report_usage` after delivery
 
 See the [Protocol Specification](/docs/signals/specification) for complete technical details.

--- a/docs/signals/specification.mdx
+++ b/docs/signals/specification.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Specification
 ---
 
 **Status**: Request for Comments
-**Last Updated**: January 25, 2026
+**Last Updated**: February 22, 2026
 
 This document defines the Signals Protocol specification. The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
@@ -19,8 +19,9 @@ The Signals Protocol provides:
 - Natural language signal discovery based on marketing objectives
 - Multi-platform signal discovery in a single request
 - Signal activation for specific platforms and accounts
-- Transparent pricing with CPM and revenue share models
-- Signal size reporting with unit types (individuals, devices, households)
+- Transparent pricing with CPM and percent-of-media models
+- Signal usage reporting for post-delivery settlement
+- Signal revenue visibility for data providers and orchestrators
 
 ## Transport Requirements
 
@@ -64,13 +65,22 @@ Every signal request involves two roles:
 
 ### Identifiers
 
-- **`signal_agent_segment_id`**: Unique identifier for a signal. Signal agents MUST return this for each signal. Orchestrators MUST use this in `activate_signal` requests.
+- **`signal_agent_segment_id`**: Unique identifier for a signal. Signal agents MUST return this for each signal. Orchestrators MUST use this in `activate_signal` and `report_usage` requests.
 
 - **`activation_key`**: Key for campaign targeting. Signal agents MUST return this when `is_live: true` AND the caller has access to the deployment. Orchestrators MUST use this for targeting (not `signal_agent_segment_id`).
 
+### Pricing Models
+
+Signals use one of two pricing models expressed via the `model` field on the `pricing` object:
+
+- **`cpm`**: Fixed cost per thousand impressions. The `cpm` field specifies the rate.
+- **`percent_of_media`**: A percentage of media spend. The `percent` field specifies the rate (e.g., `15` = 15%). An optional `max_cpm` cap may also be set — when present, the effective rate is `min(percent × media_spend_per_mille, max_cpm)`, which is the pricing model used by platforms like The Trade Desk.
+
+Both models require a `currency` field.
+
 ## Tasks
 
-The Signals Protocol defines two tasks. See task reference pages for complete request/response schemas and examples.
+The Signals Protocol defines two protocol-specific tasks. Usage reporting uses the generic [report_usage](/docs/building/integration/account-state) task shared across all vendor protocols.
 
 ### get_signals
 
@@ -81,7 +91,7 @@ The Signals Protocol defines two tasks. See task reference pages for complete re
 Discover signals matching campaign criteria.
 
 **Requirements:**
-- Orchestrators MUST include `signal_spec` and `deliver_to`
+- Orchestrators MUST include `deliver_to` and either `signal_spec` or `signal_ids`
 - Signal agents MUST return all required fields per response schema
 - Signal agents MUST include `activation_key` when `is_live: true` AND caller has deployment access
 
@@ -91,13 +101,26 @@ Discover signals matching campaign criteria.
 
 **Reference**: [`activate_signal` task](/docs/signals/tasks/activate_signal)
 
-Activate a signal for use on a decisioning platform.
+Activate a signal for use on a decisioning platform. The `buyer_campaign_ref` field links this activation to a specific media buy, enabling the signals agent to correlate subsequent `report_usage` calls.
 
 **Requirements:**
 - Orchestrators MUST include `signal_agent_segment_id` and `deployments`
+- Orchestrators SHOULD include `account_id` and `buyer_campaign_ref` to establish transaction context
 - On success, signal agents MUST return a `deployments` array with `is_live` for each deployment
 - Signal agents MUST return `activation_key` when `is_live: true` AND caller has deployment access
 - On failure, signal agents MUST return an `errors` array (with no `deployments` array)
+
+### report_usage (account management)
+
+**Schema**: [`account/report-usage-request.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-request.json) / [`account/report-usage-response.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-response.json)
+
+Report signal data consumption after campaign delivery. Usage records use `kind: "signal"` with `signal_agent_segment_id`. See [report_usage](/docs/building/integration/account-state) for full reference.
+
+**Requirements:**
+- Orchestrators SHOULD call this task at regular intervals and upon campaign completion
+- Usage records for signals MUST include `signal_agent_segment_id`, `pricing_option_id`, `impressions`, `media_spend`, `vendor_cost`, and `currency`
+- Signal agents MUST return the count of `accepted` records
+- Signal agents MUST support partial acceptance
 
 ## Error Handling
 
@@ -122,6 +145,7 @@ All Signals Protocol communications MUST use HTTPS with TLS 1.2 or higher.
 - Signal agents MUST only return `activation_key` to authenticated callers with deployment access
 - Signal agents MUST NOT return activation keys for deployments the caller cannot access
 
+
 ### Data Minimization
 
 - Signal agents MUST NOT return signals the principal is not authorized to access
@@ -138,6 +162,10 @@ A conformant Signals Protocol agent MUST:
 4. Use specified error codes
 5. Enforce access control for private signals and activation keys
 
+A conformant Signals Protocol agent that supports settlement MUST additionally:
+
+6. Implement `report_usage` with partial acceptance semantics
+
 ### Orchestrator Conformance
 
 A conformant Signals Protocol orchestrator MUST:
@@ -146,6 +174,11 @@ A conformant Signals Protocol orchestrator MUST:
 2. Include required fields as defined in request schemas
 3. Handle async activation responses
 4. Use `activation_key` for campaign targeting
+
+An orchestrator that manages signal billing SHOULD additionally:
+
+5. Include `account_id` and `buyer_campaign_ref` in `get_signals` requests
+6. Call `report_usage` at regular intervals and upon campaign completion, referencing the `pricing_option_id` from discovery
 
 ## Implementation Notes
 
@@ -163,6 +196,10 @@ Signal activation is typically asynchronous:
 
 Orchestrators MUST NOT assume immediate availability after activation request.
 
+### Settlement Cadence
+
+Orchestrators SHOULD report campaign usage monthly at minimum. For campaigns with significant spend, weekly reporting is recommended to give signals agents timely visibility into earned revenue.
+
 ## Schema Reference
 
 | Schema | Description |
@@ -171,5 +208,9 @@ Orchestrators MUST NOT assume immediate availability after activation request.
 | [`signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/v2/signals/get-signals-response.json) | get_signals response |
 | [`signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/v2/signals/activate-signal-request.json) | activate_signal request |
 | [`signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/v2/signals/activate-signal-response.json) | activate_signal response |
+| [`account/report-usage-request.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-request.json) | report_usage request |
+| [`account/report-usage-response.json`](https://adcontextprotocol.org/schemas/v2/account/report-usage-response.json) | report_usage response |
+| [`core/signal-pricing.json`](https://adcontextprotocol.org/schemas/v2/core/signal-pricing.json) | Signal pricing model |
+| [`core/signal-pricing-option.json`](https://adcontextprotocol.org/schemas/v2/core/signal-pricing-option.json) | Signal pricing option (id + pricing) |
 | [`core/deployment.json`](https://adcontextprotocol.org/schemas/v2/core/deployment.json) | Deployment target |
 | [`core/activation-key.json`](https://adcontextprotocol.org/schemas/v2/core/activation-key.json) | Activation key |

--- a/docs/signals/tasks/get_signals.mdx
+++ b/docs/signals/tasks/get_signals.mdx
@@ -18,6 +18,8 @@ The `get_signals` task returns both signal metadata and real-time deployment sta
 |-----------|------|----------|-------------|
 | `signal_spec` | string | Yes | Natural language description of the desired signals |
 | `deliver_to` | DeliverTo | Yes | Deployment targets where signals need to be activated (see Deliver To Object below) |
+| `account_id` | string | No | The caller's account with this signals agent. When provided, returns per-account pricing options if configured. |
+| `buyer_campaign_ref` | string | No | The buyer's campaign reference. Used to correlate discovery with `report_usage` calls. |
 | `filters` | Filters | No | Filters to refine results (see Filters Object below) |
 | `max_results` | number | No | Maximum number of results to return |
 | `pagination` | object | No | Pagination: `cursor` (opaque cursor from previous response) for paging through large result sets |
@@ -55,7 +57,8 @@ Each deployment target uses a `type` field to discriminate between platform-base
 |-----------|------|----------|-------------|
 | `catalog_types` | string[] | No | Filter by catalog type ("marketplace", "custom", "owned") |
 | `data_providers` | string[] | No | Filter by specific data providers |
-| `max_cpm` | number | No | Maximum CPM price filter |
+| `max_cpm` | number | No | Maximum effective CPM filter. Applies to CPM-priced signals and to percent-of-media signals that have a `max_cpm` cap set. |
+| `max_percent` | number | No | Maximum percent-of-media filter (0–100). Applies only to signals with `model='percent_of_media'`. |
 | `min_coverage_percentage` | number | No | Minimum coverage requirement |
 
 ## Response Structure
@@ -94,10 +97,17 @@ The response structure is identical across protocols, with only the transport wr
           "estimated_activation_duration_minutes": "number"
         }
       ],
-      "pricing": {
-        "cpm": "number",
-        "currency": "string"
-      }
+      "pricing_options": [
+        {
+          "pricing_option_id": "string",
+          "pricing": {
+            "model": "cpm | percent_of_media",
+            "cpm": "number (when model=cpm)",
+            "percent": "number (when model=percent_of_media)",
+            "currency": "string"
+          }
+        }
+      ]
     }
   ]
 }
@@ -116,11 +126,14 @@ The response structure is identical across protocols, with only the transport wr
     - **agent_url**: URL identifying the destination agent
     - **account**: Account identifier if applicable
     - **is_live**: Whether signal is currently active on this deployment
-    - **activation_key**: The key to use for targeting (see Activation Key below). **Only present if `is_live=true` AND this deployment has `requester=true` in the request.**
+    - **activation_key**: The key to use for targeting (see Activation Key below). Only present when `is_live=true` and the authenticated caller has access to this deployment.
     - **estimated_activation_duration_minutes**: Time to activate if not live
-  - **pricing**: Pricing information
-    - **cpm**: Cost per thousand impressions
-    - **currency**: Currency code
+  - **pricing_options**: Array of available pricing options for this signal
+    - **pricing_option_id**: Opaque identifier; pass this back in `report_usage` to reference which option was applied
+    - **pricing.model**: Pricing model — `"cpm"` or `"percent_of_media"`
+    - **pricing.cpm**: Cost per thousand impressions (present when `model="cpm"`)
+    - **pricing.percent**: Percentage of media spend, e.g. `15` = 15% (present when `model="percent_of_media"`)
+    - **pricing.currency**: ISO 4217 currency code
 
 ### Activation Key Object
 
@@ -203,10 +216,12 @@ Because the authenticated caller matches the deployment target, the response inc
           }
         }
       ],
-      "pricing": {
-        "cpm": 3.50,
-        "currency": "USD"
-      }
+      "pricing_options": [
+        {
+          "pricing_option_id": "po_lux_auto_cpm",
+          "pricing": { "model": "cpm", "cpm": 3.50, "currency": "USD" }
+        }
+      ]
     }
   ]
 }
@@ -279,10 +294,12 @@ A buyer with credentials for both The Trade Desk and Amazon DSP receives keys fo
           "estimated_activation_duration_minutes": 60
         }
       ],
-      "pricing": {
-        "cpm": 3.50,
-        "currency": "USD"
-      }
+      "pricing_options": [
+        {
+          "pricing_option_id": "po_lux_auto_cpm",
+          "pricing": { "model": "cpm", "cpm": 3.50, "currency": "USD" }
+        }
+      ]
     }
   ]
 }
@@ -376,10 +393,12 @@ A2A returns results as artifacts with the same data structure:
                     "estimated_activation_duration_minutes": 60
                   }
                 ],
-                "pricing": {
-                  "cpm": 3.50,
-                  "currency": "USD"
-                }
+                "pricing_options": [
+                  {
+                    "pricing_option_id": "po_lux_auto_cpm",
+                    "pricing": { "model": "cpm", "cpm": 3.50, "currency": "USD" }
+                  }
+                ]
               }
             ]
           }
@@ -466,10 +485,12 @@ Discover all available deployments across platforms:
         "estimated_activation_duration_minutes": 60
       }
     ],
-    "pricing": {
-      "cpm": 2.50,
-      "currency": "USD"
-    }
+    "pricing_options": [
+      {
+        "pricing_option_id": "po_peer39_lux_auto_cpm",
+        "pricing": { "model": "cpm", "cpm": 2.50, "currency": "USD" }
+      }
+    ]
   }]
 }
 ```
@@ -491,9 +512,12 @@ Discover all available deployments across platforms:
     - **scope** (string): "platform-wide" or "account-specific"
     - **decisioning_platform_segment_id** (string): Platform-specific ID to use
     - **estimated_activation_duration_minutes** (number, optional): Time to activate if not live
-  - **pricing** (object): Pricing information
-    - **cpm** (number): Cost per thousand impressions
-    - **currency** (string): Currency code
+  - **pricing_options** (array): Available pricing options for this signal
+    - **pricing_option_id** (string): Pass this back in `report_usage` to identify which option was applied
+    - **pricing.model** (string): Pricing model — `"cpm"` or `"percent_of_media"`
+    - **pricing.cpm** (number): Cost per thousand impressions (present when `model="cpm"`)
+    - **pricing.percent** (number): Percentage of media spend, e.g. `15` = 15% (present when `model="percent_of_media"`)
+    - **pricing.currency** (string): ISO 4217 currency code
 
 ## Error Codes
 
@@ -548,10 +572,12 @@ Discover all available deployments across platforms:
           "decisioning_platform_segment_id": "ox_agency123_affluent_789"
         }
       ],
-      "pricing": {
-        "cpm": 3.50,
-        "currency": "USD"
-      }
+      "pricing_options": [
+        {
+          "pricing_option_id": "po_acme_aff_cpm",
+          "pricing": { "model": "cpm", "cpm": 3.50, "currency": "USD" }
+        }
+      ]
     }
     // ... more signals
   ]
@@ -582,10 +608,12 @@ Discover all available deployments across platforms:
           "decisioning_platform_segment_id": "ttd_exp_auto_premium"
         }
       ],
-      "pricing": {
-        "cpm": 4.50,
-        "currency": "USD"
-      }
+      "pricing_options": [
+        {
+          "pricing_option_id": "po_exp_auto_cpm",
+          "pricing": { "model": "cpm", "cpm": 4.50, "currency": "USD" }
+        }
+      ]
     }
   ],
   "errors": [

--- a/static/schemas/source/account/report-usage-request.json
+++ b/static/schemas/source/account/report-usage-request.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/account/report-usage-request.json",
+  "title": "Report Usage Request",
+  "description": "Reports how a vendor's service was consumed. Called by orchestrators after delivery to inform a vendor agent (signals, governance, creative) what was used and what they are owed. Supports batching multiple campaigns in a single request. Any vendor protocol that participates in transactions should implement this task.",
+  "type": "object",
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "The caller's account with this vendor agent"
+    },
+    "operator_id": {
+      "type": "string",
+      "description": "The operator (agency or buyer) on whose behalf usage is being reported. Characterizes billing responsibility."
+    },
+    "reporting_period": {
+      "type": "object",
+      "description": "Date range for the usage report. All periods use UTC timezone.",
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 start timestamp in UTC"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 end timestamp in UTC"
+        }
+      },
+      "required": ["start", "end"],
+      "additionalProperties": false
+    },
+    "usage": {
+      "type": "array",
+      "description": "Usage records for this reporting period. Each item describes consumption of one vendor service unit. Multiple campaigns can be included in a single request by varying buyer_campaign_ref across records.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "buyer_campaign_ref": {
+            "type": "string",
+            "description": "The buyer's campaign reference for this usage record. Allows batching usage for multiple campaigns in a single request."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Type of vendor service consumed. Determines which protocol-specific fields are present.",
+            "enum": ["signal", "content_standards", "creative"]
+          },
+          "vendor_cost": {
+            "type": "number",
+            "description": "Amount owed to the vendor for this usage record, in currency",
+            "minimum": 0
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code for vendor_cost and media_spend",
+            "pattern": "^[A-Z]{3}$"
+          },
+          "impressions": {
+            "type": "number",
+            "description": "Impressions delivered for this usage record. Required for signal kind.",
+            "minimum": 0
+          },
+          "media_spend": {
+            "type": "number",
+            "description": "Media spend associated with these impressions, in currency. Required when vendor pricing is percent_of_media.",
+            "minimum": 0
+          },
+          "signal_agent_segment_id": {
+            "type": "string",
+            "description": "Signal identifier from get_signals. Required when kind='signal'."
+          },
+          "pricing_option_id": {
+            "type": "string",
+            "description": "Pricing option identifier from get_signals. Required when kind='signal'. The signals agent uses this to verify the correct rate was applied."
+          },
+          "standards_id": {
+            "type": "string",
+            "description": "Content standards configuration identifier. Required when kind='content_standards'."
+          },
+          "ext": {
+            "$ref": "/schemas/core/ext.json"
+          }
+        },
+        "required": ["kind", "vendor_cost", "currency"],
+        "if": {
+          "properties": { "kind": { "type": "string", "const": "signal" } },
+          "required": ["kind"]
+        },
+        "then": {
+          "required": ["signal_agent_segment_id", "pricing_option_id", "impressions"]
+        },
+        "additionalProperties": true
+      },
+      "minItems": 1
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "account_id",
+    "operator_id",
+    "reporting_period",
+    "usage"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/account/report-usage-response.json
+++ b/static/schemas/source/account/report-usage-response.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/account/report-usage-response.json",
+  "title": "Report Usage Response",
+  "description": "Response payload for report_usage task. Confirms how many usage records were accepted and reports any validation errors.",
+  "type": "object",
+  "properties": {
+    "accepted": {
+      "type": "integer",
+      "description": "Number of usage records successfully accepted",
+      "minimum": 0
+    },
+    "errors": {
+      "type": "array",
+      "description": "Validation errors for individual usage records. Partial acceptance is valid — accepted records are stored even when some records error.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
+    "sandbox": {
+      "type": "boolean",
+      "description": "When true, this response contains simulated data from sandbox mode."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "accepted"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/signal-filters.json
+++ b/static/schemas/source/core/signal-filters.json
@@ -23,8 +23,14 @@
     },
     "max_cpm": {
       "type": "number",
-      "description": "Maximum CPM price filter",
+      "description": "Maximum effective CPM filter. Applies to signals with model='cpm', and to signals with model='percent_of_media' that have a max_cpm cap set.",
       "minimum": 0
+    },
+    "max_percent": {
+      "type": "number",
+      "description": "Maximum percent-of-media price filter. Applies only to signals with model='percent_of_media'. Signals with model='cpm' are not filtered by this field.",
+      "minimum": 0,
+      "maximum": 100
     },
     "min_coverage_percentage": {
       "type": "number",

--- a/static/schemas/source/core/signal-pricing-option.json
+++ b/static/schemas/source/core/signal-pricing-option.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/signal-pricing-option.json",
+  "title": "Signal Pricing Option",
+  "description": "A specific pricing option offered by a signals agent for a signal. The pricing_option_id is returned in get_signals and referenced in report_usage to identify which pricing option was applied.",
+  "type": "object",
+  "properties": {
+    "pricing_option_id": {
+      "type": "string",
+      "description": "Opaque identifier for this pricing option, unique within the signals agent. Returned in get_signals; passed back in report_usage for reconciliation."
+    },
+    "pricing": {
+      "$ref": "/schemas/core/signal-pricing.json"
+    }
+  },
+  "required": ["pricing_option_id", "pricing"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/signal-pricing.json
+++ b/static/schemas/source/core/signal-pricing.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/signal-pricing.json",
+  "title": "Signal Pricing",
+  "description": "Pricing model for a signal. Discriminated by model: 'cpm' for cost per thousand impressions, 'percent_of_media' for a percentage of media spend.",
+  "type": "object",
+  "oneOf": [
+    {
+      "title": "CpmPricing",
+      "description": "Fixed cost per thousand impressions",
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string",
+          "const": "cpm"
+        },
+        "cpm": {
+          "type": "number",
+          "description": "Cost per thousand impressions",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": [
+        "model",
+        "cpm",
+        "currency"
+      ],
+      "additionalProperties": true
+    },
+    {
+      "title": "PercentOfMediaPricing",
+      "description": "Percentage of media spend charged for this signal. When max_cpm is set, the effective rate is capped at that CPM — useful for The Trade Desk and similar platforms that use percent-of-media pricing with a CPM ceiling.",
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string",
+          "const": "percent_of_media"
+        },
+        "percent": {
+          "type": "number",
+          "description": "Percentage of media spend, e.g. 15 = 15%",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "max_cpm": {
+          "type": "number",
+          "description": "Maximum CPM cap. When set, the effective charge is min(percent × media_spend_per_mille, max_cpm). Optional.",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code for the resulting charge",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": [
+        "model",
+        "percent",
+        "currency"
+      ],
+      "additionalProperties": true
+    }
+  ]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -258,6 +258,14 @@
           "$ref": "/schemas/core/signal-id.json",
           "description": "Universal signal identifier - discriminated union by source: 'catalog' (data_provider_domain + id, verifiable) or 'agent' (agent_url + id, trust-based)"
         },
+        "signal-pricing": {
+          "$ref": "/schemas/core/signal-pricing.json",
+          "description": "Signal pricing model - discriminated union by model: 'cpm' (cost per thousand impressions) or 'percent_of_media' (percentage of media spend)"
+        },
+        "signal-pricing-option": {
+          "$ref": "/schemas/core/signal-pricing-option.json",
+          "description": "A specific pricing option offered by a signals agent, combining a pricing_option_id with a signal pricing model. Returned in get_signals, referenced in report_usage."
+        },
         "signal-definition": {
           "$ref": "/schemas/core/signal-definition.json",
           "description": "Signal definition published in a data provider's adagents.json catalog"
@@ -692,7 +700,7 @@
       }
     },
     "account": {
-      "description": "Account management task request/response schemas",
+      "description": "Account management task request/response schemas. These tasks establish and maintain commercial relationships between buyers and vendor agents (media sellers, signals agents, governance agents, creative agents). Any vendor protocol can implement report_usage to participate in the transaction lifecycle.",
       "tasks": {
         "list-accounts": {
           "request": {
@@ -712,6 +720,16 @@
           "response": {
             "$ref": "/schemas/account/sync-accounts-response.json",
             "description": "Response payload for sync_accounts task"
+          }
+        },
+        "report-usage": {
+          "request": {
+            "$ref": "/schemas/account/report-usage-request.json",
+            "description": "Request parameters for reporting vendor service consumption. Supports batching multiple campaigns. Used across protocols (signals, governance, creative) to close the transaction loop."
+          },
+          "response": {
+            "$ref": "/schemas/account/report-usage-response.json",
+            "description": "Response payload confirming how many usage records were accepted"
           }
         }
       }

--- a/static/schemas/source/signals/activate-signal-request.json
+++ b/static/schemas/source/signals/activate-signal-request.json
@@ -17,6 +17,14 @@
       },
       "minItems": 1
     },
+    "account_id": {
+      "type": "string",
+      "description": "The caller's account with the signals agent. Associates this activation with a commercial relationship established via sync_accounts."
+    },
+    "buyer_campaign_ref": {
+      "type": "string",
+      "description": "The buyer's reference for the campaign or media buy this signal is being activated for. Enables the signals agent to correlate activations with subsequent report_usage calls."
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/signals/get-signals-request.json
+++ b/static/schemas/source/signals/get-signals-request.json
@@ -5,6 +5,14 @@
   "description": "Request parameters for discovering signals. Use signal_spec for natural language discovery, signal_ids for exact lookups, or both (signal_ids take precedence for exact matches, signal_spec provides additional discovery context).",
   "type": "object",
   "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "The caller's account with this signals agent. When provided, the signals agent returns per-account pricing options if configured."
+    },
+    "buyer_campaign_ref": {
+      "type": "string",
+      "description": "The buyer's campaign or media buy reference. Used to correlate signal discovery with subsequent report_usage calls."
+    },
     "signal_spec": {
       "type": "string",
       "description": "Natural language description of the desired signals. When used alone, enables semantic discovery. When combined with signal_ids, provides context for the agent but signal_ids matches are returned first."

--- a/static/schemas/source/signals/get-signals-response.json
+++ b/static/schemas/source/signals/get-signals-response.json
@@ -52,26 +52,13 @@
               "$ref": "/schemas/core/deployment.json"
             }
           },
-          "pricing": {
-            "type": "object",
-            "description": "Pricing information",
-            "properties": {
-              "cpm": {
-                "type": "number",
-                "description": "Cost per thousand impressions",
-                "minimum": 0
-              },
-              "currency": {
-                "type": "string",
-                "description": "Currency code",
-                "pattern": "^[A-Z]{3}$"
-              }
+          "pricing_options": {
+            "type": "array",
+            "description": "Available pricing options for this signal. Each option has a pricing_option_id that the buyer references in report_usage.",
+            "items": {
+              "$ref": "/schemas/core/signal-pricing-option.json"
             },
-            "required": [
-              "cpm",
-              "currency"
-            ],
-            "additionalProperties": true
+            "minItems": 1
           }
         },
         "required": [
@@ -82,7 +69,7 @@
           "data_provider",
           "coverage_percentage",
           "deployments",
-          "pricing"
+          "pricing_options"
         ],
         "additionalProperties": true
       }


### PR DESCRIPTION
## Summary

- **New `signal-pricing.json` schema**: discriminated union on `model` — `cpm` (fixed rate) and `percent_of_media` (percentage of spend, with optional `max_cpm` hybrid cap)
- **New `signal-pricing-option.json`**: wraps `pricing_option_id` + pricing model; returned in `get_signals`, referenced in `report_usage`
- **New generic `report_usage` task** (`account/report-usage-request.json` + response): cross-protocol usage reporting shared across signals, governance, and creative agents; supports batching multiple campaigns per request via per-record `buyer_campaign_ref`; requires `operator_id` to characterize billing responsibility
- **`get_signals` updates**: accepts optional `account_id` and `buyer_campaign_ref`; response replaces single `pricing` field with `pricing_options[]`
- **`activate_signal` update**: accepts optional `account_id` and `buyer_campaign_ref` for transaction context
- **`signal-filters.json`**: adds `max_percent` filter for percent-of-media signals
- **Docs**: updated signals overview, specification, `get_signals` task reference, and account management integration guide

## Standard transaction flow

```
sync_accounts → get_signals(account_id, buyer_campaign_ref) → [campaign runs] → report_usage(pricing_option_id, impressions, media_spend)
```

`activate_signal` is reserved for custom signals that require explicit DSP-side activation.

## Test plan

- [x] All 304 existing tests pass (pre-commit hook verified)
- [x] Schema validation passes (327 schemas, all $refs resolve)
- [x] Example validation passes
- [x] TypeScript typecheck passes
- [x] OpenAPI spec is current
- [x] Mintlify docs validation passes (362 MDX files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)