### PR TITLE
fix: add SSE transport to training agent

### DIFF
--- a/.changeset/training-agent-sse-transport.md
+++ b/.changeset/training-agent-sse-transport.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add legacy SSE transport support to the training agent, enabling MCP clients that only support the deprecated SSE protocol.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -10,6 +10,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import rateLimit from 'express-rate-limit';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createLogger } from '../logger.js';
 import { createTrainingAgentServer } from './task-handlers.js';
 import { startSessionCleanup } from './state.js';
@@ -198,6 +199,124 @@ export function createTrainingAgentRouter(): Router {
       id: null,
       error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
     });
+  });
+
+  // --- Legacy SSE transport ---
+  // Some MCP clients (e.g. older SDKs) only support the deprecated SSE transport.
+  // GET /sse establishes the event stream; POST /message delivers JSON-RPC messages.
+  // Rate limiter is shared with /mcp — SSE uses 2 requests per interaction (GET + POST).
+  const sseSessions = new Map<string, SSEServerTransport>();
+  const sseSessionLastSeen = new Map<string, number>();
+  const SSE_MAX_SESSIONS = 200;
+  const SSE_SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+  // Sweep stale sessions that didn't trigger a close event (e.g. LB timeout)
+  const sseSweepTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [id, ts] of sseSessionLastSeen) {
+      if (now - ts > SSE_SESSION_TTL_MS) {
+        const transport = sseSessions.get(id);
+        if (transport) transport.close().catch(() => {});
+        sseSessions.delete(id);
+        sseSessionLastSeen.delete(id);
+      }
+    }
+  }, 5 * 60 * 1000);
+  if (sseSweepTimer.unref) sseSweepTimer.unref();
+
+  router.options('/sse', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.status(204).end();
+  });
+
+  router.options('/message', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.status(204).end();
+  });
+
+  router.get('/sse', mcpRateLimiter, requireToken, async (req: Request, res: Response) => {
+    setCORSHeaders(res);
+
+    if (sseSessions.size >= SSE_MAX_SESSIONS) {
+      res.status(503).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'Too many active SSE sessions. Please try again later.' },
+      });
+      return;
+    }
+
+    let server: ReturnType<typeof createTrainingAgentServer> | null = null;
+    try {
+      const ctx: TrainingContext = { mode: 'open' };
+      server = createTrainingAgentServer(ctx);
+
+      // The endpoint path is relative to the router mount point
+      const transport = new SSEServerTransport(`${req.baseUrl}/message`, res);
+      const sessionId = transport.sessionId;
+      sseSessions.set(sessionId, transport);
+      sseSessionLastSeen.set(sessionId, Date.now());
+
+      transport.onclose = () => {
+        sseSessions.delete(sessionId);
+        sseSessionLastSeen.delete(sessionId);
+        server?.close().catch(() => {});
+        logger.debug({ sessionId }, 'SSE session closed');
+      };
+
+      await server.connect(transport);
+
+      logger.debug({ sessionId, ip: req.ip }, 'SSE session established');
+    } catch (error) {
+      logger.error({ error }, 'Training agent: SSE connection error');
+      await server?.close().catch(() => {});
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32603, message: 'Internal server error' },
+        });
+      }
+    }
+  });
+
+  router.post('/message', mcpRateLimiter, requireToken, async (req: Request, res: Response) => {
+    setCORSHeaders(res);
+
+    const sessionId = req.query.sessionId as string;
+    if (!sessionId) {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32600, message: 'Missing sessionId query parameter' },
+      });
+      return;
+    }
+
+    const transport = sseSessions.get(sessionId);
+    if (!transport) {
+      res.status(404).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'SSE session not found or expired' },
+      });
+      return;
+    }
+
+    sseSessionLastSeen.set(sessionId, Date.now());
+
+    try {
+      await transport.handlePostMessage(req, res, req.body);
+    } catch (error) {
+      logger.error({ error, sessionId }, 'Training agent: SSE message error');
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32603, message: 'Internal server error' },
+        });
+      }
+    }
   });
 
   logger.info('Training agent routes configured');

--- a/server/tests/integration/training-agent-sse.test.ts
+++ b/server/tests/integration/training-agent-sse.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import http from 'http';
+import { EventSource } from 'eventsource';
+
+// Set token before module loads (constantTimeEqual reads it at import time)
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-sse';
+});
+
+// Suppress noisy logs during tests
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Dynamic import after env is set
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+const AUTH = 'Bearer test-token-for-sse';
+
+describe('Training Agent SSE Transport', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  // ── SSE error handling ────────────────────────────────────────────
+
+  it('GET /sse without auth returns 401', async () => {
+    await request(app)
+      .get('/api/training-agent/sse')
+      .expect(401);
+  });
+
+  it('POST /message without sessionId returns 400', async () => {
+    const res = await request(app)
+      .post('/api/training-agent/message')
+      .set('Authorization', AUTH)
+      .set('Content-Type', 'application/json')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      .expect(400);
+
+    expect(res.body.error.message).toMatch(/sessionId/i);
+  });
+
+  it('POST /message with unknown sessionId returns 404', async () => {
+    const res = await request(app)
+      .post('/api/training-agent/message?sessionId=nonexistent')
+      .set('Authorization', AUTH)
+      .set('Content-Type', 'application/json')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      .expect(404);
+
+    expect(res.body.error.message).toMatch(/not found/i);
+  });
+
+  it('OPTIONS /sse returns 204 with CORS headers', async () => {
+    const res = await request(app)
+      .options('/api/training-agent/sse')
+      .expect(204);
+
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+
+  it('OPTIONS /message returns 204 with CORS headers', async () => {
+    const res = await request(app)
+      .options('/api/training-agent/message')
+      .expect(204);
+
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+
+  // ── Full SSE round-trip ──────────────────────────────────────────
+
+  describe('SSE round-trip', () => {
+    let server: http.Server;
+    let baseUrl: string;
+
+    beforeAll(async () => {
+      server = http.createServer(app);
+      await new Promise<void>((resolve) => server.listen(0, resolve));
+      const port = (server.address() as any).port;
+      baseUrl = `http://localhost:${port}/api/training-agent`;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it('establishes SSE connection and receives endpoint event', async () => {
+      const endpointUrl = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('SSE connection timeout')), 5000);
+        const es = new EventSource(`${baseUrl}/sse`, {
+          fetch: (input, init) => fetch(input, {
+            ...init,
+            headers: { ...Object.fromEntries(new Headers(init?.headers).entries()), Authorization: AUTH },
+          }),
+        });
+
+        es.addEventListener('endpoint', (event) => {
+          clearTimeout(timeout);
+          es.close();
+          resolve(event.data);
+        });
+
+        es.addEventListener('error', (err) => {
+          clearTimeout(timeout);
+          es.close();
+          reject(new Error(`SSE error: ${err.message}`));
+        });
+      });
+
+      expect(endpointUrl).toContain('/message');
+      expect(endpointUrl).toContain('sessionId=');
+    });
+
+    it('accepts POST /message for an active SSE session', async () => {
+      // Establish SSE connection
+      let es: EventSource;
+      const endpointUrl = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('SSE connection timeout')), 5000);
+        es = new EventSource(`${baseUrl}/sse`, {
+          fetch: (input, init) => fetch(input, {
+            ...init,
+            headers: { ...Object.fromEntries(new Headers(init?.headers).entries()), Authorization: AUTH },
+          }),
+        });
+
+        es.addEventListener('endpoint', (event) => {
+          clearTimeout(timeout);
+          resolve(event.data);
+        });
+
+        es.addEventListener('error', (err) => {
+          clearTimeout(timeout);
+          es.close();
+          reject(new Error(`SSE error: ${err.message}`));
+        });
+      });
+
+      try {
+        const messageUrl = endpointUrl.startsWith('http')
+          ? endpointUrl
+          : `http://localhost:${(server.address() as any).port}${endpointUrl}`;
+
+        const res = await fetch(messageUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: AUTH,
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+        });
+
+        // SSE transport returns 202 Accepted for messages
+        expect(res.status).toBe(202);
+      } finally {
+        es!.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add legacy SSE transport (`GET /sse`, `POST /message`) to the training agent alongside the existing Streamable HTTP endpoint (`POST /mcp`)
- Some MCP clients only support the deprecated SSE transport — this unblocks them
- Session tracking with TTL-based cleanup (30min idle), max 200 concurrent sessions
- Integration tests for error handling, CORS, and full SSE round-trip

Addresses feedback on #1530: "Streamable HTTP is ok. SSE - less so."

## Test plan

- [x] All 501 existing tests pass
- [x] 7 new SSE transport integration tests pass (`npx vitest run server/tests/integration/training-agent-sse.test.ts`)
- [x] Typecheck passes
- [ ] After deploy: verify `GET /api/training-agent/sse` with bearer token establishes SSE stream
- [ ] After deploy: verify `POST /api/training-agent/message?sessionId=xxx` delivers messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)