### PR TITLE
fix(signals): replace stale deployment fields in docs

### DIFF
--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -480,15 +480,16 @@ Warnings about suboptimal configuration are conveyed in the `message` field. The
 
 ## Error Handling Philosophy
 
-### Status vs Errors
-- **Task Status**: Indicates overall activation outcome (`deployed`, `failed`, etc.)
-- **Errors Array**: Contains specific issues, warnings, and remediation steps
-- **Partial Success**: Signal can be `deployed` while still having warnings in `errors` array
+### Discriminated Union
+
+`deployments` and `errors` are mutually exclusive in the response:
+
+- **`deployments` present** → activation succeeded. Any warnings or suboptimal-configuration notes are conveyed in the `message` field only.
+- **`errors` present** → activation failed. The `deployments` array is absent.
 
 ### Error Types
-- **Fatal Errors**: Prevent activation (status = `failed`)
-- **Warnings**: Signal activates successfully but with caveats (status = `deployed` + errors)
-- **Configuration Issues**: Non-blocking problems that affect performance
+- **Fatal Errors**: Prevent activation — response contains `errors` only
+- **Warnings / Configuration Issues**: Non-blocking; activation succeeds — response contains `deployments` only, with details in `message`
 
 ## Usage Notes
 

--- a/docs/signals/tasks/get_signals.mdx
+++ b/docs/signals/tasks/get_signals.mdx
@@ -507,29 +507,34 @@ Discover all available deployments across platforms:
         "platform": "index-exchange",
         "account": "agency-123-ix",
         "is_live": true,
-        "scope": "account-specific",
-        "decisioning_platform_segment_id": "ix_agency123_peer39_lux_auto"
+        "activation_key": {
+          "type": "segment_id",
+          "segment_id": "ix_agency123_peer39_lux_auto"
+        }
       },
       {
         "type": "platform",
         "platform": "index-exchange",
         "is_live": true,
-        "scope": "platform-wide",
-        "decisioning_platform_segment_id": "ix_peer39_luxury_auto_gen"
+        "activation_key": {
+          "type": "segment_id",
+          "segment_id": "ix_peer39_luxury_auto_gen"
+        }
       },
       {
         "type": "platform",
         "platform": "openx",
         "is_live": true,
-        "scope": "platform-wide",
-        "decisioning_platform_segment_id": "ox_peer39_lux_auto_456"
+        "activation_key": {
+          "type": "segment_id",
+          "segment_id": "ox_peer39_lux_auto_456"
+        }
       },
       {
         "type": "platform",
         "platform": "pubmatic",
         "account": "brand-456-pm",
         "is_live": false,
-        "scope": "account-specific",
         "estimated_activation_duration_minutes": 60
       }
     ],
@@ -559,8 +564,7 @@ Discover all available deployments across platforms:
     - **platform** (string): Target platform name
     - **account** (string, nullable): Specific account if account-specific
     - **is_live** (boolean): Whether signal is currently active
-    - **scope** (string): "platform-wide" or "account-specific"
-    - **decisioning_platform_segment_id** (string): Platform-specific ID to use
+    - **activation_key** (object, optional): The key to use for targeting. Only present when `is_live=true` and the authenticated caller has access to this deployment. See Activation Key Object above.
     - **estimated_activation_duration_minutes** (number, optional): Time to activate if not live
   - **pricing_options** (array): Array of pricing options available for this signal. Select one and pass its `pricing_option_id` in `report_usage`.
     - **pricing_option_id** (string): Unique identifier for this pricing option
@@ -642,16 +646,20 @@ The signal agent uses the provided IDs as a starting point and the spec as adjus
           "platform": "index-exchange",
           "account": "agency-123-ix",
           "is_live": true,
-          "scope": "account-specific",
-          "decisioning_platform_segment_id": "ix_agency123_acme_aff_shop"
+          "activation_key": {
+            "type": "segment_id",
+            "segment_id": "ix_agency123_acme_aff_shop"
+          }
         },
         {
           "type": "platform",
           "platform": "openx",
           "account": "agency-123-ox",
           "is_live": true,
-          "scope": "account-specific",
-          "decisioning_platform_segment_id": "ox_agency123_affluent_789"
+          "activation_key": {
+            "type": "segment_id",
+            "segment_id": "ox_agency123_affluent_789"
+          }
         }
       ],
       "pricing_options": [
@@ -688,8 +696,10 @@ The signal agent uses the provided IDs as a starting point and the spec as adjus
           "type": "platform",
           "platform": "the-trade-desk",
           "is_live": true,
-          "scope": "platform-wide",
-          "decisioning_platform_segment_id": "ttd_exp_auto_premium"
+          "activation_key": {
+            "type": "segment_id",
+            "segment_id": "ttd_exp_auto_premium"
+          }
         }
       ],
       "pricing_options": [


### PR DESCRIPTION
Fixes #1540

## Changes

### `docs/signals/tasks/get_signals.mdx`
- Replaced all occurrences of `decisioning_platform_segment_id` (plain string) with the `activation_key` structured object (`{type, segment_id}`) in the Scenarios section
- Removed the stale `scope` field (`"platform-wide"` / `"account-specific"`) from all Scenarios examples — this field has no definition in `core/deployment.json` v2.5.3
- Updated the Response Fields description to remove `decisioning_platform_segment_id` and `scope`, and add `activation_key` with the correct conditional description

### `docs/signals/tasks/activate_signal.mdx`
- Rewrote the "Error Handling Philosophy" section to correctly document the discriminated union: `deployments` and `errors` are mutually exclusive
- Removed the contradictory "Partial Success" bullet that claimed a signal could be `deployed` while also having entries in `errors`
- Aligned with the authoritative `<Note>` already present in the file: warnings go in `message` only, `errors` is reserved for failures