### PR TITLE
feat: brand registry lookup, unified enrichment, and membership inheritance

### DIFF
--- a/.changeset/brand-registry-lookup.md
+++ b/.changeset/brand-registry-lookup.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Brand registry lookup, unified enrichment, and membership inheritance

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -660,6 +660,7 @@
               <span id="memberBadge" class="member-badge prospect">Prospect</span>
               <span id="accountTypeBadge" class="member-badge" style="background: var(--color-gray-200); color: var(--color-text-heading); cursor: pointer;" onclick="openConvertAccountModal()" title="Click to change account type">Team</span>
             </h1>
+            <div id="inheritedMembershipNotice" style="display: none; margin-top: var(--space-1); font-size: var(--text-sm); color: var(--color-brand); font-weight: 500;"></div>
             <div id="headerSubtitle" class="header-subtitle"></div>
           </div>
           <div style="display: flex; gap: var(--space-2);">
@@ -1034,13 +1035,6 @@
           <input type="text" id="editName">
         </div>
 
-        <div class="form-group">
-          <label>Parent Organization</label>
-          <select id="editParentOrg">
-            <option value="">None (independent)</option>
-          </select>
-          <div class="form-hint">If this is a subsidiary or division, select the parent company.</div>
-        </div>
 
         <div class="form-row">
           <div class="form-group">
@@ -1466,6 +1460,10 @@
       if (a.is_disqualified) {
         memberBadge.className = 'member-badge disqualified';
         memberBadge.textContent = 'Disqualified';
+      } else if (a.effective_membership?.is_inherited) {
+        memberBadge.className = 'member-badge member';
+        memberBadge.textContent = 'Covered member';
+        memberBadge.title = `Covered by ${a.effective_membership.paying_org_name} membership`;
       } else {
         const statusLabels = {
           member: 'Member',
@@ -1474,6 +1472,16 @@
           prospect: 'Prospect'
         };
         memberBadge.textContent = statusLabels[a.member_status] || 'Prospect';
+      }
+
+      // Inherited membership notice
+      const inheritedNotice = document.getElementById('inheritedMembershipNotice');
+      if (a.effective_membership?.is_inherited && inheritedNotice) {
+        inheritedNotice.style.display = '';
+        inheritedNotice.innerHTML = `Covered by <a href="/admin/accounts/${a.effective_membership.paying_org_id}">${escapeHtml(a.effective_membership.paying_org_name)}</a> membership` +
+          (a.effective_membership.hierarchy_chain?.length > 1
+            ? ` <span style="color: var(--color-text-secondary); font-size: var(--text-xs);">(${a.effective_membership.hierarchy_chain.join(' → ')})</span>`
+            : '');
       }
 
       // Header subtitle (company type, revenue tier, employees, location)
@@ -2252,40 +2260,7 @@
       document.getElementById('editRevenueTier').value = accountData.revenue_tier || '';
       toggleDisqualifyReason();
 
-      // Load and populate parent org options
-      await loadParentOrgOptions();
-
       openModal('editModal');
-    }
-
-    async function loadParentOrgOptions() {
-      const select = document.getElementById('editParentOrg');
-      // Keep the "None" option
-      select.innerHTML = '<option value="">None (independent)</option>';
-
-      try {
-        const response = await fetch('/api/admin/prospects?limit=500');
-        if (!response.ok) return;
-
-        const data = await response.json();
-        const orgs = data.prospects || [];
-
-        // Filter out current org and sort by name
-        orgs
-          .filter(org => org.workos_organization_id !== accountId)
-          .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-          .forEach(org => {
-            const option = document.createElement('option');
-            option.value = org.workos_organization_id;
-            option.textContent = org.name;
-            if (org.workos_organization_id === accountData.parent_organization_id) {
-              option.selected = true;
-            }
-            select.appendChild(option);
-          });
-      } catch (error) {
-        console.error('Error loading parent org options:', error);
-      }
     }
 
     function toggleDisqualifyReason() {
@@ -2306,8 +2281,7 @@
         prospect_status: document.getElementById('editDisqualified').checked ? 'disqualified' : null,
         disqualification_reason: document.getElementById('editDisqualified').checked ?
           document.getElementById('editDisqualifyReason').value : null,
-        revenue_tier: document.getElementById('editRevenueTier').value || null,
-        parent_organization_id: document.getElementById('editParentOrg').value || null
+        revenue_tier: document.getElementById('editRevenueTier').value || null
       };
 
       try {

--- a/server/public/admin-domain-discovery.html
+++ b/server/public/admin-domain-discovery.html
@@ -217,6 +217,48 @@
           <span>Domain Discovery</span>
         </div>
 
+        <!-- Brand registry mapping -->
+        <div class="card">
+          <h2 style="margin-bottom: var(--space-2);">Brand registry mapping</h2>
+          <p class="subtitle">Organizations mapped to the brand registry for hierarchy and membership inheritance.</p>
+
+          <div style="display: flex; gap: var(--space-4); margin-bottom: var(--space-4);">
+            <div style="flex: 1; padding: var(--space-4); border-radius: var(--radius-md); background: var(--color-gray-50); text-align: center;">
+              <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--color-text-heading);" id="stat-total">-</div>
+              <div style="font-size: var(--text-sm); color: var(--color-text-secondary);">With domain</div>
+            </div>
+            <div style="flex: 1; padding: var(--space-4); border-radius: var(--radius-md); background: var(--color-success-50, #ecfdf5); text-align: center;">
+              <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--color-success, #059669);" id="stat-mapped">-</div>
+              <div style="font-size: var(--text-sm); color: var(--color-text-secondary);">Mapped</div>
+            </div>
+            <div style="flex: 1; padding: var(--space-4); border-radius: var(--radius-md); background: var(--color-warning-50, #fff7ed); text-align: center;">
+              <div style="font-size: var(--text-2xl); font-weight: 600; color: var(--color-warning, #d97706);" id="stat-unmapped">-</div>
+              <div style="font-size: var(--text-sm); color: var(--color-text-secondary);">Unmapped</div>
+            </div>
+          </div>
+
+          <div id="unmapped-section" style="display: none;">
+            <div class="count-bar" style="margin-bottom: var(--space-3);">
+              <span class="count-info" id="unmapped-count"></span>
+              <button class="btn btn-secondary btn-sm" onclick="runBackfill()" id="backfillBtn">
+                Research unmapped (max 25)
+              </button>
+            </div>
+
+            <table class="domains-table">
+              <thead>
+                <tr>
+                  <th>Organization</th>
+                  <th>Domain</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="unmappedTableBody"></tbody>
+            </table>
+          </div>
+        </div>
+
         <div class="card">
           <h1>Domain Discovery</h1>
           <p class="subtitle">Find new prospects from Slack and email contacts that haven't been mapped to organizations.</p>
@@ -266,6 +308,12 @@
   </div>
 
   <script>
+    function escapeHtml(str) {
+      if (!str) return '';
+      return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+    }
+
     // State
     let discoveredDomains = [];
     let slackDomains = [];
@@ -287,8 +335,110 @@
         console.log('Could not check enrichment config');
       }
 
-      await loadDomainDiscovery();
+      await Promise.all([
+        loadDomainDiscovery(),
+        loadMappingStats(),
+      ]);
     });
+
+    async function loadMappingStats() {
+      try {
+        const [statsRes, unmappedRes] = await Promise.all([
+          fetch('/api/admin/brand-enrichment/org-mapping-stats'),
+          fetch('/api/admin/brand-enrichment/unmapped-orgs?limit=50'),
+        ]);
+
+        if (statsRes.ok) {
+          const stats = await statsRes.json();
+          document.getElementById('stat-total').textContent = stats.total_with_domain;
+          document.getElementById('stat-mapped').textContent = stats.mapped;
+          document.getElementById('stat-unmapped').textContent = stats.unmapped;
+        }
+
+        if (unmappedRes.ok) {
+          const data = await unmappedRes.json();
+          if (data.orgs.length > 0) {
+            document.getElementById('unmapped-section').style.display = '';
+            document.getElementById('unmapped-count').textContent = `${data.count} unmapped organizations`;
+            renderUnmappedOrgs(data.orgs);
+          }
+        }
+      } catch (e) {
+        console.error('Failed to load mapping stats:', e);
+      }
+    }
+
+    function renderUnmappedOrgs(orgs) {
+      const tbody = document.getElementById('unmappedTableBody');
+      tbody.innerHTML = orgs.map(org => `
+        <tr id="unmapped-${escapeHtml(org.email_domain)}">
+          <td><a href="/admin/accounts/${encodeURIComponent(org.workos_organization_id)}">${escapeHtml(org.name)}</a></td>
+          <td><code>${escapeHtml(org.email_domain)}</code></td>
+          <td>${org.subscription_status === 'active'
+            ? '<span style="color: var(--color-success, #059669); font-weight: 500;">Member</span>'
+            : escapeHtml(org.prospect_status || 'none')}</td>
+          <td>
+            <button class="btn btn-secondary btn-sm"
+                    data-domain="${escapeHtml(org.email_domain)}"
+                    data-org-id="${escapeHtml(org.workos_organization_id)}"
+                    onclick="researchSingle(this.dataset.domain, this.dataset.orgId)">
+              Research
+            </button>
+          </td>
+        </tr>
+      `).join('');
+    }
+
+    async function researchSingle(domain, orgId) {
+      const row = document.getElementById('unmapped-' + domain);
+      const btn = row?.querySelector('button');
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Researching...';
+      }
+      try {
+        const res = await fetch(`/api/admin/brand-enrichment/research/${domain}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ org_id: orgId }),
+        });
+        if (res.ok) {
+          if (btn) {
+            btn.textContent = 'Done';
+            btn.style.color = 'var(--color-success, #059669)';
+          }
+          await loadMappingStats();
+        } else {
+          if (btn) { btn.textContent = 'Failed'; btn.disabled = false; }
+        }
+      } catch (e) {
+        if (btn) { btn.textContent = 'Error'; btn.disabled = false; }
+      }
+    }
+
+    async function runBackfill() {
+      const btn = document.getElementById('backfillBtn');
+      btn.disabled = true;
+      btn.textContent = 'Researching...';
+      try {
+        const res = await fetch('/api/admin/brand-enrichment/backfill', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ limit: 25 }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          btn.textContent = `Done (${data.researched} researched)`;
+          await loadMappingStats();
+        } else {
+          btn.textContent = 'Failed';
+        }
+      } catch (e) {
+        btn.textContent = 'Error';
+      } finally {
+        btn.disabled = false;
+      }
+    }
 
     async function loadDomainDiscovery() {
       try {

--- a/server/public/admin-prospects.html
+++ b/server/public/admin-prospects.html
@@ -993,14 +993,6 @@
           <input type="text" id="prospectDisqualificationReason" placeholder="e.g. Trade association, competitor, not in target market">
         </div>
 
-        <div class="form-group">
-          <label>Parent Company</label>
-          <select id="prospectParent">
-            <option value="">None (standalone company)</option>
-          </select>
-          <div class="form-hint">For subsidiaries, select the parent company</div>
-        </div>
-
         <h3 style="margin-top: var(--space-6); margin-bottom: var(--space-4); font-size: var(--text-base);">Contact Info</h3>
 
         <div class="form-row">
@@ -1327,13 +1319,6 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
         } catch (e) {
           // Domain discovery may not be available, that's ok
           console.log('Domain discovery not available:', e);
-        }
-
-        // Load organizations for dropdown
-        const orgsRes = await fetch('/api/admin/organizations');
-        if (orgsRes.ok) {
-          allOrganizations = await orgsRes.json();
-          populateParentDropdown();
         }
 
         // Load current view
@@ -2955,17 +2940,6 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       }
     }
 
-    function populateParentDropdown() {
-      const select = document.getElementById('prospectParent');
-      select.innerHTML = '<option value="">None (standalone company)</option>';
-
-      allOrganizations
-        .filter(org => !org.prospect_status || org.prospect_status === 'joined')
-        .forEach(org => {
-          select.innerHTML += `<option value="${org.workos_organization_id}">${org.name}</option>`;
-        });
-    }
-
     function applyFilters() {
       const ownerFilter = document.getElementById('filterOwner').value;
       const typeFilter = document.getElementById('filterType').value;
@@ -3323,7 +3297,6 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
       document.getElementById('prospectOwner').value = prospect.prospect_owner || '';
       document.getElementById('prospectStatus').value = prospect.prospect_status || 'prospect';
       document.getElementById('prospectSource').value = prospect.prospect_source || 'aao_launch_list';
-      document.getElementById('prospectParent').value = prospect.parent_organization_id || '';
       document.getElementById('prospectContactName').value = prospect.prospect_contact_name || '';
       document.getElementById('prospectContactEmail').value = prospect.prospect_contact_email || '';
       document.getElementById('prospectContactTitle').value = prospect.prospect_contact_title || '';
@@ -3360,7 +3333,6 @@ Beta Inc,Publisher,Randy,Jane Doe,Major news network"></textarea>
         prospect_owner: document.getElementById('prospectOwner').value || null,
         prospect_status: document.getElementById('prospectStatus').value,
         prospect_source: document.getElementById('prospectSource').value,
-        parent_organization_id: document.getElementById('prospectParent').value || null,
         prospect_contact_name: document.getElementById('prospectContactName').value || null,
         prospect_contact_email: document.getElementById('prospectContactEmail').value || null,
         prospect_contact_title: document.getElementById('prospectContactTitle').value || null,

--- a/server/src/db/migrations/251_drop_parent_organization_id.sql
+++ b/server/src/db/migrations/251_drop_parent_organization_id.sql
@@ -1,0 +1,6 @@
+-- Migration: 246_drop_parent_organization_id.sql
+-- Parent/subsidiary relationships are derived from the brand registry:
+-- organizations.email_domain → discovered_brands.domain → discovered_brands.house_domain → organizations.email_domain
+
+DROP INDEX IF EXISTS idx_organizations_parent;
+ALTER TABLE organizations DROP COLUMN IF EXISTS parent_organization_id;

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -1,3 +1,8 @@
+import { getPool } from './client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('org-filters');
+
 /**
  * Shared SQL filters for organization tiers
  *
@@ -147,4 +152,164 @@ export function getOrgTier(org: {
 
   // Prospect: no users at all
   return 'prospect';
+}
+
+// =============================================================================
+// Membership inheritance via brand registry hierarchy
+// =============================================================================
+
+export interface EffectiveMembership {
+  is_member: boolean;
+  is_inherited: boolean;
+  paying_org_id: string | null;
+  paying_org_name: string | null;
+  hierarchy_chain: string[];
+  membership_tier: string | null;
+}
+
+// Cache: org_id → { result, expires_at }
+const membershipCache = new Map<string, { result: EffectiveMembership; expires_at: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Resolve effective membership for an organization, including inheritance
+ * through the brand registry hierarchy (house_domain chain).
+ *
+ * If the org itself is a paying member, returns direct membership.
+ * Otherwise, walks up the house_domain chain (max 5 hops) looking for
+ * a paying ancestor org. Only traverses high-confidence classifications.
+ */
+export async function resolveEffectiveMembership(orgId: string): Promise<EffectiveMembership> {
+  // Check cache
+  const cached = membershipCache.get(orgId);
+  if (cached && cached.expires_at > Date.now()) {
+    return cached.result;
+  }
+
+  const pool = getPool();
+
+  try {
+    const result = await pool.query<{
+      workos_organization_id: string;
+      email_domain: string | null;
+      name: string;
+      subscription_status: string | null;
+      subscription_canceled_at: Date | null;
+      membership_tier: string | null;
+      depth: number;
+    }>(`
+      WITH RECURSIVE org_chain AS (
+        -- Start: the org in question
+        SELECT o.workos_organization_id, o.email_domain, o.name,
+               o.subscription_status, o.subscription_canceled_at,
+               o.membership_tier, 1 as depth,
+               ARRAY[o.email_domain] as visited
+        FROM organizations o
+        WHERE o.workos_organization_id = $1
+
+        UNION ALL
+
+        -- Walk up: join through discovered_brands.house_domain
+        SELECT parent_o.workos_organization_id, parent_o.email_domain, parent_o.name,
+               parent_o.subscription_status, parent_o.subscription_canceled_at,
+               parent_o.membership_tier, oc.depth + 1,
+               oc.visited || parent_o.email_domain
+        FROM org_chain oc
+        JOIN discovered_brands db ON db.domain = oc.email_domain
+        JOIN organizations parent_o ON parent_o.email_domain = db.house_domain
+        WHERE db.house_domain IS NOT NULL
+          AND oc.depth < 5
+          AND (db.brand_manifest->'classification'->>'confidence' = 'high'
+               OR db.source_type = 'brand_json')
+          AND parent_o.email_domain != ALL(oc.visited)
+      )
+      SELECT workos_organization_id, email_domain, name,
+             subscription_status, subscription_canceled_at,
+             membership_tier, depth
+      FROM org_chain
+      ORDER BY depth ASC
+    `, [orgId]);
+
+    const rows = result.rows;
+
+    if (rows.length === 0) {
+      const noResult: EffectiveMembership = {
+        is_member: false,
+        is_inherited: false,
+        paying_org_id: null,
+        paying_org_name: null,
+        hierarchy_chain: [],
+        membership_tier: null,
+      };
+      membershipCache.set(orgId, { result: noResult, expires_at: Date.now() + CACHE_TTL_MS });
+      return noResult;
+    }
+
+    // Check the org itself first (depth 1)
+    const self = rows[0];
+    if (self.subscription_status === 'active' && !self.subscription_canceled_at) {
+      const directResult: EffectiveMembership = {
+        is_member: true,
+        is_inherited: false,
+        paying_org_id: self.workos_organization_id,
+        paying_org_name: self.name,
+        hierarchy_chain: [self.email_domain].filter(Boolean) as string[],
+        membership_tier: self.membership_tier,
+      };
+      membershipCache.set(orgId, { result: directResult, expires_at: Date.now() + CACHE_TTL_MS });
+      return directResult;
+    }
+
+    // Check ancestors (depth > 1) for paying member
+    for (const row of rows.slice(1)) {
+      if (row.subscription_status === 'active' && !row.subscription_canceled_at) {
+        const chain = rows
+          .filter(r => r.depth <= row.depth)
+          .map(r => r.email_domain)
+          .filter(Boolean) as string[];
+
+        const inheritedResult: EffectiveMembership = {
+          is_member: true,
+          is_inherited: true,
+          paying_org_id: row.workos_organization_id,
+          paying_org_name: row.name,
+          hierarchy_chain: chain,
+          membership_tier: row.membership_tier,
+        };
+        membershipCache.set(orgId, { result: inheritedResult, expires_at: Date.now() + CACHE_TTL_MS });
+        return inheritedResult;
+      }
+    }
+
+    // No paying member in chain
+    const noMemberResult: EffectiveMembership = {
+      is_member: false,
+      is_inherited: false,
+      paying_org_id: null,
+      paying_org_name: null,
+      hierarchy_chain: rows.map(r => r.email_domain).filter(Boolean) as string[],
+      membership_tier: null,
+    };
+    membershipCache.set(orgId, { result: noMemberResult, expires_at: Date.now() + CACHE_TTL_MS });
+    return noMemberResult;
+  } catch (error) {
+    logger.error({ err: error, orgId }, 'Failed to resolve effective membership');
+    return {
+      is_member: false,
+      is_inherited: false,
+      paying_org_id: null,
+      paying_org_name: null,
+      hierarchy_chain: [],
+      membership_tier: null,
+    };
+  }
+}
+
+/** Clear the membership cache for a specific org (e.g., after subscription change) */
+export function invalidateMembershipCache(orgId?: string): void {
+  if (orgId) {
+    membershipCache.delete(orgId);
+  } else {
+    membershipCache.clear();
+  }
 }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -53,6 +53,7 @@ import { createMoltbookAdminRouter } from "./routes/moltbook-admin.js";
 import { createAddieChatRouter } from "./routes/addie-chat.js";
 import { createSiChatRoutes } from "./routes/si-chat.js";
 import { sendAccountLinkedMessage, invalidateMemberContextCache, isAddieBoltReady } from "./addie/index.js";
+import { invalidateMembershipCache } from "./db/org-filters.js";
 import { isWebUserAAOAdmin } from "./addie/mcp/admin-tools.js";
 import { createSlackRouter } from "./routes/slack.js";
 import { createWebhooksRouter } from "./routes/webhooks.js";
@@ -3340,6 +3341,7 @@ export class HTTPServer {
                 // Invalidate member context cache for all users in this org
                 // (subscription status affects is_member and subscription fields)
                 invalidateMemberContextCache();
+                invalidateMembershipCache(org.workos_organization_id);
 
                 // Send Slack notification for subscription cancellation
                 if (event.type === 'customer.subscription.deleted') {
@@ -3546,6 +3548,7 @@ export class HTTPServer {
 
                 // Invalidate member context cache
                 invalidateMemberContextCache();
+                invalidateMembershipCache(org.workos_organization_id);
               }
 
               // Record revenue event

--- a/server/src/routes/admin/brand-enrichment.ts
+++ b/server/src/routes/admin/brand-enrichment.ts
@@ -9,6 +9,7 @@ import { Router } from 'express';
 import { createLogger } from '../../logger.js';
 import { requireAuth, requireAdmin } from '../../middleware/auth.js';
 import { isBrandfetchConfigured } from '../../services/brandfetch.js';
+import { query } from '../../db/client.js';
 import {
   enrichBrand,
   enrichBrands,
@@ -16,6 +17,7 @@ import {
   getEnrichmentCandidates,
   getBrandEnrichmentStats,
   migrateLogosToHosted,
+  researchDomain,
 } from '../../services/brand-enrichment.js';
 
 const logger = createLogger('admin-brand-enrichment');
@@ -218,6 +220,174 @@ export function setupBrandEnrichmentRoutes(apiRouter: Router): void {
           error: 'House expansion failed',
           message,
         });
+      }
+    }
+  );
+
+  // GET /api/admin/brand-enrichment/org-mapping-stats
+  // How many orgs are mapped to the brand registry vs unmapped
+  apiRouter.get(
+    '/brand-enrichment/org-mapping-stats',
+    requireAuth,
+    requireAdmin,
+    async (_req, res) => {
+      try {
+        const result = await query<{
+          total_with_domain: string;
+          mapped: string;
+          unmapped: string;
+        }>(
+          `SELECT
+            COUNT(*) FILTER (WHERE o.email_domain IS NOT NULL) as total_with_domain,
+            COUNT(*) FILTER (WHERE db.domain IS NOT NULL) as mapped,
+            COUNT(*) FILTER (WHERE o.email_domain IS NOT NULL AND db.domain IS NULL) as unmapped
+          FROM organizations o
+          LEFT JOIN discovered_brands db ON db.domain = o.email_domain
+          WHERE o.is_personal = false`
+        );
+        const row = result.rows[0];
+        res.json({
+          total_with_domain: parseInt(row.total_with_domain) || 0,
+          mapped: parseInt(row.mapped) || 0,
+          unmapped: parseInt(row.unmapped) || 0,
+        });
+      } catch (error) {
+        logger.error({ err: error }, 'Error fetching org mapping stats');
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  );
+
+  // GET /api/admin/brand-enrichment/unmapped-orgs
+  // Organizations with a domain not in discovered_brands
+  apiRouter.get(
+    '/brand-enrichment/unmapped-orgs',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const rawLimit = parseInt(req.query.limit as string, 10);
+        const limit = Number.isFinite(rawLimit) ? Math.min(rawLimit, 100) : 50;
+
+        const result = await query<{
+          workos_organization_id: string;
+          name: string;
+          email_domain: string;
+          subscription_status: string | null;
+          prospect_status: string | null;
+        }>(
+          `SELECT o.workos_organization_id, o.name, o.email_domain,
+                  o.subscription_status, o.prospect_status
+           FROM organizations o
+           LEFT JOIN discovered_brands db ON db.domain = o.email_domain
+           WHERE o.is_personal = false
+             AND o.email_domain IS NOT NULL
+             AND db.domain IS NULL
+           ORDER BY o.subscription_status = 'active' DESC,
+                    o.last_activity_at DESC NULLS LAST,
+                    o.created_at DESC
+           LIMIT $1`,
+          [limit]
+        );
+
+        res.json({ orgs: result.rows, count: result.rows.length });
+      } catch (error) {
+        logger.error({ err: error }, 'Error fetching unmapped orgs');
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  );
+
+  // POST /api/admin/brand-enrichment/backfill
+  // Research unmapped orgs sequentially
+  apiRouter.post(
+    '/brand-enrichment/backfill',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const rawLimit = typeof req.body.limit === 'number' ? req.body.limit : 10;
+        const limit = Math.min(Math.max(1, Math.floor(rawLimit)), 25);
+
+        const unmapped = await query<{
+          workos_organization_id: string;
+          name: string;
+          email_domain: string;
+        }>(
+          `SELECT o.workos_organization_id, o.name, o.email_domain
+           FROM organizations o
+           LEFT JOIN discovered_brands db ON db.domain = o.email_domain
+           WHERE o.is_personal = false
+             AND o.email_domain IS NOT NULL
+             AND db.domain IS NULL
+           ORDER BY o.subscription_status = 'active' DESC,
+                    o.last_activity_at DESC NULLS LAST
+           LIMIT $1`,
+          [limit]
+        );
+
+        logger.info({ count: unmapped.rows.length, limit }, 'Starting backfill research');
+
+        const results: Array<{ domain: string; name: string; status: string }> = [];
+        for (const org of unmapped.rows) {
+          try {
+            const research = await researchDomain(org.email_domain, {
+              org_id: org.workos_organization_id,
+            });
+            const fetched = research.actions.some(a => a.action === 'fetched');
+            results.push({
+              domain: org.email_domain,
+              name: org.name,
+              status: fetched ? 'researched' : 'skipped',
+            });
+          } catch (err) {
+            logger.warn({ err, domain: org.email_domain }, 'Backfill research failed');
+            results.push({ domain: org.email_domain, name: org.name, status: 'failed' });
+          }
+          // Delay between calls
+          await new Promise(resolve => setTimeout(resolve, 1500));
+        }
+
+        const researched = results.filter(r => r.status === 'researched').length;
+        logger.info({ total: results.length, researched }, 'Backfill complete');
+        res.json({ total: results.length, researched, results });
+      } catch (error) {
+        logger.error({ err: error }, 'Error running backfill');
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  );
+
+  // POST /api/admin/brand-enrichment/research/:domain
+  // Progressive enrichment: checks what's known, fills gaps from Brandfetch + Sonnet + Lusha
+  apiRouter.post(
+    '/brand-enrichment/research/:domain',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const { domain } = req.params;
+        if (!domain || !/^[a-z0-9.-]+\.[a-z]{2,}$/i.test(domain)) {
+          return res.status(400).json({ error: 'Invalid domain format' });
+        }
+
+        const options: {
+          skip_brandfetch?: boolean;
+          skip_lusha?: boolean;
+          org_id?: string;
+        } = {};
+
+        if (req.body.skip_brandfetch === true) options.skip_brandfetch = true;
+        if (req.body.skip_lusha === true) options.skip_lusha = true;
+        if (typeof req.body.org_id === 'string') options.org_id = req.body.org_id;
+
+        logger.info({ domain, options }, 'Starting domain research');
+        const result = await researchDomain(domain, options);
+        res.json(result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        logger.error({ err: error }, 'Error researching domain');
+        res.status(500).json({ error: 'Domain research failed', message });
       }
     }
   );

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -40,9 +40,11 @@ export function setupOrganizationRoutes(
           SELECT
             o.*,
             p.name as parent_name,
-            (SELECT COUNT(*) FROM organizations WHERE parent_organization_id = o.workos_organization_id) as subsidiary_count
+            p.email_domain as parent_domain,
+            (SELECT COUNT(*) FROM organizations child JOIN discovered_brands db_child ON child.email_domain = db_child.domain WHERE db_child.house_domain = o.email_domain) as subsidiary_count
           FROM organizations o
-          LEFT JOIN organizations p ON o.parent_organization_id = p.workos_organization_id
+          LEFT JOIN discovered_brands db_parent ON o.email_domain = db_parent.domain
+          LEFT JOIN organizations p ON db_parent.house_domain = p.email_domain
           WHERE o.workos_organization_id = $1
         `,
           [orgId]

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -26,6 +26,7 @@ import {
   type PendingInvoice,
 } from "../billing/stripe-client.js";
 import { OrganizationDatabase } from "../db/organization-db.js";
+import { invalidateMembershipCache } from "../db/org-filters.js";
 
 const logger = createLogger("billing-routes");
 
@@ -757,6 +758,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
                 ]
               );
               subscriptionSynced = true;
+              invalidateMembershipCache(org_id);
             }
           }
         } catch (syncError) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -29,6 +29,7 @@ import {
   PublisherPropertySelectorSchema,
   PropertyIdentifierSchema,
   ErrorSchema,
+  FindCompanyResultSchema,
 } from "../schemas/registry.js";
 
 import type { BrandManager } from "../brand-manager.js";
@@ -807,6 +808,22 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     } catch (error) {
       logger.error({ error }, "Failed to list brands");
       return res.status(500).json({ error: "Failed to list brands" });
+    }
+  });
+
+  router.get("/brands/find", async (req, res) => {
+    try {
+      const q = (req.query.q as string | undefined)?.trim();
+      if (!q || q.length < 2) {
+        return res.status(400).json({ error: "q parameter required (min 2 characters)" });
+      }
+      const rawLimit = parseInt(req.query.limit as string, 10);
+      const limit = Number.isFinite(rawLimit) ? Math.min(rawLimit, 50) : 10;
+      const results = await brandDb.findCompany(q, { limit });
+      return res.json({ results });
+    } catch (error) {
+      logger.error({ error }, "Failed to find company");
+      return res.status(500).json({ error: "Failed to find company" });
     }
   });
 

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -25,6 +25,7 @@ import { getPool } from '../db/client.js';
 import { workos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { tryAutoLinkWebsiteUserToSlack } from '../slack/sync.js';
+import { researchDomain } from '../services/brand-enrichment.js';
 
 const logger = createLogger('workos-webhooks');
 
@@ -732,7 +733,18 @@ export function createWorkOSWebhooksRouter(): Router {
             break;
           }
 
-          case 'organization.created':
+          case 'organization.created': {
+            const newOrg = event.data as unknown as OrganizationData;
+            await syncOrganizationDomains(newOrg);
+            // Auto-research the primary domain for brand registry coverage
+            const primaryDomain = newOrg.domains.length > 0 ? newOrg.domains[0].domain : null;
+            if (primaryDomain) {
+              researchDomain(primaryDomain, { org_id: newOrg.id }).catch(err => {
+                logger.warn({ err, orgId: newOrg.id, domain: primaryDomain }, 'Background research failed for new org');
+              });
+            }
+            break;
+          }
           case 'organization.updated': {
             const org = event.data as unknown as OrganizationData;
             await syncOrganizationDomains(org);

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -131,6 +131,27 @@ export const ResolvedBrandSchema = z
   })
   .openapi("ResolvedBrand");
 
+export const CompanySearchResultSchema = z
+  .object({
+    domain: z.string().openapi({ example: "coca-cola.com" }),
+    canonical_domain: z.string().openapi({ example: "coca-cola.com" }),
+    brand_name: z.string().openapi({ example: "The Coca-Cola Company" }),
+    house_domain: z.string().optional().openapi({ example: "coca-cola.com" }),
+    keller_type: z
+      .enum(["master", "sub_brand", "endorsed", "independent"])
+      .optional(),
+    parent_brand: z.string().optional(),
+    brand_agent_url: z.string().optional(),
+    source: z.string().openapi({ example: "community" }),
+  })
+  .openapi("CompanySearchResult");
+
+export const FindCompanyResultSchema = z
+  .object({
+    results: z.array(CompanySearchResultSchema),
+  })
+  .openapi("FindCompanyResult");
+
 export const ResolvedPropertySchema = z
   .object({
     publisher_domain: z.string().openapi({ example: "examplepub.com" }),


### PR DESCRIPTION
## Summary

- **Brand registry lookup**: `GET /api/brands/find?q=` for fuzzy company search by name/domain, with `findCompany()` in brand-db using trigram + ILIKE search
- **Unified enrichment**: `researchDomain()` progressively enriches a domain — checks existing data freshness, fills gaps via Brandfetch + Sonnet + Lusha, with concurrency guard (in-memory Set) and rate limiter (50/hr)
- **Auto-enrich on org creation**: Replaces standalone `enrichOrganization()` with `researchDomain()` in prospect creation and WorkOS `organization.created` webhook
- **Admin backfill visibility**: Brand registry mapping stats, unmapped orgs table, and per-org research buttons on domain discovery page
- **Membership inheritance**: `resolveEffectiveMembership()` uses a recursive CTE to walk the `house_domain` chain (max 5 hops, high-confidence classifications only), with 5-minute TTL cache. Surfaces inherited membership in member context, admin account detail, and Addie
- **Cache invalidation**: `invalidateMembershipCache()` wired to Stripe webhook subscription events and billing link endpoint
- **Schema cleanup**: Drops `parent_organization_id` column (migration 251) in favor of brand registry hierarchy

## Test plan

- [x] TypeScript compiles cleanly (`npm run typecheck`)
- [x] All 304 tests pass (`npm test`)
- [x] Pre-commit hooks pass (schemas, examples, migrations, OpenAPI, docs)
- [x] `/api/brands/find?q=test` returns results (empty for fresh DB, correct format)
- [x] `/api/brands/find?q=a` returns 400 (min 2 characters)
- [x] Admin domain discovery page renders with mapping stats section (verified via Playwright)
- [x] Admin account detail page renders cleanly (verified via Playwright)
- [x] Docker build + migrations run successfully (migration 251 applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/agenticadvertisingorg/agenticadvertisingorg/editor/bokelley%2Fbrand-registry-lookup?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->