### PR TITLE
feat(registry): brand/property activity feed + contribute-back docs

### DIFF
--- a/.changeset/e2a36b4ada369c8c.md
+++ b/.changeset/e2a36b4ada369c8c.md
@@ -1,0 +1,4 @@
+---
+'adcontextprotocol': patch
+---
+

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -112,17 +112,61 @@ The `pending_approval` account state is where human review occurs: credit checks
 
 The [AgenticAdvertising.org brand registry](https://agenticadvertising.org) provides a community-maintained layer of brand identity for brands that haven't yet published their own `brand.json`. Buyer agents resolving brands before account setup can contribute data back to the registry as a byproduct of normal workflows — improving identity coverage for the ecosystem without extra effort.
 
-The recommended pattern for buyer agents (see [GitHub #1166](https://github.com/adcontextprotocol/adcp/issues/1166)):
+The recommended pattern for buyer agents uses three building blocks (see [#1166](https://github.com/adcontextprotocol/adcp/issues/1166)):
 
-```
-1. resolve_brand(brand_domain) → check registry
-2. If not found: research_brand(brand_domain) → enrich
-3. Confirm with user where UX permits
-4. save_brand() → contribute back to registry
-5. Establish account → sync_accounts (implicit) or list_accounts (explicit)
+| Tool | Purpose |
+|------|---------|
+| `resolve_brand` | Check registry and fetch brand.json — returns canonical identity if available |
+| `research_brand` | Enrich via Brandfetch and auto-save to registry as `enriched` |
+| `save_brand` | Manually contribute a brand to the registry as `community` |
+
+```javascript
+async function ensureBrand(domain) {
+  // 1. Check registry (brand.json or previously resolved)
+  const resolved = await resolveBrand(domain);
+
+  if (resolved.errors) {
+    // Resolution failed — brand unknown, proceed to enrich
+  } else if (resolved.source === 'brand_json' || resolved.source === 'enriched') {
+    // Authoritative or enriched data available — confirm with user, then use
+    return await confirmWithUser(resolved);
+  }
+  // source === 'community': registry has a placeholder, but enrich for richer data
+
+  // 2. Enrich via Brandfetch — auto-saves to registry as 'enriched'
+  const enriched = await researchBrand(domain);
+  if (enriched.errors) {
+    // Enrichment unavailable — fall back to community entry or prompt user to correct
+    return resolved ? await confirmWithUser(resolved) : null;
+  }
+
+  // 3. Confirm with user before using enriched data
+  // Enrichment is third-party — user confirmation catches errors and improves registry quality
+  return await confirmWithUser(enriched);
+}
 ```
 
-This means registry coverage improves as a natural byproduct of agents doing their normal job.
+`confirmWithUser` is a placeholder for whatever confirmation mechanism fits your UX — an explicit prompt, a review step in a workflow UI, or a low-confidence flag that triggers human review. The confirmation step is what makes the improvement loop work: enrichment data comes from third parties and isn't guaranteed to be correct. User verification before the data is used in a live campaign is what keeps the registry accurate over time.
+
+#### Source authority
+
+The registry tracks where brand data came from. Sources in descending authority:
+
+| Source | Meaning | Can be overwritten? |
+|--------|---------|---------------------|
+| `brand_json` | Brand self-declared via `/.well-known/brand.json` | No — returns 409 |
+| `enriched` | Third-party enrichment (Brandfetch) | Only by higher authority |
+| `community` | Manually contributed by a registry member | Yes |
+
+When an agent calls `save_brand` or `research_brand`, the registry applies merge logic: existing fields from a higher-authority source are preserved, and only missing fields are filled in. This respects what brands have declared while filling gaps.
+
+`research_brand` skips re-enrichment if the registry already has recent `enriched` data for the domain, avoiding redundant API calls.
+
+The full edit history for any brand — who contributed, when, and with what summary — is queryable via [`GET /api/brands/history`](/docs/registry/index#activity-history).
+
+#### Property contribute-back
+
+The same pattern applies to publisher properties. When a buyer agent discovers a new publisher through a sales agent interaction, it can contribute that property back to the registry via `POST /api/properties/save`. This improves property coverage for the ecosystem the same way brand contribute-back improves brand coverage. See [Registry API — save property](/docs/registry/index#save-property) for details.
 
 ## Usage reporting
 

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -101,6 +101,7 @@ All sources produce the same resolution response structure. To get full brand id
 | GET | `/api/brands/brand-json` | Fetch raw brand.json for a domain |
 | GET | `/api/brands/registry` | List all brands (search, pagination) |
 | GET | `/api/brands/enrich` | Enrich brand data via Brandfetch |
+| GET | `/api/brands/history` | Edit history for a brand |
 | POST | `/api/brands/save` | Save or update a community brand (auth required) |
 
 ### Property Resolution
@@ -111,6 +112,7 @@ All sources produce the same resolution response structure. To get full brand id
 | POST | `/api/properties/resolve/bulk` | Resolve up to 100 domains at once |
 | GET | `/api/properties/registry` | List all properties (search, pagination) |
 | GET | `/api/properties/validate` | Validate a domain's adagents.json |
+| GET | `/api/properties/history` | Edit history for a property |
 | POST | `/api/properties/save` | Save or update a hosted property (auth required) |
 
 ### Agent Discovery
@@ -154,6 +156,37 @@ All sources produce the same resolution response structure. To get full brand id
 | GET | `/api/public/agent-formats` | Get creative formats from an agent |
 | GET | `/api/public/agent-products` | Get products from a sales agent |
 | GET | `/api/public/validate-publisher` | Validate a publisher domain |
+
+## Activity history
+
+`GET /api/brands/history?domain={domain}` and `GET /api/properties/history?domain={domain}` return the edit history for a registry entry, newest first. These are public endpoints — no authentication required.
+
+```json Response
+{
+  "domain": "acmecorp.com",
+  "total": 3,
+  "revisions": [
+    {
+      "revision_number": 3,
+      "editor_name": "Pinnacle Media",
+      "edit_summary": "Updated logo URL",
+      "source": "community",
+      "is_rollback": false,
+      "created_at": "2026-03-01T12:34:56Z"
+    },
+    {
+      "revision_number": 2,
+      "editor_name": "system",
+      "edit_summary": "API: enriched via Brandfetch",
+      "source": "enriched",
+      "is_rollback": false,
+      "created_at": "2026-02-15T08:00:00Z"
+    }
+  ]
+}
+```
+
+Entries with `editor_name: "system"` were written by automated enrichment. When `is_rollback` is `true`, `rolled_back_to` contains the revision number that was restored. Pagination uses `limit` (max 100) and `offset` query parameters.
 
 ## Authentication
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -297,3 +297,29 @@ export const ValidationResultSchema = z
   })
   .openapi("ValidationResult");
 
+const ActivityEntrySchema = z.object({
+  revision_number: z.number().int().openapi({ example: 3 }),
+  editor_name: z.string().openapi({ example: "Pinnacle Media" }),
+  edit_summary: z.string().openapi({ example: "Updated logo and brand colors" }),
+  source: z.string().optional().openapi({ description: "Source type of the record at the time of this revision (brand_json, enriched, community)" }),
+  is_rollback: z.boolean(),
+  rolled_back_to: z.number().int().optional().openapi({ description: "Revision number that was restored; only present when is_rollback is true" }),
+  created_at: z.string().openapi({ example: "2026-03-01T12:34:56Z" }),
+});
+
+export const BrandActivitySchema = z
+  .object({
+    domain: z.string().openapi({ example: "acmecorp.com" }),
+    total: z.number().int().openapi({ example: 3 }),
+    revisions: z.array(ActivityEntrySchema),
+  })
+  .openapi("BrandActivity");
+
+export const PropertyActivitySchema = z
+  .object({
+    domain: z.string().openapi({ example: "examplepub.com" }),
+    total: z.number().int().openapi({ example: 3 }),
+    revisions: z.array(ActivityEntrySchema),
+  })
+  .openapi("PropertyActivity");
+

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -112,6 +112,94 @@ components:
         - source
         - has_manifest
         - verified
+    BrandActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    PropertyActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
     ResolvedProperty:
       type: object
       properties:
@@ -831,6 +919,59 @@ paths:
                 required:
                   - brands
                   - stats
+  /api/brands/history:
+    get:
+      operationId: getBrandHistory
+      summary: Brand activity history
+      description: Returns the edit history for a brand in the registry, newest first. Only brands with community or enriched edits have history; brand.json-sourced brands are authoritative and do not generate revisions.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: "20"
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+            example: "0"
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Brand activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
   /api/brands/enrich:
     get:
       operationId: enrichBrand
@@ -860,6 +1001,59 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/properties/history:
+    get:
+      operationId: getPropertyHistory
+      summary: Property activity history
+      description: Returns the edit history for a property in the registry, newest first.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: "20"
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+            example: "0"
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PropertyActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
   /api/properties/resolve:
     get:
       operationId: resolveProperty


### PR DESCRIPTION
## Summary

- Adds `GET /api/brands/history` and `GET /api/properties/history` — public, paginated endpoints that expose the existing revision tracking infrastructure (previously captured but never surfaced)
- Each revision returns `editor_name`, `edit_summary`, `source`, `is_rollback`, `rolled_back_to`, `created_at` — enough for an activity feed without exposing private `editor_email`/`editor_user_id`
- Expands `docs/accounts/overview.mdx` contribute-back section: three-building-block tool table, `ensureBrand()` code example with user confirmation step, source authority hierarchy (`brand_json > enriched > community`), and property contribute-back note
- Adds Activity history section to `docs/registry/index.mdx` with example response
- OpenAPI spec regenerated

Addresses reviewer feedback from [#1166](https://github.com/adcontextprotocol/adcp/issues/1166).

## Test plan

- [ ] All 304 unit tests pass (`npx jest`)
- [ ] TypeScript compiles clean (`npm run typecheck`)
- [ ] OpenAPI spec in sync (`npm run test:openapi`)
- [ ] `GET /api/brands/history?domain=acmecorp.com` returns `{ domain, total, revisions: [] }` for a brand with no community edits
- [ ] `GET /api/brands/history?domain=<community-brand>` returns revision entries with `editor_name` and `edit_summary`
- [ ] `GET /api/brands/history?domain=doesnotexist.com` returns 404
- [ ] `limit` and `offset` pagination works correctly; invalid values fall back to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)