### PR TITLE
Reskin registry pages and add cross-navigation

### DIFF
--- a/.changeset/free-maps-obey.md
+++ b/.changeset/free-maps-obey.md
@@ -1,0 +1,4 @@
+---
+---
+
+Reskin registry pages (agents, brands, properties) to match site design system. Add registry sub-nav, builder tool links, and consistent styling across all registry pages.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -7,7 +7,7 @@ description: "adagents.json is the publisher-hosted file in AdCP that declares a
 The `adagents.json` file provides a standardized way for publishers to declare their properties and authorize sales agents. This is the foundation of Property Governance - it defines what properties exist and who can sell them.
 
 <Tip>
-**[AdAgents.json Builder](https://adcontextprotocol.org/adagents)** - Validate existing files or create new ones with guided validation
+**[AdAgents.json Builder](https://agenticadvertising.org/adagents/builder)** - Validate existing files or create new ones with guided validation
 </Tip>
 
 ## File Location
@@ -589,7 +589,7 @@ Governance agents can include vendor-specific data in feature definitions via an
 
 ### Using the AdAgents.json Builder
 
-The easiest way to validate or create an adagents.json file is using the **[AdAgents.json Builder](https://adcontextprotocol.org/adagents)** web tool. It provides:
+The easiest way to validate or create an adagents.json file is using the **[AdAgents.json Builder](https://agenticadvertising.org/adagents/builder)** web tool. It provides:
 
 - Domain validation (fetches and checks `/.well-known/adagents.json`)
 - Structure validation against the JSON schema
@@ -757,4 +757,4 @@ After implementing adagents.json validation:
 - [AdCP Basics: Authorized Properties](https://bokonads.com/p/adcp-basics-authorized-properties) - Accessible introduction to AdCP authorization
 - [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities) - Discover agent capabilities and portfolio
 - [Property Schema](https://adcontextprotocol.org/schemas/v2/core/property.json) - Property definition structure
-- [AdAgents.json Builder](https://adcontextprotocol.org/adagents) - Web-based validator and creator
+- [AdAgents.json Builder](https://agenticadvertising.org/adagents/builder) - Web-based validator and creator

--- a/docs/guides/seller-integration.mdx
+++ b/docs/guides/seller-integration.mdx
@@ -219,7 +219,7 @@ AdCP sits alongside your existing APIs and dashboards. It doesn't replace your s
 ## Getting started
 
 <CardGroup cols={2}>
-  <Card title="adagents.json builder" icon="hammer" href="https://adcontextprotocol.org/adagents">
+  <Card title="adagents.json builder" icon="hammer" href="https://agenticadvertising.org/adagents/builder">
     Create and validate your adagents.json file using the interactive builder.
   </Card>
   <Card title="Media buy specification" icon="file-lines" href="/docs/media-buy/specification">

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -603,13 +603,13 @@ Governance isn't a gate that slows things down. It's the safety net that lets yo
   <Card title="Quickstart guide" icon="rocket" href="/docs/quickstart">
     Get started in 5 minutes with code examples
   </Card>
-  <Card title="Brand.json builder" icon="palette" href="https://adcontextprotocol.org/brand-builder">
+  <Card title="Brand.json builder" icon="palette" href="https://agenticadvertising.org/brand/builder">
     Create and validate your brand's brand.json file
   </Card>
-  <Card title="AdAgents.json builder" icon="hammer" href="https://adcontextprotocol.org/adagents">
+  <Card title="AdAgents.json builder" icon="hammer" href="https://agenticadvertising.org/adagents/builder">
     Validate or create your publisher's adagents.json file
   </Card>
-  <Card title="Registry" icon="magnifying-glass" href="https://adcontextprotocol.org/registry">
+  <Card title="Registry" icon="magnifying-glass" href="https://agenticadvertising.org/registry">
     Browse registered agents, brands, and publishers
   </Card>
   <Card title="Building with AdCP" icon="code" href="/docs/building">

--- a/docs/signals/data-providers.mdx
+++ b/docs/signals/data-providers.mdx
@@ -506,7 +506,7 @@ Retail signals are especially valuable because they're deterministic — based o
 
 ## Validation
 
-Use the [AdAgents.json Builder](https://adcontextprotocol.org/adagents) to validate your signal catalog, or validate programmatically:
+Use the [AdAgents.json Builder](https://agenticadvertising.org/adagents/builder) to validate your signal catalog, or validate programmatically:
 
 ```bash
 curl -X POST https://adcontextprotocol.org/api/adagents/validate \

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -6,6 +6,7 @@
     <title>AdAgents.json Manager - AdCP Testing Framework</title>
     <link rel="icon" href="/AAo.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
+    <link rel="stylesheet" href="/layout.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -89,6 +90,8 @@
       .page-header {
         text-align: center;
         margin-bottom: var(--space-12);
+        background: none;
+        padding: 0;
       }
 
       .page-header h1 {
@@ -754,6 +757,7 @@
     <!-- Navigation (loaded by nav.js) -->
     <div id="adcp-nav"></div>
     <script src="/nav.js"></script>
+    <script src="/registry-nav.js"></script>
 
     <div class="main-content">
       <!-- Page Header -->

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -3,96 +3,162 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Agent registry - AgenticAdvertising.org</title>
+    <title>Agents | AgenticAdvertising.org</title>
+    <meta name="description" content="Sales, creative, and signals agents implementing AdCP.">
     <link rel="icon" href="/AAo.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
+    <link rel="stylesheet" href="/layout.css">
     <style>
-        /* =============================================================================
-           Registry Page Styles
-           Uses design system variables - see /design-system.css for tokens
-           Registry uses success/green color as accent
-           ============================================================================= */
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
-            font-family: var(--font-sans);
-            line-height: var(--leading-normal);
-            color: var(--color-text-body);
-            background: var(--color-bg-page);
+            background: #fff;
             padding-top: var(--nav-height);
         }
-        header {
-            background: linear-gradient(135deg, var(--color-success-500) 0%, var(--color-success-600) 100%);
-            color: white;
-            padding: var(--space-8) 0;
-            text-align: center;
+
+        .container {
+            max-width: var(--container-xl);
+            margin: 0 auto;
+            padding: var(--space-8) var(--space-4);
         }
-        h1 { font-size: var(--text-4xl); margin-bottom: var(--space-2); }
-        .subtitle { font-size: var(--text-lg); opacity: 0.9; }
-        .container { max-width: var(--container-2xl); margin: var(--space-8) auto; padding: 0 var(--space-4); }
 
-
-        /* Search and Filters */
-        .search-filters {
+        /* Search and filters */
+        .search-section {
             background: var(--color-bg-card);
+            border-radius: var(--card-radius);
             padding: var(--space-6);
-            border-radius: var(--radius-lg);
             margin-bottom: var(--space-8);
             box-shadow: var(--shadow-sm);
         }
         .search-box { margin-bottom: var(--space-4); }
         .search-box input {
             width: 100%;
-            padding: var(--space-3);
+            padding: var(--space-3) var(--space-4);
             border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
+            border-radius: var(--radius-lg);
             font-size: var(--text-base);
+            transition: var(--transition-colors);
         }
-        .search-box input:focus { outline: none; border-color: var(--color-success-500); }
-        .filter-row { display: flex; gap: var(--space-4); flex-wrap: wrap; align-items: center; }
-        .filter-group { display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center; }
-        .filter-group label { font-weight: var(--font-semibold); font-size: var(--text-sm); color: var(--color-text-muted); }
+        .search-box input:focus {
+            outline: none;
+            border-color: var(--color-brand);
+            box-shadow: 0 0 0 3px var(--color-primary-100);
+        }
+        .filter-row {
+            display: flex;
+            gap: var(--space-4);
+            flex-wrap: wrap;
+            align-items: center;
+        }
+        .filter-group {
+            display: flex;
+            gap: var(--space-2);
+            flex-wrap: wrap;
+            align-items: center;
+        }
+        .filter-group label {
+            font-weight: var(--font-semibold);
+            font-size: var(--text-sm);
+            color: var(--color-text-muted);
+        }
         .filter-btn {
             padding: var(--space-2) var(--space-4);
-            background: var(--color-gray-50);
+            background: var(--color-gray-100);
             border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
+            border-radius: var(--radius-lg);
             cursor: pointer;
             font-size: var(--text-sm);
             transition: var(--transition-all);
         }
-        .filter-btn:hover { border-color: var(--color-success-500); color: var(--color-success-500); }
-        .filter-btn.active { background: var(--color-success-500); border-color: var(--color-success-500); color: white; }
+        .filter-btn:hover {
+            border-color: var(--color-brand);
+        }
+        .filter-btn.active {
+            background: var(--color-primary-100);
+            border-color: var(--color-brand);
+            color: var(--color-brand);
+        }
 
-        /* Agent Grid */
-        .agent-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: var(--space-6); }
+        /* Agent grid */
+        .agent-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+            gap: var(--space-6);
+        }
         .agent-card {
             background: var(--color-bg-card);
             border-radius: var(--radius-lg);
             padding: var(--space-6);
-            box-shadow: var(--shadow-sm);
-            transition: var(--transition-all);
+            border: 1px solid var(--color-border);
+            transition: border-color 0.15s ease;
             cursor: pointer;
         }
-        .agent-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); }
-        .agent-header { display: flex; justify-content: space-between; align-items: start; margin-bottom: var(--space-4); }
+        .agent-card:hover {
+            border-color: var(--color-brand);
+        }
+        .agent-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: var(--space-4);
+        }
         .agent-title { flex: 1; }
-        .agent-name { font-size: var(--text-lg); font-weight: var(--font-semibold); margin-bottom: var(--space-1); }
-        .agent-url { font-size: var(--text-sm); color: var(--color-success-500); }
+        .agent-name {
+            font-size: var(--text-lg);
+            font-weight: var(--font-semibold);
+            color: var(--color-text-heading);
+            margin-bottom: var(--space-1);
+        }
+        .agent-url {
+            font-size: var(--text-sm);
+            color: var(--color-brand);
+        }
         .status-badge {
             padding: var(--space-1) var(--space-3);
             border-radius: var(--radius-full);
             font-size: var(--text-xs);
             font-weight: var(--font-semibold);
             text-transform: uppercase;
+            white-space: nowrap;
         }
-        .status-badge.online { background: var(--color-success-100); color: var(--color-success-800); }
-        .status-badge.offline { background: var(--color-error-100); color: var(--color-error-700); }
-        .agent-meta { display: flex; gap: var(--space-4); margin-bottom: var(--space-4); flex-wrap: wrap; }
-        .meta-item { display: flex; align-items: center; gap: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
-        .meta-value { font-weight: var(--font-semibold); color: var(--color-text-heading); }
-        .agent-properties { margin-top: var(--space-4); padding-top: var(--space-4); border-top: var(--border-1) solid var(--color-border-light); }
-        .property-tags { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-top: var(--space-2); }
+        .status-badge.online {
+            background: var(--color-success-100);
+            color: var(--color-success-700);
+        }
+        .status-badge.offline {
+            background: var(--color-error-100);
+            color: var(--color-error-700);
+        }
+        .agent-description {
+            color: var(--color-text-muted);
+            font-size: var(--text-sm);
+            margin-bottom: var(--space-2);
+        }
+        .agent-meta {
+            display: flex;
+            gap: var(--space-4);
+            flex-wrap: wrap;
+        }
+        .meta-item {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            font-size: var(--text-sm);
+            color: var(--color-text-muted);
+        }
+        .meta-value {
+            font-weight: var(--font-semibold);
+            color: var(--color-text-heading);
+        }
+        .agent-properties {
+            margin-top: var(--space-4);
+            padding-top: var(--space-4);
+            border-top: 1px solid var(--color-border-light);
+        }
+        .property-tags {
+            display: flex;
+            gap: var(--space-2);
+            flex-wrap: wrap;
+            margin-top: var(--space-2);
+        }
         .property-tag {
             padding: var(--space-1) var(--space-3);
             background: var(--color-purple-100);
@@ -101,7 +167,12 @@
             font-size: var(--text-xs);
             font-weight: var(--font-semibold);
         }
-        .formats-list { margin-top: var(--space-2); display: flex; gap: var(--space-2); flex-wrap: wrap; }
+        .formats-list {
+            margin-top: var(--space-2);
+            display: flex;
+            gap: var(--space-2);
+            flex-wrap: wrap;
+        }
         .format-badge {
             padding: var(--space-1) var(--space-3);
             background: var(--color-primary-100);
@@ -111,1307 +182,1262 @@
             font-weight: var(--font-semibold);
         }
 
-        /* Detail Page */
+        /* Detail view */
+        .detail-header {
+            background: var(--color-bg-subtle);
+            padding: var(--space-8) 0 var(--space-6);
+        }
+        .detail-header h2 {
+            font-size: var(--text-3xl);
+            margin-bottom: var(--space-2);
+            color: var(--color-text-heading);
+        }
         .back-btn {
             display: inline-flex;
             align-items: center;
             gap: var(--space-2);
-            padding: var(--space-3) var(--space-6);
-            background: var(--color-bg-card);
-            border: var(--border-2) solid var(--color-success-500);
-            color: var(--color-success-500);
-            border-radius: var(--radius-md);
+            color: var(--color-brand);
             text-decoration: none;
             font-weight: var(--font-semibold);
-            margin-bottom: var(--space-8);
+            font-size: var(--text-sm);
+            margin-bottom: var(--space-4);
         }
-        .back-btn:hover { background: var(--color-success-500); color: white; }
-        .detail-hero {
-            background: linear-gradient(135deg, var(--color-success-500) 0%, var(--color-success-600) 100%);
-            color: white;
-            padding: var(--space-12) 0;
-        }
-        .detail-hero h2 { font-size: var(--text-3xl); margin-bottom: var(--space-2); }
+        .back-btn:hover { text-decoration: underline; }
+
         .detail-content {
             background: var(--color-bg-card);
-            margin-top: calc(-1 * var(--space-8));
-            border-radius: var(--card-radius) var(--card-radius) 0 0;
+            border-radius: var(--card-radius);
             padding: var(--space-8);
+            border: 1px solid var(--color-border);
         }
-        .detail-section { margin-bottom: var(--space-8); padding-bottom: var(--space-8); border-bottom: var(--border-1) solid var(--color-border-light); }
-        .detail-section:last-child { border-bottom: none; }
+        .detail-section {
+            margin-bottom: var(--space-8);
+            padding-bottom: var(--space-8);
+            border-bottom: 1px solid var(--color-border-light);
+        }
+        .detail-section:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
         .detail-section h3 {
             font-size: var(--text-xl);
             margin-bottom: var(--space-4);
-            color: var(--color-success-500);
+            color: var(--color-text-heading);
+        }
+
+        /* Status banner */
+        .status-banner {
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            margin-bottom: var(--space-8);
             display: flex;
+            justify-content: space-between;
             align-items: center;
-            gap: var(--space-2);
+            color: white;
         }
-        .tools-list, .publishers-grid { display: grid; gap: var(--space-4); }
-        .tool-item, .publisher-item {
-            background: var(--color-gray-50);
-            padding: var(--space-4);
-            border-radius: var(--radius-md);
-            border-left: 3px solid var(--color-success-500);
-        }
-        .tool-name { font-weight: var(--font-semibold); font-family: var(--font-mono); margin-bottom: var(--space-1); }
-        .tool-description { font-size: var(--text-sm); color: var(--color-text-muted); }
-        .publisher-domain { font-weight: var(--font-semibold); margin-bottom: var(--space-1); }
-        .info-box { background: var(--color-gray-50); padding: var(--space-4); border-radius: var(--radius-md); }
-        .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
-        .error-text { color: var(--color-error-500); font-size: var(--text-sm); }
-        .hidden { display: none !important; }
-        .add-record-cta { margin-top: var(--space-4); text-align: center; }
-        .view { display: none; }
-        .view.active { display: block; }
-
-        footer {
-            background: var(--color-bg-card);
-            border-top: var(--border-2) solid var(--color-border-light);
-            padding: var(--space-8);
-            margin-top: var(--space-12);
-        }
-        .footer-content {
-            max-width: var(--container-2xl);
-            margin: 0 auto;
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: var(--space-8);
-        }
-        .footer-section h3 { font-size: var(--text-lg); margin-bottom: var(--space-4); color: var(--color-success-500); }
-        .mcp-box {
-            background: var(--color-gray-50);
-            padding: var(--space-4);
-            border-radius: var(--radius-md);
-            border-left: 3px solid var(--color-success-500);
-        }
-        .mcp-box code {
-            background: var(--color-purple-100);
-            padding: var(--space-1) var(--space-2);
-            border-radius: var(--radius-sm);
-            font-family: var(--font-mono);
-            font-size: var(--text-sm);
-            color: var(--color-purple-700);
-        }
-        .mcp-url {
-            background: var(--color-purple-100);
-            padding: var(--space-3);
-            border-radius: var(--radius-md);
-            margin: var(--space-3) 0;
-            font-family: var(--font-mono);
-            font-size: var(--text-sm);
-            word-break: break-all;
-            color: var(--color-purple-700);
-        }
-        .footer-links {
-            text-align: center;
-            margin-top: var(--space-8);
-            padding-top: var(--space-8);
-            border-top: var(--border-1) solid var(--color-border-light);
-            color: var(--color-text-muted);
-        }
-        .footer-links a { color: var(--color-success-500); text-decoration: none; margin: 0 var(--space-4); }
-
-
-        /* Collapsible details */
-        details[open] summary span { transform: rotate(90deg); }
-        details summary { user-select: none; }
-        details summary::-webkit-details-marker { display: none; }
-
-        /* Dynamic JS template styles */
-        .agent-description { color: var(--color-text-muted); font-size: var(--text-sm); margin-bottom: var(--space-2); }
-        .property-section-small { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); }
-        .format-discovery-note { margin-top: var(--space-4); font-size: var(--text-xs); color: var(--color-text-light); }
-
-        /* Status banner styles */
-        .status-banner { padding: var(--space-4); border-radius: var(--radius-md); margin-bottom: var(--space-8); display: flex; justify-content: space-between; align-items: center; color: white; }
         .status-banner--online { background: var(--color-success-500); }
         .status-banner--offline { background: var(--color-error-500); }
         .status-banner__text { font-size: var(--text-lg); font-weight: var(--font-semibold); }
         .status-banner__meta { opacity: 0.9; margin-left: var(--space-4); }
         .status-banner__time { opacity: 0.9; font-size: var(--text-sm); }
 
-        /* Compliance badge styles */
-        .compliance-badge { border-left: 4px solid; padding: var(--space-4); border-radius: var(--radius-md); margin-bottom: var(--space-8); display: flex; align-items: center; gap: var(--space-3); }
+        /* Compliance badge */
+        .compliance-badge {
+            border-left: 4px solid;
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            margin-bottom: var(--space-8);
+            display: flex;
+            align-items: center;
+            gap: var(--space-3);
+        }
         .compliance-badge--compliant { background: var(--color-success-50); border-color: var(--color-success-500); }
         .compliance-badge--incomplete { background: var(--color-warning-50); border-color: var(--color-warning-500); }
-        .compliance-badge__icon { font-size: var(--text-2xl); }
         .compliance-badge__title { font-size: var(--text-lg); font-weight: var(--font-semibold); }
         .compliance-badge__subtitle { font-size: var(--text-sm); color: var(--color-text-muted); margin-top: var(--space-1); }
 
-        /* Detail section styles */
-        .detail-section__summary { font-size: var(--text-xl); font-weight: var(--font-semibold); color: var(--color-success-500); list-style: none; display: flex; align-items: center; gap: var(--space-2); cursor: pointer; }
+        /* Collapsible detail sections */
+        .detail-section__summary {
+            font-size: var(--text-xl);
+            font-weight: var(--font-semibold);
+            color: var(--color-text-heading);
+            list-style: none;
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            cursor: pointer;
+        }
         .detail-section__arrow { transition: transform 0.2s; }
+        details[open] .detail-section__arrow { transform: rotate(90deg); }
         .detail-section__content { margin-top: var(--space-4); }
+        details summary::-webkit-details-marker { display: none; }
 
-        /* Publishers grid styles */
+        /* Tools list */
+        .tools-summary {
+            background: var(--color-info-50);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            border-left: 3px solid var(--color-info-500);
+            margin-bottom: var(--space-6);
+        }
+        .tools-summary__count { font-weight: var(--font-semibold); }
+        .tools-summary__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
+        .tools-list { display: grid; gap: var(--space-4); }
+        .tool-item {
+            background: var(--color-gray-50);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            border-left: 3px solid var(--color-border);
+        }
+        .tool-item__header { display: flex; justify-content: space-between; align-items: start; margin-bottom: var(--space-2); }
+        .tool-name { font-weight: var(--font-semibold); font-family: var(--font-mono); margin-bottom: var(--space-1); }
+        .tool-description { font-size: var(--text-sm); color: var(--color-text-muted); }
+        .tool-schema-toggle { font-size: var(--text-xs); color: var(--color-brand); cursor: pointer; }
+        .tool-schema-pre { margin-top: var(--space-2); background: var(--color-bg-subtle); padding: var(--space-2); border-radius: var(--radius-sm); overflow-x: auto; font-size: var(--text-xs); max-height: 200px; }
+
+        /* Publishers grid in detail */
+        .publishers-grid { display: grid; gap: var(--space-4); }
         .publishers-group { margin-bottom: var(--space-6); }
         .publishers-group__title { font-size: var(--text-base); margin-bottom: var(--space-4); }
         .publishers-group__title--verified { color: var(--color-success-500); }
         .publishers-group__title--unverified { color: var(--color-error-500); }
         .publishers-group__title--unchecked { color: var(--color-warning-500); }
-
+        .publisher-item {
+            background: var(--color-gray-50);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+        }
         .publisher-item--verified { border-left: 3px solid var(--color-success-500); }
         .publisher-item--unverified { border-left: 3px solid var(--color-error-500); background: var(--color-error-50); }
         .publisher-item--unchecked { border-left: 3px solid var(--color-warning-500); }
-
-        .publisher-verify-link { color: var(--color-success-500); text-decoration: none; font-size: var(--text-xs); white-space: nowrap; }
+        .publisher-domain { font-weight: var(--font-semibold); margin-bottom: var(--space-1); }
+        .publisher-verify-link { color: var(--color-brand); text-decoration: none; font-size: var(--text-xs); white-space: nowrap; }
         .publisher-verify-link--error { color: var(--color-error-500); }
-
         .publisher-warning { margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-error-700); background: var(--color-error-100); padding: var(--space-2); border-radius: var(--radius-sm); }
-
-        .property-metadata-toggle { margin-top: var(--space-3); font-size: var(--text-xs); cursor: pointer; color: var(--color-success-500); }
+        .property-metadata-toggle { margin-top: var(--space-3); font-size: var(--text-xs); cursor: pointer; color: var(--color-brand); }
         .property-metadata-pre { margin-top: var(--space-2); background: var(--color-bg-subtle); padding: var(--space-2); border-radius: var(--radius-sm); overflow-x: auto; }
 
-        /* Tools section styles */
-        .tools-summary { background: var(--color-info-50); padding: var(--space-4); border-radius: var(--radius-md); border-left: 3px solid var(--color-info-500); margin-bottom: var(--space-6); }
-        .tools-summary__count { font-weight: var(--font-semibold); }
-        .tools-summary__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
+        /* Products */
+        .products-grid { display: grid; gap: var(--space-4); }
+        .product-card {
+            background: var(--color-bg-subtle);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            border-left: 3px solid var(--color-border);
+        }
+        .product-card__name { font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
+        .product-card__desc { font-size: var(--text-sm); color: var(--color-text-muted); margin-bottom: var(--space-2); }
+        .product-card__meta { font-size: var(--text-xs); color: var(--color-text-muted); }
+        .agent-params-required {
+            background: var(--color-warning-50);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
+            border-left: 3px solid var(--color-warning-500);
+        }
+        .agent-params-required__title { font-weight: var(--font-semibold); }
+        .agent-params-required__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
 
-        .tool-item__header { display: flex; justify-content: space-between; align-items: start; margin-bottom: var(--space-2); }
-        .tool-schema-toggle { font-size: var(--text-xs); color: var(--color-success-500); cursor: pointer; }
-        .tool-schema-pre { margin-top: var(--space-2); background: var(--color-bg-subtle); padding: var(--space-2); border-radius: var(--radius-sm); overflow-x: auto; font-size: var(--text-xs); max-height: 200px; }
-
-        /* Format card styles */
+        /* Format cards */
         .format-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-4); }
-        .format-card-item { background: var(--color-bg-card); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-lg); overflow: hidden; transition: var(--transition-all); cursor: pointer; }
-        .format-card-item:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+        .format-card-item {
+            background: var(--color-bg-card);
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-lg);
+            overflow: hidden;
+            transition: border-color 0.15s ease;
+            cursor: pointer;
+        }
+        .format-card-item:hover { border-color: var(--color-brand); }
         .format-card-preview { width: 100%; height: 200px; background: var(--color-bg-subtle); display: flex; align-items: center; justify-content: center; overflow: hidden; }
         .format-card-preview img { max-width: 100%; max-height: 100%; object-fit: contain; }
         .format-card-preview__placeholder { color: var(--color-text-light); font-size: var(--text-4xl); }
         .format-card-body { padding: var(--space-4); }
         .format-card-name { font-weight: var(--font-semibold); margin-bottom: var(--space-2); color: var(--color-text-heading); }
         .format-card-dimensions { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-1); }
-        .format-card-type { display: inline-block; padding: var(--space-1) var(--space-2); background: var(--color-brand-50); color: var(--color-brand); border-radius: var(--radius-sm); font-size: var(--text-xs); text-transform: capitalize; margin-top: var(--space-2); }
+        .format-card-type { display: inline-block; padding: var(--space-1) var(--space-2); background: var(--color-primary-100); color: var(--color-brand); border-radius: var(--radius-sm); font-size: var(--text-xs); text-transform: capitalize; margin-top: var(--space-2); }
 
-        /* Format filter buttons */
+        /* Format filters */
         .format-filters { margin-bottom: var(--space-4); display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center; }
         .format-filters__label { font-size: var(--text-sm); font-weight: var(--font-semibold); }
-        .format-filter-btn { padding: var(--space-2) var(--space-4); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); background: var(--color-bg-card); cursor: pointer; font-size: var(--text-xs); text-transform: capitalize; transition: var(--transition-all); }
-        .format-filter-btn.active { background: var(--color-success-500); color: white; border-color: var(--color-success-500); }
+        .format-filter-btn {
+            padding: var(--space-2) var(--space-4);
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-lg);
+            background: var(--color-bg-card);
+            cursor: pointer;
+            font-size: var(--text-xs);
+            text-transform: capitalize;
+            transition: var(--transition-all);
+        }
+        .format-filter-btn.active {
+            background: var(--color-primary-100);
+            color: var(--color-brand);
+            border-color: var(--color-brand);
+        }
 
-        /* Products grid styles */
-        .products-grid { display: grid; gap: var(--space-4); }
-        .product-card { background: var(--color-bg-subtle); padding: var(--space-4); border-radius: var(--radius-md); border-left: 3px solid var(--color-success-500); }
-        .product-card__name { font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
-        .product-card__desc { font-size: var(--text-sm); color: var(--color-text-muted); margin-bottom: var(--space-2); }
-        .product-card__meta { font-size: var(--text-xs); color: var(--color-text-muted); }
-
-        /* Agent requires params box */
-        .agent-params-required { background: var(--color-warning-50); padding: var(--space-4); border-radius: var(--radius-md); border-left: 3px solid var(--color-warning-500); }
-        .agent-params-required__title { font-weight: var(--font-semibold); }
-        .agent-params-required__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
-
-        /* Agent info box styles */
-        .info-box__desc { margin-bottom: var(--space-4); font-size: var(--text-base); }
-        .info-box__grid { display: grid; gap: var(--space-3); }
-        .info-box__code { background: var(--color-brand-50); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-size: var(--text-sm); word-break: break-all; }
-        .info-box__contact { margin-top: var(--space-6); padding-top: var(--space-6); border-top: var(--border-1) solid var(--color-border); }
-        .info-box__contact-link { color: var(--color-success-500); }
-
-        /* Modal styles for format detail */
+        /* Format modal */
         .format-modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.8); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: var(--space-8); }
         .format-modal { background: var(--color-bg-card); border-radius: var(--radius-xl); max-width: 800px; max-height: 90vh; overflow: auto; box-shadow: var(--shadow-2xl); }
-        .format-modal__header { position: sticky; top: 0; background: var(--color-bg-card); border-bottom: var(--border-1) solid var(--color-border); padding: var(--space-6); display: flex; justify-content: space-between; align-items: center; }
+        .format-modal__header { position: sticky; top: 0; background: var(--color-bg-card); border-bottom: 1px solid var(--color-border); padding: var(--space-6); display: flex; justify-content: space-between; align-items: center; }
         .format-modal__title { margin: 0; font-size: var(--text-xl); }
         .format-modal__close { background: none; border: none; font-size: var(--text-2xl); cursor: pointer; color: var(--color-text-light); }
         .format-modal__body { padding: var(--space-6); }
         .format-modal__preview { margin-bottom: var(--space-6); text-align: center; }
-        .format-modal__preview img { max-width: 100%; border-radius: var(--radius-lg); box-shadow: var(--shadow-md); }
+        .format-modal__preview img { max-width: 100%; border-radius: var(--radius-lg); }
         .format-modal__desc { color: var(--color-text-muted); margin-bottom: var(--space-6); }
         .format-modal__meta { display: grid; gap: var(--space-4); margin-bottom: var(--space-6); }
         .format-modal__code { background: var(--color-bg-subtle); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); }
-        .format-modal__cta { display: inline-block; padding: var(--space-3) var(--space-6); background: var(--color-success-500); color: white; text-decoration: none; border-radius: var(--radius-md); margin-top: var(--space-4); }
+        .format-modal__cta { display: inline-block; padding: var(--space-3) var(--space-6); background: var(--color-brand); color: white; text-decoration: none; border-radius: var(--radius-md); margin-top: var(--space-4); }
+        .format-modal__cta:hover { background: var(--color-brand-hover); }
 
-        /* Error styling in tool errors */
+        /* Info box */
+        .info-box { background: var(--color-gray-50); padding: var(--space-4); border-radius: var(--radius-md); }
+        .info-box__desc { margin-bottom: var(--space-4); font-size: var(--text-base); }
+        .info-box__grid { display: grid; gap: var(--space-3); }
+        .info-box__code { background: var(--color-primary-100); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-size: var(--text-sm); word-break: break-all; }
+        .info-box__contact { margin-top: var(--space-6); padding-top: var(--space-6); border-top: 1px solid var(--color-border); }
+        .info-box__contact-link { color: var(--color-brand); }
+
+        /* Error states */
         .tool-error-box { font-size: var(--text-xs); color: var(--color-error-600); padding: var(--space-2); background: var(--color-error-50); border-radius: var(--radius-sm); border-left: 3px solid var(--color-error-500); }
         .tool-error-box__title { font-weight: var(--font-semibold); }
         .tool-error-box__msg { font-size: var(--text-xs); color: var(--color-error-700); font-family: monospace; word-break: break-word; }
 
-        /* Footer link color */
-        .footer-resource-link { color: var(--color-success-500); text-decoration: none; }
+        .property-section-small { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); }
+        .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
+        .error-text { color: var(--color-error-500); font-size: var(--text-sm); }
+        .hidden { display: none !important; }
+        .view { display: none; }
+        .view.active { display: block; }
 
-        /* Skeleton shimmer animation */
+        /* Skeleton animation */
         @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
-        .skeleton-bg { background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border-light) 50%, var(--color-bg-subtle) 75%); background-size: 200% 100%; animation: shimmer 1.5s infinite; }
+        .skeleton-bg {
+            background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border-light) 50%, var(--color-bg-subtle) 75%);
+            background-size: 200% 100%;
+            animation: shimmer 1.5s infinite;
+        }
 
-        @media (max-width: 768px) { .footer-content { grid-template-columns: 1fr; } }
+        @media (max-width: 768px) {
+            .agent-grid { grid-template-columns: 1fr; }
+            .format-card-grid { grid-template-columns: 1fr; }
+        }
     </style>
 </head>
 <body>
-    <!-- Navigation (loaded by nav.js) -->
-    <div id="adcp-nav"></div>
-    <script src="/nav.js"></script>
 
-    <header>
-        <h1>Agent registry</h1>
-        <p class="subtitle">Discover agents for advertising automation</p>
+<div id="adcp-nav"></div>
+<script src="/nav.js"></script>
+<script src="/registry-nav.js"></script>
+
+<!-- List View -->
+<div id="list-view" class="view active">
+    <header class="page-header">
+        <h1>Agents</h1>
+        <p>Sales, creative, and signals agents implementing AdCP</p>
     </header>
 
-    <!-- List View -->
-    <div id="list-view" class="view active">
-        <div class="container">
-            <div class="search-filters">
-                <div class="search-box">
-                    <input type="text" id="agent-search" placeholder="Search by agent name, URL, or publisher..." onkeyup="filterAgents()">
+    <div class="container">
+        <div class="search-section">
+            <div class="search-box">
+                <input type="text" id="agent-search" placeholder="Search by agent name, URL, or publisher..." aria-label="Search agents" onkeyup="filterAgents()">
+            </div>
+            <div class="filter-row">
+                <div class="filter-group">
+                    <label>Type:</label>
+                    <button class="filter-btn active" data-type="all" onclick="setTypeFilter('all')">All</button>
+                    <button class="filter-btn" data-type="sales" onclick="setTypeFilter('sales')">Sales</button>
+                    <button class="filter-btn" data-type="creative" onclick="setTypeFilter('creative')">Creative</button>
+                    <button class="filter-btn" data-type="signals" onclick="setTypeFilter('signals')">Signals</button>
                 </div>
-                <div class="filter-row">
-                    <div class="filter-group">
-                        <label>Type:</label>
-                        <button class="filter-btn active" data-type="all" onclick="setTypeFilter('all')">All</button>
-                        <button class="filter-btn" data-type="sales" onclick="setTypeFilter('sales')">Sales</button>
-                        <button class="filter-btn" data-type="creative" onclick="setTypeFilter('creative')">Creative</button>
-                        <button class="filter-btn" data-type="signals" onclick="setTypeFilter('signals')">Signals</button>
-                    </div>
-                    <div class="filter-group">
-                        <label>Status:</label>
-                        <button class="filter-btn active" data-status="all" onclick="setStatusFilter('all')">All</button>
-                        <button class="filter-btn" data-status="online" onclick="setStatusFilter('online')">Active</button>
-                        <button class="filter-btn" data-status="offline" onclick="setStatusFilter('offline')">Issues</button>
-                    </div>
+                <div class="filter-group">
+                    <label>Status:</label>
+                    <button class="filter-btn active" data-status="all" onclick="setStatusFilter('all')">All</button>
+                    <button class="filter-btn" data-status="online" onclick="setStatusFilter('online')">Active</button>
+                    <button class="filter-btn" data-status="offline" onclick="setStatusFilter('offline')">Issues</button>
                 </div>
             </div>
-            <div id="agents-grid" class="agent-grid"></div>
+        </div>
+        <div id="agents-grid" class="agent-grid"></div>
+    </div>
+</div>
+
+<!-- Detail View -->
+<div id="detail-view" class="view">
+    <div class="detail-header">
+        <div class="container">
+            <a href="#" class="back-btn" onclick="navigateToList(); return false;">&larr; Back to agents</a>
+            <h2 id="detail-name"></h2>
+            <div id="detail-url" class="agent-url"></div>
         </div>
     </div>
-
-    <!-- Detail View -->
-    <div id="detail-view" class="view">
-        <div class="detail-hero">
-            <div class="container">
-                <a href="#" class="back-btn" onclick="navigateToList(); return false;">← Back to Agents</a>
-                <h2 id="detail-name"></h2>
-                <div id="detail-url" class="agent-url"></div>
-            </div>
-        </div>
-        <div class="container">
-            <div class="detail-content" id="detail-body"></div>
-        </div>
+    <div class="container">
+        <div class="detail-content" id="detail-body"></div>
     </div>
+</div>
 
-    <footer>
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>🤖 Use in Your AI Assistant</h3>
-                <div class="mcp-box">
-                    <p>Add this MCP server to Claude Desktop or ChatGPT:</p>
-                    <div class="mcp-url">https://agenticadvertising.org/mcp</div>
-                    <p class="property-section-small">Exposes 4 tools: <code>list_agents</code>, <code>get_agent</code>, <code>find_agents_for_property</code>, <code>get_properties_for_agent</code></p>
+<div id="adcp-footer"></div>
+
+<script type="module">
+    let allAgents = [];
+    let filters = { type: 'all', status: 'all', search: '' };
+    let isLoading = true;
+
+    function escapeHtml(str) {
+        if (!str) return '';
+        const div = document.createElement('div');
+        div.textContent = String(str);
+        return div.innerHTML;
+    }
+
+    window.addEventListener('DOMContentLoaded', async () => {
+        handleRoute();
+        window.addEventListener('hashchange', handleRoute);
+        renderAgents();
+        await loadAllAgents();
+        handleQueryParams();
+    });
+
+    function handleQueryParams() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const type = urlParams.get('type');
+        if (type && ['sales', 'creative', 'signals'].includes(type)) {
+            setTypeFilter(type);
+        }
+    }
+
+    async function loadAllAgents() {
+        try {
+            const response = await fetch('/api/registry/agents?health=true&properties=true&capabilities=true');
+            const data = await response.json();
+            const agents = data.agents || data;
+
+            allAgents = agents.map(agent => {
+                const hasPropertyError = agent.propertiesError && agent.propertiesError.length > 0;
+                return {
+                    ...agent,
+                    properties: agent.properties || [],
+                    formats: agent.capabilities?.creative_capabilities?.formats_supported || [],
+                    propertiesError: agent.propertiesError,
+                    health: hasPropertyError
+                        ? { ...agent.health, online: false, error: `Missing required tool: ${agent.propertiesError}` }
+                        : agent.health
+                };
+            });
+
+            isLoading = false;
+            renderAgents();
+        } catch (error) {
+            console.error('Failed to load agents:', error);
+            isLoading = false;
+            renderAgents();
+        }
+    }
+
+    function renderLoadingSkeleton(count = 4) {
+        return Array(count).fill(0).map(() => `
+            <div class="agent-card" style="pointer-events: none; opacity: 0.6;">
+                <div class="agent-header">
+                    <div class="agent-title" style="flex: 1;">
+                        <div class="skeleton-bg" style="height: 20px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
+                        <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 80%;"></div>
+                    </div>
+                    <span class="status-badge" style="background: var(--color-bg-subtle); color: transparent;">...</span>
+                </div>
+                <div class="skeleton-bg" style="height: 40px; border-radius: var(--radius-sm); margin-bottom: var(--space-4);"></div>
+                <div class="agent-meta">
+                    <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 100px;"></div>
                 </div>
             </div>
-            <div class="footer-section">
-                <h3>📚 Resources</h3>
-                <p style="margin-bottom: var(--space-2);">Learn more about the Ad Context Protocol:</p>
-                <ul style="list-style: none; padding: 0;">
-                    <li style="margin: var(--space-2) 0;"><a href="https://adcontextprotocol.org" target="_blank" class="footer-resource-link">→ AdCP Documentation</a></li>
-                    <li style="margin: var(--space-2) 0;"><a href="/api/registry/agents" class="footer-resource-link">→ REST API</a></li>
-                    <li style="margin: var(--space-2) 0;"><a href="https://github.com/adcontextprotocol" target="_blank" class="footer-resource-link">→ GitHub</a></li>
-                </ul>
-            </div>
-        </div>
-        <div class="footer-links">
-            <a href="/api/agreement?type=privacy_policy">Privacy Policy</a> |
-            <a href="/api/agreement?type=terms_of_service">Terms of Use</a> |
-            Powered by <a href="https://adcontextprotocol.org" target="_blank">Ad Context Protocol</a>
-        </div>
-    </footer>
+        `).join('');
+    }
 
-    <script type="module">
-        let allAgents = [];
-        let filters = { type: 'all', status: 'all', search: '' };
-        let isLoading = true;
+    function typeLabel(type) {
+        if (type === 'sales') return 'Sales';
+        if (type === 'creative') return 'Creative';
+        if (type === 'signals') return 'Signals';
+        return 'Unclassified';
+    }
 
-        function escapeHtml(str) {
-            if (!str) return '';
-            const div = document.createElement('div');
-            div.textContent = String(str);
-            return div.innerHTML;
+    function renderAgents() {
+        const container = document.getElementById('agents-grid');
+
+        if (isLoading) {
+            container.innerHTML = renderLoadingSkeleton(4);
+            return;
         }
 
-        // Initialize
-        window.addEventListener('DOMContentLoaded', async () => {
-            handleRoute();
-            window.addEventListener('hashchange', handleRoute);
-
-            // Show loading skeletons immediately
-            renderAgents();
-
-            await loadAllAgents();
-            handleQueryParams();
+        const filtered = allAgents.filter(agent => {
+            if (filters.type !== 'all' && agent.type !== filters.type) return false;
+            if (filters.status !== 'all') {
+                const online = agent.health?.online || false;
+                if (filters.status === 'online' && !online) return false;
+                if (filters.status === 'offline' && online) return false;
+            }
+            if (filters.search) {
+                const query = filters.search.toLowerCase();
+                const matchesName = agent.name.toLowerCase().includes(query);
+                const matchesUrl = agent.url.toLowerCase().includes(query);
+                const matchesProperty = agent.properties.some(p =>
+                    (p.identifier && p.identifier.toLowerCase().includes(query)) ||
+                    (p.domain && p.domain.toLowerCase().includes(query)) ||
+                    (p.country && p.country.toLowerCase().includes(query))
+                );
+                const matchesFormat = agent.formats.some(f => f.toLowerCase().includes(query));
+                if (!matchesName && !matchesUrl && !matchesProperty && !matchesFormat) return false;
+            }
+            return true;
         });
 
-        function handleQueryParams() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const type = urlParams.get('type');
+        // Update filter button counts
+        const typeCounts = { all: allAgents.length };
+        for (const a of allAgents) {
+            typeCounts[a.type] = (typeCounts[a.type] || 0) + 1;
+        }
+        document.querySelectorAll('.filter-btn[data-type]').forEach(btn => {
+            const t = btn.dataset.type;
+            const count = typeCounts[t] || 0;
+            const label = t === 'all' ? 'All' : typeLabel(t);
+            btn.textContent = `${label} (${count})`;
+        });
 
-            if (type && ['sales', 'creative', 'signals'].includes(type)) {
-                setTypeFilter(type);
-            }
+        if (filtered.length === 0) {
+            container.innerHTML = '<div class="loading">No agents found matching your filters.</div>';
+            return;
         }
 
-        async function loadAllAgents() {
-            try {
-                const response = await fetch('/api/registry/agents?health=true&properties=true&capabilities=true');
-                const data = await response.json();
-                const agents = data.agents || data;
+        container.innerHTML = filtered.map(agent => {
+            const agentSlug = agent.name.toLowerCase().replace(/\s+/g, '-');
+            const toolCount = agent.capabilities?.tools_count || 0;
 
-                allAgents = agents.map(agent => {
-                    const hasPropertyError = agent.propertiesError && agent.propertiesError.length > 0;
-                    return {
-                        ...agent,
-                        properties: agent.properties || [],
-                        formats: agent.capabilities?.creative_capabilities?.formats_supported || [],
-                        propertiesError: agent.propertiesError,
-                        health: hasPropertyError
-                            ? { ...agent.health, online: false, error: `Missing required tool: ${agent.propertiesError}` }
-                            : agent.health
-                    };
+            let metaHtml = `
+                <div class="meta-item">
+                    <span class="meta-value">${typeLabel(agent.type)}</span>
+                </div>
+            `;
+
+            if (toolCount > 0) {
+                metaHtml += `
+                    <div class="meta-item">
+                        <span class="meta-value">${toolCount}</span> tools
+                    </div>
+                `;
+            }
+
+            if (agent.type === 'sales' && agent.properties.length > 0) {
+                metaHtml += `
+                    <div class="meta-item">
+                        <span class="meta-value">${agent.properties.length}</span> properties
+                    </div>
+                `;
+            }
+
+            if (agent.type === 'creative' && agent.formats.length > 0) {
+                metaHtml += `
+                    <div class="meta-item">
+                        <span class="meta-value">${agent.formats.length}</span> formats
+                    </div>
+                `;
+            }
+
+            if (agent.health?.response_time_ms) {
+                metaHtml += `
+                    <div class="meta-item">
+                        <span class="meta-value">${agent.health.response_time_ms}ms</span>
+                    </div>
+                `;
+            }
+
+            let extrasHtml = '';
+
+            if (agent.type === 'sales' && agent.properties.length > 0) {
+                extrasHtml = `
+                    <div class="agent-properties">
+                        <div class="property-section-small">
+                            <strong>Publishers:</strong> ${agent.properties.slice(0, 3).map(p => escapeHtml(p.identifier || p.domain)).join(', ')}${agent.properties.length > 3 ? ` +${agent.properties.length - 3} more` : ''}
+                        </div>
+                        <div class="property-tags">
+                            ${Array.from(new Set(agent.properties.flatMap(p => p.tags || []))).slice(0, 5).map(tag =>
+                                `<span class="property-tag">${escapeHtml(tag)}</span>`
+                            ).join('')}
+                        </div>
+                    </div>
+                `;
+            } else if (agent.propertiesError) {
+                extrasHtml = `
+                    <div class="agent-properties">
+                        <div class="tool-error-box">
+                            <span class="tool-error-box__title">Tool error:</span><br>
+                            <span class="tool-error-box__msg">${escapeHtml(agent.propertiesError)}</span>
+                        </div>
+                    </div>
+                `;
+            } else if (agent.type === 'creative' && agent.formats.length > 0) {
+                extrasHtml = `
+                    <div class="formats-list">
+                        ${agent.formats.slice(0, 5).map(format =>
+                            `<span class="format-badge">${escapeHtml(format)}</span>`
+                        ).join('')}
+                        ${agent.formats.length > 5 ? `<span class="format-badge">+${agent.formats.length - 5} more</span>` : ''}
+                    </div>
+                `;
+            }
+
+            if (agent.capabilities?.discovery_error) {
+                extrasHtml += `
+                    <div class="agent-properties">
+                        <div class="tool-error-box">
+                            <span class="tool-error-box__title">Discovery error:</span><br>
+                            <span class="tool-error-box__msg">${escapeHtml(agent.capabilities.discovery_error)}</span>
+                        </div>
+                    </div>
+                `;
+            }
+
+            return `
+                <div class="agent-card" data-agent-id="${escapeHtml(agent.type)}/${escapeHtml(agentSlug)}">
+                    <div class="agent-header">
+                        <div class="agent-title">
+                            <div class="agent-name">${escapeHtml(agent.name)}</div>
+                            <div class="agent-url">${escapeHtml(agent.url)}</div>
+                        </div>
+                        <span class="status-badge ${agent.health?.online ? 'online' : 'offline'}">
+                            ${agent.health?.online ? 'Active' : 'Issues'}
+                        </span>
+                    </div>
+                    ${agent.description ? `<p class="agent-description">${escapeHtml(agent.description)}</p>` : ''}
+                    <div class="agent-meta">${metaHtml}</div>
+                    ${extrasHtml}
+                </div>
+            `;
+        }).join('');
+
+        container.querySelectorAll('.agent-card[data-agent-id]').forEach(card => {
+            card.addEventListener('click', () => navigateToAgent(card.dataset.agentId));
+        });
+    }
+
+    window.setTypeFilter = function(type) {
+        filters.type = type;
+        document.querySelectorAll('.filter-btn[data-type]').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.type === type);
+        });
+        renderAgents();
+    };
+
+    window.setStatusFilter = function(status) {
+        filters.status = status;
+        document.querySelectorAll('.filter-btn[data-status]').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.status === status);
+        });
+        renderAgents();
+    };
+
+    window.filterAgents = function() {
+        filters.search = document.getElementById('agent-search').value;
+        renderAgents();
+    };
+
+    // Navigation
+    window.navigateToAgent = function(agentId) {
+        window.location.hash = `#agent/${agentId}`;
+    };
+
+    window.navigateToList = function() {
+        window.location.hash = '';
+    };
+
+    function handleRoute() {
+        const hash = window.location.hash.slice(1);
+        if (hash.startsWith('agent/')) {
+            const agentId = hash.replace('agent/', '');
+            showAgentDetail(agentId);
+        } else {
+            showListView();
+        }
+    }
+
+    function showListView() {
+        document.getElementById('list-view').classList.add('active');
+        document.getElementById('detail-view').classList.remove('active');
+    }
+
+    async function showAgentDetail(agentId) {
+        document.getElementById('list-view').classList.remove('active');
+        document.getElementById('detail-view').classList.add('active');
+
+        try {
+            const [type, ...nameParts] = agentId.split('/');
+            const name = nameParts.join('/');
+
+            const capsResp = await fetch('/api/registry/agents?health=true&capabilities=true&properties=true');
+            const capsData = await capsResp.json();
+            const allAgents = capsData.agents || [];
+
+            const agentWithCaps =
+                allAgents.find(a => {
+                    const slugName = a.name?.toLowerCase().replace(/\s+/g, '-') || '';
+                    return a.type === type && slugName === name;
+                }) ||
+                allAgents.find(a => {
+                    try {
+                        const hostname = new URL(a.url).hostname.toLowerCase();
+                        return a.type === type && hostname.includes(name.toLowerCase());
+                    } catch { return false; }
+                }) ||
+                allAgents.find(a => {
+                    const slugName = a.name?.toLowerCase().replace(/\s+/g, '-') || '';
+                    return slugName === name;
                 });
 
-                isLoading = false;
-                renderAgents();
-            } catch (error) {
-                console.error('Failed to load agents:', error);
-                isLoading = false;
-                renderAgents();
-            }
-        }
+            const agent = agentWithCaps || { name: name, url: '', type: type };
 
-        function renderLoadingSkeleton(count = 4) {
-            return Array(count).fill(0).map(() => `
-                <div class="agent-card" style="pointer-events: none; opacity: 0.6;">
-                    <div class="agent-header">
-                        <div class="agent-title" style="flex: 1;">
-                            <div class="skeleton-bg" style="height: 20px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
-                            <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 80%;"></div>
-                        </div>
-                        <span class="status-badge" style="background: var(--color-bg-subtle); color: transparent;">...</span>
+            document.getElementById('detail-name').textContent = agent.name;
+            document.getElementById('detail-url').textContent = agent.url;
+
+            let html = '';
+
+            // Health status banner
+            const health = agent.health || {};
+            const statusText = health.online ? 'Active' : 'Offline';
+            html += `
+                <div class="status-banner ${health.online ? 'status-banner--online' : 'status-banner--offline'}">
+                    <div>
+                        <span class="status-banner__text">Status: ${statusText}</span>
+                        ${health.response_time_ms ? `<span class="status-banner__meta">Response time: ${health.response_time_ms}ms</span>` : ''}
                     </div>
-                    <div class="skeleton-bg" style="height: 40px; border-radius: var(--radius-sm); margin-bottom: var(--space-4);"></div>
-                    <div class="agent-meta">
-                        <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 100px;"></div>
-                    </div>
+                    ${health.last_check ? `<div class="status-banner__time">Last check: ${new Date(health.last_check).toLocaleString()}</div>` : ''}
                 </div>
-            `).join('');
-        }
+            `;
 
-        function typeLabel(type) {
-            if (type === 'sales') return 'Sales';
-            if (type === 'creative') return 'Creative';
-            if (type === 'signals') return 'Signals';
-            return 'Unclassified';
-        }
+            // Spec compliance badge
+            if (agentWithCaps?.capabilities) {
+                const caps = agentWithCaps.capabilities;
 
-        function typeIcon(type) {
-            if (type === 'sales') return '🏢';
-            if (type === 'creative') return '🎨';
-            if (type === 'signals') return '📊';
-            return '🤖';
-        }
+                if (agent.type === 'sales' && caps.tools) {
+                    const toolNames = new Set(caps.tools.map(t => t.name.toLowerCase()));
+                    const requiredTools = [
+                        'get_products',
+                        'create_media_buy',
+                        'update_media_buy',
+                        'get_media_buy_delivery',
+                        'sync_creatives',
+                        'list_authorized_properties'
+                    ];
+                    const implementedTools = requiredTools.filter(tool => toolNames.has(tool));
+                    const isCompliant = implementedTools.length === requiredTools.length;
 
-        function renderAgents() {
-            const container = document.getElementById('agents-grid');
-
-            if (isLoading) {
-                container.innerHTML = renderLoadingSkeleton(4);
-                return;
-            }
-
-            const filtered = allAgents.filter(agent => {
-                if (filters.type !== 'all' && agent.type !== filters.type) return false;
-
-                if (filters.status !== 'all') {
-                    const online = agent.health?.online || false;
-                    if (filters.status === 'online' && !online) return false;
-                    if (filters.status === 'offline' && online) return false;
-                }
-
-                if (filters.search) {
-                    const query = filters.search.toLowerCase();
-                    const matchesName = agent.name.toLowerCase().includes(query);
-                    const matchesUrl = agent.url.toLowerCase().includes(query);
-                    const matchesProperty = agent.properties.some(p =>
-                        (p.identifier && p.identifier.toLowerCase().includes(query)) ||
-                        (p.domain && p.domain.toLowerCase().includes(query)) ||
-                        (p.country && p.country.toLowerCase().includes(query))
-                    );
-                    const matchesFormat = agent.formats.some(f => f.toLowerCase().includes(query));
-                    if (!matchesName && !matchesUrl && !matchesProperty && !matchesFormat) return false;
-                }
-
-                return true;
-            });
-
-            // Update filter button counts
-            const typeCounts = { all: allAgents.length };
-            for (const a of allAgents) {
-                typeCounts[a.type] = (typeCounts[a.type] || 0) + 1;
-            }
-            document.querySelectorAll('.filter-btn[data-type]').forEach(btn => {
-                const t = btn.dataset.type;
-                const count = typeCounts[t] || 0;
-                const label = t === 'all' ? 'All' : typeLabel(t);
-                btn.textContent = `${label} (${count})`;
-            });
-
-            if (filtered.length === 0) {
-                container.innerHTML = '<div class="loading">No agents found matching your filters.</div>';
-                return;
-            }
-
-            container.innerHTML = filtered.map(agent => {
-                const agentSlug = agent.name.toLowerCase().replace(/\s+/g, '-');
-                const toolCount = agent.capabilities?.tools_count || 0;
-
-                let metaHtml = `
-                    <div class="meta-item">
-                        <span>${typeIcon(agent.type)}</span>
-                        <span class="meta-value">${typeLabel(agent.type)}</span>
-                    </div>
-                `;
-
-                if (toolCount > 0) {
-                    metaHtml += `
-                        <div class="meta-item">
-                            <span>🛠️</span>
-                            <span class="meta-value">${toolCount}</span> tools
-                        </div>
-                    `;
-                }
-
-                if (agent.type === 'sales' && agent.properties.length > 0) {
-                    metaHtml += `
-                        <div class="meta-item">
-                            <span>📰</span>
-                            <span class="meta-value">${agent.properties.length}</span> properties
-                        </div>
-                    `;
-                }
-
-                if (agent.type === 'creative' && agent.formats.length > 0) {
-                    metaHtml += `
-                        <div class="meta-item">
-                            <span>📐</span>
-                            <span class="meta-value">${agent.formats.length}</span> formats
-                        </div>
-                    `;
-                }
-
-                if (agent.health?.response_time_ms) {
-                    metaHtml += `
-                        <div class="meta-item">
-                            <span>⚡</span>
-                            <span class="meta-value">${agent.health.response_time_ms}ms</span>
-                        </div>
-                    `;
-                }
-
-                let extrasHtml = '';
-
-                if (agent.type === 'sales' && agent.properties.length > 0) {
-                    extrasHtml = `
-                        <div class="agent-properties">
-                            <div class="property-section-small">
-                                <strong>Publishers:</strong> ${agent.properties.slice(0, 3).map(p => escapeHtml(p.identifier || p.domain)).join(', ')}${agent.properties.length > 3 ? ` +${agent.properties.length - 3} more` : ''}
-                            </div>
-                            <div class="property-tags">
-                                ${Array.from(new Set(agent.properties.flatMap(p => p.tags || []))).slice(0, 5).map(tag =>
-                                    `<span class="property-tag">${escapeHtml(tag)}</span>`
-                                ).join('')}
-                            </div>
-                        </div>
-                    `;
-                } else if (agent.propertiesError) {
-                    extrasHtml = `
-                        <div class="agent-properties">
-                            <div class="tool-error-box">
-                                <span class="tool-error-box__title">Tool error:</span><br>
-                                <span class="tool-error-box__msg">${escapeHtml(agent.propertiesError)}</span>
-                            </div>
-                        </div>
-                    `;
-                } else if (agent.type === 'creative' && agent.formats.length > 0) {
-                    extrasHtml = `
-                        <div class="formats-list">
-                            ${agent.formats.slice(0, 5).map(format =>
-                                `<span class="format-badge">${escapeHtml(format)}</span>`
-                            ).join('')}
-                            ${agent.formats.length > 5 ? `<span class="format-badge">+${agent.formats.length - 5} more</span>` : ''}
-                        </div>
-                    `;
-                }
-
-                if (agent.capabilities?.discovery_error) {
-                    extrasHtml += `
-                        <div class="agent-properties">
-                            <div class="tool-error-box">
-                                <span class="tool-error-box__title">Discovery error:</span><br>
-                                <span class="tool-error-box__msg">${escapeHtml(agent.capabilities.discovery_error)}</span>
-                            </div>
-                        </div>
-                    `;
-                }
-
-                return `
-                    <div class="agent-card" data-agent-id="${escapeHtml(agent.type)}/${escapeHtml(agentSlug)}">
-                        <div class="agent-header">
-                            <div class="agent-title">
-                                <div class="agent-name">${escapeHtml(agent.name)}</div>
-                                <div class="agent-url">${escapeHtml(agent.url)}</div>
-                            </div>
-                            <span class="status-badge ${agent.health?.online ? 'online' : 'offline'}">
-                                ${agent.health?.online ? 'Active' : 'Issues'}
-                            </span>
-                        </div>
-                        ${agent.description ? `<p class="agent-description">${escapeHtml(agent.description)}</p>` : ''}
-                        <div class="agent-meta">${metaHtml}</div>
-                        ${extrasHtml}
-                    </div>
-                `;
-            }).join('');
-
-            // Delegated click handler for agent cards
-            container.querySelectorAll('.agent-card[data-agent-id]').forEach(card => {
-                card.addEventListener('click', () => navigateToAgent(card.dataset.agentId));
-            });
-        }
-
-        window.setTypeFilter = function(type) {
-            filters.type = type;
-            document.querySelectorAll('.filter-btn[data-type]').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.type === type);
-            });
-            renderAgents();
-        };
-
-        window.setStatusFilter = function(status) {
-            filters.status = status;
-            document.querySelectorAll('.filter-btn[data-status]').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.status === status);
-            });
-            renderAgents();
-        };
-
-        window.filterAgents = function() {
-            filters.search = document.getElementById('agent-search').value;
-            renderAgents();
-        };
-
-        // Navigation
-        window.navigateToAgent = function(agentId) {
-            window.location.hash = `#agent/${agentId}`;
-        };
-
-        window.navigateToList = function() {
-            window.location.hash = '';
-        };
-
-        function handleRoute() {
-            const hash = window.location.hash.slice(1);
-            if (hash.startsWith('agent/')) {
-                const agentId = hash.replace('agent/', '');
-                showAgentDetail(agentId);
-            } else {
-                showListView();
-            }
-        }
-
-        function showListView() {
-            document.getElementById('list-view').classList.add('active');
-            document.getElementById('detail-view').classList.remove('active');
-        }
-
-        async function showAgentDetail(agentId) {
-            document.getElementById('list-view').classList.remove('active');
-            document.getElementById('detail-view').classList.add('active');
-
-            try {
-                const [type, ...nameParts] = agentId.split('/');
-                const name = nameParts.join('/');
-
-                // Fetch all agents with enrichment and find the specific one
-                const capsResp = await fetch('/api/registry/agents?health=true&capabilities=true&properties=true');
-                const capsData = await capsResp.json();
-                const allAgents = capsData.agents || [];
-
-                // Find the specific agent using multiple matching strategies (most to least specific)
-                const agentWithCaps =
-                    // 1. Exact type + slug match
-                    allAgents.find(a => {
-                        const slugName = a.name?.toLowerCase().replace(/\s+/g, '-') || '';
-                        return a.type === type && slugName === name;
-                    }) ||
-                    // 2. Type match + URL hostname contains the name (more specific than includes)
-                    allAgents.find(a => {
-                        try {
-                            const hostname = new URL(a.url).hostname.toLowerCase();
-                            return a.type === type && hostname.includes(name.toLowerCase());
-                        } catch { return false; }
-                    }) ||
-                    // 3. Any agent with exact slug match (fallback for type mismatch)
-                    allAgents.find(a => {
-                        const slugName = a.name?.toLowerCase().replace(/\s+/g, '-') || '';
-                        return slugName === name;
-                    });
-
-                const agent = agentWithCaps || { name: name, url: '', type: type };
-
-                document.getElementById('detail-name').textContent = agent.name;
-                document.getElementById('detail-url').textContent = agent.url;
-
-                let html = '';
-
-                // Health status banner
-                const health = agent.health || {};
-                const statusText = health.online ? 'Active' : 'Offline';
-                html += `
-                    <div class="status-banner ${health.online ? 'status-banner--online' : 'status-banner--offline'}">
-                        <div>
-                            <span class="status-banner__text">Status: ${statusText}</span>
-                            ${health.response_time_ms ? `<span class="status-banner__meta">Response time: ${health.response_time_ms}ms</span>` : ''}
-                        </div>
-                        ${health.last_check ? `<div class="status-banner__time">Last check: ${new Date(health.last_check).toLocaleString()}</div>` : ''}
-                    </div>
-                `;
-
-                // Spec Compliance Badge
-                if (agentWithCaps.capabilities) {
-                    const caps = agentWithCaps.capabilities;
-
-                    if (agent.type === 'sales' && caps.tools) {
-                        // Check for actual AdCP spec required tools (from @adcp/client types)
-                        const toolNames = new Set(caps.tools.map(t => t.name.toLowerCase()));
-                        const requiredTools = [
-                            'get_products',
-                            'create_media_buy',
-                            'update_media_buy',
-                            'get_media_buy_delivery',
-                            'sync_creatives',
-                            'list_authorized_properties'
-                        ];
-                        const implementedTools = requiredTools.filter(tool => toolNames.has(tool));
-                        const isCompliant = implementedTools.length === requiredTools.length;
-
-                        html += `
-                            <div class="compliance-badge ${isCompliant ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
-                                <span class="compliance-badge__icon">${isCompliant ? '✅' : '⚠️'}</span>
-                                <div>
-                                    <div class="compliance-badge__title">${isCompliant ? 'AdCP Sales Agent' : 'Incomplete Implementation'}</div>
-                                    <div class="compliance-badge__subtitle">
-                                        Implements ${implementedTools.length} of ${requiredTools.length} required tools: ${requiredTools.join(', ')}
-                                    </div>
+                    html += `
+                        <div class="compliance-badge ${isCompliant ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
+                            <div>
+                                <div class="compliance-badge__title">${isCompliant ? 'AdCP sales agent' : 'Incomplete implementation'}</div>
+                                <div class="compliance-badge__subtitle">
+                                    Implements ${implementedTools.length} of ${requiredTools.length} required tools: ${requiredTools.join(', ')}
                                 </div>
                             </div>
-                        `;
-                    } else if (agent.type === 'creative' && caps.creative_capabilities) {
-                        const cc = caps.creative_capabilities;
-                        // Only list_creative_formats is required per AdCP spec
-                        const isCompliant = cc.formats_supported.length > 0;
-                        const hasOptionalBuild = cc.can_generate;
-                        const hasOptionalPreview = cc.can_preview;
+                        </div>
+                    `;
+                } else if (agent.type === 'creative' && caps.creative_capabilities) {
+                    const cc = caps.creative_capabilities;
+                    const isCompliant = cc.formats_supported.length > 0;
+                    const hasOptionalBuild = cc.can_generate;
+                    const hasOptionalPreview = cc.can_preview;
 
-                        const capabilities = [];
-                        if (hasOptionalBuild) capabilities.push('Generate');
-                        if (hasOptionalPreview) capabilities.push('Preview');
+                    const capabilities = [];
+                    if (hasOptionalBuild) capabilities.push('Generate');
+                    if (hasOptionalPreview) capabilities.push('Preview');
 
-                        html += `
-                            <div class="compliance-badge ${isCompliant ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
-                                <span class="compliance-badge__icon">${isCompliant ? '✅' : '⚠️'}</span>
-                                <div>
-                                    <div class="compliance-badge__title">${isCompliant ? 'AdCP Creative Agent' : 'Incomplete Implementation'}</div>
-                                    <div class="compliance-badge__subtitle">
-                                        ${isCompliant ?
-                                            `${cc.formats_supported.length} format(s)${capabilities.length > 0 ? ' • ' + capabilities.join(' • ') : ' • Formats only'}` :
-                                            'Missing required list_creative_formats tool'}
-                                    </div>
+                    html += `
+                        <div class="compliance-badge ${isCompliant ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
+                            <div>
+                                <div class="compliance-badge__title">${isCompliant ? 'AdCP creative agent' : 'Incomplete implementation'}</div>
+                                <div class="compliance-badge__subtitle">
+                                    ${isCompliant ?
+                                        `${cc.formats_supported.length} format(s)${capabilities.length > 0 ? ' &middot; ' + capabilities.join(' &middot; ') : ' &middot; Formats only'}` :
+                                        'Missing required list_creative_formats tool'}
                                 </div>
                             </div>
-                        `;
-                    }
-                }
-
-                // Type-specific sections (MOVED TO TOP)
-                if (agent.type === 'sales') {
-                    html += `
-                        <div class="detail-section">
-                            <h3>📰 Publishers & Properties</h3>
-                            <div id="publishers-section"><div class="loading">Loading publishers...</div></div>
-                        </div>
-                        <div class="detail-section">
-                            <details>
-                                <summary class="detail-section__summary">
-                                    <span class="detail-section__arrow">▶</span>
-                                    📦 Public Products
-                                </summary>
-                                <div id="products-section" class="detail-section__content"><div class="loading">Click to load available products...</div></div>
-                            </details>
-                        </div>
-                        <div class="detail-section">
-                            <details>
-                                <summary class="detail-section__summary">
-                                    <span class="detail-section__arrow">▶</span>
-                                    🎨 Creative Formats
-                                </summary>
-                                <div id="creative-formats-section" class="detail-section__content"><div class="loading">Click to load supported formats...</div></div>
-                            </details>
-                        </div>
-                    `;
-                } else if (agent.type === 'creative') {
-                    html += `
-                        <div class="detail-section">
-                            <h3>🎨 Creative Formats</h3>
-                            <div id="formats-section"><div class="loading">Loading formats...</div></div>
                         </div>
                     `;
                 }
+            }
 
-                // Tools section (moved to bottom, collapsible)
+            // Type-specific sections
+            if (agent.type === 'sales') {
                 html += `
+                    <div class="detail-section">
+                        <h3>Publishers &amp; properties</h3>
+                        <div id="publishers-section"><div class="loading">Loading publishers...</div></div>
+                    </div>
                     <div class="detail-section">
                         <details>
                             <summary class="detail-section__summary">
-                                <span class="detail-section__arrow">▶</span>
-                                🛠️ Tools (${agentWithCaps.capabilities?.tools_count || 0})
+                                <span class="detail-section__arrow">&#9654;</span>
+                                Public products
                             </summary>
-                            <div id="tools-section" class="detail-section__content"><div class="loading">Loading tools...</div></div>
+                            <div id="products-section" class="detail-section__content"><div class="loading">Click to load available products...</div></div>
+                        </details>
+                    </div>
+                    <div class="detail-section">
+                        <details>
+                            <summary class="detail-section__summary">
+                                <span class="detail-section__arrow">&#9654;</span>
+                                Creative formats
+                            </summary>
+                            <div id="creative-formats-section" class="detail-section__content"><div class="loading">Click to load supported formats...</div></div>
                         </details>
                     </div>
                 `;
-
-                // Agent info
+            } else if (agent.type === 'creative') {
                 html += `
                     <div class="detail-section">
-                        <h3>ℹ️ Agent Information</h3>
-                        <div class="info-box">
-                            ${agent.description ? `<p class="info-box__desc">${agent.description}</p>` : ''}
-                            <div class="info-box__grid">
-                                <div><strong>Type:</strong> <span style="text-transform: capitalize;">${agent.type}</span></div>
-                                <div><strong>Protocol:</strong> ${agent.protocol || 'mcp'}</div>
-                                <div><strong>Endpoint:</strong> <code class="info-box__code">${agent.url}</code></div>
-                                ${agent.mcp_endpoint ? `<div><strong>MCP Endpoint:</strong> <code class="info-box__code">${agent.mcp_endpoint}</code></div>` : ''}
-                            </div>
-                            ${agent.contact ? `
-                                <div class="info-box__contact">
-                                    <strong>Contact Information</strong><br>
-                                    <div style="margin-top: var(--space-2);">
-                                        ${agent.contact.name}<br>
-                                        <a href="mailto:${agent.contact.email}" class="info-box__contact-link">${agent.contact.email}</a>
-                                        ${agent.contact.website ? `<br><a href="${agent.contact.website}" target="_blank" class="info-box__contact-link">${agent.contact.website}</a>` : ''}
-                                    </div>
-                                </div>
-                            ` : ''}
-                        </div>
+                        <h3>Creative formats</h3>
+                        <div id="formats-section"><div class="loading">Loading formats...</div></div>
                     </div>
                 `;
-
-                document.getElementById('detail-body').innerHTML = html;
-
-                // Fetch tools and additional data
-                fetchTools(agent);
-                if (agent.type === 'sales') {
-                    fetchPublishers(agent);
-
-                    // Add event listeners for lazy-loaded sections
-                    const productsDetails = document.querySelector('#products-section').closest('details');
-                    const creativeFormatsDetails = document.querySelector('#creative-formats-section').closest('details');
-
-                    productsDetails.addEventListener('toggle', function() {
-                        if (this.open && document.getElementById('products-section').innerHTML.includes('Click to load')) {
-                            fetchPublicProducts(agent);
-                        }
-                    });
-
-                    creativeFormatsDetails.addEventListener('toggle', function() {
-                        if (this.open && document.getElementById('creative-formats-section').innerHTML.includes('Click to load')) {
-                            fetchCreativeFormats(agent);
-                        }
-                    });
-                } else if (agent.type === 'creative') {
-                    fetchFormats(agent);
-                }
-            } catch (error) {
-                document.getElementById('detail-body').innerHTML = `<div class="error-text">Failed to load agent details: ${error.message}</div>`;
             }
-        }
 
-        async function fetchTools(agent) {
-            const section = document.getElementById('tools-section');
-            try {
-                // Fetch capability discovery which includes all tools
-                const response = await fetch('/api/registry/agents?health=true&capabilities=true');
-                const data = await response.json();
-                const allAgents = data.agents || data;
-                const agentWithCaps = allAgents.find(a => a.url === agent.url);
+            // Tools section
+            html += `
+                <div class="detail-section">
+                    <details>
+                        <summary class="detail-section__summary">
+                            <span class="detail-section__arrow">&#9654;</span>
+                            Tools (${agentWithCaps?.capabilities?.tools_count || 0})
+                        </summary>
+                        <div id="tools-section" class="detail-section__content"><div class="loading">Loading tools...</div></div>
+                    </details>
+                </div>
+            `;
 
-                if (!agentWithCaps || !agentWithCaps.capabilities || agentWithCaps.capabilities.tools_count === 0) {
-                    section.innerHTML = `<div class="property-section-small">No tools discovered yet.</div>`;
-                    return;
-                }
-
-                const tools = agentWithCaps.capabilities.tools || [];
-
-                if (tools.length === 0) {
-                    section.innerHTML = `
-                        <div class="tools-summary">
-                            <span class="tools-summary__count">Total Tools: ${agentWithCaps.capabilities.tools_count}</span>
-                            <p class="tools-summary__desc">This agent exposes ${agentWithCaps.capabilities.tools_count} tools via ${agent.protocol || 'mcp'} protocol.</p>
+            // Agent info
+            html += `
+                <div class="detail-section">
+                    <h3>Agent information</h3>
+                    <div class="info-box">
+                        ${agent.description ? `<p class="info-box__desc">${escapeHtml(agent.description)}</p>` : ''}
+                        <div class="info-box__grid">
+                            <div><strong>Type:</strong> <span style="text-transform: capitalize;">${escapeHtml(agent.type)}</span></div>
+                            <div><strong>Protocol:</strong> ${escapeHtml(agent.protocol || 'mcp')}</div>
+                            <div><strong>Endpoint:</strong> <code class="info-box__code">${escapeHtml(agent.url)}</code></div>
+                            ${agent.mcp_endpoint ? `<div><strong>MCP endpoint:</strong> <code class="info-box__code">${escapeHtml(agent.mcp_endpoint)}</code></div>` : ''}
                         </div>
-                    `;
-                    return;
-                }
-
-                let html = `
-                    <div class="tools-summary">
-                        <span class="tools-summary__count">Total Tools: ${tools.length}</span>
-                        <p class="tools-summary__desc">This agent exposes ${tools.length} tools via ${agent.protocol || 'mcp'} protocol.</p>
-                    </div>
-                    <div class="tools-list">
-                `;
-
-                tools.forEach((tool, index) => {
-                    const hasSchema = tool.input_schema && Object.keys(tool.input_schema).length > 0;
-                    html += `
-                        <div class="tool-item">
-                            <div class="tool-item__header">
-                                <div class="tool-name">${index + 1}. ${tool.name}</div>
-                                ${hasSchema ? `<details class="tool-schema-toggle">
-                                    <summary>Schema</summary>
-                                    <pre class="tool-schema-pre">${JSON.stringify(tool.input_schema, null, 2)}</pre>
-                                </details>` : ''}
+                        ${agent.contact ? `
+                            <div class="info-box__contact">
+                                <strong>Contact information</strong><br>
+                                <div style="margin-top: var(--space-2);">
+                                    ${escapeHtml(agent.contact.name)}<br>
+                                    <a href="mailto:${escapeHtml(agent.contact.email)}" class="info-box__contact-link">${escapeHtml(agent.contact.email)}</a>
+                                    ${agent.contact.website ? `<br><a href="${escapeHtml(agent.contact.website)}" target="_blank" rel="noopener noreferrer" class="info-box__contact-link">${escapeHtml(agent.contact.website)}</a>` : ''}
+                                </div>
                             </div>
-                            ${tool.description ? `<div class="tool-description">${tool.description}</div>` : '<div class="tool-description" style="color: var(--color-text-light);">No description available</div>'}
-                        </div>
-                    `;
-                });
-
-                html += '</div>';
-                section.innerHTML = html;
-            } catch (error) {
-                section.innerHTML = `<div class="error-text">Failed to load tools: ${error.message}</div>`;
-            }
-        }
-
-        async function fetchPublishers(agent) {
-            try {
-                const response = await fetch(`/mcp`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        jsonrpc: '2.0',
-                        id: 1,
-                        method: 'tools/call',
-                        params: {
-                            name: 'get_properties_for_agent',
-                            arguments: { agent_url: agent.url }
-                        }
-                    })
-                });
-                const data = await response.json();
-                const result = JSON.parse(data.result.content[0].resource.text);
-
-                const section = document.getElementById('publishers-section');
-
-                if (result.error) {
-                    section.innerHTML = `<div class="tool-error-box">
-                        <strong>Error:</strong> ${result.error}
-                    </div>`;
-                    return;
-                }
-
-                if (result.properties && result.properties.length > 0) {
-                    // Group by verification status
-                    const verified = result.properties.filter(p => p.verified === true);
-                    const unverified = result.properties.filter(p => p.verified === false);
-                    const unchecked = result.properties.filter(p => p.verified === undefined);
-
-                    let html = '';
-
-                    if (verified.length > 0) {
-                        html += '<div class="publishers-group">';
-                        html += '<h4 class="publishers-group__title publishers-group__title--verified">✓ Verified Properties</h4>';
-                        html += '<div class="publishers-grid">' +
-                            verified.map(p => `
-                                <div class="publisher-item publisher-item--verified">
-                                    <div style="display: flex; justify-content: between; align-items: start; gap: var(--space-2);">
-                                        <div style="flex: 1;">
-                                            <div class="publisher-domain">${p.identifier || p.domain || 'Unknown'}</div>
-                                            <div class="property-section-small" style="margin-top: var(--space-1);">
-                                                <strong>Type:</strong> ${p.type || 'domain'}
-                                                ${p.country ? ` | <strong>Country:</strong> ${p.country}` : ''}
-                                            </div>
-                                        </div>
-                                        <a href="${p.verification_url}" target="_blank" class="publisher-verify-link" title="View adagents.json">
-                                            🔗 Verified
-                                        </a>
-                                    </div>
-                                    ${p.description ? `<div class="property-section-small" style="margin-top: var(--space-2);">${p.description}</div>` : ''}
-                                    ${p.tags && p.tags.length > 0 ? `
-                                        <div class="property-tags" style="margin-top: var(--space-3);">
-                                            ${p.tags.map(tag => `<span class="property-tag">${tag}</span>`).join('')}
-                                        </div>
-                                    ` : ''}
-                                    ${p.metadata ? `<details class="property-metadata-toggle">
-                                        <summary>Additional metadata</summary>
-                                        <pre class="property-metadata-pre">${JSON.stringify(p.metadata, null, 2)}</pre>
-                                    </details>` : ''}
-                                </div>
-                            `).join('') +
-                        '</div>';
-                        html += '</div>';
-                    }
-
-                    if (unverified.length > 0) {
-                        html += '<div class="publishers-group">';
-                        html += '<h4 class="publishers-group__title publishers-group__title--unverified">✗ Unverified Properties (Claims Not Authorized)</h4>';
-                        html += '<div class="publishers-grid">' +
-                            unverified.map(p => `
-                                <div class="publisher-item publisher-item--unverified">
-                                    <div style="display: flex; justify-content: space-between; align-items: start; gap: var(--space-2);">
-                                        <div style="flex: 1;">
-                                            <div class="publisher-domain">${p.identifier || p.domain || 'Unknown'}</div>
-                                            <div class="property-section-small" style="margin-top: var(--space-1);">${p.type || 'domain'}</div>
-                                        </div>
-                                        ${p.verification_url ? `<a href="${p.verification_url}" target="_blank" class="publisher-verify-link publisher-verify-link--error" title="Check adagents.json">
-                                            🔗 Check
-                                        </a>` : ''}
-                                    </div>
-                                    <div class="publisher-warning">
-                                        <strong>⚠️ Warning:</strong> ${p.verification_error || 'This agent is not listed in the domain\'s .well-known/adagents.json file'}
-                                    </div>
-                                </div>
-                            `).join('') +
-                        '</div>';
-                        html += '</div>';
-                    }
-
-                    if (unchecked.length > 0) {
-                        html += '<div class="publishers-group">';
-                        html += '<h4 class="publishers-group__title publishers-group__title--unchecked">⚠️ Unchecked Properties</h4>';
-                        html += '<div class="publishers-grid">' +
-                            unchecked.map(p => `
-                                <div class="publisher-item publisher-item--unchecked">
-                                    <div class="publisher-domain">${p.identifier || p.domain || 'Unknown'}</div>
-                                    <div class="property-section-small" style="margin-top: var(--space-1);">${p.type || 'domain'}</div>
-                                </div>
-                            `).join('') +
-                        '</div>';
-                        html += '</div>';
-                    }
-
-                    section.innerHTML = html;
-                } else {
-                    section.innerHTML = `<div class="property-section-small">No properties available from this agent yet.</div>`;
-                }
-            } catch (error) {
-                document.getElementById('publishers-section').innerHTML = `<div class="error-text">Failed to load publishers: ${error.message}</div>`;
-            }
-        }
-
-        async function fetchFormats(agent) {
-            const section = document.getElementById('formats-section');
-            section.innerHTML = '<div class="loading">Loading formats...</div>';
-
-            try {
-                const response = await fetch(`/mcp`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        jsonrpc: '2.0',
-                        id: 1,
-                        method: 'tools/call',
-                        params: {
-                            name: 'list_creative_formats_for_agent',
-                            arguments: { agent_url: agent.url, params: {} }
-                        }
-                    })
-                });
-                const data = await response.json();
-
-                if (data.error) {
-                    section.innerHTML = `<div class="property-section-small">Unable to fetch formats: ${data.error.message || 'Unknown error'}</div>`;
-                    return;
-                }
-
-                const result = JSON.parse(data.result.content[0].resource.text);
-
-                if (result.error) {
-                    section.innerHTML = `<div class="property-section-small">${result.error}</div>`;
-                    return;
-                }
-
-                // Handle different response formats
-                let formats = [];
-                if (Array.isArray(result)) {
-                    formats = result;
-                } else if (result.formats && Array.isArray(result.formats)) {
-                    formats = result.formats;
-                } else if (result.data && Array.isArray(result.data)) {
-                    formats = result.data;
-                } else if (result.data && result.data.formats) {
-                    formats = result.data.formats;
-                }
-
-                if (formats.length === 0) {
-                    section.innerHTML = '<div class="property-section-small">No creative formats available</div>';
-                    return;
-                }
-
-                // Display formats in a grid
-                let html = '<div class="format-card-grid">';
-                formats.forEach(format => {
-                    const formatName = typeof format === 'string' ? format : (format.name || format.format || 'Unknown');
-                    const dimensions = typeof format === 'object' ? (format.dimensions || format.size) : null;
-                    const type = typeof format === 'object' ? (format.type || format.format_type) : null;
-                    const description = typeof format === 'object' ? format.description : null;
-
-                    html += `
-                        <div class="product-card">
-                            <div class="product-card__name">${formatName}</div>
-                            ${dimensions ? `<div class="format-card-dimensions">📐 ${dimensions}</div>` : ''}
-                            ${type ? `<div class="format-card-type">${type}</div>` : ''}
-                            ${description ? `<div class="product-card__desc">${description}</div>` : ''}
-                        </div>
-                    `;
-                });
-                html += '</div>';
-
-                section.innerHTML = html;
-            } catch (error) {
-                section.innerHTML = `<div class="error-text">Failed to load formats: ${error.message}</div>`;
-            }
-        }
-
-        async function fetchPublicProducts(agent) {
-            const section = document.getElementById('products-section');
-            section.innerHTML = '<div class="loading">Loading products...</div>';
-
-            try {
-                const response = await fetch(`/mcp`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        jsonrpc: '2.0',
-                        id: 1,
-                        method: 'tools/call',
-                        params: {
-                            name: 'get_products_for_agent',
-                            arguments: { agent_url: agent.url, params: {} }
-                        }
-                    })
-                });
-                const data = await response.json();
-
-                if (data.error) {
-                    section.innerHTML = `<div class="property-section-small">Unable to fetch products: ${data.error.message || 'Unknown error'}</div>`;
-                    return;
-                }
-
-                const result = JSON.parse(data.result.content[0].resource.text);
-
-                if (result.error) {
-                    const isValidationError = result.error.includes('does not match') || result.error.includes('Input should be');
-                    section.innerHTML = `
-                        <div class="agent-params-required">
-                            <div class="agent-params-required__title">${isValidationError ? 'Agent Requires Parameters' : 'Agent Error'}</div>
-                            <div class="agent-params-required__desc">
-                                ${isValidationError ? 'This agent requires specific targeting criteria (brief, brand_manifest, etc.) and does not support browsing public products.' : result.error}
-                            </div>
-                        </div>
-                    `;
-                    return;
-                }
-
-                const products = result.products || [];
-
-                if (products.length === 0) {
-                    section.innerHTML = '<div class="property-section-small">No public products available (may require targeting)</div>';
-                    return;
-                }
-
-                let html = '<div class="products-grid">';
-                products.forEach(product => {
-                    html += `
-                        <div class="product-card">
-                            <div class="product-card__name">${product.name || product.id || 'Unnamed Product'}</div>
-                            ${product.description ? `<div class="product-card__desc">${product.description}</div>` : ''}
-                            ${product.inventory_type ? `<div class="product-card__meta"><strong>Type:</strong> ${product.inventory_type}</div>` : ''}
-                            ${product.price ? `<div class="product-card__meta"><strong>Price:</strong> ${product.price.amount} ${product.price.currency}</div>` : ''}
-                            ${product.publisher_domain ? `<div class="product-card__meta"><strong>Publisher:</strong> ${product.publisher_domain}</div>` : ''}
-                        </div>
-                    `;
-                });
-                html += '</div>';
-
-                section.innerHTML = html;
-            } catch (error) {
-                section.innerHTML = `<div class="error-text">Failed to load products: ${error.message}</div>`;
-            }
-        }
-
-        async function fetchCreativeFormats(agent) {
-            const section = document.getElementById('creative-formats-section');
-            section.innerHTML = '<div class="loading">Loading formats...</div>';
-
-            try {
-                const response = await fetch(`/mcp`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        jsonrpc: '2.0',
-                        id: 1,
-                        method: 'tools/call',
-                        params: {
-                            name: 'list_creative_formats_for_agent',
-                            arguments: { agent_url: agent.url, params: {} }
-                        }
-                    })
-                });
-                const data = await response.json();
-
-                if (data.error) {
-                    section.innerHTML = `<div class="property-section-small">Unable to fetch formats: ${data.error.message || 'Unknown error'}</div>`;
-                    return;
-                }
-
-                const result = JSON.parse(data.result.content[0].resource.text);
-
-                if (result.error) {
-                    section.innerHTML = `<div class="property-section-small">${result.error}</div>`;
-                    return;
-                }
-
-                const formats = result.formats || [];
-
-                if (formats.length === 0) {
-                    section.innerHTML = '<div class="property-section-small">No creative formats available</div>';
-                    return;
-                }
-
-                // Extract unique types for filtering
-                const types = [...new Set(formats.map(f => f.type).filter(Boolean))];
-
-                let html = `
-                    <div class="format-filters">
-                        <span class="format-filters__label">Filter:</span>
-                        <button onclick="filterFormats('all')" class="format-filter-btn active" data-type="all">
-                            All (${formats.length})
-                        </button>
-                        ${types.map(type => `
-                            <button onclick="filterFormats('${type}')" class="format-filter-btn" data-type="${type}">
-                                ${type.replace(/_/g, ' ')} (${formats.filter(f => f.type === type).length})
-                            </button>
-                        `).join('')}
-                    </div>
-                    <div id="formats-grid" class="format-card-grid">
-                `;
-
-                formats.forEach((format, index) => {
-                    const dimensions = format.renders?.[0]?.dimensions;
-                    const width = dimensions?.width || dimensions?.max_width;
-                    const height = dimensions?.height || dimensions?.max_height;
-                    const isResponsive = dimensions?.min_width || dimensions?.min_height;
-
-                    html += `
-                        <div class="format-card format-card-item" data-type="${format.type || 'unknown'}" onclick="showFormatDetails(${index}, ${JSON.stringify(format).replace(/"/g, '&quot;')})">
-                            ${format.preview_image ? `
-                                <div class="format-card-preview">
-                                    <img src="${format.preview_image}" alt="${format.name}" onerror="this.parentElement.innerHTML='<div class=&quot;format-card-preview__placeholder&quot;>🎨</div>'">
-                                </div>
-                            ` : `
-                                <div class="format-card-preview">
-                                    <span class="format-card-preview__placeholder">🎨</span>
-                                </div>
-                            `}
-                            <div class="format-card-body">
-                                <div class="format-card-name">${format.name || format.format_id || 'Unnamed Format'}</div>
-                                ${width && height ? `
-                                    <div class="format-card-dimensions">
-                                        📐 ${isResponsive ? 'Responsive: ' : ''}${width}×${height}${dimensions?.unit ? dimensions.unit : 'px'}
-                                    </div>
-                                ` : ''}
-                                ${format.type ? `
-                                    <div class="format-card-type">
-                                        ${format.type.replace(/_/g, ' ')}
-                                    </div>
-                                ` : ''}
-                            </div>
-                        </div>
-                    `;
-                });
-
-                html += '</div>';
-
-                section.innerHTML = html;
-
-                // Store formats for filtering
-                window.currentFormats = formats;
-
-            } catch (error) {
-                section.innerHTML = `<div class="error-text">Failed to load formats: ${error.message}</div>`;
-            }
-        }
-
-        function filterFormats(type) {
-            const cards = document.querySelectorAll('.format-card');
-            const buttons = document.querySelectorAll('.format-filter-btn');
-
-            buttons.forEach(btn => {
-                if (btn.dataset.type === type) {
-                    btn.classList.add('active');
-                } else {
-                    btn.classList.remove('active');
-                }
-            });
-
-            cards.forEach(card => {
-                if (type === 'all' || card.dataset.type === type) {
-                    card.style.display = 'block';
-                } else {
-                    card.style.display = 'none';
-                }
-            });
-        }
-
-        function showFormatDetails(index, format) {
-            const modal = document.createElement('div');
-            modal.className = 'format-modal-overlay';
-            modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
-
-            const dimensions = format.renders?.[0]?.dimensions;
-            const width = dimensions?.width || dimensions?.max_width;
-            const height = dimensions?.height || dimensions?.max_height;
-
-            modal.innerHTML = `
-                <div class="format-modal" onclick="event.stopPropagation()">
-                    <div class="format-modal__header">
-                        <h3 class="format-modal__title">${format.name || format.format_id}</h3>
-                        <button onclick="this.closest('.format-modal-overlay').remove()" class="format-modal__close">×</button>
-                    </div>
-                    <div class="format-modal__body">
-                        ${format.preview_image ? `
-                            <div class="format-modal__preview">
-                                <img src="${format.preview_image}" alt="${format.name}">
-                            </div>
-                        ` : ''}
-                        ${format.description ? `<p class="format-modal__desc">${format.description}</p>` : ''}
-                        <div class="format-modal__meta">
-                            ${format.format_id ? `<div><strong>Format ID:</strong> <code class="format-modal__code">${format.format_id}</code></div>` : ''}
-                            ${format.type ? `<div><strong>Type:</strong> <span style="text-transform: capitalize;">${format.type.replace(/_/g, ' ')}</span></div>` : ''}
-                            ${width && height ? `<div><strong>Dimensions:</strong> ${width}×${height}${dimensions?.unit || 'px'}</div>` : ''}
-                            ${dimensions?.min_width || dimensions?.min_height ? `<div><strong>Responsive:</strong> Yes (${dimensions.min_width || 0}×${dimensions.min_height || 0} to ${dimensions.max_width || width}×${dimensions.max_height || height})</div>` : ''}
-                        </div>
-                        ${format.example_url ? `
-                            <a href="${format.example_url}" target="_blank" class="format-modal__cta">
-                                View Examples & Demos →
-                            </a>
                         ` : ''}
                     </div>
                 </div>
             `;
 
-            document.body.appendChild(modal);
+            document.getElementById('detail-body').innerHTML = html;
+
+            // Fetch tools and additional data
+            fetchTools(agent);
+            if (agent.type === 'sales') {
+                fetchPublishers(agent);
+
+                const productsDetails = document.querySelector('#products-section').closest('details');
+                const creativeFormatsDetails = document.querySelector('#creative-formats-section').closest('details');
+
+                productsDetails.addEventListener('toggle', function() {
+                    if (this.open && document.getElementById('products-section').innerHTML.includes('Click to load')) {
+                        fetchPublicProducts(agent);
+                    }
+                });
+
+                creativeFormatsDetails.addEventListener('toggle', function() {
+                    if (this.open && document.getElementById('creative-formats-section').innerHTML.includes('Click to load')) {
+                        fetchCreativeFormats(agent);
+                    }
+                });
+            } else if (agent.type === 'creative') {
+                fetchFormats(agent);
+            }
+        } catch (error) {
+            document.getElementById('detail-body').innerHTML = `<div class="error-text">Failed to load agent details: ${escapeHtml(error.message)}</div>`;
         }
-    </script>
+    }
+
+    async function fetchTools(agent) {
+        const section = document.getElementById('tools-section');
+        try {
+            const response = await fetch('/api/registry/agents?health=true&capabilities=true');
+            const data = await response.json();
+            const allAgents = data.agents || data;
+            const agentWithCaps = allAgents.find(a => a.url === agent.url);
+
+            if (!agentWithCaps || !agentWithCaps.capabilities || agentWithCaps.capabilities.tools_count === 0) {
+                section.innerHTML = `<div class="property-section-small">No tools discovered yet.</div>`;
+                return;
+            }
+
+            const tools = agentWithCaps.capabilities.tools || [];
+
+            if (tools.length === 0) {
+                section.innerHTML = `
+                    <div class="tools-summary">
+                        <span class="tools-summary__count">Total tools: ${agentWithCaps.capabilities.tools_count}</span>
+                        <p class="tools-summary__desc">This agent exposes ${agentWithCaps.capabilities.tools_count} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                    </div>
+                `;
+                return;
+            }
+
+            let html = `
+                <div class="tools-summary">
+                    <span class="tools-summary__count">Total tools: ${tools.length}</span>
+                    <p class="tools-summary__desc">This agent exposes ${tools.length} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                </div>
+                <div class="tools-list">
+            `;
+
+            tools.forEach((tool, index) => {
+                const hasSchema = tool.input_schema && Object.keys(tool.input_schema).length > 0;
+                html += `
+                    <div class="tool-item">
+                        <div class="tool-item__header">
+                            <div class="tool-name">${index + 1}. ${escapeHtml(tool.name)}</div>
+                            ${hasSchema ? `<details class="tool-schema-toggle">
+                                <summary>Schema</summary>
+                                <pre class="tool-schema-pre">${escapeHtml(JSON.stringify(tool.input_schema, null, 2))}</pre>
+                            </details>` : ''}
+                        </div>
+                        ${tool.description ? `<div class="tool-description">${escapeHtml(tool.description)}</div>` : '<div class="tool-description" style="color: var(--color-text-light);">No description available</div>'}
+                    </div>
+                `;
+            });
+
+            html += '</div>';
+            section.innerHTML = html;
+        } catch (error) {
+            section.innerHTML = `<div class="error-text">Failed to load tools: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    async function fetchPublishers(agent) {
+        try {
+            const response = await fetch(`/mcp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'get_properties_for_agent',
+                        arguments: { agent_url: agent.url }
+                    }
+                })
+            });
+            const data = await response.json();
+            const result = JSON.parse(data.result.content[0].resource.text);
+
+            const section = document.getElementById('publishers-section');
+
+            if (result.error) {
+                section.innerHTML = `<div class="tool-error-box">
+                    <strong>Error:</strong> ${escapeHtml(result.error)}
+                </div>`;
+                return;
+            }
+
+            if (result.properties && result.properties.length > 0) {
+                const verified = result.properties.filter(p => p.verified === true);
+                const unverified = result.properties.filter(p => p.verified === false);
+                const unchecked = result.properties.filter(p => p.verified === undefined);
+
+                let html = '';
+
+                if (verified.length > 0) {
+                    html += '<div class="publishers-group">';
+                    html += '<h4 class="publishers-group__title publishers-group__title--verified">Verified properties</h4>';
+                    html += '<div class="publishers-grid">' +
+                        verified.map(p => `
+                            <div class="publisher-item publisher-item--verified">
+                                <div style="display: flex; justify-content: between; align-items: start; gap: var(--space-2);">
+                                    <div style="flex: 1;">
+                                        <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
+                                        <div class="property-section-small" style="margin-top: var(--space-1);">
+                                            <strong>Type:</strong> ${escapeHtml(p.type || 'domain')}
+                                            ${p.country ? ` | <strong>Country:</strong> ${escapeHtml(p.country)}` : ''}
+                                        </div>
+                                    </div>
+                                    <a href="${escapeHtml(p.verification_url)}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link" title="View adagents.json">
+                                        Verified
+                                    </a>
+                                </div>
+                                ${p.description ? `<div class="property-section-small" style="margin-top: var(--space-2);">${escapeHtml(p.description)}</div>` : ''}
+                                ${p.tags && p.tags.length > 0 ? `
+                                    <div class="property-tags" style="margin-top: var(--space-3);">
+                                        ${p.tags.map(tag => `<span class="property-tag">${escapeHtml(tag)}</span>`).join('')}
+                                    </div>
+                                ` : ''}
+                                ${p.metadata ? `<details class="property-metadata-toggle">
+                                    <summary>Additional metadata</summary>
+                                    <pre class="property-metadata-pre">${escapeHtml(JSON.stringify(p.metadata, null, 2))}</pre>
+                                </details>` : ''}
+                            </div>
+                        `).join('') +
+                    '</div>';
+                    html += '</div>';
+                }
+
+                if (unverified.length > 0) {
+                    html += '<div class="publishers-group">';
+                    html += '<h4 class="publishers-group__title publishers-group__title--unverified">Unverified properties (claims not authorized)</h4>';
+                    html += '<div class="publishers-grid">' +
+                        unverified.map(p => `
+                            <div class="publisher-item publisher-item--unverified">
+                                <div style="display: flex; justify-content: space-between; align-items: start; gap: var(--space-2);">
+                                    <div style="flex: 1;">
+                                        <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
+                                        <div class="property-section-small" style="margin-top: var(--space-1);">${escapeHtml(p.type || 'domain')}</div>
+                                    </div>
+                                    ${p.verification_url ? `<a href="${escapeHtml(p.verification_url)}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link publisher-verify-link--error" title="Check adagents.json">
+                                        Check
+                                    </a>` : ''}
+                                </div>
+                                <div class="publisher-warning">
+                                    <strong>Warning:</strong> ${escapeHtml(p.verification_error || 'This agent is not listed in the domain\'s .well-known/adagents.json file')}
+                                </div>
+                            </div>
+                        `).join('') +
+                    '</div>';
+                    html += '</div>';
+                }
+
+                if (unchecked.length > 0) {
+                    html += '<div class="publishers-group">';
+                    html += '<h4 class="publishers-group__title publishers-group__title--unchecked">Unchecked properties</h4>';
+                    html += '<div class="publishers-grid">' +
+                        unchecked.map(p => `
+                            <div class="publisher-item publisher-item--unchecked">
+                                <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
+                                <div class="property-section-small" style="margin-top: var(--space-1);">${escapeHtml(p.type || 'domain')}</div>
+                            </div>
+                        `).join('') +
+                    '</div>';
+                    html += '</div>';
+                }
+
+                section.innerHTML = html;
+            } else {
+                section.innerHTML = `<div class="property-section-small">No properties available from this agent yet.</div>`;
+            }
+        } catch (error) {
+            document.getElementById('publishers-section').innerHTML = `<div class="error-text">Failed to load publishers: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    async function fetchFormats(agent) {
+        const section = document.getElementById('formats-section');
+        section.innerHTML = '<div class="loading">Loading formats...</div>';
+
+        try {
+            const response = await fetch(`/mcp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'list_creative_formats_for_agent',
+                        arguments: { agent_url: agent.url, params: {} }
+                    }
+                })
+            });
+            const data = await response.json();
+
+            if (data.error) {
+                section.innerHTML = `<div class="property-section-small">Unable to fetch formats: ${escapeHtml(data.error.message || 'Unknown error')}</div>`;
+                return;
+            }
+
+            const result = JSON.parse(data.result.content[0].resource.text);
+
+            if (result.error) {
+                section.innerHTML = `<div class="property-section-small">${escapeHtml(result.error)}</div>`;
+                return;
+            }
+
+            let formats = [];
+            if (Array.isArray(result)) {
+                formats = result;
+            } else if (result.formats && Array.isArray(result.formats)) {
+                formats = result.formats;
+            } else if (result.data && Array.isArray(result.data)) {
+                formats = result.data;
+            } else if (result.data && result.data.formats) {
+                formats = result.data.formats;
+            }
+
+            if (formats.length === 0) {
+                section.innerHTML = '<div class="property-section-small">No creative formats available</div>';
+                return;
+            }
+
+            let html = '<div class="format-card-grid">';
+            formats.forEach(format => {
+                const formatName = typeof format === 'string' ? format : (format.name || format.format || 'Unknown');
+                const dimensions = typeof format === 'object' ? (format.dimensions || format.size) : null;
+                const type = typeof format === 'object' ? (format.type || format.format_type) : null;
+                const description = typeof format === 'object' ? format.description : null;
+
+                html += `
+                    <div class="product-card">
+                        <div class="product-card__name">${escapeHtml(formatName)}</div>
+                        ${dimensions ? `<div class="format-card-dimensions">${escapeHtml(String(dimensions))}</div>` : ''}
+                        ${type ? `<div class="format-card-type">${escapeHtml(type)}</div>` : ''}
+                        ${description ? `<div class="product-card__desc">${escapeHtml(description)}</div>` : ''}
+                    </div>
+                `;
+            });
+            html += '</div>';
+
+            section.innerHTML = html;
+        } catch (error) {
+            section.innerHTML = `<div class="error-text">Failed to load formats: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    async function fetchPublicProducts(agent) {
+        const section = document.getElementById('products-section');
+        section.innerHTML = '<div class="loading">Loading products...</div>';
+
+        try {
+            const response = await fetch(`/mcp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'get_products_for_agent',
+                        arguments: { agent_url: agent.url, params: {} }
+                    }
+                })
+            });
+            const data = await response.json();
+
+            if (data.error) {
+                section.innerHTML = `<div class="property-section-small">Unable to fetch products: ${escapeHtml(data.error.message || 'Unknown error')}</div>`;
+                return;
+            }
+
+            const result = JSON.parse(data.result.content[0].resource.text);
+
+            if (result.error) {
+                const isValidationError = result.error.includes('does not match') || result.error.includes('Input should be');
+                section.innerHTML = `
+                    <div class="agent-params-required">
+                        <div class="agent-params-required__title">${isValidationError ? 'Agent requires parameters' : 'Agent error'}</div>
+                        <div class="agent-params-required__desc">
+                            ${isValidationError ? 'This agent requires specific targeting criteria (brief, brand_manifest, etc.) and does not support browsing public products.' : escapeHtml(result.error)}
+                        </div>
+                    </div>
+                `;
+                return;
+            }
+
+            const products = result.products || [];
+
+            if (products.length === 0) {
+                section.innerHTML = '<div class="property-section-small">No public products available (may require targeting)</div>';
+                return;
+            }
+
+            let html = '<div class="products-grid">';
+            products.forEach(product => {
+                html += `
+                    <div class="product-card">
+                        <div class="product-card__name">${escapeHtml(product.name || product.id || 'Unnamed Product')}</div>
+                        ${product.description ? `<div class="product-card__desc">${escapeHtml(product.description)}</div>` : ''}
+                        ${product.inventory_type ? `<div class="product-card__meta"><strong>Type:</strong> ${escapeHtml(product.inventory_type)}</div>` : ''}
+                        ${product.price ? `<div class="product-card__meta"><strong>Price:</strong> ${escapeHtml(String(product.price.amount))} ${escapeHtml(product.price.currency)}</div>` : ''}
+                        ${product.publisher_domain ? `<div class="product-card__meta"><strong>Publisher:</strong> ${escapeHtml(product.publisher_domain)}</div>` : ''}
+                    </div>
+                `;
+            });
+            html += '</div>';
+
+            section.innerHTML = html;
+        } catch (error) {
+            section.innerHTML = `<div class="error-text">Failed to load products: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    async function fetchCreativeFormats(agent) {
+        const section = document.getElementById('creative-formats-section');
+        section.innerHTML = '<div class="loading">Loading formats...</div>';
+
+        try {
+            const response = await fetch(`/mcp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'list_creative_formats_for_agent',
+                        arguments: { agent_url: agent.url, params: {} }
+                    }
+                })
+            });
+            const data = await response.json();
+
+            if (data.error) {
+                section.innerHTML = `<div class="property-section-small">Unable to fetch formats: ${escapeHtml(data.error.message || 'Unknown error')}</div>`;
+                return;
+            }
+
+            const result = JSON.parse(data.result.content[0].resource.text);
+
+            if (result.error) {
+                section.innerHTML = `<div class="property-section-small">${escapeHtml(result.error)}</div>`;
+                return;
+            }
+
+            const formats = result.formats || [];
+
+            if (formats.length === 0) {
+                section.innerHTML = '<div class="property-section-small">No creative formats available</div>';
+                return;
+            }
+
+            const types = [...new Set(formats.map(f => f.type).filter(Boolean))];
+
+            // Store formats for use by filter buttons and detail modal
+            window.currentFormats = formats;
+
+            let html = `
+                <div class="format-filters">
+                    <span class="format-filters__label">Filter:</span>
+                    <button class="format-filter-btn active" data-type="all">
+                        All (${formats.length})
+                    </button>
+                    ${types.map(type => `
+                        <button class="format-filter-btn" data-type="${escapeHtml(type)}">
+                            ${escapeHtml(type.replace(/_/g, ' '))} (${formats.filter(f => f.type === type).length})
+                        </button>
+                    `).join('')}
+                </div>
+                <div id="formats-grid" class="format-card-grid">
+            `;
+
+            formats.forEach((format, index) => {
+                const dimensions = format.renders?.[0]?.dimensions;
+                const width = dimensions?.width || dimensions?.max_width;
+                const height = dimensions?.height || dimensions?.max_height;
+                const isResponsive = dimensions?.min_width || dimensions?.min_height;
+
+                html += `
+                    <div class="format-card format-card-item" data-type="${escapeHtml(format.type || 'unknown')}" data-index="${index}">
+                        ${format.preview_image ? `
+                            <div class="format-card-preview">
+                                <img src="${escapeHtml(format.preview_image)}" alt="${escapeHtml(format.name || '')}" onerror="this.parentElement.innerHTML='<div class=&quot;format-card-preview__placeholder&quot;>&#127912;</div>'">
+                            </div>
+                        ` : `
+                            <div class="format-card-preview">
+                                <span class="format-card-preview__placeholder">&#127912;</span>
+                            </div>
+                        `}
+                        <div class="format-card-body">
+                            <div class="format-card-name">${escapeHtml(format.name || format.format_id || 'Unnamed format')}</div>
+                            ${width && height ? `
+                                <div class="format-card-dimensions">
+                                    ${isResponsive ? 'Responsive: ' : ''}${escapeHtml(String(width))}&times;${escapeHtml(String(height))}${escapeHtml(dimensions?.unit ? dimensions.unit : 'px')}
+                                </div>
+                            ` : ''}
+                            ${format.type ? `
+                                <div class="format-card-type">
+                                    ${escapeHtml(format.type.replace(/_/g, ' '))}
+                                </div>
+                            ` : ''}
+                        </div>
+                    </div>
+                `;
+            });
+
+            html += '</div>';
+            section.innerHTML = html;
+
+            // Event delegation for format filter buttons
+            section.querySelectorAll('.format-filter-btn').forEach(btn => {
+                btn.addEventListener('click', () => filterFormats(btn.dataset.type));
+            });
+
+            // Event delegation for format card clicks
+            section.querySelectorAll('.format-card-item[data-index]').forEach(card => {
+                card.addEventListener('click', () => {
+                    const idx = parseInt(card.dataset.index, 10);
+                    showFormatDetails(idx, window.currentFormats[idx]);
+                });
+            });
+
+        } catch (error) {
+            section.innerHTML = `<div class="error-text">Failed to load formats: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    window.filterFormats = function(type) {
+        const cards = document.querySelectorAll('.format-card');
+        const buttons = document.querySelectorAll('.format-filter-btn');
+
+        buttons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.type === type);
+        });
+
+        cards.forEach(card => {
+            card.style.display = (type === 'all' || card.dataset.type === type) ? 'block' : 'none';
+        });
+    };
+
+    window.showFormatDetails = function(index, format) {
+        const modal = document.createElement('div');
+        modal.className = 'format-modal-overlay';
+        modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+
+        const dimensions = format.renders?.[0]?.dimensions;
+        const width = dimensions?.width || dimensions?.max_width;
+        const height = dimensions?.height || dimensions?.max_height;
+
+        modal.innerHTML = `
+            <div class="format-modal" onclick="event.stopPropagation()">
+                <div class="format-modal__header">
+                    <h3 class="format-modal__title">${escapeHtml(format.name || format.format_id || '')}</h3>
+                    <button onclick="this.closest('.format-modal-overlay').remove()" class="format-modal__close">&times;</button>
+                </div>
+                <div class="format-modal__body">
+                    ${format.preview_image ? `
+                        <div class="format-modal__preview">
+                            <img src="${escapeHtml(format.preview_image)}" alt="${escapeHtml(format.name || '')}">
+                        </div>
+                    ` : ''}
+                    ${format.description ? `<p class="format-modal__desc">${escapeHtml(format.description)}</p>` : ''}
+                    <div class="format-modal__meta">
+                        ${format.format_id ? `<div><strong>Format ID:</strong> <code class="format-modal__code">${escapeHtml(format.format_id)}</code></div>` : ''}
+                        ${format.type ? `<div><strong>Type:</strong> <span style="text-transform: capitalize;">${escapeHtml(format.type.replace(/_/g, ' '))}</span></div>` : ''}
+                        ${width && height ? `<div><strong>Dimensions:</strong> ${escapeHtml(String(width))}&times;${escapeHtml(String(height))}${escapeHtml(dimensions?.unit || 'px')}</div>` : ''}
+                        ${dimensions?.min_width || dimensions?.min_height ? `<div><strong>Responsive:</strong> Yes (${dimensions.min_width || 0}&times;${dimensions.min_height || 0} to ${dimensions.max_width || width}&times;${dimensions.max_height || height})</div>` : ''}
+                    </div>
+                    ${format.example_url ? `
+                        <a href="${escapeHtml(format.example_url)}" target="_blank" rel="noopener noreferrer" class="format-modal__cta">
+                            View examples &amp; demos &rarr;
+                        </a>
+                    ` : ''}
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(modal);
+    };
+</script>
 </body>
 </html>

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -6,6 +6,7 @@
     <title>brand.json Builder - AdCP Brand Protocol</title>
     <link rel="icon" href="/AAo.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
+    <link rel="stylesheet" href="/layout.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -78,6 +79,8 @@
       .page-header {
         text-align: center;
         margin-bottom: var(--space-12);
+        background: none;
+        padding: 0;
       }
 
       .page-header h1 {
@@ -1122,6 +1125,7 @@
     <!-- Navigation (loaded by nav.js) -->
     <div id="adcp-nav"></div>
     <script src="/nav.js"></script>
+    <script src="/registry-nav.js"></script>
 
     <div class="main-content">
       <!-- Page Header -->

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -1,639 +1,603 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Brand Registry - AdCP</title>
-    <link rel="stylesheet" href="/design-system.css">
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: var(--font-sans);
-            line-height: var(--leading-normal);
-            color: var(--color-text-body);
-            background: var(--color-bg-page);
-            padding-top: var(--nav-height);
-        }
-        header {
-            background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-primary-700) 100%);
-            color: white;
-            padding: var(--space-8) 0;
-            text-align: center;
-        }
-        h1 { font-size: var(--text-4xl); margin-bottom: var(--space-2); }
-        .subtitle { font-size: var(--text-lg); opacity: 0.9; }
-        .container { max-width: var(--container-2xl); margin: var(--space-8) auto; padding: 0 var(--space-4); }
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brands | AgenticAdvertising.org</title>
+  <meta name="description" content="Brand identities and brand.json manifests in the AdCP ecosystem.">
+  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/layout.css">
+  <style>
+    body {
+      background: #fff;
+      padding-top: var(--nav-height);
+    }
 
-        /* MCP Banner */
-        .mcp-banner {
-            background: linear-gradient(135deg, var(--color-primary-50) 0%, var(--color-primary-100) 100%);
-            border: 1px solid var(--color-primary-200);
-            border-radius: var(--radius-lg);
-            padding: var(--space-4) var(--space-6);
-            margin-bottom: var(--space-8);
-            display: flex;
-            align-items: center;
-            gap: var(--space-4);
-            flex-wrap: wrap;
-        }
-        .mcp-banner__badge {
-            background: var(--gradient-primary-dark);
-            color: white;
-            padding: var(--space-1) var(--space-3);
-            border-radius: var(--radius-md);
-            font-size: var(--text-xs);
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .mcp-banner__text {
-            flex: 1;
-            min-width: 200px;
-        }
-        .mcp-banner__title {
-            font-weight: var(--font-semibold);
-            color: var(--color-text-heading);
-        }
-        .mcp-banner__desc {
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-        }
-        .mcp-banner__code {
-            background: var(--color-bg-card);
-            border: 1px solid var(--color-border);
-            border-radius: var(--radius-md);
-            padding: var(--space-2) var(--space-3);
-            font-family: var(--font-mono);
-            font-size: var(--text-xs);
-            color: var(--color-primary-700);
-        }
+    .container {
+      max-width: var(--container-xl);
+      margin: 0 auto;
+      padding: var(--space-8) var(--space-4);
+    }
 
-        /* Stats Bar */
-        .stats-bar {
-            display: flex;
-            justify-content: center;
-            gap: var(--space-8);
-            background: var(--color-bg-card);
-            padding: var(--space-5) var(--space-6);
-            border-radius: var(--radius-lg);
-            box-shadow: var(--shadow-sm);
-            margin-bottom: var(--space-8);
-            flex-wrap: wrap;
-        }
-        .stats-bar .stat {
-            text-align: center;
-        }
-        .stats-bar .stat span {
-            display: block;
-            font-size: var(--text-2xl);
-            font-weight: var(--font-bold);
-            color: var(--color-text-heading);
-            line-height: var(--leading-tight);
-        }
-        .stats-bar .stat-label {
-            font-size: var(--text-xs);
-            color: var(--color-text-muted);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
+    /* Stats row */
+    .stats-bar {
+      display: flex;
+      justify-content: center;
+      gap: var(--space-8);
+      padding: var(--space-5) var(--space-6);
+      margin-bottom: var(--space-6);
+      border-bottom: 1px solid var(--color-border);
+      flex-wrap: wrap;
+    }
+    .stats-bar .stat { text-align: center; }
+    .stats-bar .stat span {
+      display: block;
+      font-size: var(--text-2xl);
+      font-weight: var(--font-bold);
+      color: var(--color-text-heading);
+      line-height: var(--leading-tight);
+    }
+    .stats-bar .stat-label {
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
 
-        /* Search and Filters */
-        .search-filters {
-            background: var(--color-bg-card);
-            padding: var(--space-6);
-            border-radius: var(--radius-lg);
-            margin-bottom: var(--space-8);
-            box-shadow: var(--shadow-sm);
-        }
-        .search-box { margin-bottom: var(--space-4); }
-        .search-box input {
-            width: 100%;
-            padding: var(--space-3);
-            border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
-            font-size: var(--text-base);
-        }
-        .search-box input:focus { outline: none; border-color: var(--color-primary-500); }
-        .filter-row { display: flex; gap: var(--space-4); flex-wrap: wrap; align-items: center; }
-        .filter-group { display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center; }
-        .filter-group label { font-weight: var(--font-semibold); font-size: var(--text-sm); color: var(--color-text-muted); }
-        .filter-btn {
-            padding: var(--space-2) var(--space-4);
-            background: var(--color-gray-50);
-            border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
-            cursor: pointer;
-            font-size: var(--text-sm);
-            transition: var(--transition-all);
-        }
-        .filter-btn:hover { border-color: var(--color-primary-500); color: var(--color-primary-500); }
-        .filter-btn.active { background: var(--color-primary-500); border-color: var(--color-primary-500); color: white; }
+    /* Search and filters */
+    .search-section {
+      background: var(--color-bg-card);
+      border-radius: var(--card-radius);
+      padding: var(--space-6);
+      margin-bottom: var(--space-8);
+      box-shadow: var(--shadow-sm);
+    }
+    .search-box { margin-bottom: var(--space-4); }
+    .search-box input {
+      width: 100%;
+      padding: var(--space-3) var(--space-4);
+      border: var(--border-2) solid var(--color-border);
+      border-radius: var(--radius-lg);
+      font-size: var(--text-base);
+      transition: var(--transition-colors);
+    }
+    .search-box input:focus {
+      outline: none;
+      border-color: var(--color-brand);
+      box-shadow: 0 0 0 3px var(--color-primary-100);
+    }
+    .filter-row {
+      display: flex;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .filter-group {
+      display: flex;
+      gap: var(--space-2);
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .filter-group label {
+      font-weight: var(--font-semibold);
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+    }
+    .filter-btn {
+      padding: var(--space-2) var(--space-4);
+      background: var(--color-gray-100);
+      border: var(--border-2) solid var(--color-border);
+      border-radius: var(--radius-lg);
+      cursor: pointer;
+      font-size: var(--text-sm);
+      transition: var(--transition-all);
+    }
+    .filter-btn:hover {
+      border-color: var(--color-brand);
+    }
+    .filter-btn.active {
+      background: var(--color-primary-100);
+      border-color: var(--color-brand);
+      color: var(--color-brand);
+    }
 
-        /* Brand Grid */
-        .brand-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--space-6); }
-        .brand-card {
-            background: var(--color-bg-card);
-            border-radius: var(--radius-lg);
-            padding: var(--space-5);
-            box-shadow: var(--shadow-sm);
-            transition: var(--transition-all);
-            text-decoration: none;
-            color: inherit;
-            display: block;
-            border: 1px solid var(--color-border);
-            cursor: pointer;
-            position: relative;
-        }
-        .brand-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); border-color: var(--color-primary-300); }
+    /* Brand grid */
+    .brand-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: var(--space-6);
+    }
+    .brand-card {
+      background: var(--color-bg-card);
+      border-radius: var(--radius-lg);
+      padding: var(--space-5);
+      border: 1px solid var(--color-border);
+      transition: border-color 0.15s ease;
+      text-decoration: none;
+      color: inherit;
+      display: block;
+      cursor: pointer;
+      position: relative;
+    }
+    .brand-card:hover {
+      border-color: var(--color-brand);
+    }
 
-        /* Card header: logo + name/domain + source badge */
-        .brand-card__header {
-            display: flex;
-            align-items: flex-start;
-            gap: var(--space-3);
-            margin-bottom: var(--space-3);
-        }
+    /* Card header: logo + name/domain + source badge */
+    .brand-card__header {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-3);
+      margin-bottom: var(--space-3);
+    }
+    .brand-card__logo {
+      width: 40px;
+      height: 40px;
+      min-width: 40px;
+      border-radius: var(--radius-md);
+      background: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .brand-card__logo img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+    .brand-card__logo-letter {
+      width: 40px;
+      height: 40px;
+      min-width: 40px;
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--text-lg);
+      font-weight: var(--font-bold);
+      color: white;
+      text-transform: uppercase;
+      line-height: 1;
+    }
+    .brand-card__identity {
+      flex: 1;
+      min-width: 0;
+    }
+    .brand-card__name {
+      font-size: var(--text-base);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-heading);
+      line-height: var(--leading-tight);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .brand-card__domain {
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+      margin-top: var(--space-0.5);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
 
-        /* Logo container */
-        .brand-card__logo {
-            width: 40px;
-            height: 40px;
-            min-width: 40px;
-            border-radius: var(--radius-md);
-            background: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            overflow: hidden;
-        }
-        .brand-card__logo img {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-        }
-        .brand-card__logo-letter {
-            width: 40px;
-            height: 40px;
-            min-width: 40px;
-            border-radius: var(--radius-md);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: var(--text-lg);
-            font-weight: var(--font-bold);
-            color: white;
-            text-transform: uppercase;
-            line-height: 1;
-        }
+    /* Source badge */
+    .brand-card__source {
+      padding: var(--space-1) var(--space-3);
+      border-radius: var(--radius-full);
+      font-size: var(--text-xs);
+      font-weight: var(--font-semibold);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .brand-card__source--valid { background: var(--color-success-100); color: var(--color-success-700); }
+    .brand-card__source--neutral { background: var(--color-gray-100); color: var(--color-gray-600); }
 
-        /* Identity block (name + domain) */
-        .brand-card__identity {
-            flex: 1;
-            min-width: 0;
-        }
-        .brand-card__name {
-            font-size: var(--text-base);
-            font-weight: var(--font-semibold);
-            color: var(--color-text-heading);
-            line-height: var(--leading-tight);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-        .brand-card__domain {
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-            margin-top: var(--space-0.5);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
+    /* Details row */
+    .brand-card__details {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      flex-wrap: wrap;
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+    }
+    .brand-card__detail-item {
+      display: flex;
+      align-items: center;
+      gap: var(--space-1.5);
+    }
+    .brand-card__color-dot {
+      width: 14px;
+      height: 14px;
+      min-width: 14px;
+      border-radius: var(--radius-full);
+      border: 1px solid var(--color-border-strong);
+      display: inline-block;
+    }
+    .brand-card__tag {
+      display: inline-block;
+      padding: var(--space-0.5) var(--space-2);
+      background: var(--color-primary-50);
+      color: var(--color-primary-700);
+      border-radius: var(--radius-full);
+      font-size: var(--text-xs);
+      font-weight: var(--font-medium);
+    }
+    .brand-card__separator {
+      color: var(--color-border-strong);
+      font-size: var(--text-xs);
+    }
 
-        /* Source badge */
-        .brand-card__source {
-            padding: var(--space-1) var(--space-3);
-            border-radius: var(--radius-full);
-            font-size: var(--text-xs);
-            font-weight: var(--font-semibold);
-            white-space: nowrap;
-            flex-shrink: 0;
-        }
-        .brand-card__source--valid { background: var(--color-success-100); color: var(--color-success-700); }
-        .brand-card__source--neutral { background: var(--color-gray-100); color: var(--color-gray-600); }
+    /* Meta row */
+    .brand-card__meta {
+      display: flex;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+      margin-top: var(--space-3);
+      padding-top: var(--space-3);
+      border-top: 1px solid var(--color-border);
+    }
+    .brand-card__meta-item {
+      display: flex;
+      align-items: center;
+      gap: var(--space-1.5);
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+    }
+    .brand-card__meta-icon {
+      font-size: var(--text-sm);
+      line-height: 1;
+    }
 
-        /* Details row: industry, keller type, color dot */
-        .brand-card__details {
-            display: flex;
-            align-items: center;
-            gap: var(--space-3);
-            flex-wrap: wrap;
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-        }
-        .brand-card__detail-item {
-            display: flex;
-            align-items: center;
-            gap: var(--space-1.5);
-        }
-        .brand-card__color-dot {
-            width: 14px;
-            height: 14px;
-            min-width: 14px;
-            border-radius: var(--radius-full);
-            border: 1px solid var(--color-border-strong);
-            display: inline-block;
-        }
-        .brand-card__tag {
-            display: inline-block;
-            padding: var(--space-0.5) var(--space-2);
-            background: var(--color-primary-50);
-            color: var(--color-primary-700);
-            border-radius: var(--radius-full);
-            font-size: var(--text-xs);
-            font-weight: var(--font-medium);
-        }
-        .brand-card__separator {
-            color: var(--color-border-strong);
-            font-size: var(--text-xs);
-        }
+    /* Add brand CTA */
+    .add-brand-cta {
+      text-align: center;
+      margin-top: var(--space-6);
+    }
+    .add-brand-cta button {
+      padding: var(--space-3) var(--space-6);
+      background: var(--color-brand);
+      color: white;
+      border: none;
+      border-radius: var(--radius-lg);
+      font-size: var(--text-sm);
+      font-weight: var(--font-semibold);
+      cursor: pointer;
+      transition: var(--transition-colors);
+    }
+    .add-brand-cta button:hover {
+      background: var(--color-brand-hover);
+    }
 
-        /* Meta row: manifest, verified, house domain */
-        .brand-card__meta {
-            display: flex;
-            gap: var(--space-4);
-            flex-wrap: wrap;
-            margin-top: var(--space-3);
-            padding-top: var(--space-3);
-            border-top: 1px solid var(--color-border);
-        }
-        .brand-card__meta-item {
-            display: flex;
-            align-items: center;
-            gap: var(--space-1.5);
-            font-size: var(--text-xs);
-            color: var(--color-text-muted);
-        }
-        .brand-card__meta-icon {
-            font-size: var(--text-sm);
-            line-height: 1;
-        }
+    /* Claim brand CTA */
+    .claim-brand-cta {
+      margin-top: var(--space-8);
+      padding: var(--space-8) var(--space-6);
+      background: var(--color-primary-50);
+      border: 1px solid var(--color-primary-200);
+      border-radius: var(--radius-lg);
+      text-align: center;
+    }
+    .claim-brand-cta__title {
+      font-size: var(--text-lg);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-heading);
+      margin-bottom: var(--space-2);
+    }
+    .claim-brand-cta__desc {
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-4);
+    }
+    .claim-brand-cta__links {
+      display: flex;
+      justify-content: center;
+      gap: var(--space-3);
+      flex-wrap: wrap;
+    }
+    .claim-brand-cta__primary {
+      padding: var(--space-2.5) var(--space-5);
+      background: var(--color-brand);
+      color: white;
+      border-radius: var(--radius-lg);
+      font-size: var(--text-sm);
+      font-weight: var(--font-semibold);
+      text-decoration: none;
+      transition: var(--transition-colors);
+    }
+    .claim-brand-cta__primary:hover { background: var(--color-brand-hover); }
+    .claim-brand-cta__primary:focus-visible,
+    .claim-brand-cta__secondary:focus-visible {
+      outline: 2px solid var(--color-brand);
+      outline-offset: 2px;
+    }
+    .claim-brand-cta__secondary {
+      padding: var(--space-2.5) var(--space-5);
+      background: var(--color-bg-card);
+      color: var(--color-brand);
+      border: 1px solid var(--color-primary-200);
+      border-radius: var(--radius-lg);
+      font-size: var(--text-sm);
+      font-weight: var(--font-medium);
+      text-decoration: none;
+      transition: var(--transition-colors);
+    }
+    .claim-brand-cta__secondary:hover { border-color: var(--color-brand); }
 
-        /* Add Brand CTA */
-        .add-brand-cta {
-            text-align: center;
-            margin-top: var(--space-6);
-        }
-        .add-brand-cta button {
-            padding: var(--space-3) var(--space-6);
-            background: var(--color-primary-500);
-            color: white;
-            border: none;
-            border-radius: var(--radius-md);
-            font-size: var(--text-sm);
-            font-weight: var(--font-semibold);
-            cursor: pointer;
-            transition: var(--transition-all);
-        }
-        .add-brand-cta button:hover { background: var(--color-primary-600); }
+    .hidden { display: none; }
+    .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
+    .empty-state { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
+    .empty-state__title { font-size: var(--text-xl); font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
 
-        /* Claim Brand CTA */
-        .claim-brand-cta {
-            margin-top: var(--space-8);
-            padding: var(--space-8) var(--space-6);
-            background: var(--color-primary-50);
-            border: 1px solid var(--color-primary-200);
-            border-radius: var(--radius-lg);
-            text-align: center;
-        }
-        .claim-brand-cta__title {
-            font-size: var(--text-lg);
-            font-weight: var(--font-semibold);
-            color: var(--color-text-heading);
-            margin-bottom: var(--space-2);
-        }
-        .claim-brand-cta__desc {
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-            margin-bottom: var(--space-4);
-        }
-        .claim-brand-cta__links {
-            display: flex;
-            justify-content: center;
-            gap: var(--space-3);
-            flex-wrap: wrap;
-        }
-        .claim-brand-cta__primary {
-            padding: var(--space-2.5) var(--space-5);
-            background: var(--color-primary-500);
-            color: white;
-            border-radius: var(--radius-md);
-            font-size: var(--text-sm);
-            font-weight: var(--font-semibold);
-            text-decoration: none;
-            transition: var(--transition-all);
-        }
-        .claim-brand-cta__primary:hover { background: var(--color-primary-600); }
-        .claim-brand-cta__primary:focus-visible,
-        .claim-brand-cta__secondary:focus-visible {
-            outline: 2px solid var(--color-brand);
-            outline-offset: 2px;
-        }
-        .claim-brand-cta__secondary {
-            padding: var(--space-2.5) var(--space-5);
-            background: var(--color-bg-card);
-            color: var(--color-primary-600);
-            border: 1px solid var(--color-primary-300);
-            border-radius: var(--radius-md);
-            font-size: var(--text-sm);
-            font-weight: var(--font-medium);
-            text-decoration: none;
-            transition: var(--transition-all);
-        }
-        .claim-brand-cta__secondary:hover { border-color: var(--color-primary-500); color: var(--color-primary-700); }
+    /* Skeleton animation */
+    @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+    .skeleton-bg {
+      background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border) 50%, var(--color-bg-subtle) 75%);
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+    }
 
-        .hidden { display: none; }
-
-        .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
-        .empty-state { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
-        .empty-state__title { font-size: var(--text-xl); font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
-        .empty-state__desc { font-size: var(--text-base); }
-
-        /* Skeleton animation */
-        @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
-        .skeleton-bg { background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border) 50%, var(--color-bg-subtle) 75%); background-size: 200% 100%; animation: shimmer 1.5s infinite; }
-
-        @media (max-width: 768px) {
-            .brand-grid { grid-template-columns: 1fr; }
-            .mcp-banner { flex-direction: column; text-align: center; }
-            .stats-bar { gap: var(--space-4); padding: var(--space-4); }
-        }
-    </style>
+    @media (max-width: 768px) {
+      .brand-grid { grid-template-columns: 1fr; }
+      .stats-bar { gap: var(--space-4); padding: var(--space-4); }
+    }
+  </style>
 </head>
 <body>
-    <!-- Navigation (loaded by nav.js) -->
-    <div id="adcp-nav"></div>
-    <script src="/nav.js"></script>
 
-    <header>
-        <h1>Brand registry</h1>
-        <p class="subtitle">Discover brand identities and brand.json manifests</p>
-    </header>
+<div id="adcp-nav"></div>
+<script src="/nav.js"></script>
+<script src="/registry-nav.js"></script>
 
-    <div class="container">
-        <!-- MCP Banner -->
-        <div class="mcp-banner">
-            <span class="mcp-banner__badge">MCP</span>
-            <div class="mcp-banner__text">
-                <div class="mcp-banner__title">Access via MCP</div>
-                <div class="mcp-banner__desc">Use <code>list_brands</code> tool or <code>brands://all</code> resource</div>
-            </div>
-            <code class="mcp-banner__code">https://agenticadvertising.org/mcp</code>
-        </div>
+<header class="page-header">
+  <h1>Brands</h1>
+  <p>Brand identities and brand.json manifests in the AdCP ecosystem</p>
+  <div style="margin-top: var(--space-4);">
+    <a href="/brand/builder" style="font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-brand); text-decoration: none;">Build a brand.json &rarr;</a>
+  </div>
+</header>
 
-        <!-- Stats Bar -->
-        <div class="stats-bar">
-            <div class="stat"><span id="stat-total">0</span> <div class="stat-label">Total</div></div>
-            <div class="stat"><span id="stat-houses">0</span> <div class="stat-label">Houses</div></div>
-            <div class="stat"><span id="stat-sub-brands">0</span> <div class="stat-label">Sub-brands</div></div>
-            <div class="stat"><span id="stat-manifest">0</span> <div class="stat-label">With manifest</div></div>
-            <div class="stat"><span id="stat-brand-json">0</span> <div class="stat-label">brand.json</div></div>
-        </div>
+<div class="container">
+  <!-- Stats bar -->
+  <div class="stats-bar">
+    <div class="stat"><span id="stat-total">0</span> <div class="stat-label">Total</div></div>
+    <div class="stat"><span id="stat-houses">0</span> <div class="stat-label">Houses</div></div>
+    <div class="stat"><span id="stat-sub-brands">0</span> <div class="stat-label">Sub-brands</div></div>
+    <div class="stat"><span id="stat-manifest">0</span> <div class="stat-label">With manifest</div></div>
+    <div class="stat"><span id="stat-brand-json">0</span> <div class="stat-label">brand.json</div></div>
+  </div>
 
-        <!-- Search and Filters -->
-        <div class="search-filters">
-            <div class="search-box">
-                <input type="text" id="search-input" placeholder="Search by brand name or domain..." oninput="onSearchInput()">
-            </div>
-            <div class="filter-row">
-                <div class="filter-group">
-                    <label>Type:</label>
-                    <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All</button>
-                    <button class="filter-btn" data-filter="house" onclick="setFilter('house')">Houses</button>
-                    <button class="filter-btn" data-filter="sub_brand" onclick="setFilter('sub_brand')">Sub-brands</button>
-                    <button class="filter-btn" data-filter="brand_json" onclick="setFilter('brand_json')">brand.json</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Brand Grid -->
-        <div id="brands-grid" class="brand-grid">
-            <div class="loading">Loading brands...</div>
-        </div>
-
-        <!-- Add Brand CTA (hidden by default, shown for members) -->
-        <div id="add-brand-cta" class="add-brand-cta hidden">
-            <button onclick="window.location.href='/brand/view/new?edit=true'">+ Add brand</button>
-        </div>
-
-        <!-- Claim Brand CTA (hidden by default, shown for non-members) -->
-        <div id="claim-brand-cta" class="claim-brand-cta hidden">
-            <div class="claim-brand-cta__title">Is your brand listed here?</div>
-            <div class="claim-brand-cta__desc">Join AgenticAdvertising.org to claim your brand and manage your identity in the AI advertising ecosystem.</div>
-            <div class="claim-brand-cta__links">
-                <a href="/membership" class="claim-brand-cta__primary">Claim your brand</a>
-                <a href="/community/profile-edit" class="claim-brand-cta__secondary">Set up your profile</a>
-            </div>
-        </div>
+  <!-- Search and filters -->
+  <div class="search-section">
+    <div class="search-box">
+      <input type="text" id="search-input" placeholder="Search by brand name or domain..." oninput="onSearchInput()">
     </div>
+    <div class="filter-row">
+      <div class="filter-group">
+        <label>Type:</label>
+        <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All</button>
+        <button class="filter-btn" data-filter="house" onclick="setFilter('house')">Houses</button>
+        <button class="filter-btn" data-filter="sub_brand" onclick="setFilter('sub_brand')">Sub-brands</button>
+        <button class="filter-btn" data-filter="brand_json" onclick="setFilter('brand_json')">brand.json</button>
+      </div>
+    </div>
+  </div>
 
-    <!-- Footer placeholder -->
-    <div id="adcp-footer"></div>
+  <!-- Brand grid -->
+  <div id="brands-grid" class="brand-grid">
+    <div class="loading">Loading brands...</div>
+  </div>
 
-    <script type="module">
-        let brands = [];
-        let filters = { type: 'all' };
+  <!-- Add brand CTA (hidden by default, shown for members) -->
+  <div id="add-brand-cta" class="add-brand-cta hidden">
+    <button onclick="window.location.href='/brand/view/new?edit=true'">+ Add brand</button>
+  </div>
 
-        window.addEventListener('DOMContentLoaded', async () => {
-            // Pre-fill search from ?domain= query param (e.g. linked from member profile)
-            const domainParam = new URLSearchParams(window.location.search).get('domain');
-            if (domainParam) {
-                document.getElementById('search-input').value = domainParam;
-            }
-            await loadBrands(domainParam || undefined);
-        });
+  <!-- Claim brand CTA (hidden by default, shown for non-members) -->
+  <div id="claim-brand-cta" class="claim-brand-cta hidden">
+    <div class="claim-brand-cta__title">Is your brand listed here?</div>
+    <div class="claim-brand-cta__desc">Join AgenticAdvertising.org to claim your brand and manage your identity in the AI advertising ecosystem.</div>
+    <div class="claim-brand-cta__links">
+      <a href="/membership" class="claim-brand-cta__primary">Claim your brand</a>
+      <a href="/community/profile-edit" class="claim-brand-cta__secondary">Set up your profile</a>
+    </div>
+  </div>
+</div>
 
-        let activeController = null;
-        async function loadBrands(search) {
-            if (activeController) activeController.abort();
-            activeController = new AbortController();
+<div id="adcp-footer"></div>
 
-            const grid = document.getElementById('brands-grid');
-            grid.innerHTML = renderLoadingSkeleton(6);
+<script type="module">
+  let brands = [];
+  let filters = { type: 'all' };
 
-            try {
-                const params = new URLSearchParams();
-                if (search) params.set('search', search);
-                const qs = params.toString();
-                const response = await fetch(`/api/brands/registry${qs ? '?' + qs : ''}`, { signal: activeController.signal });
-                if (!response.ok) throw new Error(`HTTP ${response.status}`);
-                const data = await response.json();
-                brands = data.brands || [];
+  window.addEventListener('DOMContentLoaded', async () => {
+    const domainParam = new URLSearchParams(window.location.search).get('domain');
+    if (domainParam) {
+      document.getElementById('search-input').value = domainParam;
+    }
+    await loadBrands(domainParam || undefined);
+  });
 
-                // Update stats
-                const stats = data.stats || {};
-                document.getElementById('stat-total').textContent = stats.total || brands.length;
-                document.getElementById('stat-houses').textContent = stats.houses || 0;
-                document.getElementById('stat-sub-brands').textContent = stats.sub_brands || 0;
-                document.getElementById('stat-manifest').textContent = stats.with_manifest || 0;
-                document.getElementById('stat-brand-json').textContent = stats.brand_json || 0;
+  let activeController = null;
+  async function loadBrands(search) {
+    if (activeController) activeController.abort();
+    activeController = new AbortController();
 
-                renderBrands();
+    const grid = document.getElementById('brands-grid');
+    grid.innerHTML = renderLoadingSkeleton(6);
 
-                // Show add CTA for members, claim CTA for non-members
-                const config = window.__APP_CONFIG__;
-                if (config?.user?.isMember) {
-                    document.getElementById('add-brand-cta')?.classList.remove('hidden');
-                } else {
-                    document.getElementById('claim-brand-cta')?.classList.remove('hidden');
-                }
-            } catch (error) {
-                if (error.name === 'AbortError') return;
-                console.error('Failed to load brands:', error);
-                grid.innerHTML = '<div class="empty-state"><div class="empty-state__title">Failed to load brands</div></div>';
-            }
-        }
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      const qs = params.toString();
+      const response = await fetch(`/api/brands/registry${qs ? '?' + qs : ''}`, { signal: activeController.signal });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      brands = data.brands || [];
 
-        function renderLoadingSkeleton(count = 6) {
-            return Array(count).fill(0).map(() => `
-                <div class="brand-card" style="pointer-events: none; opacity: 0.6;">
-                    <div class="brand-card__header">
-                        <div class="skeleton-bg" style="width: 40px; height: 40px; border-radius: var(--radius-md); flex-shrink: 0;"></div>
-                        <div style="flex: 1; min-width: 0;">
-                            <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
-                            <div class="skeleton-bg" style="height: 12px; border-radius: var(--radius-sm); width: 40%;"></div>
-                        </div>
-                        <div class="skeleton-bg" style="height: 22px; width: 70px; border-radius: var(--radius-full);"></div>
-                    </div>
-                    <div class="brand-card__details" style="margin-top: var(--space-2);">
-                        <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 80px;"></div>
-                        <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 60px;"></div>
-                    </div>
-                </div>
-            `).join('');
-        }
+      const stats = data.stats || {};
+      document.getElementById('stat-total').textContent = stats.total || brands.length;
+      document.getElementById('stat-houses').textContent = stats.houses || 0;
+      document.getElementById('stat-sub-brands').textContent = stats.sub_brands || 0;
+      document.getElementById('stat-manifest').textContent = stats.with_manifest || 0;
+      document.getElementById('stat-brand-json').textContent = stats.brand_json || 0;
 
-        function safeHex(color) {
-            if (!color) return null;
-            return /^#[0-9A-Fa-f]{6}$/.test(color) ? color : null;
-        }
+      renderBrands();
 
-        function renderBrands() {
-            const grid = document.getElementById('brands-grid');
-            const filtered = brands.filter(brand => {
-                if (filters.type === 'house' && brand.keller_type !== 'master' && brand.keller_type !== 'independent') return false;
-                if (filters.type === 'sub_brand' && brand.keller_type !== 'sub_brand' && brand.keller_type !== 'endorsed') return false;
-                if (filters.type === 'brand_json' && brand.source !== 'brand_json' && brand.source !== 'hosted') return false;
-                return true;
-            });
+      const config = window.__APP_CONFIG__;
+      if (config?.user?.isMember) {
+        document.getElementById('add-brand-cta')?.classList.remove('hidden');
+      } else {
+        document.getElementById('claim-brand-cta')?.classList.remove('hidden');
+      }
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      console.error('Failed to load brands:', error);
+      grid.innerHTML = '<div class="empty-state"><div class="empty-state__title">Failed to load brands</div></div>';
+    }
+  }
 
-            if (filtered.length === 0) {
-                const msg = brands.length === 0 ? 'No brands registered yet.' : 'No brands found matching your filters.';
-                grid.innerHTML = `<div class="empty-state"><div class="empty-state__title">${msg}</div></div>`;
-                return;
-            }
+  function renderLoadingSkeleton(count = 6) {
+    return Array(count).fill(0).map(() => `
+      <div class="brand-card" style="pointer-events: none; opacity: 0.6;">
+        <div class="brand-card__header">
+          <div class="skeleton-bg" style="width: 40px; height: 40px; border-radius: var(--radius-md); flex-shrink: 0;"></div>
+          <div style="flex: 1; min-width: 0;">
+            <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
+            <div class="skeleton-bg" style="height: 12px; border-radius: var(--radius-sm); width: 40%;"></div>
+          </div>
+          <div class="skeleton-bg" style="height: 22px; width: 70px; border-radius: var(--radius-full);"></div>
+        </div>
+        <div class="brand-card__details" style="margin-top: var(--space-2);">
+          <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 80px;"></div>
+          <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 60px;"></div>
+        </div>
+      </div>
+    `).join('');
+  }
 
-            grid.innerHTML = filtered.map(brand => {
-                const sourceLabel = {
-                    'brand_json': 'brand.json',
-                    'hosted': 'brand.json',
-                    'community': 'Community',
-                    'enriched': 'Community',
-                }[brand.source] || brand.source;
+  function safeHex(color) {
+    if (!color) return null;
+    return /^#[0-9A-Fa-f]{6}$/.test(color) ? color : null;
+  }
 
-                const sourceClass = (brand.source === 'brand_json' || brand.source === 'hosted') ? 'brand-card__source--valid' : 'brand-card__source--neutral';
-                const displayName = escapeHtml(brand.brand_name || brand.domain);
-                const firstLetter = (brand.brand_name || brand.domain || '?').charAt(0);
-                const validColor = safeHex(brand.primary_color);
+  function renderBrands() {
+    const grid = document.getElementById('brands-grid');
+    const filtered = brands.filter(brand => {
+      if (filters.type === 'house' && brand.keller_type !== 'master' && brand.keller_type !== 'independent') return false;
+      if (filters.type === 'sub_brand' && brand.keller_type !== 'sub_brand' && brand.keller_type !== 'endorsed') return false;
+      if (filters.type === 'brand_json' && brand.source !== 'brand_json' && brand.source !== 'hosted') return false;
+      return true;
+    });
 
-                // Logo or letter fallback
-                const logoHtml = brand.logo_url
-                    ? `<div class="brand-card__logo"><img src="${escapeHtml(brand.logo_url)}" alt="" loading="lazy"></div>`
-                    : `<div class="brand-card__logo-letter" style="background: ${validColor || 'var(--color-primary-500)'};">${escapeHtml(firstLetter)}</div>`;
+    if (filtered.length === 0) {
+      const msg = brands.length === 0 ? 'No brands registered yet.' : 'No brands found matching your filters.';
+      grid.innerHTML = `<div class="empty-state"><div class="empty-state__title">${msg}</div></div>`;
+      return;
+    }
 
-                // Details: industry, keller type, color dot
-                const detailParts = [];
-                if (brand.industry) {
-                    detailParts.push(`<span class="brand-card__detail-item">${escapeHtml(brand.industry)}</span>`);
-                }
-                if (brand.keller_type) {
-                    detailParts.push(`<span class="brand-card__tag">${escapeHtml(brand.keller_type)}</span>`);
-                }
-                if (validColor) {
-                    detailParts.push(`<span class="brand-card__detail-item"><span class="brand-card__color-dot" style="background: ${validColor};" title="${validColor}"></span></span>`);
-                }
+    grid.innerHTML = filtered.map(brand => {
+      const sourceLabel = {
+        'brand_json': 'brand.json',
+        'hosted': 'brand.json',
+        'community': 'Community',
+        'enriched': 'Community',
+      }[brand.source] || brand.source;
 
-                const detailsHtml = detailParts.length > 0
-                    ? `<div class="brand-card__details">${detailParts.join('<span class="brand-card__separator">&middot;</span>')}</div>`
-                    : '';
+      const sourceClass = (brand.source === 'brand_json' || brand.source === 'hosted') ? 'brand-card__source--valid' : 'brand-card__source--neutral';
+      const displayName = escapeHtml(brand.brand_name || brand.domain);
+      const firstLetter = (brand.brand_name || brand.domain || '?').charAt(0);
+      const validColor = safeHex(brand.primary_color);
 
-                // Meta row: manifest, verified, house domain, sub-brands
-                const metaParts = [];
-                if (brand.has_manifest) {
-                    metaParts.push('<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F4CB;</span> Manifest</span>');
-                }
-                if (brand.verified) {
-                    metaParts.push('<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x2713;</span> Verified</span>');
-                }
-                if (brand.sub_brand_count > 0) {
-                    metaParts.push(`<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F517;</span> ${brand.sub_brand_count} sub-brand${brand.sub_brand_count === 1 ? '' : 's'}</span>`);
-                }
-                if (brand.house_domain) {
-                    metaParts.push(`<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F3E0;</span> ${escapeHtml(brand.house_domain)}</span>`);
-                }
-                if (brand.domain && (brand.source === 'community' || brand.source === 'enriched')) {
-                    const brandJsonUrl = `https://agenticadvertising.org/brands/${encodeURIComponent(brand.domain)}/brand.json`;
-                    metaParts.push(`<a class="brand-card__meta-item" href="${escapeAttr(brandJsonUrl)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" style="color: var(--color-brand); text-decoration: none;" title="View community brand.json"><span class="brand-card__meta-icon">{}</span> brand.json</a>`);
-                }
+      const logoHtml = brand.logo_url
+        ? `<div class="brand-card__logo"><img src="${escapeHtml(brand.logo_url)}" alt="" loading="lazy"></div>`
+        : `<div class="brand-card__logo-letter" style="background: ${validColor || 'var(--color-primary-500)'};">${escapeHtml(firstLetter)}</div>`;
 
-                const metaHtml = metaParts.length > 0
-                    ? `<div class="brand-card__meta">${metaParts.join('')}</div>`
-                    : '';
+      const detailParts = [];
+      if (brand.industry) {
+        detailParts.push(`<span class="brand-card__detail-item">${escapeHtml(brand.industry)}</span>`);
+      }
+      if (brand.keller_type) {
+        detailParts.push(`<span class="brand-card__tag">${escapeHtml(brand.keller_type)}</span>`);
+      }
+      if (validColor) {
+        detailParts.push(`<span class="brand-card__detail-item"><span class="brand-card__color-dot" style="background: ${validColor};" title="${validColor}"></span></span>`);
+      }
 
-                return `
-                    <div class="brand-card" onclick="window.location.href='/brand/view/${encodeURIComponent(brand.domain)}'">
-                        <div class="brand-card__header">
-                            ${logoHtml}
-                            <div class="brand-card__identity">
-                                <div class="brand-card__name">${displayName}</div>
-                                <div class="brand-card__domain">${escapeHtml(brand.domain)}</div>
-                            </div>
-                            <span class="brand-card__source ${sourceClass}">
-                                ${escapeHtml(sourceLabel)}
-                            </span>
-                        </div>
-                        ${detailsHtml}
-                        ${metaHtml}
-                    </div>
-                `;
-            }).join('');
-        }
+      const detailsHtml = detailParts.length > 0
+        ? `<div class="brand-card__details">${detailParts.join('<span class="brand-card__separator">&middot;</span>')}</div>`
+        : '';
 
-        window.setFilter = function(type) {
-            filters.type = type;
-            document.querySelectorAll('.filter-btn[data-filter]').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.filter === type);
-            });
-            renderBrands();
-        };
+      const metaParts = [];
+      if (brand.has_manifest) {
+        metaParts.push('<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F4CB;</span> Manifest</span>');
+      }
+      if (brand.verified) {
+        metaParts.push('<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x2713;</span> Verified</span>');
+      }
+      if (brand.sub_brand_count > 0) {
+        metaParts.push(`<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F517;</span> ${brand.sub_brand_count} sub-brand${brand.sub_brand_count === 1 ? '' : 's'}</span>`);
+      }
+      if (brand.house_domain) {
+        metaParts.push(`<span class="brand-card__meta-item"><span class="brand-card__meta-icon">&#x1F3E0;</span> ${escapeHtml(brand.house_domain)}</span>`);
+      }
+      if (brand.domain && (brand.source === 'community' || brand.source === 'enriched')) {
+        const brandJsonUrl = `https://agenticadvertising.org/brands/${encodeURIComponent(brand.domain)}/brand.json`;
+        metaParts.push(`<a class="brand-card__meta-item" href="${escapeAttr(brandJsonUrl)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" style="color: var(--color-brand); text-decoration: none;" title="View community brand.json"><span class="brand-card__meta-icon">{}</span> brand.json</a>`);
+      }
 
-        let searchTimeout = null;
-        window.onSearchInput = function() {
-            clearTimeout(searchTimeout);
-            const value = document.getElementById('search-input').value.trim();
-            searchTimeout = setTimeout(() => loadBrands(value || undefined), 300);
-        };
+      const metaHtml = metaParts.length > 0
+        ? `<div class="brand-card__meta">${metaParts.join('')}</div>`
+        : '';
 
-        function escapeHtml(str) {
-            if (!str) return '';
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
-        }
+      return `
+        <div class="brand-card" onclick="window.location.href='/brand/view/${encodeURIComponent(brand.domain)}'">
+          <div class="brand-card__header">
+            ${logoHtml}
+            <div class="brand-card__identity">
+              <div class="brand-card__name">${displayName}</div>
+              <div class="brand-card__domain">${escapeHtml(brand.domain)}</div>
+            </div>
+            <span class="brand-card__source ${sourceClass}">
+              ${escapeHtml(sourceLabel)}
+            </span>
+          </div>
+          ${detailsHtml}
+          ${metaHtml}
+        </div>
+      `;
+    }).join('');
+  }
 
-        function escapeAttr(str) {
-            if (!str) return '';
-            return escapeHtml(String(str)).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-        }
-    </script>
+  window.setFilter = function(type) {
+    filters.type = type;
+    document.querySelectorAll('.filter-btn[data-filter]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.filter === type);
+    });
+    renderBrands();
+  };
+
+  let searchTimeout = null;
+  window.onSearchInput = function() {
+    clearTimeout(searchTimeout);
+    const value = document.getElementById('search-input').value.trim();
+    searchTimeout = setTimeout(() => loadBrands(value || undefined), 300);
+  };
+
+  function escapeHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  function escapeAttr(str) {
+    if (!str) return '';
+    return escapeHtml(String(str)).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+</script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -38,6 +38,7 @@
     <nav>
       <a href="/certification">Academy</a>
       <a href="/chat">Ask Addie</a>
+      <a href="/registry">Registry</a>
       <a href="/membership">Get started</a>
       <a href="https://docs.adcontextprotocol.org">AdCP Docs</a>
       <a href="/about">About</a>

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -1088,6 +1088,7 @@
   <!-- Navigation -->
   <div id="adcp-nav"></div>
   <script src="/nav.js"></script>
+  <script src="/registry-nav.js"></script>
   <script src="/member-card.js"></script>
 
   <!-- List View -->

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -129,6 +129,14 @@
 
     const isCertificationActive = currentPath.startsWith('/certification') || currentPath.startsWith('/study-guide');
     const isCommunityActive = currentPath.startsWith('/community') || currentPath.startsWith('/events') || currentPath.startsWith('/committees') || currentPath.startsWith('/meetings');
+    const isRegistryActive = currentPath === '/registry'
+      || currentPath.startsWith('/registry/')
+      || currentPath === '/agents'
+      || currentPath === '/brands'
+      || currentPath === '/publishers'
+      || currentPath.startsWith('/brand')
+      || currentPath.startsWith('/adagents')
+      || currentPath.startsWith('/property/view');
     const communityUrl = isLocal ? '/community' : 'https://agenticadvertising.org/community';
     const membershipUrl = isLocal ? '/membership' : 'https://agenticadvertising.org/membership';
 
@@ -155,6 +163,7 @@
               <a href="/certification" class="navbar__link ${isCertificationActive ? 'active' : ''}">Academy</a>
               <a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>
               <a href="${communityUrl}" class="navbar__link ${isCommunityActive ? 'active' : ''}">Community</a>
+              <a href="/registry" class="navbar__link ${isRegistryActive ? 'active' : ''}">Registry</a>
               <a href="${ctaUrl}" class="navbar__btn--cta">${ctaText}</a>
             </div>
           </div>
@@ -176,6 +185,7 @@
           <a href="/certification" class="navbar__link ${isCertificationActive ? 'active' : ''}">Academy</a>
           <a href="/chat" class="navbar__link ${currentPath === '/chat' ? 'active' : ''}">Ask Addie</a>
           <a href="${communityUrl}" class="navbar__link ${isCommunityActive ? 'active' : ''}">Community</a>
+          <a href="/registry" class="navbar__link ${isRegistryActive ? 'active' : ''}">Registry</a>
           <a href="${ctaUrl}" class="navbar__link ${currentPath === '/membership' || currentPath === '/dashboard' ? 'active' : ''}">${ctaText}</a>
           <a href="${docsUrl}" class="navbar__link">AdCP Docs</a>
         </div>

--- a/server/public/publishers.html
+++ b/server/public/publishers.html
@@ -1,393 +1,393 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Publishers Registry - AdCP</title>
-    <link rel="stylesheet" href="/design-system.css">
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: var(--font-sans);
-            line-height: var(--leading-normal);
-            color: var(--color-text-body);
-            background: var(--color-bg-page);
-            padding-top: var(--nav-height);
-        }
-        header {
-            background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-primary-700) 100%);
-            color: white;
-            padding: var(--space-8) 0;
-            text-align: center;
-        }
-        h1 { font-size: var(--text-4xl); margin-bottom: var(--space-2); }
-        .subtitle { font-size: var(--text-lg); opacity: 0.9; }
-        .container { max-width: var(--container-2xl); margin: var(--space-8) auto; padding: 0 var(--space-4); }
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Properties | AgenticAdvertising.org</title>
+  <meta name="description" content="Publisher properties and domains in the AdCP ecosystem.">
+  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/layout.css">
+  <style>
+    body {
+      background: #fff;
+      padding-top: var(--nav-height);
+    }
 
-        /* MCP Banner */
-        .mcp-banner {
-            background: linear-gradient(135deg, var(--color-purple-50) 0%, var(--color-primary-50) 100%);
-            border: 1px solid var(--color-purple-200);
-            border-radius: var(--radius-lg);
-            padding: var(--space-4) var(--space-6);
-            margin-bottom: var(--space-8);
-            display: flex;
-            align-items: center;
-            gap: var(--space-4);
-            flex-wrap: wrap;
-        }
-        .mcp-banner__badge {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            padding: var(--space-1) var(--space-3);
-            border-radius: var(--radius-md);
-            font-size: var(--text-xs);
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .mcp-banner__text {
-            flex: 1;
-            min-width: 200px;
-        }
-        .mcp-banner__title {
-            font-weight: var(--font-semibold);
-            color: var(--color-text-heading);
-        }
-        .mcp-banner__desc {
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-        }
-        .mcp-banner__code {
-            background: var(--color-bg-card);
-            border: 1px solid var(--color-border);
-            border-radius: var(--radius-md);
-            padding: var(--space-2) var(--space-3);
-            font-family: var(--font-mono);
-            font-size: var(--text-xs);
-            color: var(--color-purple-700);
-        }
+    .container {
+      max-width: var(--container-xl);
+      margin: 0 auto;
+      padding: var(--space-8) var(--space-4);
+    }
 
-        /* Stats Bar */
-        .stats-bar {
-            display: flex;
-            justify-content: center;
-            gap: var(--space-8);
-            background: var(--color-bg-card);
-            padding: var(--space-5) var(--space-6);
-            border-radius: var(--radius-lg);
-            box-shadow: var(--shadow-sm);
-            margin-bottom: var(--space-8);
-            flex-wrap: wrap;
-        }
-        .stats-bar .stat {
-            text-align: center;
-        }
-        .stats-bar .stat span {
-            display: block;
-            font-size: var(--text-2xl);
-            font-weight: var(--font-bold);
-            color: var(--color-text-heading);
-            line-height: var(--leading-tight);
-        }
-        .stats-bar .stat-label {
-            font-size: var(--text-xs);
-            color: var(--color-text-muted);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
+    /* Stats row */
+    .stats-bar {
+      display: flex;
+      justify-content: center;
+      gap: var(--space-8);
+      padding: var(--space-5) var(--space-6);
+      margin-bottom: var(--space-6);
+      border-bottom: 1px solid var(--color-border);
+      flex-wrap: wrap;
+    }
+    .stats-bar .stat { text-align: center; }
+    .stats-bar .stat span {
+      display: block;
+      font-size: var(--text-2xl);
+      font-weight: var(--font-bold);
+      color: var(--color-text-heading);
+      line-height: var(--leading-tight);
+    }
+    .stats-bar .stat-label {
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
 
-        /* Search and Filters */
-        .search-filters {
-            background: var(--color-bg-card);
-            padding: var(--space-6);
-            border-radius: var(--radius-lg);
-            margin-bottom: var(--space-8);
-            box-shadow: var(--shadow-sm);
-        }
-        .search-box { margin-bottom: var(--space-4); }
-        .search-box input {
-            width: 100%;
-            padding: var(--space-3);
-            border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
-            font-size: var(--text-base);
-        }
-        .search-box input:focus { outline: none; border-color: var(--color-primary-500); }
-        .filter-row { display: flex; gap: var(--space-4); flex-wrap: wrap; align-items: center; }
-        .filter-group { display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center; }
-        .filter-group label { font-weight: var(--font-semibold); font-size: var(--text-sm); color: var(--color-text-muted); }
-        .filter-btn {
-            padding: var(--space-2) var(--space-4);
-            background: var(--color-gray-50);
-            border: var(--border-2) solid var(--color-border);
-            border-radius: var(--radius-md);
-            cursor: pointer;
-            font-size: var(--text-sm);
-            transition: var(--transition-all);
-        }
-        .filter-btn:hover { border-color: var(--color-primary-500); color: var(--color-primary-500); }
-        .filter-btn.active { background: var(--color-primary-500); border-color: var(--color-primary-500); color: white; }
+    /* Search and filters */
+    .search-section {
+      background: var(--color-bg-card);
+      border-radius: var(--card-radius);
+      padding: var(--space-6);
+      margin-bottom: var(--space-8);
+      box-shadow: var(--shadow-sm);
+    }
+    .search-box { margin-bottom: var(--space-4); }
+    .search-box input {
+      width: 100%;
+      padding: var(--space-3) var(--space-4);
+      border: var(--border-2) solid var(--color-border);
+      border-radius: var(--radius-lg);
+      font-size: var(--text-base);
+      transition: var(--transition-colors);
+    }
+    .search-box input:focus {
+      outline: none;
+      border-color: var(--color-brand);
+      box-shadow: 0 0 0 3px var(--color-primary-100);
+    }
+    .filter-row {
+      display: flex;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .filter-group {
+      display: flex;
+      gap: var(--space-2);
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .filter-group label {
+      font-weight: var(--font-semibold);
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+    }
+    .filter-btn {
+      padding: var(--space-2) var(--space-4);
+      background: var(--color-gray-100);
+      border: var(--border-2) solid var(--color-border);
+      border-radius: var(--radius-lg);
+      cursor: pointer;
+      font-size: var(--text-sm);
+      transition: var(--transition-all);
+    }
+    .filter-btn:hover {
+      border-color: var(--color-brand);
+    }
+    .filter-btn.active {
+      background: var(--color-primary-100);
+      border-color: var(--color-brand);
+      color: var(--color-brand);
+    }
 
-        /* Publisher Grid */
-        .publisher-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: var(--space-6); }
-        .publisher-card {
-            background: var(--color-bg-card);
-            border-radius: var(--radius-lg);
-            padding: var(--space-6);
-            box-shadow: var(--shadow-sm);
-            transition: var(--transition-all);
-            text-decoration: none;
-            color: inherit;
-            display: block;
-            border-left: 4px solid var(--color-primary-500);
-            cursor: pointer;
-        }
-        .publisher-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); }
-        .publisher-header { display: flex; justify-content: space-between; align-items: start; margin-bottom: var(--space-4); }
-        .publisher-domain { font-size: var(--text-lg); font-weight: var(--font-semibold); color: var(--color-text-heading); }
-        .status-badge {
-            padding: var(--space-1) var(--space-3);
-            border-radius: var(--radius-full);
-            font-size: var(--text-xs);
-            font-weight: var(--font-semibold);
-            text-transform: uppercase;
-            white-space: nowrap;
-        }
-        .status-badge.valid { background: var(--color-success-100); color: var(--color-success-700); }
-        .status-badge.neutral { background: var(--color-gray-100); color: var(--color-gray-600); }
-        .publisher-meta { display: flex; gap: var(--space-4); flex-wrap: wrap; margin-top: var(--space-4); }
-        .stat-item { display: flex; align-items: center; gap: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
-        .stat-value { font-weight: var(--font-semibold); color: var(--color-text-heading); }
+    /* Publisher grid */
+    .publisher-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+      gap: var(--space-6);
+    }
+    .publisher-card {
+      background: var(--color-bg-card);
+      border-radius: var(--radius-lg);
+      padding: var(--space-6);
+      border: 1px solid var(--color-border);
+      transition: border-color 0.15s ease;
+      text-decoration: none;
+      color: inherit;
+      display: block;
+      cursor: pointer;
+    }
+    .publisher-card:hover {
+      border-color: var(--color-brand);
+    }
+    .publisher-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+      margin-bottom: var(--space-3);
+    }
+    .publisher-domain {
+      font-size: var(--text-lg);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-heading);
+    }
+    .status-badge {
+      padding: var(--space-1) var(--space-3);
+      border-radius: var(--radius-full);
+      font-size: var(--text-xs);
+      font-weight: var(--font-semibold);
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .status-badge.valid {
+      background: var(--color-success-100);
+      color: var(--color-success-700);
+    }
+    .status-badge.neutral {
+      background: var(--color-gray-100);
+      color: var(--color-gray-600);
+    }
+    .publisher-meta {
+      display: flex;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+    }
+    .stat-item {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+    }
+    .stat-value {
+      font-weight: var(--font-semibold);
+      color: var(--color-text-heading);
+    }
 
-        /* Add Publisher CTA */
-        .add-publisher-cta {
-            text-align: center;
-            margin-top: var(--space-6);
-        }
-        .add-publisher-cta button {
-            padding: var(--space-3) var(--space-6);
-            background: var(--color-primary-500);
-            color: white;
-            border: none;
-            border-radius: var(--radius-md);
-            font-size: var(--text-sm);
-            font-weight: var(--font-semibold);
-            cursor: pointer;
-            transition: var(--transition-all);
-        }
-        .add-publisher-cta button:hover { background: var(--color-primary-600); }
+    /* Add publisher CTA */
+    .add-publisher-cta {
+      text-align: center;
+      margin-top: var(--space-6);
+    }
+    .add-publisher-cta button {
+      padding: var(--space-3) var(--space-6);
+      background: var(--color-brand);
+      color: white;
+      border: none;
+      border-radius: var(--radius-lg);
+      font-size: var(--text-sm);
+      font-weight: var(--font-semibold);
+      cursor: pointer;
+      transition: var(--transition-colors);
+    }
+    .add-publisher-cta button:hover {
+      background: var(--color-brand-hover);
+    }
 
-        .hidden { display: none; }
+    .hidden { display: none; }
+    .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
+    .empty-state { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
+    .empty-state__title { font-size: var(--text-xl); font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
 
-        .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
-        .empty-state { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }
-        .empty-state__title { font-size: var(--text-xl); font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
-        .empty-state__desc { font-size: var(--text-base); }
+    /* Skeleton animation */
+    @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+    .skeleton-bg {
+      background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border-light) 50%, var(--color-bg-subtle) 75%);
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+    }
 
-        /* Skeleton animation */
-        @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
-        .skeleton-bg { background: linear-gradient(90deg, var(--color-bg-subtle) 25%, var(--color-border-light) 50%, var(--color-bg-subtle) 75%); background-size: 200% 100%; animation: shimmer 1.5s infinite; }
-
-        @media (max-width: 768px) {
-            .publisher-grid { grid-template-columns: 1fr; }
-            .mcp-banner { flex-direction: column; text-align: center; }
-            .stats-bar { gap: var(--space-4); padding: var(--space-4); }
-        }
-    </style>
+    @media (max-width: 768px) {
+      .publisher-grid { grid-template-columns: 1fr; }
+      .stats-bar { gap: var(--space-4); padding: var(--space-4); }
+    }
+  </style>
 </head>
 <body>
-    <!-- Navigation (loaded by nav.js) -->
-    <div id="adcp-nav"></div>
-    <script src="/nav.js"></script>
 
-    <header>
-        <h1>Publishers Registry</h1>
-        <p class="subtitle">Publisher property inventories for agentic advertising</p>
-    </header>
+<div id="adcp-nav"></div>
+<script src="/nav.js"></script>
+<script src="/registry-nav.js"></script>
 
-    <div class="container">
-        <!-- MCP Banner -->
-        <div class="mcp-banner">
-            <span class="mcp-banner__badge">MCP</span>
-            <div class="mcp-banner__text">
-                <div class="mcp-banner__title">Access via MCP</div>
-                <div class="mcp-banner__desc">Use <code>find_agents_for_property</code> tool to find agents for a property</div>
-            </div>
-            <code class="mcp-banner__code">https://agenticadvertising.org/mcp</code>
-        </div>
+<header class="page-header">
+  <h1>Properties</h1>
+  <p>Publisher properties and domains in the AdCP ecosystem</p>
+  <div style="margin-top: var(--space-4);">
+    <a href="/adagents/builder" style="font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-brand); text-decoration: none;">Build an adagents.json &rarr;</a>
+  </div>
+</header>
 
-        <!-- Stats Bar -->
-        <div class="stats-bar">
-            <div class="stat"><span id="stat-total">0</span> <div class="stat-label">Total</div></div>
-            <div class="stat"><span id="stat-enriched">0</span> <div class="stat-label">Enriched</div></div>
-            <div class="stat"><span id="stat-adagents-json">0</span> <div class="stat-label">adagents.json</div></div>
-            <div class="stat"><span id="stat-community">0</span> <div class="stat-label">Community</div></div>
-            <div class="stat"><span id="stat-hosted">0</span> <div class="stat-label">Hosted</div></div>
-        </div>
+<div class="container">
+  <!-- Stats bar -->
+  <div class="stats-bar">
+    <div class="stat"><span id="stat-total">0</span> <div class="stat-label">Total</div></div>
+    <div class="stat"><span id="stat-community">0</span> <div class="stat-label">Community</div></div>
+    <div class="stat"><span id="stat-adagents-json">0</span> <div class="stat-label">adagents.json</div></div>
+    <div class="stat"><span id="stat-hosted">0</span> <div class="stat-label">Hosted</div></div>
+  </div>
 
-        <!-- Search and Filters -->
-        <div class="search-filters">
-            <div class="search-box">
-                <input type="text" id="search-input" placeholder="Search by publisher domain..." aria-label="Search by publisher domain" onkeyup="filterPublishers()">
-            </div>
-            <div class="filter-row">
-                <div class="filter-group">
-                    <label>Source:</label>
-                    <button class="filter-btn active" data-source="all" onclick="setSourceFilter('all')">All</button>
-                    <button class="filter-btn" data-source="enriched" onclick="setSourceFilter('enriched')">Enriched</button>
-                    <button class="filter-btn" data-source="adagents_json" onclick="setSourceFilter('adagents_json')">adagents.json</button>
-                    <button class="filter-btn" data-source="community" onclick="setSourceFilter('community')">Community</button>
-                    <button class="filter-btn" data-source="hosted" onclick="setSourceFilter('hosted')">Hosted</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Publisher Grid -->
-        <div id="publishers-grid" class="publisher-grid">
-            <div class="loading">Loading publishers...</div>
-        </div>
-
-        <!-- Add Publisher CTA (hidden by default, shown for members) -->
-        <div id="add-publisher-cta" class="add-publisher-cta hidden">
-            <button onclick="window.location.href='/property/view/new?edit=true'">+ Add Publisher</button>
-        </div>
+  <!-- Search and filters -->
+  <div class="search-section">
+    <div class="search-box">
+      <input type="text" id="search-input" placeholder="Search by publisher domain..." aria-label="Search by publisher domain" onkeyup="filterPublishers()">
     </div>
+    <div class="filter-row">
+      <div class="filter-group">
+        <label>Source:</label>
+        <button class="filter-btn active" data-source="all" onclick="setSourceFilter('all')">All</button>
+        <button class="filter-btn" data-source="community" onclick="setSourceFilter('community')">Community</button>
+        <button class="filter-btn" data-source="adagents_json" onclick="setSourceFilter('adagents_json')">adagents.json</button>
+        <button class="filter-btn" data-source="hosted" onclick="setSourceFilter('hosted')">Hosted</button>
+      </div>
+    </div>
+  </div>
 
-    <!-- Footer placeholder -->
-    <div id="adcp-footer"></div>
+  <!-- Publisher grid -->
+  <div id="publishers-grid" class="publisher-grid">
+    <div class="loading">Loading properties...</div>
+  </div>
 
-    <script type="module">
-        let publishers = [];
-        let filters = { source: 'all', search: '' };
+  <!-- Add publisher CTA (hidden by default, shown for members) -->
+  <div id="add-publisher-cta" class="add-publisher-cta hidden">
+    <button onclick="window.location.href='/property/view/new?edit=true'">+ Add property</button>
+  </div>
+</div>
 
-        window.addEventListener('DOMContentLoaded', async () => {
-            // Pre-fill search from URL query param
-            const params = new URLSearchParams(window.location.search);
-            const q = params.get('q');
-            if (q) {
-                document.getElementById('search-input').value = q;
-                filters.search = q;
-            }
-            await loadPublishers();
-        });
+<div id="adcp-footer"></div>
 
-        async function loadPublishers() {
-            const grid = document.getElementById('publishers-grid');
-            grid.innerHTML = renderLoadingSkeleton(6);
+<script type="module">
+  let publishers = [];
+  let filters = { source: 'all', search: '' };
 
-            try {
-                const response = await fetch('/api/properties/registry?limit=5000');
-                if (!response.ok) throw new Error(`HTTP ${response.status}`);
-                const data = await response.json();
-                publishers = data.properties || [];
+  window.addEventListener('DOMContentLoaded', async () => {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('q');
+    if (q) {
+      document.getElementById('search-input').value = q;
+      filters.search = q;
+    }
+    await loadPublishers();
+  });
 
-                // Update stats
-                const stats = data.stats || {};
-                document.getElementById('stat-total').textContent = stats.total || publishers.length;
-                document.getElementById('stat-enriched').textContent = stats.enriched || 0;
-                document.getElementById('stat-adagents-json').textContent = stats.adagents_json || 0;
-                document.getElementById('stat-community').textContent = stats.community || 0;
-                document.getElementById('stat-hosted').textContent = stats.hosted || 0;
+  async function loadPublishers() {
+    const grid = document.getElementById('publishers-grid');
+    grid.innerHTML = renderLoadingSkeleton(6);
 
-                renderPublishers();
-            } catch (error) {
-                console.error('Failed to load publishers:', error);
-                grid.innerHTML = '<div class="empty-state"><div class="empty-state__title">Failed to load publishers</div></div>';
-            }
+    try {
+      const response = await fetch('/api/properties/registry?limit=5000');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      publishers = data.properties || [];
 
-            // Show add CTA for members
-            const config = window.__APP_CONFIG__;
-            if (config?.user?.isMember) {
-                const cta = document.getElementById('add-publisher-cta');
-                if (cta) cta.classList.remove('hidden');
-            }
-        }
+      const stats = data.stats || {};
+      document.getElementById('stat-total').textContent = stats.total || publishers.length;
+      document.getElementById('stat-community').textContent = (stats.community || 0) + (stats.enriched || 0);
+      document.getElementById('stat-adagents-json').textContent = stats.adagents_json || 0;
+      document.getElementById('stat-hosted').textContent = stats.hosted || 0;
 
-        function renderLoadingSkeleton(count = 6) {
-            return Array(count).fill(0).map(() => `
-                <div class="publisher-card" style="pointer-events: none; opacity: 0.6;">
-                    <div class="publisher-header">
-                        <div style="flex: 1;">
-                            <div class="skeleton-bg" style="height: 20px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
-                            <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 40%;"></div>
-                        </div>
-                        <div class="skeleton-bg" style="height: 24px; width: 80px; border-radius: var(--radius-full);"></div>
-                    </div>
-                    <div class="publisher-meta">
-                        <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 100px;"></div>
-                    </div>
-                </div>
-            `).join('');
-        }
+      renderPublishers();
+    } catch (error) {
+      console.error('Failed to load publishers:', error);
+      grid.innerHTML = '<div class="empty-state"><div class="empty-state__title">Failed to load properties</div></div>';
+    }
 
-        function renderPublishers() {
-            const grid = document.getElementById('publishers-grid');
-            const filtered = publishers.filter(pub => {
-                if (filters.source !== 'all' && pub.source !== filters.source) return false;
-                if (filters.search) {
-                    const q = filters.search.toLowerCase();
-                    if (!pub.domain?.toLowerCase().includes(q)) return false;
-                }
-                return true;
-            });
+    const config = window.__APP_CONFIG__;
+    if (config?.user?.isMember) {
+      const cta = document.getElementById('add-publisher-cta');
+      if (cta) cta.classList.remove('hidden');
+    }
+  }
 
-            if (filtered.length === 0) {
-                const msg = publishers.length === 0 ? 'No publishers registered yet.' : 'No publishers found matching your filters.';
-                grid.innerHTML = `<div class="empty-state"><div class="empty-state__title">${escapeHtml(msg)}</div></div>`;
-                return;
-            }
+  function renderLoadingSkeleton(count = 6) {
+    return Array(count).fill(0).map(() => `
+      <div class="publisher-card" style="pointer-events: none; opacity: 0.6;">
+        <div class="publisher-header">
+          <div style="flex: 1;">
+            <div class="skeleton-bg" style="height: 20px; border-radius: var(--radius-sm); width: 60%; margin-bottom: var(--space-2);"></div>
+            <div class="skeleton-bg" style="height: 14px; border-radius: var(--radius-sm); width: 40%;"></div>
+          </div>
+          <div class="skeleton-bg" style="height: 24px; width: 80px; border-radius: var(--radius-full);"></div>
+        </div>
+        <div class="publisher-meta">
+          <div class="skeleton-bg" style="height: 16px; border-radius: var(--radius-sm); width: 100px;"></div>
+        </div>
+      </div>
+    `).join('');
+  }
 
-            grid.innerHTML = filtered.map(pub => {
-                const sourceLabel = {
-                    'adagents_json': 'adagents.json',
-                    'hosted': 'Hosted',
-                    'community': 'Community',
-                    'enriched': 'Enriched',
-                    'discovered': 'Discovered',
-                }[pub.source] || pub.source;
+  function renderPublishers() {
+    const grid = document.getElementById('publishers-grid');
+    const filtered = publishers.filter(pub => {
+      if (filters.source !== 'all') {
+        if (filters.source === 'community') {
+          if (pub.source !== 'community' && pub.source !== 'enriched') return false;
+        } else if (pub.source !== filters.source) return false;
+      }
+      if (filters.search) {
+        const q = filters.search.toLowerCase();
+        if (!pub.domain?.toLowerCase().includes(q)) return false;
+      }
+      return true;
+    });
 
-                const isAuthoritative = pub.source === 'adagents_json';
+    if (filtered.length === 0) {
+      const msg = publishers.length === 0 ? 'No properties registered yet.' : 'No properties found matching your filters.';
+      grid.innerHTML = `<div class="empty-state"><div class="empty-state__title">${escapeHtml(msg)}</div></div>`;
+      return;
+    }
 
-                return `
-                    <div class="publisher-card" onclick="window.location.href='/property/view/${encodeURIComponent(pub.domain)}'">
-                        <div class="publisher-header">
-                            <div>
-                                <div class="publisher-domain">${escapeHtml(pub.domain)}</div>
-                            </div>
-                            <span class="status-badge ${isAuthoritative ? 'valid' : 'neutral'}">
-                                ${escapeHtml(sourceLabel)}
-                            </span>
-                        </div>
-                        <div class="publisher-meta">
-                            <div class="stat-item"><span class="stat-value">${pub.property_count || 0}</span> propert${pub.property_count !== 1 ? 'ies' : 'y'}</div>
-                            ${pub.agent_count > 0 ? `<div class="stat-item"><span class="stat-value">${pub.agent_count}</span> agent${pub.agent_count !== 1 ? 's' : ''}</div>` : ''}
-                            ${pub.verified ? '<div class="stat-item">&#x2713; Verified</div>' : ''}
-                        </div>
-                    </div>
-                `;
-            }).join('');
-        }
+    grid.innerHTML = filtered.map(pub => {
+      const sourceLabel = {
+        'adagents_json': 'adagents.json',
+        'hosted': 'Hosted',
+        'community': 'Community',
+        'enriched': 'Community',
+        'discovered': 'Discovered',
+      }[pub.source] || pub.source;
 
-        window.setSourceFilter = function(source) {
-            filters.source = source;
-            document.querySelectorAll('.filter-btn[data-source]').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.source === source);
-            });
-            renderPublishers();
-        };
+      const isAuthoritative = pub.source === 'adagents_json';
 
-        window.filterPublishers = function() {
-            filters.search = document.getElementById('search-input').value;
-            renderPublishers();
-        };
+      return `
+        <div class="publisher-card" onclick="window.location.href='/property/view/${encodeURIComponent(pub.domain)}'">
+          <div class="publisher-header">
+            <div>
+              <div class="publisher-domain">${escapeHtml(pub.domain)}</div>
+            </div>
+            <span class="status-badge ${isAuthoritative ? 'valid' : 'neutral'}">
+              ${escapeHtml(sourceLabel)}
+            </span>
+          </div>
+          <div class="publisher-meta">
+            <div class="stat-item"><span class="stat-value">${pub.property_count || 0}</span> propert${pub.property_count !== 1 ? 'ies' : 'y'}</div>
+            ${pub.agent_count > 0 ? `<div class="stat-item"><span class="stat-value">${pub.agent_count}</span> agent${pub.agent_count !== 1 ? 's' : ''}</div>` : ''}
+            ${pub.verified ? '<div class="stat-item">&#x2713; Verified</div>' : ''}
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
 
-        function escapeHtml(str) {
-            if (!str) return '';
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
-        }
-    </script>
+  window.setSourceFilter = function(source) {
+    filters.source = source;
+    document.querySelectorAll('.filter-btn[data-source]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.source === source);
+    });
+    renderPublishers();
+  };
+
+  window.filterPublishers = function() {
+    filters.search = document.getElementById('search-input').value;
+    renderPublishers();
+  };
+
+  function escapeHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+</script>
 </body>
 </html>

--- a/server/public/registry-nav.js
+++ b/server/public/registry-nav.js
@@ -1,0 +1,57 @@
+/**
+ * Registry sub-navigation
+ * Include after nav.js on any registry page:
+ *   <script src="/registry-nav.js"></script>
+ *
+ * Renders a sticky sub-nav below the main nav with links to
+ * registry sub-pages. Highlights the current page.
+ */
+(function () {
+  'use strict';
+
+  var path = window.location.pathname;
+
+  var links = [
+    { href: '/registry', label: 'Overview' },
+    { href: '/agents', label: 'Agents' },
+    { href: '/brands', label: 'Brands' },
+    { href: '/publishers', label: 'Properties' },
+    { href: '/members', label: 'Members' },
+    { href: '/registry/tools', label: 'Tools' },
+  ];
+
+  function isActive(href) {
+    if (href === '/registry') return path === '/registry' || path === '/registry/';
+    if (href === '/registry/tools') return path === '/registry/tools' || path === '/registry/tools/' || path === '/brand/builder' || path === '/adagents/builder';
+    if (href === '/brands') return path === '/brands' || path.startsWith('/brand/view');
+    if (href === '/publishers') return path === '/publishers' || path.startsWith('/property/view');
+    return path === href || path.startsWith(href + '/');
+  }
+
+  var html = '<nav class="sub-nav"><div class="sub-nav-inner" style="max-width:var(--container-xl)"><div class="sub-nav-links">';
+  for (var i = 0; i < links.length; i++) {
+    var l = links[i];
+    html += '<a href="' + l.href + '"' + (isActive(l.href) ? ' class="active"' : '') + '>' + l.label + '</a>';
+  }
+  html += '</div></div></nav>';
+
+  function insert() {
+    var navbar = document.querySelector('.navbar');
+    if (navbar) {
+      navbar.insertAdjacentHTML('afterend', html);
+    } else {
+      // Fallback: insert after nav placeholder
+      var placeholder = document.getElementById('adcp-nav');
+      if (placeholder) {
+        placeholder.insertAdjacentHTML('afterend', html);
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', insert);
+  } else {
+    // nav.js may not have run yet; defer to next tick
+    setTimeout(insert, 0);
+  }
+})();

--- a/server/public/registry-tools.html
+++ b/server/public/registry-tools.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Registry tools | AgenticAdvertising.org</title>
+  <meta name="description" content="Builder and validation workflows for brand.json, adagents.json, and other AdCP implementation tasks.">
+  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/layout.css">
+  <style>
+    body {
+      padding-top: var(--nav-height);
+    }
+
+    .tool-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-6);
+      margin-top: var(--space-8);
+    }
+
+    .tool-card {
+      height: 100%;
+    }
+
+    .tool-card .meta {
+      display: block;
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-2);
+      text-transform: uppercase;
+      letter-spacing: var(--tracking-wider);
+      font-weight: var(--font-semibold);
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      color: var(--color-brand);
+      text-decoration: none;
+      font-weight: var(--font-medium);
+      margin-bottom: var(--space-4);
+    }
+
+    .back-link:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 768px) {
+      .tool-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="adcp-nav"></div>
+  <script src="/nav.js"></script>
+  <script src="/registry-nav.js"></script>
+
+  <header class="page-header">
+    <h1>Registry tools</h1>
+    <p>Create and validate the files that agents use for discovery, identity, and authorization</p>
+  </header>
+
+  <section>
+    <div class="panel panel-wide">
+
+      <div class="tool-grid">
+        <div class="cta-card tool-card">
+          <span class="meta">Brand protocol</span>
+          <h3>brand.json builder</h3>
+          <p>Create and validate a hosted brand identity file, then publish or update it through the registry.</p>
+          <a href="/brand/builder">Open builder</a>
+        </div>
+
+        <div class="cta-card tool-card">
+          <span class="meta">Property governance</span>
+          <h3>adagents.json builder</h3>
+          <p>Validate publisher declarations, generate compliant payloads, and check referenced agent cards.</p>
+          <a href="/adagents/builder">Open builder</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-subtle">
+    <div class="panel panel-wide">
+      <div class="tool-grid">
+        <div class="cta-card tool-card">
+          <span class="meta">Specification</span>
+          <h3>brand.json docs</h3>
+          <p>Reference for the brand identity file format, its variants, and associated rights workflows.</p>
+          <a href="https://docs.adcontextprotocol.org/docs/brand-protocol/brand-json">View docs</a>
+        </div>
+
+        <div class="cta-card tool-card">
+          <span class="meta">Specification</span>
+          <h3>adagents.json docs</h3>
+          <p>Reference for publisher authorization declarations and how governance agents consume them.</p>
+          <a href="https://docs.adcontextprotocol.org/docs/governance/property/adagents">View docs</a>
+        </div>
+
+        <div class="cta-card tool-card">
+          <span class="meta">API reference</span>
+          <h3>Registry API</h3>
+          <p>Endpoint reference for brand resolution, property lookup, agent discovery, and authorization.</p>
+          <a href="https://docs.adcontextprotocol.org/docs/registry/index">View API docs</a>
+        </div>
+
+        <div class="cta-card tool-card">
+          <span class="meta">Guide</span>
+          <h3>Building with AdCP</h3>
+          <p>Architecture, implementation patterns, authentication, sessions, and transport guidance.</p>
+          <a href="https://docs.adcontextprotocol.org/docs/building/index">View guide</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div id="adcp-footer"></div>
+</body>
+</html>

--- a/server/public/registry.html
+++ b/server/public/registry.html
@@ -1,138 +1,154 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Registry - AgenticAdvertising.org</title>
-    <link rel="icon" href="/AAo.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="/design-system.css">
-    <style>
-        /* =============================================================================
-           Registry Hub Page Styles
-           Uses design system variables - see /design-system.css for tokens
-           ============================================================================= */
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Registry | AgenticAdvertising.org</title>
+  <meta name="description" content="Browse members, agents, brands, properties, and tools in the AdCP ecosystem.">
+  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/layout.css">
+  <style>
+    body {
+      padding-top: var(--nav-height);
+    }
 
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: var(--font-sans);
-            line-height: var(--leading-normal);
-            color: var(--color-text-body);
-            background: var(--color-bg-page);
-            padding-top: var(--nav-height);
-        }
+    .registry-hero {
+      text-align: center;
+      padding: var(--space-16) var(--space-6) var(--space-10);
+      background: linear-gradient(180deg, var(--color-primary-50) 0%, #fff 100%);
+    }
 
-        header {
-            background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-hover) 100%);
-            color: white;
-            padding: var(--space-12) 0;
-            text-align: center;
-        }
-        header h1 { font-size: var(--text-4xl); margin-bottom: var(--space-2); }
-        header .subtitle { font-size: var(--text-lg); opacity: 0.9; }
+    .registry-hero h1 {
+      font-size: var(--text-4xl);
+      font-weight: var(--font-bold);
+      color: var(--color-text-heading);
+      line-height: var(--leading-tight);
+      letter-spacing: var(--tracking-tight);
+      margin-bottom: var(--space-2);
+    }
 
-        .container {
-            max-width: var(--container-xl);
-            margin: 0 auto;
-            padding: var(--space-10) var(--space-4);
-        }
+    .registry-hero p {
+      font-size: var(--text-xl);
+      color: var(--color-text-secondary);
+      line-height: var(--leading-relaxed);
+      max-width: 600px;
+      margin: 0 auto;
+    }
 
-        .entity-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-            gap: var(--space-6);
-        }
+    .registry-hero-links {
+      display: flex;
+      justify-content: center;
+      gap: var(--space-6);
+      margin-top: var(--space-6);
+    }
 
-        .entity-card {
-            background: var(--color-bg-card);
-            border-radius: var(--radius-xl);
-            padding: var(--space-8);
-            box-shadow: var(--shadow-sm);
-            text-decoration: none;
-            color: inherit;
-            display: block;
-            border: var(--border-2) solid transparent;
-            transition: var(--transition-all);
-        }
-        .entity-card:hover {
-            transform: translateY(-3px);
-            box-shadow: var(--shadow-lg);
-            border-color: var(--color-brand);
-        }
+    .registry-hero-links a {
+      font-size: var(--text-sm);
+      font-weight: var(--font-semibold);
+      color: var(--color-brand);
+      text-decoration: none;
+    }
 
-        .entity-icon {
-            font-size: var(--text-4xl);
-            margin-bottom: var(--space-4);
-            display: block;
-        }
+    .registry-hero-links a:hover {
+      text-decoration: underline;
+    }
 
-        .entity-title {
-            font-size: var(--text-xl);
-            font-weight: var(--font-semibold);
-            color: var(--color-text-heading);
-            margin-bottom: var(--space-2);
-        }
+    .registry-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-6);
+      margin-top: var(--space-8);
+    }
 
-        .entity-desc {
-            font-size: var(--text-sm);
-            color: var(--color-text-muted);
-            line-height: var(--leading-relaxed);
-            margin-bottom: var(--space-4);
-        }
+    .registry-card {
+      height: 100%;
+    }
 
-        .entity-link {
-            display: inline-flex;
-            align-items: center;
-            gap: var(--space-1);
-            font-size: var(--text-sm);
-            font-weight: var(--font-semibold);
-            color: var(--color-brand);
-        }
+    .registry-card .meta {
+      display: block;
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-2);
+      text-transform: uppercase;
+      letter-spacing: var(--tracking-wider);
+      font-weight: var(--font-semibold);
+    }
 
-        @media (max-width: 640px) {
-            .entity-grid { grid-template-columns: 1fr; }
-        }
-    </style>
+    @media (max-width: 768px) {
+      .registry-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
 </head>
 <body>
-    <!-- Navigation (loaded by nav.js) -->
-    <div id="adcp-nav"></div>
-    <script src="/nav.js"></script>
+  <div id="adcp-nav"></div>
+  <script src="/nav.js"></script>
+  <script src="/registry-nav.js"></script>
 
-    <header>
-        <h1>Registry</h1>
-        <p class="subtitle">Explore the AdCP ecosystem — members, agents, brands, and properties</p>
-    </header>
-
-    <div class="container">
-        <div class="entity-grid">
-            <a href="/members" class="entity-card">
-                <span class="entity-icon">🏢</span>
-                <div class="entity-title">Members</div>
-                <div class="entity-desc">Organizations participating in AgenticAdvertising.org — brands, agencies, publishers, and technology providers.</div>
-                <div class="entity-link">Browse members →</div>
-            </a>
-
-            <a href="/agents" class="entity-card">
-                <span class="entity-icon">🤖</span>
-                <div class="entity-title">Agents</div>
-                <div class="entity-desc">Sales, creative, and signals agents implementing the Ad Context Protocol for advertising automation.</div>
-                <div class="entity-link">Browse agents →</div>
-            </a>
-
-            <a href="/brands" class="entity-card">
-                <span class="entity-icon">✨</span>
-                <div class="entity-title">Brands</div>
-                <div class="entity-desc">Brand identities and brand.json manifests for advertisers in the AI advertising ecosystem.</div>
-                <div class="entity-link">Browse brands →</div>
-            </a>
-
-            <a href="/publishers" class="entity-card">
-                <span class="entity-icon">📰</span>
-                <div class="entity-title">Properties</div>
-                <div class="entity-desc">Publisher properties and domains verified as AdCP-compatible advertising inventory sources.</div>
-                <div class="entity-link">Browse properties →</div>
-            </a>
-        </div>
+  <header class="registry-hero">
+    <h1>Registry</h1>
+    <p>Who's participating, what's live, and what's discoverable in the AdCP ecosystem</p>
+    <div class="registry-hero-links">
+      <a href="https://docs.adcontextprotocol.org/docs/registry/index">Registry API docs &rarr;</a>
+      <a href="https://docs.adcontextprotocol.org/docs/building/index">Building with AdCP &rarr;</a>
+      <a href="https://docs.adcontextprotocol.org/docs/governance/property/adagents">adagents.json spec &rarr;</a>
     </div>
+  </header>
+
+  <section>
+    <div class="panel panel-wide">
+      <div class="registry-grid">
+        <div class="cta-card registry-card">
+          <span class="meta">Community</span>
+          <h3>Members</h3>
+          <p>Organizations participating in AgenticAdvertising.org — brands, agencies, publishers, and technology providers.</p>
+          <a href="/members">Browse members</a>
+        </div>
+
+        <div class="cta-card registry-card">
+          <span class="meta">Directory</span>
+          <h3>Agents</h3>
+          <p>Sales, creative, and signals agents implementing AdCP, including health, capabilities, and linked properties.</p>
+          <a href="/agents">Browse agents</a>
+        </div>
+
+        <div class="cta-card registry-card">
+          <span class="meta">Identity</span>
+          <h3>Brands</h3>
+          <p>Brand identities with machine-readable brand.json manifests for the AI advertising ecosystem.</p>
+          <a href="/brands">Browse brands</a>
+          <span style="margin: 0 var(--space-2); color: var(--color-text-light);">&middot;</span>
+          <a href="/brand/builder">Build brand.json</a>
+        </div>
+
+        <div class="cta-card registry-card">
+          <span class="meta">Inventory</span>
+          <h3>Properties</h3>
+          <p>Publisher properties and domains verified as AdCP-compatible advertising inventory sources.</p>
+          <a href="/publishers">Browse properties</a>
+          <span style="margin: 0 var(--space-2); color: var(--color-text-light);">&middot;</span>
+          <a href="/adagents/builder">Build adagents.json</a>
+        </div>
+
+        <div class="cta-card registry-card">
+          <span class="meta">Utilities</span>
+          <h3>Tools</h3>
+          <p>Builder and validation workflows for <code>brand.json</code>, <code>adagents.json</code>, and other implementation tasks.</p>
+          <a href="/registry/tools">Open tools</a>
+        </div>
+
+        <div class="cta-card registry-card">
+          <span class="meta">Reference</span>
+          <h3>Registry API</h3>
+          <p>Endpoint reference for brand resolution, property lookup, agent discovery, and authorization validation.</p>
+          <a href="https://docs.adcontextprotocol.org/docs/registry/index">View API docs</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div id="adcp-footer"></div>
 </body>
 </html>

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1856,6 +1856,16 @@ export class HTTPServer {
       await this.serveHtmlWithConfig(req, res, 'registry.html');
     });
 
+    // Tools hub for registry utilities and builder workflows
+    this.app.get("/registry/tools", async (req, res) => {
+      await this.serveHtmlWithConfig(req, res, 'registry-tools.html');
+    });
+
+    // Backward-compatible tools alias
+    this.app.get("/tools", (_req, res) => {
+      res.redirect(301, '/registry/tools');
+    });
+
     // adagents.json project landing page
     this.app.get("/adagents", async (req, res) => {
       await this.serveHtmlWithConfig(req, res, 'adagents-landing.html');


### PR DESCRIPTION
## Summary
- Reskin agents, brands, and properties pages to match the new site design system (remove gradient headers, green accents, shadow cards; apply page-header, layout.css, brand-color styling)
- Create shared `registry-nav.js` sub-nav component across all registry pages (Overview, Agents, Brands, Properties, Members, Tools)
- Add builder tool links (brand.json, adagents.json) to page headers and registry hub cards
- Rename "Enriched" source label to "Community" on properties page and merge duplicate filters
- Fix XSS: escape all external agent data in agents.html detail view
- Fix builder pages: prevent layout.css `.page-header` from overriding gradient background
- Update builder URLs in docs to agenticadvertising.org paths

## Test plan
- [ ] Verify `/registry` hub page renders with gradient hero and doc links
- [ ] Verify `/agents` page: list view filters, card hover, detail view with tools/publishers/formats
- [ ] Verify `/brands` page: search, filters, "Build brand.json" link in header
- [ ] Verify `/publishers` page: single "Community" filter covers both enriched + community sources
- [ ] Verify `/brand/builder` and `/adagents/builder` render with blue gradient (not whited out) and sub-nav highlights "Tools"
- [ ] Verify sub-nav appears and highlights correctly on all registry pages
- [ ] Verify no XSS: agent detail view escapes external data (names, URLs, descriptions, contact info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)