### PR TITLE
fix: automate domain member backfill and pending org link as daily jobs

### DIFF
--- a/.changeset/automate-domain-member-backfill.md
+++ b/.changeset/automate-domain-member-backfill.md
@@ -1,0 +1,3 @@
+---
+---
+Automate pending org link backfill and verified-domain member backfill as daily scheduled jobs, eliminating the need for manual admin intervention.

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -30,7 +30,7 @@ import { runKnowledgeStalenessJob } from './knowledge-staleness.js';
 import { runGeoMonitorJob } from './geo-monitor.js';
 import { processUntriagedDomains, escalateUnclaimedProspects } from '../../services/prospect-triage.js';
 import { runWeeklyDigestJob } from './weekly-digest.js';
-import { autoLinkUnmappedSlackUsers } from '../../slack/sync.js';
+import { autoLinkUnmappedSlackUsers, autoAddVerifiedDomainUsersAsMembers } from '../../slack/sync.js';
 import { eventsDb } from '../../db/events-db.js';
 import { NotificationDatabase } from '../../db/notification-db.js';
 import { notifyUser } from '../../notifications/notification-service.js';
@@ -287,7 +287,16 @@ export function registerAllJobs(): void {
     interval: { value: 24, unit: 'hours' },
     initialDelay: { value: 2, unit: 'minutes' },
     runner: autoLinkUnmappedSlackUsers,
-    shouldLogResult: (r) => r.linked > 0 || r.errors > 0,
+    shouldLogResult: (r) => r.linked > 0 || r.pending_org_prospects_set > 0 || r.errors > 0,
+  });
+
+  jobScheduler.register({
+    name: 'domain-member-backfill',
+    description: 'Add verified-domain Slack users as org members if not already added',
+    interval: { value: 24, unit: 'hours' },
+    initialDelay: { value: 5, unit: 'minutes' },
+    runner: autoAddVerifiedDomainUsersAsMembers,
+    shouldLogResult: (r) => r.added > 0 || r.errors > 0,
   });
 
   // GEO prompt monitor - checks LLM visibility for AdCP mentions
@@ -363,6 +372,7 @@ export const JOB_NAMES = {
   PROSPECT_ESCALATION: 'prospect-escalation',
   WEEKLY_DIGEST: 'weekly-digest',
   SLACK_AUTO_LINK: 'slack-auto-link',
+  DOMAIN_MEMBER_BACKFILL: 'domain-member-backfill',
   EVENT_REMINDER: 'event-reminder',
   GEO_MONITOR: 'geo-monitor',
 } as const;

--- a/server/src/slack/sync.ts
+++ b/server/src/slack/sync.ts
@@ -675,6 +675,7 @@ export async function autoLinkUnmappedSlackUsers(): Promise<{
   linked: number;
   chapters_joined: number;
   organizations_assigned: number;
+  pending_org_prospects_set: number;
   errors: number;
 }> {
   // Ensure all current workspace members have rows before attempting to link.
@@ -693,6 +694,11 @@ export async function autoLinkUnmappedSlackUsers(): Promise<{
 
   const aaoEmailToUserId = await buildAaoEmailToUserIdMap();
   const mappedWorkosUserIds = await slackDb.getMappedWorkosUserIds();
+
+  // Set pending_organization_id for unmapped Slack users whose email domain matches an org.
+  // This is a DB-only operation and is safe regardless of whether Slack is configured.
+  // It is idempotent and covers users who joined Slack before the listener was active.
+  const backfillResult = await slackDb.backfillPendingOrganizations();
 
   let linked = 0;
   let chaptersJoined = 0;
@@ -732,5 +738,135 @@ export async function autoLinkUnmappedSlackUsers(): Promise<{
     invalidateMemberContextCache();
   }
 
-  return { linked, chapters_joined: chaptersJoined, organizations_assigned: orgsAssigned, errors };
+  return {
+    linked,
+    chapters_joined: chaptersJoined,
+    organizations_assigned: orgsAssigned,
+    pending_org_prospects_set: backfillResult.usersLinked,
+    errors,
+  };
+}
+
+/**
+ * Auto-add Slack users with WorkOS accounts to their org based on verified email domains.
+ * Covers users who were linked before their org's domain was added/verified,
+ * or who have no existing organization membership to trigger checkAndAssignOrganizationByDomain.
+ *
+ * Does not call the Slack API — no isSlackConfigured() guard needed. If slack_user_mappings
+ * is empty (Slack not configured), the query returns zero rows and is a no-op.
+ *
+ * Complements the slack-auto-link job: that job populates pending_organization_id for
+ * unmapped users; this job promotes already-mapped users to full WorkOS org members.
+ */
+export async function autoAddVerifiedDomainUsersAsMembers(): Promise<{
+  added: number;
+  skipped: number;
+  errors: number;
+}> {
+  const pool = getPool();
+
+  const result = await pool.query<{
+    workos_organization_id: string;
+    org_name: string;
+    domain: string;
+    users: Array<{ email: string; name: string | null; workos_user_id: string }>;
+  }>(`
+    WITH verified_domain_orgs AS (
+      SELECT
+        od.workos_organization_id,
+        LOWER(od.domain) as domain,
+        o.name as org_name
+      FROM organization_domains od
+      JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
+      WHERE od.verified = true
+    ),
+    domain_users_with_workos AS (
+      SELECT
+        vdo.workos_organization_id,
+        vdo.org_name,
+        vdo.domain,
+        sum.slack_email,
+        sum.slack_real_name,
+        sum.workos_user_id
+      FROM verified_domain_orgs vdo
+      JOIN slack_user_mappings sum ON LOWER(SPLIT_PART(sum.slack_email, '@', 2)) = vdo.domain
+      WHERE sum.workos_user_id IS NOT NULL
+        AND sum.slack_is_bot = false
+        AND sum.slack_is_deleted = false
+    )
+    SELECT
+      workos_organization_id,
+      org_name,
+      domain,
+      json_agg(json_build_object(
+        'email', slack_email,
+        'name', slack_real_name,
+        'workos_user_id', workos_user_id
+      )) as users
+    FROM domain_users_with_workos
+    GROUP BY workos_organization_id, org_name, domain
+  `);
+
+  let totalAdded = 0;
+  let totalSkipped = 0;
+  let totalErrors = 0;
+
+  for (const row of result.rows) {
+    const orgId = row.workos_organization_id;
+
+    const existingMemberUserIds = new Set<string>();
+    try {
+      let after: string | undefined;
+      do {
+        const memberships = await workos.userManagement.listOrganizationMemberships({
+          organizationId: orgId,
+          limit: 100,
+          after,
+        });
+        for (const m of memberships.data) {
+          existingMemberUserIds.add(m.userId);
+        }
+        after = memberships.listMetadata?.after ?? undefined;
+      } while (after);
+    } catch (err) {
+      logger.warn({ err, orgId }, 'Failed to list WorkOS memberships for org, skipping');
+      continue;
+    }
+
+    const users = row.users as Array<{ email: string; name: string | null; workos_user_id: string }>;
+
+    for (const user of users) {
+      if (existingMemberUserIds.has(user.workos_user_id)) {
+        totalSkipped++;
+        continue;
+      }
+
+      try {
+        await workos.userManagement.createOrganizationMembership({
+          userId: user.workos_user_id,
+          organizationId: orgId,
+          roleSlug: 'member',
+        });
+        // Mirror the WorkOS membership locally so code reading organization_memberships
+        // sees the change immediately rather than waiting for the webhook to fire.
+        await pool.query(`
+          INSERT INTO organization_memberships (workos_user_id, workos_organization_id, email, created_at, updated_at, synced_at)
+          VALUES ($1, $2, $3, NOW(), NOW(), NOW())
+          ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING
+        `, [user.workos_user_id, orgId, user.email]);
+        totalAdded++;
+        logger.info({ orgId, orgName: row.org_name, email: user.email }, 'Auto-added domain user as org member');
+      } catch (err: unknown) {
+        const code = (err as { code?: string })?.code;
+        if (code === 'organization_membership_already_exists') {
+          totalSkipped++;
+        } else {
+          logger.error({ err, orgId, email: user.email }, 'Failed to create org membership for domain user');
+          totalErrors++;
+        }
+      }
+    }
+  }
+
+  return { added: totalAdded, skipped: totalSkipped, errors: totalErrors };
 }


### PR DESCRIPTION
## Summary

- `autoLinkUnmappedSlackUsers` now calls `backfillPendingOrganizations()` on every run, so Slack users whose email domain matches an org get `pending_organization_id` set automatically instead of accumulating for manual admin action
- New daily `domain-member-backfill` job calls `autoAddVerifiedDomainUsersAsMembers()`, which finds mapped Slack users whose email domain matches a verified org and creates their WorkOS org membership if missing — covering users linked before their org's domain was added/verified
- Local `organization_memberships` is written immediately after each WorkOS membership creation so downstream code doesn't wait for the webhook
- Added `DOMAIN_MEMBER_BACKFILL` to `JOB_NAMES`

## Test plan

- [ ] Both jobs appear in the job scheduler on startup
- [ ] After one run of `domain-member-backfill`, the "Auto-Add Domain Users as Members" count on Domain Health drops to 0 (or near 0)
- [ ] After one run of `slack-auto-link`, the "Backfill Slack User Links" count drops
- [ ] No duplicate WorkOS memberships created (idempotent: `organization_membership_already_exists` is silently skipped)
- [ ] `organization_memberships` table updated immediately, not waiting for webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)