### PR TITLE
fix: use correct Fly metadata key in deploy verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
           # Get image digests for started app machines only
           images=$(flyctl machines list --json | \
-            jq -r '[.[] | select(.config.metadata.process_group == "app" and .state == "started") | .image_ref.digest] | unique')
+            jq -r '[.[] | select(.config.metadata.fly_process_group == "app" and .state == "started") | .image_ref.digest] | unique')
 
           count=$(echo "$images" | jq 'length')
 
@@ -57,7 +57,7 @@ jobs:
         run: |
           # Destroy any leftover fly_app_console machines
           consoles=$(flyctl machines list --json | \
-            jq -r '.[] | select(.config.metadata.process_group == "fly_app_console") | .id')
+            jq -r '.[] | select(.config.metadata.fly_process_group == "fly_app_console") | .id')
 
           if [ -n "$consoles" ]; then
             echo "Cleaning up stale console machines:"


### PR DESCRIPTION
## Summary

- Fix deploy verification step: Fly machines JSON uses `fly_process_group` in `config.metadata`, not `process_group`
- The previous deploy (#1418) succeeded but verification failed with "No running app machines found" because the jq filter matched nothing

Both machines deployed correctly and are on the same image — this is just the verification script fix.

## Test plan

- [ ] Merge and verify deploy workflow passes all steps including verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)