### PR TITLE
feat(events): RSVP approval gating and email interest capture

### DIFF
--- a/.changeset/long-boats-nail.md
+++ b/.changeset/long-boats-nail.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add RSVP approval gating to events and email interest capture. Events now support `require_rsvp_approval` on create and update (synced to Luma). A public interest form on event pages and a new Addie tool allow anyone to register interest, which creates a waitlisted registration record linked to the event for prospecting.

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -721,6 +721,30 @@
         `;
       }
 
+      // Email interest form (upcoming events only)
+      if (!isPast) {
+        const loggedInEmail = window.__APP_CONFIG__?.user?.email || '';
+        html += `
+          <div class="event-section" id="interest-section">
+            <h2 class="section-title">Stay informed</h2>
+            <p style="color: var(--color-text-secondary); margin-bottom: 1rem;">Enter your email to be notified about updates for this event.</p>
+            <form id="interest-form" data-slug="${escapeHtml(event.slug)}" style="display: flex; gap: 0.5rem; flex-wrap: wrap;" onsubmit="submitInterest(event)">
+              <input
+                type="email"
+                id="interest-email"
+                placeholder="you@company.com"
+                value="${escapeHtml(loggedInEmail)}"
+                required
+                style="flex: 1; min-width: 220px; padding: 0.625rem 0.875rem; border: 1px solid var(--color-border); border-radius: 6px; font-size: 0.9375rem; background: var(--color-surface); color: var(--color-text);"
+              />
+              <button type="submit" class="btn btn-primary">Notify me</button>
+            </form>
+            <p id="interest-success" style="display: none; color: var(--color-success, #16a34a); margin-top: 0.5rem;">You're on the list!</p>
+            <p id="interest-error" style="display: none; color: var(--color-error, #dc2626); margin-top: 0.5rem;">Something went wrong. Please try again.</p>
+          </div>
+        `;
+      }
+
       // Industry Gathering / Attendee Group
       if (industryGathering) {
         html += `
@@ -853,6 +877,32 @@
     function handleRegister() {
       // TODO: Implement registration flow
       alert('Registration coming soon! Check back later.');
+    }
+
+    async function submitInterest(e) {
+      e.preventDefault();
+      const slug = e.target.dataset.slug;
+      const email = document.getElementById('interest-email').value;
+      const successEl = document.getElementById('interest-success');
+      const errorEl = document.getElementById('interest-error');
+      successEl.style.display = 'none';
+      errorEl.style.display = 'none';
+
+      try {
+        const res = await fetch('/api/events/interest', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, event_slug: slug }),
+        });
+        if (res.ok) {
+          document.getElementById('interest-form').style.display = 'none';
+          successEl.style.display = 'block';
+        } else {
+          errorEl.style.display = 'block';
+        }
+      } catch {
+        errorEl.style.display = 'block';
+      }
     }
 
     function handleSponsorTier(tierId, tierName, priceCents) {

--- a/server/src/db/events-db.ts
+++ b/server/src/db/events-db.ts
@@ -45,12 +45,12 @@ export class EventsDatabase {
         external_registration_url, is_external_event,
         featured_image_url,
         sponsorship_enabled, sponsorship_tiers, stripe_product_id,
-        status, max_attendees,
+        status, max_attendees, require_rsvp_approval,
         created_by_user_id, organization_id, metadata
       ) VALUES (
         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
         $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-        $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31
+        $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32
       )
       RETURNING *`,
       [
@@ -82,6 +82,7 @@ export class EventsDatabase {
         input.stripe_product_id || null,
         input.status || 'draft',
         input.max_attendees || null,
+        input.require_rsvp_approval ?? false,
         input.created_by_user_id || null,
         input.organization_id || null,
         JSON.stringify(input.metadata || {}),
@@ -148,6 +149,7 @@ export class EventsDatabase {
       status: 'status',
       published_at: 'published_at',
       max_attendees: 'max_attendees',
+      require_rsvp_approval: 'require_rsvp_approval',
       metadata: 'metadata',
     };
 

--- a/server/src/db/migrations/243_event_rsvp_approval.sql
+++ b/server/src/db/migrations/243_event_rsvp_approval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN require_rsvp_approval BOOLEAN NOT NULL DEFAULT false;

--- a/server/src/db/migrations/244_registration_source_interest.sql
+++ b/server/src/db/migrations/244_registration_source_interest.sql
@@ -1,0 +1,5 @@
+ALTER TABLE event_registrations
+  DROP CONSTRAINT IF EXISTS event_registrations_registration_source_check;
+ALTER TABLE event_registrations
+  ADD CONSTRAINT event_registrations_registration_source_check
+  CHECK (registration_source IN ('direct', 'luma', 'import', 'admin', 'interest'));

--- a/server/src/luma/client.ts
+++ b/server/src/luma/client.ts
@@ -95,6 +95,7 @@ export interface UpdateEventInput {
   meeting_url?: string;
   cover_url?: string;
   visibility?: 'public' | 'private';
+  require_rsvp_approval?: boolean;
 }
 
 // ============================================================================

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -913,7 +913,7 @@ export type EventType = 'summit' | 'meetup' | 'webinar' | 'workshop' | 'conferen
 export type EventFormat = 'in_person' | 'virtual' | 'hybrid';
 export type EventStatus = 'draft' | 'published' | 'cancelled' | 'completed';
 export type RegistrationStatus = 'registered' | 'waitlisted' | 'cancelled' | 'no_show';
-export type RegistrationSource = 'direct' | 'luma' | 'import' | 'admin';
+export type RegistrationSource = 'direct' | 'luma' | 'import' | 'admin' | 'interest';
 export type SponsorshipPaymentStatus = 'pending' | 'paid' | 'refunded' | 'cancelled';
 
 export interface SponsorshipTier {
@@ -956,6 +956,7 @@ export interface Event {
   status: EventStatus;
   published_at?: Date;
   max_attendees?: number;
+  require_rsvp_approval: boolean;
   created_by_user_id?: string;
   organization_id?: string;
   metadata: Record<string, unknown>;
@@ -992,6 +993,7 @@ export interface CreateEventInput {
   stripe_product_id?: string;
   status?: EventStatus;
   max_attendees?: number;
+  require_rsvp_approval?: boolean;
   created_by_user_id?: string;
   organization_id?: string;
   metadata?: Record<string, unknown>;
@@ -1026,6 +1028,7 @@ export interface UpdateEventInput {
   status?: EventStatus;
   published_at?: Date;
   max_attendees?: number;
+  require_rsvp_approval?: boolean;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

- **RSVP approval gating**: `require_rsvp_approval` added to events — stored in DB, exposed in `create_event` and `update_event` Addie tools, and synced to Luma on both create and update. Direct registrations now respect the flag (status set to `waitlisted` when enabled).
- **Luma update sync**: Implemented the long-standing TODO — `update_event` now syncs title, description, times, virtual URL, status, and approval setting back to Luma when a `luma_event_id` is present.
- **Email interest capture**: New `POST /api/events/interest` public endpoint + `register_event_interest` Addie tool. Both upsert an `email_contact` and create a `waitlisted` + `interest` registration row, feeding the existing prospect pipeline with an event-specific signal.
- **Event detail page**: "Stay informed" form on upcoming event pages, pre-filled with the logged-in user's email.

Resolves Addie escalations #79, #80, #81, #82.

## Test plan

- [ ] `docker compose up --build` — confirm migrations 243 and 244 run cleanly
- [ ] Ask Addie to create an event with `require_rsvp_approval: true` — verify Luma event has approval enabled
- [ ] Ask Addie to update that event's `require_rsvp_approval` to `false` — confirm it syncs to Luma
- [ ] Ask Addie "add me to the interest list for [event]" — verify `email_contacts` row and `waitlisted/interest` registration created
- [ ] Open an event detail page as a logged-in user — email should pre-fill in the "Stay informed" form
- [ ] Submit the interest form as an anonymous user — verify `email_contacts` and `event_registrations` rows created
- [ ] Register for an event where `require_rsvp_approval = true` — verify registration status is `waitlisted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)