### PR TITLE
fix(slack): close three gaps in Slack auto-link reliability

### DIFF
--- a/.changeset/slack-sync-redteam-fixes.md
+++ b/.changeset/slack-sync-redteam-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix three gaps in Slack auto-link reliability: run syncSlackUsers() before the daily job so users who missed team_join events are visible; skip tryAutoMapByEmail for bots to prevent stolen mappings; invalidate admin status cache immediately after linking so newly linked admins are recognized by Addie without waiting 30 minutes.

--- a/server/src/routes/admin/slack.ts
+++ b/server/src/routes/admin/slack.ts
@@ -297,6 +297,8 @@ export function createAdminSlackRouter(): Router {
   });
 
   // POST /api/admin/slack/auto-link-suggested - Auto-link all suggested email matches
+  // Note: this internally calls syncSlackUsers() first, which fetches all workspace members
+  // from the Slack API before running the link pass.
   router.post('/auto-link-suggested', requireAuth, requireAdmin, async (_req, res) => {
     try {
       const result = await autoLinkUnmappedSlackUsers();

--- a/server/src/slack/events.ts
+++ b/server/src/slack/events.ts
@@ -15,7 +15,7 @@ import { getSlackUser, getChannelInfo } from './client.js';
 import { syncUserToChaptersFromSlackChannels } from './sync.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { invalidateMemberContextCache } from '../addie/index.js';
-import { invalidateWebAdminStatusCache } from '../addie/mcp/admin-tools.js';
+import { invalidateAdminStatusCache, invalidateWebAdminStatusCache } from '../addie/mcp/admin-tools.js';
 import {
   isAddieReady,
   handleAssistantThreadStarted,
@@ -155,8 +155,8 @@ export async function handleTeamJoin(event: SlackTeamJoinEvent): Promise<void> {
       slack_tz_offset: user.tz_offset ?? null,
     });
 
-    // Auto-map by email if they have a web account
-    if (email) {
+    // Auto-map by email if they have a web account (skip bots)
+    if (email && !user.is_bot) {
       await tryAutoMapByEmail(user.id, email);
     }
 
@@ -283,6 +283,7 @@ async function tryAutoMapByEmail(slackUserId: string, email: string): Promise<vo
     }
 
     // Invalidate caches
+    invalidateAdminStatusCache(slackUserId);
     invalidateUnifiedUsersCache();
     invalidateMemberContextCache(slackUserId);
   } catch (error) {

--- a/server/src/slack/sync.ts
+++ b/server/src/slack/sync.ts
@@ -13,7 +13,7 @@ import { SlackDatabase } from '../db/slack-db.js';
 import { WorkingGroupDatabase } from '../db/working-group-db.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { invalidateMemberContextCache } from '../addie/index.js';
-import { invalidateWebAdminStatusCache } from '../addie/mcp/admin-tools.js';
+import { invalidateAdminStatusCache, invalidateWebAdminStatusCache } from '../addie/mcp/admin-tools.js';
 import { getPool } from '../db/client.js';
 import { workos } from '../auth/workos-client.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
@@ -677,6 +677,13 @@ export async function autoLinkUnmappedSlackUsers(): Promise<{
   organizations_assigned: number;
   errors: number;
 }> {
+  // Ensure all current workspace members have rows before attempting to link.
+  // Users who joined before the team_join listener was active have no row otherwise.
+  const syncResult = await syncSlackUsers();
+  if (syncResult.errors.length > 0) {
+    logger.warn({ errors: syncResult.errors }, 'Slack user sync had errors; auto-link results may be incomplete');
+  }
+
   // excludeOptedOut: false — opt-out applies to nudge notifications, not account linking.
   // Linking is a system operation; it doesn't send any messages.
   const unmappedSlack = await slackDb.getUnmappedUsers({
@@ -706,6 +713,8 @@ export async function autoLinkUnmappedSlackUsers(): Promise<{
       });
       linked++;
       mappedWorkosUserIds.add(workosUserId);
+      // Clear cached admin status so Addie recognizes newly linked admins immediately.
+      invalidateAdminStatusCache(slackUser.slack_user_id);
 
       const chapterResult = await syncUserToChaptersFromSlackChannels(workosUserId, slackUser.slack_user_id);
       chaptersJoined += chapterResult.chapters_joined;


### PR DESCRIPTION
## Summary

Follows up on #1304 (daily Slack auto-link job) by closing three reliability gaps identified in a post-merge red-team review:

- **Gap #12 — missed team_join users**: The daily job only sees users who already have rows in `slack_user_mappings`. Users who joined the workspace before the `team_join` listener existed have no row and are permanently invisible. Fix: call `syncSlackUsers()` at the start of the job to ensure all workspace members have rows. Partial sync errors are logged as warnings but don't abort the pass.

- **Gap #7 — bot collision**: `tryAutoMapByEmail` in `handleTeamJoin` had no bot guard. A bot with an email matching a WorkOS user could steal that mapping. Fix: skip `tryAutoMapByEmail` when `user.is_bot` is true.

- **Gap #9 — admin cache lag**: Neither the batch job (`autoLinkUnmappedSlackUsers`) nor the event path (`tryAutoMapByEmail`) called `invalidateAdminStatusCache` after linking. Newly linked admins had to wait up to 30 minutes for Addie to recognize their admin status. Fix: call `invalidateAdminStatusCache(slackUserId)` in both paths immediately after a successful link.

## Test plan
- [ ] All 304 unit tests passing
- [ ] TypeScript clean
- [ ] Deploy to snap-adcp; check logs 2 min after startup — should see Slack sync + 0 pending matches (already fully linked from #1304)
- [ ] Have a newly added Slack bot confirm it doesn't get auto-linked to a WorkOS account
- [ ] Confirm an admin linked via `team_join` gets Addie admin tools without a wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)