### PR TITLE
Add policy registry endpoints to OpenAPI spec

### DIFF
--- a/.changeset/many-beans-switch.md
+++ b/.changeset/many-beans-switch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add policy registry endpoints to OpenAPI spec (list, resolve, bulk resolve, history, save).

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -61,6 +61,7 @@ const TAG_DESCRIPTIONS: Record<string, string> = {
   "Validation Tools": "Validate publisher adagents.json files and generate compliant configurations.",
   "Search": "Cross-entity search across brands, publishers, agents, and properties.",
   "Agent Probing": "Connect to live agents and inspect their capabilities, formats, and inventory.",
+  "Policy Registry": "Browse, resolve, and contribute governance policies for campaign compliance.",
 };
 
 const TAG_ORDER = Object.keys(TAG_DESCRIPTIONS);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -33,6 +33,9 @@ import {
   FindCompanyResultSchema,
   BrandActivitySchema,
   PropertyActivitySchema,
+  PolicySchema,
+  PolicySummarySchema,
+  PolicyHistorySchema,
 } from "../schemas/registry.js";
 
 import type { BrandManager } from "../brand-manager.js";
@@ -795,6 +798,169 @@ registry.registerPath({
         },
       },
     },
+  },
+});
+
+// ── Policy Registry ────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/api/policies/registry",
+  operationId: "listPolicies",
+  summary: "List policies",
+  description:
+    "Browse and search the governance policy registry. Returns approved policies with optional filtering by category, enforcement level, jurisdiction, vertical, and governance domain.",
+  tags: ["Policy Registry"],
+  request: {
+    query: z.object({
+      search: z.string().optional().openapi({ description: "Full-text search on policy name and description" }),
+      category: z.enum(["regulation", "standard"]).optional(),
+      enforcement: z.enum(["must", "should", "may"]).optional(),
+      jurisdiction: z.string().optional().openapi({ example: "EU", description: "Filter by jurisdiction (includes region alias matching)" }),
+      vertical: z.string().optional().openapi({ example: "finance" }),
+      domain: z.string().optional().openapi({ example: "campaign", description: "Filter by governance domain" }),
+      limit: z.string().optional().openapi({ description: "Results per page (default 20, max 1000)" }),
+      offset: z.string().optional().openapi({ description: "Pagination offset (default 0)" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Policy listing with facet stats",
+      content: {
+        "application/json": {
+          schema: z.object({
+            policies: z.array(PolicySummarySchema),
+            stats: z.object({
+              total: z.number().int(),
+              regulation: z.number().int(),
+              standard: z.number().int(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/policies/resolve",
+  operationId: "resolvePolicy",
+  summary: "Resolve policy",
+  description:
+    "Resolve a single policy by ID. Optionally pin to a specific version — returns null if the version does not match.",
+  tags: ["Policy Registry"],
+  request: {
+    query: z.object({
+      policy_id: z.string().openapi({ example: "gdpr_consent" }),
+      version: z.string().optional().openapi({ description: "Return null if the current version does not match" }),
+    }),
+  },
+  responses: {
+    200: { description: "Policy resolved", content: { "application/json": { schema: PolicySchema } } },
+    400: { description: "Missing policy_id", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Policy not found", content: { "application/json": { schema: z.object({ error: z.string(), policy_id: z.string() }) } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/policies/resolve/bulk",
+  operationId: "resolvePoliciesBulk",
+  summary: "Bulk resolve policies",
+  description:
+    "Resolve up to 100 policies by ID in a single request. Returns a map of policy_id to Policy (or null if not found).\n\n**Rate limit:** 20 requests per minute per IP address.",
+  tags: ["Policy Registry"],
+  request: {
+    body: { content: { "application/json": { schema: z.object({ policy_ids: z.array(z.string()).min(1).max(100).openapi({ example: ["gdpr_consent", "coppa_children"] }) }) } } },
+  },
+  responses: {
+    200: { description: "Bulk resolution results", content: { "application/json": { schema: z.object({ results: z.record(z.string(), PolicySchema.nullable()) }) } } },
+    400: { description: "Invalid request", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/policies/history",
+  operationId: "getPolicyHistory",
+  summary: "Policy revision history",
+  description:
+    "Retrieve the edit history for a policy. Each revision records who made the change, a summary, and whether it was a rollback.",
+  tags: ["Policy Registry"],
+  request: {
+    query: z.object({
+      policy_id: z.string().openapi({ example: "gdpr_consent" }),
+      limit: z.string().optional().openapi({ description: "Results per page (max 100, default 20)" }),
+      offset: z.string().optional().openapi({ description: "Pagination offset (default 0)" }),
+    }),
+  },
+  responses: {
+    200: { description: "Revision history", content: { "application/json": { schema: PolicyHistorySchema } } },
+    400: { description: "Missing policy_id", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Policy not found", content: { "application/json": { schema: z.object({ error: z.string(), policy_id: z.string() }) } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/policies/save",
+  operationId: "savePolicy",
+  summary: "Save policy",
+  description:
+    "Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.",
+  tags: ["Policy Registry"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            policy_id: z.string().openapi({ example: "my_brand_safety", description: "Lowercase alphanumeric with underscores" }),
+            version: z.string().openapi({ example: "1.0.0" }),
+            name: z.string().openapi({ example: "Acme Corp Brand Safety" }),
+            category: z.enum(["regulation", "standard"]),
+            enforcement: z.enum(["must", "should", "may"]),
+            policy: z.string().openapi({ example: "Ads must not appear adjacent to content depicting violence..." }),
+            description: z.string().optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            region_aliases: z.record(z.string(), z.array(z.string())).optional(),
+            verticals: z.array(z.string()).optional(),
+            channels: z.array(z.string()).optional(),
+            effective_date: z.string().optional(),
+            sunset_date: z.string().optional(),
+            governance_domains: z.array(z.string()).optional(),
+            source_url: z.string().optional().openapi({ description: "Must use http:// or https://" }),
+            source_name: z.string().optional(),
+            guidance: z.string().optional(),
+            exemplars: z.object({
+              pass: z.array(z.object({ scenario: z.string(), explanation: z.string() })).optional(),
+              fail: z.array(z.object({ scenario: z.string(), explanation: z.string() })).optional(),
+            }).optional(),
+            ext: z.record(z.string(), z.unknown()).optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Policy saved",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+            message: z.string(),
+            policy_id: z.string(),
+            revision_number: z.number().int().nullable(),
+          }),
+        },
+      },
+    },
+    400: { description: "Validation error", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Cannot edit registry-sourced or pending policy", content: { "application/json": { schema: z.object({ error: z.string(), policy_id: z.string() }) } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -323,3 +323,64 @@ export const PropertyActivitySchema = z
   })
   .openapi("PropertyActivity");
 
+// ── Policy Registry ────────────────────────────────────────────
+
+const PolicyExemplarSchema = z.object({
+  scenario: z.string().openapi({ example: "Ad for alcohol shown during children's programming" }),
+  explanation: z.string().openapi({ example: "Violates watershed timing rules for alcohol advertising" }),
+});
+
+export const PolicySchema = z
+  .object({
+    policy_id: z.string().openapi({ example: "gdpr_consent" }),
+    version: z.string().openapi({ example: "1.0.0" }),
+    name: z.string().openapi({ example: "GDPR Consent Requirements" }),
+    description: z.string().nullable().openapi({ example: "Requirements for valid consent under GDPR" }),
+    category: z.enum(["regulation", "standard"]),
+    enforcement: z.enum(["must", "should", "may"]),
+    jurisdictions: z.array(z.string()).openapi({ example: ["EU", "EEA"] }),
+    region_aliases: z.record(z.string(), z.array(z.string())).openapi({ example: { EU: ["DE", "FR", "IT"] } }),
+    verticals: z.array(z.string()).openapi({ example: ["finance", "healthcare"] }),
+    channels: z.array(z.string()).nullable().openapi({ example: ["display", "video"] }),
+    governance_domains: z.array(z.string()).openapi({ example: ["campaign", "creative"] }),
+    effective_date: z.string().nullable().openapi({ example: "2025-05-25" }),
+    sunset_date: z.string().nullable(),
+    source_url: z.string().nullable().openapi({ example: "https://eur-lex.europa.eu/eli/reg/2016/679/oj" }),
+    source_name: z.string().nullable().openapi({ example: "EUR-Lex" }),
+    policy: z.string().openapi({ example: "Data subjects must provide freely given, specific, informed and unambiguous consent..." }),
+    guidance: z.string().nullable(),
+    exemplars: z
+      .object({
+        pass: z.array(PolicyExemplarSchema).optional(),
+        fail: z.array(PolicyExemplarSchema).optional(),
+      })
+      .nullable(),
+    ext: z.record(z.string(), z.unknown()).nullable(),
+    source_type: z.enum(["registry", "community"]),
+    review_status: z.enum(["pending", "approved"]),
+    created_at: z.string().openapi({ example: "2026-03-01T12:00:00.000Z" }),
+    updated_at: z.string().openapi({ example: "2026-03-01T12:00:00.000Z" }),
+  })
+  .openapi("Policy");
+
+export const PolicySummarySchema = PolicySchema
+  .omit({ policy: true, guidance: true, exemplars: true, ext: true })
+  .openapi("PolicySummary");
+
+const PolicyRevisionEntrySchema = z.object({
+  revision_number: z.number().int().openapi({ example: 2 }),
+  editor_name: z.string().openapi({ example: "Pinnacle Media" }),
+  edit_summary: z.string().openapi({ example: "Clarified consent requirements for minors" }),
+  is_rollback: z.boolean(),
+  rolled_back_to: z.number().int().optional().openapi({ description: "Revision number that was restored; only present when is_rollback is true" }),
+  created_at: z.string().openapi({ example: "2026-03-01T12:34:56Z" }),
+});
+
+export const PolicyHistorySchema = z
+  .object({
+    policy_id: z.string().openapi({ example: "gdpr_consent" }),
+    total: z.number().int().openapi({ example: 3 }),
+    revisions: z.array(PolicyRevisionEntrySchema),
+  })
+  .openapi("PolicyHistory");
+

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -606,6 +606,344 @@ components:
           type: array
           items:
             type: string
+    PolicySummary:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        verticals:
+          type: array
+          items:
+            type: string
+          example:
+            - finance
+            - healthcare
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - verticals
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    Policy:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        verticals:
+          type: array
+          items:
+            type: string
+          example:
+            - finance
+            - healthcare
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        policy:
+          type: string
+          example: Data subjects must provide freely given, specific, informed and unambiguous consent...
+        guidance:
+          type:
+            - string
+            - "null"
+        exemplars:
+          type:
+            - object
+            - "null"
+          properties:
+            pass:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+            fail:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+        ext:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - verticals
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - policy
+        - guidance
+        - exemplars
+        - ext
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    PolicyHistory:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 2
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Clarified consent requirements for minors
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - policy_id
+        - total
+        - revisions
 paths:
   /api:
     get:
@@ -2243,6 +2581,428 @@ paths:
                   - property_count
                   - property_type_counts
                   - tag_count
+  /api/policies/registry:
+    get:
+      operationId: listPolicies
+      summary: List policies
+      description: Browse and search the governance policy registry. Returns approved policies with optional filtering by category, enforcement level, jurisdiction, vertical, and governance domain.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            description: Full-text search on policy name and description
+          required: false
+          description: Full-text search on policy name and description
+          name: search
+          in: query
+        - schema:
+            type: string
+            enum:
+              - regulation
+              - standard
+          required: false
+          name: category
+          in: query
+        - schema:
+            type: string
+            enum:
+              - must
+              - should
+              - may
+          required: false
+          name: enforcement
+          in: query
+        - schema:
+            type: string
+            example: EU
+            description: Filter by jurisdiction (includes region alias matching)
+          required: false
+          description: Filter by jurisdiction (includes region alias matching)
+          name: jurisdiction
+          in: query
+        - schema:
+            type: string
+            example: finance
+          required: false
+          name: vertical
+          in: query
+        - schema:
+            type: string
+            example: campaign
+            description: Filter by governance domain
+          required: false
+          description: Filter by governance domain
+          name: domain
+          in: query
+        - schema:
+            type: string
+            description: Results per page (default 20, max 1000)
+          required: false
+          description: Results per page (default 20, max 1000)
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Policy listing with facet stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PolicySummary"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      regulation:
+                        type: integer
+                      standard:
+                        type: integer
+                    required:
+                      - total
+                      - regulation
+                      - standard
+                required:
+                  - policies
+                  - stats
+  /api/policies/resolve:
+    get:
+      operationId: resolvePolicy
+      summary: Resolve policy
+      description: Resolve a single policy by ID. Optionally pin to a specific version — returns null if the version does not match.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: string
+            description: Return null if the current version does not match
+          required: false
+          description: Return null if the current version does not match
+          name: version
+          in: query
+      responses:
+        "200":
+          description: Policy resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Policy"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/resolve/bulk:
+    post:
+      operationId: resolvePoliciesBulk
+      summary: Bulk resolve policies
+      description: |-
+        Resolve up to 100 policies by ID in a single request. Returns a map of policy_id to Policy (or null if not found).
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Policy Registry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_ids:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  maxItems: 100
+                  example:
+                    - gdpr_consent
+                    - coppa_children
+              required:
+                - policy_ids
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/Policy"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/policies/history:
+    get:
+      operationId: getPolicyHistory
+      summary: Policy revision history
+      description: Retrieve the edit history for a policy. Each revision records who made the change, a summary, and whether it was a rollback.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: string
+            description: Results per page (max 100, default 20)
+          required: false
+          description: Results per page (max 100, default 20)
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Revision history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyHistory"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/save:
+    post:
+      operationId: savePolicy
+      summary: Save policy
+      description: Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.
+      tags:
+        - Policy Registry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+                  example: my_brand_safety
+                  description: Lowercase alphanumeric with underscores
+                version:
+                  type: string
+                  example: 1.0.0
+                name:
+                  type: string
+                  example: Acme Corp Brand Safety
+                category:
+                  type: string
+                  enum:
+                    - regulation
+                    - standard
+                enforcement:
+                  type: string
+                  enum:
+                    - must
+                    - should
+                    - may
+                policy:
+                  type: string
+                  example: Ads must not appear adjacent to content depicting violence...
+                description:
+                  type: string
+                jurisdictions:
+                  type: array
+                  items:
+                    type: string
+                region_aliases:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                verticals:
+                  type: array
+                  items:
+                    type: string
+                channels:
+                  type: array
+                  items:
+                    type: string
+                effective_date:
+                  type: string
+                sunset_date:
+                  type: string
+                governance_domains:
+                  type: array
+                  items:
+                    type: string
+                source_url:
+                  type: string
+                  description: Must use http:// or https://
+                source_name:
+                  type: string
+                guidance:
+                  type: string
+                exemplars:
+                  type: object
+                  properties:
+                    pass:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                    fail:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                ext:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - policy_id
+                - version
+                - name
+                - category
+                - enforcement
+                - policy
+      responses:
+        "200":
+          description: Policy saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  policy_id:
+                    type: string
+                  revision_number:
+                    type:
+                      - integer
+                      - "null"
+                required:
+                  - success
+                  - message
+                  - policy_id
+                  - revision_number
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit registry-sourced or pending policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 tags:
   - name: Brand Resolution
     description: Resolve advertiser domains to canonical brand identities.
@@ -2258,3 +3018,5 @@ tags:
     description: Cross-entity search across brands, publishers, agents, and properties.
   - name: Agent Probing
     description: Connect to live agents and inspect their capabilities, formats, and inventory.
+  - name: Policy Registry
+    description: Browse, resolve, and contribute governance policies for campaign compliance.


### PR DESCRIPTION
## Summary
- Add 5 policy registry REST endpoints to the generated OpenAPI spec: list, resolve, bulk resolve, history, and save
- Introduce `PolicySchema`, `PolicySummarySchema` (omits heavy fields for list responses), and `PolicyHistorySchema` as reusable OpenAPI components
- Add "Policy Registry" tag to the OpenAPI generator for grouping

## Details
The policy registry endpoints were implemented in #1351 but not wired into the OpenAPI spec generation. This adds `registry.registerPath()` calls for all 5 endpoints, matching the patterns used by brand and property endpoints.

`PolicySummarySchema` omits `policy`, `guidance`, `exemplars`, and `ext` to match the SQL query used by the list endpoint, which intentionally excludes those heavy fields.

## Test plan
- [x] `npm test` — all 20 test suites pass
- [x] `npm run test:openapi` — generated spec matches committed YAML
- [x] `npx tsc --noEmit` — no new type errors
- [x] Verified all 5 endpoints appear in generated `static/openapi/registry.yaml`
- [x] Verified `Policy`, `PolicySummary`, `PolicyHistory` components in schema section

🤖 Generated with [Claude Code](https://claude.com/claude-code)