### PR TITLE
fix(addie): increase conversation history window from 10 to 20 messages

### DIFF
--- a/.changeset/addie-prebid-improvements.md
+++ b/.changeset/addie-prebid-improvements.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Increase Addie conversation history from 10 to 20 messages for longer debugging sessions.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1081,7 +1081,7 @@ async function handleUserMessage({
 
   // Fetch conversation history from database for context
   // This ensures Claude has context from previous turns in the DM thread
-  const MAX_HISTORY_MESSAGES = 10;
+  const MAX_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
   let historyUnavailable = false;
   try {
@@ -1538,7 +1538,7 @@ async function handleAppMention({
 
   // Fetch conversation history from database for context
   // This ensures Claude remembers what Addie said in previous turns
-  const MAX_HISTORY_MESSAGES = 10;
+  const MAX_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
   let historyUnavailable = false;
   try {
@@ -2023,7 +2023,7 @@ async function handleDirectMessage(
   }
 
   // Fetch conversation history from database for context
-  const MAX_HISTORY_MESSAGES = 10;
+  const MAX_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
   let historyUnavailable = false;
   try {
@@ -2324,7 +2324,7 @@ async function handleActiveThreadReply({
 
   // Fetch conversation history from database for context
   // This ensures Claude remembers what Addie said in previous turns
-  const MAX_DB_HISTORY_MESSAGES = 10;
+  const MAX_DB_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
   let historyUnavailable = false;
   try {
@@ -3308,7 +3308,7 @@ async function handleReactionAdded({
   }
 
   // Fetch conversation history from database for context
-  const MAX_HISTORY_MESSAGES = 10;
+  const MAX_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
   let historyUnavailable = false;
   try {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -27,7 +27,7 @@ import { ROUTING_RULES } from './router.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.02.4';
+export const CODE_VERSION = '2026.02.5';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -346,7 +346,7 @@ export type { MessageTurn };
  * Options for building message turns
  */
 export interface BuildMessageTurnsOptions {
-  /** Maximum number of messages to include (default: 10, 0 = unlimited) */
+  /** Maximum number of messages to include (default: 20, 0 = unlimited) */
   maxMessages?: number;
   /** Token limit for conversation history (default: calculated from model limit) */
   tokenLimit?: number;
@@ -400,7 +400,7 @@ export function buildMessageTurnsWithMetadata(
   threadContext?: ThreadContextEntry[],
   options?: BuildMessageTurnsOptions
 ): BuildMessageTurnsResult {
-  const maxMessages = options?.maxMessages ?? 10;
+  const maxMessages = options?.maxMessages ?? 20;
   // Pass toolCount for more accurate token budget when available
   const tokenLimit = options?.tokenLimit ?? getConversationTokenLimit(options?.model, options?.toolCount);
 

--- a/tests/addie/message-turns.test.ts
+++ b/tests/addie/message-turns.test.ts
@@ -99,16 +99,16 @@ describe('buildMessageTurns', () => {
     expect(result[6]).toEqual({ role: 'user', content: 'Question 4' });
   });
 
-  it('should limit to last 10 messages from thread context', () => {
-    // Create 15 messages
+  it('should limit to last 20 messages from thread context', () => {
+    // Create 25 messages
     const threadContext: ThreadContextEntry[] = [];
-    for (let i = 1; i <= 15; i++) {
+    for (let i = 1; i <= 25; i++) {
       threadContext.push({ user: i % 2 === 1 ? 'User' : 'Addie', text: `Message ${i}` });
     }
 
     const result = buildMessageTurns('Current', threadContext);
 
-    // Should only include messages 6-15 (last 10) plus current
+    // Should only include messages 6-25 (last 20) plus current
     // Message 6 is from Addie (even index in 1-based), so placeholder is added
     const firstHistoryMessage = result.find(m => m.content.includes('Message'));
     expect(firstHistoryMessage?.content).toContain('Message 6');


### PR DESCRIPTION
## Summary

- Increases `MAX_HISTORY_MESSAGES` from 10 to 20 in all Slack handler functions in `bolt-app.ts`
- Updates the default `maxMessages` in `buildMessageTurnsWithMetadata` from 10 to 20 to keep the two limits aligned
- Updates stale JSDoc comment and the corresponding unit test
- Bumps `CODE_VERSION` to `2026.02.5`

**Context:** Erin reported that Addie was losing context in long Prebid debugging sessions. With the previous 10-message limit, Addie would forget things said more than 5 exchanges ago. The token-limiter acts as the actual hard ceiling (~120K tokens of conversation budget), so 20 messages carries no overflow risk.

A companion DB rule (ID 116, "Technical Debugging Methodology") was also deployed live to address Addie diagnosing issues as confirmed fact before asking users to verify — this is a behavioral change that doesn't require a code deploy.

## Test plan

- [x] All 304 unit tests pass (including updated `message-turns.test.ts`)
- [x] TypeScript type checks clean
- [x] `CODE_VERSION` bumped per CLAUDE.md guidelines for `bolt-app.ts` changes
- [ ] Deploy to production and verify Addie retains context across longer Prebid debugging sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)