### PR TITLE
fix: prevent Addie from posting duplicate Moltbook articles

### DIFF
--- a/.changeset/clear-papayas-fly.md
+++ b/.changeset/clear-papayas-fly.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: prevent Addie from posting duplicate Moltbook articles

--- a/server/src/db/migrations/253_moltbook_posts_knowledge_unique.sql
+++ b/server/src/db/migrations/253_moltbook_posts_knowledge_unique.sql
@@ -1,0 +1,27 @@
+-- Prevent duplicate Moltbook posts for the same addie_knowledge article.
+-- knowledge_id was added (migration 191) with only an index, not a unique constraint.
+-- Without uniqueness, concurrent poster runs (e.g. during a crash-restart cycle or
+-- multi-instance deploy) could each insert a moltbook_posts row for the same knowledge_id,
+-- bypassing the dedup logic in getUnpostedArticles() and causing repeated posts.
+
+-- Remove duplicate rows per knowledge_id.
+-- Prefer the row with a real moltbook_post_id (the one that actually succeeded on Moltbook),
+-- falling back to the earliest by created_at.
+DELETE FROM moltbook_posts
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (
+             PARTITION BY knowledge_id
+             ORDER BY (moltbook_post_id IS NULL), created_at ASC
+           ) AS rn
+    FROM moltbook_posts
+    WHERE knowledge_id IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Add unique constraint (NULLs are exempt: rows without a knowledge_id link,
+-- e.g. manually created posts, may coexist).
+ALTER TABLE moltbook_posts
+  ADD CONSTRAINT moltbook_posts_knowledge_id_unique UNIQUE (knowledge_id);

--- a/server/src/db/moltbook-db.ts
+++ b/server/src/db/moltbook-db.ts
@@ -51,7 +51,7 @@ export async function recordPost(input: CreatePostInput): Promise<MoltbookPostRe
   const result = await query<MoltbookPostRecord>(
     `INSERT INTO moltbook_posts (moltbook_post_id, perspective_id, knowledge_id, title, content, submolt, url)
      VALUES ($1, $2, $3, $4, $5, $6, $7)
-     ON CONFLICT (moltbook_post_id) DO NOTHING
+     ON CONFLICT ON CONSTRAINT moltbook_posts_knowledge_id_unique DO NOTHING
      RETURNING *`,
     [
       input.moltbookPostId || null,
@@ -64,17 +64,6 @@ export async function recordPost(input: CreatePostInput): Promise<MoltbookPostRe
     ]
   );
   return result.rows[0] || null;
-}
-
-/**
- * Check if a knowledge item has already been posted to Moltbook
- */
-export async function hasPostedKnowledge(knowledgeId: number): Promise<boolean> {
-  const result = await query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM moltbook_posts WHERE knowledge_id = $1`,
-    [knowledgeId]
-  );
-  return parseInt(result.rows[0].count) > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addie was spam-posting the same articles to Moltbook 3-4 times in rapid succession (e.g. "Manus AI lands inside Meta Ads Manager" posted at 1:02, 1:18, 1:30, and 1:56 AM), risking account suspension.

Two bugs combined to cause this:

- **No UNIQUE constraint on `moltbook_posts.knowledge_id`** — Migration 191 added this column with only an index. During crash-restart cycles or rolling Fly.io deploys, concurrent poster instances could each pass `canPost()` and `getUnpostedArticles()` before either had recorded anything, then both successfully insert a `moltbook_posts` row for the same article.
- **`recordPost()` only handled `ON CONFLICT (moltbook_post_id)`** — Once the new `knowledge_id` constraint was added, concurrent duplicate inserts would throw an unhandled exception rather than silently no-oping, causing noisy errors and missing Slack notifications.

## Changes

- **Migration 253**: deduplicates existing `moltbook_posts` rows with the same `knowledge_id` (keeping the row that has a real `moltbook_post_id`, falling back to earliest), then adds `UNIQUE (knowledge_id)` constraint
- **`recordPost()`**: switches `ON CONFLICT` to `ON CONFLICT ON CONSTRAINT moltbook_posts_knowledge_id_unique DO NOTHING` so concurrent duplicate inserts are silently ignored at the DB level
- Removes dead `hasPostedKnowledge()` function (no callers)

## Test plan

- [ ] All 304 existing tests pass
- [ ] TypeScript clean
- [ ] Migration deploys without error (verify with `fly logs` after deploy)
- [ ] Monitor `#moltbook` Slack channel — no more repeated article titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)