### PR TITLE
fix: Mintlify validate

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -11,7 +11,6 @@ server/
 tests/
 scripts/
 skills/
-static/openapi/
 *.test.*
 *.spec.*
 CHANGELOG.md


### PR DESCRIPTION
```
npx --safe-chain-skip-minimum-package-age mintlify@latest validate
success build validation passed
```