### PR TITLE
chore: remove internal/website/addie entries from rc.2 changelog

### DIFF
--- a/.changeset/1c713d804230728d.md
+++ b/.changeset/1c713d804230728d.md
@@ -1,4 +1,3 @@
 ---
-'adcontextprotocol': patch
 ---
 

--- a/.changeset/aao-brand-tone-format.md
+++ b/.changeset/aao-brand-tone-format.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Update AgenticAdvertising.org brand.json tone to structured { voice, attributes } format for agent compatibility.

--- a/.changeset/addie-list-members-individual.md
+++ b/.changeset/addie-list-members-individual.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Empty changeset - no protocol impact (Addie admin tool default change only)

--- a/.changeset/addie-passthrough-handlers.md
+++ b/.changeset/addie-passthrough-handlers.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 fix(addie): replace hand-coded AdCP tool handlers with generic passthrough

--- a/.changeset/addie-prompt-caching.md
+++ b/.changeset/addie-prompt-caching.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Enable Anthropic prompt caching for Addie to reduce latency and context window usage.

--- a/.changeset/e2a36b4ada369c8c.md
+++ b/.changeset/e2a36b4ada369c8c.md
@@ -1,4 +1,3 @@
 ---
-'adcontextprotocol': patch
 ---
 

--- a/.changeset/fix-join-request-approval.md
+++ b/.changeset/fix-join-request-approval.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix join request approval failing with "Email already invited to organization" when a stale pending invitation exists. Approval now directly creates org membership using the requester's existing user ID instead of sending an invitation.

--- a/.changeset/founding-sprint.md
+++ b/.changeset/founding-sprint.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Founding member sprint: deadline outreach goal, digest banner, throughput increase, auto-claim unowned prospects

--- a/.changeset/manage-aao-ux-fixes.md
+++ b/.changeset/manage-aao-ux-fixes.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Admin UI fixes: rename Company column to Account in prospects, add sort filter, fix analytics revenue table and matrix breakdown.

--- a/.changeset/member-escalations-invoice-draft.md
+++ b/.changeset/member-escalations-invoice-draft.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add escalation visibility to member dashboard and two-step invoice confirmation flow.


### PR DESCRIPTION
## Summary

- Removes `adcontextprotocol` package version bumps from 10 changeset files that cover internal Addie bot improvements, website UI fixes, and org management — none of which are protocol changes
- After this merges, the Version Packages PR (#1300) will be updated to only include protocol-relevant entries in the rc.2 changelog: `creative-generation-controls`, `time-budget`, and `sync_audiences` spec fix

## Changesets cleaned

| File | Description |
|------|-------------|
| `aao-brand-tone-format` | AAO brand.json tone format update |
| `addie-list-members-individual` | Addie admin default change |
| `addie-passthrough-handlers` | Addie tool handler refactor |
| `addie-prompt-caching` | Addie prompt caching |
| `fix-join-request-approval` | Org join request fix |
| `founding-sprint` | Founding member sprint features |
| `manage-aao-ux-fixes` | Admin UI improvements |
| `member-escalations-invoice-draft` | Member dashboard / invoice flow |
| `1c713d804230728d` | Migration renumbering (empty) |
| `e2a36b4ada369c8c` | Registry activity feed (empty) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)