### PR TITLE
refactor(catalog): use kind discriminator in CatalogFieldBinding schema

### DIFF
--- a/.changeset/catalog-binding-discriminator.md
+++ b/.changeset/catalog-binding-discriminator.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Refactor `CatalogFieldBinding` schema to use a `kind` discriminator field (`"scalar"`, `"asset_pool"`, `"catalog_group"`) instead of `allOf + oneOf` with negative `not` constraints. Scalar and asset pool variants are extracted to `definitions` for reuse in `per_item_bindings`. Generates a clean TypeScript discriminated union instead of triplicated intersections.

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -483,11 +483,11 @@ Formats can declare `field_bindings` inside each `catalog_requirements` entry to
         { "asset_group_id": "images_vertical",  "asset_type": "image", "required": true, "min_count": 1 }
       ],
       "field_bindings": [
-        { "asset_id": "headline",       "catalog_field": "name" },
-        { "asset_id": "price_badge",    "catalog_field": "price.amount" },
-        { "asset_id": "hero_image",     "asset_group_id": "images_landscape" },
-        { "asset_id": "snap_background","asset_group_id": "images_vertical" },
-        { "asset_id": "logo",           "asset_group_id": "logo" }
+        { "kind": "scalar",     "asset_id": "headline",        "catalog_field": "name" },
+        { "kind": "scalar",     "asset_id": "price_badge",     "catalog_field": "price.amount" },
+        { "kind": "asset_pool", "asset_id": "hero_image",      "asset_group_id": "images_landscape" },
+        { "kind": "asset_pool", "asset_id": "snap_background", "asset_group_id": "images_vertical" },
+        { "kind": "asset_pool", "asset_id": "logo",            "asset_group_id": "logo" }
       ]
     }
   ]
@@ -500,12 +500,13 @@ For repeatable groups (carousels where each slide is one catalog item), use `for
 {
   "field_bindings": [
     {
+      "kind": "catalog_group",
       "format_group_id": "slide",
       "catalog_item": true,
       "per_item_bindings": [
-        { "asset_id": "title",  "catalog_field": "name" },
-        { "asset_id": "price",  "catalog_field": "price.amount" },
-        { "asset_id": "image",  "asset_group_id": "images_landscape" }
+        { "kind": "scalar",     "asset_id": "title",  "catalog_field": "name" },
+        { "kind": "scalar",     "asset_id": "price",  "catalog_field": "price.amount" },
+        { "kind": "asset_pool", "asset_id": "image",  "asset_group_id": "images_landscape" }
       ]
     }
   ]
@@ -514,11 +515,11 @@ For repeatable groups (carousels where each slide is one catalog item), use `for
 
 Field bindings are **optional** — creative agents can still infer mappings from field names and asset types when bindings are absent. Providing them removes ambiguity and enables pre-render validation.
 
-| Binding variant | Required fields | What it does |
-|----------------|----------------|-------------|
-| Scalar | `asset_id` + `catalog_field` | Maps individual template asset to catalog item field (dot notation) |
-| Asset pool | `asset_id` + `asset_group_id` | Maps individual template asset to typed asset pool on the catalog item |
-| Catalog group | `format_group_id` + `catalog_item: true` | Iterates a format repeatable_group over catalog items |
+| `kind` | Required fields | What it does |
+|--------|----------------|-------------|
+| `"scalar"` | `asset_id` + `catalog_field` | Maps individual template asset to catalog item field (dot notation) |
+| `"asset_pool"` | `asset_id` + `asset_group_id` | Maps individual template asset to typed asset pool on the catalog item |
+| `"catalog_group"` | `format_group_id` + `catalog_item: true` | Iterates a format repeatable_group over catalog items |
 
 ## Catalogs in creatives
 

--- a/static/schemas/source/core/requirements/catalog-field-binding.json
+++ b/static/schemas/source/core/requirements/catalog-field-binding.json
@@ -2,70 +2,90 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/requirements/catalog-field-binding.json",
   "title": "Catalog Field Binding",
-  "description": "Maps a format template slot to a catalog item field or typed asset pool. Allows formats to explicitly declare how their template slots map to catalog data, making the binding self-describing for creative agents rather than leaving it implicit. All bindings are optional — agents can still infer mappings without them.",
-  "type": "object",
-  "oneOf": [
-    {
-      "description": "Scalar binding — maps an individual format asset to a catalog item field via dot-notation path",
-      "required": ["asset_id", "catalog_field"],
-      "not": { "required": ["format_group_id"] }
-    },
-    {
-      "description": "Asset pool binding — maps an individual format asset to a typed asset pool on the catalog item (e.g., images_landscape, images_vertical, logo)",
-      "required": ["asset_id", "asset_group_id"],
-      "not": { "required": ["catalog_field", "format_group_id"] }
-    },
-    {
-      "description": "Catalog group binding — a format repeatable_group where each repetition corresponds to one catalog item. Iterates the group over catalog items.",
-      "required": ["format_group_id", "catalog_item"],
+  "description": "Maps a format template slot to a catalog item field or typed asset pool. The 'kind' field identifies the binding variant. All bindings are optional — agents can still infer mappings without them.",
+  "definitions": {
+    "ScalarBinding": {
+      "type": "object",
+      "description": "Maps an individual format asset to a catalog item field via dot-notation path.",
       "properties": {
-        "catalog_item": { "const": true }
+        "kind": { "type": "string", "const": "scalar" },
+        "asset_id": {
+          "type": "string",
+          "description": "The asset_id from the format's assets array. Identifies which individual template slot this binding applies to."
+        },
+        "catalog_field": {
+          "type": "string",
+          "description": "Dot-notation path to the field on the catalog item (e.g., 'name', 'price.amount', 'location.city')."
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
       },
-      "not": { "required": ["asset_id", "catalog_field", "asset_group_id"] }
-    }
-  ],
-  "properties": {
-    "asset_id": {
-      "type": "string",
-      "description": "The asset_id from the format's assets array. Identifies which individual template slot this binding applies to."
+      "required": ["kind", "asset_id", "catalog_field"],
+      "additionalProperties": true
     },
-    "format_group_id": {
-      "type": "string",
-      "description": "The asset_group_id of a repeatable_group in the format's assets array. Used when the entire group iterates over catalog items (catalog_item: true)."
-    },
-    "catalog_field": {
-      "type": "string",
-      "description": "Dot-notation path to the field on the catalog item (e.g., 'name', 'price.amount', 'location.city'). Used for scalar bindings."
-    },
-    "asset_group_id": {
-      "type": "string",
-      "description": "The asset_group_id on the catalog item's assets array to pull from (e.g., 'images_landscape', 'images_vertical', 'logo'). Used for asset pool bindings — the format slot receives the first item in the pool."
-    },
-    "catalog_item": {
-      "type": "boolean",
-      "const": true,
-      "description": "When true on a format_group_id binding, each repetition of the format's repeatable_group maps to one item from the catalog. The group iterates in catalog item order."
-    },
-    "per_item_bindings": {
-      "type": "array",
-      "description": "For catalog_item group bindings: the scalar and asset pool bindings that apply within each repetition of the group. Only scalar and asset pool variants are allowed here — nested catalog group bindings are not permitted.",
-      "items": {
-        "allOf": [
-          { "$ref": "/schemas/core/requirements/catalog-field-binding.json" },
-          { "not": { "anyOf": [{ "required": ["catalog_item"] }, { "required": ["format_group_id"] }] } }
-        ]
+    "AssetPoolBinding": {
+      "type": "object",
+      "description": "Maps an individual format asset to a typed asset pool on the catalog item (e.g., images_landscape, images_vertical, logo). The format slot receives the first item in the pool.",
+      "properties": {
+        "kind": { "type": "string", "const": "asset_pool" },
+        "asset_id": {
+          "type": "string",
+          "description": "The asset_id from the format's assets array. Identifies which individual template slot this binding applies to."
+        },
+        "asset_group_id": {
+          "type": "string",
+          "description": "The asset_group_id on the catalog item's assets array to pull from (e.g., 'images_landscape', 'images_vertical', 'logo')."
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
       },
-      "minItems": 1
-    },
-    "ext": {
-      "$ref": "/schemas/core/ext.json"
+      "required": ["kind", "asset_id", "asset_group_id"],
+      "additionalProperties": true
     }
   },
-  "additionalProperties": true,
+  "oneOf": [
+    { "$ref": "#/definitions/ScalarBinding" },
+    { "$ref": "#/definitions/AssetPoolBinding" },
+    {
+      "type": "object",
+      "description": "A format repeatable_group where each repetition corresponds to one catalog item. Iterates the group over catalog items in catalog item order.",
+      "properties": {
+        "kind": { "type": "string", "const": "catalog_group" },
+        "format_group_id": {
+          "type": "string",
+          "description": "The asset_group_id of a repeatable_group in the format's assets array."
+        },
+        "catalog_item": {
+          "type": "boolean",
+          "const": true,
+          "description": "Each repetition of the format's repeatable_group maps to one item from the catalog."
+        },
+        "per_item_bindings": {
+          "type": "array",
+          "description": "Scalar and asset pool bindings that apply within each repetition of the group. Nested catalog_group bindings are not permitted.",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/ScalarBinding" },
+              { "$ref": "#/definitions/AssetPoolBinding" }
+            ]
+          },
+          "minItems": 1
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": ["kind", "format_group_id", "catalog_item"],
+      "additionalProperties": true
+    }
+  ],
   "examples": [
     {
       "description": "Scalar binding — hotel name to headline slot",
       "data": {
+        "kind": "scalar",
         "asset_id": "headline",
         "catalog_field": "name"
       }
@@ -73,6 +93,7 @@
     {
       "description": "Scalar binding — nested field (nightly rate)",
       "data": {
+        "kind": "scalar",
         "asset_id": "price_badge",
         "catalog_field": "price.amount"
       }
@@ -80,6 +101,7 @@
     {
       "description": "Asset pool binding — hero image from landscape pool",
       "data": {
+        "kind": "asset_pool",
         "asset_id": "hero_image",
         "asset_group_id": "images_landscape"
       }
@@ -87,6 +109,7 @@
     {
       "description": "Asset pool binding — Snap vertical background from vertical pool",
       "data": {
+        "kind": "asset_pool",
         "asset_id": "snap_background",
         "asset_group_id": "images_vertical"
       }
@@ -94,12 +117,13 @@
     {
       "description": "Catalog group binding — carousel where each slide is one hotel",
       "data": {
+        "kind": "catalog_group",
         "format_group_id": "slide",
         "catalog_item": true,
         "per_item_bindings": [
-          { "asset_id": "title", "catalog_field": "name" },
-          { "asset_id": "price", "catalog_field": "price.amount" },
-          { "asset_id": "image", "asset_group_id": "images_landscape" }
+          { "kind": "scalar",     "asset_id": "title", "catalog_field": "name" },
+          { "kind": "scalar",     "asset_id": "price", "catalog_field": "price.amount" },
+          { "kind": "asset_pool", "asset_id": "image", "asset_group_id": "images_landscape" }
         ]
       }
     }


### PR DESCRIPTION
## Summary

- Replaces the `oneOf` + `not` constraint pattern in `catalog-field-binding.json` with a proper discriminated union using a `kind` field (`"scalar"`, `"asset_pool"`, `"catalog_group"`)
- Extracts `ScalarBinding` and `AssetPoolBinding` to `definitions` so `per_item_bindings` can reference them without duplication
- Updates all examples in the schema and `docs/creative/catalogs.mdx` to include `kind`

**Why**: The previous `allOf + oneOf` pattern caused json-schema-to-ts to expand each variant with the full shared `properties` block, generating three identical intersected copies. The discriminator generates a clean TypeScript discriminated union instead.

## Test plan

- [x] All 304 existing tests pass (pre-commit hook verified)
- [x] Schema self-validation passes (examples validate against schema)
- [x] No broken links in docs
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)