### PR TITLE
feat: make delivery_measurement optional in product schema

### DIFF
--- a/.changeset/optional-delivery-measurement.md
+++ b/.changeset/optional-delivery-measurement.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Make `delivery_measurement` optional in the product schema. Publishers without integrated measurement tools can now omit this field rather than providing vague values.

--- a/docs/media-buy/advanced-topics/pricing-models.mdx
+++ b/docs/media-buy/advanced-topics/pricing-models.mdx
@@ -108,7 +108,7 @@ By accepting the product, buyers agree to use the declared measurement provider 
 
 **Billing**: Charged per 1,000 viewable impressions (impressions meeting MRC viewability threshold). Viewability is measured by the declared measurement provider.
 
-**Measurement Requirements**: Publishers should declare their viewability measurement provider in the product's `delivery_measurement` field. Common providers include IAS (Integral Ad Science), DoubleVerify, MOAT, and Google Active View.
+**Measurement**: When available, publishers declare their viewability measurement provider in the optional `delivery_measurement` field. Common providers include IAS (Integral Ad Science), DoubleVerify, MOAT, and Google Active View.
 
 ---
 

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -21,7 +21,7 @@ Products declare which pricing models they support. Buyers select a specific pri
 - `placements` (list[Placement], optional): Specific ad placements within this product. When provided, buyers can target individual placements when assigning creatives. See [Placements](#placements).
 - `delivery_type` (string, required): Either `"guaranteed"` or `"non_guaranteed"`.
 - `pricing_options` (list[PricingOption], required): Array of available pricing models for this product. See [Pricing Models](#pricing-models).
-- `delivery_measurement` (object, required): Who measures ad delivery — the ad server and viewability vendor used to count impressions (e.g., "Google Ad Manager with IAS viewability"). See [Delivery Measurement](#delivery-measurement-required).
+- `delivery_measurement` (object, optional): Who measures ad delivery — the ad server and viewability vendor used to count impressions (e.g., "Google Ad Manager with IAS viewability"). When absent, buyers should apply their own measurement defaults. See [Delivery Measurement](#delivery-measurement).
 - `outcome_measurement` (OutcomeMeasurement, optional): Business outcome measurement included with the product — incremental sales lift, brand lift studies, etc. Common for retail media products.
 - `creative_policy` (CreativePolicy, optional): Creative requirements and restrictions.
 - `is_custom` (bool, optional): `true` if the product was generated for a specific brief.
@@ -127,9 +127,9 @@ For auction-based pricing (no `fixed_price`), use `floor_price` for minimum bid 
 }
 ```
 
-#### Delivery Measurement (Required)
+#### Delivery Measurement
 
-All products MUST declare their measurement provider:
+Products SHOULD declare their measurement provider when available:
 ```json
 {
   "delivery_measurement": {

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -237,7 +237,7 @@ Returns an array of `products` and optionally `proposals`.
 | `publisher_properties` | PublisherProperty[] | Array of publisher entries, each with `publisher_domain` and either `property_ids` or `property_tags` |
 | `format_ids` | FormatID[] | Supported creative format IDs |
 | `delivery_type` | string | `"guaranteed"` or `"non_guaranteed"` |
-| `delivery_measurement` | DeliveryMeasurement | How delivery is measured (impressions, views, etc.) |
+| `delivery_measurement` | DeliveryMeasurement | (Optional) How delivery is measured (impressions, views, etc.) |
 | `pricing_options` | PricingOption[] | Available pricing models (CPM, CPCV, etc.). Auction options may include `floor_price` and optional `price_guidance`. Bid-based auction models (CPM, vCPM, CPC, CPCV, CPV) may also include optional `max_bid` (boolean). |
 | `brief_relevance` | string | Why this product matches the brief (when brief provided) |
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -89,7 +89,7 @@ describe('buildCatalog', () => {
 
   describe('schema-required fields on every product', () => {
     // product.json required: product_id, name, description,
-    // publisher_properties, format_ids, delivery_type, delivery_measurement, pricing_options
+    // publisher_properties, format_ids, delivery_type, pricing_options
 
     it('has product_id as a non-empty string', () => {
       for (const cp of catalog) {
@@ -134,12 +134,13 @@ describe('buildCatalog', () => {
       }
     });
 
-    it('has delivery_measurement with required provider field', () => {
+    it('has valid delivery_measurement when present', () => {
       for (const cp of catalog) {
-        const dm = cp.product.delivery_measurement as Record<string, unknown>;
-        expect(dm).toBeDefined();
-        expect(typeof dm.provider).toBe('string');
-        expect((dm.provider as string).length).toBeGreaterThan(0);
+        const dm = cp.product.delivery_measurement as Record<string, unknown> | undefined;
+        if (dm) {
+          expect(typeof dm.provider).toBe('string');
+          expect((dm.provider as string).length).toBeGreaterThan(0);
+        }
       }
     });
 
@@ -781,7 +782,6 @@ describe('get_products handler', () => {
       expect(Array.isArray(p.publisher_properties)).toBe(true);
       expect(Array.isArray(p.format_ids)).toBe(true);
       expect(typeof p.delivery_type).toBe('string');
-      expect(p.delivery_measurement).toBeDefined();
       expect(Array.isArray(p.pricing_options)).toBe(true);
     }
   });

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -68,7 +68,7 @@
     },
     "delivery_measurement": {
       "type": "object",
-      "description": "Measurement provider and methodology for delivery metrics. The buyer accepts the declared provider as the source of truth for the buy. REQUIRED for all products.",
+      "description": "Measurement provider and methodology for delivery metrics. The buyer accepts the declared provider as the source of truth for the buy. When absent, buyers should apply their own measurement defaults.",
       "properties": {
         "provider": {
           "type": "string",
@@ -289,7 +289,6 @@
     "publisher_properties",
     "format_ids",
     "delivery_type",
-    "delivery_measurement",
     "pricing_options"
   ],
   "additionalProperties": true

--- a/tests/VALIDATION_GUIDE.md
+++ b/tests/VALIDATION_GUIDE.md
@@ -71,7 +71,7 @@ const constraints = {
     (actual, path) => {
       const product = actual.products[0];
       if (product.delivery_type === 'guaranteed' && !product.delivery_measurement) {
-        throw new Error(`${path}: Guaranteed products must have delivery_measurement`);
+        console.warn(`${path}: Guaranteed products should have delivery_measurement`);
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Removes `delivery_measurement` from the `required` array in `core/product.json` so publishers without integrated measurement tools can omit it
- Updates docs across media-products, get_products task reference, and pricing-models to reflect optionality
- Updates training agent tests to validate the field only when present
- Softens validation guide example from error to warning

Closes #1340

## Test plan
- [x] All 359 tests pass (schema validation, examples, unit tests)
- [x] Pre-commit hooks pass (including Mintlify link check — no broken links)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)