### PR TITLE
fix(docs): correct sync_audiences schema links to v1

### DIFF
--- a/.changeset/fix-sync-audiences-schema-links.md
+++ b/.changeset/fix-sync-audiences-schema-links.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix broken schema links in sync_audiences documentation. Changed from `/schemas/v2/` to `/schemas/v1/` since this task was added after the v2.5.x and v3.0.0-beta releases and its schemas only exist in `latest` (which v1 points to).

--- a/docs/media-buy/task-reference/sync_audiences.mdx
+++ b/docs/media-buy/task-reference/sync_audiences.mdx
@@ -10,8 +10,8 @@ Audiences are distinct from [signals](/docs/signals/): signals are third-party d
 
 **Response Time**: Upload accepted in ~1–2s. The task remains active until matching completes (1–48 hours depending on the seller). Configure `push_notification_config` to receive a webhook when the audience is ready.
 
-**Request Schema**: [`/schemas/v2/media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/v2/media-buy/sync-audiences-request.json)
-**Response Schema**: [`/schemas/v2/media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/v2/media-buy/sync-audiences-response.json)
+**Request Schema**: [`/schemas/v1/media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/v1/media-buy/sync-audiences-request.json)
+**Response Schema**: [`/schemas/v1/media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/v1/media-buy/sync-audiences-response.json)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Fixed broken schema links in `sync_audiences` documentation that were pointing to `/schemas/v2/` (which doesn't contain these schemas)
- Changed links to `/schemas/v1/` which points to `latest` where the schemas exist
- Added a note explaining the schema versioning situation

## Context

The `sync_audiences` task was added after the v2.5.x and v3.0.0-beta releases, so its schemas only exist in `latest`. The version aliases work as follows:

- `v1` → `latest` (development version)
- `v2` → `2.5.3` (doesn't have sync_audiences)
- `v3` → `3.0.0-beta.3` (doesn't have sync_audiences yet)

## Test plan

- [ ] Verify links work: https://adcontextprotocol.org/schemas/v1/media-buy/sync-audiences-request.json
- [ ] Verify links work: https://adcontextprotocol.org/schemas/v1/media-buy/sync-audiences-response.json

Made with [Cursor](https://cursor.com)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/agenticadvertisingorg/agenticadvertisingorg/editor/fix%2Fsync-audiences-schema-links?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->