### PR TITLE
Remove account_resolution, derive account model from require_operator_auth

### DIFF
--- a/.changeset/kill-account-resolution.md
+++ b/.changeset/kill-account-resolution.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": major
+---
+
+Remove `account_resolution` capability field. `require_operator_auth` now determines both the auth model and account reference style: `true` means explicit accounts (discover via `list_accounts`, pass `account_id`), `false` means implicit accounts (declare via `sync_accounts`, pass natural key).

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -14,12 +14,11 @@ Six questions underlie every AdCP transaction:
 |----------|-------------|-----------|
 | Who is the advertiser? | Brand registry | `brand.domain` resolves to `brand.json` |
 | Who operates on the brand's behalf? | Brand registry | `authorized_operators` in `brand.json` declares who can buy on the brand's behalf |
-| How does the operator authenticate? | Seller capabilities | `require_operator_auth` determines whether operator credentials are needed or the agent is trusted |
-| How are accounts referenced? | Seller capabilities | `account_resolution` declares whether buyers use seller-assigned IDs (`explicit_account_id`) or natural keys (`implicit_from_sync`) |
+| How does the operator authenticate? | Seller capabilities | `require_operator_auth` determines the account model: `true` means explicit accounts (operator credentials required, discover via `list_accounts`), `false` means implicit accounts (agent trusted, declare via `sync_accounts`) |
 | Who gets billed? | Buyer declaration | Buyer passes `billing` in `sync_accounts` — `operator` or `agent`. Seller accepts or rejects. |
 | What was consumed? | Usage reporting | `report_usage` informs vendor agents how their services were used after delivery |
 
-The seller declares authentication and resolution in [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities). In the **explicit** model (`explicit_account_id`), accounts exist out-of-band and the buyer calls [`list_accounts`](/docs/accounts/tasks/list_accounts) to discover them. In the **implicit** model (`implicit_from_sync`), the buyer calls [`sync_accounts`](/docs/accounts/tasks/sync_accounts) to declare brand/operator pairs, billing, and provision accounts.
+The seller declares the account model in [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) via `require_operator_auth`. When `true` (**explicit accounts**), operators authenticate independently and the buyer discovers accounts via [`list_accounts`](/docs/accounts/tasks/list_accounts). When `false` (**implicit accounts**), the agent is trusted and the buyer declares brand/operator pairs via [`sync_accounts`](/docs/accounts/tasks/sync_accounts) to provision accounts.
 
 After delivery, the orchestrator calls [`report_usage`](/docs/accounts/tasks/report_usage) to inform vendor agents (signals, governance, creative) how their services were consumed. This is not settlement — it's consumption reporting so the vendor can track earned revenue and verify billing.
 
@@ -34,13 +33,13 @@ The Accounts Protocol applies across all vendor protocols. An orchestrator estab
 | Governance | Content standards billing |
 | Creative | Creative service billing |
 
-The account reference may be a seller-assigned `account_id` (explicit model) or a natural key — `brand` + `operator` (implicit model). The seller's `account_resolution` capability determines which form the buyer uses. See [Account references](/docs/building/integration/accounts-and-agents#account-references) for details.
+The account reference may be a seller-assigned `account_id` (explicit accounts, `require_operator_auth: true`) or a natural key — `brand` + `operator` (implicit accounts, `require_operator_auth: false`). See [Account references](/docs/building/integration/accounts-and-agents#account-references) for details.
 
 ## Transaction lifecycle
 
 ```
 1. Discover seller capabilities
-   get_adcp_capabilities → account_resolution, require_operator_auth, supported_billing
+   get_adcp_capabilities → require_operator_auth, supported_billing
 
 2. Resolve brand identity
    Fetch brand.domain/.well-known/brand.json → canonical brand (domain, brand_id)
@@ -52,9 +51,9 @@ The account reference may be a seller-assigned `account_id` (explicit model) or 
    When require_operator_auth is true → obtain operator credential via authorization_endpoint or out-of-band
 
 5. Establish account reference
-   Explicit (explicit_account_id):
+   Explicit (require_operator_auth: true):
      list_accounts() → find existing account_id for this brand/operator
-   Implicit (implicit_from_sync):
+   Implicit (require_operator_auth: false):
      sync_accounts({ accounts: [{ brand, operator, billing }] }) → status, billing terms
 
 6. Execute
@@ -81,8 +80,8 @@ The Accounts Protocol operates with four principal types. See [Accounts and agen
 
 | Task | Purpose |
 |------|---------|
-| [`sync_accounts`](/docs/accounts/tasks/sync_accounts) | Declare brand/operator pairs and billing; provision accounts (implicit model) |
-| [`list_accounts`](/docs/accounts/tasks/list_accounts) | Discover existing accounts (explicit model); poll status on pending accounts |
+| [`sync_accounts`](/docs/accounts/tasks/sync_accounts) | Declare brand/operator pairs and billing; provision accounts (implicit accounts, `require_operator_auth: false`) |
+| [`list_accounts`](/docs/accounts/tasks/list_accounts) | Discover existing accounts (explicit accounts, `require_operator_auth: true`); poll status on pending accounts |
 | [`get_account_financials`](/docs/accounts/tasks/get_account_financials) | Query spend, credit, and invoice status for operator-billed accounts |
 | [`report_usage`](/docs/accounts/tasks/report_usage) | Inform vendor agents how their services were consumed after delivery |
 

--- a/docs/accounts/tasks/sync_accounts.mdx
+++ b/docs/accounts/tasks/sync_accounts.mdx
@@ -5,7 +5,7 @@ testable: false
 
 Sync advertiser accounts with a seller for one or more brand/operator pairs. The seller provisions or links accounts, returning per-account status and any setup instructions. Brands are identified by a `brand` object containing `domain` + optional `brand_id`, resolved via `/.well-known/brand.json`.
 
-`sync_accounts` is used across all seller protocols: media buy agents, signals agents, governance agents, and creative agents. It declares the buyer's intent — the seller provisions or links accounts internally. To discover seller-assigned account IDs (for the explicit model), use [`list_accounts`](/docs/accounts/tasks/list_accounts). For the implicit model, use natural keys (`brand` + `operator`) on subsequent requests.
+`sync_accounts` is used across all seller protocols: media buy agents, signals agents, governance agents, and creative agents. It declares the buyer's intent — the seller provisions or links accounts internally. For implicit accounts (`require_operator_auth: false`), use natural keys (`brand` + `operator`) on subsequent requests. For explicit accounts (`require_operator_auth: true`), discover seller-assigned account IDs via [`list_accounts`](/docs/accounts/tasks/list_accounts).
 
 **Response Time**: ~1s. Account provisioning is synchronous; credit and legal review may require human action (indicated by `status: "pending_approval"` with a `setup.url`).
 
@@ -144,7 +144,7 @@ Returns an `accounts` array with per-account results. Individual accounts may be
 
 When `push_notification_config` is provided and the seller returns `pending_approval`, the seller sends a webhook notification when the account status changes (e.g., approved → `active`, declined → `rejected`).
 
-The notification payload includes the `(brand, operator)` natural key so the buyer can correlate it to the original sync request. For the explicit model, the notification also includes the seller-assigned `account_id` once provisioned.
+The notification payload includes the `(brand, operator)` natural key so the buyer can correlate it to the original sync request. For explicit accounts (`require_operator_auth: true`), the notification also includes the seller-assigned `account_id` once provisioned.
 
 ```json
 {
@@ -387,4 +387,4 @@ asyncio.run(main())
 - [list_accounts](/docs/accounts/tasks/list_accounts) -- Poll for status changes on pending accounts
 - [Accounts and agents](/docs/building/integration/accounts-and-agents) -- Billing models, trust models, and authorized operators
 - [Brand protocol](/docs/brand-protocol/brand-json) -- How seller agents resolve brand identity from the `brand.domain`
-- [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities) -- Discover `supported_billing` and `account_resolution` before syncing accounts
+- [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities) -- Discover `supported_billing` and `require_operator_auth` before syncing accounts

--- a/docs/building/integration/accounts-and-agents.mdx
+++ b/docs/building/integration/accounts-and-agents.mdx
@@ -37,18 +37,11 @@ The buyer must pass one of these values as `billing` in every `sync_accounts` en
 
 **2. Do you require operator-level auth?** (`require_operator_auth`)
 
-When `false` (default): the seller trusts the agent. The agent authenticates once and sets up accounts via `sync_accounts`.
+This single field determines both the authentication model and how accounts are referenced:
 
-When `true`: each operator must authenticate with the seller directly. The agent obtains a credential per operator — via OAuth using the seller's `authorization_endpoint`, or via API key out-of-band.
+When `false` (default) — **implicit accounts**: the seller trusts the agent. The agent authenticates once and declares accounts via `sync_accounts`. On subsequent requests, the buyer passes the natural key (`brand` + `operator`) and the seller resolves internally.
 
-**3. How do you resolve account references?** (`account_resolution`)
-
-| Resolution | Model | Description |
-|-----------|-------|-------------|
-| `explicit_account_id` | Explicit account IDs | Accounts are managed out-of-band (advertiser portal, sales rep). Buyer discovers them via `list_accounts` and passes a seller-assigned `account_id`. |
-| `implicit_from_sync` | Implicit account IDs | Buyer declares intent via `sync_accounts` — who's advertising, who's paying — and the seller provisions accounts. On subsequent requests, the buyer passes brand identity (`brand`, `operator`) and the seller resolves internally. |
-
-Default: `"explicit_account_id"`. See [Account references](#account-references) for detailed workflows.
+When `true` — **explicit accounts**: each operator must authenticate with the seller directly. The agent obtains a credential per operator — via OAuth using the seller's `authorization_endpoint`, or via API key out-of-band. The buyer discovers accounts via `list_accounts` and passes a seller-assigned `account_id`.
 
 Sellers can also declare `account_financials: true` to expose account-level financial data (spend, credit, invoices) via [`get_account_financials`](/docs/accounts/tasks/get_account_financials). This only applies to operator-billed accounts.
 
@@ -57,14 +50,13 @@ Sellers can also declare `account_financials: true` to expose account-level fina
 ```json
 {
   "account": {
-    "account_resolution": "implicit_from_sync",
     "require_operator_auth": false,
     "supported_billing": ["operator", "agent"]
   }
 }
 ```
 
-These three fields combine into four common patterns.
+These two fields combine into three common patterns.
 
 ## Seller patterns
 
@@ -85,7 +77,6 @@ The operator already has an account on the platform — an ad account, a busines
 ```json
 {
   "account": {
-    "account_resolution": "explicit_account_id",
     "require_operator_auth": true,
     "supported_billing": ["operator"],
     "authorization_endpoint": "https://seller.example.com/oauth/authorize"
@@ -143,7 +134,6 @@ Many publishers also accept agent billing (`supported_billing: ["operator", "age
 ```json
 {
   "account": {
-    "account_resolution": "explicit_account_id",
     "supported_billing": ["operator", "agent"]
   }
 }
@@ -331,9 +321,9 @@ Verification is a trust signal, not a gate. Finding the operator in `brand.json`
 
 ## Account references
 
-Every account-scoped operation accepts an `account` object instead of a flat `account_id` string. The seller's `account_resolution` capability declares which model it supports — and the model determines the buyer's entire integration path.
+Every account-scoped operation accepts an `account` object instead of a flat `account_id` string. The seller's `require_operator_auth` capability determines which model applies — and the model determines the buyer's entire integration path.
 
-### Explicit account IDs
+### Explicit accounts (`require_operator_auth: true`)
 
 Accounts are managed outside of AdCP. The advertiser creates an account on the seller's platform, grants the operator permission to manage it, and the agent discovers the account via `list_accounts`. The agent is not involved in authentication or billing — those are handled between the advertiser and seller directly.
 
@@ -349,11 +339,11 @@ Accounts are managed outside of AdCP. The advertiser creates an account on the s
 
 The agent doesn't set up accounts, negotiate billing, or manage authentication with the seller. It just discovers what already exists and lets the human choose.
 
-### Implicit account IDs
+### Implicit accounts (`require_operator_auth: false`)
 
 The agent manages the buying relationship. It calls `sync_accounts` to tell the seller who's advertising, who's operating on the brand's behalf, and who's paying. The seller provisions accounts and responds with status — the account IDs are a byproduct of the declaration, not something the buyer needs to know upfront.
 
-**Typical sellers:** Traditional publishers, retail media networks — anywhere the buying relationship is established programmatically.
+**Typical sellers:** Traditional publishers, retail media networks, DSPs — anywhere the buying relationship is established programmatically.
 
 `sync_accounts` is the declaration tool. Each entry is a set of flags that tells the seller what the buyer needs:
 
@@ -374,8 +364,8 @@ Every combination of flags that might require the seller to do something differe
    - `pending_approval` — seller reviewing (human may need to visit `setup.url`)
    - `rejected` — seller declined the request
 3. For subsequent requests, pass the account reference:
-   - **Explicit model**: discover account IDs via `list_accounts`, pass `{ "account_id": "acc_acme_001" }`
-   - **Implicit model**: pass the natural key `{ "brand": { "domain": "acme-corp.com" }, "operator": "pinnacle-media.com" }`
+   - **Explicit accounts** (`require_operator_auth: true`): discover account IDs via `list_accounts`, pass `{ "account_id": "acc_acme_001" }`
+   - **Implicit accounts** (`require_operator_auth: false`): pass the natural key `{ "brand": { "domain": "acme-corp.com" }, "operator": "pinnacle-media.com" }`
 4. When anything changes (billing model, new brand, new operator), call `sync_accounts` again
 
 The agent may be involved in billing (when `billing` is `"agent"` or `"operator"`). The seller may require human approval before activating accounts.
@@ -412,7 +402,7 @@ The agent does not choose the scope — the seller assigns it based on its own a
 
 When multiple natural keys resolve to the same scope, the `account_scope` explains why.
 
-`sync_accounts` does not return `account_id` — the seller manages account identifiers internally. For the explicit model, discover account IDs via `list_accounts`. For the implicit model, use natural keys (`brand` + `operator`) on subsequent requests.
+`sync_accounts` does not return `account_id` — the seller manages account identifiers internally. For explicit accounts (`require_operator_auth: true`), discover account IDs via `list_accounts`. For implicit accounts (`require_operator_auth: false`), use natural keys (`brand` + `operator`) on subsequent requests.
 
 ## Error codes
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -70,18 +70,17 @@ Account and authentication capabilities. Optional — sellers that don't manage 
 | Field | Type | Description |
 |-------|------|-------------|
 | `supported_billing` | string[] | **Required.** Billing models this seller supports: `operator`, `agent`. The buyer must pass one of these values as `billing` in every `sync_accounts` entry. |
-| `require_operator_auth` | boolean | Default: `false`. Determines who authenticates to the seller (see below). |
+| `require_operator_auth` | boolean | Default: `false`. Determines the account model. When `true` (explicit accounts): each operator authenticates independently, buyer discovers accounts via `list_accounts`, passes `account.account_id`. When `false` (implicit accounts): agent is trusted, buyer declares accounts via `sync_accounts`, passes natural key (`account.brand` + `operator`). |
 | `authorization_endpoint` | string | OAuth URL for operator authentication. Present when the seller supports OAuth for operator authentication. Relevant when `require_operator_auth: true`; if absent, operators obtain credentials out-of-band (seller portal, API key). |
-| `account_resolution` | string | How this seller resolves account references in requests. Either `explicit_account_id` (seller-assigned identifier) or `implicit_from_sync` (resolved from brand + operator). Buyers use this to determine whether to pass `account.account_id` or `account.brand` (with `operator`) in task requests. Default: `explicit_account_id`. |
 | `required_for_products` | boolean | Default: `false`. When `true`, the buyer must establish an account before calling `get_products`. When `false`, the buyer can browse products without an account — useful for price comparison and discovery before committing to a seller. |
 | `account_financials` | boolean | Default: `false`. When `true`, the seller supports [`get_account_financials`](/docs/accounts/tasks/get_account_financials) for querying spend, credit, and invoice status. Only applicable to operator-billed accounts. |
 | `sandbox` | boolean | Default: `false`. When `true`, the seller supports sandbox accounts for testing. Buyers provision a sandbox account via `sync_accounts` with `sandbox: true`; all requests using that `account_id` are treated as sandbox — no real platform calls or spend. See [Sandbox mode](/docs/media-buy/advanced-topics/sandbox). |
 
 #### Auth models
 
-**Agent-trusted** (`require_operator_auth: false`) — The seller trusts the agent's identity claims. The agent authenticates once with its own bearer token, then calls `sync_accounts` to declare which brands and operators it represents. The seller provisions accounts based on the agent's claims, optionally verifying operators against `brand.json`. All subsequent calls use the agent's single credential.
+**Implicit accounts** (`require_operator_auth: false`) — The seller trusts the agent's identity claims. The agent authenticates once with its own bearer token, then calls `sync_accounts` to declare which brands and operators it represents. The seller provisions accounts based on the agent's claims, optionally verifying operators against `brand.json`. All subsequent calls use the agent's single credential and pass natural keys (`brand` + `operator`).
 
-**Operator-scoped** (`require_operator_auth: true`) — Each operator must authenticate with the seller directly. The agent obtains a credential per operator — via OAuth using `authorization_endpoint`, or out-of-band — opens a per-operator session, and calls `sync_accounts` within each session to declare brands. The operator's credential authorizes all calls in that session.
+**Explicit accounts** (`require_operator_auth: true`) — Each operator must authenticate with the seller directly. The agent obtains a credential per operator — via OAuth using `authorization_endpoint`, or out-of-band — opens a per-operator session, and discovers accounts via `list_accounts`. The buyer passes seller-assigned `account_id` values on all subsequent requests.
 
 See [Accounts and Agents](/docs/building/integration/accounts-and-agents#what-sellers-declare) for full workflows and [seller patterns](/docs/building/integration/accounts-and-agents#seller-patterns) for common combinations of auth model and billing support.
 

--- a/static/schemas/source/core/account-ref.json
+++ b/static/schemas/source/core/account-ref.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/account-ref.json",
   "title": "Account Reference",
-  "description": "Reference to an account by seller-assigned ID or natural key. Use account_id when the buyer manages accounts (e.g., picked from list_accounts). Use the natural key (brand + operator) when the seller resolves accounts internally.",
+  "description": "Reference to an account by seller-assigned ID or natural key. Use account_id for explicit accounts (require_operator_auth: true, discovered via list_accounts). Use the natural key (brand + operator) for implicit accounts (require_operator_auth: false, declared via sync_accounts).",
   "type": "object",
   "oneOf": [
     {

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -42,15 +42,9 @@
       "type": "object",
       "description": "Account management capabilities. Describes how accounts are established, what billing models are supported, and whether an account is required before browsing products.",
       "properties": {
-        "account_resolution": {
-          "type": "string",
-          "description": "How the seller resolves account references. explicit_account_id: accounts are managed out-of-band (advertiser portal, sales rep) and discovered via list_accounts. implicit_from_sync: buyer declares intent via sync_accounts and the seller provisions accounts.",
-          "enum": ["explicit_account_id", "implicit_from_sync"],
-          "default": "explicit_account_id"
-        },
         "require_operator_auth": {
           "type": "boolean",
-          "description": "Whether the seller requires operator-level credentials. When false (default), the seller trusts the agent's identity claims — the agent authenticates once and declares brands/operators via sync_accounts. When true, each operator must authenticate independently with the seller, and the agent opens a per-operator session using the operator's credential.",
+          "description": "Whether the seller requires operator-level credentials. When true (explicit accounts), operators authenticate independently with the seller and the buyer discovers accounts via list_accounts. When false (default, implicit accounts), the seller trusts the agent's identity claims — the agent authenticates once and declares brands/operators via sync_accounts.",
           "default": false
         },
         "authorization_endpoint": {


### PR DESCRIPTION
## Summary

- Remove `account_resolution` field from capabilities schema — it was redundant with `require_operator_auth`
- `require_operator_auth: true` → explicit accounts (discover via `list_accounts`, pass `account_id`)
- `require_operator_auth: false` → implicit accounts (declare via `sync_accounts`, pass natural key)

## Changes

**Schema:**
- `get-adcp-capabilities-response.json` — removed `account_resolution` enum, updated `require_operator_auth` description
- `account-ref.json` — updated description to reference `require_operator_auth`

**Docs:**
- `accounts/overview.mdx` — replaced all `account_resolution` references
- `accounts/tasks/sync_accounts.mdx` — updated model references
- `building/integration/accounts-and-agents.mdx` — collapsed "What sellers declare" from 3 to 2 fields, updated all examples and section headers
- `protocol/get_adcp_capabilities.mdx` — removed `account_resolution` row, updated auth model labels

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (323 tests, all schemas validate)
- [x] No broken links in docs
- [ ] Verify no remaining `account_resolution` references in source files (only in dist/ and CHANGELOG.md)