### PR TITLE
feat(addie): Weekly digest with Editorial approval

### DIFF
--- a/.changeset/weekly-digest.md
+++ b/.changeset/weekly-digest.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add weekly digest: Addie generates a Tuesday briefing with curated industry news and community updates. Editorial working group approves via Slack reaction. Delivered to Slack and email with segment-specific CTAs.

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -28,6 +28,7 @@ import { runPersonaInferenceJob } from '../services/persona-inference.js';
 import { runJourneyComputationJob } from '../services/journey-computation.js';
 import { runKnowledgeStalenessJob } from './knowledge-staleness.js';
 import { processUntriagedDomains, escalateUnclaimedProspects } from '../../services/prospect-triage.js';
+import { runWeeklyDigestJob } from './weekly-digest.js';
 import { logger } from '../../logger.js';
 
 const jobLogger = logger.child({ module: 'content-curator-job' });
@@ -264,6 +265,16 @@ export function registerAllJobs(): void {
     businessHours: { startHour: 9, endHour: 18, skipWeekends: true },
     shouldLogResult: (r) => r.escalated > 0,
   });
+
+  // Weekly digest - generates and sends Tuesday digest after Editorial approval
+  jobScheduler.register({
+    name: 'weekly-digest',
+    description: 'Weekly digest',
+    interval: { value: 1, unit: 'hours' },
+    initialDelay: { value: 6, unit: 'minutes' },
+    runner: runWeeklyDigestJob,
+    shouldLogResult: (r) => r.generated || r.sent > 0,
+  });
 }
 
 /**
@@ -287,4 +298,5 @@ export const JOB_NAMES = {
   KNOWLEDGE_STALENESS: 'knowledge-staleness',
   PROSPECT_TRIAGE: 'prospect-triage',
   PROSPECT_ESCALATION: 'prospect-escalation',
+  WEEKLY_DIGEST: 'weekly-digest',
 } as const;

--- a/server/src/addie/jobs/weekly-digest.ts
+++ b/server/src/addie/jobs/weekly-digest.ts
@@ -1,0 +1,242 @@
+import crypto from 'crypto';
+import { createLogger } from '../../logger.js';
+import { buildDigestContent, hasMinimumContent } from '../services/digest-builder.js';
+import {
+  createDigest,
+  getDigestByDate,
+  setReviewMessage,
+  markSent,
+  markSkipped,
+  getDigestEmailRecipients,
+  type DigestSendStats,
+} from '../../db/digest-db.js';
+import { WorkingGroupDatabase } from '../../db/working-group-db.js';
+import { sendChannelMessage } from '../../slack/client.js';
+import { sendBatchMarketingEmails, type BatchMarketingEmail } from '../../notifications/email.js';
+import { renderDigestEmail, renderDigestSlack, renderDigestReview, type DigestSegment } from '../templates/weekly-digest.js';
+
+const logger = createLogger('weekly-digest');
+const workingGroupDb = new WorkingGroupDatabase();
+
+const EDITORIAL_SLUG = 'editorial';
+const ANNOUNCEMENTS_CHANNEL = process.env.ANNOUNCEMENTS_CHANNEL_ID;
+
+interface WeeklyDigestResult {
+  generated: boolean;
+  sent: number;
+  skipped: boolean;
+  error?: string;
+}
+
+/**
+ * Get the current hour in US Eastern time
+ */
+function getETHour(): number {
+  const now = new Date();
+  const etString = now.toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', hour12: false });
+  return parseInt(etString, 10);
+}
+
+/**
+ * Get today's edition date as YYYY-MM-DD in ET
+ */
+function getTodayEditionDate(): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return formatter.format(new Date());
+}
+
+/**
+ * Main weekly digest job runner.
+ * Runs hourly. On Tuesdays:
+ * - 7-8am ET: Generates a draft and posts to Editorial channel for review
+ * - 10-11am ET: Sends the digest if approved, or marks it skipped
+ */
+export async function runWeeklyDigestJob(): Promise<WeeklyDigestResult> {
+  const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
+
+  const now = new Date();
+  const dayOfWeek = now.toLocaleString('en-US', { timeZone: 'America/New_York', weekday: 'short' });
+
+  if (dayOfWeek !== 'Tue') {
+    return result;
+  }
+
+  const etHour = getETHour();
+  const editionDate = getTodayEditionDate();
+
+  // Phase 1: Generate draft (7-8am ET)
+  if (etHour >= 7 && etHour < 8) {
+    return generateDraft(editionDate);
+  }
+
+  // Phase 2: Send if approved (10-11am ET)
+  if (etHour >= 10 && etHour < 11) {
+    return sendApprovedDigest(editionDate);
+  }
+
+  return result;
+}
+
+/**
+ * Generate digest draft and post to Editorial channel for review
+ */
+async function generateDraft(editionDate: string): Promise<WeeklyDigestResult> {
+  const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
+
+  // Check if draft already exists for this week
+  const existing = await getDigestByDate(editionDate);
+  if (existing) {
+    logger.debug({ editionDate }, 'Digest already exists for this date');
+    return result;
+  }
+
+  // Build content
+  const content = await buildDigestContent();
+
+  // Check minimum content threshold
+  if (!hasMinimumContent(content)) {
+    logger.info({ editionDate }, 'Not enough content for digest this week');
+    result.skipped = true;
+    return result;
+  }
+
+  // Save draft (ON CONFLICT handles race condition if two instances run simultaneously)
+  const digest = await createDigest(editionDate, content);
+  if (!digest) {
+    logger.debug({ editionDate }, 'Digest already created by another instance');
+    return result;
+  }
+  result.generated = true;
+
+  // Post to Editorial working group channel for review
+  const editorial = await workingGroupDb.getWorkingGroupBySlug(EDITORIAL_SLUG);
+  if (!editorial?.slack_channel_id) {
+    logger.error('Editorial working group has no Slack channel configured');
+    return result;
+  }
+
+  const reviewMessage = renderDigestReview(content, editionDate);
+  const postResult = await sendChannelMessage(editorial.slack_channel_id, reviewMessage);
+
+  if (postResult.ok && postResult.ts) {
+    await setReviewMessage(digest.id, editorial.slack_channel_id, postResult.ts);
+    logger.info({ editionDate, channel: editorial.slack_channel_id }, 'Digest draft posted for review');
+  } else {
+    logger.error({ error: postResult.error }, 'Failed to post digest review to Editorial channel');
+  }
+
+  return result;
+}
+
+/**
+ * Send the approved digest to all segments, or mark as skipped
+ */
+async function sendApprovedDigest(editionDate: string): Promise<WeeklyDigestResult> {
+  const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
+
+  const digest = await getDigestByDate(editionDate);
+  if (!digest) {
+    return result;
+  }
+
+  // Already sent or skipped
+  if (digest.status === 'sent' || digest.status === 'skipped') {
+    return result;
+  }
+
+  // Not approved yet - skip
+  if (digest.status === 'draft') {
+    await markSkipped(digest.id);
+    result.skipped = true;
+
+    // Notify Editorial channel
+    if (digest.review_channel_id && digest.review_message_ts) {
+      await sendChannelMessage(digest.review_channel_id, {
+        text: `This week's digest was not approved in time and has been skipped.`,
+        thread_ts: digest.review_message_ts,
+      });
+    }
+
+    logger.info({ editionDate }, 'Digest skipped - no approval received');
+    return result;
+  }
+
+  // Status is 'approved' - send it
+  const stats: DigestSendStats = { email_count: 0, slack_count: 0, by_segment: {} };
+
+  // Post to Slack #announcements
+  if (ANNOUNCEMENTS_CHANNEL) {
+    const slackMessage = renderDigestSlack(digest.content, editionDate);
+    const slackResult = await sendChannelMessage(ANNOUNCEMENTS_CHANNEL, slackMessage);
+    if (slackResult.ok) {
+      stats.slack_count = 1;
+    }
+  }
+
+  // Prepare and batch-send emails to eligible recipients
+  const recipients = await getDigestEmailRecipients();
+  const topNewsTitle = digest.content.news?.[0]?.title;
+  const subject = topNewsTitle
+    ? `${topNewsTitle} + more | AgenticAdvertising.org Weekly`
+    : `AgenticAdvertising.org Weekly - ${formatShortDate(editionDate)}`;
+
+  const emailBatch: BatchMarketingEmail[] = [];
+
+  for (const recipient of recipients) {
+    const segment: DigestSegment = recipient.has_slack ? 'both' : 'website_only';
+    const feedbackId = crypto.randomUUID();
+    const { html, text } = renderDigestEmail(digest.content, feedbackId, editionDate, segment, recipient.first_name || undefined);
+
+    emailBatch.push({
+      to: recipient.email,
+      subject,
+      htmlContent: html,
+      textContent: text,
+      category: 'weekly_digest',
+      workosUserId: recipient.workos_user_id,
+    });
+
+    stats.by_segment[segment] = (stats.by_segment[segment] || 0) + 1;
+  }
+
+  const batchResult = await sendBatchMarketingEmails(emailBatch);
+  stats.email_count = batchResult.sent;
+
+  // Adjust segment counts if there were failures
+  if (batchResult.failed > 0) {
+    stats.by_segment = { total: batchResult.sent };
+  }
+
+  // Only mark as sent if at least something was delivered
+  if (stats.email_count > 0 || stats.slack_count > 0) {
+    await markSent(digest.id, stats);
+    result.sent = stats.email_count + stats.slack_count;
+  } else {
+    logger.error({ editionDate, batchResult }, 'Digest delivery failed - nothing delivered, leaving as approved for retry');
+  }
+
+  logger.info(
+    { editionDate, emailCount: stats.email_count, slackCount: stats.slack_count },
+    'Weekly digest sent',
+  );
+
+  // Notify Editorial channel
+  if (digest.review_channel_id && digest.review_message_ts) {
+    await sendChannelMessage(digest.review_channel_id, {
+      text: `Digest sent! ${stats.email_count} emails, ${stats.slack_count} Slack posts.`,
+      thread_ts: digest.review_message_ts,
+    });
+  }
+
+  return result;
+}
+
+function formatShortDate(editionDate: string): string {
+  const date = new Date(editionDate + 'T12:00:00Z');
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}

--- a/server/src/addie/services/digest-builder.ts
+++ b/server/src/addie/services/digest-builder.ts
@@ -1,0 +1,300 @@
+import { createLogger } from '../../logger.js';
+import { complete, isLLMConfigured } from '../../utils/llm.js';
+import {
+  getRecentArticlesForDigest,
+  getNewOrganizations,
+  type DigestContent,
+  type DigestNewsItem,
+  type DigestNewMember,
+  type DigestConversation,
+  type DigestWorkingGroup,
+} from '../../db/digest-db.js';
+import { WorkingGroupDatabase } from '../../db/working-group-db.js';
+import { MeetingsDatabase } from '../../db/meetings-db.js';
+
+const workingGroupDb = new WorkingGroupDatabase();
+const meetingsDb = new MeetingsDatabase();
+import { getChannelHistory, resolveSlackUserDisplayName } from '../../slack/client.js';
+import { query } from '../../db/client.js';
+
+const logger = createLogger('digest-builder');
+
+const SLACK_WORKSPACE_URL = process.env.SLACK_WORKSPACE_URL || 'https://agenticadvertising.slack.com';
+
+/**
+ * Build all content sections for the weekly digest.
+ * Assembles news, new members, conversations, and working group updates.
+ */
+export async function buildDigestContent(): Promise<DigestContent> {
+  logger.info('Building weekly digest content');
+
+  const [news, newMembers, conversations, workingGroups] = await Promise.all([
+    buildNewsSection(),
+    buildNewMembersSection(),
+    buildConversationsSection(),
+    buildWorkingGroupsSection(),
+  ]);
+
+  const intro = await generateIntro(news, newMembers, conversations, workingGroups);
+
+  const content: DigestContent = {
+    intro,
+    news,
+    newMembers,
+    conversations,
+    workingGroups,
+    generatedAt: new Date().toISOString(),
+  };
+
+  logger.info(
+    {
+      newsCount: news.length,
+      newMemberCount: newMembers.length,
+      conversationCount: conversations.length,
+      workingGroupCount: workingGroups.length,
+    },
+    'Digest content built',
+  );
+
+  return content;
+}
+
+/**
+ * Check if there's enough content to justify sending a digest this week.
+ */
+export function hasMinimumContent(content: DigestContent): boolean {
+  const totalItems = content.news.length + content.conversations.length + content.workingGroups.length;
+  return totalItems >= 2;
+}
+
+// --- News Section ---
+
+async function buildNewsSection(): Promise<DigestNewsItem[]> {
+  const articles = await getRecentArticlesForDigest(7, 10);
+
+  if (articles.length === 0) {
+    logger.info('No recent articles for digest');
+    return [];
+  }
+
+  if (!isLLMConfigured()) {
+    // Return raw articles without AI curation
+    return articles.slice(0, 3).map((a) => ({
+      title: a.title,
+      url: a.source_url,
+      summary: a.summary || '',
+      whyItMatters: a.addie_notes || '',
+      tags: a.relevance_tags || [],
+      knowledgeId: a.id,
+    }));
+  }
+
+  // Use Claude to select top 3 and generate "why it matters"
+  const articleList = articles
+    .map((a, i) => `${i + 1}. "${a.title}" (score: ${a.quality_score}) - ${a.summary || 'No summary'}`)
+    .join('\n');
+
+  const result = await complete({
+    system: `You are Addie, the AI assistant for AgenticAdvertising.org, a standards organization for AI-powered advertising.
+Select the 3 most relevant articles for our weekly digest and write a brief "why it matters" take for each.
+Respond in JSON format: [{"index": 1, "whyItMatters": "..."}]
+Keep each "whyItMatters" to 1-2 sentences. Be opinionated and specific about relevance to agentic advertising.`,
+    prompt: `Select the top 3 articles from this list for our weekly digest:\n\n${articleList}`,
+    maxTokens: 500,
+    model: 'fast',
+    operationName: 'digest-news-selection',
+  });
+
+  try {
+    const cleaned = result.text.replace(/^```(?:json)?\n?/m, '').replace(/\n?```$/m, '');
+    const selections: Array<{ index: number; whyItMatters: string }> = JSON.parse(cleaned);
+    return selections.slice(0, 3).map((sel) => {
+      const article = articles[sel.index - 1];
+      if (!article) return null;
+      return {
+        title: article.title,
+        url: article.source_url,
+        summary: article.summary || '',
+        whyItMatters: sel.whyItMatters,
+        tags: article.relevance_tags || [],
+        knowledgeId: article.id,
+      };
+    }).filter((item): item is NonNullable<typeof item> => item !== null) as DigestNewsItem[];
+  } catch {
+    logger.warn('Failed to parse LLM news selection, using top 3 by score');
+    return articles.slice(0, 3).map((a) => ({
+      title: a.title,
+      url: a.source_url,
+      summary: a.summary || '',
+      whyItMatters: a.addie_notes || '',
+      tags: a.relevance_tags || [],
+      knowledgeId: a.id,
+    }));
+  }
+}
+
+// --- New Members Section ---
+
+async function buildNewMembersSection(): Promise<DigestNewMember[]> {
+  const orgs = await getNewOrganizations(7);
+  return orgs.map((org) => ({
+    name: org.name,
+  }));
+}
+
+// --- Notable Conversations Section ---
+
+async function buildConversationsSection(): Promise<DigestConversation[]> {
+  // Get public working group channels to scan for notable threads
+  const groups = await query<{
+    id: string;
+    name: string;
+    slack_channel_id: string;
+  }>(
+    `SELECT id, name, slack_channel_id
+     FROM working_groups
+     WHERE slack_channel_id IS NOT NULL
+       AND is_private = FALSE
+       AND status = 'active'`,
+  );
+
+  if (groups.rows.length === 0) {
+    return [];
+  }
+
+  const oneWeekAgo = String(Math.floor((Date.now() - 7 * 24 * 60 * 60 * 1000) / 1000));
+  const notableThreads: Array<{
+    channelName: string;
+    channelId: string;
+    text: string;
+    ts: string;
+    replyCount: number;
+    user?: string;
+  }> = [];
+
+  // Scan each public channel for threads with high reply counts
+  for (const group of groups.rows) {
+    try {
+      const history = await getChannelHistory(group.slack_channel_id, {
+        oldest: oneWeekAgo,
+        limit: 50,
+      });
+
+      for (const msg of history.messages) {
+        if (msg.reply_count && msg.reply_count >= 3 && msg.text && !msg.bot_id) {
+          notableThreads.push({
+            channelName: group.name,
+            channelId: group.slack_channel_id,
+            text: msg.text.slice(0, 200),
+            ts: msg.ts,
+            replyCount: msg.reply_count,
+            user: msg.user,
+          });
+        }
+      }
+    } catch (err) {
+      logger.warn({ channelId: group.slack_channel_id, error: err }, 'Failed to fetch channel history');
+    }
+  }
+
+  if (notableThreads.length === 0) {
+    return [];
+  }
+
+  // Sort by reply count and take top 2
+  notableThreads.sort((a, b) => b.replyCount - a.replyCount);
+  const topThreads = notableThreads.slice(0, 2);
+
+  const conversations: DigestConversation[] = [];
+  for (const thread of topThreads) {
+    let participantName = 'A member';
+    if (thread.user) {
+      const resolved = await resolveSlackUserDisplayName(thread.user);
+      if (resolved?.display_name) {
+        participantName = resolved.display_name;
+      }
+    }
+
+    const threadUrl = `${SLACK_WORKSPACE_URL}/archives/${thread.channelId}/p${thread.ts.replace('.', '')}`;
+
+    conversations.push({
+      summary: `${participantName} started a discussion with ${thread.replyCount} replies: "${thread.text.slice(0, 100)}..."`,
+      channelName: thread.channelName,
+      threadUrl,
+      participants: [participantName],
+    });
+  }
+
+  return conversations;
+}
+
+// --- Working Groups Section ---
+
+async function buildWorkingGroupsSection(): Promise<DigestWorkingGroup[]> {
+  const groups = await query<{
+    id: string;
+    name: string;
+  }>(
+    `SELECT id, name FROM working_groups
+     WHERE status = 'active'
+       AND committee_type IN ('working_group', 'steering_committee')
+     ORDER BY display_order`,
+  );
+
+  const results: DigestWorkingGroup[] = [];
+  const allUpcomingMeetings = await meetingsDb.getUpcomingMeetings(10);
+
+  for (const group of groups.rows) {
+    const summaries = await workingGroupDb.getCurrentSummaries(group.id);
+    const groupMeetings = allUpcomingMeetings.filter(
+      (m: { working_group_id?: string }) => m.working_group_id === group.id,
+    );
+
+    // Only include groups with recent activity
+    if (summaries.length === 0 && groupMeetings.length === 0) {
+      continue;
+    }
+
+    const latestSummary = summaries[0];
+    const nextMeeting = groupMeetings[0];
+
+    results.push({
+      name: group.name,
+      summary: latestSummary?.summary_text?.slice(0, 200) || 'Active this week',
+      nextMeeting: nextMeeting
+        ? `${nextMeeting.title} - ${new Date(nextMeeting.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}`
+        : undefined,
+    });
+  }
+
+  return results;
+}
+
+// --- Intro Generation ---
+
+async function generateIntro(
+  news: DigestNewsItem[],
+  newMembers: DigestNewMember[],
+  conversations: DigestConversation[],
+  workingGroups: DigestWorkingGroup[],
+): Promise<string> {
+  if (!isLLMConfigured()) {
+    return `This week at AgenticAdvertising.org: ${news.length} industry stories, ${newMembers.length} new members, and ${conversations.length} notable conversations.`;
+  }
+
+  const context = [];
+  if (news.length > 0) context.push(`${news.length} industry stories (top: "${news[0].title}")`);
+  if (newMembers.length > 0) context.push(`${newMembers.length} new member${newMembers.length > 1 ? 's' : ''}`);
+  if (conversations.length > 0) context.push(`${conversations.length} notable conversation${conversations.length > 1 ? 's' : ''}`);
+  if (workingGroups.length > 0) context.push(`${workingGroups.length} working group update${workingGroups.length > 1 ? 's' : ''}`);
+
+  const result = await complete({
+    system: `You are Addie, the friendly AI assistant for AgenticAdvertising.org. Write a 1-2 sentence intro for the weekly digest. Be warm, concise, and specific. No emojis.`,
+    prompt: `Write an intro for this week's digest. Content: ${context.join(', ')}.`,
+    maxTokens: 150,
+    model: 'fast',
+    operationName: 'digest-intro',
+  });
+
+  return result.text;
+}

--- a/server/src/addie/templates/weekly-digest.ts
+++ b/server/src/addie/templates/weekly-digest.ts
@@ -1,0 +1,341 @@
+import type { DigestContent } from '../../db/digest-db.js';
+import type { SlackBlock, SlackBlockMessage } from '../../slack/types.js';
+
+const BASE_URL = process.env.BASE_URL || 'https://agenticadvertising.org';
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+function escapeSlackMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export type DigestSegment = 'website_only' | 'slack_only' | 'both' | 'active';
+
+/**
+ * Render the weekly digest as email HTML + text.
+ * The HTML is the inner content only - sendMarketingEmail wraps it in the outer shell + footer.
+ */
+export function renderDigestEmail(
+  content: DigestContent,
+  trackingId: string,
+  editionDate: string,
+  segment: DigestSegment,
+  firstName?: string,
+): { html: string; text: string } {
+  const viewInBrowserUrl = `${BASE_URL}/digest/${editionDate}`;
+  const greeting = firstName ? `Hi ${escapeHtml(firstName)},` : '';
+
+  const html = `
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">
+    ${escapeHtml(content.intro)}
+  </div>
+  <div style="max-width: 560px; margin: 0 auto;">
+    <!-- View in browser -->
+    <p style="font-size: 12px; color: #888; text-align: center; margin-bottom: 24px;">
+      <a href="${viewInBrowserUrl}" style="color: #888; text-decoration: underline;">View in browser</a>
+    </p>
+
+    <!-- Header -->
+    <h1 style="font-size: 22px; color: #1a1a2e; margin-bottom: 4px;">AgenticAdvertising.org Weekly</h1>
+    <p style="font-size: 14px; color: #666; margin-top: 0;">${formatDate(editionDate)}</p>
+
+    ${greeting ? `<p style="font-size: 15px; color: #333; margin-bottom: 0;">${greeting}</p>` : ''}
+
+    <!-- Intro -->
+    <p style="font-size: 15px; color: #333; line-height: 1.6;">${escapeHtml(content.intro)}</p>
+
+    <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
+
+    <!-- Industry Briefing -->
+    ${content.news.length > 0 ? `
+    <h2 style="font-size: 17px; color: #1a1a2e; margin-bottom: 16px;">Industry Briefing</h2>
+    ${content.news.map((item) => `
+    <div style="margin-bottom: 20px;">
+      <h3 style="font-size: 15px; margin: 0 0 4px 0;">
+        <a href="${escapeHtml(item.url)}" style="color: #2563eb; text-decoration: none;">${escapeHtml(item.title)}</a>
+      </h3>
+      <p style="font-size: 14px; color: #555; margin: 4px 0;">${escapeHtml(item.summary)}</p>
+      <p style="font-size: 13px; color: #1a1a2e; margin: 4px 0; font-style: italic;">Why it matters: ${escapeHtml(item.whyItMatters)}</p>
+    </div>
+    `).join('')}
+    <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
+    ` : ''}
+
+    <!-- Community Pulse -->
+    ${content.newMembers.length > 0 ? `
+    <h2 style="font-size: 17px; color: #1a1a2e; margin-bottom: 12px;">New Members</h2>
+    <p style="font-size: 14px; color: #555;">
+      Welcome to ${content.newMembers.map((m) => `<strong>${escapeHtml(m.name)}</strong>`).join(', ')}
+      who joined this week.
+    </p>
+    ` : ''}
+
+    ${content.conversations.length > 0 ? `
+    <h2 style="font-size: 17px; color: #1a1a2e; margin-bottom: 12px;">Notable Conversations</h2>
+    ${content.conversations.map((conv) => `
+    <div style="margin-bottom: 16px; padding: 12px; background: #f8f9fa; border-radius: 6px;">
+      <p style="font-size: 14px; color: #333; margin: 0 0 6px 0;">${escapeHtml(conv.summary)}</p>
+      <p style="font-size: 13px; color: #666; margin: 0;">
+        in <strong>${escapeHtml(conv.channelName)}</strong>
+        ${segment !== 'website_only' ? ` &middot; <a href="${escapeHtml(conv.threadUrl)}" style="color: #2563eb;">Join the conversation</a>` : ''}
+      </p>
+    </div>
+    `).join('')}
+    ` : ''}
+
+    ${content.workingGroups.length > 0 ? `
+    <h2 style="font-size: 17px; color: #1a1a2e; margin-bottom: 12px;">Working Group Updates</h2>
+    ${content.workingGroups.map((wg) => `
+    <div style="margin-bottom: 12px;">
+      <p style="font-size: 14px; margin: 0;">
+        <strong>${escapeHtml(wg.name)}</strong>: ${escapeHtml(wg.summary.slice(0, 150))}
+        ${wg.nextMeeting ? `<br><span style="font-size: 13px; color: #666;">Next: ${escapeHtml(wg.nextMeeting)}</span>` : ''}
+      </p>
+    </div>
+    `).join('')}
+    ` : ''}
+
+    <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
+
+    <!-- Segment-specific CTA -->
+    ${renderCta(segment)}
+
+    <!-- Feedback -->
+    <p style="font-size: 13px; color: #888; text-align: center; margin-top: 30px;">
+      Was this useful?
+      <a href="${BASE_URL}/digest/${editionDate}/feedback?vote=yes&t=${trackingId}" style="text-decoration: none; font-size: 16px;">&#128077;</a>
+      <a href="${BASE_URL}/digest/${editionDate}/feedback?vote=no&t=${trackingId}" style="text-decoration: none; font-size: 16px;">&#128078;</a>
+    </p>
+  </div>`.trim();
+
+  const text = renderDigestText(content, editionDate, segment, firstName);
+
+  return { html, text };
+}
+
+function renderCta(segment: DigestSegment): string {
+  switch (segment) {
+    case 'website_only':
+      return `
+      <div style="text-align: center; padding: 16px; background: #f0f4ff; border-radius: 8px;">
+        <p style="font-size: 15px; color: #1a1a2e; margin: 0 0 8px 0;">
+          Join 1,400+ members discussing agentic advertising in Slack
+        </p>
+        <a href="${BASE_URL}/slack" style="display: inline-block; padding: 10px 24px; background: #2563eb; color: white; text-decoration: none; border-radius: 6px; font-size: 14px;">
+          Join the conversation
+        </a>
+      </div>`;
+    case 'slack_only':
+      return `
+      <div style="text-align: center; padding: 16px; background: #f0f4ff; border-radius: 8px;">
+        <p style="font-size: 15px; color: #1a1a2e; margin: 0 0 8px 0;">
+          Get listed in the member directory and access your full profile
+        </p>
+        <a href="${BASE_URL}/signup" style="display: inline-block; padding: 10px 24px; background: #2563eb; color: white; text-decoration: none; border-radius: 6px; font-size: 14px;">
+          Create your account
+        </a>
+      </div>`;
+    case 'both':
+    case 'active':
+      return `
+      <div style="text-align: center; padding: 16px; background: #f0f4ff; border-radius: 8px;">
+        <p style="font-size: 15px; color: #1a1a2e; margin: 0;">
+          Know someone who should be part of this community?
+          <a href="${BASE_URL}/invite" style="color: #2563eb;">Invite a colleague</a>
+        </p>
+      </div>`;
+  }
+}
+
+function renderDigestText(content: DigestContent, editionDate: string, segment: DigestSegment, firstName?: string): string {
+  const lines: string[] = [
+    `AgenticAdvertising.org Weekly - ${formatDate(editionDate)}`,
+    '',
+  ];
+  if (firstName) lines.push(`Hi ${firstName},`, '');
+  lines.push(content.intro, '');
+
+  if (content.news.length > 0) {
+    lines.push('--- INDUSTRY BRIEFING ---', '');
+    for (const item of content.news) {
+      lines.push(`* ${item.title}`);
+      lines.push(`  ${item.summary}`);
+      lines.push(`  Why it matters: ${item.whyItMatters}`);
+      lines.push(`  ${item.url}`);
+      lines.push('');
+    }
+  }
+
+  if (content.newMembers.length > 0) {
+    lines.push('--- NEW MEMBERS ---', '');
+    lines.push(`Welcome to ${content.newMembers.map((m) => m.name).join(', ')} who joined this week.`);
+    lines.push('');
+  }
+
+  if (content.conversations.length > 0) {
+    lines.push('--- NOTABLE CONVERSATIONS ---', '');
+    for (const conv of content.conversations) {
+      lines.push(`* ${conv.summary}`);
+      lines.push(`  in ${conv.channelName}`);
+      if (segment !== 'website_only') {
+        lines.push(`  ${conv.threadUrl}`);
+      }
+      lines.push('');
+    }
+  }
+
+  if (content.workingGroups.length > 0) {
+    lines.push('--- WORKING GROUP UPDATES ---', '');
+    for (const wg of content.workingGroups) {
+      lines.push(`* ${wg.name}: ${wg.summary.slice(0, 150)}`);
+      if (wg.nextMeeting) lines.push(`  Next: ${wg.nextMeeting}`);
+      lines.push('');
+    }
+  }
+
+  lines.push(`View in browser: ${BASE_URL}/digest/${editionDate}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Render the digest as a Slack Block Kit message (concise summary with link)
+ */
+export function renderDigestSlack(content: DigestContent, editionDate: string): SlackBlockMessage {
+  const webUrl = `${BASE_URL}/digest/${editionDate}`;
+  const blocks: SlackBlock[] = [];
+
+  // Header
+  blocks.push({
+    type: 'header',
+    text: { type: 'plain_text', text: `Weekly Digest - ${formatDate(editionDate)}` },
+  });
+
+  // Intro
+  blocks.push({
+    type: 'section',
+    text: { type: 'mrkdwn', text: escapeSlackMrkdwn(content.intro) },
+  });
+
+  // Top news headlines
+  if (content.news.length > 0) {
+    const newsText = content.news
+      .map((item) => `> *<${item.url}|${escapeSlackMrkdwn(item.title)}>*\n> _${escapeSlackMrkdwn(item.whyItMatters)}_`)
+      .join('\n\n');
+    blocks.push({ type: 'divider' });
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Industry Briefing*\n\n${newsText}` },
+    });
+  }
+
+  // Community summary
+  const communityParts: string[] = [];
+  if (content.newMembers.length > 0) {
+    communityParts.push(`${content.newMembers.length} new member${content.newMembers.length > 1 ? 's' : ''} joined this week`);
+  }
+  if (content.conversations.length > 0) {
+    communityParts.push(`${content.conversations.length} notable conversation${content.conversations.length > 1 ? 's' : ''}`);
+  }
+  if (content.workingGroups.length > 0) {
+    communityParts.push(`${content.workingGroups.length} working group update${content.workingGroups.length > 1 ? 's' : ''}`);
+  }
+
+  if (communityParts.length > 0) {
+    blocks.push({ type: 'divider' });
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Community Pulse*\n${communityParts.join(' · ')}` },
+    });
+  }
+
+  // Read more link
+  blocks.push({ type: 'divider' });
+  blocks.push({
+    type: 'section',
+    text: { type: 'mrkdwn', text: `<${webUrl}|Read the full digest>` },
+  });
+
+  const fallbackText = `Weekly Digest - ${formatDate(editionDate)}: ${content.intro}`;
+
+  return { text: fallbackText, blocks };
+}
+
+/**
+ * Render the digest for the Slack review message in the Editorial channel
+ */
+export function renderDigestReview(content: DigestContent, editionDate: string): SlackBlockMessage {
+  const slackMessage = renderDigestSlack(content, editionDate);
+  const blocks: SlackBlock[] = slackMessage.blocks || [];
+
+  // Prepend review instructions
+  blocks.unshift({
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `*Weekly Digest Draft for ${formatDate(editionDate)}*\nReact with :white_check_mark: to approve for Tuesday 10am ET delivery. Reply in thread with any edits.`,
+    },
+  });
+  blocks.splice(1, 0, { type: 'divider' });
+
+  return {
+    text: `Weekly Digest draft ready for review - ${formatDate(editionDate)}`,
+    blocks,
+  };
+}
+
+/**
+ * Render the full web-viewable HTML page for a digest edition
+ */
+export function renderDigestWebPage(content: DigestContent, editionDate: string): string {
+  // Reuse email renderer with a dummy tracking ID and "both" segment
+  const { html: innerHtml } = renderDigestEmail(content, 'web', editionDate, 'both');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>AgenticAdvertising.org Weekly - ${formatDate(editionDate)}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      background: #fafafa;
+    }
+    a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  ${innerHtml}
+  <p style="text-align: center; margin-top: 40px; font-size: 13px; color: #888;">
+    <a href="${BASE_URL}" style="color: #888;">AgenticAdvertising.org</a>
+  </p>
+</body>
+</html>`;
+}
+
+function formatDate(editionDate: string): string {
+  const date = new Date(editionDate + 'T12:00:00Z');
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -1,0 +1,293 @@
+import { query } from './client.js';
+
+export interface DigestRecord {
+  id: number;
+  edition_date: Date;
+  status: 'draft' | 'approved' | 'sent' | 'skipped';
+  approved_by: string | null;
+  approved_at: Date | null;
+  review_channel_id: string | null;
+  review_message_ts: string | null;
+  content: DigestContent;
+  created_at: Date;
+  sent_at: Date | null;
+  send_stats: DigestSendStats | null;
+}
+
+export interface DigestContent {
+  intro: string;
+  news: DigestNewsItem[];
+  newMembers: DigestNewMember[];
+  conversations: DigestConversation[];
+  workingGroups: DigestWorkingGroup[];
+  generatedAt: string;
+}
+
+export interface DigestNewsItem {
+  title: string;
+  url: string;
+  summary: string;
+  whyItMatters: string;
+  tags: string[];
+  knowledgeId?: number;
+}
+
+export interface DigestNewMember {
+  name: string;
+}
+
+export interface DigestConversation {
+  summary: string;
+  channelName: string;
+  threadUrl: string;
+  participants: string[];
+}
+
+export interface DigestWorkingGroup {
+  name: string;
+  summary: string;
+  nextMeeting?: string;
+}
+
+export interface DigestSendStats {
+  email_count: number;
+  slack_count: number;
+  by_segment: Record<string, number>;
+}
+
+export interface DigestEmailRecipient {
+  workos_user_id: string;
+  email: string;
+  first_name: string | null;
+  has_slack: boolean;
+}
+
+export interface DigestArticle {
+  id: number;
+  title: string;
+  source_url: string;
+  summary: string;
+  addie_notes: string;
+  quality_score: number;
+  relevance_tags: string[];
+  published_at: Date | null;
+}
+
+/**
+ * Create a new digest draft. Returns null if one already exists for this date.
+ */
+export async function createDigest(
+  editionDate: string,
+  content: DigestContent,
+): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `INSERT INTO weekly_digests (edition_date, status, content)
+     VALUES ($1, 'draft', $2)
+     ON CONFLICT (edition_date) DO NOTHING
+     RETURNING *`,
+    [editionDate, JSON.stringify(content)],
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Get a digest by its edition date (YYYY-MM-DD)
+ */
+export async function getDigestByDate(editionDate: string): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `SELECT * FROM weekly_digests WHERE edition_date = $1`,
+    [editionDate],
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Get the current week's digest (most recent by edition_date)
+ */
+export async function getCurrentWeekDigest(): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `SELECT * FROM weekly_digests
+     WHERE edition_date >= CURRENT_DATE - INTERVAL '7 days'
+     ORDER BY edition_date DESC
+     LIMIT 1`,
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Approve a digest. Sets status to 'approved' and records who approved it.
+ */
+export async function approveDigest(id: number, approvedBy: string): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `UPDATE weekly_digests
+     SET status = 'approved', approved_by = $2, approved_at = NOW()
+     WHERE id = $1 AND status = 'draft'
+     RETURNING *`,
+    [id, approvedBy],
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Update the review message reference after posting to Slack
+ */
+export async function setReviewMessage(
+  id: number,
+  channelId: string,
+  messageTs: string,
+): Promise<void> {
+  await query(
+    `UPDATE weekly_digests
+     SET review_channel_id = $2, review_message_ts = $3
+     WHERE id = $1`,
+    [id, channelId, messageTs],
+  );
+}
+
+/**
+ * Mark a digest as sent with stats
+ */
+export async function markSent(id: number, stats: DigestSendStats): Promise<void> {
+  await query(
+    `UPDATE weekly_digests
+     SET status = 'sent', sent_at = NOW(), send_stats = $2
+     WHERE id = $1`,
+    [id, JSON.stringify(stats)],
+  );
+}
+
+/**
+ * Mark a digest as skipped (no approval received in time)
+ */
+export async function markSkipped(id: number): Promise<void> {
+  await query(
+    `UPDATE weekly_digests SET status = 'skipped' WHERE id = $1`,
+    [id],
+  );
+}
+
+/**
+ * Find a digest by its Slack review message
+ */
+export async function getDigestByReviewMessage(
+  channelId: string,
+  messageTs: string,
+): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `SELECT * FROM weekly_digests
+     WHERE review_channel_id = $1 AND review_message_ts = $2`,
+    [channelId, messageTs],
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Get recent high-quality articles from addie_knowledge for digest inclusion.
+ * Excludes articles already included in a previous sent digest.
+ */
+export async function getRecentArticlesForDigest(
+  days: number = 7,
+  limit: number = 10,
+): Promise<DigestArticle[]> {
+  const result = await query<DigestArticle>(
+    `SELECT k.id, k.title, k.source_url, k.summary, k.addie_notes,
+            k.quality_score, k.relevance_tags, k.published_at
+     FROM addie_knowledge k
+     WHERE k.quality_score >= 4
+       AND k.fetch_status = 'success'
+       AND k.is_active = TRUE
+       AND k.source_url IS NOT NULL
+       AND k.addie_notes IS NOT NULL
+       AND k.created_at > NOW() - make_interval(days => $1)
+       AND NOT EXISTS (
+         SELECT 1 FROM weekly_digests wd
+         WHERE wd.status = 'sent'
+           AND wd.content::jsonb -> 'news' @> jsonb_build_array(jsonb_build_object('knowledgeId', k.id))
+       )
+     ORDER BY k.quality_score DESC, k.published_at DESC NULLS LAST
+     LIMIT $2`,
+    [days, limit],
+  );
+  return result.rows;
+}
+
+/**
+ * Get organizations created in the last N days (non-personal)
+ */
+export async function getNewOrganizations(days: number = 7): Promise<Array<{
+  name: string;
+  description: string | null;
+  created_at: Date;
+}>> {
+  const result = await query<{
+    name: string;
+    description: string | null;
+    created_at: Date;
+  }>(
+    `SELECT name, description, created_at
+     FROM organizations
+     WHERE created_at > NOW() - make_interval(days => $1)
+       AND is_personal = FALSE
+     ORDER BY created_at DESC`,
+    [days],
+  );
+  return result.rows;
+}
+
+/**
+ * Get users eligible to receive the weekly digest email.
+ * Returns users with email who haven't opted out of the weekly_digest category.
+ */
+export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]> {
+  const result = await query<DigestEmailRecipient>(
+    `SELECT
+       u.workos_user_id,
+       u.email,
+       u.first_name,
+       (u.primary_slack_user_id IS NOT NULL) AS has_slack
+     FROM users u
+     WHERE u.email IS NOT NULL
+       AND u.email != ''
+       AND NOT EXISTS (
+         SELECT 1 FROM user_email_preferences uep
+         JOIN user_email_category_preferences uecp ON uecp.user_preference_id = uep.id
+         WHERE uep.workos_user_id = u.workos_user_id
+           AND uecp.category_id = 'weekly_digest'
+           AND uecp.enabled = FALSE
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM user_email_preferences uep
+         WHERE uep.workos_user_id = u.workos_user_id
+           AND uep.global_unsubscribe = TRUE
+       )`,
+  );
+  return result.rows;
+}
+
+/**
+ * Get the most recent sent digests for the web archive
+ */
+export async function getRecentDigests(limit: number = 10): Promise<DigestRecord[]> {
+  const result = await query<DigestRecord>(
+    `SELECT * FROM weekly_digests
+     WHERE status = 'sent'
+     ORDER BY edition_date DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return result.rows;
+}
+
+/**
+ * Record a feedback vote from a digest email
+ */
+export async function recordDigestFeedback(
+  editionDate: string,
+  vote: 'yes' | 'no',
+  trackingId?: string,
+): Promise<void> {
+  await query(
+    `INSERT INTO digest_feedback (edition_date, vote, tracking_id) VALUES ($1, $2, $3)`,
+    [editionDate, vote, trackingId || null],
+  );
+}

--- a/server/src/db/migrations/254_weekly_digest.sql
+++ b/server/src/db/migrations/254_weekly_digest.sql
@@ -1,0 +1,43 @@
+-- Migration: 254_weekly_digest.sql
+-- Weekly digest table and email category for Addie's weekly briefing
+
+-- Track digest editions
+CREATE TABLE IF NOT EXISTS weekly_digests (
+  id SERIAL PRIMARY KEY,
+  edition_date DATE NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'approved', 'sent', 'skipped')),
+  approved_by TEXT,                       -- WorkOS user ID of approver
+  approved_at TIMESTAMP WITH TIME ZONE,
+  review_channel_id TEXT,                 -- Slack channel where review was posted
+  review_message_ts TEXT,                 -- Slack message ts for the review post
+  content JSONB NOT NULL,                 -- Tagged content sections
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  sent_at TIMESTAMP WITH TIME ZONE,
+  send_stats JSONB                        -- { email_count, slack_count, by_segment }
+);
+
+CREATE INDEX IF NOT EXISTS idx_weekly_digests_status ON weekly_digests (status);
+CREATE INDEX IF NOT EXISTS idx_weekly_digests_edition_date ON weekly_digests (edition_date DESC);
+CREATE INDEX IF NOT EXISTS idx_weekly_digests_review_message ON weekly_digests (review_channel_id, review_message_ts) WHERE review_channel_id IS NOT NULL;
+
+-- Add weekly_digest email category
+INSERT INTO email_categories (id, name, description, default_enabled, sort_order)
+VALUES (
+  'weekly_digest',
+  'Weekly Digest',
+  'Tuesday briefing with community updates and industry news',
+  true,
+  1
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Track digest feedback (thumbs up/down from email)
+CREATE TABLE IF NOT EXISTS digest_feedback (
+  id SERIAL PRIMARY KEY,
+  edition_date DATE NOT NULL,
+  vote TEXT NOT NULL CHECK (vote IN ('yes', 'no')),
+  tracking_id TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_digest_feedback_edition ON digest_feedback (edition_date);

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -68,6 +68,7 @@ import { createReferralsRouter } from "./routes/referrals.js";
 import { convertReferral, listAllReferralCodes } from "./db/referral-codes-db.js";
 import { createEventsRouter } from "./routes/events.js";
 import { createLatestRouter } from "./routes/latest.js";
+import { createDigestRouter } from "./routes/digest.js";
 import { createCommitteeRouters } from "./routes/committees.js";
 import { createContentRouter, createMyContentRouter } from "./routes/content.js";
 import { createMeetingRouters } from "./routes/meetings.js";
@@ -1002,6 +1003,9 @@ export class HTTPServer {
     const { pageRouter: latestPageRouter, apiRouter: latestApiRouter } = createLatestRouter();
     this.app.use('/', latestPageRouter);                    // Page routes: /latest, /latest/:slug
     this.app.use('/api', latestApiRouter);                  // API routes: /api/latest/*
+
+    // Mount weekly digest routes (public web view)
+    this.app.use('/digest', createDigestRouter());
 
     // Mount webhook routes (external services like Resend, WorkOS)
     const webhooksRouter = createWebhooksRouter();

--- a/server/src/routes/digest.ts
+++ b/server/src/routes/digest.ts
@@ -1,0 +1,66 @@
+import { Router, type Request, type Response } from 'express';
+import { createLogger } from '../logger.js';
+import { getDigestByDate, recordDigestFeedback } from '../db/digest-db.js';
+import { renderDigestWebPage } from '../addie/templates/weekly-digest.js';
+
+const logger = createLogger('digest-routes');
+
+export function createDigestRouter(): Router {
+  const router = Router();
+
+  /**
+   * GET /digest/:date - Public web view of a sent digest
+   * Unlisted (noindex) but accessible without auth for email "view in browser" links
+   */
+  router.get('/:date', async (req: Request, res: Response) => {
+    const { date } = req.params;
+
+    // Validate date format
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).send('Invalid date format');
+      return;
+    }
+
+    try {
+      const digest = await getDigestByDate(date);
+
+      if (!digest || digest.status !== 'sent') {
+        res.status(404).send('Digest not found');
+        return;
+      }
+
+      const html = renderDigestWebPage(digest.content, date);
+      res.type('html').send(html);
+    } catch (error) {
+      logger.error({ error, date }, 'Failed to render digest');
+      res.status(500).send('Internal server error');
+    }
+  });
+
+  /**
+   * GET /digest/:date/feedback - Record thumbs up/down feedback
+   * Redirects back to digest after recording
+   */
+  router.get('/:date/feedback', async (req: Request, res: Response) => {
+    const { date } = req.params;
+    const { vote, t: trackingId } = req.query;
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).send('Invalid date format');
+      return;
+    }
+
+    if (vote === 'yes' || vote === 'no') {
+      try {
+        await recordDigestFeedback(date, vote, typeof trackingId === 'string' ? trackingId : undefined);
+        logger.info({ date, vote, trackingId }, 'Digest feedback recorded');
+      } catch (error) {
+        logger.error({ error, date, vote }, 'Failed to record digest feedback');
+      }
+    }
+
+    res.redirect(`/digest/${date}`);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- Addie generates a Tuesday briefing combining curated industry news, new member orgs, notable Slack conversations, and working group updates
- Editorial working group approves each edition via Slack checkmark reaction before delivery
- Emails sent via Resend batch API (up to 100/call) with per-recipient first name personalization and segment-specific CTAs
- Public web view at `/digest/:date` for "view in browser" links with feedback tracking

## Details

**New files:**
- `server/src/db/migrations/254_weekly_digest.sql` — tables: `weekly_digests`, `digest_feedback` + `weekly_digest` email category
- `server/src/db/digest-db.ts` — CRUD, article queries, recipient lookup, feedback recording
- `server/src/addie/services/digest-builder.ts` — assembles news, members, conversations, WG updates
- `server/src/addie/templates/weekly-digest.ts` — email HTML/text, Slack blocks, review message, web page
- `server/src/addie/jobs/weekly-digest.ts` — Tuesday job: 7am draft → Editorial review → 10am batch send
- `server/src/routes/digest.ts` — web view + feedback endpoint

**Modified files:**
- `server/src/addie/jobs/job-definitions.ts` — register weekly-digest job
- `server/src/addie/bolt-app.ts` — digest approval handler (checkmark reaction from Editorial leaders)
- `server/src/http.ts` — mount `/digest` route
- `server/src/notifications/email.ts` — new `sendBatchMarketingEmails()` via `resend.batch.send()`

**How it works:**
1. Every Tuesday 7–8am ET, Addie builds a digest from curated articles, new member orgs, notable Slack threads (≥3 replies), and working group summaries
2. Draft posts to the Editorial working group's Slack channel with approval instructions
3. An Editorial leader approves with ✅ reaction (validated against `workingGroupDb.getLeaders()`)
4. At 10–11am ET, if approved: batch-sends personalized emails + posts to Slack #announcements. If not approved: marks skipped and notifies Editorial.
5. If delivery fails completely, digest stays as `approved` for retry within the window

## Test plan

- [x] `npm run test:unit` — 304/304 pass (no new test failures)
- [x] Docker build compiles cleanly (no new TS errors)
- [x] Docker compose: migration applies, tables created, email category seeded
- [x] Route tests: `/digest/:date` → 404 (no digest), `/digest/bad` → 400, feedback → 302 + DB record
- [ ] Manual: trigger digest generation and verify Slack review post
- [ ] Manual: approve via reaction and verify batch email delivery
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)