### PR TITLE
fix: hide Sync from Stripe button for non-admins

### DIFF
--- a/.changeset/hide-sync-btn-non-admin.md
+++ b/.changeset/hide-sync-btn-non-admin.md
@@ -1,0 +1,3 @@
+---
+---
+fix: hide "Sync from Stripe" button on analytics page for non-admins

--- a/server/public/manage-analytics.html
+++ b/server/public/manage-analytics.html
@@ -234,7 +234,7 @@
   <div class="container">
     <h1>Analytics Dashboard</h1>
 
-    <div class="actions-bar">
+    <div class="actions-bar" id="sync-actions" style="display: none;">
       <button id="backfill-btn" class="btn btn-primary" onclick="backfillRevenue()">
         Sync from Stripe
       </button>
@@ -602,6 +602,11 @@
 
     function downloadMembershipCSV() {
       window.location.href = '/api/admin/membership-metrics/csv';
+    }
+
+    // Only admins can trigger the Stripe sync
+    if (window.__APP_CONFIG__ && window.__APP_CONFIG__.isAdmin) {
+      document.getElementById('sync-actions').style.display = '';
     }
 
     // Load analytics on page load


### PR DESCRIPTION
## Summary

- The "Sync from Stripe" button on `/manage/analytics` was visible to all manage users, but the underlying `/api/admin/backfill-revenue` endpoint is admin-only — causing an error for non-admins
- Button is now hidden by default and only shown when `window.__APP_CONFIG__.isAdmin` is true

Closes #1330

## Test plan

- [ ] Log in as a non-admin manage user → "Sync from Stripe" button should not be visible
- [ ] Log in as an admin → button should appear and function as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)