### PR TITLE
feat(addie): document property registry tools in tool reference

### DIFF
--- a/.changeset/addie-property-registry-context.md
+++ b/.changeset/addie-property-registry-context.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add property registry context to Addie's tool reference so she understands what the community property registry is, how data is managed across the three source tiers (authoritative/enriched/community), and when to use each property tool.

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -107,6 +107,21 @@ When there is an active SI session, use send_to_si_agent for EVERY user message 
 - list_brands: List brands in the registry with optional filters
 - list_missing_brands: List most-requested brands not yet in the registry
 
+**Property Registry:**
+The community property registry maps publisher domains to their inventory properties and agent authorizations. It has three data sources:
+- **Authoritative** (source: adagents_json): Publisher self-hosts /.well-known/adagents.json. The registry validates and indexes it automatically. These entries cannot be community-edited — the publisher controls them directly.
+- **Enriched** (source: hosted, enriched): Pre-seeded from Scope3 data (~1,250 publishers). Community-editable with revision tracking.
+- **Community** (source: hosted, community): Contributed by members or Addie. New entries submitted by members go to pending review; entries Addie creates are auto-approved. All edits are revision-tracked (Wikipedia-style).
+
+Typical workflow for an unknown domain: use check_property_list to audit a domain list → unknown domains land in the "assess" bucket → use enhance_property to analyze and submit each one as pending.
+
+- resolve_property: Look up a publisher domain — checks the registry, then falls back to live adagents.json validation
+- save_property: Create or update a hosted property entry. New properties created by Addie are auto-approved; updates to existing approved entries stay approved. Use source_type "community" for member-contributed data, "enriched" for data from third-party sources.
+- list_properties: Browse registry entries. Optional filters: source (adagents_json, hosted, or discovered), search term.
+- list_missing_properties: Show most-requested domains not yet in the registry (demand signals — pair with save_property to fill gaps)
+- check_property_list: Audit up to 10,000 publisher domains at once. Returns four buckets: remove (ad tech infrastructure / duplicates), modify (normalized), assess (unknown), ok (found in registry). Always returns a report_url for full details — surface this to the member.
+- enhance_property: Analyze an unknown domain from the assess bucket. Checks domain age (flags < 90 days as high risk), validates adagents.json presence, uses AI to assess whether it's a real publisher. Submits to registry as pending — Addie runs an automated quality review and approves if it looks legitimate. Run one domain at a time.
+
 **Content:**
 - list_perspectives: Browse community articles
 


### PR DESCRIPTION
## Summary

- Addie had no context about the community property registry despite having six property tools available — the Brand Registry had a full documented section but the property registry had nothing
- Adds a **Property Registry** section to `ADDIE_TOOL_REFERENCE` explaining the three data source tiers (authoritative/enriched/community), their editability rules, and the check→assess→enhance workflow
- Per-tool guidance is accurate to the implementation (verified against `property-tools.ts` and `property-db.ts`)

## Test plan

- [x] All 304 tests pass
- [x] TypeScript typecheck passes
- [x] Code review run; reviewer feedback addressed (save_property approval behavior, enhance_property review process, list_properties source filter values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/agenticadvertisingorg/agenticadvertisingorg/editor/bokelley%2Faddie-property-registry-context?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->