### PR TITLE
fix: certification admin 401 — missing requireAuth

### DIFF
--- a/.changeset/cert-admin-auth.md
+++ b/.changeset/cert-admin-auth.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix certification admin routes returning 401 by adding requireAuth middleware before requireAdmin

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -298,7 +298,7 @@ export function createCertificationRouters() {
   // =====================================================
 
   const adminRouter = Router();
-  adminRouter.use(requireAdmin);
+  adminRouter.use(requireAuth, requireAdmin);
 
   // POST /api/admin/certification/backfill-badges — retry Certifier for credentials missing data
   adminRouter.post('/backfill-badges', async (_req, res) => {


### PR DESCRIPTION
## Summary
- Certification admin API routes (`/api/admin/certification/overview`, `/api/admin/certification/learners`) returned 401 for authenticated admin users
- Root cause: the admin router only applied `requireAdmin` middleware, but `requireAdmin` expects `req.user` to be populated by `requireAuth` first
- Added `requireAuth` before `requireAdmin` to match all other admin route patterns

## Test plan
- [x] All 501 tests pass
- [x] TypeScript compiles clean
- [x] Code review confirms no other routes have this bug
- [ ] Verify `/admin/certification` page loads and both API calls succeed in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)