### PR TITLE
fix: member logo resolution falls back to discovered_brands

### DIFF
--- a/.changeset/fix-member-brand-fallback.md
+++ b/.changeset/fix-member-brand-fallback.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix member logo resolution in public member directory and carousel endpoints to fall back to discovered_brands when no hosted brand entry exists, consistent with the authenticated profile endpoint.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6492,6 +6492,16 @@ Disallow: /api/admin/
               const logos = (primaryBrand?.logos ?? bj.logos) as Array<Record<string, unknown>> | undefined;
               const colors = (primaryBrand?.colors ?? bj.colors) as Record<string, unknown> | undefined;
               profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: hosted.domain_verified };
+            } else {
+              const discovered = await this.brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+              if (discovered) {
+                const manifest = discovered.brand_manifest as Record<string, unknown> | undefined;
+                const brands = manifest?.brands as Array<Record<string, unknown>> | undefined;
+                const primaryBrand = brands?.[0];
+                const logos = (primaryBrand?.logos ?? manifest?.logos) as Array<Record<string, unknown>> | undefined;
+                const colors = (primaryBrand?.colors ?? manifest?.colors) as Record<string, unknown> | undefined;
+                profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: true };
+              }
             }
           }
         }));
@@ -6522,6 +6532,16 @@ Disallow: /api/admin/
               const logos = (primaryBrand?.logos ?? bj.logos) as Array<Record<string, unknown>> | undefined;
               const colors = (primaryBrand?.colors ?? bj.colors) as Record<string, unknown> | undefined;
               profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: hosted.domain_verified };
+            } else {
+              const discovered = await this.brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+              if (discovered) {
+                const manifest = discovered.brand_manifest as Record<string, unknown> | undefined;
+                const brands = manifest?.brands as Array<Record<string, unknown>> | undefined;
+                const primaryBrand = brands?.[0];
+                const logos = (primaryBrand?.logos ?? manifest?.logos) as Array<Record<string, unknown>> | undefined;
+                const colors = (primaryBrand?.colors ?? manifest?.colors) as Record<string, unknown> | undefined;
+                profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: true };
+              }
             }
           }
         }));
@@ -6632,6 +6652,16 @@ Disallow: /api/admin/
             const logos = (primaryBrand?.logos ?? bj.logos) as Array<Record<string, unknown>> | undefined;
             const colors = (primaryBrand?.colors ?? bj.colors) as Record<string, unknown> | undefined;
             profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: hostedBrand.domain_verified };
+          } else {
+            const discovered = await this.brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+            if (discovered) {
+              const manifest = discovered.brand_manifest as Record<string, unknown> | undefined;
+              const brands = manifest?.brands as Array<Record<string, unknown>> | undefined;
+              const primaryBrand = brands?.[0];
+              const logos = (primaryBrand?.logos ?? manifest?.logos) as Array<Record<string, unknown>> | undefined;
+              const colors = (primaryBrand?.colors ?? manifest?.colors) as Record<string, unknown> | undefined;
+              profile.resolved_brand = { domain: profile.primary_brand_domain, logo_url: logos?.[0]?.url as string | undefined, brand_color: colors?.primary as string | undefined, verified: true };
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

- The public `/api/members`, `/api/members/carousel`, and `/api/members/:slug` endpoints only checked `hosted_brands` when resolving member logos, with no fallback to `discovered_brands`
- The authenticated `/api/me/member-profile` endpoint used `resolveBrand()` which already had a `discovered_brands` fallback — this inconsistency meant logos could appear on your own profile settings page but not on the public member directory
- Fixes the code gap exposed by escalation #102 (Affinity Global Inc logo not showing)

## Root cause (escalation #102)

The brand viewer reads logos from the **live `brand.json`** at the member's domain. The member directory reads from our database. When a member's brand data only exists in `discovered_brands` (e.g. from Brandfetch enrichment), the public directory showed no logo even though the brand viewer showed one correctly.

## What this doesn't fix

The **data-level fix** for Affinity Global specifically still requires an admin action: use Addie's `update_member_logo` tool to write a `hosted_brands` entry with their logo URL. This code change ensures future members with `discovered_brands` data show their logos without needing a manual `hosted_brands` entry.

## Test plan
- [x] TypeScript type check passes
- [x] All 310 tests pass
- [ ] Verify Affinity Global logo appears after admin runs `update_member_logo(org_name="Affinity Global Inc", logo_url="<their logo URL>")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)