### PR TITLE
fix: copy reference-formats.json to dist in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/server/public ./server/public
 COPY --from=builder /app/server/src/db/migrations ./dist/db/migrations
+COPY --from=builder /app/server/src/creative-agent/reference-formats.json ./dist/creative-agent/
 COPY --from=builder /app/static ./static
 COPY --from=builder /app/docs ./docs
 


### PR DESCRIPTION
## Summary
- Fixes a production deploy crash caused by `reference-formats.json` not being copied into the Docker production image
- The creative agent's `task-handlers.js` requires `./reference-formats.json` at runtime, but the multi-stage Docker build only copies compiled JS from `dist/` — the JSON file (which isn't processed by tsc) was missing
- Adds a `COPY --from=builder` line to include `reference-formats.json` in `dist/creative-agent/`

**Error:**
```
Error: Cannot find module './reference-formats.json'
Require stack:
- /app/dist/creative-agent/task-handlers.js
```

## Test plan
- [ ] Deploy to staging and verify the creative agent starts without module errors
- [ ] Verify `reference-formats.json` exists at `/app/dist/creative-agent/reference-formats.json` in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)