### PR TITLE
fix: stop duplicate Slack notifications from concurrent Moltbook poster runs

### DIFF
--- a/.changeset/fix-moltbook-spam.md
+++ b/.changeset/fix-moltbook-spam.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix duplicate Moltbook Slack notifications from concurrent poster runs


### PR DESCRIPTION
## Summary

- Migration 253 added a `UNIQUE` constraint on `moltbook_posts.knowledge_id` and updated `recordPost()` to use `ON CONFLICT DO NOTHING` to prevent duplicate DB records during concurrent runs
- However, the poster never checked `recordPost()`'s return value — when `DO NOTHING` fires and returns `null`, execution continued to `notifySlack()`, sending a duplicate Slack message
- Fix: check the return value and return early when `null`, so only the instance that actually recorded the post sends the notification
- Also passes `submolt` to `recordPost()` which was previously always stored as `NULL` in the DB

## Test plan

- [ ] TypeScript typechecks pass (`npm run typecheck`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] Deploy to production and confirm no further spam in `#addie_moltbook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)