### PR TITLE
feat: add Deals protocol documentation and schemas

### DIFF
--- a/DEALS_PROTOCOL_V1_CHANGES.md
+++ b/DEALS_PROTOCOL_V1_CHANGES.md
@@ -1,0 +1,137 @@
+# Deals Protocol v1 – List of Changes
+
+This document lists all changes made to add the Deals protocol (Phase 1) to the adcp repository.
+
+---
+
+## 1. New enum schemas (`static/schemas/source/enums/`)
+
+| File | Description |
+|------|-------------|
+| `transaction-type.json` | PMP, PG, AP |
+| `deal-state.json` | DRAFT, PROPOSED, ACCEPTED, SCHEDULED, LIVE, PAUSED, REJECTED, CANCELLED, COMPLETED |
+| `deal-deployment-status.json` | PENDING, ACTIVE, FAILED, DISABLED |
+| `deal-visibility.json` | PRIVATE, INVITE_ONLY, PUBLIC |
+
+---
+
+## 2. New core schemas (`static/schemas/source/core/`)
+
+| File | Description |
+|------|-------------|
+| `deal.json` | Logical deal: deal_id, product_id, transaction_type, buyer_seat_id, state, version, accepted_version, terms, deployments[], visibility |
+| `deal-terms.json` | Versioned terms: transaction_type, floor, bid_cap, commitment_units, makegood_rules, start_time, end_time |
+| `deal-deployment.json` | Per-destination activation: deployment_id, platform_type, platform_name, account_id, platform_deal_id, deployment_status, error, updated_at |
+| `deal-destination.json` | Activation destination: platform_type (DSP/SSP), platform_name, account_id, mode (CREATE_AND_SYNC, BIND_EXISTING) |
+
+---
+
+## 3. Extended existing schemas
+
+### `static/schemas/source/core/product.json`
+
+- **Added optional properties:**  
+  `supported_transaction_types` (array of transaction-type),  
+  `transaction_terms_by_type` (object),  
+  `requires_channel_split` (boolean),  
+  `deal_capabilities` (object with supports_bid_cap, supports_reject_over_under, supports_deal_level_reporting, supports_reason_codes, supports_multi_destination_activation).
+
+### `static/schemas/source/core/product-filters.json`
+
+- **Added optional property:**  
+  `transaction_type` (ref to transaction-type enum) for filtering products by deal type (PMP, PG, AP).
+
+---
+
+## 4. New deals protocol schemas (`static/schemas/source/deals/`)
+
+| Request | Response |
+|---------|----------|
+| `create-deal-request.json` | `create-deal-response.json` |
+| `list-deals-request.json` | `list-deals-response.json` |
+| `update-deal-terms-request.json` | `update-deal-terms-response.json` |
+| `transition-deal-state-request.json` | `transition-deal-state-response.json` |
+| `activate-deal-request.json` | `activate-deal-response.json` |
+| `get-deal-activation-status-request.json` | `get-deal-activation-status-response.json` |
+| `list-deal-mappings-request.json` | `list-deal-mappings-response.json` |
+| `get-deal-metrics-request.json` | `get-deal-metrics-response.json` |
+| `get-deal-diagnostics-request.json` | `get-deal-diagnostics-response.json` |
+
+---
+
+## 5. Schema registry and capabilities
+
+### `static/schemas/source/index.json`
+
+- **Core schemas:** Registered `deal`, `deal-terms`, `deal-deployment`, `deal-destination`.
+- **Enums:** Registered `transaction-type`, `deal-state`, `deal-deployment-status`, `deal-visibility`.
+- **Protocols:** Added `deals` protocol block with tasks: create-deal, list-deals, update-deal-terms, transition-deal-state, activate-deal, get-deal-activation-status, list-deal-mappings, get-deal-metrics, get-deal-diagnostics.
+
+### `static/schemas/source/protocol/get-adcp-capabilities-response.json`
+
+- **supported_protocols:** Added `"deals"` to the enum.
+- **New top-level property:** `deals` (object), only when deals is in supported_protocols, with:
+  - `supported_transaction_types` (required array: PMP, PG, AP),
+  - `features` (optional: supports_bid_cap, supports_reject_over_under, supports_deal_level_reporting, supports_reason_codes, supports_multi_destination_activation).
+
+---
+
+## 6. Build and skills
+
+### `scripts/build-schemas.cjs`
+
+- **Bundling:** Added bundle patterns for `deals/*-request.json` and `deals/*-response.json`.
+- **Skills:** Added `{ protocol: 'deals', skillName: 'adcp-deals' }` to the skills array.
+
+### `skills/adcp-deals/`
+
+- **New directory:** `skills/adcp-deals/` with `SKILL.md` (skill description and task summary).
+- **Generated:** `skills/adcp-deals/schemas/` is populated by the schema build (no manual files added).
+
+---
+
+## 7. Documentation
+
+### New docs (`docs/deals/`)
+
+| File | Purpose |
+|------|---------|
+| `index.mdx` | Deals protocol overview, discovery via get_products, lifecycle, activation, monitoring, design principles |
+| `specification.mdx` | Normative spec: scope, transport, deal states, transitions, activation, visibility, task summary, product/filter extensions |
+| `task-reference/index.mdx` | Task reference index and schema URLs |
+| `task-reference/create_deal.mdx` | create_deal task |
+| `task-reference/list_deals.mdx` | list_deals task |
+| `task-reference/update_deal_terms.mdx` | update_deal_terms task |
+| `task-reference/transition_deal_state.mdx` | transition_deal_state task |
+| `task-reference/activate_deal.mdx` | activate_deal task |
+| `task-reference/get_deal_activation_status.mdx` | get_deal_activation_status task |
+| `task-reference/list_deal_mappings.mdx` | list_deal_mappings task |
+| `task-reference/get_deal_metrics.mdx` | get_deal_metrics task |
+| `task-reference/get_deal_diagnostics.mdx` | get_deal_diagnostics task |
+
+### `docs.json`
+
+- **Navigation:** Added “Deals Protocol” group (for both default nav versions that include Media Buy and Creative) with:
+  - `docs/deals/index`
+  - `docs/deals/specification`
+  - Task Reference subgroup with all 9 task-reference pages above.
+
+### `README.md`
+
+- **Protocols table:** Added Deals row: “PMP, PG, AP deal lifecycle, activation, diagnostics” with key tasks.
+- **Repository structure:** Added `deals/` under `docs/`.
+
+---
+
+## 8. Design decisions (no separate get_product / get_deal)
+
+- **Single-product detail:** Use **get_products** (Media Buy) with filters that target one product (e.g. product_id). No separate get_product task.
+- **Single-deal fetch:** Use **list_deals** with `deal_ids: ["<deal_id>"]`. No separate get_deal task.
+
+---
+
+## Summary
+
+- **New files:** 4 enums, 4 core schemas, 18 deals request/response schemas, 1 skill SKILL.md, 12 doc pages.
+- **Modified files:** product.json, product-filters.json, index.json, get-adcp-capabilities-response.json, build-schemas.cjs, docs.json (2 nav blocks), README.md.
+- **Build:** `npm run build:schemas` runs successfully and generates bundled schemas and `skills/adcp-deals/schemas/`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AdCP is an open standard that enables AI agents to discover inventory, buy media
 | Protocol | Description | Key tasks |
 |----------|-------------|-----------|
 | **Media Buy** | Inventory discovery, campaign creation, delivery reporting | `get_products`, `create_media_buy`, `get_media_buy_delivery` |
+| **Deals** | PMP, PG, AP deal lifecycle, activation, diagnostics | `create_deal`, `list_deals`, `activate_deal`, `get_deal_metrics`, `get_deal_diagnostics` |
 | **Creative** | Ad creative management across channels | `build_creative`, `preview_creative`, `list_creative_formats` |
 | **Signals** | Audience and targeting data activation | `get_signals`, `activate_signal` |
 | **Accounts** | Commercial identity and billing | `sync_accounts`, `list_accounts`, `report_usage` |
@@ -31,6 +32,7 @@ AdCP is an open standard that enables AI agents to discover inventory, buy media
 adcontextprotocol/
 ├── docs/                  # Protocol documentation (Mintlify)
 │   ├── media-buy/         # Media Buy protocol
+│   ├── deals/             # Deals protocol (PMP, PG, AP)
 │   ├── creative/          # Creative protocol
 │   ├── signals/           # Signals protocol
 │   ├── accounts/          # Accounts protocol

--- a/docs.json
+++ b/docs.json
@@ -725,6 +725,30 @@
                 ]
               },
               {
+                "group": "Deals",
+                "expanded": false,
+                "pages": [
+                  "docs/deals/index",
+                  "docs/deals/specification",
+                  {
+                    "group": "Reference",
+                    "expanded": false,
+                    "pages": [
+                      "docs/deals/task-reference/index",
+                      "docs/deals/task-reference/create_deal",
+                      "docs/deals/task-reference/list_deals",
+                      "docs/deals/task-reference/update_deal_terms",
+                      "docs/deals/task-reference/transition_deal_state",
+                      "docs/deals/task-reference/activate_deal",
+                      "docs/deals/task-reference/get_deal_activation_status",
+                      "docs/deals/task-reference/list_deal_mappings",
+                      "docs/deals/task-reference/get_deal_metrics",
+                      "docs/deals/task-reference/get_deal_diagnostics"
+                    ]
+                  }
+                ]
+              },
+              {
                 "group": "Creative",
                 "expanded": false,
                 "pages": [

--- a/docs/adcp-buyer-agent-tool-design.md
+++ b/docs/adcp-buyer-agent-tool-design.md
@@ -1,0 +1,449 @@
+# ADCP-Compliant Buyer Agent Tool — Design Document (RFC)
+
+## 0) Executive Summary
+
+This document defines an **ADCP-compliant Buyer Agent Tool** that enables buyer-side users to execute advertising workflows (e.g., **product discovery**, **create media buy**, **creative listing/sync**) through a **workflow-first UI** backed by an **Agent Runtime (LLM + MCP client)** and an **MCP Server** that exposes ADCP tools.
+
+A key architectural constraint from the whiteboard is that **browser-to-MCP calls cause CORS issues**; therefore, **all MCP interactions must be server-to-server** via a **Middleware/BFF**.
+
+The system is designed to support **multi-tenant white-labeling**, strong tenant isolation, and operational visibility (auditing, metrics, tracing).
+
+---
+
+## 1) Source of Truth (Verified from Whiteboard + Provided Notes)
+
+### Repos / Major Components (as written on the board)
+
+- **UI**
+  - Repo: `ui-adcp-buyer-agent`
+  - Pages/features listed:
+    1. Login / Signup
+    2. Add Agent / MCP Server
+    3. Workflows:
+       1) Product Discovery
+       2) Create Media Buy
+       3) Creative Listing
+       4) Creative Creation (optional)
+       5) Activate Media Buy + Reporting
+
+- **Middleware / Proxy (Python)**
+  - Repo: `buyer-agent`
+  - Purpose: proxy for MCP server; handles “action, data” handoff
+
+- **Agent Runtime (MCP Client + Agent)**
+  - Repo: `pubmatic-agents`
+  - Notes on board:
+    - MCP client
+    - Agent
+    - “use LLM to get all tool schemas”
+    - routing
+    - calling tools
+    - response back to middleware
+
+- **MCP Server**
+  - Repo: `mcp-server`
+  - Notes: “Activate MCP server”
+  - Tools (board bullets):
+    1) Product discovery
+    2) Create media buy
+    3) Sync creative
+
+### Explicit Constraint
+
+- **CORS issue** blocks **UI → MCP Server** direct calls.
+- The design must route calls **UI → Middleware → Agent → MCP Server**.
+
+### White-labeling Notes (board)
+
+- Tenant selection by:
+  - **OrgId**
+  - **Domain level**
+- **CSS/template hosting on CDN**
+- “loading app → orgId/domain → static UI modules”
+- Open question on board:
+  - “How do we get domain from clients?”
+    - “Expose API”
+    - “Build config UI”
+
+---
+
+## 2) Problem Statement
+
+Buyer-side users need a guided tool to execute common advertising buying workflows using standardized ADCP tool calls. The tool must:
+
+- Be **workflow-first** (reduce prompt engineering)
+- Remain **ADCP compliant** via **MCP tools**
+- Prevent insecure browser access to MCP servers and avoid CORS limitations
+- Support **multi-tenant** operation with **white-label branding**
+- Provide traceability, auditing, and operational controls
+
+---
+
+## 3) Goals & Non-Goals
+
+### Goals (v1)
+
+- **Workflow-first UI** for primary buyer tasks
+- **Hybrid interaction model**: forms + optional free-text prompt per workflow
+- **BFF/Middleware** as the only external boundary for the UI
+- **Agent Runtime** that:
+  - fetches and caches MCP tool schemas
+  - routes intent/workflow steps to tool calls
+  - returns structured output + next-step suggestions
+- **Tenant isolation + white-labeling** using org/domain mapping and CDN-hosted themes
+- **Secure-by-default**: credentials server-side, least privilege, audit logs
+
+### Non-goals (v1)
+
+- Fully autonomous “hands-off” buying (human-in-the-loop approvals required)
+- Advanced optimization and budget pacing algorithms (“Bucket 3” later)
+- Building a complete creative authoring suite (only if MCP server supports it)
+
+---
+
+## 4) High-Level Architecture
+
+### Logical Components
+
+1) **UI (Buyer Tool)**
+- Presents workflow pages and guided steps
+- Collects inputs, validates forms, renders results
+- Never talks to MCP Server directly
+
+2) **Middleware / BFF (Python)**
+- Single API surface for UI
+- Solves CORS by performing server-to-server calls
+- Enforces:
+  - auth/session/JWT
+  - org/tenant scoping
+  - policy checks (e.g., approval gates)
+  - rate limits
+  - request normalization & response shaping
+- Calls Agent Runtime with `action + data`
+
+3) **Agent Runtime (LLM + MCP Client)**
+- Orchestrates execution:
+  - tool discovery (`list_tools`, `describe_tool`) with caching
+  - tool selection and sequencing
+  - tool invocation with validated payloads
+  - response synthesis into structured UI-friendly format
+- Emits tool-call traces for transparency/debugging
+
+4) **MCP Server (ADCP Tools)**
+- Authoritative execution layer exposing ADCP-compliant tools:
+  - product discovery
+  - create media buy
+  - sync creative
+  - optional listing/creation/reporting tools depending on backend
+
+---
+
+## 5) Primary Workflows (v1)
+
+### 5.1 Product Discovery
+
+- Inputs:
+  - advertiser/brand context
+  - targeting constraints (geo, audience, inventory types)
+  - budget or spend bands (optional)
+- Output:
+  - product/inventory candidates
+  - recommended shortlist
+  - fields needed for next step (to create media buy)
+
+### 5.2 Create Media Buy
+
+- Inputs:
+  - selected product(s)
+  - budget, flight dates, targeting
+  - creative references (existing creative IDs) or placeholder to sync later
+- Output:
+  - `media_buy_id`, initial status
+  - validation errors/warnings if any
+  - next steps: “sync creative”, “activate”, “view status/report”
+
+### 5.3 Creative Listing / Sync
+
+- Listing:
+  - retrieve creatives by advertiser/campaign context
+- Sync:
+  - associate creatives with media buys and/or upload/publish creative artifacts
+- Output:
+  - synced creative status, errors per creative, actionable remediation steps
+
+### 5.4 Activate + Reporting (optional scope boundary)
+
+- If ADCP/MCP server exposes activation/reporting:
+  - activate media buy (with explicit approval)
+  - status retrieval and reporting summaries
+
+---
+
+## 6) APIs & Interfaces (Concrete Contracts)
+
+### 6.1 UI → Middleware (BFF)
+
+**Auth**
+- Session cookie or JWT (implementation choice)
+- Every request must include tenant context:
+  - `orgId` (preferred)
+  - domain resolved to orgId (fallback)
+
+#### `POST /v1/workflows/execute`
+
+Executes a workflow step (or a whole small workflow) via the agent.
+
+Example request shape:
+
+```json
+{
+  "orgId": "org_123",
+  "workflowType": "CREATE_MEDIA_BUY",
+  "input": {
+    "prompt": "Create a media buy for sports audience in CA for Feb",
+    "form": {
+      "budget": 50000,
+      "flightStart": "2026-02-01",
+      "flightEnd": "2026-02-28",
+      "geo": ["US-CA"],
+      "productIds": ["prod_abc"]
+    }
+  },
+  "context": {
+    "userId": "user_789",
+    "sessionId": "sess_456",
+    "pageContext": {
+      "currentStep": "review"
+    }
+  }
+}
+```
+
+Example response shape:
+
+```json
+{
+  "status": "SUCCESS",
+  "result": {
+    "mediaBuyId": "mb_001",
+    "details": { "state": "DRAFT" }
+  },
+  "toolCalls": [
+    {
+      "tool": "create_media_buy",
+      "input": { "...": "..." },
+      "outputSummary": "Created draft media buy mb_001"
+    }
+  ],
+  "nextActions": [
+    { "type": "SYNC_CREATIVE", "label": "Sync creatives to this media buy" },
+    { "type": "ACTIVATE", "label": "Request activation approval" }
+  ],
+  "errors": []
+}
+```
+
+#### MCP Server management (admin)
+
+- `GET /v1/mcp/servers`
+- `POST /v1/mcp/servers`
+- `PATCH /v1/mcp/servers/{id}`
+- Stored secrets (API keys/resource headers) remain in BFF (never in UI)
+
+### 6.2 Middleware → Agent Runtime
+
+#### `POST /agent/execute`
+
+Normalized invocation.
+
+```json
+{
+  "orgId": "org_123",
+  "action": "CREATE_MEDIA_BUY",
+  "data": { "...workflow payload..." },
+  "userContext": {
+    "userId": "user_789",
+    "roles": ["buyer"],
+    "correlationId": "corr_abc"
+  }
+}
+```
+
+### 6.3 Agent Runtime → MCP Server
+
+- Uses MCP conventions:
+  - `list_tools`
+  - `describe_tool`
+  - `call_tool(name, input)`
+- Tool schema caching:
+  - cache by MCP server + version + tenant (if applicable)
+  - TTL-based invalidation and manual refresh endpoint
+
+---
+
+## 7) CORS, Security, and Trust Boundaries
+
+### Why CORS Happens
+
+- MCP endpoints may use SSE (`text/event-stream`), custom headers, and strict origin policies.
+- Many MCP servers are not configured for browser origins.
+
+### Required Policy
+
+- **UI must never call MCP Server directly**
+- **Only Middleware/BFF calls MCP Server**, optionally via Agent Runtime, all server-to-server.
+
+### Security Requirements
+
+- **Credential handling**
+  - API keys/resource headers stored server-side only
+  - encrypted at rest (KMS or equivalent)
+- **Tenant isolation**
+  - `orgId` required for every request
+  - enforce org scoping at BFF and in Agent Runtime
+- **Human-in-the-loop**
+  - activation and budget-committing actions require explicit approval gate
+- **Audit logging**
+  - who initiated
+  - what workflow/action
+  - which MCP tool(s) called
+  - input hash or redacted payload
+  - result summary + status
+
+---
+
+## 8) White-Labeling / Multi-Tenant Branding
+
+### Tenant identification (recommended precedence)
+
+1) **orgId** (explicit; strongest)
+2) **domain → orgId mapping** (for white-labeled deployments)
+
+### Theme/config model
+
+- BFF endpoint:
+  - `GET /v1/tenant/{orgId}/theme`
+- Returns:
+  - theme name
+  - CSS URLs
+  - logo URLs
+  - feature toggles (e.g., enable creative creation page)
+
+### CDN assets
+
+- `/themes/{orgId}/theme.css`
+- `/themes/{orgId}/logo.svg`
+- `/themes/{orgId}/config.json`
+
+### Domain acquisition (“How do we get domain from clients?”)
+
+- In browser: `window.location.host` is the domain signal.
+- For secure mapping, implement:
+  - **Admin config UI** to register domains to orgId
+  - **Domain verification** step (recommended):
+    - DNS TXT record, or
+    - `/.well-known/` HTTP file proof
+- Runtime behavior:
+  - UI sends `host` (or BFF infers from request host header)
+  - BFF resolves `domain → orgId` and returns theme config
+
+---
+
+## 9) Observability & Operations
+
+### Logging
+
+- Correlation ID generated at BFF, propagated to Agent and tool calls
+- Log events:
+  - workflow start/end
+  - tool call start/end
+  - tool failures with categorized error codes
+
+### Metrics (minimum)
+
+- workflow success rate by type
+- tool latency p50/p95
+- tool error rate by tool name and category
+- LLM token usage and cost per workflow
+
+### Tracing
+
+- OpenTelemetry recommended across:
+  - UI request → BFF → Agent → MCP Server
+
+---
+
+## 10) Deployment Model
+
+- **UI**: static site served from CDN
+- **Middleware/BFF (Python)**: scalable service (k8s or similar)
+- **Agent Runtime**:
+  - separate service (recommended), or
+  - colocated initially with BFF for simplicity
+- **MCP Server**: separate service (e.g., Activate MCP server)
+
+---
+
+## 11) Open Questions (To Make Implementation Exact)
+
+- **Tool names & schemas**: What are the exact MCP tool names today (e.g., `get_products` vs `product_discovery`)?
+- **Auth model**: SSO/JWT? How do you derive `resource-id` / `resource-type` and where do those live?
+- **Workflow mode**: chat-first, workflow-form-first, or hybrid?
+- **Activation/reporting**: are these tools in scope on the MCP server for v1?
+
+---
+
+# Diagrams (Mermaid)
+
+## A) System Block Diagram
+
+```mermaid
+flowchart LR
+  UI[UI: ADCP Buyer Tool<br/>(repo: ui-adcp-buyer-agent)<br/>- Login/Signup<br/>- Add Agent/MCP<br/>- Workflows] -->|HTTPS JSON| BFF[Middleware / BFF (Python)<br/>(repo: buyer-agent)<br/>- Auth & Tenant<br/>- Proxy (CORS-safe)<br/>- Normalization<br/>- Approval gates]
+
+  BFF -->|action + data| AG[Agent Runtime (LLM + MCP Client)<br/>(repo: pubmatic-agents)<br/>- Tool schema fetch/cache<br/>- Routing<br/>- Tool calls<br/>- Response synthesis]
+
+  AG -->|MCP tool calls| MCP[MCP Server (ADCP Tools)<br/>(repo: mcp-server)<br/>- Product discovery<br/>- Create media buy<br/>- Sync creative]
+
+  MCP --> ACT[Activate / Backend Systems]
+
+  UI -.->|CORS blocked| MCP
+```
+
+## B) Sequence Diagram — Create Media Buy
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant UI as UI (Buyer Tool)
+  participant BFF as Middleware/BFF (Python)
+  participant A as Agent Runtime (LLM + MCP Client)
+  participant M as MCP Server (ADCP Tools)
+
+  U->>UI: Fill form / prompt (Create Media Buy)
+  UI->>BFF: POST /v1/workflows/execute (orgId, inputs)
+  BFF->>A: POST /agent/execute (action=CREATE_MEDIA_BUY)
+  A->>M: list_tools/describe_tools (cached if available)
+  A->>M: call_tool(create_media_buy, payload)
+  M-->>A: media_buy_id + status + details
+  A-->>BFF: structured result + next steps
+  BFF-->>UI: status + result + nextActions
+  UI-->>U: Show media buy + follow-ups (sync/activate/status)
+```
+
+## C) White-Labeling / Tenant Resolution Flow
+
+```mermaid
+flowchart TD
+  Start[App Load] --> Identify{Tenant signal available?}
+
+  Identify -->|orgId provided| Org[Use orgId]
+  Identify -->|no orgId| Host[Use browser host/domain]
+
+  Host --> Resolve[Resolve domain to orgId<br/>(BFF: /v1/tenant/resolve)]
+  Resolve --> Org
+
+  Org --> Theme[Fetch theme config<br/>(BFF: /v1/tenant/{orgId}/theme)]
+  Theme --> CDN[Load assets from CDN<br/>/themes/{orgId}/...]
+  CDN --> Render[Render branded UI<br/>(feature toggles applied)]
+```

--- a/docs/deals/index.mdx
+++ b/docs/deals/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Deals Protocol
+description: AdCP Deals Protocol - PMP, PG, and AP deal lifecycle, activation, and diagnostics.
+keywords: [deals protocol, PMP, programmatic guaranteed, auction package, deal activation, deal diagnostics]
+---
+
+Products are the discovery surface; deals are the negotiated transaction wrapper. The Deals protocol lets AI agents create, negotiate, activate, and monitor deals (PMP, Programmatic Guaranteed, Auction Package) with sales agents.
+
+## Protocol Access
+
+Deals tasks are accessible through the same transports as Media Buy:
+
+- **[MCP (Model Context Protocol)](/docs/building/integration/mcp-guide)**: Tool-based interaction
+- **[A2A (Agent-to-Agent)](/docs/building/integration/a2a-guide)**: Message-based interaction
+
+Sales agents that support deals declare `deals` in `get_adcp_capabilities` → `supported_protocols` and expose the deals tasks.
+
+## Discovery
+
+- **Product discovery**: Use **`get_products`** (Media Buy) with `filters.transaction_type` set to `PMP`, `PG`, or `AP` to find products that can be turned into deals. Products may include `supported_transaction_types`, `transaction_terms_by_type`, and `deal_capabilities`.
+- **Single product**: Call `get_products` with filters that target one product (e.g. by product_id in filters or selection) to get full product detail for deal creation.
+
+## Deal Lifecycle
+
+| Task | Purpose |
+|------|---------|
+| **`create_deal`** | Create a logical deal (starts in PROPOSED or DRAFT) |
+| **`list_deals`** | Browse/filter deals; use `deal_ids` for single-deal fetch |
+| **`update_deal_terms`** | Negotiate or counter-offer (versioned terms) |
+| **`transition_deal_state`** | Move deal through states (e.g. PROPOSED → ACCEPTED → SCHEDULED → LIVE → COMPLETED) |
+
+## Activation
+
+A deal is not transact-able until it is activated on decisioning platforms (DSP/SSP).
+
+| Task | Purpose |
+|------|---------|
+| **`activate_deal`** | Push or bind the deal to one or more DSP/SSP destinations |
+| **`get_deal_activation_status`** | Check per-destination activation status (async) |
+| **`list_deal_mappings`** | Get logical deal_id → physical platform_deal_id mappings |
+
+## Monitoring and Troubleshooting
+
+| Task | Purpose |
+|------|---------|
+| **`get_deal_metrics`** | Canonical reporting (impressions, spend, CPM, win/fill, reject reasons) |
+| **`get_deal_diagnostics`** | Health score, top issues, root causes, recommendations |
+
+## Key Design Principles
+
+1. **Product-first discovery**: Deals are created from products discovered via `get_products`. No separate get_product task; use `get_products` with filters for single-product detail.
+2. **Single-deal fetch**: Use **`list_deals`** with `deal_ids: [id]` instead of a separate get_deal task.
+3. **Versioned terms**: Negotiation happens in PROPOSED via `update_deal_terms`; each update increments the version. ACCEPTED state locks an `accepted_version`.
+4. **Activation required**: A deal becomes transact-able only after successful activation on the relevant DSP/SSP destinations.
+5. **Per-destination status**: Deal state (e.g. LIVE) is logical; `deployments[]` tracks activation status per platform (PENDING, ACTIVE, FAILED, DISABLED).
+
+## Specification
+
+See [Deals Specification](/docs/deals/specification) for state definitions, transitions, and normative behavior.
+
+## Task Reference
+
+See [Deals Task Reference](/docs/deals/task-reference) for request/response schemas and usage.

--- a/docs/deals/specification.mdx
+++ b/docs/deals/specification.mdx
@@ -1,0 +1,116 @@
+---
+title: Deals Specification
+sidebarTitle: Specification
+---
+
+<Info>
+**AdCP Deals v1** - This specification defines the Deals protocol for PMP, PG, and AP deal lifecycle, activation, and diagnostics.
+</Info>
+
+**Status**: Request for Comments
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Abstract
+
+The Deals Protocol extends the advertising automation model with a first-class **deal** resource. Products remain the discovery surface ("what is sellable"); deals represent negotiated transaction wrappers ("how it is bought"). Activation is explicit so that a deal becomes transact-able on decisioning platforms (DSP and/or SSP).
+
+## Scope
+
+- **Transaction types**: PMP (Private Marketplace), PG (Programmatic Guaranteed), AP (Auction Package).
+- **Discovery**: Via existing `get_products` with `filters.transaction_type` and product fields `supported_transaction_types`, `transaction_terms_by_type`, `deal_capabilities`.
+- **Lifecycle**: Create deal → negotiate terms (versioned) → accept → schedule → activate → live → complete (or reject/cancel).
+- **Activation**: Deals MUST be activated on each target DSP/SSP before they can be used for bidding.
+- **Monitoring**: Canonical metrics and diagnostics per logical deal.
+
+## Transport and Capabilities
+
+Sales agents MUST declare Deals Protocol support via `get_adcp_capabilities`:
+
+- `supported_protocols` MUST include `"deals"`.
+- When `deals` is present, a `deals` capability object MUST be present with at least `supported_transaction_types` (array of "PMP", "PG", "AP"). Optional `features` (e.g. supports_bid_cap, supports_deal_level_reporting) MAY be included.
+
+## Core Concepts
+
+### Deal
+
+A **deal** is a logical resource that:
+
+- References a **product** (product_id).
+- Has a **transaction_type** (PMP, PG, or AP).
+- Has **terms** (versioned); structure varies by transaction type (e.g. floor, bid_cap for PMP; commitment_units for PG).
+- Has a **state** (lifecycle).
+- Has zero or more **deployments** (per-destination activation status).
+
+### Deal States
+
+| State | Description |
+|-------|-------------|
+| DRAFT | Optional; not yet visible to buyer; seller staging |
+| PROPOSED | Visible to buyer; negotiation via update_deal_terms (versioned) |
+| ACCEPTED | Parties agree on a specific terms version (accepted_version set) |
+| SCHEDULED | Accepted + activation complete + start time in future |
+| LIVE | Eligible for transaction now (activated + within flight window) |
+| PAUSED | Temporarily stopped (may resume) |
+| REJECTED | Terminated at proposal stage (no agreement) |
+| CANCELLED | Permanently stopped before completion |
+| COMPLETED | Flight ended or commitment satisfied |
+
+### State Transitions
+
+Typical transitions:
+
+- PROPOSED → ACCEPTED (agreement)
+- ACCEPTED → SCHEDULED (future start)
+- SCHEDULED → LIVE (when in flight)
+- LIVE → PAUSED → LIVE (temporary pause)
+- LIVE → COMPLETED (flight ended)
+- PROPOSED → REJECTED (no agreement)
+- Any → CANCELLED (stop permanently)
+
+Negotiation does not require a separate NEGOTIATING state: `update_deal_terms` increments the version and keeps state PROPOSED. When moving to ACCEPTED, the seller sets `accepted_version` to the current version.
+
+### Activation
+
+A deal is not transact-able until it is **activated** on decisioning platforms.
+
+- **activate_deal**: Request specifies `deal_id` and `destinations[]` (platform_type, platform_name, account_id, mode). Mode may be CREATE_AND_SYNC (create physical deal if needed) or BIND_EXISTING (attach to existing physical id).
+- Response includes `deployments[]` with per-destination `platform_deal_id`, `deployment_status` (PENDING, ACTIVE, FAILED, DISABLED), and optional error details.
+- **Per-destination status** is separate from deal state: `deal.state` is the logical lifecycle; `deal.deployments[]` is the operational activation per destination. A deal may be LIVE while only a subset of destinations are ACTIVE.
+
+### Visibility (Marketplace)
+
+Deals may be listed with a **visibility**:
+
+- **PRIVATE**: Only explicitly addressed buyer seats can see.
+- **INVITE_ONLY**: Visible but may require seller approval.
+- **PUBLIC**: Visible to any eligible buyer seat (marketplace shelf).
+
+Sales agents that support marketplace-style discovery MUST support `list_deals` with filtering (e.g. by state, transaction_type, visibility) so buyers can discover PROPOSED or LIVE deals.
+
+## Identifiers
+
+- **deal_id**: Unique identifier for the deal (seller-assigned). Returned on create_deal; used for all subsequent operations.
+- **deployment_id**: Optional seller-assigned identifier for a single deployment; used in get_deal_activation_status when querying one destination.
+- **platform_deal_id**: Physical deal ID (or line item / targeting id) on the DSP/SSP; returned in activate_deal and list_deal_mappings.
+
+## Task Summary
+
+| Task | Purpose |
+|------|---------|
+| create_deal | Create logical deal (product_id, transaction_type, terms, optional buyer_seat_id, visibility) |
+| list_deals | List/filter deals; use deal_ids for single-deal fetch |
+| update_deal_terms | Propose new terms (increments version); deal in PROPOSED (or DRAFT if allowed) |
+| transition_deal_state | Move to target state (ACCEPTED, SCHEDULED, LIVE, PAUSED, COMPLETED, REJECTED, CANCELLED) |
+| activate_deal | Activate on one or more DSP/SSP destinations |
+| get_deal_activation_status | Per-destination activation status (async) |
+| list_deal_mappings | Logical deal_id → physical platform_deal_id mappings |
+| get_deal_metrics | Canonical reporting (time_range, granularity, dimensions, optional by_destination) |
+| get_deal_diagnostics | Health score, top_issues, root_causes, recommendations; optional viewer_role for field filtering |
+
+## Product and Filter Extensions
+
+For deal discovery, products and filters are extended as follows:
+
+- **Product** (in get_products response): May include `supported_transaction_types` (array of PMP, PG, AP), `transaction_terms_by_type` (high-level defaults/allowed ranges), `requires_channel_split` (boolean), `deal_capabilities` (e.g. supports_bid_cap, supports_deal_level_reporting).
+- **Product filters** (in get_products request): May include `transaction_type` (PMP, PG, or AP) to filter to products that support that deal type.

--- a/docs/deals/task-reference/activate_deal.mdx
+++ b/docs/deals/task-reference/activate_deal.mdx
@@ -1,0 +1,20 @@
+---
+title: activate_deal
+testable: true
+---
+
+Activate a deal on one or more decisioning platforms (DSP/SSP) so it becomes transact-able. Required before the deal can be used for bidding.
+
+**Request schema**: `/schemas/latest/deals/activate-deal-request.json`  
+**Response schema**: `/schemas/latest/deals/activate-deal-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to activate |
+| destinations | array | Yes | Each: platform_type (DSP/SSP), platform_name, account_id, mode (CREATE_AND_SYNC or BIND_EXISTING) |
+
+## Response
+
+Returns `deal_id`, `deployments` (per-destination platform_deal_id, deployment_status, error details), and optional `errors`. Activation may be asynchronous; use `get_deal_activation_status` to poll.

--- a/docs/deals/task-reference/create_deal.mdx
+++ b/docs/deals/task-reference/create_deal.mdx
@@ -1,0 +1,24 @@
+---
+title: create_deal
+testable: true
+---
+
+Create a logical deal. The deal starts in PROPOSED or DRAFT. Negotiate via `update_deal_terms`, move state via `transition_deal_state`, and make it transact-able via `activate_deal`.
+
+**Request schema**: `/schemas/latest/deals/create-deal-request.json`  
+**Response schema**: `/schemas/latest/deals/create-deal-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| product_id | string | Yes | Product this deal is based on (from get_products) |
+| transaction_type | enum | Yes | PMP, PG, or AP |
+| terms | object | Yes | Initial negotiated terms (see deal-terms schema) |
+| buyer_seat_id | string | No | Buyer seat/account; omit for marketplace shelf deals |
+| advertiser_id | string | No | Advertiser or brand identifier |
+| visibility | enum | No | PRIVATE, INVITE_ONLY, or PUBLIC |
+
+## Response
+
+Returns `deal` (full deal object with deal_id, state, version, terms) and optional `errors`.

--- a/docs/deals/task-reference/get_deal_activation_status.mdx
+++ b/docs/deals/task-reference/get_deal_activation_status.mdx
@@ -1,0 +1,20 @@
+---
+title: get_deal_activation_status
+testable: true
+---
+
+Get per-destination activation status for a deal. Use for asynchronous activation tracking.
+
+**Request schema**: `/schemas/latest/deals/get-deal-activation-status-request.json`  
+**Response schema**: `/schemas/latest/deals/get-deal-activation-status-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to check |
+| deployment_id | string | No | Limit to this deployment |
+
+## Response
+
+Returns `deal_id`, `deployments` (status, timestamps, last error per destination), and optional `errors`.

--- a/docs/deals/task-reference/get_deal_diagnostics.mdx
+++ b/docs/deals/task-reference/get_deal_diagnostics.mdx
@@ -1,0 +1,20 @@
+---
+title: get_deal_diagnostics
+testable: true
+---
+
+Health summary, root cause analysis, and recommendations for a deal. Optional viewer_role (buyer, seller, admin) filters sensitive fields.
+
+**Request schema**: `/schemas/latest/deals/get-deal-diagnostics-request.json`  
+**Response schema**: `/schemas/latest/deals/get-deal-diagnostics-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to diagnose |
+| viewer_role | enum | No | buyer, seller, or admin; response may filter by role |
+
+## Response
+
+Returns `deal_id`, optional `deal_summary`, `health_score`, `status`, `top_issues`, `root_causes`, `recommendations`, and optional `errors`.

--- a/docs/deals/task-reference/get_deal_metrics.mdx
+++ b/docs/deals/task-reference/get_deal_metrics.mdx
@@ -1,0 +1,23 @@
+---
+title: get_deal_metrics
+testable: true
+---
+
+Canonical reporting for a logical deal: impressions, spend, CPM, win/fill, reject reasons. Optional per-destination breakdown.
+
+**Request schema**: `/schemas/latest/deals/get-deal-metrics-request.json`  
+**Response schema**: `/schemas/latest/deals/get-deal-metrics-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to report on |
+| time_range | object | No | Start and end time |
+| granularity | enum | No | hour, day, week, month |
+| dimensions | array | No | Breakdown dimensions (geo, device, channel, publisher) |
+| by_destination | boolean | No | Include per-destination breakdown |
+
+## Response
+
+Returns `deal_id`, `metrics` (normalized metrics), optional `by_destination`, and optional `errors`.

--- a/docs/deals/task-reference/index.mdx
+++ b/docs/deals/task-reference/index.mdx
@@ -1,0 +1,39 @@
+---
+title: Deals Task Reference
+description: Request and response schemas for Deals protocol tasks.
+---
+
+This page lists all Deals protocol tasks. Use **get_products** (Media Buy) with `filters.transaction_type` for deal discovery; use **list_deals** with `deal_ids` for single-deal fetch.
+
+## Deal Lifecycle
+
+| Task | Description |
+|------|-------------|
+| [create_deal](/docs/deals/task-reference/create_deal) | Create a logical deal (starts PROPOSED or DRAFT) |
+| [list_deals](/docs/deals/task-reference/list_deals) | List or filter deals; use deal_ids for single-deal fetch |
+| [update_deal_terms](/docs/deals/task-reference/update_deal_terms) | Negotiate/counter-offer (versioned terms) |
+| [transition_deal_state](/docs/deals/task-reference/transition_deal_state) | Move deal through lifecycle states |
+
+## Activation
+
+| Task | Description |
+|------|-------------|
+| [activate_deal](/docs/deals/task-reference/activate_deal) | Activate deal on DSP/SSP destinations |
+| [get_deal_activation_status](/docs/deals/task-reference/get_deal_activation_status) | Per-destination activation status |
+| [list_deal_mappings](/docs/deals/task-reference/list_deal_mappings) | Logical-to-physical deal ID mappings |
+
+## Monitoring and Diagnostics
+
+| Task | Description |
+|------|-------------|
+| [get_deal_metrics](/docs/deals/task-reference/get_deal_metrics) | Canonical deal reporting |
+| [get_deal_diagnostics](/docs/deals/task-reference/get_deal_diagnostics) | Health, root causes, recommendations |
+
+## Schema URLs
+
+Schemas are versioned. For the latest:
+
+- Registry: `/schemas/latest/index.json`
+- Deals tasks: `/schemas/latest/deals/*.json` (request/response pairs)
+- Core: `/schemas/latest/core/deal.json`, `deal-terms.json`, `deal-deployment.json`, `deal-destination.json`
+- Enums: `/schemas/latest/enums/transaction-type.json`, `deal-state.json`, `deal-deployment-status.json`, `deal-visibility.json`

--- a/docs/deals/task-reference/list_deal_mappings.mdx
+++ b/docs/deals/task-reference/list_deal_mappings.mdx
@@ -1,0 +1,19 @@
+---
+title: list_deal_mappings
+testable: true
+---
+
+Return logical deal_id to physical platform_deal_id mappings. Used for reporting and troubleshooting across platforms.
+
+**Request schema**: `/schemas/latest/deals/list-deal-mappings-request.json`  
+**Response schema**: `/schemas/latest/deals/list-deal-mappings-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to list mappings for |
+
+## Response
+
+Returns `deal_id`, `mappings` (platform_type, platform_name, account_id, platform_deal_id, related_ids), and optional `errors`.

--- a/docs/deals/task-reference/list_deals.mdx
+++ b/docs/deals/task-reference/list_deals.mdx
@@ -1,0 +1,26 @@
+---
+title: list_deals
+testable: true
+---
+
+List or filter deals. To fetch a single deal, use `deal_ids: ["<deal_id>"]`. Supports pagination and `updated_since` for sync patterns.
+
+**Request schema**: `/schemas/latest/deals/list-deals-request.json`  
+**Response schema**: `/schemas/latest/deals/list-deals-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_ids | array of string | No | Specific deal IDs (use for single-deal fetch) |
+| buyer_seat_id | string | No | Filter by buyer seat |
+| product_id | string | No | Filter by product |
+| transaction_type | enum | No | PMP, PG, or AP |
+| state | enum or array | No | Filter by deal state(s) |
+| visibility | enum | No | PRIVATE, INVITE_ONLY, PUBLIC |
+| updated_since | date-time | No | Only deals updated after this time |
+| pagination | object | No | Cursor-based pagination |
+
+## Response
+
+Returns `deals` (array of deal objects), optional `pagination`, and optional `errors`.

--- a/docs/deals/task-reference/transition_deal_state.mdx
+++ b/docs/deals/task-reference/transition_deal_state.mdx
@@ -1,0 +1,20 @@
+---
+title: transition_deal_state
+testable: true
+---
+
+Move a deal through its lifecycle. Typical transitions: PROPOSED → ACCEPTED, ACCEPTED → SCHEDULED, SCHEDULED → LIVE, LIVE → PAUSED/LIVE/COMPLETED, PROPOSED → REJECTED, any → CANCELLED.
+
+**Request schema**: `/schemas/latest/deals/transition-deal-state-request.json`  
+**Response schema**: `/schemas/latest/deals/transition-deal-state-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to transition |
+| state | enum | Yes | Target state (e.g. ACCEPTED, LIVE, COMPLETED) |
+
+## Response
+
+Returns `deal` in the new state and optional `errors`.

--- a/docs/deals/task-reference/update_deal_terms.mdx
+++ b/docs/deals/task-reference/update_deal_terms.mdx
@@ -1,0 +1,21 @@
+---
+title: update_deal_terms
+testable: true
+---
+
+Update deal terms (negotiation/counter-offer). Increments the deal version. Deal must be in PROPOSED (or DRAFT if seller allows). Used by both buyer and seller.
+
+**Request schema**: `/schemas/latest/deals/update-deal-terms-request.json`  
+**Response schema**: `/schemas/latest/deals/update-deal-terms-response.json`
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| deal_id | string | Yes | Deal to update |
+| terms | object | Yes | New proposed terms (replaces current version) |
+| change_summary | string | No | Human-readable summary of changes |
+
+## Response
+
+Returns `deal` with incremented version and new terms, and optional `errors`.

--- a/docs/media-buy/advanced-topics/mcp-buyside-integration.md
+++ b/docs/media-buy/advanced-topics/mcp-buyside-integration.md
@@ -1,0 +1,385 @@
+---
+sidebar_position: 7
+title: MCP Buy-Side Integration Guide
+description: End-to-end guide for integrating AdCP buy-side operations via Model Context Protocol (MCP), including context management, tool catalog, workflows, validation, and diagrams.
+keywords: [adcp, mcp, buy-side, media buy, programmatic, integration, signals]
+---
+
+# MCP Buy-Side Integration Guide
+
+This guide explains how to integrate AdCP for all buy-side operations using the Model Context Protocol (MCP). It covers prerequisites, context management, tool catalog, end-to-end workflows, validation, and deployment notes.
+
+- See `docs/protocols/mcp-guide.md` for MCP concepts and status handling.
+- See `static/schemas/v1/` for JSON Schemas of requests/responses and core models.
+
+## Prerequisites
+
+- MCP client and server foundations; Node 18+ recommended.
+- Access and credentials for your decisioning platform(s) (DSP, ad server).
+- Familiarity with the Media Buy docs at `docs/media-buy/` and Signals at `docs/signals/`.
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+  Client["AI / MCP Client (via Claude/MCP)"] -->|call tool| Server["MCP Server (Your Integration)"]
+  Server -->|executes tasks| DSP[(Decisioning Platform)]
+  Server -->|optional signals| SIG[(Signals Platform)]
+  Server -->|validates| Schemas[(static/schemas/v1)]
+  Server -->|logs/metrics| Obs[(Observability)]
+```
+
+- The MCP client invokes tools exposed by your MCP server.
+- Your server integrates with platforms and validates payloads against canonical schemas.
+
+## Context Management (MCP)
+
+MCP requires manual context persistence. Always pass a `context_id` to maintain session state.
+
+```ts
+// Example: generate and reuse a context ID for the session
+const context_id = crypto.randomUUID();
+await mcp.call('get_products', { context_id, brief: 'CTV sports in US' });
+// ... reuse context_id in all subsequent calls
+```
+
+Store session-scoped data (advertiser, markets, objectives) keyed by `context_id`.
+
+## Tool Catalog (Buy-Side)
+
+All tasks are available as MCP tools.
+
+- Media Buy
+  - `get_products`
+  - `list_creative_formats`
+  - `list_authorized_properties`
+  - `create_media_buy`
+  - `sync_creatives`
+  - `update_media_buy`
+  - `get_media_buy_delivery`
+  - `provide_performance_feedback`
+- Signals (optional)
+  - `get_signals`
+  - `activate_signal`
+
+Schemas live under `static/schemas/v1/` (see Schema Registry in `static/schemas/README.md`).
+
+## End-to-End Workflow
+
+```mermaid
+sequenceDiagram
+  participant C as MCP Client
+  participant S as MCP Server
+  participant D as Decisioning Platform
+  participant G as Signals Platform
+
+  C->>S: list_creative_formats [context_id]
+  S->>D: Fetch supported formats
+  D-->>S: Formats
+  S-->>C: Formats (validated)
+
+  C->>S: get_products [context_id, brief, filters]
+  S->>D: Product discovery
+  D-->>S: Products
+  S-->>C: Products (validated)
+
+  C->>S: create_media_buy (...)
+  S->>D: Create campaign
+  D-->>S: MediaBuyId
+  S-->>C: Response (validated)
+
+  C->>S: sync_creatives (...)
+  S->>D: Upload/map assets
+  D-->>S: CreativeIds
+  S-->>C: Response (validated)
+
+  C->>S: get_media_buy_delivery [granularity]
+  S->>D: Fetch delivery
+  D-->>S: Metrics
+  S-->>C: Delivery (validated)
+
+  Note over C: Optional: get_signals / activate_signal
+```
+
+## Critical Requirements & Patterns
+
+### Authorization Validation (adagents.json)
+
+Buyers MUST validate seller authorization before purchasing inventory. See `docs/media-buy/capability-discovery/adagents.md`.
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Agent
+    participant Sales as Sales Agent
+    participant Publisher as Publisher Domain
+
+    Buyer->>Sales: get_products(...)
+    Sales-->>Buyer: products (properties or property_tags)
+    alt properties provided
+        loop each property.publisher_domain and domain identifiers
+            Buyer->>Publisher: GET /.well-known/adagents.json
+            Publisher-->>Buyer: authorized_agents
+            Buyer->>Buyer: verify agent URL and scope
+        end
+    else property_tags provided
+        Buyer->>Sales: list_authorized_properties()
+        Sales-->>Buyer: properties + tags
+        Buyer->>Buyer: resolve tags -> properties and validate as above
+    end
+```
+
+Key rules:
+- **Resolve tags** via `list_authorized_properties` when products return `property_tags`.
+- **Domain matching** must follow base/subdomain/wildcard rules defined in `adagents.md`.
+- **Reject unauthorized** or scope-mismatched products.
+
+### Format Workflow
+
+AdCP uses a two-step format flow:
+- `get_products` returns only `format_ids`.
+- Use `list_creative_formats` to retrieve full specifications.
+- `create_media_buy` MUST include `format_ids` per package to enable placeholder creation and validation.
+
+### Async & HITL Status
+
+All tasks return a unified `status` (`working`, `input-required`, `completed`, `failed`). Long-running tasks may require human approval (HITL). Handle with polling, webhooks, or streaming as per `docs/protocols/mcp-guide.md` and `docs/media-buy/media-buys/index.md`.
+
+```ts
+// Polling pattern with context_id
+let resp = await session.call('create_media_buy', args);
+while (resp.status === 'working') {
+  await delay(2000);
+  resp = await session.call('create_media_buy', { context_id: resp.context_id });
+}
+if (resp.status !== 'completed') throw new Error(resp.message);
+```
+
+### Brief Requirements
+
+`promoted_offering` is required for `get_products` and `create_media_buy`. See `docs/media-buy/product-discovery/brief-expectations.md`.
+
+---
+
+### Capability Discovery
+
+```js
+const formats = await mcp.call('list_creative_formats', {
+  context_id: "ctx-123",
+  media_types: ["video", "display"]
+});
+
+const properties = await mcp.call('list_authorized_properties', {
+  context_id: "ctx-123",
+  tags: ["premium", "sports_network"]
+});
+```
+
+- Schemas: `media-buy/list-creative-formats-*.json`.
+- Specs: `static/schemas/creative-formats-v1.json`, `static/schemas/asset-types-v1.json`.
+
+### Product Discovery (Schema-Aligned)
+
+```js
+const products = await mcp.call('get_products', {
+  context_id: "ctx-123",
+  promoted_offering: "Running Shoes Spring 2026",
+  brief: "Premium CTV/video against sports audiences in US/CA",
+  filters: {
+    delivery_type: "guaranteed",
+    format_types: ["video"]
+  }
+});
+```
+
+### Create Media Buy (Schema-Aligned)
+
+```js
+const createResp = await mcp.call('create_media_buy', {
+  context_id: "ctx-123",
+  buyer_ref: "spring_ctv_2026",
+  promoted_offering: "Running Shoes Spring 2026",
+  start_time: "2026-03-01T00:00:00Z",
+  end_time: "2026-04-30T23:59:59Z",
+  budget: { total: 250000, currency: "USD", pacing: "even" },
+  packages: [
+    {
+      buyer_ref: "pkg_ctv_sports",
+      products: ["video_ctv_30s_hosted"],
+      format_ids: ["video_16x9_30s"],
+      budget: { total: 250000, currency: "USD" },
+      targeting_overlay: {
+        geo_country_any_of: ["US"],
+        device_type_any_of: ["connected_tv"],
+        signals: ["peer39_luxury_auto"],
+        frequency_cap: { suppress_minutes: 30 }
+      }
+    }
+  ]
+});
+```
+
+### Sync Creatives (Schema-Aligned)
+
+```js
+const sync = await mcp.call('sync_creatives', {
+  context_id: "ctx-123",
+  creatives: [
+    {
+      creative_id: "hero_video_30s",
+      name: "Brand Hero Video 30s",
+      format: "video_16x9_30s",
+      snippet: "https://vast.example.com/video/123",
+      snippet_type: "vast_url",
+      click_url: "https://example.com/products",
+      duration: 30000,
+      tags: ["spring_2026", "video"]
+    }
+  ],
+  assignments: {
+    hero_video_30s: [createResp.packages[0].package_id]
+  }
+});
+```
+
+### Update Media Buy (Schema-Aligned)
+
+```js
+const update = await mcp.call('update_media_buy', {
+  context_id: "ctx-123",
+  media_buy_id: createResp.media_buy_id,
+  budget: { total: 300000, currency: "USD", pacing: "front_loaded" },
+  packages: [
+    {
+      package_id: createResp.packages[0].package_id,
+      budget: { total: 300000, currency: "USD" },
+      targeting_overlay: { device_type_any_of: ["connected_tv", "desktop"] }
+    }
+  ]
+});
+```
+
+### Delivery Reporting (Schema-Aligned)
+
+```js
+const delivery = await mcp.call('get_media_buy_delivery', {
+  context_id: "ctx-123",
+  buyer_refs: ["spring_ctv_2026"],
+  start_date: "2026-03-01",
+  end_date: "2026-03-31"
+});
+```
+
+### Optional Signals (Schema-Aligned)
+
+```js
+const signals = await mcp.call('get_signals', {
+  context_id: "ctx-123",
+  signal_spec: "High-income households interested in sustainable fashion",
+  deliver_to: { platforms: ["the-trade-desk"], countries: ["US"] }
+});
+
+await mcp.call('activate_signal', {
+  context_id: "ctx-123",
+  signal_agent_segment_id: signals.signals[0].signal_agent_segment_id,
+  platform: "the-trade-desk",
+  account: "acct_xyz"
+});
+```
+
+## Validation & Errors
+
+- Validate all requests/responses with AJV (`ajv`, `ajv-formats`), mirroring `tests/schema-validation.test.js`.
+- Standard errors: `static/schemas/v1/core/error.json`.
+- Idempotency keys for mutating calls to avoid duplicates on retries.
+- Retry only transient failures; do not retry validation/auth failures.
+
+## PubMatic × Scope3 Integration via AdCP
+
+This section summarizes how PubMatic integrates with Scope3 using AdCP tasks exposed over MCP. For a deeper, PubMatic-specific mapping, see `docs/media-buy/advanced-topics/pubmatic-activate-adcp-integration.md`.
+
+### Roles and Agents
+
+- **Orchestrator (Scope3)**: Coordinates discovery, creation, creative ops, and optimization.
+- **Sales Agent (PubMatic MCP Server)**: Exposes `get_products`, `list_authorized_properties`, `create_media_buy`, `update_media_buy`, `sync_creatives`, `get_media_buy_delivery`.
+- **Signal Agent**: Exposes `get_signals`, `activate_signal` to deliver `decisioning_platform_segment_id` into targeting overlays.
+- **Creative Management Agent**: Exposes `list_creatives`, `sync_creatives`, and manages assignments to packages.
+
+### End-to-End Steps
+
+1. **Signal discovery and activation**: `get_signals` → `activate_signal` for PubMatic platform/account.
+2. **Capability discovery**: `list_creative_formats` and `list_authorized_properties` (cache for tag resolution).
+3. **Product discovery**: `get_products` with `promoted_offering` and optional `brief`/`filters`.
+4. **Authorization validation**: Validate products via publisher `/.well-known/adagents.json` and domain rules.
+5. **Create media buy**: `create_media_buy` with packages, `format_ids`, targeting overlay including activated `signals`.
+6. **Creative sync and assignment**: `sync_creatives` via Creative Agent; assign creative IDs to package IDs returned from creation.
+7. **Activation and delivery**: Track async status/HITL to `active`.
+8. **Reporting and optimization**: `get_media_buy_delivery` then `update_media_buy` (budgets/targeting/pauses).
+
+### Sequence Diagram (Scope3 ↔ PubMatic over MCP)
+
+```mermaid
+sequenceDiagram
+    participant Scope3 as Orchestrator (Scope3)
+    participant Signal as Signal Agent
+    participant Sales as PubMatic Sales Agent (MCP)
+    participant Creative as Creative Agent
+    participant Publisher as Publisher Domain
+
+    Note over Scope3: Capability & Signals
+    Scope3->>Signal: get_signals(signal_spec, deliver_to=PubMatic)
+    Signal-->>Scope3: signals + deployments
+    alt Not live on PubMatic
+        Scope3->>Signal: activate_signal(signal_agent_segment_id, platform=pubmatic, account)
+        Signal-->>Scope3: status=deployed, decisioning_platform_segment_id
+    end
+
+    Note over Scope3: Discovery & Authorization
+    Scope3->>Sales: list_creative_formats()
+    Sales-->>Scope3: format specs
+    Scope3->>Sales: list_authorized_properties()
+    Sales-->>Scope3: properties + tags
+    Scope3->>Sales: get_products(promoted_offering, brief, filters)
+    Sales-->>Scope3: products (properties or property_tags)
+    loop Validate
+        Scope3->>Publisher: GET /.well-known/adagents.json
+        Publisher-->>Scope3: authorized_agents
+        Scope3->>Scope3: verify agent URL + scope, resolve tags
+    end
+
+    Note over Scope3: Execution
+    Scope3->>Sales: create_media_buy(buyer_ref, packages{products, format_ids, targeting_overlay.signals})
+    Sales-->>Scope3: status=working | completed, media_buy_id, package_ids
+    Scope3->>Creative: sync_creatives(creatives, assignments{creative_id -> package_id})
+    Creative-->>Scope3: sync results
+
+    Note over Scope3: Delivery & Optimization
+    Scope3->>Sales: get_media_buy_delivery(buyer_refs, dates)
+    Sales-->>Scope3: totals, by_package, daily
+    Scope3->>Sales: update_media_buy(budget/targeting/status)
+    Sales-->>Scope3: status updates
+```
+
+### Data Mapping Notes
+
+- Signals activated on PubMatic yield a `decisioning_platform_segment_id` that should be supplied in `targeting_overlay.signals` for `create_media_buy`.
+- Products from PubMatic map to AdCP `Product` models; if `property_tags` are used, resolve via `list_authorized_properties`.
+- Creative assignments should map buyer creative IDs to AdCP package IDs returned by the PubMatic Sales Agent.
+
+## Observability
+
+- Log per-tool invocations with `context_id`, status, and latency.
+- Metrics: success/failure rates, p95 latency, retries, platform response IDs.
+
+## Deployment Notes
+
+- Your MCP server deploys independently.
+- This repo’s `Dockerfile`/`nginx.conf`/`fly.toml` cover docs site deployment; reuse patterns as needed.
+
+## References
+
+- `docs/protocols/mcp-guide.md`
+- `docs/media-buy/index.md` and `docs/media-buy/task-reference/`
+- `docs/signals/overview.md`
+- `static/schemas/README.md`
+- `static/schemas/creative-formats-v1.json`
+- `static/schemas/asset-types-v1.json`

--- a/docs/media-buy/advanced-topics/pubmatic-activate-adcp-integration.md
+++ b/docs/media-buy/advanced-topics/pubmatic-activate-adcp-integration.md
@@ -1,0 +1,287 @@
+# PubMatic Buy-Side Integration using Ad Context Protocol (AdCP)
+
+## Overview
+This document describes how PubMatic can integrate its **buy-side workflows** using the **Ad Context Protocol (AdCP)** framework. It maps AdCP constructs like **Products**, **Signals**, and **Media Buys** to PubMatic’s domain (where *Products* = *Deal Templates*).
+
+The integration focuses on how PubMatic’s MCP (Media Context Protocol) server can expose standardized APIs (as a **Sales Agent**) and interoperate with orchestrators like **Scope3** or any DSP through AdCP’s task model.
+
+---
+
+## Objectives
+- Standardize buy-side communication using AdCP.
+- Map PubMatic deal templates to AdCP Products.
+- Support audience activation via AdCP Signals.
+- Enable transparent and interoperable Media Buy creation and reporting.
+
+---
+
+## Agents and Responsibilities
+
+| Agent | Role | Key AdCP Tasks | Description |
+|-------|------|----------------|--------------|
+| **Sales Agent (PubMatic MCP)** | Exposes PubMatic deal templates and handles buy execution | `get_products`, `create_media_buy`, `update_media_buy`, `sync_creatives`, `get_media_buy_delivery` | Central agent handling all buy-side workflows |
+| **Signal Agent (3rd-party or internal)** | Provides audience and contextual signals | `get_signals`, `activate_signal` | Optional: PubMatic can expose its own contextual or audience signals |
+| **Authorization Agent** | Verifies publisher domain authorization | `list_authorized_properties` | Prevents unauthorized resale of inventory |
+| **Reporting Agent** | Exposes delivery metrics | `get_media_buy_delivery` | Maps internal PubMatic metrics to AdCP schema |
+
+---
+
+## AdCP to PubMatic Mapping
+
+| AdCP Concept | PubMatic Equivalent |
+|---------------|---------------------|
+| **Product** | Deal Template |
+| **Signal** | Audience / Contextual Segment (peer39, Scope3, etc.) |
+| **Media Buy** | Campaign / Deal Execution |
+| **Principal** | Buyer / Advertiser |
+| **Orchestrator** | Scope3, DSP, or Agency Platform |
+
+---
+
+## Core API Implementations
+
+### 1. `get_products` → Fetch Deal Templates
+
+**Request:**
+```json
+{
+  "tool": "get_products",
+  "arguments": {
+    "promoted_offering": "Nike Shoes Q4 2026",
+    "brief": "Premium video deals across Yahoo properties in US",
+    "filters": {
+      "format_types": ["video"],
+      "geo": {"country_in": ["US"]},
+      "min_budget": 1000
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "products": [
+    {
+      "product_id": "pm_dealtemplate_yt_vid_us_100k",
+      "title": "Yahoo Video Deal – US – 100k min spend",
+      "format_ids": ["video_15s", "video_30s"],
+      "properties": ["yahoo.com", "finance.yahoo.com"],
+      "geo": {"country_in": ["US"]},
+      "device_types": ["CTV", "mobile", "desktop"],
+      "min_budget": 100000,
+      "reporting_currency": "USD",
+      "reporting_capabilities": {
+        "can_webhook": true,
+        "webhook_granularity": ["hourly", "daily"]
+      }
+    }
+  ]
+}
+```
+
+---
+
+### 2. `list_authorized_properties`
+
+**Request:**
+```json
+{
+  "tool": "list_authorized_properties",
+  "arguments": {
+    "property_tags": ["finance", "news"],
+    "domains": ["finance.yahoo.com", "yahoo.com"]
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "authorized_properties": ["finance.yahoo.com", "yahoo.com"]
+}
+```
+
+---
+
+### 3. `create_media_buy`
+
+**Request:**
+```json
+{
+  "tool": "create_media_buy",
+  "arguments": {
+    "buyer_ref": "nike_q4_promo",
+    "promoted_offering": "Nike Shoes Q4 2026",
+    "start_time": "2026-10-01T00:00:00Z",
+    "end_time": "2026-12-31T23:59:59Z",
+    "budget": {
+      "total": 200000,
+      "currency": "USD",
+      "pacing": "even"
+    },
+    "packages": [
+      {
+        "buyer_ref": "pkg_yahoo_video",
+        "product_id": "pm_dealtemplate_yt_vid_us_100k",
+        "format_ids": ["video_15s", "video_30s"],
+        "budget": {"total": 200000, "currency": "USD"},
+        "targeting_overlay": {
+          "geo": {"country_in": ["US"]},
+          "devices": ["CTV", "desktop"],
+          "ad_size": ["1920x1080", "1280x720"],
+          "signals": ["pm_peer39_luxury_auto"],
+          "freq_cap": {"impressions": 3, "per": "day"}
+        }
+      }
+    ],
+    "reporting_webhook": {
+      "url": "https://scope3.example.com/pubmatic/report",
+      "auth_type": "bearer",
+      "auth_token": "xyz",
+      "reporting_frequency": "hourly",
+      "requested_metrics": ["impressions", "spend", "video_completions"]
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "media_buy_id": "mb_nike_q4_001",
+  "package_ids": ["pkg_yahoo_video"],
+  "creative_deadline": "2026-09-25T00:00:00Z"
+}
+```
+
+---
+
+### 4. `sync_creatives`
+
+**Request:**
+```json
+{
+  "tool": "sync_creatives",
+  "arguments": {
+    "media_buy_id": "mb_nike_q4_001",
+    "creatives": [
+      {
+        "creative_id": "nike_vid30_001",
+        "format_id": "video_30s",
+        "url": "https://ads.nike.com/vid30_001.mp4",
+        "tracking_macros": {
+           "impression": "{IMP_URL}",
+           "video_complete": "{COMP_URL}"
+        }
+      }
+    ]
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "synced_creatives": [
+    {"creative_id": "nike_vid30_001", "status": "OK"}
+  ]
+}
+```
+
+---
+
+### 5. `get_media_buy_delivery`
+
+**Request:**
+```json
+{
+  "tool": "get_media_buy_delivery",
+  "arguments": {
+    "media_buy_id": "mb_nike_q4_001",
+    "start_time": "2026-10-01T00:00:00Z",
+    "end_time": "2026-10-31T23:59:59Z",
+    "granularity": "hourly"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "delivery": [
+    {"timestamp": "2026-10-01T00:00:00Z", "impressions": 1200, "spend": 180.5, "video_completions": 800},
+    {"timestamp": "2026-10-01T01:00:00Z", "impressions": 1300, "spend": 195.7, "video_completions": 850}
+  ]
+}
+```
+
+---
+
+## Integration Flow
+
+### Step-by-Step Sequence
+1. **Buyer Agent (Scope3)** → `get_signals()` → Fetch audience/context signals.
+2. **Signal Agent** → Returns signal list + deployment info.
+3. **Buyer Agent** → `activate_signal()` → Deploys signals to PubMatic.
+4. **Sales Agent (PubMatic)** → `get_products()` → Returns available deal templates.
+5. **Buyer Agent** → `list_authorized_properties()` → Confirms domain authorization.
+6. **Buyer Agent** → `create_media_buy()` → Creates campaign with target overlays.
+7. **Sales Agent** → `sync_creatives()` → Uploads creatives.
+8. **Ad Delivery** → PubMatic enforces deal + overlay targeting.
+9. **Reporting** → `get_media_buy_delivery()` → Fetch performance.
+10. **Optimization** → `update_media_buy()` → Adjust targeting/budget.
+
+---
+
+## Mermaid Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Buyer Agent (Scope3)
+    participant Signal Agent
+    participant PubMatic Sales Agent
+
+    Buyer Agent (Scope3)->>Signal Agent: get_signals(promoted_offering)
+    Signal Agent-->>Buyer Agent (Scope3): signals with deployment info
+    Buyer Agent (Scope3)->>Signal Agent: activate_signal(signal_id, platform=PubMatic)
+    Signal Agent-->>Buyer Agent (Scope3): decisioning_platform_segment_id
+
+    Buyer Agent (Scope3)->>PubMatic Sales Agent: get_products(brief, filters)
+    PubMatic Sales Agent-->>Buyer Agent (Scope3): deal templates (products)
+
+    Buyer Agent (Scope3)->>PubMatic Sales Agent: list_authorized_properties(domains)
+    PubMatic Sales Agent-->>Buyer Agent (Scope3): authorized_domains
+
+    Buyer Agent (Scope3)->>PubMatic Sales Agent: create_media_buy(packages, targeting_overlay with signals)
+    PubMatic Sales Agent-->>Buyer Agent (Scope3): campaign_id & details
+
+    Buyer Agent (Scope3)->>PubMatic Sales Agent: sync_creatives(media_buy_id, creatives)
+    PubMatic Sales Agent-->>Buyer Agent (Scope3): confirmation
+
+    PubMatic Sales Agent-->>Buyer Agent (Scope3): get_media_buy_delivery(report)
+```
+
+---
+
+## Implementation Notes
+- **Signal Integration:** Signals activated via AdCP become `decisioning_platform_segment_id` in PubMatic.
+- **Authorization:** Must check publisher’s `.well-known/adagents.json` for compliance.
+- **Async Tasks:** Each AdCP task should return a `task_id` for polling.
+- **Partial Success Handling:** Multi-package buys may succeed partially.
+- **Reporting:** Map internal PubMatic metrics (impressions, spend, CTR) to AdCP schema.
+
+---
+
+## Next Steps
+1. Implement MCP Sales Agent endpoints as per AdCP’s Media Buy spec.
+2. Integrate with PubMatic’s deal template system.
+3. Map existing API parameters (ad_size, geo, targeting) to AdCP targeting overlay.
+4. Add async task management for long-running operations.
+5. Validate through Scope3 orchestrator sandbox.
+
+---
+
+**Author:** PubMatic Engineering / AdCP Integration Team  
+**Version:** 1.0.0  
+**Date:** October 2025

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -686,6 +686,8 @@ async function generateBundledSchemas(sourceDir, bundledDir, version) {
   const bundlePatterns = [
     /media-buy\/.*-request\.json$/,
     /media-buy\/.*-response\.json$/,
+    /deals\/.*-request\.json$/,
+    /deals\/.*-response\.json$/,
     /signals\/.*-request\.json$/,
     /signals\/.*-response\.json$/,
     /creative\/.*-request\.json$/,
@@ -807,6 +809,7 @@ function generateSkillSchemas(versionDir, version) {
     { protocol: 'media-buy', skillName: 'adcp-media-buy' },
     { protocol: 'creative', skillName: 'adcp-creative' },
     { protocol: 'signals', skillName: 'adcp-signals' },
+    { protocol: 'deals', skillName: 'adcp-deals' },
   ];
 
   let totalCount = 0;

--- a/skills/adcp-deals/SKILL.md
+++ b/skills/adcp-deals/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: adcp-deals
+description: Execute AdCP Deals Protocol operations - create and manage PMP, PG, and AP deals with sales agents. Use when users want to create deals, negotiate terms, activate deals on DSP/SSP, or get deal diagnostics.
+---
+
+# AdCP Deals Protocol
+
+This skill enables you to execute the AdCP Deals Protocol with sales agents. Use the standard MCP tools (`create_deal`, `list_deals`, `update_deal_terms`, `transition_deal_state`, `activate_deal`, etc.) exposed by the connected agent.
+
+## Overview
+
+The Deals Protocol provides tasks for deal lifecycle, activation, and diagnostics:
+
+| Task | Purpose |
+|------|---------|
+| `get_products` | Discover products with deal support (filter by transaction_type: PMP, PG, AP) |
+| `create_deal` | Create a logical deal (starts PROPOSED or DRAFT) |
+| `list_deals` | List/filter deals; use deal_ids for single-deal fetch |
+| `update_deal_terms` | Negotiate/counter-offer (versioned terms) |
+| `transition_deal_state` | Accept, schedule, pause, reject, cancel, complete |
+| `activate_deal` | Make deal transact-able on DSP/SSP |
+| `get_deal_activation_status` | Per-destination activation status |
+| `list_deal_mappings` | Logical-to-physical deal ID mappings |
+| `get_deal_metrics` | Canonical deal reporting |
+| `get_deal_diagnostics` | Health, root causes, recommendations |
+
+## Typical Workflow
+
+1. **Discover products**: `get_products` with filters.transaction_type (PMP, PG, or AP)
+2. **Create deal**: `create_deal` with product_id, transaction_type, terms
+3. **Negotiate**: `update_deal_terms` as needed; then `transition_deal_state` to ACCEPTED
+4. **Activate**: `activate_deal` with destinations (DSP/SSP)
+5. **Monitor**: `get_deal_metrics`, `get_deal_diagnostics`

--- a/static/schemas/source/core/deal-deployment.json
+++ b/static/schemas/source/core/deal-deployment.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/deal-deployment.json",
+  "title": "Deal Deployment",
+  "description": "One activation of a logical deal on a decisioning platform. Tracks platform_deal_id and per-destination status.",
+  "type": "object",
+  "properties": {
+    "deployment_id": {
+      "type": "string",
+      "description": "Unique identifier for this deployment (seller-assigned)"
+    },
+    "platform_type": {
+      "type": "string",
+      "enum": ["DSP", "SSP"],
+      "description": "Decisioning platform type"
+    },
+    "platform_name": {
+      "type": "string",
+      "description": "Platform identifier"
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Account or seat ID on the platform"
+    },
+    "platform_deal_id": {
+      "type": "string",
+      "description": "Physical deal ID (or line item / targeting ID) on the platform"
+    },
+    "deployment_status": {
+      "$ref": "/schemas/enums/deal-deployment-status.json"
+    },
+    "error": {
+      "type": "object",
+      "description": "Last error details when deployment_status is FAILED",
+      "properties": {
+        "message": { "type": "string" },
+        "code": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last status update (ISO 8601)"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["platform_type", "deployment_status"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/deal-destination.json
+++ b/static/schemas/source/core/deal-destination.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/deal-destination.json",
+  "title": "Deal Destination",
+  "description": "A destination where a deal is activated (DSP or SSP). Used in activate_deal request.",
+  "type": "object",
+  "properties": {
+    "platform_type": {
+      "type": "string",
+      "enum": ["DSP", "SSP"],
+      "description": "Decisioning platform type: DSP (buyer-side) or SSP (sell-side)"
+    },
+    "platform_name": {
+      "type": "string",
+      "description": "Identifier or name of the platform (e.g. vendor name)"
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Account or seat ID on the destination platform"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["CREATE_AND_SYNC", "BIND_EXISTING"],
+      "description": "CREATE_AND_SYNC: create physical deal if needed and sync. BIND_EXISTING: attach to existing physical deal ID."
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["platform_type"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/deal-terms.json
+++ b/static/schemas/source/core/deal-terms.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/deal-terms.json",
+  "title": "Deal Terms",
+  "description": "Versioned negotiated terms for a deal. Structure varies by transaction_type (PMP: floor/bid cap; PG: commitment/makegood; AP: package/auction rules). Used in create_deal, update_deal_terms, and returned on the deal object.",
+  "type": "object",
+  "properties": {
+    "transaction_type": {
+      "$ref": "/schemas/enums/transaction-type.json",
+      "description": "Deal transaction type (PMP, PG, AP)"
+    },
+    "floor": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Price floor (e.g. CPM). Relevant for PMP."
+    },
+    "bid_cap": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Maximum bid. Only present when seller supports bid caps (PMP)."
+    },
+    "commitment_units": {
+      "type": "object",
+      "description": "Commitment for PG: impressions or spend",
+      "properties": {
+        "impressions": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Committed impression volume"
+        },
+        "spend": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Committed spend amount"
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "Currency for spend"
+        }
+      },
+      "additionalProperties": true
+    },
+    "makegood_rules": {
+      "type": "string",
+      "description": "Human-readable or structured makegood policy for PG. Optional."
+    },
+    "start_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Flight start (ISO 8601)"
+    },
+    "end_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Flight end (ISO 8601)"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/deal.json
+++ b/static/schemas/source/core/deal.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/deal.json",
+  "title": "Deal",
+  "description": "Logical deal wrapping a product with negotiated terms, lifecycle state, and per-destination activation. Products are discovered via get_products; deals are created, updated, and activated via the Deals protocol.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Unique identifier for the deal (seller-assigned)"
+    },
+    "product_id": {
+      "type": "string",
+      "description": "Product this deal is based on"
+    },
+    "transaction_type": {
+      "$ref": "/schemas/enums/transaction-type.json"
+    },
+    "buyer_seat_id": {
+      "type": "string",
+      "description": "Buyer seat (or account) this deal is for. Null for marketplace shelf deals (visibility PUBLIC)."
+    },
+    "advertiser_id": {
+      "type": "string",
+      "description": "Optional advertiser or brand identifier"
+    },
+    "state": {
+      "$ref": "/schemas/enums/deal-state.json"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Current terms version; increments on each update_deal_terms"
+    },
+    "accepted_version": {
+      "type": "integer",
+      "description": "Terms version that was accepted when state moved to ACCEPTED. Omitted when state is not ACCEPTED or later."
+    },
+    "terms": {
+      "$ref": "/schemas/core/deal-terms.json",
+      "description": "Current negotiated terms (at current version)"
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Per-destination activation status. Deal may be LIVE while only a subset of destinations are ACTIVE.",
+      "items": {
+        "$ref": "/schemas/core/deal-deployment.json"
+      }
+    },
+    "visibility": {
+      "$ref": "/schemas/enums/deal-visibility.json",
+      "description": "Who can see this deal when listing (PRIVATE, INVITE_ONLY, PUBLIC)"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp (ISO 8601)"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last update timestamp (ISO 8601)"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "product_id", "transaction_type", "state", "version", "terms"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -374,6 +374,10 @@
         "additionalProperties": false
       },
       "minItems": 1
+    },
+    "transaction_type": {
+      "$ref": "/schemas/enums/transaction-type.json",
+      "description": "Filter to products that support this deal transaction type (PMP, PG, or AP). When provided, only products with supported_transaction_types including this value are returned."
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -440,6 +440,39 @@
       "minProperties": 1,
       "additionalProperties": true
     },
+    "supported_transaction_types": {
+      "type": "array",
+      "description": "Deal transaction types supported for this product (PMP, PG, AP). When present, the product can be used to create deals of these types. Omitted when the product is not sold as deals.",
+      "items": {
+        "$ref": "/schemas/enums/transaction-type.json"
+      },
+      "uniqueItems": true
+    },
+    "transaction_terms_by_type": {
+      "type": "object",
+      "description": "High-level default or allowed ranges per transaction type (PMP/PG/AP). Keys are transaction_type values; structure is product-specific (e.g. floor range, commitment units). Used for deal discovery and create_deal defaults.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "requires_channel_split": {
+      "type": "boolean",
+      "description": "When true, supply may require separate deals per channel. Used for deal discovery.",
+      "default": false
+    },
+    "deal_capabilities": {
+      "type": "object",
+      "description": "Deal-related capabilities for this product. Only present when supported_transaction_types is non-empty.",
+      "properties": {
+        "supports_bid_cap": { "type": "boolean", "description": "Product supports bid cap for PMP" },
+        "supports_reject_over_under": { "type": "boolean", "description": "Supports reject over/under semantics" },
+        "supports_deal_level_reporting": { "type": "boolean", "description": "Deal-level reporting available" },
+        "supports_reason_codes": { "type": "boolean", "description": "Reject/fill reason codes available" },
+        "supports_multi_destination_activation": { "type": "boolean", "description": "Activation to multiple DSP/SSP destinations" }
+      },
+      "additionalProperties": true
+    },
     "ext": {
       "$ref": "/schemas/core/ext.json"
     }

--- a/static/schemas/source/deals/activate-deal-request.json
+++ b/static/schemas/source/deals/activate-deal-request.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/activate-deal-request.json",
+  "title": "Activate Deal Request",
+  "description": "Request to push or bind a logical deal into decisioning platforms (DSP/SSP) so it becomes transact-able. Activation is required before the deal can be used for bidding.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to activate"
+    },
+    "destinations": {
+      "type": "array",
+      "description": "Where to activate: each destination specifies platform_type (DSP/SSP), platform_name, account_id, and mode (CREATE_AND_SYNC or BIND_EXISTING)",
+      "items": {
+        "$ref": "/schemas/core/deal-destination.json"
+      },
+      "minItems": 1
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "destinations"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/activate-deal-response.json
+++ b/static/schemas/source/deals/activate-deal-response.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/activate-deal-response.json",
+  "title": "Activate Deal Response",
+  "description": "Response payload for activate_deal task. Returns per-destination deployment status; activation may be asynchronous.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal that was activated"
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Per-destination result: platform_deal_id, deployment_status, error details",
+      "items": {
+        "$ref": "/schemas/core/deal-deployment.json"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "deployments"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/create-deal-request.json
+++ b/static/schemas/source/deals/create-deal-request.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/create-deal-request.json",
+  "title": "Create Deal Request",
+  "description": "Request parameters for creating a logical deal. Deal starts in PROPOSED or DRAFT. Buyer and seller negotiate via update_deal_terms; state moves via transition_deal_state; activation via activate_deal.",
+  "type": "object",
+  "properties": {
+    "product_id": {
+      "type": "string",
+      "description": "Product this deal is based on (from get_products)"
+    },
+    "transaction_type": {
+      "$ref": "/schemas/enums/transaction-type.json",
+      "description": "Deal type: PMP, PG, or AP"
+    },
+    "buyer_seat_id": {
+      "type": "string",
+      "description": "Buyer seat (or account) for this deal. Omit for marketplace shelf deals (visibility PUBLIC)."
+    },
+    "advertiser_id": {
+      "type": "string",
+      "description": "Optional advertiser or brand identifier"
+    },
+    "terms": {
+      "$ref": "/schemas/core/deal-terms.json",
+      "description": "Initial negotiated terms; may be defaults from product"
+    },
+    "visibility": {
+      "$ref": "/schemas/enums/deal-visibility.json",
+      "description": "Who can see this deal when listing. Defaults to PRIVATE when buyer_seat_id is set, else seller-defined."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["product_id", "transaction_type", "terms"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/create-deal-response.json
+++ b/static/schemas/source/deals/create-deal-response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/create-deal-response.json",
+  "title": "Create Deal Response",
+  "description": "Response payload for create_deal task",
+  "type": "object",
+  "properties": {
+    "deal": {
+      "$ref": "/schemas/core/deal.json",
+      "description": "Created deal with deal_id, state, version, and terms"
+    },
+    "errors": {
+      "type": "array",
+      "description": "Task-specific errors and warnings",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-activation-status-request.json
+++ b/static/schemas/source/deals/get-deal-activation-status-request.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-activation-status-request.json",
+  "title": "Get Deal Activation Status Request",
+  "description": "Request for asynchronous activation status per destination. Optionally scope to a single deployment_id.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to check"
+    },
+    "deployment_id": {
+      "type": "string",
+      "description": "Optional: limit to this deployment"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-activation-status-response.json
+++ b/static/schemas/source/deals/get-deal-activation-status-response.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-activation-status-response.json",
+  "title": "Get Deal Activation Status Response",
+  "description": "Response with per-destination activation status, timestamps, and last error.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string"
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Per-destination status, timestamps, last error",
+      "items": {
+        "$ref": "/schemas/core/deal-deployment.json"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "deployments"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-diagnostics-request.json
+++ b/static/schemas/source/deals/get-deal-diagnostics-request.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-diagnostics-request.json",
+  "title": "Get Deal Diagnostics Request",
+  "description": "Request for health summary, root cause analysis, and recommendations for a deal. Optional viewer_role filters sensitive fields (buyer, seller, admin).",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to diagnose"
+    },
+    "viewer_role": {
+      "type": "string",
+      "enum": ["buyer", "seller", "admin"],
+      "description": "Role of the caller; response may filter sensitive fields by role. Omit for default visibility."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-diagnostics-response.json
+++ b/static/schemas/source/deals/get-deal-diagnostics-response.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-diagnostics-response.json",
+  "title": "Get Deal Diagnostics Response",
+  "description": "Health summary, top issues, root causes, and recommendations for the deal. Role-filtered when viewer_role was provided.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string"
+    },
+    "deal_summary": {
+      "type": "object",
+      "description": "High-level deal info (id, name, advertiser, start_date, end_date, deal_type)",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "advertiser": { "type": "string" },
+        "start_date": { "type": "string", "format": "date" },
+        "end_date": { "type": "string", "format": "date" },
+        "deal_type": { "$ref": "/schemas/enums/transaction-type.json" }
+      },
+      "additionalProperties": true
+    },
+    "health_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Overall health score (0-100)"
+    },
+    "status": {
+      "type": "string",
+      "description": "Summary status (e.g. underperforming, healthy, at_risk)"
+    },
+    "top_issues": {
+      "type": "array",
+      "description": "Primary issues (e.g. low fill rate, high bid rejection)",
+      "items": { "type": "string" }
+    },
+    "root_causes": {
+      "type": "array",
+      "description": "Root cause analysis with issue and evidence",
+      "items": {
+        "type": "object",
+        "properties": {
+          "issue": { "type": "string" },
+          "evidence": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "recommendations": {
+      "type": "array",
+      "description": "Actionable recommendations",
+      "items": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-metrics-request.json
+++ b/static/schemas/source/deals/get-deal-metrics-request.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-metrics-request.json",
+  "title": "Get Deal Metrics Request",
+  "description": "Request for canonical reporting for a logical deal: time range, granularity, dimensions. Optional by_destination for per-platform breakdown.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to report on"
+    },
+    "time_range": {
+      "$ref": "/schemas/core/datetime-range.json",
+      "description": "Start and end time for metrics"
+    },
+    "granularity": {
+      "type": "string",
+      "enum": ["hour", "day", "week", "month"],
+      "description": "Reporting granularity"
+    },
+    "dimensions": {
+      "type": "array",
+      "description": "Optional breakdown dimensions (e.g. geo, device, channel, publisher)",
+      "items": { "type": "string" }
+    },
+    "by_destination": {
+      "type": "boolean",
+      "description": "When true, include per-destination (platform) breakdown",
+      "default": false
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/get-deal-metrics-response.json
+++ b/static/schemas/source/deals/get-deal-metrics-response.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/get-deal-metrics-response.json",
+  "title": "Get Deal Metrics Response",
+  "description": "Canonical deal metrics: imps, spend, CPM, win/fill, reject reasons when available.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Normalized metrics (impressions, spend, cpm, win_rate, fill_rate, etc.)",
+      "properties": {
+        "impressions": { "type": "number", "minimum": 0 },
+        "spend": { "type": "number", "minimum": 0 },
+        "cpm": { "type": "number" },
+        "win_rate": { "type": "number" },
+        "fill_rate": { "type": "number" },
+        "reject_reasons": {
+          "type": "array",
+          "items": { "type": "object", "additionalProperties": true }
+        }
+      },
+      "additionalProperties": true
+    },
+    "by_destination": {
+      "type": "array",
+      "description": "Per-destination metrics when by_destination was true",
+      "items": {
+        "type": "object",
+        "properties": {
+          "platform_type": { "type": "string" },
+          "platform_name": { "type": "string" },
+          "account_id": { "type": "string" },
+          "metrics": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "metrics"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/list-deal-mappings-request.json
+++ b/static/schemas/source/deals/list-deal-mappings-request.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/list-deal-mappings-request.json",
+  "title": "List Deal Mappings Request",
+  "description": "Request for logical deal to physical platform ID mappings. Used for reporting and troubleshooting across platforms.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to list mappings for"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/list-deal-mappings-response.json
+++ b/static/schemas/source/deals/list-deal-mappings-response.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/list-deal-mappings-response.json",
+  "title": "List Deal Mappings Response",
+  "description": "Logical deal to physical platform ID mappings: platform_type, platform_name, account_id, platform_deal_id, related_ids.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string"
+    },
+    "mappings": {
+      "type": "array",
+      "description": "One entry per destination with platform_deal_id and related_ids",
+      "items": {
+        "type": "object",
+        "properties": {
+          "platform_type": { "type": "string", "enum": ["DSP", "SSP"] },
+          "platform_name": { "type": "string" },
+          "account_id": { "type": "string" },
+          "platform_deal_id": { "type": "string" },
+          "related_ids": {
+            "type": "object",
+            "description": "Platform-specific IDs (e.g. line_item_id, targeting_id)",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "required": ["platform_type", "platform_deal_id"],
+        "additionalProperties": true
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "mappings"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/list-deals-request.json
+++ b/static/schemas/source/deals/list-deals-request.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/list-deals-request.json",
+  "title": "List Deals Request",
+  "description": "Request parameters for listing and filtering deals. Use deal_ids for single-deal fetch (get_deal equivalent). Supports pagination and updated_since for sync patterns.",
+  "type": "object",
+  "properties": {
+    "deal_ids": {
+      "type": "array",
+      "description": "Specific deal IDs to fetch. When provided, returns only these deals (e.g. single deal when length 1).",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "buyer_seat_id": {
+      "type": "string",
+      "description": "Filter by buyer seat (or account)"
+    },
+    "product_id": {
+      "type": "string",
+      "description": "Filter by product"
+    },
+    "transaction_type": {
+      "$ref": "/schemas/enums/transaction-type.json",
+      "description": "Filter by deal type (PMP, PG, AP)"
+    },
+    "state": {
+      "oneOf": [
+        { "$ref": "/schemas/enums/deal-state.json" },
+        {
+          "type": "array",
+          "items": { "$ref": "/schemas/enums/deal-state.json" },
+          "minItems": 1
+        }
+      ],
+      "description": "Filter by deal state(s)"
+    },
+    "visibility": {
+      "$ref": "/schemas/enums/deal-visibility.json",
+      "description": "Filter by visibility (e.g. PUBLIC for marketplace shelf)"
+    },
+    "updated_since": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Return only deals updated after this timestamp (ISO 8601)"
+    },
+    "pagination": {
+      "$ref": "/schemas/core/pagination-request.json"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/list-deals-response.json
+++ b/static/schemas/source/deals/list-deals-response.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/list-deals-response.json",
+  "title": "List Deals Response",
+  "description": "Response payload for list_deals task. Returns deals matching filters; supports pagination.",
+  "type": "object",
+  "properties": {
+    "deals": {
+      "type": "array",
+      "description": "Matching deals",
+      "items": {
+        "$ref": "/schemas/core/deal.json"
+      }
+    },
+    "pagination": {
+      "$ref": "/schemas/core/pagination-response.json",
+      "description": "Pagination metadata when list was paginated"
+    },
+    "errors": {
+      "type": "array",
+      "description": "Task-specific errors and warnings",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deals"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/transition-deal-state-request.json
+++ b/static/schemas/source/deals/transition-deal-state-request.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/transition-deal-state-request.json",
+  "title": "Transition Deal State Request",
+  "description": "Request to move a deal through its lifecycle. Typical transitions: PROPOSED→ACCEPTED, ACCEPTED→SCHEDULED, SCHEDULED→LIVE, LIVE→PAUSED/LIVE, LIVE→COMPLETED, PROPOSED→REJECTED, any→CANCELLED.",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to transition"
+    },
+    "state": {
+      "$ref": "/schemas/enums/deal-state.json",
+      "description": "Target state"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "state"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/transition-deal-state-response.json
+++ b/static/schemas/source/deals/transition-deal-state-response.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/transition-deal-state-response.json",
+  "title": "Transition Deal State Response",
+  "description": "Response payload for transition_deal_state task",
+  "type": "object",
+  "properties": {
+    "deal": {
+      "$ref": "/schemas/core/deal.json",
+      "description": "Deal in new state"
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/update-deal-terms-request.json
+++ b/static/schemas/source/deals/update-deal-terms-request.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/update-deal-terms-request.json",
+  "title": "Update Deal Terms Request",
+  "description": "Request to update deal terms (negotiation/counter-offer). Increments version; stores proposed_by and optional change_summary. Used by both buyer and seller. Deal must be in PROPOSED (or DRAFT if seller allows).",
+  "type": "object",
+  "properties": {
+    "deal_id": {
+      "type": "string",
+      "description": "Deal to update"
+    },
+    "terms": {
+      "$ref": "/schemas/core/deal-terms.json",
+      "description": "New proposed terms (replaces current version)"
+    },
+    "change_summary": {
+      "type": "string",
+      "description": "Optional human-readable summary of what changed"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal_id", "terms"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/deals/update-deal-terms-response.json
+++ b/static/schemas/source/deals/update-deal-terms-response.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/deals/update-deal-terms-response.json",
+  "title": "Update Deal Terms Response",
+  "description": "Response payload for update_deal_terms task",
+  "type": "object",
+  "properties": {
+    "deal": {
+      "$ref": "/schemas/core/deal.json",
+      "description": "Deal with incremented version and new terms"
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "/schemas/core/error.json" }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["deal"],
+  "additionalProperties": true
+}

--- a/static/schemas/source/enums/deal-deployment-status.json
+++ b/static/schemas/source/enums/deal-deployment-status.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/deal-deployment-status.json",
+  "title": "Deal Deployment Status",
+  "description": "Per-destination activation status for a deal on a decisioning platform (DSP/SSP)",
+  "type": "string",
+  "enum": ["PENDING", "ACTIVE", "FAILED", "DISABLED"]
+}

--- a/static/schemas/source/enums/deal-state.json
+++ b/static/schemas/source/enums/deal-state.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/deal-state.json",
+  "title": "Deal State",
+  "description": "Lifecycle state of a deal. Negotiation happens in PROPOSED via versioned terms; ACCEPTED locks a version; activation and flight drive SCHEDULED/LIVE/COMPLETED.",
+  "type": "string",
+  "enum": [
+    "DRAFT",
+    "PROPOSED",
+    "ACCEPTED",
+    "SCHEDULED",
+    "LIVE",
+    "PAUSED",
+    "REJECTED",
+    "CANCELLED",
+    "COMPLETED"
+  ]
+}

--- a/static/schemas/source/enums/deal-visibility.json
+++ b/static/schemas/source/enums/deal-visibility.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/deal-visibility.json",
+  "title": "Deal Visibility",
+  "description": "Who can see the deal when listing: PRIVATE (only addressed buyer seats), INVITE_ONLY (visible but requires seller approval), PUBLIC (any eligible buyer seat)",
+  "type": "string",
+  "enum": ["PRIVATE", "INVITE_ONLY", "PUBLIC"]
+}

--- a/static/schemas/source/enums/transaction-type.json
+++ b/static/schemas/source/enums/transaction-type.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/transaction-type.json",
+  "title": "Transaction Type",
+  "description": "Deal transaction type: PMP (Private Marketplace), PG (Programmatic Guaranteed), or AP (Auction Package)",
+  "type": "string",
+  "enum": ["PMP", "PG", "AP"]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -385,6 +385,22 @@
         "provenance": {
           "$ref": "/schemas/core/provenance.json",
           "description": "AI provenance and disclosure metadata — declares how content was produced, C2PA references, regulatory disclosure requirements, and third-party verification results"
+        },
+        "deal": {
+          "$ref": "/schemas/core/deal.json",
+          "description": "Logical deal wrapping a product with negotiated terms, state, and per-destination activation"
+        },
+        "deal-terms": {
+          "$ref": "/schemas/core/deal-terms.json",
+          "description": "Versioned negotiated terms for a deal (PMP/PG/AP)"
+        },
+        "deal-deployment": {
+          "$ref": "/schemas/core/deal-deployment.json",
+          "description": "Per-destination activation of a deal on a DSP/SSP"
+        },
+        "deal-destination": {
+          "$ref": "/schemas/core/deal-destination.json",
+          "description": "Destination for deal activation (platform_type, account_id, mode)"
         }
       },
       "requirements": {
@@ -611,6 +627,22 @@
         "right-type": {
           "$ref": "/schemas/enums/right-type.json",
           "description": "Categories of licensable rights (talent, music, brand_ip, stock_media)"
+        },
+        "transaction-type": {
+          "$ref": "/schemas/enums/transaction-type.json",
+          "description": "Deal transaction type (PMP, PG, AP)"
+        },
+        "deal-state": {
+          "$ref": "/schemas/enums/deal-state.json",
+          "description": "Lifecycle state of a deal"
+        },
+        "deal-deployment-status": {
+          "$ref": "/schemas/enums/deal-deployment-status.json",
+          "description": "Per-destination activation status for a deal (PENDING, ACTIVE, FAILED, DISABLED)"
+        },
+        "deal-visibility": {
+          "$ref": "/schemas/enums/deal-visibility.json",
+          "description": "Deal visibility (PRIVATE, INVITE_ONLY, PUBLIC)"
         },
         "http-method": {
           "$ref": "/schemas/enums/http-method.json",
@@ -1121,6 +1153,101 @@
           "response": {
             "$ref": "/schemas/signals/activate-signal-response.json",
             "description": "Response payload for activate_signal task"
+          }
+        }
+      }
+    },
+    "deals": {
+      "description": "Deals protocol task request/response schemas. PMP, PG, and AP deal lifecycle, activation, and diagnostics.",
+      "tasks": {
+        "create-deal": {
+          "request": {
+            "$ref": "/schemas/deals/create-deal-request.json",
+            "description": "Request parameters for creating a logical deal"
+          },
+          "response": {
+            "$ref": "/schemas/deals/create-deal-response.json",
+            "description": "Response payload for create_deal task"
+          }
+        },
+        "list-deals": {
+          "request": {
+            "$ref": "/schemas/deals/list-deals-request.json",
+            "description": "Request parameters for listing/filtering deals (use deal_ids for single-deal fetch)"
+          },
+          "response": {
+            "$ref": "/schemas/deals/list-deals-response.json",
+            "description": "Response payload for list_deals task"
+          }
+        },
+        "update-deal-terms": {
+          "request": {
+            "$ref": "/schemas/deals/update-deal-terms-request.json",
+            "description": "Request parameters for negotiation/counter-offer (versioned terms)"
+          },
+          "response": {
+            "$ref": "/schemas/deals/update-deal-terms-response.json",
+            "description": "Response payload for update_deal_terms task"
+          }
+        },
+        "transition-deal-state": {
+          "request": {
+            "$ref": "/schemas/deals/transition-deal-state-request.json",
+            "description": "Request parameters for moving deal through lifecycle states"
+          },
+          "response": {
+            "$ref": "/schemas/deals/transition-deal-state-response.json",
+            "description": "Response payload for transition_deal_state task"
+          }
+        },
+        "activate-deal": {
+          "request": {
+            "$ref": "/schemas/deals/activate-deal-request.json",
+            "description": "Request parameters for activating deal on DSP/SSP destinations"
+          },
+          "response": {
+            "$ref": "/schemas/deals/activate-deal-response.json",
+            "description": "Response payload for activate_deal task"
+          }
+        },
+        "get-deal-activation-status": {
+          "request": {
+            "$ref": "/schemas/deals/get-deal-activation-status-request.json",
+            "description": "Request parameters for async activation status per destination"
+          },
+          "response": {
+            "$ref": "/schemas/deals/get-deal-activation-status-response.json",
+            "description": "Response payload for get_deal_activation_status task"
+          }
+        },
+        "list-deal-mappings": {
+          "request": {
+            "$ref": "/schemas/deals/list-deal-mappings-request.json",
+            "description": "Request parameters for logical-to-physical deal ID mappings"
+          },
+          "response": {
+            "$ref": "/schemas/deals/list-deal-mappings-response.json",
+            "description": "Response payload for list_deal_mappings task"
+          }
+        },
+        "get-deal-metrics": {
+          "request": {
+            "$ref": "/schemas/deals/get-deal-metrics-request.json",
+            "description": "Request parameters for canonical deal reporting"
+          },
+          "response": {
+            "$ref": "/schemas/deals/get-deal-metrics-response.json",
+            "description": "Response payload for get_deal_metrics task"
+          }
+        },
+        "get-deal-diagnostics": {
+          "request": {
+            "$ref": "/schemas/deals/get-deal-diagnostics-request.json",
+            "description": "Request parameters for deal health, root causes, and recommendations"
+          },
+          "response": {
+            "$ref": "/schemas/deals/get-deal-diagnostics-response.json",
+            "description": "Response payload for get_deal_diagnostics task"
           }
         }
       }

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -81,6 +81,7 @@
         "enum": [
           "media_buy",
           "signals",
+          "deals",
           "governance",
           "sponsored_intelligence",
           "creative",
@@ -560,6 +561,51 @@
           }
         }
       }
+    },
+    "deals": {
+      "type": "object",
+      "description": "Deals protocol capabilities. Only present if deals is in supported_protocols. Sales agents that support PMP, PG, or AP deals declare supported transaction types and optional features here.",
+      "properties": {
+        "supported_transaction_types": {
+          "type": "array",
+          "description": "Deal transaction types this seller supports (PMP, PG, AP)",
+          "items": {
+            "type": "string",
+            "enum": ["PMP", "PG", "AP"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "features": {
+          "type": "object",
+          "description": "Optional deal features supported across the seller's product portfolio",
+          "properties": {
+            "supports_bid_cap": {
+              "type": "boolean",
+              "description": "Products may support bid cap for PMP"
+            },
+            "supports_reject_over_under": {
+              "type": "boolean",
+              "description": "Supports reject over/under semantics"
+            },
+            "supports_deal_level_reporting": {
+              "type": "boolean",
+              "description": "Deal-level reporting available"
+            },
+            "supports_reason_codes": {
+              "type": "boolean",
+              "description": "Reject/fill reason codes available"
+            },
+            "supports_multi_destination_activation": {
+              "type": "boolean",
+              "description": "Activation to multiple DSP/SSP destinations"
+            }
+          },
+          "additionalProperties": { "type": "boolean" }
+        }
+      },
+      "required": ["supported_transaction_types"],
+      "additionalProperties": true
     },
     "governance": {
       "type": "object",


### PR DESCRIPTION
This commit introduces comprehensive support for the Deals protocol, including:
- New sections in `docs.json` for Deals and Task Reference pages.
- Updates to `README.md` to include Deals protocol overview and key tasks.
- Enhancements in schema files to define request/response structures for deal-related tasks such as creating, listing, and activating deals.
- Modifications to existing schemas to incorporate deal transaction types and capabilities.

These changes aim to provide a robust framework for managing deal lifecycles and diagnostics within the AdCP ecosystem.