### PR TITLE
feat(addie): include individual members in list_paying_members by default

### DIFF
--- a/.changeset/addie-list-members-individual.md
+++ b/.changeset/addie-list-members-individual.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Empty changeset - no protocol impact (Addie admin tool default change only)

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -1147,14 +1147,14 @@ Roles: member (default), admin (can manage team), owner (full control)`,
   },
   {
     name: 'list_paying_members',
-    description: 'List all paying members grouped by subscription level ($50K ICL, $10K corporate, $2.5K SMB). Defaults to corporate members only.',
-    usage_hints: 'Use when asked about paying members, subscription breakdown, who pays what, or membership revenue by tier.',
+    description: 'List all paying members grouped by subscription level ($50K ICL, $10K corporate, $2.5K SMB, individual). Includes individual members by default. Pass include_individual: false for corporate-only.',
+    usage_hints: 'Use when asked about paying members, subscription breakdown, who pays what, membership revenue by tier, or listing members for events/outreach.',
     input_schema: {
       type: 'object' as const,
       properties: {
         include_individual: {
           type: 'boolean',
-          description: 'Include individual (personal) memberships (default: false, corporate only)',
+          description: 'Include individual (personal) memberships (default: true)',
         },
         limit: {
           type: 'number',
@@ -6573,7 +6573,7 @@ Use add_committee_leader to assign a leader.`;
   handlers.set('list_paying_members', async (input) => {
     try {
       const pool = getPool();
-      const includeIndividual = (input.include_individual as boolean) || false;
+      const includeIndividual = input.include_individual !== false;
       const limit = Math.min(Math.max((input.limit as number) || 50, 1), 100);
 
       const result = await pool.query(


### PR DESCRIPTION
## Summary

- `list_paying_members` now includes individual (personal workspace) members by default
- Changed `include_individual` default from `false` to `true` using `input.include_individual !== false`
- Updated description to mention individual members and clarify how to get corporate-only (`include_individual: false`)

## Why

Individual members had no reliable way to surface in Addie for admin tasks like event invite lists. `list_members` only shows public directory profiles (individual members have none), and `list_users_by_engagement` drops members with zero engagement score. Members like John Battelle — active paying member, `lifecycle_stage: new`, engagement score 0 — were invisible to every tool.

## Test plan

- [x] All 304 existing tests pass
- [x] TypeScript type check passes
- [x] Verify `list_paying_members` called with no args now returns individual members
- [x] Verify `list_paying_members` with `include_individual: false` still returns corporate-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)