### PR TITLE
feat: add optional inline preview to build_creative

### DIFF
--- a/.changeset/build-creative-inline-preview.md
+++ b/.changeset/build-creative-inline-preview.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": minor
 ---
 
-Add optional inline preview to build_creative. Request can set `include_preview: true` to get preview renders in the response alongside the manifest. The preview structure matches preview_creative's single response, so clients parse previews identically regardless of source. Agents that don't support inline preview simply omit the field.
+Add optional inline preview to build_creative. Request can set `include_preview: true` to get preview renders in the response alongside the manifest. The preview structure matches preview_creative's single response, so clients parse previews identically regardless of source. For single-format requests, `preview_inputs` controls variant generation. For multi-format requests, one default preview per format is returned with explicit `format_id` on each entry. `preview_error` uses the standard error structure (`code`, `message`, `recovery`) for agent-friendly failure handling. Agents that don't support inline preview simply omit the field.

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -29,7 +29,7 @@ For information about format IDs and how to reference formats, see [Creative For
 | `quality` | string | No | Quality tier: `"draft"` (fast, lower-fidelity for iteration) or `"production"` (full quality for final delivery). If omitted, the creative agent uses its own default. |
 | `item_limit` | integer | No | Maximum number of catalog items to use when generating. Caps generation cost for catalog-driven formats. |
 | `include_preview` | boolean | No | When true, requests preview renders alongside the manifest. Agents that support this return a `preview` object in the response. Agents that don't simply omit it. |
-| `preview_inputs` | array | No | Input sets for preview generation when `include_preview` is true. Each entry has `name` (required), optional `macros`, and optional `context_description`. If omitted, the agent generates a single default preview. |
+| `preview_inputs` | array | No | Input sets for preview generation when `include_preview` is true. Each entry has `name` (required), optional `macros`, and optional `context_description`. If omitted, the agent generates a single default preview. Only supported with `target_format_id` (single-format) — ignored for multi-format requests. |
 | `preview_output_format` | string | No | Output format for preview renders: `"url"` (default) or `"html"`. Only used when `include_preview` is true. |
 | `macro_values` | object | No | Macro values to pre-substitute into the output manifest's assets. Keys are universal macro names (e.g., `CLICK_URL`, `CACHEBUSTER`); values are the literal substitution strings. The creative agent translates universal macros to its platform's native syntax. Macros not provided here remain as `{MACRO}` placeholders for the sales agent to resolve at serve time. |
 
@@ -344,8 +344,8 @@ When the request uses `target_format_ids`, the response contains an array of cre
 - **format_id**: The target format (matches the requested format)
 - **assets**: Map of asset keys to asset content — includes creative content (images, text, URLs), catalogs, briefs, and anything else the format requires
 - **expires_at**: Optional ISO 8601 timestamp when generated asset URLs in the manifest expire. Set to the earliest expiration across all generated assets. Re-build the creative after this time to get fresh URLs. Not present when the manifest contains no expiring URLs (e.g., pure text generation or assembly-only transforms).
-- **preview**: Optional. Present when `include_preview` was true in the request and the agent supports inline preview. Contains the same content fields as a `preview_creative` single response (`previews`, `interactive_url`, `expires_at`) minus the `response_type` discriminator, so clients can reuse the same preview rendering logic.
-- **preview_error**: Optional. When `include_preview` was true but preview generation failed (e.g., rendering service unavailable), explains why. Distinguishes "agent doesn't support inline preview" (field absent, no error) from "preview generation failed" (field present with reason).
+- **preview**: Optional. Present when `include_preview` was true in the request and the agent supports inline preview. Contains the same content fields as a `preview_creative` single response (`previews`, `interactive_url`, `expires_at`) minus the `response_type` discriminator, so clients can reuse the same preview rendering logic. For single-format responses, each entry in `previews[]` corresponds to an input set from `preview_inputs`. For multi-format responses, each entry includes a `format_id` and corresponds to one requested format (one default preview per format; `preview_inputs` is ignored).
+- **preview_error**: Optional. Standard error object (`code`, `message`, `recovery`) present when `include_preview` was true but preview generation failed. The `recovery` field indicates whether the failure is `transient` (retry later), `correctable`, or `terminal`. Distinguishes "agent doesn't support inline preview" (field absent, no error) from "preview generation failed" (field present with structured error).
 
 ### Compliance errors
 
@@ -958,7 +958,7 @@ Build a creative and get preview renders in the same response:
 }
 ```
 
-The `preview` object contains the same content fields as a `preview_creative` single response (`previews`, `interactive_url`, `expires_at`). If the agent does not support inline preview, this field is absent — the buyer agent falls back to a separate `preview_creative` call. If preview generation fails, the response includes `preview_error` with a reason instead.
+The `preview` object contains the same content fields as a `preview_creative` single response (`previews`, `interactive_url`, `expires_at`). If the agent does not support inline preview, this field is absent — the buyer agent falls back to a separate `preview_creative` call. If preview generation fails, the response includes `preview_error` with a standard error object (`code`, `message`, `recovery`) instead.
 
 ### Example 8: Draft generation with item limit
 

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -972,11 +972,12 @@ export const ADCP_CREATIVE_TOOLS: AddieTool[] = [
         },
         include_preview: {
           type: 'boolean',
-          description: 'When true, requests preview renders alongside the manifest. Agents that support this return a preview object in the response.',
+          description: 'When true, requests preview renders alongside the manifest. Response includes a preview object if supported, or preview_error (standard error with code/message/recovery) if generation failed. If neither is present, the agent does not support inline preview.',
         },
         preview_inputs: {
           type: 'array',
-          description: 'Input sets for preview generation when include_preview is true. Each entry has name (required), optional macros, and optional context_description.',
+          minItems: 1,
+          description: 'Input sets for preview generation when include_preview is true. Each entry has name (required), optional macros, and optional context_description. Only supported with target_format_id (single-format) — ignored for multi-format requests.',
           items: {
             type: 'object',
             properties: {

--- a/static/schemas/source/media-buy/build-creative-request.json
+++ b/static/schemas/source/media-buy/build-creative-request.json
@@ -60,7 +60,7 @@
     },
     "preview_inputs": {
       "type": "array",
-      "description": "Input sets for preview generation when include_preview is true. Each input set defines macros and context values for one preview variant. If include_preview is true but this is omitted, the agent generates a single default preview. Ignored when include_preview is false or omitted.",
+      "description": "Input sets for preview generation when include_preview is true. Each input set defines macros and context values for one preview variant. If include_preview is true but this is omitted, the agent generates a single default preview. Only supported with target_format_id (single-format requests). Ignored when using target_format_ids — multi-format requests generate one default preview per format. Ignored when include_preview is false or omitted.",
       "items": {
         "type": "object",
         "properties": {

--- a/static/schemas/source/media-buy/build-creative-response.json
+++ b/static/schemas/source/media-buy/build-creative-response.json
@@ -67,7 +67,8 @@
                     },
                     "required": [
                       "name"
-                    ]
+                    ],
+                    "additionalProperties": true
                   }
                 },
                 "required": [
@@ -95,8 +96,8 @@
           ]
         },
         "preview_error": {
-          "type": "string",
-          "description": "When include_preview was true in the request but preview generation failed, explains why. Distinguishes 'agent does not support inline preview' (preview and preview_error both absent) from 'preview generation failed' (preview absent, preview_error present with reason). Omitted when preview succeeded or was not requested."
+          "$ref": "/schemas/core/error.json",
+          "description": "When include_preview was true in the request but preview generation failed. Uses the standard error structure with code, message, and recovery classification. Distinguishes 'agent does not support inline preview' (preview and preview_error both absent) from 'preview generation failed' (preview absent, preview_error present). Omitted when preview succeeded or was not requested."
         },
         "context": {
           "$ref": "/schemas/core/context.json"
@@ -131,6 +132,87 @@
           "type": "string",
           "format": "date-time",
           "description": "ISO 8601 timestamp when the earliest generated asset URL expires across all manifests. Re-build after this time to get fresh URLs."
+        },
+        "preview": {
+          "type": "object",
+          "description": "Preview renders included when the request set include_preview to true and the agent supports it. Contains one default preview per requested format. preview_inputs is ignored for multi-format requests.",
+          "properties": {
+            "previews": {
+              "type": "array",
+              "description": "Array of preview entries, one per requested format. Array order matches creative_manifests. Each entry includes a format_id for explicit correlation.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "preview_id": {
+                    "type": "string",
+                    "description": "Unique identifier for this preview"
+                  },
+                  "format_id": {
+                    "$ref": "/schemas/core/format-id.json",
+                    "description": "The format this preview was generated for. Matches one of the requested target_format_ids."
+                  },
+                  "renders": {
+                    "type": "array",
+                    "description": "Array of rendered pieces for this format's preview. Most formats render as a single piece. Companion ad formats render as multiple pieces.",
+                    "items": {
+                      "$ref": "/schemas/creative/preview-render.json"
+                    },
+                    "minItems": 1
+                  },
+                  "input": {
+                    "type": "object",
+                    "description": "The input parameters that generated this preview. For multi-format responses, this is always a default input.",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Human-readable name for this preview"
+                      },
+                      "macros": {
+                        "type": "object",
+                        "description": "Macro values applied to this preview",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "context_description": {
+                        "type": "string",
+                        "description": "Context description applied to this preview"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "preview_id",
+                  "format_id",
+                  "renders",
+                  "input"
+                ]
+              },
+              "minItems": 1
+            },
+            "interactive_url": {
+              "type": "string",
+              "format": "uri",
+              "description": "Optional URL to an interactive testing page that shows all format previews with controls to switch between them."
+            },
+            "expires_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 timestamp when preview URLs expire. May differ from the manifest's expires_at."
+            }
+          },
+          "required": [
+            "previews",
+            "expires_at"
+          ]
+        },
+        "preview_error": {
+          "$ref": "/schemas/core/error.json",
+          "description": "When include_preview was true in the request but preview generation failed. Uses the standard error structure with code, message, and recovery classification. Omitted when preview succeeded or was not requested."
         },
         "context": {
           "$ref": "/schemas/core/context.json"


### PR DESCRIPTION
## Summary

- Adds `include_preview` boolean to `build_creative` request so buyers can request preview renders alongside the manifest in a single round trip
- Adds optional `preview` object to both single-format and multi-format success responses, reusing the same content structure as `preview_creative` (`previews`, `interactive_url`, `expires_at`)
- Single-format: supports `preview_inputs` for multiple variant previews (e.g., "Default", "Dark mode")
- Multi-format: one default preview per format with explicit `format_id` on each entry (`preview_inputs` ignored)
- `preview_error` uses standard error structure (`$ref` to `error.json`) with `code`, `message`, and `recovery` classification for agent-friendly failure handling
- No capability flag needed — agents that don't support inline preview simply omit the field

## Design decisions

Per discussion on #1399:
- **Request parameter, not capability**: `include_preview` is a request-level flag. The response gracefully degrades — agents that don't support it omit the field
- **Reuse preview_creative structure**: The `preview` object contains the same content fields minus the `response_type` discriminator, so clients parse previews identically regardless of source
- **Three-state signaling**: `preview` present = success; both absent = not supported; `preview_error` present = transient failure (with structured error for retry decisions)
- **Multi-format clarity**: `preview_inputs` is single-format only. Multi-format responses include `format_id` on each preview entry for explicit correlation

## Test plan

- [x] All schema validation tests pass (352 schemas)
- [x] All example validation tests pass
- [x] Schema drift test passes (Addie tool definitions cover all new properties)
- [x] TypeScript type check passes
- [x] Migration validation passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)