### PR TITLE
fix: update AAO brand.json tone to structured { voice, attributes } format

### DIFF
--- a/.changeset/aao-brand-tone-format.md
+++ b/.changeset/aao-brand-tone-format.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update AgenticAdvertising.org brand.json tone to structured { voice, attributes } format for agent compatibility.

--- a/server/src/db/migrations/254_aao_brand_tone_format.sql
+++ b/server/src/db/migrations/254_aao_brand_tone_format.sql
@@ -1,0 +1,41 @@
+-- Update tone for AgenticAdvertising.org brands to use structured { voice, attributes } format.
+-- Migration 237 seeded with ON CONFLICT DO NOTHING, so existing rows may have the old string format.
+-- Split into two statements so each brand update is independent; CASE guards against a missing brand ID.
+
+UPDATE hosted_brands
+SET brand_json = (
+  SELECT
+    CASE WHEN pos->>'agenticadvertising' IS NOT NULL THEN
+      jsonb_set(
+        brand_json,
+        ARRAY['brands', (pos->>'agenticadvertising')::text, 'tone'],
+        '{"voice": "Professional and collaborative, championing the future of agentic advertising", "attributes": ["professional", "collaborative", "forward-thinking", "inclusive", "visionary"]}'::jsonb
+      )
+    ELSE brand_json
+    END
+  FROM (
+    SELECT jsonb_object_agg(elem->>'id', (idx - 1)::text) AS pos
+    FROM jsonb_array_elements(brand_json->'brands') WITH ORDINALITY AS t(elem, idx)
+    WHERE elem->>'id' IN ('agenticadvertising', 'adcp')
+  ) AS indices
+)
+WHERE brand_domain = 'agenticadvertising.org';
+
+UPDATE hosted_brands
+SET brand_json = (
+  SELECT
+    CASE WHEN pos->>'adcp' IS NOT NULL THEN
+      jsonb_set(
+        brand_json,
+        ARRAY['brands', (pos->>'adcp')::text, 'tone'],
+        '{"voice": "Technical and precise, empowering developers to build the next generation of advertising", "attributes": ["technical", "precise", "developer-friendly", "clear", "innovative"]}'::jsonb
+      )
+    ELSE brand_json
+    END
+  FROM (
+    SELECT jsonb_object_agg(elem->>'id', (idx - 1)::text) AS pos
+    FROM jsonb_array_elements(brand_json->'brands') WITH ORDINALITY AS t(elem, idx)
+    WHERE elem->>'id' IN ('agenticadvertising', 'adcp')
+  ) AS indices
+)
+WHERE brand_domain = 'agenticadvertising.org';


### PR DESCRIPTION
## Summary

- Adds migration 254 to update `agenticadvertising.org` hosted brand tone fields to the structured `{ voice, attributes }` format
- Migration 237 seeded this brand with `ON CONFLICT DO NOTHING`, so environments with a pre-existing row retain the old format
- Fixes compatibility with agent parsers (e.g. Celtra) that expect the structured tone format

## Details

The migration updates both brands in the portfolio:
- `agenticadvertising` — professional/collaborative voice
- `adcp` — technical/precise voice

Each update uses brand ID lookup (not hardcoded array index) with a null guard via `CASE` to handle gracefully if a brand is missing.

## Test plan

- [ ] All existing tests pass (pre-commit hook verified)
- [ ] Migration is idempotent — safe to run twice
- [ ] No UI changes — browser testing not required
- [ ] No API/MCP logic changes — server testing not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)