### PR TITLE
fix: certification UX — links, active tab, demo timing, deploy

### DIFF
--- a/.changeset/cert-ux-fixes.md
+++ b/.changeset/cert-ux-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Certification UX fixes: links open in new tabs, active tab highlighting, demo timing, deploy grace period.

--- a/fly.toml
+++ b/fly.toml
@@ -31,7 +31,7 @@ primary_region = 'iad'
   [[http_service.checks]]
     interval = "15s"
     timeout = "5s"
-    grace_period = "30s"
+    grace_period = "120s"
     method = "GET"
     path = "/health"
     protocol = "http"

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -1168,6 +1168,18 @@
 
     .tab-item.active {
       background: var(--color-primary-50);
+      font-weight: 500;
+    }
+
+    .tab-item.active::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 6px;
+      bottom: 6px;
+      width: 3px;
+      border-radius: 2px;
+      background: var(--color-brand);
     }
 
     .tab-item-indicator {
@@ -3389,9 +3401,9 @@
           // Validate URL scheme - only allow safe protocols
           const safeHref = /^(https?:\/\/|mailto:|#|\/)/i.test(href) ? href : '#';
           const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
-          // Use target="_blank" only for external links
-          const isExternal = /^https?:\/\//i.test(href);
-          const targetAttr = isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
+          // Open all navigable links in new tab — chat is an SPA, navigating away loses context
+          const isAnchor = /^#/.test(href);
+          const targetAttr = !isAnchor ? ' target="_blank" rel="noopener noreferrer"' : '';
           return `<a href="${escapeAttr(safeHref)}"${titleAttr}${targetAttr}>${text}</a>`;
         };
 

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -220,6 +220,7 @@ export async function buildCertificationContext(
   lines.push('- End EVERY response with a question or task for the learner.');
   lines.push('- Vary turn structure: some bare questions, some "try this", some analogies. Not always explain-then-ask.');
   lines.push('- Share doc links INLINE when discussing a concept (see resources below). At least 2-3 per session.');
+  lines.push('- First turn: greet the learner and ask about their background. Never run tools on the first turn.');
   lines.push('- If a demo fails, pivot immediately. Never offer the same failed demo twice.');
   lines.push('- At concept transitions, ask the learner to self-assess: "Which feels solid? Which needs more work?"');
   lines.push('');
@@ -935,12 +936,13 @@ export function createCertificationToolHandlers(
         lines.push('- **Keep responses SHORT.** Maximum 150 words per response. One idea per turn — teach one thing, then ask a question. If you have more to say, save it for the next turn. Brevity forces participation.');
         lines.push('- **Every response MUST end with a question or task.** Never end with only an explanation. Ask the learner something, give them a scenario, or have them try something. This is a conversation, not a lecture.');
         lines.push('- **Vary your turn structure.** Don\'t fall into explain-then-ask every turn. Some turns should be a bare question with no preamble. Some should be "try this and tell me what you see." Some should be a short analogy followed by a scenario. Vary the rhythm.');
-        lines.push('- **Start with a live demo when possible.** If the module has demo_scenarios or exercises, do the hands-on part FIRST. If a demo fails or is blocked, pivot immediately — describe what the result would look like, or move to the next concept. Never offer the same failed demo twice.');
+        lines.push('- **Your first turn is ALWAYS about the learner.** Greet them, ask what they work on and what they already know. Never run a tool call or demo on the first turn — build rapport first.');
+        lines.push('- **Demo early, but not first.** If the module has demo_scenarios or exercises, run them on turn 2-3 after you know the learner. If a demo fails or is blocked, pivot immediately — describe what the result would look like, or move to the next concept. Never offer the same failed demo twice.');
         lines.push('');
         lines.push('### Teaching flow');
         lines.push('');
         lines.push('1. **Understand the learner first.** Before teaching anything, ask what they already know, what they work on, what they\'re curious about. Use their answer to personalize everything that follows. If they sell running shoes, your examples should be about running shoes — and keep using their context throughout the session, not just in the first turn. When a concept maps naturally to their domain, use it. When the mapping would be forced, use the protocol\'s own examples and explain why the concept matters regardless of vertical.');
-        lines.push('2. **Demo early.** If the lesson plan has live demos or exercises, run them in the first 2-3 turns. Let the learner see a real agent response before you explain the theory. "Let me show you something" is more powerful than "Let me explain something."');
+        lines.push('2. **Demo early (turn 2-3).** If the lesson plan has live demos or exercises, run them after your opening question — once you know the learner. Let the learner see a real agent response before you explain the theory. "Let me show you something" is more powerful than "Let me explain something."');
         lines.push('3. **Teach from where they are.** If they claim prior knowledge, verify it with a targeted question before skipping ahead: "You mentioned you\'ve worked with programmatic — can you describe how second-price auctions differ from first-price in practice?" If they demonstrate real understanding, advance to where their knowledge ends. Don\'t re-teach what they already know.');
         lines.push('4. **When you correct a misconception, check that the correction landed.** Don\'t just explain the right answer — ask a follow-up question that tests whether they got it. "Does that reframe make sense? Can you think of an example where that would apply?"');
         lines.push('5. **Scaffold then fade.** Early in a module, guide heavily: give examples, offer choices, provide hints. As the learner demonstrates understanding, pull back: ask open-ended questions, present novel scenarios, expect them to reason without help. By assessment time, the learner should be doing most of the thinking.');

--- a/server/src/db/migrations/282_a1_teaching_notes_fix.sql
+++ b/server/src/db/migrations/282_a1_teaching_notes_fix.sql
@@ -1,0 +1,24 @@
+-- Fix A1 teaching notes: don't attempt live demo on the very first turn.
+-- When the sandbox agent is slow or unreachable, the learner's first experience
+-- is a failure message. Instead, greet the learner and ask about their background
+-- first, then run the demo on turn 2-3.
+
+UPDATE certification_modules SET
+  lesson_plan = '{
+    "objectives": [
+      "Explain the difference between agentic and traditional programmatic advertising",
+      "Understand AdCP covers 19 channels including linear TV, radio, print, and DOOH — not just digital",
+      "Query a live agent and interpret the response",
+      "Articulate why a shared protocol matters for AI-powered advertising"
+    ],
+    "key_concepts": [
+      {"topic": "Agentic vs traditional programmatic", "teaching_notes": "First, learn about the learner — what they work on, what they know about programmatic. Then query @cptestagent using get_products to show the paradigm shift — goal-driven agents vs rigid APIs. Let the protocol speak for itself before lecturing."},
+      {"topic": "Not just digital", "teaching_notes": "AdCP covers 19 channels: display, social, search, CTV, linear TV, AM/FM radio, podcast, streaming audio, DOOH, OOH, print, cinema, email, gaming, retail media, influencer, affiliate, product placement. Can you buy local radio? Yes. Broadcast syndication? Yes. The same protocol buys a TikTok ad and a local news spot."},
+      {"topic": "AI agents in advertising", "teaching_notes": "An agent perceives, decides, and acts autonomously. In advertising, agents discover inventory, negotiate pricing, manage creatives, and optimize campaigns. Use the live @cptestagent interaction to ground this — the learner just talked to an agent."},
+      {"topic": "The protocol hierarchy", "teaching_notes": "AdCP is built on MCP (Model Context Protocol). MCP handles transport. AdCP adds the advertising domain. Multiple transports work: MCP and A2A. Keep this brief — the point is that AdCP works across different connection methods."}
+    ],
+    "demo_scenarios": [
+      {"description": "Query @cptestagent for available products", "tools": ["get_products"], "expected_outcome": "See products with pricing, targeting options, and format support — a real agent response, not a slide deck"}
+    ]
+  }'
+WHERE id = 'A1';


### PR DESCRIPTION
## Summary
- Chat links now open in new tabs (SPA navigation loses conversation context)
- Active sidebar tab gets a brand-colored pill indicator for visibility
- Teaching prompt: first turn greets the learner, demos on turn 2-3 (prevents first-message demo failures when sandbox agent is slow)
- Fly health check grace period 30s → 120s (Addie initializes async, old value caused 503s during rolling deploys)

## Context
Addresses feedback from Steve Giacomelli testing the certification program.

## Test plan
- [ ] Open chat, click a link in Addie's response → opens in new tab
- [ ] Start a conversation → active tab shows brand-colored pill indicator on left edge
- [ ] Start module A1 → Addie greets and asks about background before attempting demo
- [ ] Deploy to staging → verify zero-downtime with `fly deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)