### PR TITLE
docs: per-vertical catalog schema reference and sync_catalogs tool

### DIFF
--- a/.changeset/catalog-docs-sync-tool.md
+++ b/.changeset/catalog-docs-sync-tool.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add per-vertical catalog item schema reference docs and sync_catalogs Addie tool.

--- a/docs.json
+++ b/docs.json
@@ -320,6 +320,7 @@
               "docs/creative/generative-creative",
               "docs/creative/template-format-ids",
               "docs/creative/catalogs",
+              "docs/creative/catalog-schemas",
               "docs/creative/accessibility",
               "docs/creative/provenance",
               {
@@ -649,6 +650,7 @@
               "docs/creative/generative-creative",
               "docs/creative/template-format-ids",
               "docs/creative/catalogs",
+              "docs/creative/catalog-schemas",
               "docs/creative/accessibility",
               "docs/creative/provenance",
               {

--- a/docs/creative/catalog-schemas.mdx
+++ b/docs/creative/catalog-schemas.mdx
@@ -1,0 +1,517 @@
+---
+title: Catalog item schemas
+description: Field tables, required fields, and starter templates for every vertical catalog type — job, hotel, vehicle, flight, real estate, education, destination, and app
+testable: true
+keywords: [catalog schema, job catalog, hotel catalog, vehicle catalog, flight catalog, real estate catalog, education catalog, destination catalog, app catalog, item schema, universal asset registry]
+---
+
+# Catalog item schemas
+
+Each vertical catalog type maps to a single AdCP schema that works across platforms — Google, Meta, LinkedIn, and others. Provide items in this format once, and every platform gets what it needs.
+
+All vertical items share a common pattern: a unique ID field, core display fields, an optional `assets` array for [typed creative asset pools](/docs/creative/catalogs#typed-catalog-assets), an optional `tags` array for filtering, and an `ext` object for vendor-specific extensions. **Conversion events** listed for each vertical are the standard event names used for [attribution](/docs/media-buy/conversion-tracking) when an ad drives action on a catalog item.
+
+<a id="common-fields"></a>
+**Common fields** — In addition to the domain-specific fields listed in each vertical's table, all vertical items support:
+
+| Field | Type | Description |
+|---|---|---|
+| `image_url` | uri | Primary image URL (most verticals — see note) |
+| `url` | uri | Landing page URL (most verticals — see note) |
+| `assets` | OfferingAssetGroup[] | [Typed creative asset pools](/docs/creative/catalogs#typed-catalog-assets) (landscape, vertical, square, logo, video) |
+| `tags` | string[] | Tags for filtering and targeting |
+| `ext` | object | Vendor-specific extensions |
+
+**Exceptions:** Job items use `apply_url` instead of `url` and have no `image_url`. App items use `icon_url` and `store_url` instead of `image_url` and `url`. See each vertical's field table for the exact fields.
+
+## Job catalog
+
+Job postings for recruitment campaigns. Maps to LinkedIn Jobs XML, Google DynamicJobsAsset, and schema.org JobPosting.
+
+**Schema**: [`/schemas/core/job-item.json`](https://adcontextprotocol.org/schemas/v3/core/job-item.json)
+**Required**: `job_id`, `title`, `company_name`, `description`
+**Conversion events**: `submit_application`, `complete_registration`
+
+| Field | Type | Description |
+|---|---|---|
+| `job_id` | string | Unique identifier for this posting |
+| `title` | string | Job title |
+| `company_name` | string | Hiring company name |
+| `description` | string | Full job description |
+| `location` | string | Display string — "Amsterdam, NL" or "Remote" |
+| `employment_type` | enum | `full_time`, `part_time`, `contract`, `temporary`, `internship`, `freelance` |
+| `experience_level` | enum | `entry_level`, `mid_level`, `senior`, `director`, `executive` |
+| `salary` | object | `{ min, max, currency, period }` — period is `hour`, `month`, or `year` |
+| `date_posted` | date | ISO 8601 date |
+| `valid_through` | date | Application deadline |
+| `apply_url` | uri | Direct application URL |
+| `job_functions` | string[] | e.g., `["engineering", "marketing"]` |
+| `industries` | string[] | e.g., `["technology", "healthcare"]` |
+| `tags` | string[] | For filtering — e.g., `["remote", "visa-sponsorship"]` |
+
+Plus [common fields](#common-fields) (`assets`, `tags`, `ext`) shared by all verticals. Job items use `apply_url` instead of `url` and have no `image_url`.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
+  "job_id": "eng-sr-2025-042",
+  "title": "Senior Software Engineer",
+  "company_name": "Acme Corp",
+  "description": "Senior engineer to lead our platform team, designing distributed systems serving millions of daily requests."
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
+  "job_id": "eng-sr-2025-042",
+  "title": "Senior Software Engineer",
+  "company_name": "Acme Corp",
+  "description": "We're looking for a senior engineer to lead our platform team. You'll design and build distributed systems serving millions of daily requests.",
+  "location": "Amsterdam, NL",
+  "employment_type": "full_time",
+  "experience_level": "senior",
+  "salary": { "min": 80000, "max": 110000, "currency": "EUR", "period": "year" },
+  "date_posted": "2025-06-01",
+  "valid_through": "2025-08-01",
+  "apply_url": "https://acmecorp.com/careers/eng-sr-2025-042",
+  "job_functions": ["engineering"],
+  "industries": ["technology"],
+  "tags": ["visa-sponsorship", "equity"]
+}
+```
+
+## Hotel catalog
+
+Hotel and lodging properties for travel ads and dynamic remarketing. Maps to Google Hotel Center feeds and Meta hotel catalogs.
+
+**Schema**: [`/schemas/core/hotel-item.json`](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json)
+**Required**: `hotel_id`, `name`, `location`
+**Conversion events**: `purchase` (booking)
+
+| Field | Type | Description |
+|---|---|---|
+| `hotel_id` | string | Unique identifier |
+| `name` | string | Property name |
+| `description` | string | Property description |
+| `location` | object | `{ lat, lng }` — WGS 84 coordinates |
+| `address` | object | `{ street, city, region, postal_code, country }` |
+| `star_rating` | integer | 1–5 |
+| `price` | object | `{ amount, currency, period }` — use period `"night"` |
+| `image_url` | uri | Primary property image |
+| `url` | uri | Property landing page |
+| `amenities` | string[] | e.g., `["spa", "pool", "wifi"]` |
+| `check_in_time` | string | HH:MM format (e.g., `"15:00"`) |
+| `check_out_time` | string | HH:MM format (e.g., `"11:00"`) |
+| `phone` | string | Property phone number in E.164 format |
+| `valid_from` | date | Start of seasonal availability window |
+| `valid_to` | date | End of seasonal availability window |
+| `tags` | string[] | e.g., `["luxury", "city-center"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
+  "hotel_id": "grand-amsterdam",
+  "name": "Grand Hotel Amsterdam",
+  "location": { "lat": 52.3676, "lng": 4.9041 }
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
+  "hotel_id": "grand-amsterdam",
+  "name": "Grand Hotel Amsterdam",
+  "description": "Five-star canal-side hotel in the heart of Amsterdam with rooftop bar and spa.",
+  "location": { "lat": 52.3676, "lng": 4.9041 },
+  "address": {
+    "street": "Herengracht 100",
+    "city": "Amsterdam",
+    "region": "NL-NH",
+    "postal_code": "1015 BS",
+    "country": "NL"
+  },
+  "star_rating": 5,
+  "price": { "amount": 289, "currency": "EUR", "period": "night" },
+  "image_url": "https://images.acmehotels.com/grand-amsterdam/hero.jpg",
+  "url": "https://acmehotels.com/amsterdam/grand",
+  "amenities": ["spa", "pool", "restaurant", "wifi", "parking"],
+  "check_in_time": "15:00",
+  "check_out_time": "11:00",
+  "tags": ["luxury", "city-center", "business"]
+}
+```
+
+## Vehicle catalog
+
+Vehicle listings for automotive inventory ads. Maps to Meta Automotive Inventory Ads, Microsoft Auto Inventory feeds, and Google vehicle ads.
+
+**Schema**: [`/schemas/core/vehicle-item.json`](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json)
+**Required**: `vehicle_id`, `title`, `make`, `model`, `year`
+**Conversion events**: `lead`, `schedule` (test drive)
+
+| Field | Type | Description |
+|---|---|---|
+| `vehicle_id` | string | Unique identifier |
+| `title` | string | Listing title (e.g., "2024 Apex Horizon EX Sedan") |
+| `make` | string | Manufacturer |
+| `model` | string | Model name |
+| `year` | integer | Model year |
+| `price` | object | `{ amount, currency }` |
+| `condition` | enum | `new`, `used`, `certified_pre_owned` |
+| `vin` | string | 17-character VIN |
+| `trim` | string | Trim level (e.g., "EX", "Limited") |
+| `mileage` | object | `{ value, unit }` — unit is `km` or `mi` |
+| `body_style` | enum | `sedan`, `suv`, `truck`, `coupe`, `convertible`, `wagon`, `van`, `hatchback` |
+| `transmission` | enum | `automatic`, `manual`, `cvt` |
+| `fuel_type` | enum | `gasoline`, `diesel`, `electric`, `hybrid`, `plug_in_hybrid` |
+| `exterior_color` | string | Exterior color |
+| `interior_color` | string | Interior color |
+| `location` | object | `{ lat, lng }` — dealer or vehicle location |
+| `tags` | string[] | e.g., `["low-mileage", "one-owner"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
+  "vehicle_id": "dlr-2024-horizon-001",
+  "title": "2024 Apex Horizon EX Sedan",
+  "make": "Apex",
+  "model": "Horizon",
+  "year": 2024
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
+  "vehicle_id": "dlr-2024-horizon-001",
+  "title": "2024 Apex Horizon EX Sedan",
+  "make": "Apex",
+  "model": "Horizon",
+  "year": 2024,
+  "trim": "EX",
+  "price": { "amount": 28500, "currency": "USD" },
+  "condition": "new",
+  "body_style": "sedan",
+  "transmission": "cvt",
+  "fuel_type": "gasoline",
+  "exterior_color": "Lunar Silver Metallic",
+  "image_url": "https://images.apexmotors.com/horizon-ex-2024.jpg",
+  "url": "https://apexmotors.com/inventory/horizon-001",
+  "tags": ["new-arrival"]
+}
+```
+
+## Flight catalog
+
+Flight routes for travel ads and dynamic remarketing. Maps to Google DynamicFlightsAsset and Meta flight catalogs.
+
+**Schema**: [`/schemas/core/flight-item.json`](https://adcontextprotocol.org/schemas/v3/core/flight-item.json)
+**Required**: `flight_id`, `origin`, `destination`
+**Conversion events**: `purchase` (booking)
+
+| Field | Type | Description |
+|---|---|---|
+| `flight_id` | string | Unique identifier for this route |
+| `origin` | object | `{ airport_code, city }` — IATA 3-letter code required |
+| `destination` | object | `{ airport_code, city }` — IATA 3-letter code required |
+| `airline` | string | Airline name or IATA code |
+| `price` | object | `{ amount, currency }` |
+| `description` | string | Route description or promotional text |
+| `departure_time` | datetime | ISO 8601 |
+| `arrival_time` | datetime | ISO 8601 |
+| `image_url` | uri | Destination photo |
+| `url` | uri | Booking page |
+| `tags` | string[] | e.g., `["direct", "red-eye"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
+  "flight_id": "ams-jfk-summer",
+  "origin": { "airport_code": "AMS" },
+  "destination": { "airport_code": "JFK" }
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
+  "flight_id": "ams-jfk-summer",
+  "origin": { "airport_code": "AMS", "city": "Amsterdam" },
+  "destination": { "airport_code": "JFK", "city": "New York" },
+  "airline": "Acme Air",
+  "price": { "amount": 449, "currency": "EUR" },
+  "description": "Direct flights from Amsterdam to New York, daily departures.",
+  "image_url": "https://images.acmeair.com/routes/ams-jfk.jpg",
+  "url": "https://acmeair.com/flights/ams-jfk",
+  "tags": ["direct", "transatlantic"]
+}
+```
+
+## Real estate catalog
+
+Property listings for real estate ads. Maps to Google DynamicRealEstateAsset and Meta home listing catalogs.
+
+**Schema**: [`/schemas/core/real-estate-item.json`](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json)
+**Required**: `listing_id`, `title`, `address`
+**Conversion events**: `lead`, `schedule` (viewing)
+
+| Field | Type | Description |
+|---|---|---|
+| `listing_id` | string | Unique identifier |
+| `title` | string | Listing title |
+| `description` | string | Property description |
+| `address` | object | `{ street, city, region, postal_code, country }` |
+| `price` | object | `{ amount, currency, period }` — use `"month"` for rentals |
+| `property_type` | enum | `house`, `apartment`, `condo`, `townhouse`, `land`, `commercial` |
+| `listing_type` | enum | `for_sale`, `for_rent` |
+| `bedrooms` | integer | Number of bedrooms |
+| `bathrooms` | number | Number of bathrooms (e.g., 2.5) |
+| `area` | object | `{ value, unit }` — unit is `sqft` or `sqm` |
+| `location` | object | `{ lat, lng }` |
+| `neighborhood` | string | Area name |
+| `year_built` | integer | Year built |
+| `tags` | string[] | e.g., `["garden", "renovated"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
+  "listing_id": "ams-jordaan-3br",
+  "title": "Spacious 3BR Apartment in Jordaan",
+  "address": { "city": "Amsterdam", "country": "NL" }
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
+  "listing_id": "ams-jordaan-3br",
+  "title": "Spacious 3BR Apartment in Jordaan",
+  "description": "Bright canal-view apartment with original features and modern kitchen, steps from Noordermarkt.",
+  "address": {
+    "street": "Prinsengracht 450",
+    "city": "Amsterdam",
+    "region": "NL-NH",
+    "postal_code": "1017 KE",
+    "country": "NL"
+  },
+  "price": { "amount": 650000, "currency": "EUR" },
+  "property_type": "apartment",
+  "listing_type": "for_sale",
+  "bedrooms": 3,
+  "bathrooms": 1,
+  "area": { "value": 95, "unit": "sqm" },
+  "location": { "lat": 52.3667, "lng": 4.8833 },
+  "neighborhood": "Jordaan",
+  "year_built": 1920,
+  "tags": ["canal-view", "renovated"]
+}
+```
+
+## Education catalog
+
+Educational programs and courses for student recruitment. Maps to Google DynamicEducationAsset and schema.org Course.
+
+**Schema**: [`/schemas/core/education-item.json`](https://adcontextprotocol.org/schemas/v3/core/education-item.json)
+**Required**: `program_id`, `name`, `school`
+**Conversion events**: `submit_application`, `complete_registration`
+
+| Field | Type | Description |
+|---|---|---|
+| `program_id` | string | Unique identifier |
+| `name` | string | Program name |
+| `school` | string | Institution name |
+| `description` | string | Program description |
+| `subject` | string | Field of study |
+| `degree_type` | enum | `certificate`, `associate`, `bachelor`, `master`, `doctorate`, `professional`, `bootcamp` |
+| `level` | enum | `beginner`, `intermediate`, `advanced` |
+| `price` | object | `{ amount, currency, period }` |
+| `duration` | string | e.g., "4 weeks", "2 years" |
+| `start_date` | date | Next available start date |
+| `language` | string | Language code (e.g., "en") |
+| `modality` | enum | `online`, `in_person`, `hybrid` |
+| `location` | string | Campus location (e.g., "Amsterdam, NL"). Omit for fully online. |
+| `tags` | string[] | e.g., `["stem", "research"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
+  "program_id": "pinnacle-msc-cs-2025",
+  "name": "MSc Computer Science",
+  "school": "Pinnacle University"
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
+  "program_id": "pinnacle-msc-cs-2025",
+  "name": "MSc Computer Science",
+  "school": "Pinnacle University",
+  "description": "Two-year research master's covering AI, distributed systems, and software engineering.",
+  "subject": "computer-science",
+  "degree_type": "master",
+  "level": "advanced",
+  "price": { "amount": 2314, "currency": "EUR", "period": "year" },
+  "duration": "2 years",
+  "start_date": "2025-09-01",
+  "language": "en",
+  "modality": "in_person",
+  "location": "Amsterdam, NL",
+  "url": "https://pinnacle-university.com/programmes/masters/computer-science",
+  "tags": ["stem", "research"]
+}
+```
+
+## Destination catalog
+
+Travel destinations for destination ads and travel remarketing. Maps to Meta destination catalogs and Google travel ads.
+
+**Schema**: [`/schemas/core/destination-item.json`](https://adcontextprotocol.org/schemas/v3/core/destination-item.json)
+**Required**: `destination_id`, `name`
+**Conversion events**: `purchase` (booking)
+
+| Field | Type | Description |
+|---|---|---|
+| `destination_id` | string | Unique identifier |
+| `name` | string | Destination name |
+| `description` | string | Highlights and appeal |
+| `city` | string | City name |
+| `region` | string | State/province |
+| `country` | string | ISO 3166-1 alpha-2 |
+| `location` | object | `{ lat, lng }` |
+| `destination_type` | enum | `beach`, `mountain`, `urban`, `cultural`, `adventure`, `wellness`, `cruise` |
+| `price` | object | Starting trip price |
+| `rating` | number | 1–5 |
+| `tags` | string[] | e.g., `["family", "romantic"]` |
+
+Plus [common fields](#common-fields) (`image_url`, `url`, `assets`, `tags`, `ext`) shared by all verticals.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
+  "destination_id": "barcelona",
+  "name": "Barcelona"
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
+  "destination_id": "barcelona",
+  "name": "Barcelona",
+  "description": "Mediterranean city blending Gaudí architecture, beaches, and world-class dining.",
+  "city": "Barcelona",
+  "region": "Catalonia",
+  "country": "ES",
+  "location": { "lat": 41.3874, "lng": 2.1686 },
+  "destination_type": "urban",
+  "price": { "amount": 399, "currency": "EUR" },
+  "image_url": "https://images.acmetravel.com/barcelona/hero.jpg",
+  "url": "https://acmetravel.com/destinations/barcelona",
+  "rating": 4.7,
+  "tags": ["city-break", "beach", "culture"]
+}
+```
+
+## App catalog
+
+Mobile applications for app install and re-engagement campaigns. Maps to Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, and Snapchat App Install Ads. iOS and Android variants are separate items.
+
+**Schema**: [`/schemas/core/app-item.json`](https://adcontextprotocol.org/schemas/v3/core/app-item.json)
+**Required**: `app_id`, `name`, `platform`
+**Conversion events**: `app_install`, `app_launch`
+
+| Field | Type | Description |
+|---|---|---|
+| `app_id` | string | Buyer-assigned unique identifier |
+| `name` | string | App display name |
+| `platform` | enum | `ios`, `android` |
+| `bundle_id` | string | Reverse-domain identifier (e.g., `com.acme.app`) |
+| `apple_id` | string | Numeric Apple App Store ID (iOS only) |
+| `description` | string | App description (overrides store listing) |
+| `category` | string | Store category (e.g., "games", "finance") |
+| `genre` | string | Sub-genre (e.g., "puzzle", "strategy") |
+| `icon_url` | uri | App icon (1024x1024 px) |
+| `screenshots` | uri[] | App store screenshots |
+| `preview_video_url` | uri | Gameplay or demo video for video ad creatives |
+| `store_url` | uri | App store listing URL |
+| `deep_link_url` | uri | For re-engagement campaigns |
+| `price` | object | `{ amount, currency }` — set amount to 0 for free |
+| `rating` | number | 0–5 store rating |
+| `rating_count` | integer | Total number of store ratings |
+| `content_rating` | string | Age rating (e.g., "4+", "Everyone") |
+| `tags` | string[] | e.g., `["casual", "offline"]` |
+
+Plus [common fields](#common-fields) (`assets`, `tags`, `ext`) shared by all verticals. App items use `icon_url` and `store_url` instead of `image_url` and `url`.
+
+Minimal — just required fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
+  "app_id": "puzzlequest-ios",
+  "name": "Puzzle Quest: Match 3",
+  "platform": "ios"
+}
+```
+
+Full example with optional fields:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
+  "app_id": "puzzlequest-ios",
+  "name": "Puzzle Quest: Match 3",
+  "platform": "ios",
+  "bundle_id": "com.acmegames.puzzlequest",
+  "apple_id": "1234567890",
+  "category": "games",
+  "genre": "puzzle",
+  "icon_url": "https://assets.acmegames.com/puzzlequest/icon-1024.png",
+  "store_url": "https://apps.apple.com/app/puzzle-quest-match-3/id1234567890",
+  "price": { "amount": 0, "currency": "USD" },
+  "rating": 4.7,
+  "rating_count": 82000,
+  "content_rating": "4+",
+  "tags": ["casual", "offline"]
+}
+```

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -1,7 +1,8 @@
 ---
 title: Catalogs
 description: Typed data feeds — products, hotels, jobs, vehicles, stores, and more — that provide the items publishers render in ads
-keywords: [catalogs, product feed, inventory, stores, promotions, offerings, hotel, flight, job, vehicle, real estate, education, destination, app, mobile app, sync_catalogs, catalog requirements]
+testable: true
+keywords: [catalogs, product feed, inventory, stores, promotions, offerings, hotel, flight, job, vehicle, real estate, education, destination, app, mobile app, sync_catalogs, catalog requirements, universal asset registry, asset registry]
 ---
 
 # Catalogs
@@ -13,6 +14,28 @@ Catalogs are a foundational building block in AdCP:
 - **Formats declare** what catalog types they need as `catalog` asset types in their `assets` array
 - **Buyers sync** catalogs to seller accounts via `sync_catalogs`, with platform review and approval
 - **Creatives reference** synced catalogs by `catalog_id` in the manifest's `assets` map instead of embedding items inline
+
+## Which catalog type should I use?
+
+Pick the catalog type that matches what you're advertising.
+
+| I'm advertising... | Catalog type | Item schema | Required fields |
+|---|---|---|---|
+| Physical products / ecommerce SKUs | `product` | *(your existing feed — Google Merchant, Shopify, etc.)* | Depends on feed format |
+| Job openings / recruitment | `job` | [JobItem](/docs/creative/catalog-schemas#job-catalog) | `job_id`, `title`, `company_name`, `description` |
+| Hotels / lodging | `hotel` | [HotelItem](/docs/creative/catalog-schemas#hotel-catalog) | `hotel_id`, `name`, `location` |
+| Vehicles (new or used) | `vehicle` | [VehicleItem](/docs/creative/catalog-schemas#vehicle-catalog) | `vehicle_id`, `title`, `make`, `model`, `year` |
+| Flights / air travel | `flight` | [FlightItem](/docs/creative/catalog-schemas#flight-catalog) | `flight_id`, `origin`, `destination` |
+| Real estate listings | `real_estate` | [RealEstateItem](/docs/creative/catalog-schemas#real-estate-catalog) | `listing_id`, `title`, `address` |
+| University programs / courses | `education` | [EducationItem](/docs/creative/catalog-schemas#education-catalog) | `program_id`, `name`, `school` |
+| Travel destinations | `destination` | [DestinationItem](/docs/creative/catalog-schemas#destination-catalog) | `destination_id`, `name` |
+| Mobile apps | `app` | [AppItem](/docs/creative/catalog-schemas#app-catalog) | `app_id`, `name`, `platform` |
+| Store locations | `store` | [StoreItem](#stores) | `store_id`, `name`, `location` |
+| Campaigns, services, events | `offering` | [Offering](#offerings) | `offering_id`, `name` |
+| Stock levels per location | `inventory` | *(your existing feed format)* | Depends on feed format |
+| Sales, deals, pricing | `promotion` | *(your existing feed format)* | Depends on feed format |
+
+Each vertical type (job through app) has a defined AdCP schema with examples — see the [catalog item schemas](/docs/creative/catalog-schemas) page for field tables and starter templates. Structural types (product, inventory, promotion) use freeform schemas that map to your existing feed format via `feed_format` and `feed_field_mappings`.
 
 ## Where sync_catalogs fits
 
@@ -82,10 +105,10 @@ Catalog types fall into two categories: **structural** types that describe the d
 | Type | Item Schema | Description |
 |------|-------------|-------------|
 | `offering` | [Offering](https://adcontextprotocol.org/schemas/v3/core/offering.json) | AdCP Offering objects — campaigns, vacancies, events, services |
-| `product` | *(freeform)* | Ecommerce product entries (Google Merchant Center, Shopify, etc.) |
-| `inventory` | *(freeform)* | Stock and availability per product per location |
-| `store` | [StoreItem](https://adcontextprotocol.org/schemas/latest/core/store-item.json) | Physical locations with addresses and catchment areas |
-| `promotion` | *(freeform)* | Sales, deals, and promotional pricing |
+| `product` | *(your existing feed format)* | Ecommerce product entries (Google Merchant Center, Shopify, etc.) |
+| `inventory` | *(your existing feed format)* | Stock and availability per product per location |
+| `store` | [StoreItem](https://adcontextprotocol.org/schemas/v3/core/store-item.json) | Physical locations with addresses and catchment areas |
+| `promotion` | *(your existing feed format)* | Sales, deals, and promotional pricing |
 
 ### Vertical types
 
@@ -93,14 +116,14 @@ Each vertical type has a defined AdCP item schema, so formats can declare `catal
 
 | Type | Item Schema | Maps To |
 |------|-------------|---------|
-| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/latest/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
-| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/latest/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
-| `job` | [JobItem](https://adcontextprotocol.org/schemas/latest/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
-| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
-| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
-| `education` | [EducationItem](https://adcontextprotocol.org/schemas/latest/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
-| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/latest/core/destination-item.json) | Meta destination catalogs, Google travel ads |
-| `app` | [AppItem](https://adcontextprotocol.org/schemas/latest/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
+| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
+| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/v3/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
+| `job` | [JobItem](https://adcontextprotocol.org/schemas/v3/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
+| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
+| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
+| `education` | [EducationItem](https://adcontextprotocol.org/schemas/v3/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
+| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/v3/core/destination-item.json) | Meta destination catalogs, Google travel ads |
+| `app` | [AppItem](https://adcontextprotocol.org/schemas/v3/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
 
 ## Typed catalog assets
 
@@ -146,9 +169,9 @@ Formats use `field_bindings` (see [Format catalog requirements](#format-catalog-
 
 ## The Catalog object
 
-**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/latest/core/catalog.json)
+**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/v3/core/catalog.json)
 
-```typescript
+```typescript test=false
 interface Catalog {
   // Identity (required for sync_catalogs, optional for inline use)
   catalog_id?: string;  // Buyer's identifier — also used to reference synced catalogs
@@ -446,6 +469,10 @@ Each mapping entry is one of:
 
 Multiple mappings can assemble a nested object. The `price.amount` and `price.currency` mappings above each write one field of the `price` object independently.
 
+## Item schema reference
+
+Each vertical catalog type has a defined item schema with field tables, required fields, and starter templates. See **[Catalog item schemas](/docs/creative/catalog-schemas)** for the complete reference with minimal and full examples for every vertical type.
+
 ## Format catalog requirements
 
 Formats that render product listings, store locators, or promotional content declare what catalog feeds they need as `catalog` asset types in their `assets` array. Each catalog asset carries `requirements` with fields like `catalog_type`, `min_items`, and `required_fields`. This tells buying agents which catalogs to sync before submitting creatives.
@@ -593,7 +620,7 @@ When a format declares catalog asset types, the buying agent syncs the required 
 
 An Offering is an individual promotable item within an `offering`-type catalog — a campaign, product, service, promotion, or vacancy. Each offering is a semantic unit with its own name, validity window, landing URL, creative assets, and geographic scope.
 
-```typescript
+```typescript test=false
 interface Offering {
   // Identity (required)
   offering_id: string;
@@ -645,11 +672,11 @@ interface Offering {
 
 ### OfferingAssetGroup
 
-**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/latest/core/offering-asset-group.json)
+**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/v3/core/offering-asset-group.json)
 
 A typed pool of creative assets within an offering. Uses the same `asset_group_id` vocabulary as format-level asset definitions, enabling formats to declare per-group constraints on what each offering must provide.
 
-```typescript
+```typescript test=false
 interface OfferingAssetGroup {
   asset_group_id: string;        // e.g., 'headlines', 'images_landscape'
   asset_type: AssetContentType;  // Type of all items in this group
@@ -665,11 +692,11 @@ interface OfferingAssetGroup {
 
 ### OfferingAssetConstraint
 
-**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/latest/core/requirements/offering-asset-constraint.json)
+**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/v3/core/requirements/offering-asset-constraint.json)
 
 Declared by a format to specify what asset groups each offering must provide. Used within a catalog asset's `requirements` to constrain what offerings in a catalog must provide.
 
-```typescript
+```typescript test=false
 interface OfferingAssetConstraint {
   asset_group_id: string;
   asset_type: AssetContentType;
@@ -745,11 +772,11 @@ Call `list_creative_formats` and check the format's `assets` array for `catalog`
 
 ## Stores
 
-**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/latest/core/store-item.json)
+**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/v3/core/store-item.json)
 
 A StoreItem represents a physical location within a `store`-type catalog. Each store carries coordinates, an optional address, and one or more catchment areas that define the geographic reach around that location.
 
-```typescript
+```typescript test=false
 interface StoreItem {
   store_id: string;              // Unique identifier
   name: string;                  // Human-readable name
@@ -785,7 +812,7 @@ interface StoreItem {
 
 ### Catchment areas
 
-**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/latest/core/catchment.json)
+**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/v3/core/catchment.json)
 
 A catchment defines the geographic area a store serves. Three methods are supported — provide exactly one per catchment:
 

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -217,6 +217,102 @@ export const ADCP_MEDIA_BUY_TOOLS: AddieTool[] = [
     },
   },
   {
+    name: 'sync_catalogs',
+    description:
+      'Sync product catalogs, store locations, job postings, hotel listings, and other structured feeds to a seller account. Supports inline items or external feed URLs. When called without catalogs, returns all catalogs on the account (discovery mode).',
+    usage_hints:
+      'use when the user wants to push product feeds, catalog data, store locations, job postings, hotel listings, or other structured data to a seller account. Also use to discover what catalogs already exist on an account. Use after list_creative_formats shows catalog asset requirements, or before sync_creatives when the format needs catalog data.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_url: {
+          type: 'string',
+          description: 'The sales agent URL (must be HTTPS)',
+        },
+        account: {
+          type: 'object',
+          description: 'The account that owns the catalogs',
+          properties: {
+            account_id: { type: 'string', description: 'Account identifier' },
+          },
+          required: ['account_id'],
+        },
+        catalogs: {
+          type: 'array',
+          description: 'Catalog objects to sync. Omit for discovery mode (returns all catalogs on the account).',
+          items: {
+            type: 'object',
+            properties: {
+              catalog_id: { type: 'string', description: "Buyer's identifier for this catalog" },
+              name: { type: 'string', description: 'Human-readable catalog name' },
+              type: {
+                type: 'string',
+                description: 'Catalog type',
+                enum: [
+                  'offering', 'product', 'inventory', 'store', 'promotion',
+                  'hotel', 'flight', 'job', 'vehicle', 'real_estate',
+                  'education', 'destination', 'app',
+                ],
+              },
+              url: { type: 'string', description: 'External feed URL (mutually exclusive with items)' },
+              feed_format: {
+                type: 'string',
+                description: 'Feed format when using url',
+                enum: ['google_merchant_center', 'facebook_catalog', 'shopify', 'linkedin_jobs', 'custom'],
+              },
+              update_frequency: {
+                type: 'string',
+                description: 'How often the feed should be refreshed',
+                enum: ['realtime', 'hourly', 'daily', 'weekly'],
+              },
+              items: {
+                type: 'array',
+                description: 'Inline catalog data (mutually exclusive with url). Item schema depends on catalog type — e.g., Offering objects for "offering", JobItem for "job", HotelItem for "hotel".',
+                items: { type: 'object' },
+              },
+              feed_field_mappings: {
+                type: 'array',
+                description: 'Field normalization rules for mapping non-standard feed fields to AdCP schema',
+                items: {
+                  type: 'object',
+                  properties: {
+                    source_field: { type: 'string', description: 'Field name in the external feed' },
+                    target_field: { type: 'string', description: 'AdCP schema field to map to' },
+                    transform: { type: 'string', description: 'Named transform (date, divide, boolean, split)' },
+                  },
+                },
+              },
+            },
+            required: ['type'],
+          },
+        },
+        catalog_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Filter to specific catalog IDs. In discovery mode (catalogs omitted), returns only these catalogs.',
+        },
+        delete_missing: {
+          type: 'boolean',
+          description: 'Remove catalogs not included in this sync (default: false). Use with caution — catalogs not in the request will be permanently deleted from the account.',
+        },
+        dry_run: {
+          type: 'boolean',
+          description: 'Preview changes without applying',
+        },
+        validation_mode: {
+          type: 'string',
+          description: 'Validation strictness for catalog data',
+          enum: ['strict', 'lenient'],
+        },
+        debug: {
+          type: 'boolean',
+          description: 'Enable debug logging to see protocol-level details',
+        },
+      },
+      required: ['agent_url', 'account'],
+    },
+  },
+  {
     name: 'list_creative_formats',
     description:
       'View supported creative specifications from a sales or creative agent. Returns format definitions with dimensions and asset requirements.',


### PR DESCRIPTION
## Summary

- **New page**: `docs/creative/catalog-schemas.mdx` — per-vertical schema reference with field tables, required fields, conversion events, and minimal/full JSON examples for all 8 vertical catalog types (job, hotel, vehicle, flight, real_estate, education, destination, app)
- **sync_catalogs tool**: Added to Addie MCP tools with full catalog type enum, discovery mode, dry_run, and feed field mappings
- **Schema URL cleanup**: Updated all `latest` → `v3` schema links in catalogs.mdx (schemas exist in 3.0.0-rc.1)
- **Navigation**: Added catalog-schemas to docs.json

## Context

Triggered by a member question about "Universal Asset Registry" — the catalog system IS the answer, but the docs didn't make it easy to find field-level details for vertical catalogs. This PR closes that gap.

## Test plan

- [x] All 323 unit tests pass
- [x] Schema validation passes (347 schemas)
- [x] OpenAPI spec is current
- [x] TypeScript typecheck passes
- [x] Mintlify link check passes (no broken links)
- [x] All JSON examples in catalog-schemas.mdx have `$schema` refs pointing to v3
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)