### PR TITLE
fix: discriminate flat_rate parameters by type and name PackageStatus

### DIFF
--- a/.changeset/fix-flat-rate-params-and-package-naming.md
+++ b/.changeset/fix-flat-rate-params-and-package-naming.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Discriminate flat_rate pricing parameters by inventory type and clarify package type names.
+
+**Breaking for existing v3 DOOH flat_rate parameters:** `flat-rate-option.json` `parameters` now requires a `"type": "dooh"` discriminator field. Existing implementations passing `parameters` without `type` must add `"type": "dooh"`. Sponsorship/takeover flat_rate options that have no `parameters` are unaffected.
+
+DOOH `parameters` fields: `sov_percentage`, `loop_duration_seconds`, `min_plays_per_hour`, `venue_package`, `duration_hours`, `daypart`, `estimated_impressions`. `min_plays_per_hour` minimum is now 1 (was 0).
+
+`get-media-buys-response.json` inline package items are now titled `PackageStatus` to distinguish them from `PackageRequest` (create input) and `Package` (create output). The name reflects what this type adds: creative approval state and an optional delivery snapshot.

--- a/docs/media-buy/advanced-topics/pricing-models.mdx
+++ b/docs/media-buy/advanced-topics/pricing-models.mdx
@@ -296,18 +296,50 @@ Buyers should verify the measurement provider meets their campaign requirements 
 ### Flat Rate
 **Fixed cost** - Single payment regardless of delivery volume.
 
-**Use Cases**: Sponsorships, takeovers, exclusive placements, branded content
+**Use Cases**: Sponsorships, takeovers, exclusive placements, branded content, DOOH fixed slots
 
-**Example**:
+**Example** (sponsorship):
 ```json
 {
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "pricing_option_id": "flat_rate_usd_sponsorship",
   "pricing_model": "flat_rate",
   "fixed_price": 50000.00,
   "currency": "USD"
 }
 ```
 
-**Billing**: Fixed cost for the entire campaign period
+**Example** (DOOH slot with parameters):
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "pricing_option_id": "flat_rate_usd_dooh_morning",
+  "pricing_model": "flat_rate",
+  "fixed_price": 5000.00,
+  "currency": "USD",
+  "parameters": {
+    "type": "dooh",
+    "daypart": "morning_commute",
+    "duration_hours": 4,
+    "sov_percentage": 25,
+    "loop_duration_seconds": 15,
+    "estimated_impressions": 120000
+  }
+}
+```
+
+**Billing**: Fixed cost for the entire campaign period regardless of delivery volume.
+
+**DOOH parameters** (`parameters.type: "dooh"`):
+- `sov_percentage`: Guaranteed share of voice as a percentage (0-100)
+- `loop_duration_seconds`: Duration of ad loop rotation in seconds
+- `min_plays_per_hour`: Minimum guaranteed plays per hour
+- `venue_package`: Named collection of screens
+- `duration_hours`: Duration of the slot in hours (e.g., 24 for a full-day takeover)
+- `daypart`: Named daypart (e.g., `morning_commute`, `evening_rush`)
+- `estimated_impressions`: Audience impression estimate (informational, not a delivery guarantee)
+
+Sponsorship flat_rate options omit `parameters` — the fixed price covers the placement without DOOH-specific constraints.
 
 ---
 
@@ -386,14 +418,9 @@ DOOH advertising uses existing pricing models—typically **CPM** or **flat_rate
 }
 ```
 
-### DOOH Parameters (Optional)
+### DOOH parameters (optional)
 
-Publishers may include additional parameters to describe DOOH inventory allocation:
-
-- `duration_hours`: Duration for time-based pricing
-- `sov_percentage`: Share of voice (% of available plays)
-- `daypart`: Specific time periods (e.g., "morning_commute")
-- `venue_package`: Named collection of screens
+For flat_rate DOOH inventory, publishers may include a `parameters` object with `"type": "dooh"`. See the [flat_rate pricing model](#flat-rate) section above for a complete example and full field list.
 
 **Note**: DOOH measurement and buying practices vary by market. Publishers should clearly explain their measurement methodology and inventory allocation in the product description and `delivery_measurement` field.
 

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -73,7 +73,19 @@ A media buy contains:
 - **Status tracking** through creation, approval, and execution phases
 
 
-### Package Model
+### Package types
+
+Three distinct types represent a package at different lifecycle stages:
+
+| Type | Schema | Used in | Purpose |
+|------|--------|---------|---------|
+| `PackageRequest` | `media-buy/package-request.json` | `create_media_buy` request | What the buyer sends to create a package |
+| `Package` | `core/package.json` | `create_media_buy` success response | What the seller returns after creation (confirmed state) |
+| `PackageStatus` | inline in `media-buy/get-media-buys-response.json` | `get_media_buys` response | Delivery/reporting view — includes creative approvals and optional snapshot |
+
+When implementing `create_media_buy`, send a `PackageRequest`. The response returns `Package` objects. When calling `get_media_buys` to check status or delivery, the response contains `PackageStatus` items with delivery-specific fields.
+
+### Package model
 Packages are the building blocks of media buys:
 - **Single product** selection from discovery results - when you buy a product, you buy the entire product (unless using property targeting)
 - **Creative formats** to be provided for this package

--- a/docs/reference/migration/pricing.mdx
+++ b/docs/reference/migration/pricing.mdx
@@ -124,15 +124,13 @@ All fields are optional. Publishers include whichever percentiles they can provi
 
 ## Flat-rate pricing
 
-Flat-rate pricing (DOOH, sponsorships, time-based) follows the same pattern:
-
+**v2** (DOOH with parameters, no type discriminator):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
   "pricing_option_id": "dooh_times_square",
   "pricing_model": "flat_rate",
   "currency": "USD",
-  "fixed_price": 50000.00,
+  "fixed_rate": 50000.00,
   "parameters": {
     "duration_hours": 24,
     "sov_percentage": 100,
@@ -141,7 +139,28 @@ Flat-rate pricing (DOOH, sponsorships, time-based) follows the same pattern:
 }
 ```
 
-The `parameters` object is specific to flat-rate pricing and is unchanged from v2. Note that `fixed_price` is optional on flat-rate options — when absent, the flat-rate is auction-based (uncommon but valid for some DOOH inventory).
+**v3:**
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "pricing_option_id": "dooh_times_square",
+  "pricing_model": "flat_rate",
+  "currency": "USD",
+  "fixed_price": 50000.00,
+  "parameters": {
+    "type": "dooh",
+    "duration_hours": 24,
+    "sov_percentage": 100,
+    "estimated_impressions": 1500000
+  }
+}
+```
+
+Two changes:
+1. `fixed_rate` renames to `fixed_price` (same as other pricing models)
+2. `parameters` gains a required `"type": "dooh"` discriminator for DOOH inventory
+
+Sponsorship flat_rate options that had no `parameters` in v2 continue to omit it in v3. Note that `fixed_price` is optional on flat-rate options — when absent, the flat-rate is auction-based (uncommon but valid for some DOOH inventory).
 
 ## Minimum spend
 

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -69,6 +69,8 @@
             "type": "array",
             "description": "Packages within this media buy, augmented with creative approval status and optional delivery snapshots",
             "items": {
+              "title": "PackageStatus",
+              "description": "Current status of a package within a media buy — includes creative approval state and optional delivery snapshot. For the creation input shape, see PackageRequest. For the creation output shape, see Package.",
               "type": "object",
               "properties": {
                 "package_id": {

--- a/static/schemas/source/pricing-options/flat-rate-option.json
+++ b/static/schemas/source/pricing-options/flat-rate-option.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/pricing-options/flat-rate-option.json",
   "title": "Flat Rate Pricing Option",
-  "description": "Flat rate pricing for DOOH, sponsorships, and time-based campaigns. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.",
+  "description": "Flat rate pricing for sponsorships, takeovers, and DOOH exclusive placements. A fixed total cost regardless of delivery volume. For duration-scaled pricing (rate × time units), use the `time` model instead. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.",
   "type": "object",
   "properties": {
     "pricing_option_id": {
@@ -35,44 +35,51 @@
       "$ref": "/schemas/pricing-options/price-guidance.json"
     },
     "parameters": {
+      "title": "DoohParameters",
+      "description": "DOOH inventory allocation parameters. Sponsorship and takeover flat_rate options omit this field entirely — only include for digital out-of-home inventory.",
       "type": "object",
-      "description": "Flat rate parameters for DOOH and time-based campaigns",
       "properties": {
-        "duration_hours": {
-          "type": "number",
-          "description": "Duration in hours for time-based pricing",
-          "minimum": 0
+        "type": {
+          "type": "string",
+          "const": "dooh",
+          "description": "Discriminator identifying this as DOOH parameters"
         },
         "sov_percentage": {
           "type": "number",
-          "description": "Guaranteed share of voice (0-100)",
+          "description": "Guaranteed share of voice as a percentage (0-100)",
           "minimum": 0,
           "maximum": 100
         },
         "loop_duration_seconds": {
           "type": "integer",
-          "description": "Duration of ad loop rotation in seconds",
+          "description": "Duration of the ad loop rotation in seconds",
           "minimum": 1
         },
         "min_plays_per_hour": {
           "type": "integer",
-          "description": "Minimum plays per hour",
-          "minimum": 0
+          "description": "Minimum number of plays per hour guaranteed",
+          "minimum": 1
         },
         "venue_package": {
           "type": "string",
-          "description": "Named venue package identifier"
+          "description": "Named collection of screens included in this buy"
         },
-        "estimated_impressions": {
-          "type": "integer",
-          "description": "Estimated impressions (informational)",
+        "duration_hours": {
+          "type": "number",
+          "description": "Duration of the DOOH slot in hours (e.g., 24 for a full-day takeover)",
           "minimum": 0
         },
         "daypart": {
           "type": "string",
-          "description": "Specific daypart for time-based pricing"
+          "description": "Named daypart for this slot (e.g., morning_commute, evening_rush)"
+        },
+        "estimated_impressions": {
+          "type": "integer",
+          "description": "Estimated audience impressions for this slot (informational, not a delivery guarantee)",
+          "minimum": 0
         }
       },
+      "required": ["type"],
       "additionalProperties": true
     },
     "min_spend_per_package": {


### PR DESCRIPTION
## Summary

- **#1373**: `flat-rate-option.json` parameters restructured from a grab-bag of all DOOH/generic fields into a typed object. DOOH inventory uses `parameters: { "type": "dooh", ... }`; sponsorship/takeover flat_rate options omit `parameters` entirely. `min_plays_per_hour` minimum raised to 1 (0 was semantically meaningless).
- **#1374**: `get-media-buys-response.json` inline package items titled `PackageStatus` to eliminate the naming confusion between `PackageRequest` (create input), `Package` (create output), and the delivery/reporting view. Added a Package types table to the media buys lifecycle doc.

## Migration impact

Existing v3 publishers sending `parameters` on flat_rate options must add `"type": "dooh"`. Sponsorship options with no `parameters` are unaffected. Migration doc (`docs/reference/migration/pricing.mdx`) updated with a v2/v3 side-by-side showing both changes.

## Test plan

- [x] `npm test` — 180/180 schema validations, 323/323 unit tests pass
- [x] OpenAPI spec regenerated
- [x] Migration doc example validates against schema

Closes #1373
Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)