### PR TITLE
feat(events): 3-tier event visibility — public, invite-only listed, invite-only unlisted

### DIFF
--- a/.changeset/event-visibility-tiers.md
+++ b/.changeset/event-visibility-tiers.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add 3-tier event visibility: public, invite-only listed, and invite-only unlisted. Invite-only events support explicit email invite lists and rule-based access (membership required, org allow-list). Adds `interested` as a distinct registration status for non-invited users who express interest.

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -80,6 +80,7 @@
     .badge-in_person { background: var(--color-info-100); color: var(--color-info-700); }
     .badge-virtual { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-hybrid { background: var(--color-purple-100, var(--color-primary-100)); color: var(--color-purple-700, var(--color-primary-700)); }
+    .badge-invite { background: #fef3c7; color: #92400e; }
     .btn {
       padding: var(--space-2) var(--space-4);
       border: none;
@@ -569,6 +570,45 @@
           </div>
         </div>
 
+        <!-- Access Control -->
+        <div class="section-divider">
+          <div class="section-title">Access control</div>
+        </div>
+
+        <div class="form-group">
+          <label for="visibility">Visibility</label>
+          <select id="visibility" onchange="toggleAccessSection()">
+            <option value="public">Public — anyone can see and register</option>
+            <option value="invite_listed">Invite only, listed — shown in listings; registration restricted</option>
+            <option value="invite_unlisted">Invite only, unlisted — hidden from public listing</option>
+          </select>
+        </div>
+
+        <div id="accessRulesSection" style="display: none;">
+          <div class="form-group">
+            <div class="checkbox-group">
+              <input type="checkbox" id="membershipRequired">
+              <label for="membershipRequired">Require AgenticAdvertising.org membership to register</label>
+            </div>
+          </div>
+        </div>
+
+        <!-- Invite list (only shown when editing an existing event with invite visibility) -->
+        <div id="inviteListSection" style="display: none;">
+          <div class="form-group">
+            <label>Invite list</label>
+            <small style="display: block; margin-bottom: var(--space-2); color: var(--color-text-secondary);">
+              Add email addresses, one per line or comma-separated. All emails are automatically lowercased.
+            </small>
+            <textarea id="inviteEmails" placeholder="name@company.com&#10;another@company.com" rows="4"
+              style="width: 100%; padding: var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); resize: vertical;"></textarea>
+            <button type="button" class="btn btn-secondary btn-small" onclick="addInvites()" style="margin-top: var(--space-2);">
+              Add to invite list
+            </button>
+          </div>
+          <div id="currentInvitesList" style="margin-top: var(--space-3);"></div>
+        </div>
+
         <!-- Attendee Group (only shown when editing existing event) -->
         <div id="eventGroupSection" style="display: none;">
           <div class="section-divider">
@@ -700,6 +740,7 @@
               <div class="event-meta">
                 <span class="badge badge-${event.status}">${event.status}</span>
                 <span class="badge badge-${event.event_format}">${event.event_format.replace('_', ' ')}</span>
+                ${event.visibility && event.visibility !== 'public' ? `<span class="badge badge-invite">${event.visibility === 'invite_listed' ? 'invite only' : 'unlisted'}</span>` : ''}
                 <span>${dateStr} at ${timeStr}</span>
                 ${event.venue_city ? `<span>${escapeHtml(event.venue_city)}</span>` : ''}
               </div>
@@ -728,6 +769,7 @@
       sponsorshipTierCount = 0;
       toggleLocationFields();
       toggleSponsorshipTiers();
+      toggleAccessSection();
       document.getElementById('eventModal').style.display = 'flex';
     }
 
@@ -778,6 +820,12 @@
       // Sponsorship
       document.getElementById('sponsorshipEnabled').checked = event.sponsorship_enabled || false;
       toggleSponsorshipTiers();
+
+      // Access control
+      document.getElementById('visibility').value = event.visibility || 'public';
+      document.getElementById('membershipRequired').checked = event.access_rules?.membership_required || false;
+      toggleAccessSection();
+      loadInvites(id);
 
       // Show Stripe product info if linked
       if (event.stripe_product_id) {
@@ -921,6 +969,10 @@
         sponsorship_enabled: document.getElementById('sponsorshipEnabled').checked,
         sponsorship_tiers: getSponsorshipTiers(),
         // stripe_product_id is auto-managed by the server when sponsorship_tiers are set
+        visibility: document.getElementById('visibility').value,
+        access_rules: {
+          membership_required: document.getElementById('membershipRequired').checked || undefined,
+        },
       };
 
       try {
@@ -1001,6 +1053,11 @@
       document.getElementById('eventGroupExists').style.display = 'none';
       document.getElementById('eventGroupNotExists').style.display = 'none';
       document.getElementById('eventGroupLoading').style.display = 'none';
+      // Reset access control section
+      document.getElementById('accessRulesSection').style.display = 'none';
+      document.getElementById('inviteListSection').style.display = 'none';
+      document.getElementById('currentInvitesList').innerHTML = '';
+      document.getElementById('inviteEmails').value = '';
     }
 
     // Toggle location fields based on event format
@@ -1025,6 +1082,101 @@
     function toggleSponsorshipTiers() {
       const enabled = document.getElementById('sponsorshipEnabled').checked;
       document.getElementById('sponsorshipTiersSection').style.display = enabled ? 'block' : 'none';
+    }
+
+    // Toggle access rules and invite sections based on visibility
+    function toggleAccessSection() {
+      const visibility = document.getElementById('visibility').value;
+      const isInviteOnly = visibility !== 'public';
+      document.getElementById('accessRulesSection').style.display = isInviteOnly ? 'block' : 'none';
+      // Invite list only shown when editing an existing event
+      if (isInviteOnly && editingEventId) {
+        document.getElementById('inviteListSection').style.display = 'block';
+      } else {
+        document.getElementById('inviteListSection').style.display = 'none';
+      }
+    }
+
+    // Load existing invites for an event
+    async function loadInvites(eventId) {
+      const visibility = document.getElementById('visibility').value;
+      if (visibility === 'public') return;
+
+      document.getElementById('inviteListSection').style.display = 'block';
+      document.getElementById('currentInvitesList').innerHTML = '<p style="font-size: var(--text-sm); color: var(--color-text-secondary);">Loading...</p>';
+
+      try {
+        const res = await fetch(`/api/admin/events/${eventId}/invites`);
+        if (!res.ok) throw new Error('Failed to load invites');
+        const data = await res.json();
+        renderInviteList(data.invites || []);
+      } catch (error) {
+        document.getElementById('currentInvitesList').innerHTML = '';
+      }
+    }
+
+    // Render invite list
+    function renderInviteList(invites) {
+      const container = document.getElementById('currentInvitesList');
+      if (invites.length === 0) {
+        container.innerHTML = '<p style="font-size: var(--text-sm); color: var(--color-text-secondary);">No invites yet.</p>';
+        return;
+      }
+      container.innerHTML = `
+        <label style="display: block; margin-bottom: var(--space-2); font-weight: 500;">Current invite list (${invites.length})</label>
+        <div style="border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden;">
+          ${invites.map(invite => `
+            <div style="display: flex; align-items: center; justify-content: space-between; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border-subtle); font-size: var(--text-sm);">
+              <span>${escapeHtml(invite.email)}</span>
+              <button type="button" class="btn btn-secondary btn-small" data-email="${escapeHtml(invite.email)}" onclick="removeInvite(this.dataset.email)" style="font-size: var(--text-xs); padding: 2px 8px;">Remove</button>
+            </div>
+          `).join('')}
+        </div>
+      `;
+    }
+
+    // Add invites from textarea
+    async function addInvites() {
+      if (!editingEventId) return;
+      const raw = document.getElementById('inviteEmails').value.trim();
+      if (!raw) return;
+
+      // Support newline or comma-separated emails
+      const emails = raw.split(/[\n,]+/).map(e => e.trim()).filter(e => e.includes('@'));
+      if (emails.length === 0) {
+        alert('No valid email addresses found.');
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/admin/events/${editingEventId}/invites`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ emails }),
+        });
+        if (!res.ok) throw new Error('Failed to add invites');
+        const data = await res.json();
+        document.getElementById('inviteEmails').value = '';
+        await loadInvites(editingEventId);
+      } catch (error) {
+        alert(error.message);
+      }
+    }
+
+    // Remove a single invite
+    async function removeInvite(email) {
+      if (!editingEventId) return;
+      if (!confirm(`Remove ${email} from the invite list?`)) return;
+
+      try {
+        const res = await fetch(`/api/admin/events/${editingEventId}/invites/${encodeURIComponent(email)}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error('Failed to remove invite');
+        await loadInvites(editingEventId);
+      } catch (error) {
+        alert(error.message);
+      }
     }
 
     // Add sponsorship tier

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -88,6 +88,7 @@
     .badge-hybrid { background: var(--color-success-100); color: var(--color-success-700); }
     .badge-type { background: var(--color-gray-100); color: var(--color-gray-700); }
     .badge-external { background: var(--color-warning-100); color: var(--color-warning-700); }
+    .badge-invite { background: #fef3c7; color: #92400e; }
 
     .event-title {
       font-size: 2rem;
@@ -637,6 +638,7 @@
               <span class="event-badge badge-${event.event_format}">${formatLabel}</span>
               <span class="event-badge badge-type">${typeLabel}</span>
               ${event.is_external_event ? '<span class="event-badge badge-external">Industry Event</span>' : ''}
+              ${event.visibility && event.visibility !== 'public' ? '<span class="event-badge badge-invite">Invite only</span>' : ''}
             </div>
             <h1 class="event-title">${escapeHtml(event.title)}</h1>
 
@@ -874,9 +876,44 @@
       document.getElementById('content').innerHTML = html;
     }
 
-    function handleRegister() {
-      // TODO: Implement registration flow
-      alert('Registration coming soon! Check back later.');
+    async function handleRegister() {
+      const slug = window.location.pathname.split('/').pop();
+      const user = window.__APP_CONFIG__?.user;
+
+      if (!user) {
+        window.location.href = `/sign-in?redirect=/events/${slug}`;
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/events/${slug}/register`, { method: 'POST' });
+        const data = await res.json();
+
+        if (res.status === 403 && data.invite_only) {
+          // Surface the interest form so they can express interest
+          const interestSection = document.getElementById('interest-section');
+          if (interestSection) {
+            interestSection.scrollIntoView({ behavior: 'smooth' });
+            const heading = interestSection.querySelector('.section-title');
+            if (heading) heading.textContent = 'Request an invitation';
+            const subtext = interestSection.querySelector('p:not(#interest-success):not(#interest-error)');
+            if (subtext) subtext.textContent = "This event is by invitation only. Share your email and we'll reach out if a spot opens up.";
+          } else {
+            alert('This event is by invitation only. Please contact us if you\'d like to attend.');
+          }
+          return;
+        }
+
+        if (!res.ok) {
+          alert(data.message || 'Failed to register. Please try again.');
+          return;
+        }
+
+        // Reload to show updated registration status
+        window.location.reload();
+      } catch {
+        alert('Something went wrong. Please try again.');
+      }
     }
 
     async function submitInterest(e) {

--- a/server/public/events.html
+++ b/server/public/events.html
@@ -198,6 +198,11 @@
       color: var(--color-success-700);
     }
 
+    .badge-invite {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
     .event-location {
       display: flex;
       align-items: center;
@@ -446,6 +451,7 @@
               <p class="event-description">${escapeHtml(event.short_description || event.description?.substring(0, 150) || '')}</p>
               <div class="event-meta">
                 <span class="event-badge badge-${event.event_format}">${formatLabel}</span>
+                ${event.visibility === 'invite_listed' ? '<span class="event-badge badge-invite">Invite only</span>' : ''}
                 ${locationText ? `
                   <span class="event-location">
                     <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">

--- a/server/src/db/migrations/245_event_visibility.sql
+++ b/server/src/db/migrations/245_event_visibility.sql
@@ -1,0 +1,59 @@
+-- Add visibility control to events
+-- visibility 'public'          = anyone sees and registers (existing behavior)
+-- visibility 'invite_listed'   = shown in listings with invite badge; registration gated
+-- visibility 'invite_unlisted' = hidden from all public listings; 404 for non-invited users
+ALTER TABLE events
+  ADD COLUMN visibility VARCHAR(20) NOT NULL DEFAULT 'public'
+    CHECK (visibility IN ('public', 'invite_listed', 'invite_unlisted'));
+
+-- JSON rules for rule-based access on invite-only events
+-- Shape: { "membership_required": boolean, "organizations": ["workos_org_id"] }
+ALTER TABLE events
+  ADD COLUMN access_rules JSONB NOT NULL DEFAULT '{}';
+
+-- Explicit per-email invite list for invite-only events
+-- email is stored as lowercase (enforced by CHECK) so unique constraint is case-insensitive
+CREATE TABLE event_invites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  email TEXT NOT NULL CHECK (email = LOWER(email)),
+  invited_by_user_id VARCHAR(255),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT event_invites_unique_email UNIQUE (event_id, email)
+);
+
+CREATE INDEX idx_event_invites_event_id ON event_invites(event_id);
+CREATE INDEX idx_event_invites_email ON event_invites(LOWER(email));
+
+-- Add 'interested' registration status, distinct from 'waitlisted'
+-- 'waitlisted' = eligible user, event is full (real queue with expectation of getting in)
+-- 'interested' = user expressed interest but is not invited/eligible (no implied commitment)
+ALTER TABLE event_registrations
+  DROP CONSTRAINT IF EXISTS event_registrations_registration_status_check;
+ALTER TABLE event_registrations
+  ADD CONSTRAINT event_registrations_registration_status_check
+    CHECK (registration_status IN ('registered', 'waitlisted', 'interested', 'cancelled', 'no_show'));
+
+-- Rebuild upcoming_events view to exclude invite_unlisted events from public-facing queries
+DROP VIEW IF EXISTS upcoming_events;
+CREATE OR REPLACE VIEW upcoming_events AS
+SELECT
+  e.*,
+  (SELECT COUNT(*) FROM event_registrations er
+   WHERE er.event_id = e.id AND er.registration_status = 'registered') as registration_count,
+  (SELECT COUNT(*) FROM event_registrations er
+   WHERE er.event_id = e.id AND er.attended = TRUE) as attendance_count,
+  (SELECT COUNT(*) FROM event_sponsorships es
+   WHERE es.event_id = e.id AND es.payment_status = 'paid') as sponsor_count,
+  (SELECT COALESCE(SUM(es.amount_cents), 0) FROM event_sponsorships es
+   WHERE es.event_id = e.id AND es.payment_status = 'paid') as sponsorship_revenue_cents
+FROM events e
+WHERE e.status = 'published'
+  AND e.start_time > NOW()
+  AND e.visibility != 'invite_unlisted'
+ORDER BY e.start_time ASC;
+
+COMMENT ON VIEW upcoming_events IS 'Published events in the future with registration and sponsorship counts (excludes invite_unlisted events)';
+COMMENT ON COLUMN events.visibility IS 'public = open to all; invite_listed = shown in listings but registration gated; invite_unlisted = hidden from public listing';
+COMMENT ON COLUMN events.access_rules IS 'Rule-based access criteria: { "membership_required": boolean, "organizations": ["org_id"] }';
+COMMENT ON TABLE event_invites IS 'Explicit email invite list for invite-only events';

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -115,6 +115,14 @@ const workingGroupDb = new WorkingGroupDatabase();
 const logger = createLogger("events-routes");
 
 /**
+ * Look up the WorkOS organization ID for a user from local DB.
+ * Returns null if the user has no org membership.
+ */
+async function getUserOrgId(workosUserId: string): Promise<string | null> {
+  return eventsDb.getUserOrgId(workosUserId);
+}
+
+/**
  * Create events routes
  * Returns separate routers for:
  * - pageRouter: Page routes (/admin/events, /events, /events/:slug)
@@ -187,6 +195,7 @@ export function createEventsRouter(): {
         search,
         limit,
         offset,
+        include_invite_unlisted: true,  // Admin sees all events regardless of visibility
       });
 
       res.json({ events });
@@ -909,6 +918,99 @@ export function createEventsRouter(): {
     }
   );
 
+  // GET /api/admin/events/:id/invites - List invite list for an event
+  adminApiRouter.get(
+    "/:id/invites",
+    requireAuth,
+    requireAdmin,
+    async (req: Request, res: Response) => {
+      try {
+        const { id } = req.params;
+        const invites = await eventsDb.getEventInvites(id);
+        res.json({ invites });
+      } catch (error) {
+        logger.error({ err: error }, "Error getting event invites");
+        res.status(500).json({
+          error: "Failed to get invites",
+          message: "An unexpected error occurred",
+        });
+      }
+    }
+  );
+
+  // POST /api/admin/events/:id/invites - Add emails to invite list
+  adminApiRouter.post(
+    "/:id/invites",
+    requireAuth,
+    requireAdmin,
+    async (req: Request, res: Response) => {
+      try {
+        const { id } = req.params;
+        const { emails } = req.body as { emails: string[] };
+        const user = req.user!;
+
+        if (!emails || !Array.isArray(emails) || emails.length === 0) {
+          return res.status(400).json({
+            error: "Invalid input",
+            message: "emails must be a non-empty array of email addresses",
+          });
+        }
+
+        if (emails.length > 500) {
+          return res.status(400).json({
+            error: "Too many emails",
+            message: "Maximum 500 emails per request",
+          });
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        const invalidEmails = emails.filter(e => typeof e !== 'string' || !emailRegex.test(e.trim()));
+        if (invalidEmails.length > 0) {
+          return res.status(400).json({
+            error: "Invalid emails",
+            message: `Invalid email addresses: ${invalidEmails.slice(0, 5).join(', ')}`,
+          });
+        }
+
+        const added = await eventsDb.addInvites(id, emails, user.id);
+        logger.info({ eventId: id, count: added, userId: user.id }, "Added event invites");
+        res.json({ added });
+      } catch (error) {
+        logger.error({ err: error }, "Error adding event invites");
+        res.status(500).json({
+          error: "Failed to add invites",
+          message: "An unexpected error occurred",
+        });
+      }
+    }
+  );
+
+  // DELETE /api/admin/events/:id/invites/:email - Remove an email from invite list
+  adminApiRouter.delete(
+    "/:id/invites/:email",
+    requireAuth,
+    requireAdmin,
+    async (req: Request, res: Response) => {
+      try {
+        const { id, email } = req.params;
+        const removed = await eventsDb.removeInvite(id, decodeURIComponent(email));
+        if (!removed) {
+          return res.status(404).json({
+            error: "Invite not found",
+            message: "No invite found for that email",
+          });
+        }
+        res.json({ success: true });
+      } catch (error) {
+        logger.error({ err: error }, "Error removing event invite");
+        res.status(500).json({
+          error: "Failed to remove invite",
+          message: "An unexpected error occurred",
+        });
+      }
+    }
+  );
+
   // =========================================================================
   // PUBLIC API ROUTES (mounted at /api/events)
   // =========================================================================
@@ -994,7 +1096,7 @@ export function createEventsRouter(): {
               email_contact_id: contact.contactId,
               email: email.toLowerCase().trim(),
               name: displayName,
-              registration_status: 'waitlisted',
+              registration_status: 'interested',
               registration_source: 'interest',
             });
           } catch (err) {
@@ -1017,7 +1119,7 @@ export function createEventsRouter(): {
   });
 
   // GET /api/events/:slug - Get event by slug (public)
-  publicApiRouter.get("/:slug", async (req: Request, res: Response) => {
+  publicApiRouter.get("/:slug", optionalAuth, async (req: Request, res: Response) => {
     try {
       const { slug } = req.params;
 
@@ -1027,6 +1129,26 @@ export function createEventsRouter(): {
           error: "Event not found",
           message: "No published event found with that slug",
         });
+      }
+
+      // invite_unlisted events are 404 for non-invited users
+      // Return 404 (not 403) so the event's existence is not revealed
+      if (event.visibility === "invite_unlisted") {
+        const user = req.user;
+        if (!user) {
+          return res.status(404).json({
+            error: "Event not found",
+            message: "No published event found with that slug",
+          });
+        }
+        const userOrgId = await getUserOrgId(user.id);
+        const hasAccess = await eventsDb.checkUserAccess(event.id, user.email, userOrgId ?? undefined);
+        if (!hasAccess) {
+          return res.status(404).json({
+            error: "Event not found",
+            message: "No published event found with that slug",
+          });
+        }
       }
 
       // Get sponsors for display
@@ -1082,6 +1204,19 @@ export function createEventsRouter(): {
           error: "Already registered",
           message: "You are already registered for this event",
         });
+      }
+
+      // Gate registration for invite-only events
+      if (event.visibility === "invite_listed" || event.visibility === "invite_unlisted") {
+        const userOrgId = await getUserOrgId(user.id);
+        const hasAccess = await eventsDb.checkUserAccess(event.id, user.email, userOrgId ?? undefined);
+        if (!hasAccess) {
+          return res.status(403).json({
+            error: "Invite only",
+            message: "This event is by invitation only.",
+            invite_only: true,
+          });
+        }
       }
 
       // Check capacity

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -912,8 +912,22 @@ export interface DomainLookupResult {
 export type EventType = 'summit' | 'meetup' | 'webinar' | 'workshop' | 'conference' | 'other';
 export type EventFormat = 'in_person' | 'virtual' | 'hybrid';
 export type EventStatus = 'draft' | 'published' | 'cancelled' | 'completed';
-export type RegistrationStatus = 'registered' | 'waitlisted' | 'cancelled' | 'no_show';
+export type EventVisibility = 'public' | 'invite_listed' | 'invite_unlisted';
+export type RegistrationStatus = 'registered' | 'waitlisted' | 'interested' | 'cancelled' | 'no_show';
 export type RegistrationSource = 'direct' | 'luma' | 'import' | 'admin' | 'interest';
+
+export interface EventAccessRules {
+  membership_required?: boolean;
+  organizations?: string[];
+}
+
+export interface EventInvite {
+  id: string;
+  event_id: string;
+  email: string;
+  invited_by_user_id?: string;
+  created_at: Date;
+}
 export type SponsorshipPaymentStatus = 'pending' | 'paid' | 'refunded' | 'cancelled';
 
 export interface SponsorshipTier {
@@ -957,6 +971,8 @@ export interface Event {
   published_at?: Date;
   max_attendees?: number;
   require_rsvp_approval: boolean;
+  visibility: EventVisibility;
+  access_rules: EventAccessRules;
   created_by_user_id?: string;
   organization_id?: string;
   metadata: Record<string, unknown>;
@@ -994,6 +1010,8 @@ export interface CreateEventInput {
   status?: EventStatus;
   max_attendees?: number;
   require_rsvp_approval?: boolean;
+  visibility?: EventVisibility;
+  access_rules?: EventAccessRules;
   created_by_user_id?: string;
   organization_id?: string;
   metadata?: Record<string, unknown>;
@@ -1029,6 +1047,8 @@ export interface UpdateEventInput {
   published_at?: Date;
   max_attendees?: number;
   require_rsvp_approval?: boolean;
+  visibility?: EventVisibility;
+  access_rules?: EventAccessRules;
   metadata?: Record<string, unknown>;
 }
 
@@ -1042,6 +1062,7 @@ export interface ListEventsOptions {
   search?: string;
   limit?: number;
   offset?: number;
+  include_invite_unlisted?: boolean;  // Admin-only: include invite_unlisted events in results
 }
 
 export interface EventRegistration {


### PR DESCRIPTION
## Summary

- Adds `visibility` column to events with three values: `public` (existing behavior), `invite_listed` (shown in listings with badge; registration gated), and `invite_unlisted` (hidden from all listings; 404 for non-invited users)
- Adds `event_invites` table for per-email invite lists and `access_rules` JSONB for rule-based access (membership required, org allow-list)
- Adds `'interested'` as a distinct registration status for non-invited users who express interest (separate from `'waitlisted'` which is for eligible users when event is full)
- Admin invite CRUD: `GET/POST/DELETE /api/admin/events/:id/invites` with email validation and 500-email batch cap
- Public events listing shows "Invite only" badge for `invite_listed` events; unlisted events are completely excluded
- Event detail page shows badge; 403 from registration API surfaces the interest-capture form with contextual copy
- `getEventsByCity` and `getEventsByCommittee` now filter `invite_unlisted` events from public-facing queries

## Test plan

- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] All 304 unit tests passing (`npm test`)
- [x] Migration 245 applies cleanly on fresh Docker build
- [x] Public events API (`/api/events/`) returns `invite_listed` event with badge, excludes `invite_unlisted`
- [x] `GET /api/events/secret-leadership-roundtable` returns 404 without auth
- [x] Non-invited user gets 403 with `invite_only: true` on registration attempt
- [x] Invited user (email on invite list) can register successfully
- [x] Admin sees both events with correct visibility badges in admin UI
- [x] Public events listing shows "Invite only" badge on event card
- [x] Event detail page shows "Invite only" badge alongside format badges
- [x] Admin invite list endpoint returns stored invites with correct lowercased emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)