### PR TITLE
fix: surface error details in auto-add members backfill

### DIFF
--- a/.changeset/huge-clouds-check.md
+++ b/.changeset/huge-clouds-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Surface error details in auto-add domain users backfill (admin-only)

--- a/server/public/admin-domain-health.html
+++ b/server/public/admin-domain-health.html
@@ -1998,6 +1998,40 @@
       }
     }
 
+    function renderErrorDetails(details) {
+      const errorOrgs = details.filter(d => d.error_details && d.error_details.length > 0);
+      if (errorOrgs.length === 0) return '';
+
+      // Group errors by message to find common patterns
+      const errorsByMessage = {};
+      for (const org of errorOrgs) {
+        for (const e of org.error_details) {
+          const key = e.message;
+          if (!errorsByMessage[key]) errorsByMessage[key] = [];
+          errorsByMessage[key].push({ org_name: org.org_name, email: e.email });
+        }
+      }
+
+      let html = `<details style="margin-top: var(--space-2);">
+        <summary style="cursor: pointer; font-size: var(--text-sm); color: var(--color-error-600); font-weight: var(--font-medium);">
+          View error details
+        </summary>
+        <div style="margin-top: var(--space-2); padding: var(--space-3); background: var(--color-error-50); border: 1px solid var(--color-error-200); border-radius: var(--radius-md); font-size: var(--text-sm);">`;
+
+      for (const [message, items] of Object.entries(errorsByMessage)) {
+        html += `<div style="margin-bottom: var(--space-3);">
+          <div style="font-weight: var(--font-medium); color: var(--color-error-700);">${escapeHtml(message)} (${items.length})</div>
+          <ul style="margin: var(--space-1) 0 0 var(--space-4); color: var(--color-text-secondary);">
+            ${items.slice(0, 10).map(i => `<li>${escapeHtml(i.email)} — ${escapeHtml(i.org_name)}</li>`).join('')}
+            ${items.length > 10 ? `<li>...and ${items.length - 10} more</li>` : ''}
+          </ul>
+        </div>`;
+      }
+
+      html += `</div></details>`;
+      return html;
+    }
+
     // Run member backfill
     async function runMemberBackfill() {
       const btn = document.getElementById('memberBackfillBtn');
@@ -2041,9 +2075,10 @@
               ${result.total_skipped > 0 ? `<div style="font-size: var(--text-sm); color: var(--color-text-secondary);">${result.total_skipped} already members (skipped)</div>` : ''}
               ${result.total_errors > 0 ? `<div style="font-size: var(--text-sm); color: var(--color-error-600);">${result.total_errors} errors</div>` : ''}
               <ul style="margin: var(--space-2) 0 0 var(--space-4); font-size: var(--text-sm); color: var(--color-text-secondary);">
-                ${result.details.slice(0, 5).map(d => `<li>${escapeHtml(d.org_name)} (${d.domain}): ${d.added} added${d.skipped > 0 ? `, ${d.skipped} skipped` : ''}</li>`).join('')}
+                ${result.details.slice(0, 5).map(d => `<li>${escapeHtml(d.org_name)} (${escapeHtml(d.domain)}): ${d.added} added${d.skipped > 0 ? `, ${d.skipped} skipped` : ''}${d.errors > 0 ? `, ${d.errors} failed` : ''}</li>`).join('')}
                 ${result.details.length > 5 ? `<li>...and ${result.details.length - 5} more</li>` : ''}
               </ul>
+              ${result.total_errors > 0 ? renderErrorDetails(result.details) : ''}
             </div>
           `;
         } else {

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -2386,6 +2386,7 @@ export function setupDomainRoutes(
           added: number;
           skipped: number;
           errors: number;
+          error_details?: Array<{ email: string; message: string }>;
         }> = [];
 
         for (const row of result.rows) {
@@ -2393,6 +2394,7 @@ export function setupDomainRoutes(
           let orgAdded = 0;
           let orgSkipped = 0;
           let orgErrors = 0;
+          const orgErrorDetails: Array<{ email: string; message: string }> = [];
 
           // Get existing members for this org (paginate through all)
           const existingMemberUserIds = new Set<string>();
@@ -2409,8 +2411,25 @@ export function setupDomainRoutes(
               }
               after = memberships.listMetadata?.after ?? undefined;
             } while (after);
-          } catch (err) {
+          } catch (err: any) {
+            const rawMessage = err?.message || err?.code || 'Unknown error';
+            const errorMessage = rawMessage.length > 200 ? rawMessage.slice(0, 200) + '...' : rawMessage;
             logger.warn({ err, orgId }, 'Failed to get memberships for org, skipping');
+            const userCount = (row.users as Array<unknown>).length;
+            orgErrors += userCount;
+            for (const user of row.users as Array<{ email: string }>) {
+              orgErrorDetails.push({ email: user.email, message: `Could not list org memberships: ${errorMessage}` });
+            }
+            details.push({
+              org_id: orgId,
+              org_name: row.org_name,
+              domain: row.domain,
+              added: 0,
+              skipped: 0,
+              errors: userCount,
+              error_details: orgErrorDetails,
+            });
+            totalErrors += userCount;
             continue;
           }
 
@@ -2442,8 +2461,11 @@ export function setupDomainRoutes(
                 // User is already a member or has a pending invitation
                 orgSkipped++;
               } else {
+                const rawMessage = err?.message || err?.code || 'Unknown error';
+                const errorMessage = rawMessage.length > 200 ? rawMessage.slice(0, 200) + '...' : rawMessage;
                 logger.warn({ err, orgId, email: user.email }, 'Failed to add domain user');
                 orgErrors++;
+                orgErrorDetails.push({ email: user.email, message: errorMessage });
               }
             }
           }
@@ -2456,6 +2478,7 @@ export function setupDomainRoutes(
               added: orgAdded,
               skipped: orgSkipped,
               errors: orgErrors,
+              ...(orgErrorDetails.length > 0 && { error_details: orgErrorDetails }),
             });
           }
 


### PR DESCRIPTION
## Summary
- **Backend**: Capture actual WorkOS error messages per user/org instead of just incrementing a counter. Org-level membership listing failures now counted as errors (previously silently skipped via `continue`). Error messages capped at 200 chars.
- **Frontend**: Collapsible "View error details" section groups errors by message type, showing affected emails and orgs. All dynamic values escaped. Per-org lines now show failure counts.
- **XSS fix**: Pre-existing unescaped `d.domain` in result HTML now uses `escapeHtml()`

## Test plan
- [ ] Run auto-add backfill on staging, verify error details appear in collapsible section
- [ ] Verify errors are grouped by message type (e.g., "User not found" shows all affected emails)
- [ ] Verify XSS protection: all dynamic values in result HTML are escaped
- [ ] Verify 0-error case: collapsible section does not appear when no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)