### PR TITLE
Move GEO visibility dashboard to Manage AAO

### DIFF
--- a/.changeset/geo-dashboard-manage.md
+++ b/.changeset/geo-dashboard-manage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Move GEO visibility dashboard to Manage AAO section

--- a/server/public/admin-sidebar.js
+++ b/server/public/admin-sidebar.js
@@ -12,7 +12,6 @@
         label: 'Overview',
         items: [
           { href: '/admin', label: 'Dashboard', icon: '📊' },
-          { href: '/admin/geo', label: 'GEO visibility', icon: '🔍' },
         ]
       },
       {

--- a/server/public/manage-geo.html
+++ b/server/public/manage-geo.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/AAo.svg" type="image/svg+xml">
-  <title>GEO visibility - AdCP Admin</title>
+  <title>GEO visibility - Manage AAO</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
-  <script src="/admin-sidebar.js"></script>
+  <script src="/manage-sidebar.js"></script>
   <style>
     * {
       margin: 0;
@@ -488,12 +488,6 @@
 
       try {
         const response = await fetch('/api/admin/geo-visibility');
-
-        if (response.status === 503) {
-          loadingEl.style.display = 'none';
-          unconfiguredEl.style.display = 'block';
-          return;
-        }
 
         if (!response.ok) {
           throw new Error('Failed to load GEO visibility data');

--- a/server/public/manage-sidebar.js
+++ b/server/public/manage-sidebar.js
@@ -25,6 +25,7 @@
         label: 'Analytics',
         items: [
           { href: '/manage/analytics', label: 'Revenue analytics', icon: '📈' },
+          { href: '/manage/geo', label: 'GEO visibility', icon: '🔍' },
         ]
       }
     ]

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3993,10 +3993,13 @@ export class HTTPServer {
       this.serveHtmlWithConfig(req, res, 'admin-account-detail.html'));
     this.app.get('/manage/analytics', requireAuth, requireManage, (req, res) =>
       this.serveHtmlWithConfig(req, res, 'manage-analytics.html'));
+    this.app.get('/manage/geo', requireAuth, requireManage, (req, res) =>
+      this.serveHtmlWithConfig(req, res, 'manage-geo.html'));
 
     // Redirect moved admin pages to their new /manage paths
     this.app.get('/admin/prospects', (req, res) => res.redirect(301, '/manage/accounts'));
     this.app.get('/admin/analytics', (req, res) => res.redirect(302, '/manage/analytics'));
+    this.app.get('/admin/geo', (req, res) => res.redirect(301, '/manage/geo'));
 
     // Admin routes
     // GET /admin - Admin landing page
@@ -4953,9 +4956,6 @@ Disallow: /api/admin/
       await this.serveHtmlWithConfig(req, res, 'admin-escalations.html');
     });
 
-    this.app.get('/admin/geo', requireAuth, requireManage, async (req, res) => {
-      await this.serveHtmlWithConfig(req, res, 'admin-geo.html');
-    });
 
   }
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -972,6 +972,12 @@ export async function requireManage(req: Request, res: Response, next: NextFunct
     return next();
   }
 
+  // Static admin API key has manage access
+  if ((req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey) {
+    logger.debug({ path: req.path, method: req.method }, 'Manage access via static admin API key');
+    return next();
+  }
+
   if (!req.user) {
     if (isHtmlRequest) {
       return res.redirect(`/auth/login?return_to=${encodeURIComponent(req.originalUrl)}`);


### PR DESCRIPTION
## Summary
- Moves GEO visibility dashboard from `/admin/geo` to `/manage/geo`
- Adds GEO visibility link to the Manage AAO sidebar under Analytics
- Redirects `/admin/geo` → `/manage/geo` (301 permanent)
- Fixes `requireManage` to accept the static admin API key (matching the existing `requireAdmin` pattern), enabling programmatic access to the GEO visibility API

## Test plan
- [ ] Visit `/manage/geo` — should show GEO visibility dashboard with manage sidebar
- [ ] Visit `/admin/geo` — should redirect 301 to `/manage/geo`
- [ ] Admin API key (`Authorization: Bearer <ADMIN_API_KEY>`) should work against `/api/admin/geo-visibility`
- [ ] GEO visibility link appears in Manage AAO sidebar under Analytics
- [ ] GEO visibility link no longer appears in admin sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)