### PR TITLE
docs: clarify xor semantics for update_media_buy identifiers

### DIFF
--- a/.changeset/clarify-xor-identifiers.md
+++ b/.changeset/clarify-xor-identifiers.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify mutual exclusivity of identifier parameters in `update_media_buy` docs: `media_buy_id` xor `buyer_ref` at the campaign level, `package_id` xor `buyer_ref` at the package level. Supplying both or neither now explicitly documented as a validation failure.

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -147,7 +147,7 @@ asyncio.run(create_and_pause_campaign())
 | `reporting_webhook` | object | No | Update reporting webhook configuration (see below) |
 | `push_notification_config` | object | No | Webhook for async operation notifications |
 
-*Either `media_buy_id` OR `buyer_ref` is required (not both)
+*Exactly one required — `media_buy_id` xor `buyer_ref`. Requests with both or neither are rejected.
 
 ### Reporting Webhook Object
 
@@ -186,7 +186,7 @@ Configure automated delivery reporting for this media buy:
 | `creative_assignments` | CreativeAssignment[] | Replace assigned creatives with optional weights and placement targeting |
 | `creatives` | CreativeAsset[] | Upload and assign new creatives inline (must not exist in library) |
 
-*Either `package_id` OR `buyer_ref` is required for each package update
+*Exactly one required — `package_id` xor `buyer_ref`. Entries with both or neither are rejected.
 
 ## Response
 


### PR DESCRIPTION
## Summary
- Rewrites ambiguous "Either X OR Y is required (not both)" phrasing in `update_media_buy` docs to clearly communicate XOR semantics
- Both campaign-level (`media_buy_id` xor `buyer_ref`) and package-level (`package_id` xor `buyer_ref`) footnotes updated
- Supplying both or neither now explicitly documented as a validation failure

## Test plan
- [x] All pre-commit checks pass (schema validation, docs nav, link checks)
- [ ] Review rendered docs to confirm footnotes read clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)