### PR TITLE
fix: brand viewer for adcontextprotocol.org and brand.json count

### DIFF
--- a/.changeset/fix-adcontextprotocol-brand-viewer.md
+++ b/.changeset/fix-adcontextprotocol-brand-viewer.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix brand viewer for adcontextprotocol.org and brand.json count stat.

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -457,21 +457,21 @@ export class BrandDatabase {
       `
       SELECT
         brand_domain as domain,
-        COALESCE(brand_json->>'name', brand_domain) as brand_name,
+        COALESCE(brand_json->>'name', brand_json->'house'->>'name', brand_domain) as brand_name,
         'hosted' as source,
         true as has_manifest,
         domain_verified as verified,
         db.house_domain,
         COALESCE(db.keller_type, 'master') as keller_type,
-        brand_json->'logos'->0->>'url' as logo_url,
-        brand_json->'colors'->>'primary' as primary_color,
-        brand_json->'company'->>'industry' as industry,
+        COALESCE(brand_json->'logos'->0->>'url', brand_json->'brands'->0->'logos'->0->>'url') as logo_url,
+        COALESCE(brand_json->'colors'->>'primary', brand_json->'brands'->0->'colors'->>'primary') as primary_color,
+        COALESCE(brand_json->'company'->>'industry', brand_json->'brands'->0->>'industry') as industry,
         (SELECT COUNT(*)::int FROM discovered_brands sub WHERE sub.house_domain = brand_domain) as sub_brand_count,
         COALESCE(CASE WHEN brand_json->'company'->>'employees' ~ '^\d+$' THEN (brand_json->'company'->>'employees')::int ELSE 0 END, 0) as employee_count
       FROM hosted_brands
       LEFT JOIN discovered_brands db ON db.domain = hosted_brands.brand_domain
       WHERE is_public = true
-        AND ($1::text IS NULL OR brand_domain ILIKE $1 OR brand_json->>'name' ILIKE $1)
+        AND ($1::text IS NULL OR brand_domain ILIKE $1 OR brand_json->>'name' ILIKE $1 OR brand_json->'house'->>'name' ILIKE $1)
 
       UNION ALL
 

--- a/server/src/db/migrations/264_seed_adcontextprotocol_brand.sql
+++ b/server/src/db/migrations/264_seed_adcontextprotocol_brand.sql
@@ -1,0 +1,56 @@
+-- Seed adcontextprotocol.org as a discovered sub-brand of agenticadvertising.org.
+-- This makes the brand viewer work for adcontextprotocol.org and ensures
+-- the agenticadvertising.org brand card shows the correct sub-brand count.
+INSERT INTO discovered_brands (
+  domain,
+  brand_name,
+  source_type,
+  has_brand_manifest,
+  keller_type,
+  house_domain,
+  brand_manifest,
+  review_status
+) VALUES (
+  'adcontextprotocol.org',
+  'AdCP',
+  'enriched',
+  true,
+  'sub_brand',
+  'agenticadvertising.org',
+  '{
+    "id": "adcp",
+    "names": [
+      { "en": "AdCP" },
+      { "en": "Advertising Context Protocol" },
+      { "en": "Ad Context Protocol" }
+    ],
+    "description": "Open standard for AI-powered advertising workflows built on Model Context Protocol (MCP)",
+    "industry": "advertising_technology",
+    "target_audience": "Ad tech developers, platform providers, and media buyers implementing agentic advertising",
+    "logos": [
+      {
+        "url": "https://adcontextprotocol.org/adcp_logo.svg",
+        "tags": ["icon", "square", "light-bg"],
+        "width": 204,
+        "height": 204
+      }
+    ],
+    "colors": {
+      "primary": "#1a36b4",
+      "secondary": "#2d4fd6",
+      "accent": "#a4c2f4",
+      "background": "#FFFFFF",
+      "text": "#1d1d1d"
+    },
+    "fonts": {
+      "primary": "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    },
+    "tone": {
+      "voice": "Technical and precise, empowering developers to build the next generation of advertising",
+      "attributes": ["technical", "precise", "developer-friendly", "clear", "innovative"]
+    },
+    "tagline": "The Open Standard for Agentic Advertising"
+  }',
+  'approved'
+)
+ON CONFLICT (domain) DO NOTHING;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -227,7 +227,6 @@ registry.registerPath({
             stats: z.object({
               total: z.number().int(),
               brand_json: z.number().int(),
-              hosted: z.number().int(),
               community: z.number().int(),
               enriched: z.number().int(),
             }),
@@ -843,8 +842,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       const stats = {
         total: brands.length,
-        brand_json: brands.filter((b) => b.source === "brand_json").length,
-        hosted: brands.filter((b) => b.source === "hosted").length,
+        brand_json: brands.filter((b) => b.source === "brand_json" || b.source === "hosted").length,
         community: brands.filter((b) => b.source === "community").length,
         enriched: brands.filter((b) => b.source === "enriched").length,
         houses: brands.filter((b) => b.keller_type === "master" || b.keller_type === "independent").length,

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -904,8 +904,6 @@ paths:
                         type: integer
                       brand_json:
                         type: integer
-                      hosted:
-                        type: integer
                       community:
                         type: integer
                       enriched:
@@ -913,7 +911,6 @@ paths:
                     required:
                       - total
                       - brand_json
-                      - hosted
                       - community
                       - enriched
                 required:


### PR DESCRIPTION
## Summary

- **Brand viewer error**: `adcontextprotocol.org` showed "Brand not found or invalid" because the AdCP sub-brand lives inside the `agenticadvertising.org` hosted brand JSON with no separate `discovered_brands` entry. Migration 264 seeds it as an approved `sub_brand`, fixing the viewer and bumping the `agenticadvertising.org` sub-brand count from 0 to 1.

- **brand.json count off**: The stat was counting only `source='brand_json'` (self-hosted) brands. Platform-hosted brands (`source='hosted'`) also have a brand.json — they just let us serve it. Rolling them together fixes the count that dropped when `agenticadvertising.org` moved to `hosted_brands` in migration 237. Removed the now-redundant `hosted` key from the OpenAPI response schema.

- **Hosted brand display**: Fixed JSON path fallbacks in the `getAllBrandsForRegistry` query so house_portfolio-format brand.json files (like `agenticadvertising.org`) correctly surface their name, logo, color, and industry. Also fixed the search clause to match on `house->>'name'`.

## Test plan

- [ ] Navigate to `/brand/view/adcontextprotocol.org` — should show AdCP brand data (no more "Brand not found" error)
- [ ] `agenticadvertising.org` card on `/brands` shows "1 sub-brand"
- [ ] brands page "brand.json" stat includes hosted brands (count is higher than before)
- [ ] Search for "AgenticAdvertising" on `/brands` returns the agenticadvertising.org result
- [ ] All 323 unit tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)