### PR TITLE
feat(admin): prospects page quick actions, badge fixes, and richer context

### DIFF
--- a/.changeset/social-ends-attack.md
+++ b/.changeset/social-ends-attack.md
@@ -1,0 +1,4 @@
+---
+---
+
+Prospects page improvements: fix badge count discrepancies (personal accounts excluded, open invoices count stabilized), add quick DQ and note actions per row, surface disqualified status in edit modal, show engagement reasons as visible text, and restrict pipeline status badges to All/My Accounts views.

--- a/server/public/admin-prospects.html
+++ b/server/public/admin-prospects.html
@@ -176,6 +176,24 @@
       padding: var(--space-1.5) var(--space-3);
       font-size: var(--text-xs);
     }
+    .btn-danger {
+      background: var(--color-error-600);
+      color: white;
+      border-color: var(--color-error-600);
+    }
+    .btn-danger:hover {
+      background: var(--color-error-700);
+    }
+    #statusMessage {
+      display: none;
+      padding: var(--space-2) var(--space-4);
+      margin-bottom: var(--space-2);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-sm);
+      background: var(--color-success-100);
+      color: var(--color-success-700);
+      border: 1px solid var(--color-success-200);
+    }
 
     /* Table */
     .prospects-table {
@@ -230,6 +248,13 @@
     .status-prospect { background: var(--color-warning-100); color: var(--color-warning-700); }
     .status-cold { background: var(--color-gray-200); color: var(--color-text-secondary); }
     .status-disqualified { background: var(--color-gray-300); color: var(--color-text-muted); }
+    .status-signed_up { background: var(--color-primary-50); color: var(--color-primary-700); }
+    .status-contacted { background: var(--color-primary-100); color: var(--color-primary-700); }
+    .status-responded { background: var(--color-primary-200); color: var(--color-primary-800); }
+    .status-interested { background: var(--color-warning-100); color: var(--color-warning-800); }
+    .status-negotiating { background: var(--color-warning-200); color: var(--color-warning-900); }
+    .status-converted { background: var(--color-success-100); color: var(--color-success-700); }
+    .status-declined { background: var(--color-gray-200); color: var(--color-text-secondary); }
 
     /* Source badges for domain discovery */
     .source-badge {
@@ -865,6 +890,8 @@
           </div>
         </div>
 
+        <div id="statusMessage"></div>
+
         <div id="prospectsCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2.5); font-size: var(--text-sm);">
           Showing 0 accounts
         </div>
@@ -938,7 +965,7 @@
         <div class="form-row">
           <div class="form-group">
             <label>Status</label>
-            <select id="prospectStatus">
+            <select id="prospectStatus" onchange="toggleDisqualificationReason()">
               <option value="prospect">Prospect</option>
               <option value="signed_up">Signed Up</option>
               <option value="contacted">Contacted</option>
@@ -947,6 +974,7 @@
               <option value="negotiating">Negotiating</option>
               <option value="converted">Converted</option>
               <option value="declined">Declined</option>
+              <option value="disqualified">Disqualified</option>
             </select>
           </div>
           <div class="form-group">
@@ -958,6 +986,11 @@
               <option value="inbound">Inbound</option>
             </select>
           </div>
+        </div>
+
+        <div class="form-group" id="disqualificationReasonGroup" style="display: none;">
+          <label>Disqualification reason</label>
+          <input type="text" id="prospectDisqualificationReason" placeholder="e.g. Trade association, competitor, not in target market">
         </div>
 
         <div class="form-group">
@@ -1318,6 +1351,7 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
     function updateViewCounts() {
       document.getElementById('count-needs_followup').textContent = viewCounts.needs_followup || 0;
       document.getElementById('count-new_signups').textContent = viewCounts.new_signups || 0;
+      document.getElementById('count-open_invoices').textContent = viewCounts.open_invoices || 0;
       document.getElementById('count-going_cold').textContent = viewCounts.going_cold || 0;
       document.getElementById('count-renewals').textContent = viewCounts.renewals || 0;
       document.getElementById('count-my_accounts').textContent = viewCounts.my_accounts || 0;
@@ -1402,13 +1436,11 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       const hasNonZeroInvoice = (p) => p.pending_invoices?.some(inv => inv.amount_due > 0);
       if (view === 'open_invoices') {
         filteredProspects = allProspects.filter(hasNonZeroInvoice);
-        // Update badge count
+        // Update badge to reflect actual filtered count for this view
         document.getElementById('count-open_invoices').textContent = filteredProspects.length;
       } else {
         filteredProspects = allProspects;
-        // Update open_invoices count when loading other views
-        const openInvoicesCount = allProspects.filter(hasNonZeroInvoice).length;
-        document.getElementById('count-open_invoices').textContent = openInvoicesCount;
+        // Don't overwrite the open_invoices badge — it's managed by the server-side view-counts
       }
 
       applyFilters();
@@ -3022,7 +3054,7 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
 
       tbody.innerHTML = filteredProspects.map(prospect => {
         // Company name with link and type badge
-        let companyHtml = `<a href="/admin/organizations/${prospect.workos_organization_id}" class="company-link">${prospect.name}</a>`;
+        let companyHtml = `<a href="/admin/organizations/${escapeHtml(prospect.workos_organization_id)}" class="company-link">${escapeHtml(prospect.name)}</a>`;
         // Add type label inline - support both array and legacy single value
         let typeLabel = '';
         if (prospect.is_personal) {
@@ -3033,19 +3065,39 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
           if (typeLabel === '-') typeLabel = '';
         }
         if (typeLabel) {
-          companyHtml += `<br><small style="color: var(--color-text-muted);">${typeLabel}</small>`;
+          companyHtml += `<br><small style="color: var(--color-text-muted);">${escapeHtml(typeLabel)}</small>`;
         }
         // Add member status badge
         if (prospect.subscription_status === 'active') {
           companyHtml += ` <span class="status-badge status-member">Member</span>`;
         }
+        // Add prospect pipeline status badge — only on "All" and "My Accounts" views
+        // where it adds context; on single-purpose views (New Signups, Hot Prospects, etc.)
+        // the tab already implies the status so the badge is redundant.
+        const pStatus = prospect.prospect_status;
+        if (pStatus && pStatus !== 'prospect' && (currentView === 'all' || currentView === 'my_accounts')) {
+          const statusLabels = { signed_up: 'Signed up', contacted: 'Contacted', responded: 'Responded',
+            interested: 'Interested', negotiating: 'Negotiating', converted: 'Converted',
+            declined: 'Declined', disqualified: 'Disqualified' };
+          const label = statusLabels[pStatus] ? statusLabels[pStatus] : escapeHtml(pStatus);
+          const safeClass = statusLabels[pStatus] ? `status-${pStatus}` : 'status-unknown';
+          companyHtml += `<br><span class="status-badge ${safeClass}">${label}</span>`;
+          if (pStatus === 'disqualified' && prospect.disqualification_reason) {
+            companyHtml += `<small style="color: var(--color-text-muted); margin-left: var(--space-1);">${escapeHtml(prospect.disqualification_reason)}</small>`;
+          }
+        }
 
-        // Engagement fires with score
+        // Engagement fires with score and top reason as visible text
         const fires = '\u{1F525}'.repeat(prospect.engagement_level || 1);
         const score = prospect.engagement_score || 0;
-        const reasons = prospect.engagement_reasons?.join(', ') || 'New prospect';
-        const engagementTooltip = `Score: ${score}/100\n${reasons}`;
-        const engagementHtml = `<span class="engagement-fires" title="${engagementTooltip}">${fires}</span>`;
+        const reasonsList = prospect.engagement_reasons || [];
+        const reasons = reasonsList.join(', ') || 'New prospect';
+        const engagementTooltip = escapeHtml(`Score: ${score}/100\n${reasons}`);
+        const topReason = reasonsList[0] || null;
+        const engagementHtml = `<div style="text-align: center;">
+          <span class="engagement-fires" title="${engagementTooltip}">${fires}</span>
+          ${topReason ? `<br><small style="color: var(--color-text-muted); font-size: 0.7em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 80px; display: block; margin: 0 auto;" title="${escapeHtml(reasons)}">${escapeHtml(topReason)}</small>` : ''}
+        </div>`;
 
         // Domain - show primary domain and count of others
         let domainHtml = '<span style="color: var(--color-text-muted);">-</span>';
@@ -3157,8 +3209,10 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
             <td>${usersHtml}</td>
             <td>${activityHtml}</td>
             <td>${ownerHtml}</td>
-            <td>
+            <td id="actions-${prospect.workos_organization_id}">
               ${watchHtml}
+              <button class="btn-icon" onclick="showNoteForm('${prospect.workos_organization_id}')" title="Add note">📝</button>
+              ${prospect.subscription_status !== 'active' ? `<button class="btn-icon" onclick="showDisqualifyForm('${prospect.workos_organization_id}')" title="Disqualify">DQ</button>` : ''}
               <button class="btn-icon" onclick="editProspect('${prospect.workos_organization_id}')" title="Edit">Edit</button>
             </td>
           </tr>
@@ -3234,6 +3288,11 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       }
     }
 
+    function toggleDisqualificationReason() {
+      const status = document.getElementById('prospectStatus').value;
+      document.getElementById('disqualificationReasonGroup').style.display = status === 'disqualified' ? 'block' : 'none';
+    }
+
     // Modal functions
     function openAddProspectModal() {
       document.getElementById('prospectModalTitle').textContent = 'Add Prospect';
@@ -3271,6 +3330,8 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       document.getElementById('prospectNextAction').value = prospect.prospect_next_action || '';
       document.getElementById('prospectNextActionDate').value = prospect.prospect_next_action_date ? prospect.prospect_next_action_date.split('T')[0] : '';
       document.getElementById('prospectNotes').value = prospect.prospect_notes || '';
+      document.getElementById('prospectDisqualificationReason').value = prospect.disqualification_reason || '';
+      toggleDisqualificationReason();
 
       // Show payment link and invoice buttons for non-members
       const paymentLinkBtn = document.getElementById('getPaymentLinkBtn');
@@ -3305,7 +3366,8 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
         prospect_contact_title: document.getElementById('prospectContactTitle').value || null,
         prospect_next_action: document.getElementById('prospectNextAction').value || null,
         prospect_next_action_date: document.getElementById('prospectNextActionDate').value || null,
-        prospect_notes: document.getElementById('prospectNotes').value || null
+        prospect_notes: document.getElementById('prospectNotes').value || null,
+        disqualification_reason: document.getElementById('prospectDisqualificationReason').value || null
       };
 
       const btn = document.getElementById('saveProspectBtn');
@@ -3338,6 +3400,104 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       } finally {
         btn.disabled = false;
         btn.textContent = 'Save Prospect';
+      }
+    }
+
+    let _statusTimer = null;
+    function showStatusMessage(msg) {
+      const el = document.getElementById('statusMessage');
+      if (!el) return;
+      el.textContent = msg;
+      el.style.display = 'block';
+      clearTimeout(_statusTimer);
+      _statusTimer = setTimeout(() => { el.style.display = 'none'; }, 3000);
+    }
+
+    function restoreCell(orgId) {
+      const cell = document.getElementById(`actions-${orgId}`);
+      if (cell) cell.innerHTML = cell.dataset.originalHtml || '';
+    }
+
+    // Quick action: show inline disqualify form in the row's actions cell
+    function showDisqualifyForm(orgId) {
+      const cell = document.getElementById(`actions-${orgId}`);
+      if (!cell) return;
+      cell.dataset.originalHtml = cell.innerHTML;
+      cell.innerHTML = `
+        <div style="display: flex; flex-direction: column; gap: var(--space-2); min-width: 200px;">
+          <input type="text" id="disq-reason-${orgId}" placeholder="Reason (optional)"
+            style="font-size: var(--text-sm); padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm);">
+          <div style="display: flex; gap: var(--space-2);">
+            <button class="btn-sm btn-danger" onclick="confirmDisqualify('${orgId}')">Disqualify</button>
+            <button class="btn-sm" onclick="restoreCell('${orgId}')">Cancel</button>
+          </div>
+        </div>`;
+      document.getElementById(`disq-reason-${orgId}`)?.focus();
+    }
+
+    async function confirmDisqualify(orgId) {
+      const reason = document.getElementById(`disq-reason-${orgId}`)?.value || null;
+      try {
+        const res = await fetch(`/api/admin/prospects/${orgId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prospect_status: 'disqualified', disqualification_reason: reason })
+        });
+        if (!res.ok) throw new Error('Failed to disqualify');
+        allProspects = allProspects.filter(p => p.workos_organization_id !== orgId);
+        filteredProspects = filteredProspects.filter(p => p.workos_organization_id !== orgId);
+        renderProspects();
+        showStatusMessage('Marked as disqualified');
+      } catch (err) {
+        console.error('Disqualify failed:', err);
+        restoreCell(orgId);
+        alert('Failed to disqualify. Please try again.');
+      }
+    }
+
+    // Quick action: show inline add-note form in the row's actions cell
+    function showNoteForm(orgId) {
+      const cell = document.getElementById(`actions-${orgId}`);
+      if (!cell) return;
+      cell.dataset.originalHtml = cell.innerHTML;
+      cell.innerHTML = `
+        <div style="display: flex; flex-direction: column; gap: var(--space-2); min-width: 220px;">
+          <textarea id="note-text-${orgId}" placeholder="Add a note..." rows="2"
+            style="font-size: var(--text-sm); padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm); resize: vertical;"></textarea>
+          <div style="display: flex; gap: var(--space-2);">
+            <button class="btn-sm btn-primary" onclick="saveNote('${orgId}')">Save note</button>
+            <button class="btn-sm" onclick="restoreCell('${orgId}')">Cancel</button>
+          </div>
+        </div>`;
+      document.getElementById(`note-text-${orgId}`)?.focus();
+    }
+
+    async function saveNote(orgId) {
+      const text = document.getElementById(`note-text-${orgId}`)?.value?.trim();
+      if (!text) { restoreCell(orgId); return; }
+      try {
+        const res = await fetch(`/api/admin/organizations/${orgId}/activities`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ activity_type: 'note', description: text })
+        });
+        if (!res.ok) throw new Error('Failed to save note');
+        // On going_cold view: a new note means recent activity, so remove from list
+        // and decrement the tab badge to stay consistent with the displayed count
+        if (currentView === 'going_cold') {
+          allProspects = allProspects.filter(p => p.workos_organization_id !== orgId);
+          filteredProspects = filteredProspects.filter(p => p.workos_organization_id !== orgId);
+          const badge = document.getElementById('count-going_cold');
+          if (badge) badge.textContent = Math.max(0, parseInt(badge.textContent || '0') - 1);
+          renderProspects();
+        } else {
+          restoreCell(orgId);
+        }
+        showStatusMessage('Note saved');
+      } catch (err) {
+        console.error('Save note failed:', err);
+        restoreCell(orgId);
+        alert('Failed to save note. Please try again.');
       }
     }
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -397,6 +397,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
           goingCold,
           renewals,
           myAccounts,
+          openInvoices,
         ] = await Promise.all([
           pool.query(`
             SELECT COUNT(DISTINCT o.workos_organization_id) as count
@@ -405,12 +406,15 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
               AND na.is_next_step = TRUE
               AND na.next_step_completed_at IS NULL
               AND (na.next_step_due_date IS NULL OR na.next_step_due_date <= NOW() + INTERVAL '7 days')
+            WHERE (o.is_personal IS NOT TRUE)
           `),
           pool.query(`
             SELECT COUNT(*) as count
             FROM organizations o
-            WHERE o.created_at > NOW() - INTERVAL '14 days'
+            WHERE o.created_at >= NOW() - INTERVAL '14 days'
               AND NOT EXISTS (SELECT 1 FROM org_activities WHERE organization_id = o.workos_organization_id)
+              AND (o.is_personal IS NOT TRUE)
+              AND COALESCE(o.prospect_status, 'prospect') != 'disqualified'
           `),
           pool.query(`
             SELECT COUNT(*) as count
@@ -422,6 +426,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
                 OR o.subscription_status NOT IN ('active', 'trialing')
                 OR o.subscription_canceled_at IS NOT NULL
               )
+              AND (o.is_personal IS NOT TRUE)
           `),
           pool.query(`
             SELECT COUNT(*) as count
@@ -430,13 +435,24 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
               AND o.subscription_current_period_end IS NOT NULL
               AND o.subscription_current_period_end >= NOW()
               AND o.subscription_current_period_end <= NOW() + INTERVAL '60 days'
+              AND (o.is_personal IS NOT TRUE)
           `),
           userId
             ? pool.query(
-                `SELECT COUNT(*) as count FROM org_stakeholders WHERE user_id = $1`,
+                `SELECT COUNT(*) as count FROM org_stakeholders os
+                 JOIN organizations o ON o.workos_organization_id = os.organization_id
+                 WHERE os.user_id = $1 AND (o.is_personal IS NOT TRUE)`,
                 [userId]
               )
             : Promise.resolve({ rows: [{ count: 0 }] }),
+          pool.query(`
+            SELECT COUNT(DISTINCT oi.workos_organization_id) as count
+            FROM org_invoices oi
+            JOIN organizations o ON o.workos_organization_id = oi.workos_organization_id
+            WHERE oi.status IN ('draft', 'open')
+              AND oi.amount_due > 0
+              AND (o.is_personal IS NOT TRUE)
+          `),
         ]);
 
         res.json({
@@ -445,6 +461,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
           going_cold: parseInt(goingCold.rows[0]?.count || "0"),
           renewals: parseInt(renewals.rows[0]?.count || "0"),
           my_accounts: parseInt(myAccounts.rows[0]?.count || "0"),
+          open_invoices: parseInt(openInvoices.rows[0]?.count || "0"),
         });
       } catch (error) {
         logger.error({ err: error }, "Error fetching view counts");


### PR DESCRIPTION
## Summary

- **Badge count fixes**: All view-count queries now exclude personal accounts so badges match the Companies Only default display; open_invoices count is fetched server-side on load and no longer resets to 0 when switching tabs; new_signups count now excludes disqualified orgs and uses consistent `>=` date comparison
- **Quick row actions**: Each prospect row gets a 📝 note button (inline textarea → posts to activities API) and a DQ button (inline form with optional reason → marks disqualified, hidden on active member rows); cancel restores original cell HTML via data attribute with no scroll jump
- **Richer context**: Top engagement reason visible as text below fires emoji; pipeline status badge shown on All/My Accounts views only; Disqualified added to Edit modal dropdown with conditional reason field
- **XSS hardening**: `escapeHtml()` applied to org name, type label, disqualification reason, engagement reasons, and status labels throughout `renderProspects()`

## Test plan

- [ ] New Signups badge matches displayed company count
- [ ] Open Invoices badge stays stable when switching tabs
- [ ] DQ button opens inline form; cancel restores row without scroll jump; confirm removes row and shows toast
- [ ] DQ button absent on member rows
- [ ] Note button opens inline textarea; save posts activity; going_cold row removed + badge decremented on save
- [ ] Edit modal shows Disqualified in dropdown; reason field appears when selected
- [ ] Engagement reason text visible below fires emoji on rows with activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)