### PR TITLE
Show community-hosted brand.json URL on brand pages

### DIFF
--- a/.changeset/show-brand-json-url.md
+++ b/.changeset/show-brand-json-url.md
@@ -1,0 +1,4 @@
+---
+---
+
+Show community-hosted brand.json URL on brand listing and viewer pages.

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -1825,6 +1825,14 @@
                 <div class="community-info-value"><a href="https://${escapeAttr(domain)}" target="_blank" style="color: var(--color-brand); text-decoration: none;">${escapeHtml(domain)}</a></div>
               </div>`;
 
+            // Community-hosted brand.json URL
+            const hostedBrandJsonUrl = `https://agenticadvertising.org/brands/${encodeURIComponent(domain)}/brand.json`;
+            gridHtml += `
+              <div class="community-info-item">
+                <div class="community-info-label">Community brand.json</div>
+                <div class="community-info-value"><a href="${escapeAttr(hostedBrandJsonUrl)}" target="_blank" style="color: var(--color-brand); text-decoration: none; word-break: break-all;">${escapeHtml(hostedBrandJsonUrl)}</a></div>
+              </div>`;
+
             if (brandInfo.source_type) {
               gridHtml += `
                 <div class="community-info-item">

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -580,6 +580,10 @@
                 if (brand.house_domain) {
                     metaParts.push(`<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F3E0;</span> ${escapeHtml(brand.house_domain)}</span>`);
                 }
+                if (brand.domain && (brand.source === 'community' || brand.source === 'enriched')) {
+                    const brandJsonUrl = `https://agenticadvertising.org/brands/${encodeURIComponent(brand.domain)}/brand.json`;
+                    metaParts.push(`<a class="brand-card__meta-item" href="${escapeAttr(brandJsonUrl)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" style="color: var(--color-brand); text-decoration: none;" title="View community brand.json"><span class="brand-card__meta-icon">{}</span> brand.json</a>`);
+                }
 
                 const metaHtml = metaParts.length > 0
                     ? `<div class="brand-card__meta">${metaParts.join('')}</div>`
@@ -624,6 +628,11 @@
             const div = document.createElement('div');
             div.textContent = str;
             return div.innerHTML;
+        }
+
+        function escapeAttr(str) {
+            if (!str) return '';
+            return escapeHtml(String(str)).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary

- **Brand listing page** (`brands.html`): Adds a `{} brand.json` link in the meta row of community/enriched brand cards, linking directly to `https://agenticadvertising.org/brands/{domain}/brand.json`
- **Brand viewer page** (`brand-viewer.html`): Adds a "Community brand.json" field in the info grid when viewing a community-contributed brand, showing the full URL as a clickable link

## Motivation

Users browsing the brand registry couldn't find the community-hosted brand.json URL from the UI. The URL pattern (`agenticadvertising.org/brands/{domain}/brand.json`) wasn't surfaced anywhere on either the listing or detail pages.

## Test plan

- [ ] Visit `/brands` — community and enriched brand cards show a `{} brand.json` link in the meta row
- [ ] Click a brand.json link — opens JSON in a new tab
- [ ] Visit `/brand/view/celtra.com` — "Community brand.json" appears in the info grid with the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)