### PR TITLE
fix: split Zoom webhook handlers to reduce API failure rate

### DIFF
--- a/server/src/routes/webhooks.ts
+++ b/server/src/routes/webhooks.ts
@@ -15,6 +15,7 @@ import { ModelConfig } from '../config/models.js';
 import { verifyWebhookSignature as verifyZoomSignature } from '../integrations/zoom.js';
 import {
   handleRecordingCompleted,
+  handleTranscriptCompleted,
   handleMeetingStarted,
   handleMeetingEnded,
 } from '../services/meeting-service.js';
@@ -1527,15 +1528,24 @@ export function createWebhooksRouter(): Router {
 
         // Handle different event types
         switch (body.event) {
-          case 'recording.completed':
+          case 'recording.completed': {
+            const recUuid = body.payload?.object?.uuid;
+            const recId = body.payload?.object?.id;
+            if (recUuid && typeof recUuid === 'string' && recUuid.length < 256) {
+              await handleRecordingCompleted(recUuid, recId?.toString());
+            } else if (recUuid) {
+              logger.warn({ meetingUuidType: typeof recUuid }, 'Invalid meetingUuid format');
+            }
+            break;
+          }
+
           case 'recording.transcript_completed': {
-            const meetingUuid = body.payload?.object?.uuid;
-            const meetingId = body.payload?.object?.id;
-            if (meetingUuid && typeof meetingUuid === 'string' && meetingUuid.length < 256) {
-              // Pass both UUID and numeric ID - we store the numeric ID in our DB
-              await handleRecordingCompleted(meetingUuid, meetingId?.toString());
-            } else if (meetingUuid) {
-              logger.warn({ meetingUuidType: typeof meetingUuid }, 'Invalid meetingUuid format');
+            const txUuid = body.payload?.object?.uuid;
+            const txId = body.payload?.object?.id;
+            if (txUuid && typeof txUuid === 'string' && txUuid.length < 256) {
+              await handleTranscriptCompleted(txUuid, txId?.toString());
+            } else if (txUuid) {
+              logger.warn({ meetingUuidType: typeof txUuid }, 'Invalid meetingUuid format');
             }
             break;
           }

--- a/server/src/services/meeting-service.ts
+++ b/server/src/services/meeting-service.ts
@@ -416,44 +416,83 @@ export async function addAttendeeToSeries(
 }
 
 /**
- * Handle Zoom recording completed webhook
- * Stores transcript and fetches Zoom AI Companion summary
+ * Look up a meeting by Zoom meeting ID
+ */
+async function findMeetingByZoomId(zoomMeetingId?: string): Promise<Meeting | null> {
+  if (!zoomMeetingId) return null;
+  return meetingsDb.getMeetingByZoomId(zoomMeetingId);
+}
+
+/**
+ * Handle Zoom recording.completed webhook
+ * Fetches the AI Companion meeting summary (available once recording finishes)
  */
 export async function handleRecordingCompleted(meetingUuid: string, zoomMeetingId?: string): Promise<void> {
   logger.info({ meetingUuid, zoomMeetingId }, 'Processing recording completed');
 
-  // Find meeting in database - try zoom_meeting_id first (numeric ID), fall back to UUID lookup
-  let meeting: Meeting | null = null;
-  if (zoomMeetingId) {
-    meeting = await meetingsDb.getMeetingByZoomId(zoomMeetingId);
-  }
-
+  const meeting = await findMeetingByZoomId(zoomMeetingId);
   if (!meeting) {
-    logger.warn({ meetingUuid, zoomMeetingId }, 'Meeting not found in database - transcript will not be stored');
+    logger.warn({ meetingUuid, zoomMeetingId: zoomMeetingId ?? 'none' }, 'Meeting not found in database - cannot store summary');
     return;
   }
 
   const meetingCtx = { meetingId: meeting.id, meetingTitle: meeting.title, zoomMeetingId, meetingUuid };
 
-  // Get transcript
-  const transcriptText = await zoom.getTranscriptText(meetingUuid);
-  let hadTranscript = false;
-  if (transcriptText) {
-    const plainText = zoom.parseVttToText(transcriptText);
-    await meetingsDb.updateMeeting(meeting.id, { transcript_text: plainText });
-    hadTranscript = true;
+  if (meeting.summary) {
+    logger.info(meetingCtx, 'Meeting summary already stored, skipping');
+    return;
   }
 
-  // Fetch Zoom AI Companion meeting summary (getMeetingSummary handles errors internally and returns null)
-  let hadSummary = false;
   const zoomSummary = await zoom.getMeetingSummary(meetingUuid);
   if (zoomSummary) {
     const summary = zoom.formatMeetingSummaryAsMarkdown(zoomSummary);
     await meetingsDb.updateMeeting(meeting.id, { summary });
-    hadSummary = true;
+    logger.info(meetingCtx, 'Stored meeting summary');
+  } else {
+    logger.info(meetingCtx, 'No meeting summary available');
+  }
+}
+
+/**
+ * Handle Zoom recording.transcript_completed webhook
+ * Fetches the transcript (available once Zoom finishes transcription)
+ * Also fetches the meeting summary if not already stored
+ */
+export async function handleTranscriptCompleted(meetingUuid: string, zoomMeetingId?: string): Promise<void> {
+  logger.info({ meetingUuid, zoomMeetingId }, 'Processing transcript completed');
+
+  const meeting = await findMeetingByZoomId(zoomMeetingId);
+  if (!meeting) {
+    logger.warn({ meetingUuid, zoomMeetingId: zoomMeetingId ?? 'none' }, 'Meeting not found in database - cannot store transcript');
+    return;
   }
 
-  logger.info({ ...meetingCtx, hadTranscript, hadSummary }, 'Recording processing completed');
+  const meetingCtx = { meetingId: meeting.id, meetingTitle: meeting.title, zoomMeetingId, meetingUuid };
+
+  // Build updates in a single DB write
+  const updates: { transcript_text?: string; summary?: string } = {};
+  let hadTranscript = false;
+  let hadSummary = false;
+
+  const transcriptText = await zoom.getTranscriptText(meetingUuid);
+  if (transcriptText) {
+    updates.transcript_text = zoom.parseVttToText(transcriptText);
+    hadTranscript = true;
+  }
+
+  if (!meeting.summary) {
+    const zoomSummary = await zoom.getMeetingSummary(meetingUuid);
+    if (zoomSummary) {
+      updates.summary = zoom.formatMeetingSummaryAsMarkdown(zoomSummary);
+      hadSummary = true;
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await meetingsDb.updateMeeting(meeting.id, updates);
+  }
+
+  logger.info({ ...meetingCtx, hadTranscript, hadSummary }, 'Transcript processing completed');
 }
 
 /**


### PR DESCRIPTION
## Problem

Zoom reported a 57% API failure rate over the last 7 days on two endpoints:
- `/v2/meetings/**/recordings` (GET)
- `/v2/meetings/**/meeting_summary` (GET)

Both `recording.completed` and `recording.transcript_completed` webhooks were routed to the same handler, which called both endpoints every time. When `recording.completed` fires, the transcript isn't ready yet, so the recordings call 404s. The meeting summary is also often unavailable at that point.

## Fix

Split into two handlers matched to the Zoom webhook lifecycle:

- **`recording.completed`** → only fetches the AI Companion meeting summary
- **`recording.transcript_completed`** → fetches the transcript, backfills summary if missing

Both handlers are idempotent (skip if data already stored) and `handleTranscriptCompleted` batches DB writes into a single call.

## Changes

- `server/src/services/meeting-service.ts`: Split `handleRecordingCompleted` into two functions, added `findMeetingByZoomId` helper, added idempotency guards, batched DB writes
- `server/src/routes/webhooks.ts`: Route each webhook event type to its own handler