### PR TITLE
fix: add missing layout.css to members page so registry sub-nav inherits correct styles

### DIFF
--- a/.changeset/fix-members-subnav-css.md
+++ b/.changeset/fix-members-subnav-css.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: add missing layout.css to members page so registry sub-nav inherits correct styles

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ yarn-error.log*
 
 pre-push
 
+.idea/
+
 # Test cache
 tests/.tested-files.json
 tests/temp-snippet-*

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -6,6 +6,7 @@
   <title>Partner Directory - AgenticAdvertising.org</title>
   <link rel="icon" href="/AAo.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/layout.css">
   <style>
     /* =============================================================================
        Members Directory - Uses design system tokens


### PR DESCRIPTION
## Summary

- Adds the missing `layout.css` stylesheet reference to `members.html` so the registry sub-nav inherits the correct CSS styles
- Fixes unstyled submenu links on the `/members` page

Closes #1551

## Test plan

- [ ] Visit `/members` and confirm registry sub-nav links are styled correctly
- [ ] Verify no regressions on other pages that already include `layout.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)