### PR TITLE
fix: include all membership statuses in auto-add dedup

### DIFF
--- a/.changeset/fix-auto-add-membership-statuses.md
+++ b/.changeset/fix-auto-add-membership-statuses.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix auto-add domain users to include inactive and pending memberships in filter

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6168,6 +6168,7 @@ Disallow: /api/admin/
             // If org has no admin/owner yet, promote this user to owner
             const existingMembers = await workos!.userManagement.listOrganizationMemberships({
               organizationId: organization_id,
+              statuses: ['active', 'inactive', 'pending'],
               limit: 100,
             });
             const hasAdmin = existingMembers.data.some((m) => {
@@ -6299,6 +6300,7 @@ Disallow: /api/admin/
         // Check if org has any existing members
         const orgMemberships = await workos!.userManagement.listOrganizationMemberships({
           organizationId: organization_id,
+          statuses: ['active', 'inactive', 'pending'],
         });
 
         // If org has no members (e.g., prospect org) AND user's email domain matches,

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -2249,6 +2249,7 @@ export function setupDomainRoutes(
             do {
               const memberships = await config.workos!.userManagement.listOrganizationMemberships({
                 organizationId: orgId,
+                statuses: ['active', 'inactive', 'pending'],
                 limit: 100,
                 after,
               });
@@ -2400,6 +2401,7 @@ export function setupDomainRoutes(
             do {
               const memberships = await config.workos!.userManagement.listOrganizationMemberships({
                 organizationId: orgId,
+                statuses: ['active', 'inactive', 'pending'],
                 limit: 100,
                 after,
               });

--- a/server/src/slack/sync.ts
+++ b/server/src/slack/sync.ts
@@ -31,6 +31,7 @@ async function roleForNewMember(orgId: string): Promise<'owner' | 'member'> {
   try {
     const memberships = await workos.userManagement.listOrganizationMemberships({
       organizationId: orgId,
+      statuses: ['active', 'inactive', 'pending'],
       limit: 100,
     });
     const hasAdmin = memberships.data.some((m) => {
@@ -848,6 +849,7 @@ export async function autoAddVerifiedDomainUsersAsMembers(): Promise<{
       do {
         const memberships = await workos.userManagement.listOrganizationMemberships({
           organizationId: orgId,
+          statuses: ['active', 'inactive', 'pending'],
           limit: 100,
           after,
         });


### PR DESCRIPTION
## Summary
- WorkOS `listOrganizationMemberships` only returns active memberships by default. Users with inactive or pending memberships were counted as eligible for auto-add but couldn't actually be added, causing a persistent "25 users" count that never resolved after clicking "Complete."
- Added `statuses: ['active', 'inactive', 'pending']` to 6 call sites across `domains.ts`, `http.ts`, and `sync.ts` that build membership dedup sets or check for existing admins/owners.

## Test plan
- [ ] Run auto-add domain users from admin domain health page — count should match actual eligible users
- [ ] Verify backfill completes and count drops to 0 when all users are added
- [ ] Verify role assignment (owner vs member) accounts for inactive/pending admin memberships

🤖 Generated with [Claude Code](https://claude.com/claude-code)