### PR TITLE
Remove brand_agent from brand.json spec

### DIFF
--- a/.changeset/brand-agent-identity-task.md
+++ b/.changeset/brand-agent-identity-task.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Remove brand_agent from brand.json entirely — both the top-level variant and the field on individual brands. Brand identity is public data that belongs in static files. SI agent discovery happens through get_adcp_capabilities and the registry, not through brand.json.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -2,7 +2,7 @@
 title: brand.json Specification
 ---
 
-The `brand.json` file provides a standardized way for brands to claim their identity and establish discoverable brand information. It supports four mutually exclusive variants to accommodate different use cases.
+The `brand.json` file provides a standardized way for brands to claim their identity and establish discoverable brand information. It supports three mutually exclusive variants to accommodate different use cases.
 
 <Info>
 `brand.json` is the canonical source of brand identity data. The brand object defined here (logos, colors, tone, tagline) is the single brand definition used across AdCP. Tasks reference brands by domain and brand_id — the system resolves full identity from `brand.json` or the [registry](/docs/registry/index).
@@ -20,7 +20,7 @@ Following [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) well-known U
 
 ## Variants
 
-The brand.json file supports four mutually exclusive variants:
+The brand.json file supports three mutually exclusive variants:
 
 ### 1. Authoritative Location Redirect
 
@@ -59,27 +59,7 @@ Use this when:
 - Regional/localized domains point to main house
 - Legacy domains redirect to canonical
 
-### 3. Brand Agent
-
-Designates an MCP agent that provides brand information:
-
-```json
-{
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
-  "version": "1.0",
-  "brand_agent": {
-    "url": "https://agent.acme.com/mcp",
-    "id": "acme_brand_agent"
-  }
-}
-```
-
-Optional fields:
-- `contact`: Contact information
-
-When a brand has an agent, the agent is the authoritative source for brand identity data.
-
-### 4. House Portfolio
+### 3. House Portfolio
 
 Contains the full brand hierarchy with all brands and properties:
 
@@ -127,7 +107,6 @@ Each brand in the `brands` array:
 | `keller_type` | enum | No | `master`, `sub_brand`, `endorsed`, `independent` |
 | `parent_brand` | string | No | Parent brand's id |
 | `properties` | array | No | Digital properties owned by brand |
-| `brand_agent` | object | No | Agent providing brand identity data `{ url, id }` |
 | `logos` | array | No | Brand logo assets |
 | `colors` | object | No | Brand color palette |
 | `fonts` | object | No | Brand typography |
@@ -194,7 +173,6 @@ To resolve a domain to a canonical brand:
 2. Check variant:
    - **authoritative_location**: Fetch from that URL, continue from step 2
    - **house** (string): Fetch from house domain, continue from step 2
-   - **brand_agent**: Return agent URL (agent provides brand info)
    - **house** (object) + **brands**: Search for domain in properties
 3. For house portfolio, find the brand whose properties contain the query domain
 4. Return canonical brand information
@@ -227,23 +205,6 @@ Maximum redirect depth: 3 hops.
       "colors": { "primary": "#FF6B35" }
     }
   ]
-}
-```
-
-### Enterprise with Agent
-
-```json
-{
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
-  "version": "1.0",
-  "brand_agent": {
-    "url": "https://brand-agent.enterprise.com/mcp",
-    "id": "enterprise_brand_agent"
-  },
-  "contact": {
-    "name": "Enterprise Brand Team",
-    "email": "brand@enterprise.com"
-  }
 }
 ```
 
@@ -321,4 +282,3 @@ Recommended cache TTLs:
 2. **Use redirects for subsidiaries**: Point brand domains to house domain
 3. **List all properties**: Include regional domains, apps, and legacy domains
 4. **Keep names current**: Include localized names and common aliases
-5. **Use brand agents for dynamic data**: If brand info changes frequently, use an agent

--- a/docs/brand-protocol/index.mdx
+++ b/docs/brand-protocol/index.mdx
@@ -3,7 +3,7 @@ title: Brand Protocol
 sidebarTitle: Overview
 ---
 
-The Brand Protocol enables brands to claim their identity and establish a verifiable source of truth through a standardized discovery mechanism. By hosting a `brand.json` file at a well-known location, brands can declare their identity, brand hierarchy, and optionally designate official brand agents.
+The Brand Protocol enables brands to claim their identity and establish a verifiable source of truth through a standardized discovery mechanism. By hosting a `brand.json` file at a well-known location, brands can declare their identity, brand hierarchy, and digital properties.
 
 ## Purpose
 
@@ -19,31 +19,28 @@ This parallel structure makes brands first-class citizens in AdCP.
 
 ## How it works
 
-Brands host a `brand.json` file at `/.well-known/brand.json` on their domain. The file can take one of four forms:
+Brands host a `brand.json` file at `/.well-known/brand.json` on their domain. The file can take one of three forms:
 
-1. **Brand Agent**: Points to an MCP agent that provides brand information
-2. **House Portfolio**: Contains full brand hierarchy with all brands and properties
-3. **House Redirect**: Points to a house domain that contains the portfolio
-4. **Authoritative Location**: Points to a hosted brand.json URL
+1. **House Portfolio**: Contains full brand hierarchy with all brands and properties
+2. **House Redirect**: Points to a house domain that contains the portfolio
+3. **Authoritative Location**: Points to a hosted brand.json URL
 
 ```mermaid
 sequenceDiagram
     participant Agent as Buyer Agent
     participant Domain as Brand Domain
     participant House as House Domain
-    participant BrandAgent as Brand Agent (MCP)
 
     Agent->>Domain: GET /.well-known/brand.json
     alt House Redirect
         Domain-->>Agent: { "house": "nikeinc.com" }
         Agent->>House: GET /.well-known/brand.json
         House-->>Agent: Full portfolio (house + brands)
-    else Brand Agent
-        Domain-->>Agent: { "brand_agent": { "url": "..." } }
-        Agent->>BrandAgent: MCP: get brand identity
-        BrandAgent-->>Agent: Brand identity data
     else House Portfolio
         Domain-->>Agent: Full portfolio (house + brands)
+    else Authoritative Location
+        Domain-->>Agent: { "authoritative_location": "https://..." }
+        Agent->>Agent: Fetch from authoritative URL
     end
 ```
 
@@ -95,23 +92,6 @@ A house domain with multiple brands:
 }
 ```
 
-## Example: brand agent
-
-A brand with an MCP agent that provides brand information:
-
-```json
-{
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
-  "version": "1.0",
-  "brand_agent": {
-    "url": "https://agent.acme.com/mcp",
-    "id": "acme_brand_agent"
-  }
-}
-```
-
-The agent provides brand identity data (logos, colors, tone) on behalf of the brand.
-
 ## Example: house redirect
 
 A brand domain pointing to its house:
@@ -156,7 +136,7 @@ Regardless of source, the result is a brand identity that can be referenced by a
 When a creative agent needs brand assets:
 
 1. Resolve domain to canonical brand via brand.json
-2. Get brand identity data (from brand.json, agent, or registry)
+2. Get brand identity data (from brand.json or registry)
 3. Generate on-brand creatives
 
 ### Brand verification
@@ -211,18 +191,6 @@ Brand information changes infrequently (logo updates, guideline refreshes). Reco
 
 Agents should respect HTTP caching headers when fetching brand.json files.
 
-## Future considerations
-
-### Digital asset management (DAM)
-
-For brands requiring fine-grained control over asset usage, the `brand_agent` variant provides a natural integration point for DAM systems. Agents can:
-- Enforce access control per asset
-- Track usage and licensing
-- Provide assets with usage terms
-- Log access for compliance
-
-This is optional—brands publishing static brand.json files grant implied permission for compliant creative use. DAM integration is for enterprises with complex licensing requirements.
-
 ## MCP tools
 
 The Brand Protocol provides MCP tools for programmatic access:
@@ -231,7 +199,6 @@ The Brand Protocol provides MCP tools for programmatic access:
 |------|-------------|
 | `resolve_brand` | Resolve domain to canonical brand identity |
 | `validate_brand_json` | Validate a domain's brand.json |
-| `validate_brand_agent` | Test brand agent reachability |
 
 ## Learn more
 

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -1224,13 +1224,6 @@
                   </div>
                 </button>
 
-                <button class="decision-option" onclick="selectVariant('agent')">
-                  <div class="option-icon">🤖</div>
-                  <div class="option-content">
-                    <strong>I have an MCP agent</strong>
-                    <span>My brand info is served dynamically by an AI agent</span>
-                  </div>
-                </button>
               </div>
             </div>
 
@@ -1484,31 +1477,6 @@
             </div>
           </div>
 
-          <!-- Brand Agent Form -->
-          <div id="form-agent" class="hidden">
-            <button class="back-link" onclick="goBackTo('step-single-hosting')">← Back</button>
-            <div class="form-group">
-              <label>Agent URL</label>
-              <input
-                type="url"
-                id="agent-url"
-                placeholder="https://agent.example.com/mcp"
-                oninput="updatePreview()"
-              />
-              <p class="hint">The MCP endpoint URL for the brand agent</p>
-            </div>
-            <div class="form-group">
-              <label>Agent ID</label>
-              <input
-                type="text"
-                id="agent-id"
-                placeholder="my_brand_agent"
-                oninput="updatePreview()"
-              />
-              <p class="hint">Unique identifier for the agent</p>
-            </div>
-          </div>
-
           <!-- Contact Information (root-level, shown for single + portfolio) -->
           <div id="contact-section" class="hidden" style="margin-top: var(--space-5);">
             <details class="brand-section-toggle">
@@ -1611,7 +1579,7 @@
       // ============================================================================
 
       let currentDomain = '';
-      let currentVariant = 'single'; // single, portfolio, redirect, agent
+      let currentVariant = 'single'; // single, portfolio, redirect
       let brands = [];
       let brandIdCounter = 0;
       let singleBrandProperties = [];
@@ -1659,10 +1627,6 @@
           },
           redirect: {
             houseDomain: document.getElementById('redirect-house-domain')?.value || ''
-          },
-          agent: {
-            url: document.getElementById('agent-url')?.value || '',
-            id: document.getElementById('agent-id')?.value || ''
           }
         };
       }
@@ -1703,16 +1667,11 @@
         if (state.redirect) {
           document.getElementById('redirect-house-domain').value = state.redirect.houseDomain || '';
         }
-        if (state.agent) {
-          document.getElementById('agent-url').value = state.agent.url || '';
-          document.getElementById('agent-id').value = state.agent.id || '';
-        }
         // Show the correct form, hide decision tree
         document.getElementById('decision-tree').classList.add('hidden');
         document.getElementById('form-single').classList.toggle('hidden', currentVariant !== 'single');
         document.getElementById('form-portfolio').classList.toggle('hidden', currentVariant !== 'portfolio');
         document.getElementById('form-redirect').classList.toggle('hidden', currentVariant !== 'redirect');
-        document.getElementById('form-agent').classList.toggle('hidden', currentVariant !== 'agent');
 
         // Re-render dynamic parts
         if (currentVariant === 'single') {
@@ -1861,7 +1820,6 @@
         document.getElementById('form-single').classList.add('hidden');
         document.getElementById('form-portfolio').classList.remove('hidden');
         document.getElementById('form-redirect').classList.add('hidden');
-        document.getElementById('form-agent').classList.add('hidden');
 
         // Show contact section and viewer link
         document.getElementById('contact-section').classList.remove('hidden');
@@ -2020,7 +1978,6 @@
         document.getElementById('form-single').classList.add('hidden');
         document.getElementById('form-portfolio').classList.add('hidden');
         document.getElementById('form-redirect').classList.add('hidden');
-        document.getElementById('form-agent').classList.add('hidden');
 
         updatePreview();
         updateRegistryButton();
@@ -2067,7 +2024,6 @@
         document.getElementById('form-single').classList.toggle('hidden', variant !== 'single');
         document.getElementById('form-portfolio').classList.toggle('hidden', variant !== 'portfolio');
         document.getElementById('form-redirect').classList.toggle('hidden', variant !== 'redirect');
-        document.getElementById('form-agent').classList.toggle('hidden', variant !== 'agent');
 
         // Show contact section for single/portfolio
         const showContact = variant === 'single' || variant === 'portfolio';
@@ -2146,7 +2102,7 @@
                 ⚠️ <strong>Found a file, but it doesn't match the AdCP brand.json format.</strong><br>
                 <span style="font-size: var(--text-sm); opacity: 0.8;">
                   Your domain has a brand.json file, but it doesn't use one of the recognized variants
-                  (house portfolio, house redirect, brand agent, or authoritative location).
+                  (house portfolio, house redirect, or authoritative location).
                 </span><br>
                 <span style="font-size: var(--text-sm); margin-top: var(--space-1); display: inline-block;">
                   Use the Brand Builder to generate a compatible file, then re-upload.
@@ -3442,15 +3398,6 @@
             }
             break;
 
-          case 'agent':
-            // Brand agent reference - schema requires both url and id
-            const agentUrl = document.getElementById('agent-url').value.trim();
-            const agentId = document.getElementById('agent-id').value.trim();
-            if (agentUrl && agentId) {
-              json.version = "1.0";
-              json.brand_agent = { url: agentUrl, id: agentId };
-            }
-            break;
         }
 
         // Add contact info for single/portfolio variants

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -1283,23 +1283,6 @@
 
         const brands = data.brands || [];
         if (brands.length === 0) {
-          // Brand agent or simple format — show what we have
-          if (data.brand_agent) {
-            document.getElementById('brand-info-section').classList.remove('hidden');
-            document.getElementById('brand-info-content').innerHTML = `
-              <div class="card">
-                <div class="info-grid">
-                  <div class="info-item">
-                    <div class="info-label">Brand agent URL</div>
-                    <div class="info-value">${isSafeUrl(data.brand_agent.url) ? `<a href="${escapeAttr(data.brand_agent.url)}" target="_blank">${escapeHtml(data.brand_agent.url)}</a>` : escapeHtml(data.brand_agent.url)}</div>
-                  </div>
-                  <div class="info-item">
-                    <div class="info-label">Agent ID</div>
-                    <div class="info-value">${escapeHtml(data.brand_agent.id)}</div>
-                  </div>
-                </div>
-              </div>`;
-          }
           if (data.contact) renderContact(data.contact);
           return;
         }

--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -314,7 +314,6 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
       house_domain: resolved.house_domain,
       house_name: resolved.house_name,
       keller_type: resolved.keller_type,
-      brand_agent_url: resolved.brand_agent_url,
       has_manifest: resolved.source === 'brand_json',
     }, null, 2);
   });

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -5,7 +5,6 @@ import type {
   BrandProperty,
   BrandDefinition,
   HouseDefinition,
-  BrandAgentConfig,
   ResolvedBrand,
   KellerType,
 } from './types';
@@ -30,7 +29,7 @@ export interface BrandValidationResult {
   url: string;
   status_code?: number;
   raw_data?: unknown;
-  variant?: 'authoritative_location' | 'house_redirect' | 'brand_agent' | 'house_portfolio';
+  variant?: 'authoritative_location' | 'house_redirect' | 'house_portfolio';
 }
 
 // brand.json variant types
@@ -45,25 +44,6 @@ export interface HouseRedirectVariant {
   house: string;  // Domain string
   region?: string;
   note?: string;
-  last_updated?: string;
-}
-
-export interface BrandAgentVariant {
-  $schema?: string;
-  version?: string;
-  brand_agent: BrandAgentConfig;
-  auth?: {
-    required?: boolean;
-    method?: 'api_key' | 'oauth2' | 'bearer_token';
-    token_endpoint?: string;
-    scopes?: string[];
-    instructions_url?: string;
-  };
-  contact?: {
-    name: string;
-    email?: string;
-    domain?: string;
-  };
   last_updated?: string;
 }
 
@@ -85,16 +65,7 @@ export interface HousePortfolioVariant {
   last_updated?: string;
 }
 
-export type BrandJson = AuthoritativeLocationVariant | HouseRedirectVariant | BrandAgentVariant | HousePortfolioVariant;
-
-export interface BrandAgentValidationResult {
-  agent_url: string;
-  valid: boolean;
-  errors: string[];
-  status_code?: number;
-  response_time_ms?: number;
-  agent_data?: unknown;
-}
+export type BrandJson = AuthoritativeLocationVariant | HouseRedirectVariant | HousePortfolioVariant;
 
 export class BrandManager {
   // Cache for successful brand.json lookups (24 hours)
@@ -216,16 +187,13 @@ export class BrandManager {
         case 'house_redirect':
           this.validateHouseRedirectVariant(brandData as HouseRedirectVariant, result);
           break;
-        case 'brand_agent':
-          this.validateBrandAgentVariant(brandData as BrandAgentVariant, result);
-          break;
         case 'house_portfolio':
           this.validateHousePortfolioVariant(brandData as HousePortfolioVariant, result);
           break;
         default:
           result.errors.push({
             field: 'root',
-            message: 'Unable to determine brand.json variant. Must contain one of: authoritative_location, house (string), brand_agent, or house (object) + brands',
+            message: 'Unable to determine brand.json variant. Must contain one of: authoritative_location, house (string), or house (object) + brands',
             severity: 'error',
           });
       }
@@ -278,7 +246,7 @@ export class BrandManager {
    */
   private detectVariant(
     data: unknown
-  ): 'authoritative_location' | 'house_redirect' | 'brand_agent' | 'house_portfolio' | null {
+  ): 'authoritative_location' | 'house_redirect' | 'house_portfolio' | null {
     if (typeof data !== 'object' || data === null) {
       return null;
     }
@@ -288,11 +256,6 @@ export class BrandManager {
     // Check for authoritative_location redirect
     if ('authoritative_location' in obj && typeof obj.authoritative_location === 'string') {
       return 'authoritative_location';
-    }
-
-    // Check for brand_agent
-    if ('brand_agent' in obj && typeof obj.brand_agent === 'object') {
-      return 'brand_agent';
     }
 
     // Check for house - could be string (redirect) or object (portfolio)
@@ -376,67 +339,6 @@ export class BrandManager {
           field: 'region',
           message: 'region must be an ISO 3166-1 alpha-2 country code (e.g., US, GB)',
           severity: 'error',
-        });
-      }
-    }
-  }
-
-  /**
-   * Validate brand_agent variant
-   */
-  private validateBrandAgentVariant(
-    data: BrandAgentVariant,
-    result: BrandValidationResult
-  ): void {
-    if (!data.brand_agent || typeof data.brand_agent !== 'object') {
-      result.errors.push({
-        field: 'brand_agent',
-        message: 'brand_agent object is required',
-        severity: 'error',
-      });
-      return;
-    }
-
-    if (!data.brand_agent.id) {
-      result.errors.push({
-        field: 'brand_agent.id',
-        message: 'brand_agent.id is required',
-        severity: 'error',
-      });
-    }
-
-    if (!data.brand_agent.url) {
-      result.errors.push({
-        field: 'brand_agent.url',
-        message: 'brand_agent.url is required',
-        severity: 'error',
-      });
-    } else {
-      try {
-        const url = new URL(data.brand_agent.url);
-        if (!url.protocol.startsWith('https:')) {
-          result.errors.push({
-            field: 'brand_agent.url',
-            message: 'brand_agent.url must use HTTPS',
-            severity: 'error',
-          });
-        }
-      } catch {
-        result.errors.push({
-          field: 'brand_agent.url',
-          message: 'brand_agent.url must be a valid URL',
-          severity: 'error',
-        });
-      }
-    }
-
-    // Validate auth if present
-    if (data.auth) {
-      if (data.auth.method === 'oauth2' && !data.auth.token_endpoint) {
-        result.warnings.push({
-          field: 'auth.token_endpoint',
-          message: 'token_endpoint is recommended when using oauth2 authentication',
-          suggestion: 'Add token_endpoint for OAuth2 authentication flow',
         });
       }
     }
@@ -671,19 +573,6 @@ export class BrandManager {
           continue;
         }
 
-        case 'brand_agent': {
-          const agentData = data as BrandAgentVariant;
-          const result: ResolvedBrand = {
-            canonical_id: currentDomain,
-            canonical_domain: currentDomain,
-            brand_name: currentDomain, // Agent should provide the name via MCP
-            brand_agent_url: agentData.brand_agent.url,
-            source: 'brand_json',
-          };
-          this.resolutionCache.set(cacheKey, result);
-          return result;
-        }
-
         case 'house_portfolio': {
           const portfolioData = data as HousePortfolioVariant;
           // Find the brand that owns this domain
@@ -832,55 +721,6 @@ export class BrandManager {
   }
 
   /**
-   * Validate that a brand agent is reachable
-   */
-  async validateBrandAgent(agentUrl: string): Promise<BrandAgentValidationResult> {
-    const result: BrandAgentValidationResult = {
-      agent_url: agentUrl,
-      valid: false,
-      errors: [],
-    };
-
-    const startTime = Date.now();
-    const MCP_TIMEOUT_MS = 5000;
-
-    try {
-      const { AdCPClient } = await import('@adcp/client');
-      const multiClient = new AdCPClient([
-        {
-          id: 'brand-agent-check',
-          name: 'Brand Agent Checker',
-          agent_uri: agentUrl,
-          protocol: 'mcp',
-        },
-      ]);
-      const client = multiClient.agent('brand-agent-check');
-
-      const agentInfo = await Promise.race([
-        client.getAgentInfo(),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('MCP connection timed out')), MCP_TIMEOUT_MS)
-        ),
-      ]);
-
-      result.response_time_ms = Date.now() - startTime;
-      result.valid = true;
-      result.agent_data = {
-        name: agentInfo.name,
-        protocol: 'mcp',
-        tools: agentInfo.tools?.map((t: { name: string }) => t.name) || [],
-        tools_count: agentInfo.tools?.length || 0,
-      };
-    } catch (error) {
-      result.response_time_ms = Date.now() - startTime;
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      result.errors.push(`MCP connection failed: ${message}`);
-    }
-
-    return result;
-  }
-
-  /**
    * Create a house redirect brand.json file
    */
   createHouseRedirect(houseDomain: string, options?: { region?: string; note?: string }): string {
@@ -911,33 +751,6 @@ export class BrandManager {
       authoritative_location: authoritativeUrl,
       last_updated: new Date().toISOString(),
     };
-
-    return JSON.stringify(brandJson, null, 2);
-  }
-
-  /**
-   * Create a brand agent brand.json file
-   */
-  createBrandAgentFile(
-    agentUrl: string,
-    agentId: string,
-    capabilities?: string[],
-    auth?: BrandAgentVariant['auth']
-  ): string {
-    const brandJson: BrandAgentVariant = {
-      $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
-      version: '1.0',
-      brand_agent: {
-        url: agentUrl,
-        id: agentId,
-        capabilities: capabilities || [],
-      },
-      last_updated: new Date().toISOString(),
-    };
-
-    if (auth) {
-      brandJson.auth = auth;
-    }
 
     return JSON.stringify(brandJson, null, 2);
   }

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -180,7 +180,6 @@ export class CrawlerService {
             // Invalid URL in authoritative_location — skip
           }
         } else if (result.variant === 'house_portfolio' ||
-                   result.variant === 'brand_agent' ||
                    result.variant === 'house_redirect') {
           const brandName = this.extractBrandName(result.raw_data, domain);
           await this.brandDb.upsertDiscoveredBrand({

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -42,8 +42,6 @@ export interface UpsertDiscoveredBrandInput {
   brand_names?: LocalizedName[];
   keller_type?: KellerType;
   parent_brand?: string;
-  brand_agent_url?: string;
-  brand_agent_capabilities?: string[];
   has_brand_manifest?: boolean;
   brand_manifest?: Record<string, unknown>;
   source_type: 'brand_json' | 'community' | 'enriched';
@@ -215,9 +213,9 @@ export class BrandDatabase {
     const result = await query<DiscoveredBrand>(
       `INSERT INTO discovered_brands (
         domain, brand_id, canonical_domain, house_domain, brand_name, brand_names,
-        keller_type, parent_brand, brand_agent_url, brand_agent_capabilities,
+        keller_type, parent_brand,
         has_brand_manifest, brand_manifest, source_type, last_validated, expires_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14)
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), $12)
       ON CONFLICT (domain) DO UPDATE SET
         brand_id = COALESCE(EXCLUDED.brand_id, discovered_brands.brand_id),
         canonical_domain = EXCLUDED.canonical_domain,
@@ -226,8 +224,6 @@ export class BrandDatabase {
         brand_names = EXCLUDED.brand_names,
         keller_type = EXCLUDED.keller_type,
         parent_brand = EXCLUDED.parent_brand,
-        brand_agent_url = EXCLUDED.brand_agent_url,
-        brand_agent_capabilities = EXCLUDED.brand_agent_capabilities,
         has_brand_manifest = COALESCE(EXCLUDED.has_brand_manifest, discovered_brands.has_brand_manifest),
         brand_manifest = COALESCE(EXCLUDED.brand_manifest, discovered_brands.brand_manifest),
         source_type = EXCLUDED.source_type,
@@ -243,8 +239,6 @@ export class BrandDatabase {
         input.brand_names ? JSON.stringify(input.brand_names) : '[]',
         input.keller_type || null,
         input.parent_brand || null,
-        input.brand_agent_url || null,
-        input.brand_agent_capabilities || null,
         input.has_brand_manifest != null ? input.has_brand_manifest : null,
         input.brand_manifest ? JSON.stringify(input.brand_manifest) : null,
         input.source_type,
@@ -358,7 +352,6 @@ export class BrandDatabase {
     house_domain?: string;
     keller_type?: string;
     parent_brand?: string;
-    brand_agent_url?: string;
     source: string;
   }>> {
     const limit = options.limit ?? 10;
@@ -372,7 +365,6 @@ export class BrandDatabase {
       house_domain: string | null;
       keller_type: string | null;
       parent_brand: string | null;
-      brand_agent_url: string | null;
       source_type: string;
     }>(
       `SELECT
@@ -382,7 +374,6 @@ export class BrandDatabase {
         house_domain,
         keller_type,
         parent_brand,
-        brand_agent_url,
         source_type
       FROM discovered_brands
       WHERE
@@ -408,7 +399,6 @@ export class BrandDatabase {
       house_domain: row.house_domain ?? undefined,
       keller_type: row.keller_type ?? undefined,
       parent_brand: row.parent_brand ?? undefined,
-      brand_agent_url: row.brand_agent_url ?? undefined,
       source: row.source_type,
     }));
   }
@@ -519,9 +509,9 @@ export class BrandDatabase {
       const insertResult = await client.query<DiscoveredBrand>(
         `INSERT INTO discovered_brands (
           domain, canonical_domain, house_domain, brand_name, brand_names,
-          keller_type, parent_brand, brand_agent_url, brand_agent_capabilities,
+          keller_type, parent_brand,
           has_brand_manifest, brand_manifest, source_type, review_status, last_validated, expires_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'pending', NOW(), $13)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'pending', NOW(), $11)
         RETURNING *`,
         [
           input.domain.toLowerCase(),
@@ -531,8 +521,6 @@ export class BrandDatabase {
           input.brand_names ? JSON.stringify(input.brand_names) : '[]',
           input.keller_type || null,
           input.parent_brand || null,
-          input.brand_agent_url || null,
-          input.brand_agent_capabilities || null,
           input.has_brand_manifest ?? false,
           input.brand_manifest ? JSON.stringify(input.brand_manifest) : null,
           input.source_type,
@@ -591,8 +579,6 @@ export class BrandDatabase {
       parent_brand?: string;
       house_domain?: string;
       canonical_domain?: string;
-      brand_agent_url?: string;
-      brand_agent_capabilities?: string[];
       brand_manifest?: Record<string, unknown>;
       has_brand_manifest?: boolean;
       edit_summary: string;
@@ -675,14 +661,6 @@ export class BrandDatabase {
       if (input.canonical_domain !== undefined) {
         updates.push(`canonical_domain = $${paramIndex++}`);
         values.push(input.canonical_domain);
-      }
-      if (input.brand_agent_url !== undefined) {
-        updates.push(`brand_agent_url = $${paramIndex++}`);
-        values.push(input.brand_agent_url);
-      }
-      if (input.brand_agent_capabilities !== undefined) {
-        updates.push(`brand_agent_capabilities = $${paramIndex++}`);
-        values.push(input.brand_agent_capabilities);
       }
       if (input.brand_manifest !== undefined) {
         updates.push(`brand_manifest = $${paramIndex++}`);
@@ -786,10 +764,8 @@ export class BrandDatabase {
           brand_names = $5,
           keller_type = $6,
           parent_brand = $7,
-          brand_agent_url = $8,
-          brand_agent_capabilities = $9,
-          has_brand_manifest = $10,
-          brand_manifest = $11
+          has_brand_manifest = $8,
+          brand_manifest = $9
         WHERE domain = $1
         RETURNING *`,
         [
@@ -800,8 +776,6 @@ export class BrandDatabase {
           snapshot.brand_names ? JSON.stringify(snapshot.brand_names) : '[]',
           snapshot.keller_type || null,
           snapshot.parent_brand || null,
-          snapshot.brand_agent_url || null,
-          snapshot.brand_agent_capabilities || null,
           snapshot.has_brand_manifest ?? false,
           snapshot.brand_manifest ? JSON.stringify(snapshot.brand_manifest) : null,
         ]

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -334,21 +334,6 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "validate_brand_agent",
-    description:
-      "Validate that a brand agent is reachable and responding via MCP protocol",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        agent_url: {
-          type: "string",
-          description: "Brand agent URL to validate (e.g., 'https://agent.nike.com/mcp')",
-        },
-      },
-      required: ["agent_url"],
-    },
-  },
-  {
     name: "enrich_brand",
     description:
       "Fetch brand data (logo, colors, company info) from Brandfetch API when no brand.json exists. Returns enriched brand manifest.",
@@ -1104,7 +1089,6 @@ export class MCPToolHandler {
                       brand_name: discovered.brand_name,
                       house_domain: discovered.house_domain,
                       keller_type: discovered.keller_type,
-                      brand_agent_url: discovered.brand_agent_url,
                       has_manifest: discovered.has_brand_manifest,
                     }, null, 2),
                   },
@@ -1171,34 +1155,6 @@ export class MCPToolHandler {
               type: "resource",
               resource: {
                 uri: `brand://validation/${encodeURIComponent(domain)}`,
-                mimeType: "application/json",
-                text: JSON.stringify(validation, null, 2),
-              },
-            },
-          ],
-        };
-      }
-
-      case "validate_brand_agent": {
-        const agentUrl = args?.agent_url as string;
-        if (!agentUrl) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify({ error: "Missing required parameter: agent_url" }),
-              },
-            ],
-            isError: true,
-          };
-        }
-        const validation = await this.brandManager.validateBrandAgent(agentUrl);
-        return {
-          content: [
-            {
-              type: "resource",
-              resource: {
-                uri: `brand://agent/${encodeURIComponent(agentUrl)}/validation`,
                 mimeType: "application/json",
                 text: JSON.stringify(validation, null, 2),
               },

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -125,7 +125,6 @@ export const ResolvedBrandSchema = z
     parent_brand: z.string().optional(),
     house_domain: z.string().optional(),
     house_name: z.string().optional(),
-    brand_agent_url: z.string().optional(),
     brand_manifest: z.record(z.string(), z.unknown()).optional(),
     source: z.enum(["brand_json", "community", "enriched"]),
   })
@@ -141,7 +140,6 @@ export const CompanySearchResultSchema = z
       .enum(["master", "sub_brand", "endorsed", "independent"])
       .optional(),
     parent_brand: z.string().optional(),
-    brand_agent_url: z.string().optional(),
     source: z.string().openapi({ example: "community" }),
   })
   .openapi("CompanySearchResult");

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -339,15 +339,6 @@ export interface HouseDefinition {
 }
 
 /**
- * Brand agent configuration
- */
-export interface BrandAgentConfig {
-  url: string;
-  id: string;
-  capabilities?: string[];
-}
-
-/**
  * Hosted brand record
  */
 export interface HostedBrand {
@@ -377,8 +368,6 @@ export interface DiscoveredBrand {
   brand_names?: LocalizedName[];
   keller_type?: KellerType;
   parent_brand?: string;
-  brand_agent_url?: string;
-  brand_agent_capabilities?: string[];
   has_brand_manifest: boolean;
   brand_manifest?: Record<string, unknown>;
   source_type: 'brand_json' | 'community' | 'enriched';
@@ -400,7 +389,6 @@ export interface ResolvedBrand {
   parent_brand?: string;
   house_domain?: string;
   house_name?: string;
-  brand_agent_url?: string;
   brand_manifest?: Record<string, unknown>;
   source: 'brand_json' | 'community' | 'enriched';
 }

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -51,8 +51,6 @@ components:
           type: string
         house_name:
           type: string
-        brand_agent_url:
-          type: string
         brand_manifest:
           type: object
           additionalProperties: {}

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/brand.json",
   "title": "Brand Discovery",
-  "description": "Brand identity and discovery file. Hosted at /.well-known/brand.json on house domains. Contains the full brand portfolio with identity, creative assets, and digital properties. Brands are identified by house + brand_id (like properties are identified by publisher + property_id). Supports variants: house portfolio (full brand data), brand agent (agent provides brand info via MCP), house redirect (pointer to house domain), or authoritative location redirect.",
+  "description": "Brand identity and discovery file. Hosted at /.well-known/brand.json on house domains. Contains the full brand portfolio with identity, creative assets, and digital properties. Brands are identified by house + brand_id (like properties are identified by publisher + property_id). Supports variants: house portfolio (full brand data), house redirect (pointer to house domain), or authoritative location redirect.",
   "definitions": {
     "domain": {
       "type": "string",
@@ -334,10 +334,6 @@
           },
           "additionalProperties": true
         },
-        "brand_agent": {
-          "$ref": "#/definitions/brand_agent",
-          "description": "Brand agent that provides dynamic brand data via MCP"
-        },
         "contact": {
           "type": "object",
           "description": "Brand-level contact information",
@@ -375,25 +371,6 @@
         }
       },
       "required": ["domain", "name"],
-      "additionalProperties": true
-    },
-    "brand_agent": {
-      "type": "object",
-      "description": "Reference to a brand agent that provides brand data via MCP",
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https://",
-          "description": "Brand agent MCP endpoint URL"
-        },
-        "id": {
-          "type": "string",
-          "description": "Agent identifier (useful for logging, multi-tenant DAMs)",
-          "pattern": "^[a-z0-9_]+$"
-        }
-      },
-      "required": ["url", "id"],
       "additionalProperties": true
     },
     "authorized_operator": {
@@ -478,20 +455,6 @@
     },
     {
       "type": "object",
-      "title": "Brand Agent",
-      "description": "Brand with an agent that provides brand info via MCP",
-      "properties": {
-        "$schema": { "type": "string" },
-        "version": { "type": "string" },
-        "brand_agent": { "$ref": "#/definitions/brand_agent" },
-        "contact": { "$ref": "#/definitions/contact" },
-        "last_updated": { "type": "string", "format": "date-time" }
-      },
-      "required": ["brand_agent"],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
       "title": "House Portfolio",
       "description": "Full house/brand portfolio with hierarchy, creative assets, and properties",
       "properties": {
@@ -538,14 +501,6 @@
       "$schema": "/schemas/brand.json",
       "house": "nikeinc.com",
       "note": "Redirect to house domain for full brand portfolio"
-    },
-    {
-      "$schema": "/schemas/brand.json",
-      "version": "1.0",
-      "brand_agent": {
-        "url": "https://agent.acme.com/mcp",
-        "id": "acme_brand_agent"
-      }
     },
     {
       "$schema": "/schemas/brand.json",
@@ -677,11 +632,7 @@
           "properties": [
             {"type": "website", "identifier": "jordan.com", "primary": true},
             {"type": "website", "identifier": "jumpman23.com"}
-          ],
-          "brand_agent": {
-            "url": "https://dam.nike.com/mcp",
-            "id": "nike_dam"
-          }
+          ]
         },
         {
           "id": "converse",


### PR DESCRIPTION
## Summary
- Remove `brand_agent` entirely from the brand.json specification — the top-level variant, the field on individual brands, and all supporting code
- Brand identity is public data that belongs in static files; SI agent discovery happens through `get_adcp_capabilities` and the registry, not through brand.json
- Clean up `brand_agent_url` from server types, Zod schemas, API responses, OpenAPI spec, and HTML admin tools

## Changes
- **Schema**: Remove brand_agent variant and definition from `brand.json` schema (3 variants remain: authoritative_location, house_redirect, house_portfolio)
- **Server**: Remove `BrandAgentConfig`, `BrandAgentVariant`, validation/resolution logic, `validate_brand_agent` MCP tool
- **API**: Remove `brand_agent_url` from TypeScript interfaces, Zod schemas, MCP tool responses, and OpenAPI spec
- **DB**: Stop selecting/inserting `brand_agent_url` columns (columns remain for historical data)
- **UI**: Remove brand_agent variant from brand-builder.html and brand-viewer.html
- **Docs**: Update brand protocol overview and brand.json spec to reflect 3-variant structure

## Test plan
- [x] All 323 unit tests pass
- [x] TypeScript typecheck clean
- [x] Schema validation passes (348 schemas)
- [x] Example validation passes
- [x] OpenAPI spec regenerated
- [x] Grep confirms no stale brand_agent references in active code (remaining refs are in `dist/` frozen releases, CHANGELOG, and SI session role which is a different concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)