### PR TITLE
feat(schema): add geo_proximity targeting

### DIFF
--- a/.changeset/geo-proximity-targeting.md
+++ b/.changeset/geo-proximity-targeting.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `geo_proximity` targeting for arbitrary-location proximity targeting. Three methods: travel time isochrones (e.g., "within 2hr drive of Düsseldorf"), simple radius (e.g., "within 30km of Heathrow"), and pre-computed GeoJSON geometry (buyer provides the polygon). Structured capability declaration in `get_adcp_capabilities` allows sellers to declare supported methods and transport modes independently.

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -351,6 +351,8 @@ Inclusion targeting works the same way for cases where you want to specify exact
 | Third-party audience segment (interest targeting) | | ✅ "Auto intenders" in brief, or use signals protocol |
 | Search/retail media keyword targeting | ✅ `keyword_targets` / `negative_keywords` | |
 | Broad thematic intent ("people searching for shoes") | | ✅ "Reach in-market shoe shoppers" |
+| Proximity to specific coordinates (within 2hr drive of a city) | ✅ `geo_proximity` | |
+| Nearby audience ("people near coffee shops") | | ✅ "Reach people near coffee shops" |
 
 **Why briefs work better for preferences:**
 - Natural language captures intent more clearly
@@ -560,6 +562,119 @@ Geographic targeting supports both inclusion (restrict to) and exclusion (exclud
 ```
 
 When `store_ids` is omitted, all stores in the catalog are targeted. When `catchment_ids` is omitted, all catchment zones are targeted. The seller must declare support for store catchment targeting in `get_adcp_capabilities`.
+
+### geo_proximity
+- **Description**: Target users within travel time, distance, or a custom boundary around arbitrary geographic points
+- **Format**: Array of objects, each with exactly one method: `travel_time` + `transport_mode`, `radius`, or `geometry`
+- **Required fields**: `lat` + `lng` (for travel_time and radius methods), or `geometry` (for pre-computed boundaries)
+- **Optional fields**: `label` (human-readable name for the entry)
+- **Use cases**: Tourism campaigns (within 2hr drive of a city), event targeting (near a venue), airport catchment areas
+- **Semantics**: Multiple entries use OR — a user within range of any listed point is eligible. Intersects with other geo targeting fields (e.g., combining with `geo_countries` restricts proximity to those countries)
+
+Travel time (isochrone) example:
+
+```json
+{
+  "targeting_overlay": {
+    "geo_proximity": [
+      {
+        "lat": 51.2277,
+        "lng": 6.7735,
+        "label": "Düsseldorf",
+        "travel_time": { "value": 2, "unit": "hr" },
+        "transport_mode": "driving"
+      }
+    ]
+  }
+}
+```
+
+Radius-based example:
+
+```json
+{
+  "targeting_overlay": {
+    "geo_proximity": [
+      {
+        "lat": 51.4700,
+        "lng": -0.4543,
+        "label": "Heathrow Airport",
+        "radius": { "value": 30, "unit": "km" }
+      }
+    ]
+  }
+}
+```
+
+Pre-computed geometry example (buyer provides the polygon):
+
+```json
+{
+  "targeting_overlay": {
+    "geo_proximity": [
+      {
+        "label": "2hr drive from Düsseldorf",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [[[5.87, 50.35], [8.23, 50.35], [8.23, 52.10], [5.87, 52.10], [5.87, 50.35]]]
+        }
+      }
+    ]
+  }
+}
+```
+
+For travel time entries, the platform resolves the isochrone to a geographic boundary based on actual transportation networks. Transport modes: `driving`, `walking`, `cycling`, `public_transport`. The `geometry` method allows buyers who have already computed isochrones (via TravelTime, Mapbox, etc.) to pass the polygon directly — this also enables sellers without routing engines to participate.
+
+For campaigns targeting 10+ locations, consider using `store_catchments` with a location catalog instead, which supports ongoing management and per-location reporting. `geo_proximity` does not have an exclusion variant — this is by design, as excluding "everyone near a point" is rarely a meaningful targeting constraint.
+
+Sellers SHOULD enforce minimum area thresholds consistent with their privacy policies and applicable regulations. The seller must declare `geo_proximity` support in `get_adcp_capabilities`, specifying which methods (`radius`, `travel_time`, `geometry`) and transport modes are supported.
+
+Validated examples:
+
+```json
+{
+  "$schema": "/schemas/core/targeting.json",
+  "geo_proximity": [
+    {
+      "lat": 51.2277,
+      "lng": 6.7735,
+      "label": "Düsseldorf",
+      "travel_time": { "value": 2, "unit": "hr" },
+      "transport_mode": "driving"
+    }
+  ]
+}
+```
+
+```json
+{
+  "$schema": "/schemas/core/targeting.json",
+  "geo_proximity": [
+    {
+      "lat": 51.4700,
+      "lng": -0.4543,
+      "label": "Heathrow Airport",
+      "radius": { "value": 30, "unit": "km" }
+    }
+  ]
+}
+```
+
+```json
+{
+  "$schema": "/schemas/core/targeting.json",
+  "geo_proximity": [
+    {
+      "label": "2hr drive from Düsseldorf",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[5.87, 50.35], [8.23, 50.35], [8.23, 52.10], [5.87, 52.10], [5.87, 50.35]]]
+      }
+    }
+  ]
+}
+```
 
 ## Benefits for Different Stakeholders
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -126,8 +126,18 @@ Technical execution capabilities:
 | `geo_metros` | object | Metro area targeting with system-specific support |
 | `geo_postal_areas` | object | Postal area targeting with country and precision support |
 | `device_type` | boolean | Device form factor targeting (desktop, mobile, tablet, ctv, dooh) |
+| `geo_proximity` | object | Proximity targeting from arbitrary coordinates (see below) |
 
 Sellers that support a geographic targeting level SHOULD support both inclusion and exclusion at that level. For example, `geo_metros.nielsen_dma: true` SHOULD mean the seller supports both `geo_metros` and `geo_metros_exclude` with Nielsen DMA codes. If a seller only supports one direction (e.g., inclusion but not exclusion), it MUST return a validation error for unsupported fields rather than silently ignoring them. See [Targeting Overlays](/docs/media-buy/advanced-topics/targeting) for exclusion semantics.
+
+**geo_proximity** specifies which proximity targeting methods are supported:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `radius` | boolean | Simple radius targeting (distance circle from a point) |
+| `travel_time` | boolean | Travel time isochrone targeting (requires a routing engine) |
+| `geometry` | boolean | Pre-computed GeoJSON geometry (buyer provides the polygon) |
+| `transport_modes` | string[] | Transport modes supported for isochrones: `driving`, `walking`, `cycling`, `public_transport` |
 
 **geo_metros** specifies which metro classification systems are supported:
 

--- a/static/schemas/source/core/catchment.json
+++ b/static/schemas/source/core/catchment.json
@@ -62,6 +62,7 @@
           "description": "GeoJSON geometry type."
         },
         "coordinates": {
+          "type": "array",
           "description": "GeoJSON coordinates array. For Polygon: array of linear rings. For MultiPolygon: array of polygons."
         }
       },

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/targeting.json",
   "title": "Targeting Overlay",
-  "description": "Optional restriction overlays for media buys. Most targeting should be expressed in the brief and handled by the publisher. These fields are for functional restrictions: geographic (RCT testing, regulatory compliance), age verification (alcohol, gambling), device platform (app compatibility), language (localization), and keyword targeting (search/retail media).",
+  "description": "Optional restriction overlays for media buys. Most targeting should be expressed in the brief and handled by the publisher. These fields are for functional restrictions: geographic (RCT testing, regulatory compliance, proximity targeting), age verification (alcohol, gambling), device platform (app compatibility), language (localization), and keyword targeting (search/retail media).",
   "type": "object",
   "properties": {
     "geo_countries": {
@@ -255,6 +255,121 @@
           }
         },
         "required": ["catalog_id"],
+        "additionalProperties": true
+      },
+      "minItems": 1
+    },
+    "geo_proximity": {
+      "type": "array",
+      "description": "Target users within travel time, distance, or a custom boundary around arbitrary geographic points. Multiple entries use OR semantics — a user within range of any listed point is eligible. For campaigns targeting 10+ locations, consider using store_catchments with a location catalog instead. Seller must declare support in get_adcp_capabilities.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "lat": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "Latitude in decimal degrees (WGS 84). Required for travel_time and radius methods."
+          },
+          "lng": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "Longitude in decimal degrees (WGS 84). Required for travel_time and radius methods."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for this entry (e.g., 'Düsseldorf', 'Heathrow Airport', 'Primary trade area')."
+          },
+          "travel_time": {
+            "type": "object",
+            "description": "Travel time limit for isochrone calculation. The platform resolves this to a geographic boundary based on actual transportation networks.",
+            "properties": {
+              "value": {
+                "type": "number",
+                "minimum": 1,
+                "description": "Travel time limit."
+              },
+              "unit": {
+                "type": "string",
+                "enum": ["min", "hr"],
+                "description": "Time unit."
+              }
+            },
+            "required": ["value", "unit"],
+            "additionalProperties": false
+          },
+          "transport_mode": {
+            "$ref": "/schemas/enums/transport-mode.json",
+            "description": "Transportation mode for isochrone calculation. Required when travel_time is provided."
+          },
+          "radius": {
+            "type": "object",
+            "description": "Simple radius from the point. The platform draws a circle of this distance around the coordinates.",
+            "properties": {
+              "value": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Radius distance."
+              },
+              "unit": {
+                "$ref": "/schemas/enums/distance-unit.json",
+                "description": "Distance unit."
+              }
+            },
+            "required": ["value", "unit"],
+            "additionalProperties": false
+          },
+          "geometry": {
+            "type": "object",
+            "description": "Pre-computed GeoJSON geometry defining the proximity boundary. Use when the buyer has already calculated isochrones (via TravelTime, Mapbox, etc.) or has custom boundaries. When geometry is provided, lat/lng are not required.",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["Polygon", "MultiPolygon"],
+                "description": "GeoJSON geometry type."
+              },
+              "coordinates": {
+                "type": "array",
+                "description": "GeoJSON coordinates array. For Polygon: array of linear rings. For MultiPolygon: array of polygons."
+              }
+            },
+            "required": ["type", "coordinates"],
+            "additionalProperties": false
+          },
+          "ext": {
+            "$ref": "/schemas/core/ext.json"
+          }
+        },
+        "oneOf": [
+          {
+            "required": ["lat", "lng", "travel_time", "transport_mode"],
+            "not": {
+              "anyOf": [
+                { "required": ["radius"] },
+                { "required": ["geometry"] }
+              ]
+            }
+          },
+          {
+            "required": ["lat", "lng", "radius"],
+            "not": {
+              "anyOf": [
+                { "required": ["travel_time"] },
+                { "required": ["geometry"] }
+              ]
+            }
+          },
+          {
+            "required": ["geometry"],
+            "not": {
+              "anyOf": [
+                { "required": ["travel_time"] },
+                { "required": ["radius"] }
+              ]
+            }
+          }
+        ],
         "additionalProperties": true
       },
       "minItems": 1

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -257,6 +257,32 @@
                 "negative_keywords": {
                   "type": "boolean",
                   "description": "Whether seller supports negative keyword targeting via targeting_overlay.negative_keywords and negative_keywords_add/remove in update_media_buy"
+                },
+                "geo_proximity": {
+                  "type": "object",
+                  "description": "Proximity targeting capabilities from arbitrary coordinates via targeting_overlay.geo_proximity.",
+                  "properties": {
+                    "radius": {
+                      "type": "boolean",
+                      "description": "Whether seller supports simple radius targeting (distance circle from a point)"
+                    },
+                    "travel_time": {
+                      "type": "boolean",
+                      "description": "Whether seller supports travel time isochrone targeting (requires a routing engine)"
+                    },
+                    "geometry": {
+                      "type": "boolean",
+                      "description": "Whether seller supports pre-computed GeoJSON geometry (buyer provides the polygon)"
+                    },
+                    "transport_modes": {
+                      "type": "array",
+                      "description": "Transport modes supported for travel_time isochrones. Only relevant when travel_time is true.",
+                      "items": {
+                        "$ref": "/schemas/enums/transport-mode.json"
+                      },
+                      "minItems": 1
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary

- Add `geo_proximity` targeting overlay for point-based proximity targeting from arbitrary coordinates
- Three methods: travel time isochrones (e.g., "within 2hr drive of Düsseldorf"), simple radius (e.g., "within 30km of Heathrow"), and pre-computed GeoJSON geometry (buyer provides the polygon)
- Structured capability declaration in `get_adcp_capabilities` — sellers declare supported methods (`radius`, `travel_time`, `geometry`) and transport modes independently
- Fills the gap between postal code targeting and store-catalog-based catchments for tourism, events, and airport catchment use cases

**Motivation**: Dubai Tourism wants to target "people within 2hr drive of Düsseldorf." Today this requires store_catchments with a fake catalog entry. geo_proximity lets the brand agent geocode the city, express the isochrone directly, and query publishers for support — no catalog infrastructure needed.

### Files changed

| File | Change |
|------|--------|
| `static/schemas/source/core/targeting.json` | New `geo_proximity` field with oneOf constraint for three methods |
| `static/schemas/source/protocol/get-adcp-capabilities-response.json` | Structured capability object (radius, travel_time, geometry, transport_modes) |
| `static/schemas/source/core/catchment.json` | Add `type: array` to `geometry.coordinates` for basic validation |
| `docs/media-buy/advanced-topics/targeting.mdx` | Documentation, examples (including $schema-validated), decision table |
| `docs/protocol/get_adcp_capabilities.mdx` | Capability table entry |
| `.changeset/geo-proximity-targeting.md` | Minor semver bump |

## Test plan

- [x] `npm run build` — schemas compile
- [x] `npm test` — 304 tests pass, 140 schema-validated examples (3 new)
- [x] `npm run typecheck` — clean
- [x] Pre-commit hook (full test suite) passes
- [x] Push hook (version sync, broken links, accessibility) passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)