### PR TITLE
fix: notify WG Slack when committee document added

### DIFF
--- a/.changeset/wg-document-slack-notify.md
+++ b/.changeset/wg-document-slack-notify.md
@@ -1,0 +1,4 @@
+---
+---
+
+Notify working group Slack channels when a committee document is added by a WG leader. Previously only published posts triggered Slack notifications; documents were silently added without channel visibility.

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -19,7 +19,7 @@ import { notifyPublishedPost } from "../notifications/slack.js";
 import { notifyUser } from "../notifications/notification-service.js";
 import { decodeHtmlEntities } from "../utils/html-entities.js";
 import { reindexDocument } from "../addie/jobs/committee-document-indexer.js";
-import { createChannel, setChannelPurpose } from "../slack/client.js";
+import { createChannel, setChannelPurpose, sendChannelMessage, isSlackConfigured } from "../slack/client.js";
 import { CommunityDatabase } from "../db/community-db.js";
 
 const logger = createLogger("committee-routes");
@@ -1655,6 +1655,48 @@ export function createCommitteeRouters(): {
       });
 
       logger.info({ documentId: document.id, groupSlug: slug, userId: user.id }, 'Committee document created');
+
+      // Notify the working group's Slack channel
+      if (group.slack_channel_id && isSlackConfigured()) {
+        const docTypeLabel = document_type === 'spreadsheet' ? 'Spreadsheet' : document_type === 'presentation' ? 'Presentation' : 'Document';
+        const userName = user.firstName && user.lastName
+          ? `${user.firstName} ${user.lastName}`
+          : user.email || 'A working group leader';
+        const appUrl = process.env.APP_URL || 'https://agenticadvertising.org';
+        const groupUrl = `${appUrl}/working-groups/${slug}`;
+        // Sanitize for Slack mrkdwn link syntax (pipe breaks <url|label>)
+        const safeTitle = title.replace(/[|<>]/g, '-');
+
+        sendChannelMessage(group.slack_channel_id, {
+          text: `📄 New ${docTypeLabel} added to ${group.name}: ${title}`,
+          blocks: [
+            {
+              type: 'header',
+              text: {
+                type: 'plain_text' as const,
+                text: `📄 New ${docTypeLabel} Added`,
+                emoji: true,
+              },
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn' as const,
+                text: `*<${document_url}|${safeTitle}>*${description ? `\n${description}` : ''}`,
+              },
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn' as const,
+                text: `Added by ${userName} · <${groupUrl}|View all ${group.name} resources>`,
+              },
+            },
+          ],
+        }).catch(err => {
+          logger.warn({ err, groupSlug: slug, documentId: document.id }, 'Failed to send Slack notification for new committee document');
+        });
+      }
 
       res.status(201).json({ document });
     } catch (error) {


### PR DESCRIPTION
## Summary
- When a WG leader adds a committee document, post a notification to the WG's Slack channel with the document title, link, description, and who added it
- Previously only published posts triggered Slack notifications; documents were silently added
- Resolves Addie escalation #123 (Pia/Creative WG — document added but no Slack notification fired)

## Changes
- Added `sendChannelMessage` + `isSlackConfigured` call after document creation in `POST /api/working-groups/:slug/documents`
- Uses `APP_URL` env var instead of hardcoded domain
- Sanitizes title for Slack mrkdwn link syntax (pipe/angle brackets)
- Fire-and-forget pattern matching existing `notifyPublishedPost` convention

## Test plan
- [ ] Add a document to a WG that has a Slack channel configured (e.g. Creative WG) — verify notification appears in channel
- [ ] Add a document to a WG without a Slack channel — verify no error, document still created
- [ ] Add a document with a title containing `|` or `<` characters — verify Slack message renders correctly
- [ ] Verify existing published post notifications still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)