### PR TITLE
feat(dashboard): escalation visibility and invoice draft-confirm flow

### DIFF
--- a/.changeset/member-escalations-invoice-draft.md
+++ b/.changeset/member-escalations-invoice-draft.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Add escalation visibility to member dashboard and two-step invoice confirmation flow.
+
+Members can now see their support requests (escalations) in the dashboard. The invoice flow now creates a draft and asks for customer confirmation before sending, to prevent invoices going to the wrong email address.

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -799,6 +799,19 @@
         </div>
       </section>
 
+      <!-- ========== SUPPORT REQUESTS SECTION ========== -->
+      <section id="escalations" class="dashboard-section" style="display: none;">
+        <div class="section-header">
+          <h2>Support requests</h2>
+          <p>Requests escalated to the AgenticAdvertising.org team</p>
+        </div>
+        <div class="section-card" id="escalationsCard">
+          <div id="escalationsContent" class="section-card-body">
+            <div style="text-align: center; color: var(--color-text-secondary);">Loading...</div>
+          </div>
+        </div>
+      </section>
+
       <!-- Hidden legacy elements for JS compatibility -->
       <div id="memberProfileDetails" style="display: none;"></div>
       <div id="membershipCardContent" style="display: none;"></div>
@@ -2410,6 +2423,70 @@
       }
     }
 
+    // Load support requests (escalations) for the current user
+    async function loadEscalations() {
+      const section = document.getElementById('escalations');
+      const content = document.getElementById('escalationsContent');
+      if (!section || !content) return;
+
+      try {
+        const response = await fetch('/api/user/escalations', { credentials: 'include' });
+        if (!response.ok) {
+          section.style.display = '';
+          content.innerHTML = '<p style="padding: 16px; color: var(--color-text-secondary); font-size: 14px;">Unable to load your support requests.</p>';
+          return;
+        }
+
+        const data = await response.json();
+        const escalations = data.escalations || [];
+
+        if (escalations.length === 0) {
+          section.style.display = 'none';
+          return;
+        }
+
+        section.style.display = '';
+
+        const statusConfig = {
+          open:         { label: 'Open',          bg: 'var(--color-primary-50)',   color: 'var(--color-primary-700)' },
+          acknowledged: { label: 'Acknowledged',  bg: 'var(--color-primary-50)',   color: 'var(--color-primary-700)' },
+          in_progress:  { label: 'In progress',   bg: 'var(--color-warning-50)',   color: 'var(--color-warning-700)' },
+          resolved:     { label: 'Resolved',      bg: 'var(--color-success-50)',   color: 'var(--color-success-700)' },
+          wont_do:      { label: 'Closed',        bg: 'var(--color-gray-100)',     color: 'var(--color-text-secondary)' },
+          expired:      { label: 'Expired',       bg: 'var(--color-gray-100)',     color: 'var(--color-text-secondary)' },
+        };
+
+        content.innerHTML = escalations.map(e => {
+          const cfg = statusConfig[e.status] || statusConfig.open;
+          const date = new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+          const notes = e.resolution_notes
+            ? `<p style="margin: 8px 0 0 0; font-size: 13px; color: var(--color-text-secondary);">${escapeHtml(e.resolution_notes)}</p>`
+            : '';
+          return `
+            <div style="display: flex; align-items: start; gap: 12px; padding: 16px; border-bottom: 1px solid var(--color-border);">
+              <div style="flex: 1; min-width: 0;">
+                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px; flex-wrap: wrap;">
+                  <span style="font-size: 14px; font-weight: 500; color: var(--color-text-heading);">${escapeHtml(e.summary)}</span>
+                  <span style="padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; background: ${cfg.bg}; color: ${cfg.color}; white-space: nowrap;">${cfg.label}</span>
+                </div>
+                <p style="margin: 0; font-size: 12px; color: var(--color-text-secondary);">Submitted ${date}</p>
+                ${notes}
+              </div>
+            </div>
+          `;
+        }).join('');
+
+        // Remove border from last item
+        const items = content.querySelectorAll('[style*="border-bottom"]');
+        if (items.length > 0) items[items.length - 1].style.borderBottom = 'none';
+
+      } catch (error) {
+        console.error('Error loading escalations:', error);
+        section.style.display = '';
+        content.innerHTML = '<p style="padding: 16px; color: var(--color-text-secondary); font-size: 14px;">Unable to load your support requests.</p>';
+      }
+    }
+
     // Handle interest click for launching committees
     async function handleCommitteeInterest(committeeSlug, committeeName, buttonEl) {
       try {
@@ -3010,6 +3087,9 @@
 
           // Check for outdated agreements (only for subscribers)
           await checkOutdatedAgreements();
+
+          // Load support requests for this user
+          loadEscalations();
 
         } else {
           // No organizations - redirect to onboarding

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -14,6 +14,7 @@ import {
   getProductsForCustomer,
   createCheckoutSession,
   createAndSendInvoice,
+  validateInvoiceDetails,
   createStripeCustomer,
   getPriceByLookupKey,
   type BillingProduct,
@@ -73,11 +74,10 @@ If the user doesn't have an account, tell them to sign up first.`,
   },
   {
     name: 'send_invoice',
-    description: `Send an invoice for a membership product to a customer.
-Use this when the customer needs to pay via invoice/PO instead of credit card.
-Requires full billing information including address.
-If the organization has a discount on file (from grant_discount), it will be automatically applied.
-You can also pass an explicit coupon_id to override.`,
+    description: `Preview an invoice for a membership product so the customer can confirm before it is sent.
+Use this when the customer needs to pay by invoice/PO instead of credit card.
+This does NOT send the invoice — it returns the amount and billing email for confirmation.
+After calling this, confirm the details with the customer, then call confirm_send_invoice with the same billing info to send it.`,
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -113,6 +113,51 @@ You can also pass an explicit coupon_id to override.`,
         coupon_id: {
           type: 'string',
           description: 'Explicit Stripe coupon ID to apply (optional - org discount is used automatically if available)',
+        },
+      },
+      required: ['lookup_key', 'company_name', 'contact_name', 'contact_email', 'billing_address'],
+    },
+  },
+  {
+    name: 'confirm_send_invoice',
+    description: `Send an invoice after the customer has confirmed the billing details shown by send_invoice.
+Use this only after the customer explicitly confirms the email address and amount are correct.
+Pass the same billing information as send_invoice.`,
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        lookup_key: {
+          type: 'string',
+          description: 'The product lookup key from find_membership_products',
+        },
+        company_name: {
+          type: 'string',
+          description: 'Company name for the invoice',
+        },
+        contact_name: {
+          type: 'string',
+          description: 'Contact person name',
+        },
+        contact_email: {
+          type: 'string',
+          description: 'Contact email address confirmed by the customer',
+        },
+        billing_address: {
+          type: 'object',
+          description: 'Billing address',
+          properties: {
+            line1: { type: 'string', description: 'Street address line 1' },
+            line2: { type: 'string', description: 'Street address line 2 (optional)' },
+            city: { type: 'string', description: 'City' },
+            state: { type: 'string', description: 'State/Province' },
+            postal_code: { type: 'string', description: 'Postal/ZIP code' },
+            country: { type: 'string', description: 'Country code (e.g., US)' },
+          },
+          required: ['line1', 'city', 'state', 'postal_code', 'country'],
+        },
+        coupon_id: {
+          type: 'string',
+          description: 'Explicit Stripe coupon ID to apply (optional)',
         },
       },
       required: ['lookup_key', 'company_name', 'contact_name', 'contact_email', 'billing_address'],
@@ -300,8 +345,81 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     }
   });
 
-  // Send invoice
+  // Preview invoice details for customer confirmation (no Stripe mutations)
   handlers.set('send_invoice', async (input) => {
+    const lookupKey = input.lookup_key as string;
+    const contactEmail = input.contact_email as string;
+    const explicitCouponId = input.coupon_id as string | undefined;
+    const companyName = input.company_name as string;
+
+    // Use authenticated org context directly; fall back to name search for Slack-only users
+    let effectiveCouponId = explicitCouponId;
+    let orgDiscount: string | undefined;
+
+    try {
+      const orgId = memberContext?.organization?.workos_organization_id;
+      const org = orgId
+        ? await orgDb.getOrganization(orgId)
+        : (await orgDb.searchOrganizations({ query: companyName, limit: 1 })
+            .then(results => results.length > 0 ? orgDb.getOrganization(results[0].workos_organization_id) : null));
+
+      if (org && !explicitCouponId && org.stripe_coupon_id) {
+        effectiveCouponId = org.stripe_coupon_id;
+        orgDiscount = org.discount_percent
+          ? `${org.discount_percent}% off`
+          : org.discount_amount_cents
+            ? `$${org.discount_amount_cents / 100} off`
+            : undefined;
+        logger.info(
+          { orgId: org.workos_organization_id, couponId: effectiveCouponId, discount: orgDiscount },
+          'Addie: Using org stored discount for invoice preview'
+        );
+      }
+    } catch (orgLookupError) {
+      logger.debug({ error: orgLookupError }, 'Could not look up org discount for invoice preview');
+    }
+
+    logger.info({ lookupKey, contactEmail, hasCoupon: !!effectiveCouponId }, 'Addie: Previewing invoice');
+
+    try {
+      const preview = await validateInvoiceDetails({
+        lookupKey,
+        contactEmail,
+        couponId: effectiveCouponId,
+      });
+
+      if (!preview) {
+        return JSON.stringify({
+          success: false,
+          error: 'Product not found or Stripe is not configured.',
+        });
+      }
+
+      const amount = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: preview.currency.toUpperCase(),
+      }).format(preview.amountDue / 100);
+
+      return JSON.stringify({
+        success: true,
+        amount,
+        contact_email: contactEmail,
+        product_name: preview.productName,
+        discount_applied: preview.discountApplied,
+        discount_description: orgDiscount,
+        discount_warning: preview.discountWarning,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Addie: Error previewing invoice');
+      return JSON.stringify({
+        success: false,
+        error: 'Failed to preview invoice. Please try again.',
+      });
+    }
+  });
+
+  // Create and send invoice after customer confirms the details
+  handlers.set('confirm_send_invoice', async (input) => {
     const lookupKey = input.lookup_key as string;
     const companyName = input.company_name as string;
     const contactName = input.contact_name as string;
@@ -316,41 +434,34 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     };
     const explicitCouponId = input.coupon_id as string | undefined;
 
-    // Try to find organization by name to get stored discount
+    // Same org coupon lookup as send_invoice
     let effectiveCouponId = explicitCouponId;
     let orgDiscount: string | undefined;
     let workosOrgId: string | undefined;
 
     try {
-      const orgs = await orgDb.searchOrganizations({ query: companyName, limit: 1 });
-      if (orgs.length > 0) {
-        const org = await orgDb.getOrganization(orgs[0].workos_organization_id);
-        if (org) {
-          workosOrgId = org.workos_organization_id;
-          // Use org's stored coupon if no explicit coupon provided
-          if (!explicitCouponId && org.stripe_coupon_id) {
-            effectiveCouponId = org.stripe_coupon_id;
-            orgDiscount = org.discount_percent
-              ? `${org.discount_percent}% off`
-              : org.discount_amount_cents
-                ? `$${org.discount_amount_cents / 100} off`
-                : undefined;
-            logger.info(
-              { orgId: org.workos_organization_id, orgName: org.name, couponId: effectiveCouponId, discount: orgDiscount },
-              'Addie: Using organization stored discount for invoice'
-            );
-          }
+      const orgId = memberContext?.organization?.workos_organization_id;
+      const org = orgId
+        ? await orgDb.getOrganization(orgId)
+        : (await orgDb.searchOrganizations({ query: companyName, limit: 1 })
+            .then(results => results.length > 0 ? orgDb.getOrganization(results[0].workos_organization_id) : null));
+
+      if (org) {
+        workosOrgId = org.workos_organization_id;
+        if (!explicitCouponId && org.stripe_coupon_id) {
+          effectiveCouponId = org.stripe_coupon_id;
+          orgDiscount = org.discount_percent
+            ? `${org.discount_percent}% off`
+            : org.discount_amount_cents
+              ? `$${org.discount_amount_cents / 100} off`
+              : undefined;
         }
       }
     } catch (orgLookupError) {
-      // Non-fatal - continue without org lookup
-      logger.debug({ error: orgLookupError, companyName }, 'Could not look up organization for discount');
+      logger.debug({ error: orgLookupError }, 'Could not look up org discount for invoice send');
     }
 
-    logger.info(
-      { lookupKey, contactEmail, companyName, hasCoupon: !!effectiveCouponId, usingOrgDiscount: !!orgDiscount },
-      'Addie: Sending invoice'
-    );
+    logger.info({ lookupKey, contactEmail, companyName, hasCoupon: !!effectiveCouponId }, 'Addie: Sending confirmed invoice');
 
     try {
       const result = await createAndSendInvoice({
@@ -370,18 +481,6 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
         });
       }
 
-      // Build response message
-      let message = `Invoice sent to ${contactEmail}. They will receive an email with payment instructions.`;
-      if (result.discountWarning) {
-        message += `\n\n⚠️ WARNING: ${result.discountWarning}`;
-      } else if (result.discountApplied) {
-        if (orgDiscount) {
-          message += `\n\n✅ Organization discount applied: ${orgDiscount}`;
-        } else {
-          message += `\n\n✅ Discount applied successfully.`;
-        }
-      }
-
       return JSON.stringify({
         success: true,
         invoice_id: result.invoiceId,
@@ -389,7 +488,6 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
         discount_applied: result.discountApplied,
         discount_description: orgDiscount,
         discount_warning: result.discountWarning,
-        message,
       });
     } catch (error) {
       logger.error({ error }, 'Addie: Error sending invoice');

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -12,8 +12,10 @@ import type { MemberContext } from '../member-context.js';
 import {
   createEscalation,
   markNotificationSent,
+  listEscalationsForUser,
   type EscalationCategory,
   type EscalationPriority,
+  type EscalationStatus,
 } from '../../db/escalation-db.js';
 import { getThreadService } from '../thread-service.js';
 import { sendChannelMessage } from '../../slack/client.js';
@@ -81,6 +83,18 @@ When you escalate, be honest with the user that you're passing this to a human w
         },
       },
       required: ['summary', 'category'],
+    },
+  },
+  {
+    name: 'get_escalation_status',
+    description: `Check the status of support requests previously escalated for the current user.
+Use this when a user asks about the status of a previous request, a ticket, or whether someone followed up.
+Returns a list of their escalations with current status and any resolution notes.`,
+    usage_hints: 'use when user asks about status of a previous request or escalation',
+    input_schema: {
+      type: 'object',
+      properties: {},
+      required: [],
     },
   },
   {
@@ -301,6 +315,62 @@ export function createEscalationToolHandlers(
     } catch (error) {
       logger.error({ error, category, threadId }, 'Failed to create escalation');
       return 'I tried to escalate this but encountered an error. Please reach out directly to the AgenticAdvertising.org team for help.';
+    }
+  });
+
+  // ============================================
+  // GET ESCALATION STATUS
+  // ============================================
+  handlers.set('get_escalation_status', async (_input) => {
+    const workosUserId = memberContext?.workos_user?.workos_user_id;
+
+    if (!workosUserId && !slackUserId) {
+      return JSON.stringify({
+        success: false,
+        message: "I can't look up your support requests — I don't have enough information to identify you.",
+      });
+    }
+
+    try {
+      const escalations = await listEscalationsForUser(workosUserId, slackUserId);
+
+      if (escalations.length === 0) {
+        return JSON.stringify({
+          success: true,
+          message: "You don't have any previous support requests on file.",
+          escalations: [],
+        });
+      }
+
+      const statusLabel: Record<EscalationStatus, string> = {
+        open: 'Open — waiting for the team to pick it up',
+        acknowledged: 'Acknowledged — the team has seen it',
+        in_progress: 'In progress — someone is working on it',
+        resolved: 'Resolved',
+        wont_do: 'Closed',
+        expired: 'Expired',
+      };
+
+      const formatted = escalations.map(e => ({
+        id: e.id,
+        summary: e.summary,
+        status: e.status,
+        status_label: statusLabel[e.status] || e.status,
+        submitted: new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
+        resolution_notes: e.resolution_notes || undefined,
+      }));
+
+      return JSON.stringify({
+        success: true,
+        escalations: formatted,
+        count: formatted.length,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to fetch escalation status');
+      return JSON.stringify({
+        success: false,
+        message: 'I had trouble looking up your support requests. Please try again.',
+      });
     }
   });
 

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -999,6 +999,72 @@ export async function createAndSendInvoice(
 }
 
 /**
+ * Validate invoice details and return a preview without creating any Stripe resources.
+ * Use this to show the customer the amount and billing email before committing.
+ * Call createAndSendInvoice after confirmation to actually create and send.
+ */
+export async function validateInvoiceDetails(data: {
+  lookupKey: string;
+  contactEmail: string;
+  couponId?: string;
+}): Promise<{
+  amountDue: number;
+  currency: string;
+  productName: string;
+  discountApplied: boolean;
+  discountWarning?: string;
+} | null> {
+  if (!stripe) {
+    logger.warn('validateInvoiceDetails: Stripe not initialized');
+    return null;
+  }
+
+  const priceId = await getPriceByLookupKey(data.lookupKey);
+  if (!priceId) {
+    logger.error({ lookupKey: data.lookupKey }, 'validateInvoiceDetails: No price found');
+    return null;
+  }
+
+  try {
+    const price = await stripe.prices.retrieve(priceId, { expand: ['product'] });
+    if (!price || price.unit_amount === null || price.unit_amount === 0) {
+      logger.error({ priceId, lookupKey: data.lookupKey }, 'validateInvoiceDetails: Price has zero or null amount');
+      return null;
+    }
+
+    let discountApplied = false;
+    let discountWarning: string | undefined;
+    if (data.couponId) {
+      try {
+        const coupon = await stripe.coupons.retrieve(data.couponId);
+        if (!coupon || !coupon.valid) {
+          discountWarning = `Coupon "${data.couponId}" is invalid or expired. Invoice will be sent without discount.`;
+        } else {
+          discountApplied = true;
+        }
+      } catch {
+        discountWarning = `Coupon "${data.couponId}" does not exist in Stripe. Invoice will be sent without discount.`;
+      }
+    }
+
+    const productName = typeof price.product === 'object' && price.product && 'name' in price.product
+      ? (price.product as { name: string }).name
+      : data.lookupKey;
+
+    return {
+      amountDue: price.unit_amount,
+      currency: price.currency,
+      productName,
+      discountApplied,
+      discountWarning,
+    };
+  } catch (error) {
+    logger.error({ err: error, lookupKey: data.lookupKey }, 'validateInvoiceDetails: Error');
+    return null;
+  }
+}
+
+/**
  * Resend an existing open invoice to the customer's billing email
  */
 export async function resendInvoice(invoiceId: string): Promise<{

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -262,6 +262,38 @@ export async function markNotificationSent(
 }
 
 /**
+ * Get escalations for a specific user (member-facing).
+ * Matches on workos_user_id or slack_user_id — whichever is provided.
+ */
+export async function listEscalationsForUser(
+  workosUserId?: string,
+  slackUserId?: string
+): Promise<Escalation[]> {
+  if (!workosUserId && !slackUserId) return [];
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (workosUserId) {
+    params.push(workosUserId);
+    conditions.push(`workos_user_id = $${params.length}`);
+  }
+  if (slackUserId) {
+    params.push(slackUserId);
+    conditions.push(`slack_user_id = $${params.length}`);
+  }
+
+  const result = await query<Escalation>(
+    `SELECT * FROM addie_escalations
+     WHERE ${conditions.join(' OR ')}
+     ORDER BY created_at DESC
+     LIMIT 50`,
+    params
+  );
+  return result.rows;
+}
+
+/**
  * Get escalations for a specific thread
  */
 export async function getEscalationsForThread(threadId: string): Promise<Escalation[]> {

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -34,6 +34,7 @@ import {
   mapIndustryToCompanyType,
   mapRevenueToTier,
 } from "../services/lusha.js";
+import { listEscalationsForUser } from "../db/escalation-db.js";
 import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
 import { WorkOS } from "@workos-inc/node";
 
@@ -810,6 +811,28 @@ export function createPublicBillingRouter(): Router {
           error: "Failed to update billing info",
           message: "An unexpected error occurred. Please try again.",
         });
+      }
+    }
+  );
+
+  // GET /api/user/escalations - Get escalations for the authenticated user
+  router.get(
+    "/user/escalations",
+    requireAuth,
+    async (req: Request, res: Response) => {
+      try {
+        const user = req.user!;
+        // WorkOS auth doesn't carry a Slack user ID, so escalations created via
+        // Slack before the user linked their WorkOS account won't appear here.
+        const rows = await listEscalationsForUser(user.id, undefined);
+        // Return only member-safe fields; addie_context and original_request are internal
+        const escalations = rows.map(({ id, summary, status, created_at, resolution_notes }) => ({
+          id, summary, status, created_at, resolution_notes,
+        }));
+        res.json({ escalations });
+      } catch (error) {
+        logger.error({ err: error }, "Error fetching user escalations");
+        res.status(500).json({ error: "Failed to fetch escalations" });
       }
     }
   );

--- a/tests/addie/billing-tools.test.ts
+++ b/tests/addie/billing-tools.test.ts
@@ -6,6 +6,7 @@ jest.mock('../../server/src/billing/stripe-client.js', () => ({
   getProductsForCustomer: jest.fn(),
   createCheckoutSession: jest.fn(),
   createAndSendInvoice: jest.fn(),
+  validateInvoiceDetails: jest.fn(),
   createStripeCustomer: jest.fn().mockResolvedValue('cus_new_123'),
   getPriceByLookupKey: jest.fn(),
 }));
@@ -363,12 +364,13 @@ describe('billing-tools', () => {
   });
 
   describe('send_invoice', () => {
-    test('sends invoice successfully with subscription', async () => {
-      const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
-      (createAndSendInvoice as jest.Mock).mockResolvedValue({
-        invoiceId: 'in_abc123',
-        invoiceUrl: 'https://invoice.stripe.com/i/acct_xxx/test_xxx',
-        subscriptionId: 'sub_xyz789',
+    test('returns invoice preview without creating Stripe resources', async () => {
+      const { validateInvoiceDetails } = await import('../../server/src/billing/stripe-client.js');
+      (validateInvoiceDetails as jest.Mock).mockResolvedValue({
+        amountDue: 150000,
+        currency: 'usd',
+        productName: 'Corporate Membership',
+        discountApplied: false,
       });
 
       const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
@@ -391,28 +393,22 @@ describe('billing-tools', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.success).toBe(true);
-      expect(parsed.invoice_id).toBe('in_abc123');
-      expect(parsed.invoice_url).toBe('https://invoice.stripe.com/i/acct_xxx/test_xxx');
-      expect(parsed.message).toContain('Invoice sent to ruben.schreurs@ebiquity.com');
+      expect(parsed.contact_email).toBe('ruben.schreurs@ebiquity.com');
+      expect(parsed.amount).toContain('1,500');
+      expect(parsed.product_name).toBe('Corporate Membership');
+      // No invoice_id — no Stripe resources created
+      expect(parsed.invoice_id).toBeUndefined();
 
-      expect(createAndSendInvoice).toHaveBeenCalledWith({
+      expect(validateInvoiceDetails).toHaveBeenCalledWith({
         lookupKey: 'aao_membership_corporate_5m',
-        companyName: 'Ebiquity Plc',
-        contactName: 'Ruben Schreurs',
         contactEmail: 'ruben.schreurs@ebiquity.com',
-        billingAddress: {
-          line1: '123 Test Street',
-          city: 'London',
-          state: 'Greater London',
-          postal_code: 'EC1A 1BB',
-          country: 'GB',
-        },
+        couponId: undefined,
       });
     });
 
-    test('returns error when invoice creation fails', async () => {
-      const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
-      (createAndSendInvoice as jest.Mock).mockResolvedValue(null);
+    test('returns error when product not found', async () => {
+      const { validateInvoiceDetails } = await import('../../server/src/billing/stripe-client.js');
+      (validateInvoiceDetails as jest.Mock).mockResolvedValue(null);
 
       const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
       const handlers = createBillingToolHandlers();
@@ -434,13 +430,12 @@ describe('billing-tools', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.success).toBe(false);
-      expect(parsed.error).toContain('Failed to send invoice');
-      expect(parsed.error).toContain('Stripe may not be configured');
+      expect(parsed.error).toContain('Product not found');
     });
 
     test('handles exceptions gracefully', async () => {
-      const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
-      (createAndSendInvoice as jest.Mock).mockRejectedValue(new Error('Stripe API error'));
+      const { validateInvoiceDetails } = await import('../../server/src/billing/stripe-client.js');
+      (validateInvoiceDetails as jest.Mock).mockRejectedValue(new Error('Stripe API error'));
 
       const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
       const handlers = createBillingToolHandlers();
@@ -459,6 +454,62 @@ describe('billing-tools', () => {
           country: 'US',
         },
       });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('Failed to preview invoice');
+    });
+  });
+
+  describe('confirm_send_invoice', () => {
+    const billingInput = {
+      lookup_key: 'aao_membership_corporate_5m',
+      company_name: 'Ebiquity Plc',
+      contact_name: 'Ruben Schreurs',
+      contact_email: 'ruben.schreurs@ebiquity.com',
+      billing_address: {
+        line1: '123 Test Street',
+        city: 'London',
+        state: 'Greater London',
+        postal_code: 'EC1A 1BB',
+        country: 'GB',
+      },
+    };
+
+    test('creates and sends invoice after confirmation', async () => {
+      const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
+      (createAndSendInvoice as jest.Mock).mockResolvedValue({
+        invoiceId: 'in_abc123',
+        invoiceUrl: 'https://invoice.stripe.com/i/acct_xxx/test_xxx',
+        subscriptionId: 'sub_xyz789',
+        discountApplied: false,
+      });
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers();
+      const confirmSend = handlers.get('confirm_send_invoice')!;
+
+      const result = await confirmSend(billingInput);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.invoice_id).toBe('in_abc123');
+      expect(parsed.invoice_url).toBe('https://invoice.stripe.com/i/acct_xxx/test_xxx');
+      expect(createAndSendInvoice).toHaveBeenCalledWith(expect.objectContaining({
+        lookupKey: 'aao_membership_corporate_5m',
+        contactEmail: 'ruben.schreurs@ebiquity.com',
+      }));
+    });
+
+    test('returns error when invoice send fails', async () => {
+      const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
+      (createAndSendInvoice as jest.Mock).mockResolvedValue(null);
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers();
+      const confirmSend = handlers.get('confirm_send_invoice')!;
+
+      const result = await confirmSend(billingInput);
       const parsed = JSON.parse(result);
 
       expect(parsed.success).toBe(false);
@@ -484,6 +535,7 @@ describe('billing-tools', () => {
       expect(toolNames).toContain('find_membership_products');
       expect(toolNames).toContain('create_payment_link');
       expect(toolNames).toContain('send_invoice');
+      expect(toolNames).toContain('confirm_send_invoice');
     });
   });
 });

--- a/tests/addie/escalation-tools.test.ts
+++ b/tests/addie/escalation-tools.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import type { MemberContext } from '../../server/src/addie/member-context.js';
+
+// Mock escalation-db
+const mockListEscalationsForUser = jest.fn();
+jest.mock('../../server/src/db/escalation-db.js', () => ({
+  createEscalation: jest.fn(),
+  markNotificationSent: jest.fn(),
+  listEscalationsForUser: (...args: unknown[]) => mockListEscalationsForUser(...args),
+}));
+
+// Mock slack client
+jest.mock('../../server/src/slack/client.js', () => ({
+  sendChannelMessage: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+// Mock system settings
+jest.mock('../../server/src/db/system-settings-db.js', () => ({
+  getEscalationChannel: jest.fn().mockResolvedValue({ channel_id: 'C_ESCALATION' }),
+}));
+
+// Mock thread service
+jest.mock('../../server/src/addie/thread-service.js', () => ({
+  getThreadService: jest.fn().mockReturnValue({
+    flagThread: jest.fn(),
+    getThreadWithMessages: jest.fn(),
+  }),
+}));
+
+// Mock addie-db
+jest.mock('../../server/src/db/addie-db.js', () => ({
+  AddieDatabase: jest.fn().mockImplementation(() => ({
+    createInsightSource: jest.fn(),
+  })),
+}));
+
+const mockMemberContext: MemberContext = {
+  is_mapped: true,
+  is_member: true,
+  workos_user: {
+    workos_user_id: 'user_test123',
+    email: 'test@example.com',
+    first_name: 'Test',
+    last_name: 'User',
+  } as MemberContext['workos_user'],
+  organization: {
+    workos_organization_id: 'org_test456',
+    name: 'Test Corp',
+    subscription_status: 'active',
+    is_personal: false,
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListEscalationsForUser.mockResolvedValue([]);
+});
+
+describe('get_escalation_status', () => {
+  test('returns empty message when user has no escalations', async () => {
+    mockListEscalationsForUser.mockResolvedValue([]);
+
+    const { createEscalationToolHandlers } = await import('../../server/src/addie/mcp/escalation-tools.js');
+    const handlers = createEscalationToolHandlers(mockMemberContext, 'U_SLACK_123', 'thread_abc');
+    const getStatus = handlers.get('get_escalation_status')!;
+
+    const result = await getStatus({});
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.escalations).toHaveLength(0);
+    expect(parsed.message).toContain("don't have any previous support requests");
+  });
+
+  test('returns formatted escalation list', async () => {
+    mockListEscalationsForUser.mockResolvedValue([
+      {
+        id: 42,
+        summary: 'Invoice never received',
+        status: 'in_progress',
+        created_at: new Date('2026-01-04T10:00:00Z'),
+        resolution_notes: null,
+        thread_id: null,
+        message_id: null,
+        slack_user_id: 'U_SLACK_123',
+        workos_user_id: 'user_test123',
+        user_display_name: 'Test User',
+        category: 'needs_human_action',
+        priority: 'high',
+        original_request: 'I never got my invoice',
+        addie_context: 'User has an active subscription',
+        notification_channel_id: null,
+        notification_sent_at: null,
+        notification_message_ts: null,
+        resolved_by: null,
+        resolved_at: null,
+        updated_at: new Date(),
+      },
+    ]);
+
+    const { createEscalationToolHandlers } = await import('../../server/src/addie/mcp/escalation-tools.js');
+    const handlers = createEscalationToolHandlers(mockMemberContext, 'U_SLACK_123', 'thread_abc');
+    const getStatus = handlers.get('get_escalation_status')!;
+
+    const result = await getStatus({});
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.escalations).toHaveLength(1);
+    expect(parsed.escalations[0].id).toBe(42);
+    expect(parsed.escalations[0].summary).toBe('Invoice never received');
+    expect(parsed.escalations[0].status).toBe('in_progress');
+    expect(parsed.escalations[0].status_label).toContain('In progress');
+    expect(mockListEscalationsForUser).toHaveBeenCalledWith('user_test123', 'U_SLACK_123');
+  });
+
+  test('returns error when user identity is unavailable', async () => {
+    const { createEscalationToolHandlers } = await import('../../server/src/addie/mcp/escalation-tools.js');
+    // No member context, no slack user ID
+    const handlers = createEscalationToolHandlers(null, undefined, undefined);
+    const getStatus = handlers.get('get_escalation_status')!;
+
+    const result = await getStatus({});
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.message).toContain("don't have enough information");
+  });
+
+  test('handles DB errors gracefully', async () => {
+    mockListEscalationsForUser.mockRejectedValue(new Error('DB connection failed'));
+
+    const { createEscalationToolHandlers } = await import('../../server/src/addie/mcp/escalation-tools.js');
+    const handlers = createEscalationToolHandlers(mockMemberContext, 'U_SLACK_123', 'thread_abc');
+    const getStatus = handlers.get('get_escalation_status')!;
+
+    const result = await getStatus({});
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.message).toContain('trouble looking up');
+  });
+});


### PR DESCRIPTION
## Summary

- **Member dashboard**: New "Support requests" section showing escalation status; hidden when empty, visible with status badges when escalations exist
- **Invoice flow**: Replaced immediate-send with two-step preview → confirm flow — `send_invoice` now previews price/details without touching Stripe, `confirm_send_invoice` creates and sends after member approval
- **Addie tool**: Added `get_escalation_status` so members can ask Addie about the status of their support requests in conversation
- **Security**: API endpoint projects only safe escalation fields (no `addie_context` or `original_request` leakage)

## Motivation

Two recurring pain points:
1. Members had no way to see their support request history without contacting an admin
2. Invoices were being sent to wrong email addresses (e.g., Constantine Mirin/Postindustria never received their invoice), with no way to catch errors before sending

## Test plan

- [x] 310/310 tests passing
- [x] Browser test: dashboard loads without JS errors, `#escalations` section hidden when empty, API returns `{escalations: []}` for dev user
- [x] Code review issues addressed (zombie subscriptions, field leakage, ownership checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)