### PR TITLE
feat(schema): error codes, frequency cap semantics, and schema robustness

### DIFF
--- a/.changeset/schema-agentic-robustness.md
+++ b/.changeset/schema-agentic-robustness.md
@@ -73,3 +73,23 @@ Address schema gaps that block autonomous agent operation, plus consistency fixe
 
 **Package catalogs**
 - `Package`, `PackageRequest`: change `catalog` (single) to `catalogs` (array) to support multi-catalog packages (e.g., product + store catalogs)
+
+**Error code vocabulary expansion (#1269–1276)**
+- `ErrorCode`: add `BUDGET_EXHAUSTED` (account/campaign budget spent, distinct from `BUDGET_TOO_LOW`) and `CONFLICT` (concurrent modification)
+- `Error.code`: stays `type: string` (not wired to enum) so sellers can use platform-specific codes; description references error-code.json as the standard vocabulary
+
+**Frequency cap semantics (#1272)**
+- `FrequencyCap`: add normative AND semantics — when both `suppress` and `max_impressions` are set, an impression is delivered only if both constraints permit it
+
+**Catalog uniqueness (#1276)**
+- `Package`, `PackageRequest`: strengthen catalog type uniqueness from SHOULD to MUST; sellers MUST reject duplicates with `validation_error`
+
+**Creative weight semantics**
+- `CreativeAssignment`, `SyncCreativesRequest.assignments`: clarify weight is relative proportional (weight 2 = 2x weight 1), omitted = equal rotation, 0 = assigned but paused
+
+**Outcome measurement window (breaking)**
+- `OutcomeMeasurement.window`: change from `type: string` (e.g., `"30_days"`) to `$ref: duration.json` (structured `{interval, unit}`)
+
+**Media buy lifecycle**
+- `MediaBuyStatus`: add `canceled` (buyer-initiated termination, distinct from `completed` and `rejected`)
+- `GetMediaBuyDeliveryResponse`: add `canceled` to inline status enum

--- a/docs/guides/commerce-media.mdx
+++ b/docs/guides/commerce-media.mdx
@@ -69,7 +69,7 @@ The simplest commerce media product. The retailer renders the creative from the 
   "outcome_measurement": {
     "type": "attributed_sales",
     "attribution": "deterministic_purchase",
-    "window": "14_days",
+    "window": { "interval": 14, "unit": "days" },
     "reporting": "daily_api"
   },
   "conversion_tracking": {
@@ -130,7 +130,7 @@ Display and video ads on retailer properties, targeted using retailer first-part
   "outcome_measurement": {
     "type": "incremental_sales_lift",
     "attribution": "deterministic_purchase",
-    "window": "30_days",
+    "window": { "interval": 30, "unit": "days" },
     "reporting": "weekly_dashboard"
   },
   "creative_policy": {
@@ -177,7 +177,7 @@ The retailer uses first-party purchase data to target audiences on third-party i
   "outcome_measurement": {
     "type": "incremental_sales_lift",
     "attribution": "deterministic_purchase",
-    "window": "30_days",
+    "window": { "interval": 30, "unit": "days" },
     "reporting": "weekly_dashboard"
   }
 }
@@ -486,7 +486,7 @@ Products signal closed-loop capability through two fields:
   "outcome_measurement": {
     "type": "attributed_sales",
     "attribution": "deterministic_purchase",
-    "window": "14_days",
+    "window": { "interval": 14, "unit": "days" },
     "reporting": "daily_api"
   }
 }

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -153,7 +153,7 @@ For products that include outcome measurement (common in retail media):
 {
   "type": "incremental_sales_lift",
   "attribution": "deterministic_purchase",
-  "window": "30_days",
+  "window": { "interval": 30, "unit": "days" },
   "reporting": "weekly_dashboard"
 }
 ```
@@ -446,7 +446,7 @@ A server can offer a general catalog, but it can also return:
   "outcome_measurement": {
     "type": "incremental_sales_lift",
     "attribution": "deterministic_purchase",
-    "window": "30_days",
+    "window": { "interval": 30, "unit": "days" },
     "reporting": "weekly_dashboard"
   },
   "creative_policy": {

--- a/static/schemas/source/core/creative-assignment.json
+++ b/static/schemas/source/core/creative-assignment.json
@@ -11,7 +11,7 @@
     },
     "weight": {
       "type": "number",
-      "description": "Delivery weight for this creative",
+      "description": "Relative delivery weight for this creative (0–100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).",
       "minimum": 0,
       "maximum": 100
     },

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -7,7 +7,7 @@
   "properties": {
     "code": {
       "type": "string",
-      "description": "Error code for programmatic handling"
+      "description": "Error code for programmatic handling. Standard codes are defined in error-code.json and enable autonomous agent recovery. Sellers MAY use codes not in the standard vocabulary for platform-specific errors; agents MUST handle unknown codes gracefully by falling back to the recovery classification."
     },
     "message": {
       "type": "string",

--- a/static/schemas/source/core/frequency-cap.json
+++ b/static/schemas/source/core/frequency-cap.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/frequency-cap.json",
   "title": "Frequency Cap",
-  "description": "Frequency capping settings for package-level application. Two types of frequency control can be used independently or together: suppress enforces a cooldown between consecutive exposures; max_impressions + per + window caps total exposures per entity in a time window. At least one of suppress, suppress_minutes, or max_impressions must be set.",
+  "description": "Frequency capping settings for package-level application. Two types of frequency control can be used independently or together: suppress enforces a cooldown between consecutive exposures; max_impressions + per + window caps total exposures per entity in a time window. When both suppress and max_impressions are set, an impression is delivered only if both constraints permit it (AND semantics). At least one of suppress, suppress_minutes, or max_impressions must be set.",
   "type": "object",
   "properties": {
     "suppress": {

--- a/static/schemas/source/core/outcome-measurement.json
+++ b/static/schemas/source/core/outcome-measurement.json
@@ -23,12 +23,8 @@
       ]
     },
     "window": {
-      "type": "string",
-      "description": "Attribution window",
-      "examples": [
-        "30_days",
-        "7_days"
-      ]
+      "allOf": [{ "$ref": "/schemas/core/duration.json" }],
+      "description": "Attribution window as a structured duration (e.g., {\"interval\": 30, \"unit\": \"days\"})."
     },
     "reporting": {
       "type": "string",

--- a/static/schemas/source/core/package.json
+++ b/static/schemas/source/core/package.json
@@ -41,7 +41,7 @@
     },
     "catalogs": {
       "type": "array",
-      "description": "Catalogs this package promotes. Each catalog should have a distinct type (e.g., one product catalog, one store catalog). Echoed from the create_media_buy request.",
+      "description": "Catalogs this package promotes. Each catalog MUST have a distinct type (e.g., one product catalog, one store catalog). This constraint is enforced at the application level — sellers MUST reject requests containing multiple catalogs of the same type with a validation_error. Echoed from the create_media_buy request.",
       "items": {
         "$ref": "/schemas/core/catalog.json"
       }

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/error-code.json",
   "title": "Error Code",
-  "description": "Standard error code vocabulary for AdCP. Codes are machine-readable so agents can apply autonomous recovery strategies based on the recovery classification.",
+  "description": "Standard error code vocabulary for AdCP. Codes are machine-readable so agents can apply autonomous recovery strategies based on the recovery classification. Sellers MAY return codes not listed here for platform-specific errors — the error.json code field accepts any string. Agents MUST handle unknown codes by falling back to the recovery classification.",
   "type": "string",
   "enum": [
     "INVALID_REQUEST",
@@ -22,7 +22,9 @@
     "ACCOUNT_AMBIGUOUS",
     "ACCOUNT_PAYMENT_REQUIRED",
     "ACCOUNT_SUSPENDED",
-    "COMPLIANCE_UNSATISFIED"
+    "COMPLIANCE_UNSATISFIED",
+    "BUDGET_EXHAUSTED",
+    "CONFLICT"
   ],
   "enumDescriptions": {
     "INVALID_REQUEST": "Request is malformed, missing required fields, or violates schema constraints. Recovery: correctable (check request parameters and fix).",
@@ -42,6 +44,8 @@
     "ACCOUNT_AMBIGUOUS": "Natural key resolves to multiple accounts. Recovery: correctable (pass explicit account_id or a more specific natural key).",
     "ACCOUNT_PAYMENT_REQUIRED": "Account has an outstanding balance requiring payment before new buys. Recovery: terminal (buyer must resolve billing).",
     "ACCOUNT_SUSPENDED": "Account has been suspended. Recovery: terminal (contact seller to resolve suspension).",
-    "COMPLIANCE_UNSATISFIED": "A required disclosure from the brief's compliance section cannot be satisfied by the target format. Recovery: correctable (choose a format that supports the required disclosure positions, or remove the disclosure requirement)."
+    "COMPLIANCE_UNSATISFIED": "A required disclosure from the brief's compliance section cannot be satisfied by the target format. Recovery: correctable (choose a format that supports the required disclosure positions, or remove the disclosure requirement).",
+    "BUDGET_EXHAUSTED": "Account or campaign budget has been fully spent. Distinct from BUDGET_TOO_LOW (rejected at submission). Recovery: terminal (buyer must add funds or increase budget cap).",
+    "CONFLICT": "Concurrent modification detected. The resource was modified by another request between read and write. Recovery: transient (re-read the resource and retry with current state)."
   }
 }

--- a/static/schemas/source/enums/media-buy-status.json
+++ b/static/schemas/source/enums/media-buy-status.json
@@ -2,20 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/media-buy-status.json",
   "title": "Media Buy Status",
-  "description": "Status of a media buy",
+  "description": "Status of a media buy.",
   "type": "string",
   "enum": [
     "pending_activation",
     "active",
     "paused",
     "completed",
-    "rejected"
+    "rejected",
+    "canceled"
   ],
   "enumDescriptions": {
     "pending_activation": "Media buy created but not yet activated",
     "active": "Media buy is currently running",
     "paused": "Media buy is temporarily paused",
     "completed": "Media buy has finished running",
-    "rejected": "Media buy was declined by the seller after creation"
+    "rejected": "Media buy was declined by the seller after creation",
+    "canceled": "Media buy was terminated by the buyer before natural completion"
   }
 }

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -147,7 +147,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Current media buy status. Lifecycle states use the same taxonomy as media-buy-status (`pending_activation`, `active`, `paused`, `completed`, `rejected`). In webhook context, reporting_delayed indicates data temporarily unavailable. `pending` is accepted as a legacy alias for pending_activation.",
+            "description": "Current media buy status. Lifecycle states use the same taxonomy as media-buy-status (`pending_activation`, `active`, `paused`, `completed`, `rejected`, `canceled`). In webhook context, reporting_delayed indicates data temporarily unavailable. `pending` is accepted as a legacy alias for pending_activation.",
             "enum": [
               "pending_activation",
               "pending",
@@ -155,6 +155,7 @@
               "paused",
               "completed",
               "rejected",
+              "canceled",
               "failed",
               "reporting_delayed"
             ]

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -50,7 +50,7 @@
     },
     "catalogs": {
       "type": "array",
-      "description": "Catalogs this package promotes. Each catalog should have a distinct type (e.g., one product catalog, one store catalog). Makes the package catalog-driven: one budget envelope, platform optimizes across items.",
+      "description": "Catalogs this package promotes. Each catalog MUST have a distinct type (e.g., one product catalog, one store catalog). This constraint is enforced at the application level — sellers MUST reject requests containing multiple catalogs of the same type with a validation_error. Makes the package catalog-driven: one budget envelope, platform optimizes across items.",
       "items": {
         "$ref": "/schemas/core/catalog.json"
       }

--- a/static/schemas/source/media-buy/sync-creatives-request.json
+++ b/static/schemas/source/media-buy/sync-creatives-request.json
@@ -43,7 +43,7 @@
           },
           "weight": {
             "type": "number",
-            "description": "Relative delivery weight (0–100). When multiple creatives are assigned to the same package, weights determine the distribution of impressions.",
+            "description": "Relative delivery weight (0–100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).",
             "minimum": 0,
             "maximum": 100
           },


### PR DESCRIPTION
## Summary

Addresses upstream issues #1269–#1276 and additional schema robustness gaps identified during triage:

- **Error codes**: Add `BUDGET_EXHAUSTED` and `CONFLICT` to standard vocabulary. Keep `error.code` as `type: string` so sellers can use platform-specific codes — the enum is a vocabulary reference, not a schema constraint.
- **FrequencyCap (#1272)**: Add normative AND semantics — when both `suppress` and `max_impressions` are set, both must permit delivery.
- **Catalog uniqueness (#1276)**: Strengthen from SHOULD to MUST. Sellers MUST reject duplicate catalog types with `validation_error`. Note: enforced at application level (not expressible in JSON Schema).
- **Creative weight**: Clarify semantics — relative proportional weights, omitted = equal rotation, 0 = assigned but paused.
- **Outcome measurement window**: Change from `type: string` (`"30_days"`) to `$ref: duration.json` (structured `{interval, unit}`). **Breaking** for sellers populating this optional field.
- **Media buy status**: Add `canceled` (American spelling, matching A2A's `task-status.json`). Added to both canonical enum and delivery response inline enum.
- **Docs**: Update all `outcome_measurement.window` examples to Duration format.

### Issues triaged as already-fixed or won't-fix

| Issue | Verdict |
|-------|---------|
| #1269 target_frequency untyped | Already fixed — schema has `min`, `max`, `window` with constraints |
| #1270 reach_unit conditional required | Won't fix — draft-07 can't express metric-conditional required cleanly |
| #1271 FrequencyCap.per reuses ReachUnit | Won't fix — premature separation for hypothetical divergence |
| #1273 buying_mode backward compat | Invalid — field is required in v3, versioning handled at transport |
| #1274 refine without refine object | Already fixed — `oneOf` requires `refine` when `buying_mode: "refine"` |
| #1275 agent-scoped accounts | Invalid — agency self-promo uses `brand: {domain: "agency.com"}` |

## Test plan

- [x] `npm run test:schemas` — 7/7 pass (all schemas valid, examples validate)
- [x] `npm run test:examples` — 17/17 pass (including updated outcome measurement)
- [x] `npm test` — 304/304 pass
- [x] `npm run typecheck` — clean
- [x] Pre-push hooks pass (version sync, broken links, accessibility)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)