### PR TITLE
fix: paginate knowledge base listing to prevent timeout

### DIFF
--- a/.changeset/fix-addie-knowledge-pagination.md
+++ b/.changeset/fix-addie-knowledge-pagination.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset for addie knowledge pagination fix

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -2243,7 +2243,11 @@
     }
 
     // Load unified knowledge list (docs, curated resources, slack messages)
-    async function loadKnowledge() {
+    let knowledgePage = 0;
+    const knowledgePageSize = 100;
+
+    async function loadKnowledge(page) {
+      if (typeof page === 'number') knowledgePage = page;
       const sourceType = document.getElementById('source-type-filter').value;
       const category = document.getElementById('category-filter').value;
       const fetchStatus = document.getElementById('fetch-status-filter').value;
@@ -2252,13 +2256,15 @@
       const fetchStatusFilter = document.getElementById('fetch-status-filter');
       fetchStatusFilter.style.display = sourceType === 'curated' ? 'block' : 'none';
 
-      // Build URL with filters
+      // Build URL with filters and pagination
       const params = new URLSearchParams();
       if (sourceType) params.append('source_type', sourceType);
       if (category) params.append('category', category);
       if (fetchStatus && sourceType === 'curated') params.append('status', fetchStatus);
+      params.append('limit', knowledgePageSize.toString());
+      params.append('offset', (knowledgePage * knowledgePageSize).toString());
 
-      const url = '/api/admin/addie/knowledge' + (params.toString() ? '?' + params.toString() : '');
+      const url = '/api/admin/addie/knowledge?' + params.toString();
 
       try {
         // Load stats
@@ -2374,6 +2380,22 @@
             </div>
           `;
         }).join('');
+
+        // Pagination controls
+        const totalPages = Math.ceil(data.total / knowledgePageSize);
+        if (totalPages > 1) {
+          list.innerHTML += `
+            <div style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-3) 0; border-top: var(--border-1) solid var(--color-gray-200); margin-top: var(--space-3);">
+              <span style="color: var(--color-text-muted); font-size: var(--text-sm);">
+                Showing ${knowledgePage * knowledgePageSize + 1}–${Math.min((knowledgePage + 1) * knowledgePageSize, data.total)} of ${data.total}
+              </span>
+              <div style="display: flex; gap: var(--space-2);">
+                ${knowledgePage > 0 ? `<button class="btn btn-small btn-secondary" onclick="loadKnowledge(${knowledgePage - 1})">Previous</button>` : ''}
+                ${knowledgePage < totalPages - 1 ? `<button class="btn btn-small btn-secondary" onclick="loadKnowledge(${knowledgePage + 1})">Next</button>` : ''}
+              </div>
+            </div>
+          `;
+        }
       } catch (error) {
         console.error('Error loading knowledge:', error);
         document.getElementById('knowledge-list').innerHTML =
@@ -3002,9 +3024,9 @@
     }
 
     // Event listeners
-    document.getElementById('source-type-filter').addEventListener('change', loadKnowledge);
-    document.getElementById('category-filter').addEventListener('change', loadKnowledge);
-    document.getElementById('fetch-status-filter').addEventListener('change', loadKnowledge);
+    document.getElementById('source-type-filter').addEventListener('change', () => loadKnowledge(0));
+    document.getElementById('category-filter').addEventListener('change', () => loadKnowledge(0));
+    document.getElementById('fetch-status-filter').addEventListener('change', () => loadKnowledge(0));
 
     // Close modal on outside click
     document.getElementById('knowledge-modal').addEventListener('click', (e) => {

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -430,7 +430,7 @@ export class AddieDatabase {
     activeOnly?: boolean;
     limit?: number;
     offset?: number;
-  } = {}): Promise<AddieKnowledge[]> {
+  } = {}): Promise<{ rows: AddieKnowledge[]; total: number }> {
     const conditions: string[] = [];
     const params: unknown[] = [];
     let paramIndex = 1;
@@ -456,28 +456,35 @@ export class AddieDatabase {
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-    let sql = `
-      SELECT * FROM addie_knowledge
+    const limit = options.limit ?? 100;
+    const offset = options.offset ?? 0;
+
+    params.push(limit);
+    const limitParam = `$${paramIndex++}`;
+    params.push(offset);
+    const offsetParam = `$${paramIndex++}`;
+
+    const sql = `
+      SELECT id, title, category, source_url, source_type, is_active,
+        LEFT(content, 250) as content,
+        fetch_url, fetch_status, last_fetched_at, summary, addie_notes,
+        relevance_tags, quality_score, discovery_source,
+        slack_channel_name, slack_username, slack_permalink,
+        created_by, created_at, updated_at,
+        COUNT(*) OVER()::int as total_count
+      FROM addie_knowledge
       ${whereClause}
       ORDER BY
         CASE WHEN source_type = 'curated' AND fetch_status = 'pending' THEN 0 ELSE 1 END,
         updated_at DESC,
         category,
         title
+      LIMIT ${limitParam} OFFSET ${offsetParam}
     `;
 
-    if (options.limit) {
-      sql += ` LIMIT $${paramIndex++}`;
-      params.push(options.limit);
-    }
-
-    if (options.offset) {
-      sql += ` OFFSET $${paramIndex++}`;
-      params.push(options.offset);
-    }
-
-    const result = await query<AddieKnowledge>(sql, params);
-    return result.rows;
+    const result = await query<AddieKnowledge & { total_count: number }>(sql, params);
+    const total = result.rows[0]?.total_count ?? 0;
+    return { rows: result.rows, total };
   }
 
   /**

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -91,18 +91,21 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
     try {
       const { category, active_only, source_type, status, limit, offset } = req.query;
 
-      const documents = await addieDb.listKnowledge({
+      const parsedLimit = limit ? parseInt(limit as string, 10) : 100;
+      const parsedOffset = offset ? parseInt(offset as string, 10) : 0;
+
+      const { rows: documents, total } = await addieDb.listKnowledge({
         category: category as string | undefined,
         sourceType: source_type as string | undefined,
         fetchStatus: status as string | undefined,
         activeOnly: active_only !== "false",
-        limit: limit ? parseInt(limit as string, 10) : undefined,
-        offset: offset ? parseInt(offset as string, 10) : undefined,
+        limit: isNaN(parsedLimit) ? 100 : Math.min(Math.max(parsedLimit, 1), 500),
+        offset: isNaN(parsedOffset) ? 0 : Math.max(parsedOffset, 0),
       });
 
       res.json({
         documents,
-        total: documents.length,
+        total,
       });
     } catch (error) {
       logger.error({ err: error }, "Error fetching knowledge documents");


### PR DESCRIPTION
## Summary
- The admin Knowledge Base tab was failing with "Error loading knowledge" because it fetched all 16k+ documents with full content in a single unbounded request
- Added server-side pagination (100 per page default, max 500) with `LIMIT`/`OFFSET` and `COUNT(*) OVER()` window function
- Truncated content to 250 chars in list view via `LEFT(content, 250)` to reduce payload size
- Added input validation on `limit`/`offset` query params (NaN, negative, excessive values)
- Added Previous/Next pagination controls in the frontend

## Test plan
- [ ] Load the Addie Dashboard Knowledge Base tab — should display first 100 docs with pagination
- [ ] Click Next/Previous buttons — should page through results correctly
- [ ] Change source type or category filter — should reset to page 1
- [ ] Verify "Showing X–Y of Z" counts are accurate
- [ ] Test with `?limit=abc` and `?limit=-1` — should fall back to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)