### PR TITLE
feat(schema): agent ergonomics improvements from #1240

### DIFF
--- a/.changeset/v3-ergonomic-improvements.md
+++ b/.changeset/v3-ergonomic-improvements.md
@@ -1,0 +1,21 @@
+---
+"adcontextprotocol": minor
+---
+
+Agent ergonomics improvements from #1240 tracking issue.
+
+**Media Buy**
+- `get_products`: Add `fields` parameter for response field projection, reducing context window cost for discovery calls
+- `get_media_buy_delivery`: Add `include_package_daily_breakdown` opt-in for per-package daily pacing data
+- `get_media_buy_delivery`: Add `attribution_window` on request for buyer-controlled attribution windows (model optional)
+- `get_media_buys`: Add buy-level `start_time`/`end_time` (min/max of package flight dates)
+
+**Capabilities**
+- `get_adcp_capabilities`: Add `supported_pricing_models` and `reporting` block (date range, daily breakdown, webhooks, available dimensions) at seller level
+
+**Audiences**
+- `sync_audiences` request: Add `description`, `audience_type` (crm/suppression/lookalike_seed), and `tags` metadata
+- `sync_audiences` response: Add `total_uploaded_count` for match rate calculation
+
+**Forecasting**
+- `ForecastPoint.metrics`: Add explicit typed properties for all 13 forecastable-metric enum values

--- a/static/schemas/source/core/forecast-point.json
+++ b/static/schemas/source/core/forecast-point.json
@@ -12,7 +12,22 @@
     },
     "metrics": {
       "type": "object",
-      "description": "Forecasted metric values at this budget level. Keys are either forecastable-metric values for delivery/engagement (impressions, reach, spend, etc.) or event-type values for outcomes (purchase, lead, app_install, etc.). Values are ForecastRange objects (low/mid/high). Use { \"mid\": value } for point estimates. Include spend when the platform predicts it will differ from budget.",
+      "description": "Forecasted metric values at this budget level. Keys are forecastable-metric enum values for delivery/engagement or event-type enum values for outcomes. Values are ForecastRange objects (low/mid/high). Use { \"mid\": value } for point estimates. Include spend when the platform predicts it will differ from budget. Additional keys beyond the documented properties are allowed for event-type values (purchase, lead, app_install, etc.).",
+      "properties": {
+        "audience_size": { "$ref": "/schemas/core/forecast-range.json" },
+        "reach": { "$ref": "/schemas/core/forecast-range.json" },
+        "frequency": { "$ref": "/schemas/core/forecast-range.json" },
+        "impressions": { "$ref": "/schemas/core/forecast-range.json" },
+        "clicks": { "$ref": "/schemas/core/forecast-range.json" },
+        "spend": { "$ref": "/schemas/core/forecast-range.json" },
+        "views": { "$ref": "/schemas/core/forecast-range.json" },
+        "completed_views": { "$ref": "/schemas/core/forecast-range.json" },
+        "grps": { "$ref": "/schemas/core/forecast-range.json" },
+        "engagements": { "$ref": "/schemas/core/forecast-range.json" },
+        "follows": { "$ref": "/schemas/core/forecast-range.json" },
+        "saves": { "$ref": "/schemas/core/forecast-range.json" },
+        "profile_visits": { "$ref": "/schemas/core/forecast-range.json" }
+      },
       "additionalProperties": {
         "$ref": "/schemas/core/forecast-range.json"
       }

--- a/static/schemas/source/media-buy/get-media-buy-delivery-request.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-request.json
@@ -50,9 +50,33 @@
       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
       "description": "End date for reporting period (YYYY-MM-DD). When omitted along with start_date, returns campaign lifetime data. Only accepted when the product's reporting_capabilities.date_range_support is 'date_range'."
     },
+    "include_package_daily_breakdown": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, include daily_breakdown arrays within each package in by_package. Useful for per-package pacing analysis and line-item monitoring. Omit or set false to reduce response size — package daily data can be large for multi-package buys over long flights."
+    },
+    "attribution_window": {
+      "type": "object",
+      "description": "Attribution window to apply for conversion metrics. When provided, the seller returns conversion data using the requested lookback windows instead of their platform default. The seller echoes the applied window in the response. Sellers that do not support configurable windows ignore this field and return their default. Check get_adcp_capabilities conversion_tracking.attribution_windows for available options.",
+      "properties": {
+        "post_click": {
+          "allOf": [{ "$ref": "/schemas/core/duration.json" }],
+          "description": "Post-click attribution window to apply."
+        },
+        "post_view": {
+          "allOf": [{ "$ref": "/schemas/core/duration.json" }],
+          "description": "Post-view attribution window to apply."
+        },
+        "model": {
+          "$ref": "/schemas/enums/attribution-model.json",
+          "description": "Attribution model to use. When omitted, the seller applies their default model."
+        }
+      },
+      "additionalProperties": true
+    },
     "reporting_dimensions": {
       "type": "object",
-      "description": "Request dimensional breakdowns in delivery reporting. Each key enables a specific breakdown dimension within by_package — include as an empty object (e.g., \"device_type\": {}) to activate with defaults. Omit entirely for no breakdowns (backward compatible). Unsupported dimensions are silently omitted from the response.",
+      "description": "Request dimensional breakdowns in delivery reporting. Each key enables a specific breakdown dimension within by_package — include as an empty object (e.g., \"device_type\": {}) to activate with defaults. Omit entirely for no breakdowns (backward compatible). Unsupported dimensions are silently omitted from the response. Note: keyword, catalog_item, and creative breakdowns are returned automatically when the seller supports them and are not controlled by this object.",
       "properties": {
         "geo": {
           "type": "object",

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -507,6 +507,57 @@
                     "by_placement_truncated": {
                       "type": "boolean",
                       "description": "Whether by_placement was truncated. Sellers MUST return this flag whenever by_placement is present (false means the list is complete)."
+                    },
+                    "daily_breakdown": {
+                      "type": "array",
+                      "description": "Day-by-day delivery for this package. Only present when include_package_daily_breakdown is true in the request. Enables per-package pacing analysis and line-item monitoring.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                            "description": "Date (YYYY-MM-DD)"
+                          },
+                          "impressions": {
+                            "type": "number",
+                            "description": "Daily impressions for this package",
+                            "minimum": 0
+                          },
+                          "spend": {
+                            "type": "number",
+                            "description": "Daily spend for this package",
+                            "minimum": 0
+                          },
+                          "conversions": {
+                            "type": "number",
+                            "description": "Daily conversions for this package",
+                            "minimum": 0
+                          },
+                          "conversion_value": {
+                            "type": "number",
+                            "description": "Daily conversion value for this package",
+                            "minimum": 0
+                          },
+                          "roas": {
+                            "type": "number",
+                            "description": "Daily return on ad spend (conversion_value / spend)",
+                            "minimum": 0
+                          },
+                          "new_to_brand_rate": {
+                            "type": "number",
+                            "description": "Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)",
+                            "minimum": 0,
+                            "maximum": 1
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "impressions",
+                          "spend"
+                        ],
+                        "additionalProperties": true
+                      }
                     }
                   },
                   "required": [

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -40,6 +40,16 @@
             "description": "Total budget amount across all packages, denominated in media_buy.currency",
             "minimum": 0
           },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 flight start time for this media buy (earliest package start_time). Avoids requiring buyers to compute min(packages[].start_time)."
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 flight end time for this media buy (latest package end_time). Avoids requiring buyers to compute max(packages[].end_time)."
+          },
           "creative_deadline": {
             "type": "string",
             "format": "date-time",

--- a/static/schemas/source/media-buy/get-products-request.json
+++ b/static/schemas/source/media-buy/get-products-request.json
@@ -104,6 +104,40 @@
       "$ref": "/schemas/core/property-list-ref.json",
       "description": "[AdCP 3.0] Reference to an externally managed property list. When provided, the sales agent should filter products to only those available on properties in the list."
     },
+    "fields": {
+      "type": "array",
+      "description": "Specific product fields to include in the response. When omitted, all fields are returned. Use for lightweight discovery calls where only a subset of product data is needed (e.g., just IDs and pricing for comparison). Required fields (product_id, name) are always included regardless of selection.",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "product_id",
+          "name",
+          "description",
+          "publisher_properties",
+          "channels",
+          "format_ids",
+          "placements",
+          "delivery_type",
+          "pricing_options",
+          "forecast",
+          "outcome_measurement",
+          "delivery_measurement",
+          "reporting_capabilities",
+          "creative_policy",
+          "catalog_types",
+          "metric_optimization",
+          "conversion_tracking",
+          "data_provider_signals",
+          "max_optimization_goals",
+          "catalog_match",
+          "brief_relevance",
+          "expires_at",
+          "product_card",
+          "product_card_detailed"
+        ]
+      }
+    },
     "pagination": {
       "$ref": "/schemas/core/pagination-request.json"
     },

--- a/static/schemas/source/media-buy/sync-audiences-request.json
+++ b/static/schemas/source/media-buy/sync-audiences-request.json
@@ -24,6 +24,24 @@
             "type": "string",
             "description": "Human-readable name for this audience"
           },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of this audience's composition or purpose (e.g., 'High-value customers who purchased in the last 90 days')."
+          },
+          "audience_type": {
+            "type": "string",
+            "enum": ["crm", "suppression", "lookalike_seed"],
+            "description": "Intended use for this audience. 'crm': target these users. 'suppression': exclude these users from delivery. 'lookalike_seed': use as a seed for the seller's lookalike modeling. Sellers may handle audiences differently based on type (e.g., suppression lists bypass minimum size requirements on some platforms)."
+          },
+          "tags": {
+            "type": "array",
+            "description": "Buyer-defined tags for organizing and filtering audiences (e.g., 'holiday_2026', 'high_ltv'). Tags are stored by the seller and returned in discovery-only calls.",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
           "add": {
             "type": "array",
             "description": "Members to add to this audience. Hashed before sending — normalize emails to lowercase+trim, phones to E.164.",

--- a/static/schemas/source/media-buy/sync-audiences-response.json
+++ b/static/schemas/source/media-buy/sync-audiences-response.json
@@ -43,6 +43,11 @@
                 "description": "Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.",
                 "minimum": 0
               },
+              "total_uploaded_count": {
+                "type": "integer",
+                "description": "Cumulative number of members uploaded across all syncs for this audience. Compare with matched_count to calculate match rate (matched_count / total_uploaded_count). Populated when the seller tracks cumulative upload counts.",
+                "minimum": 0
+              },
               "matched_count": {
                 "type": "integer",
                 "description": "Total members matched to platform users across all syncs (cumulative, not just this call). Populated when status is 'ready'.",

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -84,6 +84,51 @@
       "type": "object",
       "description": "Media-buy protocol capabilities. Only present if media_buy is in supported_protocols.",
       "properties": {
+        "supported_pricing_models": {
+          "type": "array",
+          "description": "Pricing models this seller supports across its product portfolio. Buyers can use this for pre-flight filtering before querying individual products. Individual products may support a subset of these models.",
+          "items": {
+            "$ref": "/schemas/enums/pricing-model.json"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "reporting": {
+          "type": "object",
+          "description": "Seller-level reporting capabilities. Summarizes what reporting features are available across the seller's product portfolio. Individual products may vary — check product-level reporting_capabilities for specifics.",
+          "properties": {
+            "supports_date_range": {
+              "type": "boolean",
+              "description": "Whether any products support date range filtering (date_range_support: 'date_range'). When false, all products return lifetime-only data."
+            },
+            "supports_daily_breakdown": {
+              "type": "boolean",
+              "description": "Whether delivery reporting includes daily_breakdown at the media buy and/or package level."
+            },
+            "supports_webhooks": {
+              "type": "boolean",
+              "description": "Whether any products support webhook-based reporting notifications."
+            },
+            "available_dimensions": {
+              "type": "array",
+              "description": "Reporting dimensions available across the seller's portfolio. Individual products may support a subset. Dimensions geo, device_type, device_platform, audience, and placement are opt-in via reporting_dimensions on the delivery request. Dimensions creative, keyword, and catalog_item are included automatically when the seller supports them (not controlled by reporting_dimensions).",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "geo",
+                  "device_type",
+                  "device_platform",
+                  "audience",
+                  "placement",
+                  "creative",
+                  "keyword",
+                  "catalog_item"
+                ]
+              },
+              "uniqueItems": true
+            }
+          }
+        },
         "features": {
           "$ref": "/schemas/core/media-buy-features.json"
         },


### PR DESCRIPTION
## Summary

Implements high-value, non-breaking schema improvements from the [v3 nice-to-have tracking issue](https://github.com/adcontextprotocol/adcp/issues/1240). Focused on reducing context window cost for agents and improving pre-flight planning.

### Media Buy
- **`get_products` field projection** — `fields` parameter with 24 projectable product fields. Agents requesting just `["product_id", "name", "pricing_options"]` skip formats, targeting templates, cards, etc. Required fields (`product_id`, `name`) always included.
- **Package-level `daily_breakdown`** — Opt-in via `include_package_daily_breakdown` on delivery request. Prevents response bloat for agents that don't need per-package pacing data.
- **Request-side `attribution_window`** — Buyers specify post-click/post-view windows for cross-platform comparison. `model` is optional on the request (unlike the response schema where it's required). Sellers that don't support configurable windows ignore it.
- **Buy-level `start_time`/`end_time`** — Echoes min/max of package flight dates on `get_media_buys` response. Saves agents from computing this across packages.

### Capabilities
- **`supported_pricing_models`** — Seller-level array of pricing model enums for pre-flight filtering.
- **`reporting` block** — `supports_date_range`, `supports_daily_breakdown`, `supports_webhooks`, `available_dimensions` with clear documentation of which dimensions are opt-in vs. automatic.

### Audiences
- **Metadata fields** — `description`, `audience_type` (crm/suppression/lookalike_seed), `tags` on sync request.
- **`total_uploaded_count`** — Cumulative upload count in response for match rate calculation.

### Forecasting
- **Typed `ForecastPoint.metrics`** — Explicit properties for all 13 forecastable-metric enum values. `additionalProperties` preserved for event-type keys.

### Separate issues created
- #1264 — PushNotificationConfig credential_id reference pattern
- #1265 — Sub-agent delegation convention via ext.adcp.delegation

## Test plan

- [x] All 304 unit tests pass
- [x] Schema validation tests pass (342 schemas, 7 test suites)
- [x] Example validation tests pass (13 examples)
- [x] OpenAPI spec regenerates cleanly
- [x] TypeScript typecheck passes
- [x] All 8 modified JSON schemas are valid JSON
- [x] Pre-commit and pre-push hooks pass (version sync, broken links, accessibility)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)