### PR TITLE
Include tool result summaries in conversation history

### DIFF
--- a/.changeset/fiery-facts-heal.md
+++ b/.changeset/fiery-facts-heal.md
@@ -1,0 +1,4 @@
+---
+---
+
+Include tool result summaries in conversation history so follow-up turns can reference prior search results without redundant tool calls.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -69,7 +69,7 @@ import {
   createMeetingToolHandlers,
   canScheduleMeetings,
 } from './mcp/meeting-tools.js';
-import { SUGGESTED_PROMPTS, buildDynamicSuggestedPrompts, HISTORY_UNAVAILABLE_NOTE } from './prompts.js';
+import { SUGGESTED_PROMPTS, buildDynamicSuggestedPrompts, HISTORY_UNAVAILABLE_NOTE, summarizeToolCalls } from './prompts.js';
 import { AddieModelConfig, ModelConfig } from '../config/models.js';
 import { getMemberContext, formatMemberContextForPrompt, type MemberContext } from './member-context.js';
 import {
@@ -1119,7 +1119,7 @@ async function handleUserMessage({
         .slice(-MAX_HISTORY_MESSAGES)
         .map(msg => ({
           user: msg.role === 'user' ? 'User' : 'Addie',
-          text: msg.content_sanitized || msg.content,
+          text: (msg.content_sanitized || msg.content) + summarizeToolCalls(msg.tool_calls),
         }));
 
       if (conversationHistory.length > 0) {
@@ -1583,7 +1583,7 @@ async function handleAppMention({
         .slice(-MAX_HISTORY_MESSAGES)
         .map(msg => ({
           user: msg.role === 'user' ? 'User' : 'Addie',
-          text: msg.content_sanitized || msg.content,
+          text: (msg.content_sanitized || msg.content) + summarizeToolCalls(msg.tool_calls),
         }));
 
       if (conversationHistory.length > 0) {
@@ -2276,7 +2276,7 @@ async function handleDirectMessage(
         .slice(-MAX_HISTORY_MESSAGES)
         .map(msg => ({
           user: msg.role === 'user' ? 'User' : 'Addie',
-          text: msg.content_sanitized || msg.content,
+          text: (msg.content_sanitized || msg.content) + summarizeToolCalls(msg.tool_calls),
         }));
 
       if (conversationHistory.length > 0) {
@@ -2578,7 +2578,7 @@ async function handleActiveThreadReply({
         .slice(-MAX_DB_HISTORY_MESSAGES)
         .map(msg => ({
           user: msg.role === 'user' ? 'User' : 'Addie',
-          text: msg.content_sanitized || msg.content,
+          text: (msg.content_sanitized || msg.content) + summarizeToolCalls(msg.tool_calls),
         }));
 
       if (conversationHistory.length > 0) {
@@ -3648,7 +3648,7 @@ async function handleReactionAdded({
         .slice(-MAX_HISTORY_MESSAGES)
         .map(msg => ({
           user: msg.role === 'user' ? 'User' : 'Addie',
-          text: msg.content_sanitized || msg.content,
+          text: (msg.content_sanitized || msg.content) + summarizeToolCalls(msg.tool_calls),
         }));
 
       if (conversationHistory.length > 0) {

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -365,6 +365,40 @@ export interface ThreadContextEntry {
   text: string;
 }
 
+/**
+ * Produce a compact summary of tool calls for conversation context.
+ * Appended to assistant messages so follow-up turns can reference prior tool results
+ * without re-calling tools. Capped at 1000 chars total to protect context budget.
+ */
+const MAX_RESULT_HINT_CHARS = 200;
+const MAX_SUMMARY_CHARS = 1000;
+
+export function summarizeToolCalls(
+  toolCalls: Array<{ name: string; result: unknown; is_error?: boolean }> | null | undefined
+): string {
+  if (!toolCalls || toolCalls.length === 0) return '';
+
+  const parts: string[] = [];
+  let totalLen = 0;
+
+  for (const tc of toolCalls) {
+    const prefix = tc.is_error ? `${tc.name}(error)` : tc.name;
+    const resultStr = typeof tc.result === 'string'
+      ? tc.result
+      : tc.result != null ? JSON.stringify(tc.result) : '';
+    const hint = resultStr.length > MAX_RESULT_HINT_CHARS
+      ? resultStr.slice(0, MAX_RESULT_HINT_CHARS) + '...'
+      : resultStr;
+    const part = `${prefix}: ${hint}`;
+
+    if (totalLen + part.length > MAX_SUMMARY_CHARS) break;
+    parts.push(part);
+    totalLen += part.length;
+  }
+
+  return `\n\n[Tool results from this turn:\n${parts.join('\n')}]`;
+}
+
 // Re-export MessageTurn from token-limiter for backwards compatibility
 export type { MessageTurn };
 

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -105,6 +105,7 @@ import {
 } from "../addie/thread-service.js";
 import { UsersDatabase } from "../db/users-db.js";
 import { isRetriesExhaustedError } from "../utils/anthropic-retry.js";
+import { summarizeToolCalls } from "../addie/prompts.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -654,13 +655,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       }
 
       // Get conversation history for context
-      const messages = await threadService.getThreadMessages(thread.thread_id);
-      const history: ConversationMessage[] = messages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
-        .map((m) => ({
-          role: m.role as 'user' | 'assistant',
-          content: m.content,
-        }));
+      const threadMessages = await threadService.getThreadMessages(thread.thread_id);
 
       // Save user message
       await threadService.addMessage({
@@ -672,11 +667,14 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
       });
 
-      // Build context from history (last N messages)
-      const contextMessages = history.slice(-10).map((m) => ({
-        user: m.role === "user" ? "User" : "Addie",
-        text: m.content,
-      }));
+      // Build context from history (last N messages), including tool result summaries
+      const contextMessages = threadMessages
+        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .slice(-10)
+        .map((m) => ({
+          user: m.role === "user" ? "User" : "Addie",
+          text: m.content + summarizeToolCalls(m.tool_calls),
+        }));
 
       // Build tiered access: anonymous gets Haiku + restricted tools,
       // authenticated gets Sonnet + full tools
@@ -885,13 +883,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       sendEvent("meta", { conversation_id: externalId });
 
       // Get conversation history
-      const messages = await threadService.getThreadMessages(thread.thread_id);
-      const history: ConversationMessage[] = messages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
-        .map((m) => ({
-          role: m.role as 'user' | 'assistant',
-          content: m.content,
-        }));
+      const threadMessages = await threadService.getThreadMessages(thread.thread_id);
 
       // Save user message
       await threadService.addMessage({
@@ -903,11 +895,14 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
       });
 
-      // Build context messages
-      const contextMessages = history.slice(-10).map((m) => ({
-        user: m.role === "user" ? "User" : "Addie",
-        text: m.content,
-      }));
+      // Build context messages, including tool result summaries
+      const contextMessages = threadMessages
+        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .slice(-10)
+        .map((m) => ({
+          user: m.role === "user" ? "User" : "Addie",
+          text: m.content + summarizeToolCalls(m.tool_calls),
+        }));
 
       // Build tiered access: anonymous gets Haiku + restricted tools,
       // authenticated gets Sonnet + full tools

--- a/server/tests/unit/summarize-tool-calls.test.ts
+++ b/server/tests/unit/summarize-tool-calls.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeToolCalls } from '../../src/addie/prompts.js';
+
+describe('summarizeToolCalls', () => {
+  it('returns empty string for null', () => {
+    expect(summarizeToolCalls(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(summarizeToolCalls(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(summarizeToolCalls([])).toBe('');
+  });
+
+  it('summarizes a single tool call', () => {
+    const result = summarizeToolCalls([
+      { name: 'search_repos', result: 'Found 3 results' },
+    ]);
+    expect(result).toContain('search_repos');
+    expect(result).toContain('Found 3 results');
+    expect(result).toContain('[Tool results from this turn:');
+  });
+
+  it('summarizes multiple tool calls', () => {
+    const result = summarizeToolCalls([
+      { name: 'search_docs', result: 'Doc A found' },
+      { name: 'get_doc', result: 'Full content here' },
+    ]);
+    expect(result).toContain('search_docs');
+    expect(result).toContain('get_doc');
+  });
+
+  it('marks errors', () => {
+    const result = summarizeToolCalls([
+      { name: 'search_repos', result: 'Invalid repo_id', is_error: true },
+    ]);
+    expect(result).toContain('search_repos(error)');
+  });
+
+  it('truncates long results at 200 characters', () => {
+    const longResult = 'x'.repeat(300);
+    const result = summarizeToolCalls([
+      { name: 'search_repos', result: longResult },
+    ]);
+    expect(result).toContain('...');
+    const hintMatch = result.match(/search_repos: (.+)/);
+    expect(hintMatch).toBeTruthy();
+    expect(hintMatch![1].length).toBeLessThanOrEqual(210);
+  });
+
+  it('handles non-string results by JSON-stringifying', () => {
+    const result = summarizeToolCalls([
+      { name: 'get_products', result: { items: ['a', 'b'] } },
+    ]);
+    expect(result).toContain('get_products');
+    expect(result).toContain('"items"');
+  });
+
+  it('handles null result', () => {
+    const result = summarizeToolCalls([
+      { name: 'do_thing', result: null },
+    ]);
+    expect(result).toContain('do_thing');
+    expect(result).not.toContain('null');
+  });
+
+  it('handles undefined result', () => {
+    const result = summarizeToolCalls([
+      { name: 'do_thing', result: undefined },
+    ]);
+    expect(result).toContain('do_thing');
+  });
+
+  it('caps total summary at 1000 characters', () => {
+    // Create 10 tool calls each with 200-char results — would be ~2500 chars uncapped
+    const calls = Array.from({ length: 10 }, (_, i) => ({
+      name: `tool_${i}`,
+      result: 'a'.repeat(200),
+    }));
+    const result = summarizeToolCalls(calls);
+    // Strip the wrapper to measure just the tool summaries
+    const inner = result.replace(/\n\n\[Tool results from this turn:\n/, '').replace(/\]$/, '');
+    expect(inner.length).toBeLessThanOrEqual(1100); // some tolerance for tool names + formatting
+    // Not all 10 tools should be included
+    expect((result.match(/tool_/g) || []).length).toBeLessThan(10);
+  });
+});


### PR DESCRIPTION
## Summary
- Appends compact tool result summaries to assistant messages in conversation history, so follow-up turns can reference prior search/lookup results without redundant tool calls
- Adds `summarizeToolCalls()` helper with per-result (200 char) and per-message (1000 char) caps to protect context budget
- Updates all 7 history-building sites across Slack (bolt-app.ts) and web chat (addie-chat.ts) channels

## Motivation
[Thread example](https://agenticadvertising.org/admin/addie/?thread=2d1002af-285a-48e5-8d81-a06e933573ca): User asked "what is the open source creative agent url", Addie searched and found the answer. On follow-up ("but what is the actual endpoint?"), Addie made 4 redundant tool calls (9.9s, 5 iterations) because prior tool results weren't in conversation context.

With this change, Claude sees prior tool results in context and can answer immediately.

## Test plan
- [x] New unit tests for `summarizeToolCalls` (11 tests: null/undefined/empty, single/multiple calls, errors, truncation, total cap, null/undefined results)
- [x] Typecheck passes
- [x] Pre-commit hooks pass (all existing tests)
- [ ] Manual test: send a follow-up question in web chat and verify Addie references prior tool results without re-searching

🤖 Generated with [Claude Code](https://claude.com/claude-code)