### PR TITLE
fix: prevent duplicate Addie DM responses

### DIFF
--- a/.changeset/thick-sites-wave.md
+++ b/.changeset/thick-sites-wave.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: prevent duplicate Addie DM responses for threaded messages

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2992,6 +2992,13 @@ async function handleChannelMessage({
       ts: 'ts' in event ? event.ts : undefined,
     }, 'Addie Bolt: Received DM in handleChannelMessage');
 
+    // DMs with thread_ts are handled by the Assistant framework (handleUserMessage).
+    // Only handle first DMs (no thread_ts) here to avoid sending duplicate responses.
+    if (hasThreadTs) {
+      logger.debug({ channelId: event.channel, userId }, 'Addie Bolt: Skipping threaded DM - handled by Assistant framework');
+      return;
+    }
+
     if (!hasText && !hasAttachments && !hasFiles) {
       logger.debug({ channelId: event.channel, userId }, 'Addie Bolt: Ignoring DM without content');
       return;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -27,7 +27,7 @@ import { ROUTING_RULES } from './router.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.03.3';
+export const CODE_VERSION = '2026.03.4';
 
 // Types
 export interface ConfigVersion {


### PR DESCRIPTION
## Summary
- DMs with `thread_ts` were processed by **both** the Bolt Assistant framework (`handleUserMessage`) and the `message` event handler (`handleChannelMessage` → `handleDirectMessage`), causing duplicate responses
- Added early return in `handleChannelMessage` to skip threaded DMs since the Assistant framework already handles them
- Bumped `CODE_VERSION` to `2026.03.4`

Resolves Escalation #124 (Pia Malovrh / Celtra — duplicate messages in Addie DM replies).

## Test plan
- [ ] Send a first DM to Addie (no thread) — should get one response (routed through middleware → `handleDirectMessage`)
- [ ] Reply in the DM thread — should get one response (handled by Assistant framework only, no longer also by `handleChannelMessage`)
- [ ] Send DM with attachment — should still work
- [ ] Verify no regression in channel mentions or HITL proposed responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)