### PR TITLE
feat(schema): add AI provenance and disclosure metadata

### DIFF
--- a/.changeset/provenance-schema.md
+++ b/.changeset/provenance-schema.md
@@ -1,0 +1,24 @@
+---
+"adcontextprotocol": minor
+---
+
+Add AI provenance and disclosure schema for creatives and artifacts.
+
+New schemas:
+- `digital-source-type` enum — IPTC-aligned classification of AI involvement (with `enumDescriptions`)
+- `provenance` core object — declares how content was produced, C2PA references, disclosure requirements, and verification results
+
+Key design decisions:
+- `verification` is an array (multiple services can independently evaluate content)
+- `declared_by` identifies who attached the provenance claim, enabling trust assessment
+- Provenance is a claim — the enforcing party should verify independently
+- Inheritance uses full-object replacement (no field-level merging)
+- IPTC vocabulary uses current values (`digital_creation`, `human_edits`)
+
+Optional `provenance` field added to:
+- `creative-manifest` (default for all assets in the manifest)
+- `creative-asset` (default for the creative in the library)
+- `artifact` (top-level and per inline asset type)
+- All 11 typed asset schemas (image, video, audio, text, html, css, javascript, vast, daast, url, webhook)
+
+Optional `provenance_required` field added to `creative-policy`.

--- a/docs.json
+++ b/docs.json
@@ -159,7 +159,8 @@
                 "group": "Creative Governance",
                 "pages": [
                   "docs/governance/creative/index",
-                  "docs/governance/creative/get_creative_features"
+                  "docs/governance/creative/get_creative_features",
+                  "docs/governance/creative/provenance-verification"
                 ]
               }
             ]
@@ -316,6 +317,7 @@
               "docs/creative/template-format-ids",
               "docs/creative/catalogs",
               "docs/creative/accessibility",
+              "docs/creative/provenance",
               {
                 "group": "Channel Guides",
                 "pages": [
@@ -663,7 +665,8 @@
                 "group": "Creative Governance",
                 "pages": [
                   "docs/governance/creative/index",
-                  "docs/governance/creative/get_creative_features"
+                  "docs/governance/creative/get_creative_features",
+                  "docs/governance/creative/provenance-verification"
                 ]
               }
             ]
@@ -820,6 +823,7 @@
               "docs/creative/template-format-ids",
               "docs/creative/catalogs",
               "docs/creative/accessibility",
+              "docs/creative/provenance",
               {
                 "group": "Channel Guides",
                 "pages": [

--- a/docs/creative/provenance.mdx
+++ b/docs/creative/provenance.mdx
@@ -1,0 +1,445 @@
+---
+title: AI provenance and disclosure
+sidebarTitle: Provenance
+---
+
+Provenance metadata declares how creative content was produced — whether AI was involved, which tools were used, and what disclosure obligations apply. As regulations like the EU AI Act and California SB 942 require machine-readable AI disclosure in advertising, AdCP carries this metadata at the protocol level so every party in the supply chain can declare, transmit, and verify it using the same structure. Provenance attaches to creative manifests, individual assets, or content-standards artifacts. It is a claim by the declaring party — receiving parties verify claims independently using their own detection tools.
+
+<Info>
+EU AI Act Article 50 enforcement begins August 2026. California SB 942 is already in effect. Major platforms mandate AI content labeling today. AdCP's provenance metadata provides the structured, machine-readable disclosure that these regulations require — carried through the programmatic supply chain where no standard for it previously existed.
+</Info>
+
+## The provenance object
+
+Provenance is an optional object that can attach to creative assets, creative manifests, individual typed assets, and content artifacts. No fields are required at the provenance level -- each section is independently useful.
+
+**Schema**: [provenance.json](https://adcontextprotocol.org/schemas/latest/core/provenance.json)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `digital_source_type` | enum | IPTC-aligned classification of AI involvement |
+| `ai_tool` | object | AI system used (`name` required, plus optional `version` and `provider`) |
+| `human_oversight` | enum | Level of human involvement in the creation process |
+| `declared_by` | object | Party attaching this provenance claim (`role` required, plus optional `agent_url`) |
+| `created_time` | string (date-time) | When the content was created (ISO 8601) |
+| `c2pa` | object | C2PA Content Credentials reference (`manifest_url` required) |
+| `disclosure` | object | Regulatory disclosure requirements and jurisdiction details |
+| `verification` | array | Third-party verification or detection results |
+| `ext` | object | Standard extension point |
+
+### Full example
+
+```json
+{
+  "$schema": "/schemas/core/provenance.json",
+  "digital_source_type": "trained_algorithmic_media",
+  "ai_tool": {
+    "name": "DALL-E 3",
+    "version": "3.0",
+    "provider": "OpenAI"
+  },
+  "human_oversight": "selected",
+  "declared_by": {
+    "agent_url": "https://creative.pinnaclemedia.example.com",
+    "role": "agency"
+  },
+  "created_time": "2026-02-15T14:30:00Z",
+  "c2pa": {
+    "manifest_url": "https://cdn.pinnaclemedia.example.com/c2pa/manifests/hero_img_abc123.c2pa"
+  },
+  "disclosure": {
+    "required": true,
+    "jurisdictions": [
+      {
+        "country": "US",
+        "region": "CA",
+        "regulation": "ca_sb_942",
+        "label_text": "Created with AI"
+      },
+      {
+        "country": "DE",
+        "regulation": "eu_ai_act_article_50",
+        "label_text": "KI-generiert"
+      }
+    ]
+  },
+  "verification": [
+    {
+      "verified_by": "Reality Defender",
+      "verified_time": "2026-02-15T15:00:00Z",
+      "result": "ai_generated",
+      "confidence": 0.97,
+      "details_url": "https://realitydefender.example.com/reports/abc123"
+    }
+  ]
+}
+```
+
+## Digital source type
+
+The `digital_source_type` enum classifies AI involvement in content production, aligned with the [IPTC digitalsourcetype vocabulary](https://cv.iptc.org/newscodes/digitalsourcetype/).
+
+**Schema**: [digital-source-type.json](https://adcontextprotocol.org/schemas/latest/enums/digital-source-type.json)
+
+| Value | Description | When to use |
+|-------|-------------|-------------|
+| `digital_capture` | Captured by a digital device (camera, scanner, screen recording) with no AI involvement | Photos from a product shoot, screen recordings of app demos |
+| `digital_creation` | Created by a human using digital tools (Photoshop, Illustrator, After Effects) without AI generation | Hand-designed banner ads, manually composed layouts |
+| `trained_algorithmic_media` | Generated entirely by a trained AI model (DALL-E, Midjourney, Stable Diffusion, Sora) | AI-generated hero images, AI-produced video spots |
+| `composite_with_trained_algorithmic_media` | Human-created content combined with AI-generated elements | Product photo with AI-generated background, human-shot video with AI visual effects |
+| `algorithmic_media` | Produced by deterministic algorithms without machine learning (procedural generation, rule-based systems) | Programmatic visualizations, procedural pattern generation |
+| `composite_capture` | Multiple digital captures composited together without AI | Panoramic stitching, multi-exposure HDR composites |
+| `composite_synthetic` | Composite of multiple elements where at least one is AI-generated | Stock photo composited with AI-generated background, AI text overlay on captured video |
+| `human_edits` | Content augmented, corrected, or enhanced by humans using non-generative tools | Color-corrected product photography, manually retouched portraits, human copy editing |
+| `data_driven_media` | Assembled from structured data feeds (DCO templates, product catalogs, weather-triggered variants) | Dynamic creative optimization, catalog-driven product carousels, weather-responsive ads |
+
+### Choosing the right value
+
+For mixed-production creatives, choose the value that best describes the **overall creative** at the level where provenance is attached. If you need to distinguish AI involvement per-asset, attach provenance at the individual asset level instead (see [Inheritance](#inheritance) below).
+
+Common patterns:
+
+- **AI image + human copy**: Attach `trained_algorithmic_media` to the image asset, `digital_creation` to the text asset, and `composite_with_trained_algorithmic_media` at the manifest level
+- **DCO with AI-generated headlines**: `data_driven_media` at the manifest level, `trained_algorithmic_media` on the AI-generated text assets
+- **Human photographer + AI background removal**: `composite_with_trained_algorithmic_media` at the manifest level
+
+## Human oversight
+
+The `human_oversight` enum describes the level of human involvement in an AI-assisted creation process.
+
+| Value | Description |
+|-------|-------------|
+| `none` | Fully automated with no human involvement in generation |
+| `prompt_only` | Human provided the prompt or instructions but did not review outputs |
+| `selected` | Human selected from multiple AI-generated candidates |
+| `edited` | Human edited or refined AI-generated output |
+| `directed` | Human directed the creative process with AI as an assistive tool |
+
+This field is relevant when `digital_source_type` indicates AI involvement. For non-AI content, omit it.
+
+## Inheritance
+
+Provenance attaches at three levels in the creative hierarchy. The most specific provenance wins, and replacement is **full-object** -- there is no field-level merging.
+
+```
+creative-asset.provenance        (1) default for the creative in the library
+  creative-manifest.provenance   (2) default for this manifest
+    individual asset .provenance (3) override for a specific asset
+```
+
+### Resolution rules
+
+1. If an individual asset has `provenance`, use it
+2. Otherwise, if the manifest has `provenance`, use it
+3. Otherwise, if the creative asset has `provenance`, use it
+4. Otherwise, no provenance is declared for that asset
+
+### Example: mixed creative
+
+A creative where the image is AI-generated but the copy is human-written. The manifest-level provenance covers the overall creative. The image asset overrides with its own, more specific provenance.
+
+```json
+{
+  "$schema": "/schemas/core/creative-manifest.json",
+  "format_id": {
+    "agent_url": "https://creative.adcontextprotocol.org",
+    "id": "display_300x250"
+  },
+  "provenance": {
+    "digital_source_type": "composite_with_trained_algorithmic_media",
+    "declared_by": { "role": "agency" }
+  },
+  "assets": {
+    "banner_image": {
+      "url": "https://cdn.novabrands.example.com/hero_ai.jpg",
+      "width": 300,
+      "height": 250,
+      "provenance": {
+        "digital_source_type": "trained_algorithmic_media",
+        "ai_tool": {
+          "name": "DALL-E 3",
+          "version": "3.0",
+          "provider": "OpenAI"
+        },
+        "human_oversight": "selected",
+        "declared_by": { "role": "agency" },
+        "c2pa": {
+          "manifest_url": "https://cdn.novabrands.example.com/c2pa/hero_ai.c2pa"
+        }
+      }
+    },
+    "headline": {
+      "content": "Nutrition dogs love"
+    },
+    "clickthrough_url": {
+      "url": "https://novabrands.example.com/products"
+    }
+  }
+}
+```
+
+In this example:
+- `banner_image` uses its own provenance: `trained_algorithmic_media` with full AI tool details
+- `headline` inherits the manifest-level provenance: `composite_with_trained_algorithmic_media`
+- `clickthrough_url` also inherits the manifest-level provenance
+
+Note that the image's provenance is a complete replacement. Even though the manifest-level provenance has `declared_by`, the image asset must re-declare it in its own provenance object if that information should carry through.
+
+### Artifact inheritance
+
+For content artifacts (publisher content), the same pattern applies:
+
+```
+artifact.provenance                  (1) default for the artifact
+  artifact.assets[].provenance       (2) override for a specific inline asset
+```
+
+```json
+{
+  "$schema": "/schemas/content-standards/artifact.json",
+  "property_id": { "type": "domain", "value": "aimagazine.example.com" },
+  "artifact_id": "article_ai_trends_2026",
+  "provenance": {
+    "digital_source_type": "digital_creation",
+    "declared_by": { "role": "platform" }
+  },
+  "assets": [
+    {
+      "type": "text",
+      "role": "title",
+      "content": "AI trends reshaping the industry in 2026"
+    },
+    {
+      "type": "image",
+      "url": "https://cdn.aimagazine.example.com/illustration.jpg",
+      "alt_text": "Conceptual illustration of neural networks",
+      "provenance": {
+        "digital_source_type": "trained_algorithmic_media",
+        "ai_tool": { "name": "Midjourney", "version": "v7" },
+        "human_oversight": "directed",
+        "declared_by": { "role": "platform" }
+      }
+    }
+  ]
+}
+```
+
+The article text inherits `digital_creation` from the artifact. The illustration overrides with its own `trained_algorithmic_media` provenance.
+
+## Trust model
+
+<Warning>
+Provenance is a **claim** by the declaring party. It is not proof. The enforcing party should verify independently.
+</Warning>
+
+In advertising, the party declaring provenance and the party enforcing it have competing incentives. A buyer submitting a creative has reason to claim the content is human-made — AI-generated creatives may face placement restrictions, mandatory disclosure labels, or outright rejection on certain inventory. A seller accepting that creative has the opposite incentive: publishing AI-generated content without proper disclosure creates regulatory liability for the publisher, not the advertiser. AdCP handles this tension by treating provenance as a claim, not a fact. The buyer declares; the seller verifies. Verification happens at each enforcement point independently, using AI detection services (via `get_creative_features`), C2PA manifest validation, or both. No party needs to trust any other party's assertion. The protocol provides the structure for claims and the integration points for verification — the supply chain provides the adversarial pressure that keeps both honest.
+
+The `declared_by` field identifies who attached the provenance claim. The `verification` array carries any detection results the declaring party wants to disclose. But the party enforcing a provenance requirement runs its own verification through existing governance infrastructure.
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Agent
+    participant Seller as Seller Agent
+    participant Detector as AI Detection Agent
+
+    Note over Buyer: 1. DECLARATION
+    Buyer->>Seller: sync_creatives with provenance<br/>digital_source_type: "digital_capture"
+
+    Note over Seller: 2. POLICY CHECK
+    Seller->>Seller: creative_policy.provenance_required = true<br/>Provenance present? Yes
+
+    Note over Seller: 3. INDEPENDENT VERIFICATION
+    Seller->>Detector: get_creative_features<br/>(creative manifest)
+    Detector-->>Seller: feature_id: "ai_generated"<br/>value: true, confidence: 0.94
+
+    Note over Seller: 4. ENFORCEMENT
+    Seller->>Seller: Buyer claims "digital_capture"<br/>Detection says "ai_generated"<br/>Mismatch -- reject creative
+
+    Seller-->>Buyer: Creative rejected:<br/>"AI detection contradicts provenance claim"
+```
+
+### Declaring party roles
+
+| Role | Description |
+|------|-------------|
+| `creator` | The party that created or generated the content |
+| `advertiser` | The brand or advertiser that owns the content |
+| `agency` | Agency acting on behalf of the advertiser |
+| `platform` | Ad platform or publisher that processed the content |
+| `tool` | Automated tool or service that attached provenance metadata |
+
+### Buyer-attached verification
+
+The `verification` array on the provenance object lets the declaring party share detection results for transparency. Multiple services can independently evaluate the same content:
+
+```json
+{
+  "verification": [
+    {
+      "verified_by": "Hive Moderation",
+      "verified_time": "2026-02-15T15:00:00Z",
+      "result": "ai_generated",
+      "confidence": 0.96,
+      "details_url": "https://hive.example.com/reports/abc123"
+    },
+    {
+      "verified_by": "Reality Defender",
+      "verified_time": "2026-02-15T15:05:00Z",
+      "result": "ai_generated",
+      "confidence": 0.93
+    }
+  ]
+}
+```
+
+These results are **supplementary**. A seller that requires provenance verification runs its own detection through [`get_creative_features`](/docs/governance/creative/get_creative_features) rather than trusting the buyer's attached results.
+
+Verification results use one of four outcomes:
+
+| Result | Description |
+|--------|-------------|
+| `authentic` | Content verified as non-AI-generated |
+| `ai_generated` | Content detected as AI-generated |
+| `ai_modified` | Content detected as AI-modified (original non-AI content with AI alterations) |
+| `inconclusive` | Detection was unable to reach a confident determination |
+
+### Example: provenance through a campaign
+
+Acme Brands is running a spring campaign. Their agency, Meridian Media, uses an AI image generator to produce a set of display banners — photorealistic product shots with AI-generated backgrounds. Meridian attaches provenance to the creative manifest: `digital_source_type` is `composite_with_trained_algorithmic_media`, `ai_tool` identifies the generator, and `disclosure.required` is `true` with `eu_ai_act_article_50` and `ca_sb_942` listed as applicable regulations.
+
+The campaign is submitted to Pinnacle Publishing through AdCP. Pinnacle's ad operations platform checks the provenance claim, then runs the creative through its verification pipeline via `get_creative_features`. The AI detection service returns `ai_modified` with 0.94 confidence — consistent with the declared source type. Pinnacle's system confirms the claim, applies the required disclosure label to the ad unit, and clears the creative for serving. The provenance metadata, the detection result, and the disclosure decision are all recorded and auditable.
+
+If Meridian had declared `digital_capture` instead — claiming no AI involvement — Pinnacle's detection service would have flagged the inconsistency. The creative would be held for review, not served.
+
+## C2PA integration
+
+The `c2pa` field provides a soft reference to [C2PA Content Credentials](https://c2pa.org/) -- the cryptographic provenance standard developed by the Coalition for Content Provenance and Authenticity.
+
+```json
+{
+  "c2pa": {
+    "manifest_url": "https://cdn.acmecorp.example.com/c2pa/manifests/hero_abc123.c2pa"
+  }
+}
+```
+
+### Why a URL reference
+
+C2PA bindings are typically embedded in the media file itself. But ad tech pipelines routinely transcode, resize, and reformat creative assets -- breaking file-level C2PA bindings in the process. A URL reference to the original C2PA manifest store survives this transcoding, preserving the chain of provenance through the supply chain.
+
+The reference is a pointer, not a replacement for C2PA. Any party in the chain can fetch the manifest from the URL and verify the original content credentials, even after the media file has been transcoded.
+
+### Usage pattern
+
+1. Creator generates content and produces a C2PA manifest
+2. Creator uploads the manifest store to a stable URL
+3. Creator attaches the `manifest_url` in AdCP provenance
+4. Downstream parties (agencies, platforms, sellers) can verify the original credentials at any time by fetching the manifest
+
+## Disclosure requirements
+
+The `disclosure` object declares regulatory obligations for AI-generated content.
+
+```json
+{
+  "disclosure": {
+    "required": true,
+    "jurisdictions": [
+      {
+        "country": "US",
+        "region": "CA",
+        "regulation": "ca_sb_942",
+        "label_text": "Created with AI"
+      },
+      {
+        "country": "DE",
+        "regulation": "eu_ai_act_article_50",
+        "label_text": "KI-generiert"
+      },
+      {
+        "country": "CN",
+        "regulation": "cn_deep_synthesis",
+        "label_text": "AI-generated content"
+      }
+    ]
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `required` | No | Whether AI disclosure is required based on applicable regulations |
+| `jurisdictions` | No | Array of jurisdictions where disclosure obligations apply |
+| `jurisdictions[].country` | Yes | ISO 3166-1 alpha-2 country code |
+| `jurisdictions[].region` | No | Sub-national region code (e.g., `CA` for California) |
+| `jurisdictions[].regulation` | Yes | Regulation identifier |
+| `jurisdictions[].label_text` | No | Required disclosure label text in the local language |
+
+### Known regulation identifiers
+
+| Identifier | Regulation | Status |
+|------------|-----------|--------|
+| `eu_ai_act_article_50` | EU AI Act Article 50 | Enforcement August 2026 |
+| `ca_sb_942` | California SB 942 | Live since January 2026 |
+| `cn_deep_synthesis` | China Deep Synthesis Provisions | In effect |
+
+Regulation identifiers are conventions, not a closed enum. New regulations can be referenced without protocol changes.
+
+## Creative policy enforcement
+
+Sellers can require provenance on submitted creatives through the `provenance_required` field in `creative-policy`:
+
+```json
+{
+  "$schema": "/schemas/core/creative-policy.json",
+  "co_branding": "optional",
+  "landing_page": "any",
+  "templates_available": false,
+  "provenance_required": true
+}
+```
+
+When `provenance_required` is `true`:
+
+1. Buyers must attach provenance to creative submissions
+2. The seller may independently verify claims via `get_creative_features`
+3. Creatives without provenance are rejected
+
+This field is surfaced in product discovery through `get_products`, so buyers know the requirement before submitting creatives.
+
+## Where provenance attaches
+
+| Schema | Field | Description |
+|--------|-------|-------------|
+| `creative-asset` | `provenance` | Default for the creative in the library |
+| `creative-manifest` | `provenance` | Default for all assets in this manifest |
+| `image-asset` | `provenance` | Override for a specific image |
+| `video-asset` | `provenance` | Override for a specific video |
+| `audio-asset` | `provenance` | Override for a specific audio file |
+| `text-asset` | `provenance` | Override for specific text content |
+| `html-asset` | `provenance` | Override for HTML content |
+| `css-asset` | `provenance` | Override for CSS content |
+| `javascript-asset` | `provenance` | Override for JavaScript content |
+| `vast-asset` | `provenance` | Override for a VAST tag |
+| `daast-asset` | `provenance` | Override for a DAAST tag |
+| `url-asset` | `provenance` | Override for a URL asset |
+| `artifact` | `provenance` | Default for the content artifact |
+| `artifact.assets[]` (text, image, video, audio) | `provenance` | Override for a specific inline asset |
+
+## Schema reference
+
+| Schema | Location |
+|--------|----------|
+| Provenance object | [`/schemas/core/provenance.json`](https://adcontextprotocol.org/schemas/latest/core/provenance.json) |
+| Digital source type enum | [`/schemas/enums/digital-source-type.json`](https://adcontextprotocol.org/schemas/latest/enums/digital-source-type.json) |
+| Creative asset (with provenance) | [`/schemas/core/creative-asset.json`](https://adcontextprotocol.org/schemas/latest/core/creative-asset.json) |
+| Creative manifest (with provenance) | [`/schemas/core/creative-manifest.json`](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json) |
+| Creative policy (provenance_required) | [`/schemas/core/creative-policy.json`](https://adcontextprotocol.org/schemas/latest/core/creative-policy.json) |
+| Artifact (with provenance) | [`/schemas/content-standards/artifact.json`](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json) |
+
+## Related
+
+- [Provenance verification](/docs/governance/creative/provenance-verification) -- How the governance infrastructure verifies AI provenance claims
+- [Creative Governance](/docs/governance/creative/index) -- Feature-based creative evaluation via `get_creative_features`
+- [Content Standards](/docs/governance/content-standards/index) -- Privacy-preserving brand suitability for publisher content
+- [Generative Creative](/docs/creative/generative-creative) -- AI-powered creative generation with `build_creative`

--- a/docs/governance/creative/provenance-verification.mdx
+++ b/docs/governance/creative/provenance-verification.mdx
@@ -1,0 +1,435 @@
+---
+title: Provenance verification
+sidebarTitle: Provenance verification
+---
+
+When a creative arrives with a provenance claim, the receiving party needs to decide whether to trust it. This page describes how AdCP handles that decision: provenance claims travel with the creative from buyer to seller, and each enforcement point — the publisher, the SSP, the verification vendor — runs its own independent check. No single party's attestation is taken at face value. This separation between declaration and verification is what makes the system work when the parties involved have competing incentives.
+
+## Three-moment lifecycle
+
+AI provenance flows through three distinct moments, each handled by existing AdCP tasks.
+
+```mermaid
+flowchart LR
+    subgraph declare["1. DECLARATION"]
+        direction TB
+        D1["sync_creatives / build_creative"]
+        D2["Buyer attaches provenance<br/>to creative manifest or assets"]
+        D1 --> D2
+    end
+
+    subgraph verify["2. VERIFICATION"]
+        direction TB
+        V1["get_creative_features /<br/>calibrate_content"]
+        V2["Governance agent evaluates<br/>content independently"]
+        V1 --> V2
+    end
+
+    subgraph enforce["3. ENFORCEMENT"]
+        direction TB
+        E1["creative_policy /<br/>validate_content_delivery"]
+        E2["Seller/publisher applies rules<br/>and accepts or rejects"]
+        E1 --> E2
+    end
+
+    declare --> verify --> enforce
+```
+
+| Moment | When | Who | Task |
+|--------|------|-----|------|
+| **Declaration** | Creative submission | Buyer, agency, or creative tool | `sync_creatives`, `build_creative` |
+| **Verification** | Before trafficking or during calibration | Seller's governance agent | `get_creative_features`, `calibrate_content` |
+| **Enforcement** | Acceptance decision or post-delivery audit | Seller agent, buyer agent | `creative_policy`, `validate_content_delivery` |
+
+Each moment is independent. A buyer can declare provenance without any verification having occurred. A seller can verify without requiring a declaration. Enforcement can happen with or without both.
+
+## AI detection via get_creative_features
+
+AI detection is a creative governance feature, evaluated by specialist agents through `get_creative_features` -- the same task used for security scanning, creative quality, and content categorization. AI detection does not require a separate protocol or workflow.
+
+### Agent declares AI detection capabilities
+
+An AI detection agent advertises its features via `get_adcp_capabilities`:
+
+```json
+{
+  "governance": {
+    "creative_features": [
+      {
+        "feature_id": "ai_generated",
+        "type": "binary",
+        "description": "Whether the creative contains AI-generated content",
+        "methodology_url": "https://detector.example.com/methodology"
+      },
+      {
+        "feature_id": "ai_modified",
+        "type": "binary",
+        "description": "Whether the creative contains AI-modified elements",
+        "methodology_url": "https://detector.example.com/methodology"
+      },
+      {
+        "feature_id": "ai_confidence",
+        "type": "quantitative",
+        "range": { "min": 0, "max": 1 },
+        "description": "Confidence score for AI detection result",
+        "methodology_url": "https://detector.example.com/methodology"
+      }
+    ]
+  }
+}
+```
+
+### Seller evaluates a creative
+
+The seller sends the creative manifest to the AI detection agent:
+
+```json
+{
+  "creative_manifest": {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org",
+      "id": "display_300x250"
+    },
+    "assets": {
+      "banner_image": {
+        "url": "https://cdn.novabrands.example.com/hero.jpg",
+        "width": 300,
+        "height": 250
+      },
+      "headline": {
+        "content": "Nutrition dogs love"
+      }
+    }
+  },
+  "feature_ids": ["ai_generated", "ai_modified", "ai_confidence"]
+}
+```
+
+### Agent returns detection results
+
+```json
+{
+  "results": [
+    { "feature_id": "ai_generated", "value": true, "confidence": 0.94 },
+    { "feature_id": "ai_modified", "value": false },
+    { "feature_id": "ai_confidence", "value": 0.94 }
+  ],
+  "detail_url": "https://detector.example.com/reports/ctx_xyz789"
+}
+```
+
+### Seller applies enforcement logic
+
+The seller compares the detection result against the buyer's provenance claim:
+
+```javascript
+const provenance = creative.manifest.provenance;
+const detection = await detectionAgent.getCreativeFeatures({
+  creative_manifest: creative.manifest,
+  feature_ids: ['ai_generated']
+});
+
+if (detection.errors) {
+  // Detection failed - handle based on policy
+  return;
+}
+
+const aiDetected = detection.results.find(
+  f => f.feature_id === 'ai_generated'
+);
+
+// Case 1: Provenance claims non-AI, detection says AI
+if (
+  provenance?.digital_source_type === 'digital_capture' &&
+  aiDetected?.value === true &&
+  aiDetected?.confidence > 0.9
+) {
+  // Reject - provenance claim contradicts detection
+  return;
+}
+
+// Case 2: AI content in jurisdiction requiring disclosure
+if (
+  aiDetected?.value === true &&
+  !provenance?.disclosure?.required
+) {
+  // Reject - AI content without required disclosure metadata
+  return;
+}
+```
+
+### Multi-agent evaluation
+
+AI detection fits naturally into the multi-agent creative governance pattern. A seller evaluating a creative can call multiple specialist agents in parallel:
+
+| Agent | Features | Provenance relevance |
+|-------|----------|---------------------|
+| Security scanner | `auto_redirect`, `cloaking` | None -- independent concern |
+| AI detection | `ai_generated`, `ai_modified` | Verifies provenance claims |
+| Content categorizer | `iab_casinos_gambling` | None -- independent concern |
+| Creative quality | `brand_consistency` | None -- independent concern |
+
+The orchestrator calls all agents via `get_creative_features`, aggregates results, and applies its requirements across all of them. AI detection is one column in the evaluation matrix, not a separate workflow.
+
+## Content standards integration
+
+For publisher content (artifacts), provenance verification uses the content standards infrastructure: `calibrate_content` for alignment and `validate_content_delivery` for auditing.
+
+### Artifact provenance
+
+Publishers declare provenance on artifacts the same way buyers declare it on creatives:
+
+```json
+{
+  "property_id": { "type": "domain", "value": "newssite.example.com" },
+  "artifact_id": "article_trends_2026",
+  "provenance": {
+    "digital_source_type": "digital_creation",
+    "declared_by": { "role": "platform" }
+  },
+  "assets": [
+    {
+      "type": "text",
+      "role": "title",
+      "content": "Industry trends to watch in 2026"
+    },
+    {
+      "type": "image",
+      "url": "https://cdn.newssite.example.com/ai-illustration.jpg",
+      "alt_text": "Conceptual illustration",
+      "provenance": {
+        "digital_source_type": "trained_algorithmic_media",
+        "ai_tool": { "name": "Midjourney", "version": "v7" },
+        "declared_by": { "role": "platform" }
+      }
+    }
+  ]
+}
+```
+
+### Calibration for AI provenance
+
+During `calibrate_content`, the verification agent can evaluate whether artifact provenance claims are accurate. This uses the same calibration dialogue as brand suitability -- the verification agent returns verdicts with explanations:
+
+```json
+{
+  "verdict": "fail",
+  "explanation": "The article's hero image shows strong indicators of AI generation (GAN artifacts, inconsistent lighting) but is marked as digital_creation. The provenance claim does not match detection results.",
+  "features": [
+    {
+      "feature_id": "provenance_accuracy",
+      "status": "failed",
+      "explanation": "Image asset provenance claims digital_creation but AI detection confidence is 0.92."
+    },
+    {
+      "feature_id": "brand_safety",
+      "status": "passed",
+      "explanation": "No safety concerns with the content itself."
+    }
+  ]
+}
+```
+
+### Post-delivery validation
+
+Buyers can audit AI provenance in delivered content through `validate_content_delivery`, the same task used for brand suitability auditing:
+
+```json
+{
+  "standards_id": "acme_ai_disclosure_policy",
+  "records": [
+    {
+      "record_id": "imp_54321",
+      "media_buy_id": "mb_acme_q1",
+      "artifact": {
+        "property_id": { "type": "domain", "value": "newssite.example.com" },
+        "artifact_id": "article_trends_2026",
+        "provenance": {
+          "digital_source_type": "digital_creation",
+          "declared_by": { "role": "platform" }
+        },
+        "assets": [
+          {
+            "type": "image",
+            "url": "https://cdn.newssite.example.com/ai-illustration.jpg"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Compliance profiles
+
+Different regulatory environments require different levels of provenance enforcement. Here are example configurations.
+
+<CodeGroup>
+```json EU (strict)
+{
+  "profile": "eu_strict",
+  "creative_policy": {
+    "provenance_required": true
+  },
+  "enforcement_rules": {
+    "ai_detection_required": true,
+    "ai_detection_confidence_threshold": 0.85,
+    "disclosure_required_for": [
+      "trained_algorithmic_media",
+      "composite_with_trained_algorithmic_media",
+      "human_edits"
+    ],
+    "reject_on_mismatch": true,
+    "jurisdictions": [
+      {
+        "country": "DE",
+        "regulation": "eu_ai_act_article_50",
+        "label_text": "KI-generiert"
+      },
+      {
+        "country": "FR",
+        "regulation": "eu_ai_act_article_50",
+        "label_text": "Contenu généré par l'IA"
+      }
+    ]
+  }
+}
+```
+
+```json US/California (moderate)
+{
+  "profile": "us_california",
+  "creative_policy": {
+    "provenance_required": true
+  },
+  "enforcement_rules": {
+    "ai_detection_required": true,
+    "ai_detection_confidence_threshold": 0.90,
+    "disclosure_required_for": [
+      "trained_algorithmic_media",
+      "composite_with_trained_algorithmic_media"
+    ],
+    "reject_on_mismatch": true,
+    "jurisdictions": [
+      {
+        "country": "US",
+        "region": "CA",
+        "regulation": "ca_sb_942",
+        "label_text": "Created with AI"
+      }
+    ]
+  }
+}
+```
+
+```json Permissive
+{
+  "profile": "permissive",
+  "creative_policy": {
+    "provenance_required": false
+  },
+  "enforcement_rules": {
+    "ai_detection_required": false,
+    "log_provenance_if_present": true,
+    "reject_on_mismatch": false
+  }
+}
+```
+</CodeGroup>
+
+<Info>
+These profiles are illustrative configurations, not schema-defined objects. Each seller implements enforcement logic suited to their regulatory requirements. The AdCP schemas provide the data model; the enforcement rules are implementation decisions.
+</Info>
+
+## For regulators
+
+AdCP provides a machine-readable, protocol-level mechanism for AI disclosure in programmatic advertising. Every creative and content artifact in the supply chain can carry structured provenance metadata that declares the digital source type, the AI tools used, the level of human oversight, and the applicable disclosure requirements by jurisdiction — including specific regulation identifiers such as `eu_ai_act_article_50`, `ca_sb_942`, and `cn_deep_synthesis`.
+
+This metadata uses the IPTC digital source type vocabulary, the same classification system adopted by C2PA Content Credentials, Meta, and Google for AI content labeling. AdCP does not invent a new taxonomy. It carries an existing, widely adopted one through the advertising supply chain where it has not previously been available in structured form.
+
+### Verification is independent, not self-reported
+
+Provenance in AdCP is explicitly a claim, not a certification. The declaring party — typically the advertiser or their agency — attaches provenance when submitting a creative. The enforcing party — typically the publisher or their supply-side platform — verifies that claim independently using AI detection services, C2PA manifest validation, or both. This verification happens through existing AdCP governance mechanisms (`get_creative_features` for creatives, `calibrate_content` for publisher content) and does not require new infrastructure.
+
+This architecture addresses a structural problem in advertising compliance: the party submitting the creative has an incentive to understate AI involvement (to avoid placement restrictions or disclosure requirements), while the party publishing the creative bears the regulatory liability for non-disclosure. By treating provenance as a verifiable claim rather than a trusted assertion, the protocol ensures that compliance does not depend on the good faith of any single participant.
+
+### Mapping to regulatory requirements
+
+**EU AI Act Article 50**: Requires that AI-generated content be labeled in a machine-readable way. AdCP's `digital_source_type` field provides this classification at the asset level. The `disclosure.jurisdictions` array allows creatives to carry jurisdiction-specific label text. Enforcement points can filter or flag creatives based on `digital_source_type` values that indicate AI generation (`trained_algorithmic_media`, `composite_with_trained_algorithmic_media`).
+
+**California SB 942**: Requires disclosure when content is generated or substantially modified by AI. The `digital_source_type` and `human_oversight` fields together provide the information needed to determine whether a creative meets the disclosure threshold. The `disclosure.required` flag provides a direct signal for enforcement.
+
+**Platform mandates (Meta, Google, TikTok)**: Major platforms already require AI content labeling using IPTC-aligned metadata. AdCP's provenance structure is directly compatible with these requirements because it uses the same underlying vocabulary.
+
+AdCP does not determine which regulations apply to a given creative. It provides the structured metadata that allows each enforcement point to apply its own jurisdictional rules. The protocol carries the data; the enforcing party makes the compliance decision.
+
+### Verification flow
+
+```mermaid
+flowchart TB
+    subgraph creative["Advertising creatives"]
+        C1["Buyer declares provenance<br/>on creative manifest"]
+        C2["Seller requires provenance<br/>via creative_policy"]
+        C3["AI detection agent evaluates<br/>via get_creative_features"]
+        C4["Seller compares claim vs detection<br/>accepts or rejects"]
+        C1 --> C2 --> C3 --> C4
+    end
+
+    subgraph content["Publisher content"]
+        P1["Publisher declares provenance<br/>on artifact and assets"]
+        P2["Verification agent calibrates<br/>via calibrate_content"]
+        P3["Buyer audits delivery<br/>via validate_content_delivery"]
+        P1 --> P2 --> P3
+    end
+```
+
+## Implementation checklist
+
+### Buyers (brands and agencies)
+
+| Requirement | Description |
+|-------------|-------------|
+| Attach provenance to creatives | Set `provenance` on `creative-asset` or `creative-manifest` when submitting via `sync_creatives` |
+| Classify AI involvement | Use the correct `digital_source_type` for each creative and asset |
+| Declare AI tooling | Populate `ai_tool` when AI systems were used in production |
+| Set human oversight level | Indicate `human_oversight` when AI is involved |
+| Declare disclosure obligations | Populate `disclosure.jurisdictions` for each applicable regulation |
+| Preserve C2PA references | Include `c2pa.manifest_url` when content credentials exist |
+| Run pre-submission detection | Optionally attach `verification` results from your own detection services |
+
+### Sellers (publishers and platforms)
+
+| Requirement | Description |
+|-------------|-------------|
+| Set creative policy | Add `provenance_required: true` to `creative-policy` if provenance is required |
+| Run AI detection | Call `get_creative_features` with an AI detection agent to verify provenance claims |
+| Compare claims vs detection | Implement logic to compare `digital_source_type` against `ai_generated` feature results |
+| Enforce disclosure | Verify that AI content includes appropriate `disclosure` metadata for target jurisdictions |
+| Reject mismatches | Reject creatives where provenance claims contradict detection results |
+| Declare artifact provenance | Attach `provenance` to content artifacts submitted via content standards |
+
+### Creative agents
+
+| Requirement | Description |
+|-------------|-------------|
+| Attach provenance to generated content | When `build_creative` generates AI content, attach provenance with `digital_source_type`, `ai_tool`, and `human_oversight` |
+| Set `declared_by` role to `tool` | Creative agents that attach provenance should identify themselves with role `tool` |
+| Carry through C2PA | If source assets have C2PA manifests, carry the reference through to the generated manifest |
+
+### Governance agents (AI detection)
+
+| Requirement | Description |
+|-------------|-------------|
+| Declare detection features | Advertise `ai_generated` and related features via `get_adcp_capabilities` |
+| Implement `get_creative_features` | Accept creative manifests and return detection results |
+| Return confidence scores | Include `confidence` on detection results for probabilistic assessments |
+| Provide detail URLs | Link to full reports via `detail_url` for audit trails |
+
+## Related
+
+- [AI provenance and disclosure](/docs/creative/provenance) -- The provenance schema reference, digital source type enum, and inheritance model
+- [Creative Governance](/docs/governance/creative/index) -- Feature-based creative evaluation via `get_creative_features`
+- [`get_creative_features`](/docs/governance/creative/get_creative_features) -- Task reference for creative feature evaluation
+- [Content Standards](/docs/governance/content-standards/index) -- Privacy-preserving brand suitability for publisher content
+- [`calibrate_content`](/docs/governance/content-standards/tasks/calibrate_content) -- Calibration task for content standards alignment
+- [`validate_content_delivery`](/docs/governance/content-standards/tasks/validate_content_delivery) -- Post-delivery content validation

--- a/static/schemas/source/content-standards/artifact.json
+++ b/static/schemas/source/content-standards/artifact.json
@@ -64,6 +64,10 @@
                 "minimum": 1,
                 "maximum": 6,
                 "description": "Heading level (1-6), only for role=heading"
+              },
+              "provenance": {
+                "$ref": "/schemas/core/provenance.json",
+                "description": "Provenance for this text block, overrides artifact-level provenance"
               }
             },
             "required": ["type", "content"]
@@ -97,6 +101,10 @@
               "height": {
                 "type": "integer",
                 "description": "Image height in pixels"
+              },
+              "provenance": {
+                "$ref": "/schemas/core/provenance.json",
+                "description": "Provenance for this image, overrides artifact-level provenance"
               }
             },
             "required": ["type", "url"]
@@ -132,6 +140,10 @@
                 "type": "string",
                 "format": "uri",
                 "description": "Video thumbnail URL"
+              },
+              "provenance": {
+                "$ref": "/schemas/core/provenance.json",
+                "description": "Provenance for this video, overrides artifact-level provenance"
               }
             },
             "required": ["type", "url"]
@@ -162,6 +174,10 @@
                 "type": "string",
                 "enum": ["original_script", "closed_captions", "generated"],
                 "description": "How the transcript was generated"
+              },
+              "provenance": {
+                "$ref": "/schemas/core/provenance.json",
+                "description": "Provenance for this audio, overrides artifact-level provenance"
               }
             },
             "required": ["type", "url"]
@@ -203,6 +219,10 @@
         }
       },
       "additionalProperties": true
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this artifact. Serves as the default provenance for all assets within this artifact — individual assets can override with their own provenance."
     },
     "identifiers": {
       "type": "object",

--- a/static/schemas/source/core/assets/audio-asset.json
+++ b/static/schemas/source/core/assets/audio-asset.json
@@ -60,6 +60,10 @@
       "format": "uri",
       "description": "URL to text transcript of the audio content",
       "x-accessibility": true
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/css-asset.json
+++ b/static/schemas/source/core/assets/css-asset.json
@@ -12,6 +12,10 @@
     "media": {
       "type": "string",
       "description": "CSS media query context (e.g., 'screen', 'print')"
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/daast-asset.json
+++ b/static/schemas/source/core/assets/daast-asset.json
@@ -42,6 +42,10 @@
           "format": "uri",
           "description": "URL to text transcript of the audio content",
           "x-accessibility": true
+        },
+        "provenance": {
+          "$ref": "/schemas/core/provenance.json",
+          "description": "Provenance metadata for this asset, overrides manifest-level provenance"
         }
       },
       "required": [
@@ -87,6 +91,10 @@
           "format": "uri",
           "description": "URL to text transcript of the audio content",
           "x-accessibility": true
+        },
+        "provenance": {
+          "$ref": "/schemas/core/provenance.json",
+          "description": "Provenance metadata for this asset, overrides manifest-level provenance"
         }
       },
       "required": [

--- a/static/schemas/source/core/assets/html-asset.json
+++ b/static/schemas/source/core/assets/html-asset.json
@@ -35,6 +35,10 @@
           "description": "Whether the creative has been tested with screen readers"
         }
       }
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/image-asset.json
+++ b/static/schemas/source/core/assets/image-asset.json
@@ -28,6 +28,10 @@
       "type": "string",
       "description": "Alternative text for accessibility",
       "x-accessibility": true
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/javascript-asset.json
+++ b/static/schemas/source/core/assets/javascript-asset.json
@@ -35,6 +35,10 @@
           "description": "Whether the creative has been tested with screen readers"
         }
       }
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/text-asset.json
+++ b/static/schemas/source/core/assets/text-asset.json
@@ -12,6 +12,10 @@
     "language": {
       "type": "string",
       "description": "Language code (e.g., 'en', 'es', 'fr')"
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/url-asset.json
+++ b/static/schemas/source/core/assets/url-asset.json
@@ -17,6 +17,10 @@
     "description": {
       "type": "string",
       "description": "Description of what this URL points to"
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/vast-asset.json
+++ b/static/schemas/source/core/assets/vast-asset.json
@@ -48,6 +48,10 @@
           "format": "uri",
           "description": "URL to audio description track for visually impaired users",
           "x-accessibility": true
+        },
+        "provenance": {
+          "$ref": "/schemas/core/provenance.json",
+          "description": "Provenance metadata for this asset, overrides manifest-level provenance"
         }
       },
       "required": [
@@ -99,6 +103,10 @@
           "format": "uri",
           "description": "URL to audio description track for visually impaired users",
           "x-accessibility": true
+        },
+        "provenance": {
+          "$ref": "/schemas/core/provenance.json",
+          "description": "Provenance metadata for this asset, overrides manifest-level provenance"
         }
       },
       "required": [

--- a/static/schemas/source/core/assets/video-asset.json
+++ b/static/schemas/source/core/assets/video-asset.json
@@ -143,6 +143,10 @@
       "format": "uri",
       "description": "URL to audio description track for visually impaired users",
       "x-accessibility": true
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/assets/webhook-asset.json
+++ b/static/schemas/source/core/assets/webhook-asset.json
@@ -66,6 +66,10 @@
       "required": [
         "method"
       ]
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this asset, overrides manifest-level provenance"
     }
   },
   "required": [

--- a/static/schemas/source/core/creative-asset.json
+++ b/static/schemas/source/core/creative-asset.json
@@ -118,6 +118,10 @@
         "type": "string"
       },
       "minItems": 1
+    },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this creative. Serves as the default provenance for all manifests and assets within this creative. A manifest or asset with its own provenance replaces this object entirely (no field-level merging)."
     }
   },
   "required": [

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -61,6 +61,10 @@
       },
       "additionalProperties": true
     },
+    "provenance": {
+      "$ref": "/schemas/core/provenance.json",
+      "description": "Provenance metadata for this creative manifest. Serves as the default provenance for all assets in this manifest. An asset with its own provenance replaces this object entirely (no field-level merging)."
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/core/creative-policy.json
+++ b/static/schemas/source/core/creative-policy.json
@@ -16,6 +16,10 @@
     "templates_available": {
       "type": "boolean",
       "description": "Whether creative templates are provided"
+    },
+    "provenance_required": {
+      "type": "boolean",
+      "description": "Whether creatives must include provenance metadata. When true, the seller requires buyers to attach provenance declarations to creative submissions. The seller may independently verify claims via get_creative_features."
     }
   },
   "required": [

--- a/static/schemas/source/core/provenance.json
+++ b/static/schemas/source/core/provenance.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/provenance.json",
+  "title": "Provenance",
+  "description": "Declares how content was produced, whether AI was involved, and what disclosure obligations apply. Attaches to creative manifests, individual assets, or content-standards artifacts. When present at multiple levels, the most specific provenance object replaces the inherited one entirely (no field-level merging). Provenance is a claim by the declaring party — receiving parties should verify claims independently via their own detection tools.",
+  "type": "object",
+  "properties": {
+    "digital_source_type": {
+      "$ref": "/schemas/enums/digital-source-type.json",
+      "description": "IPTC-aligned classification of AI involvement in producing this content"
+    },
+    "ai_tool": {
+      "type": "object",
+      "description": "AI system used to generate or modify this content. Aligns with IPTC 2025.1 AI metadata fields and C2PA claim_generator.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the AI tool or model (e.g., 'DALL-E 3', 'Stable Diffusion XL', 'Gemini')"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version identifier for the AI tool"
+        },
+        "provider": {
+          "type": "string",
+          "description": "Organization that provides the AI tool (e.g., 'OpenAI', 'Stability AI', 'Google')"
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "human_oversight": {
+      "type": "string",
+      "description": "Level of human involvement in the AI-assisted creation process",
+      "enum": [
+        "none",
+        "prompt_only",
+        "selected",
+        "edited",
+        "directed"
+      ],
+      "enumDescriptions": {
+        "none": "Fully automated with no human involvement in generation",
+        "prompt_only": "Human provided the prompt or instructions but did not review outputs",
+        "selected": "Human selected from multiple AI-generated candidates",
+        "edited": "Human edited or refined AI-generated output",
+        "directed": "Human directed the creative process with AI as an assistive tool"
+      }
+    },
+    "declared_by": {
+      "type": "object",
+      "description": "Party declaring this provenance. Identifies who attached the provenance claim, enabling receiving parties to assess trust.",
+      "properties": {
+        "agent_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the agent or service that declared this provenance"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["creator", "advertiser", "agency", "platform", "tool"],
+          "description": "Role of the declaring party in the supply chain",
+          "enumDescriptions": {
+            "creator": "The party that created or generated the content",
+            "advertiser": "The brand or advertiser that owns the content",
+            "agency": "Agency acting on behalf of the advertiser",
+            "platform": "Ad platform or publisher that processed the content",
+            "tool": "Automated tool or service that attached provenance metadata"
+          }
+        }
+      },
+      "required": ["role"],
+      "additionalProperties": true
+    },
+    "created_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this content was created or generated (ISO 8601)"
+    },
+    "c2pa": {
+      "type": "object",
+      "description": "C2PA Content Credentials reference. Links to the cryptographic provenance manifest for this content. Because file-level C2PA bindings break during ad-tech transcoding, this URL reference preserves the chain of provenance through the supply chain.",
+      "properties": {
+        "manifest_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the C2PA manifest store for this content"
+        }
+      },
+      "required": ["manifest_url"],
+      "additionalProperties": true
+    },
+    "disclosure": {
+      "type": "object",
+      "description": "Regulatory disclosure requirements for this content. Indicates whether AI disclosure is required and under which jurisdictions.",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether AI disclosure is required for this content based on applicable regulations"
+        },
+        "jurisdictions": {
+          "type": "array",
+          "description": "Jurisdictions where disclosure obligations apply",
+          "items": {
+            "type": "object",
+            "properties": {
+              "country": {
+                "type": "string",
+                "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'DE', 'CN')"
+              },
+              "region": {
+                "type": "string",
+                "description": "Sub-national region code (e.g., 'CA' for California, 'BY' for Bavaria)"
+              },
+              "regulation": {
+                "type": "string",
+                "description": "Regulation identifier (e.g., 'eu_ai_act_article_50', 'ca_sb_942', 'cn_deep_synthesis')"
+              },
+              "label_text": {
+                "type": "string",
+                "description": "Required disclosure label text for this jurisdiction, in the local language"
+              }
+            },
+            "required": ["country", "regulation"],
+            "additionalProperties": true
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["required"],
+      "additionalProperties": true
+    },
+    "verification": {
+      "type": "array",
+      "description": "Third-party verification or detection results for this content. Multiple services may independently evaluate the same content. Provenance is a claim — verification results attached by the declaring party are supplementary. The enforcing party (e.g., seller/publisher) should run its own verification via get_creative_features or calibrate_content.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "verified_by": {
+            "type": "string",
+            "description": "Name of the verification service (e.g., 'DoubleVerify', 'Hive Moderation', 'Reality Defender')"
+          },
+          "verified_time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the verification was performed (ISO 8601)"
+          },
+          "result": {
+            "type": "string",
+            "enum": ["authentic", "ai_generated", "ai_modified", "inconclusive"],
+            "description": "Verification outcome"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Confidence score of the verification result (0.0 to 1.0)"
+          },
+          "details_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the full verification report"
+          }
+        },
+        "required": ["verified_by", "result"],
+        "additionalProperties": true
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/enums/digital-source-type.json
+++ b/static/schemas/source/enums/digital-source-type.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/digital-source-type.json",
+  "title": "Digital Source Type",
+  "description": "Classification of AI involvement in content creation, aligned with IPTC digitalsourcetype vocabulary. Used in provenance metadata to declare how a creative asset, artifact, or individual asset was produced.",
+  "type": "string",
+  "enum": [
+    "digital_capture",
+    "digital_creation",
+    "trained_algorithmic_media",
+    "composite_with_trained_algorithmic_media",
+    "algorithmic_media",
+    "composite_capture",
+    "composite_synthetic",
+    "human_edits",
+    "data_driven_media"
+  ],
+  "enumDescriptions": {
+    "digital_capture": "Captured by a digital device (camera, scanner, screen recording) with no AI involvement",
+    "digital_creation": "Created by a human using digital tools (Photoshop, Illustrator, After Effects) without AI generation",
+    "trained_algorithmic_media": "Generated entirely by a trained AI model (DALL-E, Midjourney, Stable Diffusion, Sora)",
+    "composite_with_trained_algorithmic_media": "Human-created content combined with AI-generated elements (e.g., photo with AI background)",
+    "algorithmic_media": "Produced by deterministic algorithms without machine learning (procedural generation, rule-based systems)",
+    "composite_capture": "Multiple digital captures composited together without AI",
+    "composite_synthetic": "Composite of multiple elements where at least one is AI-generated (e.g., stock photo composited with AI-generated background)",
+    "human_edits": "Content augmented, corrected, or enhanced by humans using non-generative tools",
+    "data_driven_media": "Assembled from structured data feeds (DCO templates, product catalogs, weather-triggered variants)"
+  }
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -329,6 +329,10 @@
         "account-ref": {
           "$ref": "/schemas/core/account-ref.json",
           "description": "Reference to an account by seller-assigned ID or natural key (brand, operator)"
+        },
+        "provenance": {
+          "$ref": "/schemas/core/provenance.json",
+          "description": "AI provenance and disclosure metadata — declares how content was produced, C2PA references, regulatory disclosure requirements, and third-party verification results"
         }
       },
       "requirements": {
@@ -699,6 +703,10 @@
         "consent-basis": {
           "$ref": "/schemas/enums/consent-basis.json",
           "description": "GDPR Article 6(1) lawful basis for processing personal data"
+        },
+        "digital-source-type": {
+          "$ref": "/schemas/enums/digital-source-type.json",
+          "description": "IPTC-aligned classification of AI involvement in content creation (digital_capture, trained_algorithmic_media, composite_with_trained_algorithmic_media, etc.)"
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds AI provenance and disclosure metadata to the AdCP protocol, enabling the ad supply chain to declare and verify how content was produced — whether AI was involved, which tools were used, and what disclosure obligations apply. Closes #1253.

- **New `digital-source-type` enum** — IPTC-aligned classification of AI involvement (9 values)
- **New `provenance` core object** — digital_source_type, ai_tool, human_oversight, declared_by, created_time, c2pa, disclosure, verification[], ext
- **Optional `provenance` field** added to creative-manifest, creative-asset, artifact (top-level + 4 inline types), all 11 typed asset schemas
- **`provenance_required`** added to creative-policy for seller enforcement
- **Two documentation pages** — schema reference + verification/compliance guide with regulatory mapping

### Key design decisions

- **Provenance is a claim, not a fact** — the enforcing party (seller/publisher) verifies independently via `get_creative_features` or `calibrate_content`
- **Full-object replacement inheritance** — asset provenance replaces manifest provenance entirely (no field-level merge)
- **C2PA soft reference** — URL to manifest store survives ad-tech transcoding where embedded bindings break
- **IPTC vocabulary** — uses current values per Sept 2024 update (`digital_creation`, `human_edits`)
- **`verification` is an array** — multiple detection services can independently evaluate the same content
- **`declared_by` with role** — identifies who attached the claim, enabling trust assessment

### Regulatory context

- EU AI Act Article 50 enforcement: August 2026
- California SB 942: already in effect
- China Deep Synthesis: already in effect
- Platform mandates (Meta, Google, TikTok): in effect

## Test plan

- [x] `npm run build:schemas` — 340 schemas validated
- [x] `npm test` — 304 tests pass
- [x] `npm run test:json-schema` — 144 JSON blocks in docs validated against schemas
- [x] `npm run typecheck` — clean
- [x] Mintlify link checker — no broken links
- [x] Pre-commit and pre-push hooks pass
- [x] Code review: IPTC definitions verified against current vocabulary, `disclosure.required` made mandatory when disclosure is present, `minItems: 1` on verification array

🤖 Generated with [Claude Code](https://claude.com/claude-code)