### PR TITLE
feat: collect contact info on escalations

### DIFF
--- a/.changeset/escalation-contact-info.md
+++ b/.changeset/escalation-contact-info.md
@@ -1,0 +1,4 @@
+---
+---
+
+Collect email address and Slack handle on escalations so admins can follow up with users who aren't yet linked to an AgenticAdvertising.org account.

--- a/server/public/admin-escalations.html
+++ b/server/public/admin-escalations.html
@@ -354,6 +354,8 @@
                 <span><span class="badge category-badge">${categoryLabels[e.category] || e.category}</span></span>
                 <span>${createdAt}</span>
                 ${e.user_display_name ? `<span>From: ${escapeHtml(e.user_display_name)}</span>` : ''}
+                ${e.user_email ? `<span>Email: ${escapeHtml(e.user_email)}</span>` : ''}
+                ${e.user_slack_handle ? `<span>Slack: ${escapeHtml(e.user_slack_handle)}</span>` : ''}
               </div>
             </div>
             ${!isResolved ? `

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -51,6 +51,7 @@ CONFIRM WITH USER BEFORE ESCALATING — you must get the user's consent first:
 BEFORE CALLING THIS TOOL — gather enough context to make the escalation actionable:
 - If the request is vague, ask clarifying questions first
 - Confirm who the request is from: their name and organization
+- ALWAYS collect an email address and/or Slack handle so the team can follow up. If the user hasn't provided one, ask before escalating.
 - If someone is asking on behalf of another person, capture that person's name and contact details in the summary
 - Include any relevant context (timeline, urgency, what they've already tried)
 
@@ -80,6 +81,14 @@ When you escalate, be honest with the user that you're passing this to a human w
         addie_context: {
           type: 'string',
           description: 'Why you are escalating - what you tried or why you cannot help',
+        },
+        user_email: {
+          type: 'string',
+          description: 'Email address of the user requesting help (ask for this if not already known)',
+        },
+        user_slack_handle: {
+          type: 'string',
+          description: 'Slack display name or handle of the user (e.g. "jean-sebastien")',
         },
       },
       required: ['summary', 'category'],
@@ -157,6 +166,8 @@ async function sendEscalationNotification(
     userDisplayName?: string;
     orgName?: string;
     slackUserId?: string;
+    userEmail?: string;
+    userSlackHandle?: string;
     threadId?: string;
     originalRequest?: string;
     addieContext?: string;
@@ -183,15 +194,28 @@ async function sendEscalationNotification(
       ? `<@${context.slackUserId}>`
       : 'Unknown user';
 
+  // Build contact line from available info
+  const contactParts: string[] = [];
+  if (context.userEmail) contactParts.push(context.userEmail);
+  if (context.userSlackHandle) contactParts.push(`Slack: ${context.userSlackHandle}`);
+  if (context.slackUserId && !context.userSlackHandle) contactParts.push(`Slack: <@${context.slackUserId}>`);
+
   const lines = [
     `${priorityEmoji[priority]} *New Escalation #${escalationId}*`,
     '',
     `*From:* ${userInfo}`,
+  ];
+
+  if (contactParts.length > 0) {
+    lines.push(`*Contact:* ${contactParts.join(' · ')}`);
+  }
+
+  lines.push(
     `*Category:* ${categoryLabel[category]}`,
     `*Priority:* ${priority}`,
     '',
     `*Summary:* ${summary}`,
-  ];
+  );
 
   if (context.originalRequest) {
     lines.push('', `*Original Request:* ${context.originalRequest}`);
@@ -244,6 +268,18 @@ export function createEscalationToolHandlers(
     const priority = (input.priority as EscalationPriority) || 'normal';
     const originalRequest = input.original_request as string | undefined;
     const addieContext = input.addie_context as string | undefined;
+    const userEmail = input.user_email as string | undefined;
+    const userSlackHandle = input.user_slack_handle as string | undefined;
+
+    // Validate email format if provided
+    if (userEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
+      return 'Error: user_email does not look like a valid email address. Please ask the user to confirm their email.';
+    }
+
+    // Ensure we have some way to contact the user
+    if (!userEmail && !userSlackHandle && !memberContext?.workos_user?.email && !slackUserId) {
+      return 'Error: Please collect an email address or Slack handle from the user before escalating. The team needs a way to follow up.';
+    }
 
     // Get display name from slack_user or workos_user
     const userDisplayName = memberContext?.slack_user?.display_name
@@ -253,12 +289,17 @@ export function createEscalationToolHandlers(
     const orgName = memberContext?.organization?.name;
 
     try {
+      // Resolve email: explicit input > WorkOS user email > undefined
+      const resolvedEmail = userEmail || memberContext?.workos_user?.email;
+
       // 1. Create escalation record
       const escalation = await createEscalation({
         thread_id: threadId,
         slack_user_id: slackUserId,
         workos_user_id: memberContext?.workos_user?.workos_user_id,
         user_display_name: userDisplayName,
+        user_email: resolvedEmail,
+        user_slack_handle: userSlackHandle,
         category,
         priority,
         summary,
@@ -290,6 +331,8 @@ export function createEscalationToolHandlers(
             userDisplayName,
             orgName,
             slackUserId,
+            userEmail: resolvedEmail,
+            userSlackHandle,
             threadId,
             originalRequest,
             addieContext,

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -34,6 +34,8 @@ export interface Escalation {
   slack_user_id: string | null;
   workos_user_id: string | null;
   user_display_name: string | null;
+  user_email: string | null;
+  user_slack_handle: string | null;
   category: EscalationCategory;
   priority: EscalationPriority;
   summary: string;
@@ -56,6 +58,8 @@ export interface EscalationInput {
   slack_user_id?: string;
   workos_user_id?: string;
   user_display_name?: string;
+  user_email?: string;
+  user_slack_handle?: string;
   category: EscalationCategory;
   priority?: EscalationPriority;
   summary: string;
@@ -79,8 +83,9 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
   const result = await query<Escalation>(
     `INSERT INTO addie_escalations (
       thread_id, message_id, slack_user_id, workos_user_id, user_display_name,
+      user_email, user_slack_handle,
       category, priority, summary, original_request, addie_context
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
     RETURNING *`,
     [
       input.thread_id || null,
@@ -88,6 +93,8 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
       input.slack_user_id || null,
       input.workos_user_id || null,
       input.user_display_name || null,
+      input.user_email || null,
+      input.user_slack_handle || null,
       input.category,
       input.priority || 'normal',
       input.summary,

--- a/server/src/db/migrations/281_escalation_contact_info.sql
+++ b/server/src/db/migrations/281_escalation_contact_info.sql
@@ -1,0 +1,10 @@
+-- Add contact info fields to escalations
+-- Ensures admins can always reach users who escalate, even when their
+-- Slack is not linked to an AgenticAdvertising.org account.
+
+ALTER TABLE addie_escalations
+  ADD COLUMN user_email TEXT,
+  ADD COLUMN user_slack_handle TEXT;
+
+CREATE INDEX idx_escalations_workos_user ON addie_escalations(workos_user_id)
+  WHERE workos_user_id IS NOT NULL;

--- a/tests/addie/escalation-tools.test.ts
+++ b/tests/addie/escalation-tools.test.ts
@@ -85,6 +85,8 @@ describe('get_escalation_status', () => {
         slack_user_id: 'U_SLACK_123',
         workos_user_id: 'user_test123',
         user_display_name: 'Test User',
+        user_email: 'test@example.com',
+        user_slack_handle: 'testuser',
         category: 'needs_human_action',
         priority: 'high',
         original_request: 'I never got my invoice',


### PR DESCRIPTION
## Summary
- Adds `user_email` and `user_slack_handle` columns to escalations so admins can follow up with users whose Slack isn't linked to an AgenticAdvertising.org account
- Addie now asks for contact info before escalating and validates email format
- Handler rejects escalations when there's no way to contact the user (no email, no Slack handle, no WorkOS account, no Slack ID)
- Slack notification includes a Contact line; admin UI displays email and Slack handle
- Adds `workos_user_id` index for faster user-facing escalation lookups

## Test plan
- [x] All 333 existing tests pass
- [x] TypeCheck clean
- [x] Pre-commit hooks pass (schemas, migrations, docs, unit tests, OpenAPI)
- [ ] Deploy and verify migration 281 runs cleanly
- [ ] Test escalation flow in Slack with unlinked user — confirm email/handle are collected and shown in notification


🤖 Generated with [Claude Code](https://claude.com/claude-code)