### PR TITLE
feat(addie): require user consent before escalating, add create_committee tool

### DIFF
--- a/.changeset/addie-escalation-confirm-create-wg.md
+++ b/.changeset/addie-escalation-confirm-create-wg.md
@@ -1,0 +1,4 @@
+---
+---
+
+Addie now requires user confirmation before escalating to the team instead of escalating automatically. Admins can also create working groups, councils, and governance bodies directly with the new `create_committee` tool.

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -41,9 +41,15 @@ DO NOT USE FOR:
 - Things that don't require admin attention
 - General conversation
 
-BEFORE ESCALATING — gather enough context to make the escalation actionable:
-- Ask what specifically they need if the request is vague
-- Confirm who the request is from: their name and organization. If someone is asking on behalf of another person, capture that person's name and contact details in the summary.
+CONFIRM WITH USER BEFORE ESCALATING — you must get the user's consent first:
+- Tell the user you don't have a tool for this and explain what you'd escalate
+- Ask if they'd like you to pass it to the team
+- Only call this tool after the user confirms they want you to escalate
+
+BEFORE CALLING THIS TOOL — gather enough context to make the escalation actionable:
+- If the request is vague, ask clarifying questions first
+- Confirm who the request is from: their name and organization
+- If someone is asking on behalf of another person, capture that person's name and contact details in the summary
 - Include any relevant context (timeline, urgency, what they've already tried)
 
 When you escalate, be honest with the user that you're passing this to a human who can help.`,


### PR DESCRIPTION
## Summary

- Addie was escalating to the admin team immediately when she couldn't help, generating escalation spam. She now must explain what she'd escalate, ask the user if they want that, and only call the tool after they confirm.
- New admin-only `create_committee` tool lets Addie create working groups, councils, and governance bodies directly. Accepts an optional existing Slack channel name to link. Chapters and industry gatherings continue to use their dedicated tools.

## Test plan

- [ ] Ask Addie something she can't do (e.g. "change this channel to private") — she should explain and ask before escalating, not fire-and-forget
- [ ] As an admin, ask Addie to create a working group with a channel name — should succeed and show slug + channel mention
- [ ] Ask for a `council` type — label in response should say "Industry Council"
- [ ] Provide a channel name that doesn't exist — should return a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)