### PR TITLE
refactor: route brand protocol tools through training agent

### DIFF
--- a/.changeset/brand-sandbox-to-adcp.md
+++ b/.changeset/brand-sandbox-to-adcp.md
@@ -1,0 +1,4 @@
+---
+---
+
+Refactor brand sandbox tools into AdCP training agent handlers

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -96,7 +96,6 @@ import { GOOGLE_DOCS_TOOLS, createGoogleDocsToolHandlers } from './mcp/google-do
 // DIRECTORY_TOOLS registered via registerBaselineTools()
 import { SI_HOST_TOOLS, createSiHostToolHandlers } from './mcp/si-host-tools.js';
 import { BRAND_TOOLS, createBrandToolHandlers } from './mcp/brand-tools.js';
-import { BRAND_SANDBOX_TOOLS, createBrandSandboxToolHandlers } from './mcp/brand-sandbox-tools.js';
 import { COLLABORATION_TOOLS, createCollaborationToolHandlers } from './mcp/collaboration-tools.js';
 import { SOCIAL_DRAFT_TOOLS, createSocialDraftToolHandlers } from './mcp/social-draft-tools.js';
 import { COMMITTEE_LEADER_TOOLS, createCommitteeLeaderToolHandlers } from './mcp/committee-leader-tools.js';
@@ -798,13 +797,6 @@ async function createUserScopedTools(
     allHandlers.set(name, handler);
   }
 
-  // Add brand sandbox tools (certification exercises)
-  const brandSandboxHandlers = createBrandSandboxToolHandlers();
-  allTools.push(...BRAND_SANDBOX_TOOLS);
-  for (const [name, handler] of brandSandboxHandlers) {
-    allHandlers.set(name, handler);
-  }
-
   // Add collaboration tools (DMs between members)
   const collaborationHandlers = createCollaborationToolHandlers(memberContext, slackUserId, threadId);
   allTools.push(...COLLABORATION_TOOLS);
@@ -1367,7 +1359,7 @@ async function handleUserMessage({
                 title: event.tool_name.replace(/_/g, ' '),
                 status: 'in_progress',
               }],
-            } as any);
+            });
           } catch {
             // Ignore stream errors for status updates
           }
@@ -1387,7 +1379,7 @@ async function handleUserMessage({
                 title: event.tool_name.replace(/_/g, ' '),
                 status: event.is_error ? 'error' : 'complete',
               }],
-            } as any);
+            });
           } catch {
             // Ignore stream errors for status updates
           }

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -1835,6 +1835,178 @@ export const ADCP_PROTOCOL_TOOLS: AddieTool[] = [
 ];
 
 // ============================================
+// BRAND PROTOCOL TOOLS
+// ============================================
+
+export const ADCP_BRAND_PROTOCOL_TOOLS: AddieTool[] = [
+  {
+    name: 'get_brand_identity',
+    description:
+      'Get brand identity data from a brand agent. Returns public data by default. Set authorized=true to simulate a linked account (sandbox) or use actual OAuth credentials (production) to see protected fields like colors, fonts, tone, voice synthesis, and rights.',
+    usage_hints:
+      'use when the user wants to look up a talent or brand\'s identity, creative guidelines, or available rights from a brand agent',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_url: {
+          type: 'string',
+          description: 'The brand agent URL (must be HTTPS)',
+        },
+        brand_id: {
+          type: 'string',
+          description: 'Brand identifier within the agent\'s roster',
+        },
+        fields: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Sections to include: description, industry, keller_type, logos, colors, fonts, visual_guidelines, tone, tagline, voice_synthesis, assets, rights. Omit for all.',
+        },
+        use_case: {
+          type: 'string',
+          description: 'Intended use case: endorsement, voice_synthesis, likeness, creative_production, media_planning',
+        },
+        authorized: {
+          type: 'boolean',
+          description: 'Sandbox only: simulate authorized access to see protected fields. Real agents use OAuth credentials instead. Default false.',
+        },
+        debug: { type: 'boolean' },
+      },
+      required: ['agent_url', 'brand_id'],
+    },
+  },
+  {
+    name: 'get_rights',
+    description:
+      'Search for licensable rights (talent, IP, content) from a brand agent. Returns matches with pricing options. Supports natural language queries. Set include_excluded=true to see filtered-out results with reasons.',
+    usage_hints:
+      'use when the user wants to find licensable talent, discover rights pricing, or search for IP available for campaigns',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_url: {
+          type: 'string',
+          description: 'The brand agent URL (must be HTTPS)',
+        },
+        query: {
+          type: 'string',
+          description: 'Natural language description of desired rights (e.g., "Dutch athlete for restaurant brand in Amsterdam, budget 400 EUR/month")',
+        },
+        uses: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Rights uses: likeness, voice, name, endorsement',
+        },
+        buyer_brand: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string' },
+            brand_id: { type: 'string' },
+          },
+          description: 'Buyer brand for compatibility filtering',
+        },
+        countries: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Countries where rights are needed (ISO 3166-1 alpha-2)',
+        },
+        brand_id: {
+          type: 'string',
+          description: 'Search within a specific brand only',
+        },
+        include_excluded: {
+          type: 'boolean',
+          description: 'Include filtered-out results with reasons. Default false.',
+        },
+        debug: { type: 'boolean' },
+      },
+      required: ['agent_url', 'query', 'uses'],
+    },
+  },
+  {
+    name: 'acquire_rights',
+    description:
+      'Acquire rights from a brand agent. Returns acquired (with generation credentials), pending_approval, or rejected based on campaign category and existing contracts.',
+    usage_hints:
+      'use when the user wants to acquire talent rights, license IP, or secure rights for a campaign',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_url: {
+          type: 'string',
+          description: 'The brand agent URL (must be HTTPS)',
+        },
+        rights_id: {
+          type: 'string',
+          description: 'Rights offering identifier from get_rights',
+        },
+        pricing_option_id: {
+          type: 'string',
+          description: 'Selected pricing option from the rights offering',
+        },
+        buyer: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string' },
+            brand_id: { type: 'string' },
+          },
+          required: ['domain'],
+          description: 'Buyer brand identity',
+        },
+        campaign: {
+          type: 'object',
+          properties: {
+            description: { type: 'string', description: 'How the rights will be used' },
+            uses: { type: 'array', items: { type: 'string' }, description: 'Rights uses for this campaign' },
+            countries: { type: 'array', items: { type: 'string' }, description: 'Campaign countries' },
+            estimated_impressions: { type: 'integer', description: 'Estimated total impressions' },
+            start_date: { type: 'string', description: 'Campaign start date (YYYY-MM-DD)' },
+            end_date: { type: 'string', description: 'Campaign end date (YYYY-MM-DD)' },
+          },
+          required: ['description', 'uses'],
+          description: 'Campaign details for rights clearance',
+        },
+        debug: { type: 'boolean' },
+      },
+      required: ['agent_url', 'rights_id', 'pricing_option_id', 'buyer', 'campaign'],
+    },
+  },
+  {
+    name: 'update_rights',
+    description:
+      'Update an existing rights grant — extend dates, adjust impression caps, or pause/resume.',
+    usage_hints:
+      'use when the user wants to extend a rights grant, change impression caps, or pause/resume an active license',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_url: {
+          type: 'string',
+          description: 'The brand agent URL (must be HTTPS)',
+        },
+        rights_id: {
+          type: 'string',
+          description: 'Rights grant identifier from acquire_rights',
+        },
+        end_date: {
+          type: 'string',
+          description: 'New end date (must be >= current end date)',
+        },
+        impression_cap: {
+          type: 'number',
+          description: 'New impression cap (must be >= current)',
+        },
+        paused: {
+          type: 'boolean',
+          description: 'Pause or resume the grant',
+        },
+        debug: { type: 'boolean' },
+      },
+      required: ['agent_url', 'rights_id'],
+    },
+  },
+];
+
+// ============================================
 // ALL ADCP TOOLS
 // ============================================
 
@@ -1845,6 +2017,7 @@ export const ADCP_TOOLS: AddieTool[] = [
   ...ADCP_GOVERNANCE_PROPERTY_TOOLS,
   ...ADCP_GOVERNANCE_CONTENT_TOOLS,
   ...ADCP_SI_TOOLS,
+  ...ADCP_BRAND_PROTOCOL_TOOLS,
   ...ADCP_PROTOCOL_TOOLS,
 ];
 
@@ -1953,7 +2126,8 @@ export function createAdcpToolHandlers(
     // In-process shortcut for training agent (avoids HTTP round-trip and localhost restrictions)
     try {
       const parsedUrl = new URL(agentUrl);
-      if (parsedUrl.pathname.startsWith('/api/training-agent')) {
+      const selfHost = new URL(getBaseUrl()).hostname;
+      if (parsedUrl.pathname.startsWith('/api/training-agent') && parsedUrl.hostname === selfHost) {
         const { executeTrainingAgentTool } = await import('../../training-agent/task-handlers.js');
         const userId = memberContext?.workos_user?.workos_user_id;
         const ctx = { mode: 'training' as const, userId };

--- a/server/src/addie/register-baseline-tools.ts
+++ b/server/src/addie/register-baseline-tools.ts
@@ -32,10 +32,6 @@ import {
   createBrandToolHandlers,
 } from "./mcp/brand-tools.js";
 import {
-  BRAND_SANDBOX_TOOLS,
-  createBrandSandboxToolHandlers,
-} from "./mcp/brand-sandbox-tools.js";
-import {
   PROPERTY_TOOLS,
   createPropertyToolHandlers,
 } from "./mcp/property-tools.js";
@@ -65,6 +61,5 @@ export async function registerBaselineTools(client: AddieClaudeClient): Promise<
   registerToolsFromMap(client, SCHEMA_TOOLS, createSchemaToolHandlers());
   registerToolsFromMap(client, DIRECTORY_TOOLS, createDirectoryToolHandlers());
   registerToolsFromMap(client, BRAND_TOOLS, createBrandToolHandlers());
-  registerToolsFromMap(client, BRAND_SANDBOX_TOOLS, createBrandSandboxToolHandlers());
   registerToolsFromMap(client, PROPERTY_TOOLS, createPropertyToolHandlers());
 }

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -174,6 +174,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'si_send_message',
       'si_get_offering',
       'si_terminate_session',
+      // Brand Protocol
+      'get_brand_identity',
+      'get_rights',
+      'acquire_rights',
+      'update_rights',
       // Protocol
       'get_adcp_capabilities',
       // Agent management
@@ -351,11 +356,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'test_out_modules',
       'start_certification_exam',
       'complete_certification_exam',
-      // Brand sandbox tools for certification exercises
-      'sandbox_get_brand_identity',
-      'sandbox_get_rights',
-      'sandbox_acquire_rights',
-      'sandbox_update_rights',
+      // Brand protocol tools (route to training agent during certification)
+      'get_brand_identity',
+      'get_rights',
+      'acquire_rights',
+      'update_rights',
     ],
   },
 };

--- a/server/src/db/migrations/313_c2_brand_tools_rename.sql
+++ b/server/src/db/migrations/313_c2_brand_tools_rename.sql
@@ -1,0 +1,18 @@
+-- Rename sandbox_* brand tools to standard AdCP tool names in C2 exercise definitions.
+-- These tools now route through adcp-tools.ts to the training agent, like all other AdCP tools.
+-- One-way: the sandbox_* tool names no longer exist in the codebase.
+UPDATE certification_modules
+SET exercise_definitions = REPLACE(
+  REPLACE(
+    REPLACE(
+      REPLACE(
+        exercise_definitions::text,
+        'sandbox_get_brand_identity', 'get_brand_identity'
+      ),
+      'sandbox_get_rights', 'get_rights'
+    ),
+    'sandbox_acquire_rights', 'acquire_rights'
+  ),
+  'sandbox_update_rights', 'update_rights'
+)::jsonb
+WHERE id = 'C2';

--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -1,16 +1,14 @@
 /**
- * Brand Protocol Sandbox Tools for Addie
+ * Brand protocol tool definitions and handlers for the training agent.
  *
- * Provides in-memory brand protocol task handlers (get_brand_identity,
- * get_rights, acquire_rights, update_rights) using fictional talent seed data.
- * Used during certification exercises to demonstrate the brand protocol.
+ * Implements get_brand_identity, get_rights, acquire_rights, and
+ * update_rights using fictional talent seed data from Loti Entertainment.
+ * Responses are deterministic — built from in-memory data, not LLM calls.
  */
 
-import type { AddieTool } from '../types.js';
+import type { TrainingContext } from './types.js';
 
-// =====================================================
-// TYPES
-// =====================================================
+// ── Types ─────────────────────────────────────────────────────────
 
 interface LocalizedName {
   [lang: string]: string;
@@ -98,9 +96,7 @@ interface TalentEntry {
   exclusion_reasons?: Record<string, string | { reason: string; suggestions?: string[] }>;
 }
 
-// =====================================================
-// SEED DATA
-// =====================================================
+// ── Seed data ─────────────────────────────────────────────────────
 
 const HOUSE: House = {
   domain: 'lotientertainment.com',
@@ -409,124 +405,69 @@ const TALENT: TalentEntry[] = [
 const TALENT_MAP = new Map(TALENT.map(t => [t.brand_id, t]));
 
 // Fields that are always returned (public, not selectable)
-const CORE_FIELDS = ['brand_id', 'house', 'names'] as const;
-
-// Fields that are public (returned without auth)
 const PUBLIC_FIELDS = ['description', 'industry', 'keller_type', 'logos', 'tagline'] as const;
-
-// Fields that require authorization
 const AUTHORIZED_FIELDS = ['colors', 'fonts', 'visual_guidelines', 'tone', 'voice_synthesis', 'assets', 'rights'] as const;
-
-// All selectable fields
 const ALL_FIELDS = [...PUBLIC_FIELDS, ...AUTHORIZED_FIELDS] as const;
 
-// =====================================================
-// TOOL DEFINITIONS
-// =====================================================
+// ── Tool definitions ──────────────────────────────────────────────
 
-export const BRAND_SANDBOX_TOOLS: AddieTool[] = [
+export const BRAND_TOOLS = [
   {
-    name: 'sandbox_get_brand_identity',
-    description: 'Get brand identity data from the Loti Entertainment sandbox roster. Returns public data by default. Set authorized=true to simulate a linked account and see all fields. Available brands: daan_janssen, sofia_reyes, pieter_van_dijk, yuki_tanaka.',
-    usage_hints: 'use during certification brand protocol exercises to demonstrate get_brand_identity, public vs authorized data, available_fields',
-    input_schema: {
-      type: 'object',
+    name: 'get_brand_identity',
+    description: 'Get brand identity data from the talent roster. Returns public data by default. Set authorized=true to simulate a linked account and see all fields (colors, fonts, tone, voice synthesis, rights). Available brands: daan_janssen, sofia_reyes, pieter_van_dijk, yuki_tanaka.',
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    inputSchema: {
+      type: 'object' as const,
       properties: {
-        brand_id: {
-          type: 'string',
-          description: 'Brand identifier (e.g., daan_janssen, sofia_reyes, pieter_van_dijk, yuki_tanaka)',
-        },
-        fields: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Sections to include: description, industry, keller_type, logos, colors, fonts, visual_guidelines, tone, tagline, voice_synthesis, assets, rights. Omit for all.',
-        },
-        use_case: {
-          type: 'string',
-          description: 'Intended use case: endorsement, voice_synthesis, likeness, creative_production, media_planning',
-        },
-        authorized: {
-          type: 'boolean',
-          description: 'Simulate an authorized caller (linked via sync_accounts). Default false — returns public-only data.',
-        },
+        brand_id: { type: 'string', description: 'Brand identifier (e.g., daan_janssen, sofia_reyes)' },
+        fields: { type: 'array', items: { type: 'string' }, description: 'Sections to include. Omit for all.' },
+        use_case: { type: 'string', description: 'Intended use case: endorsement, voice_synthesis, likeness, creative_production, media_planning' },
+        authorized: { type: 'boolean', description: 'Simulate authorized caller (linked via sync_accounts). Default false.' },
       },
       required: ['brand_id'],
     },
   },
   {
-    name: 'sandbox_get_rights',
-    description: 'Search for licensable talent rights in the Loti Entertainment sandbox roster. Returns matches with pricing options. Supports natural language queries. Set include_excluded=true to see filtered-out talent with reasons.',
-    usage_hints: 'use during certification brand protocol exercises to demonstrate get_rights, rights discovery, pricing comparison',
-    input_schema: {
-      type: 'object',
+    name: 'get_rights',
+    description: 'Search for licensable talent rights. Returns matches with pricing options. Supports natural language queries — interprets intent, budget, and geography. Set include_excluded=true to see filtered-out talent with reasons.',
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    inputSchema: {
+      type: 'object' as const,
       properties: {
-        query: {
-          type: 'string',
-          description: 'Natural language description of desired rights (e.g., "Dutch athlete for restaurant brand in Amsterdam, budget 400 EUR/month")',
-        },
-        uses: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Rights uses: likeness, voice, name, endorsement',
-        },
-        buyer_brand: {
-          type: 'object',
-          properties: {
-            domain: { type: 'string' },
-            brand_id: { type: 'string' },
-          },
-          description: 'Buyer brand for compatibility filtering',
-        },
-        countries: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Countries where rights are needed (ISO 3166-1 alpha-2)',
-        },
-        brand_id: {
-          type: 'string',
-          description: 'Search within a specific brand only',
-        },
-        include_excluded: {
-          type: 'boolean',
-          description: 'Include filtered-out results with reasons. Default false.',
-        },
+        query: { type: 'string', description: 'Natural language description of desired rights' },
+        uses: { type: 'array', items: { type: 'string' }, description: 'Rights uses: likeness, voice, name, endorsement' },
+        buyer_brand: { type: 'object', description: 'Buyer brand for compatibility filtering' },
+        countries: { type: 'array', items: { type: 'string' }, description: 'Countries where rights are needed (ISO 3166-1 alpha-2)' },
+        brand_id: { type: 'string', description: 'Search within a specific brand only' },
+        include_excluded: { type: 'boolean', description: 'Include filtered-out results with reasons. Default false.' },
       },
       required: ['query', 'uses'],
     },
   },
   {
-    name: 'sandbox_acquire_rights',
-    description: 'Acquire rights from the Loti Entertainment sandbox roster. Returns acquired (with generation credentials), pending_approval, or rejected based on campaign category and talent contracts.',
-    usage_hints: 'use during certification brand protocol exercises to demonstrate acquire_rights, rights clearance, generation credentials',
-    input_schema: {
-      type: 'object',
+    name: 'acquire_rights',
+    description: 'Acquire rights from the talent roster. Returns acquired (with generation credentials), pending_approval, or rejected based on campaign category and existing contracts.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    inputSchema: {
+      type: 'object' as const,
       properties: {
-        rights_id: {
-          type: 'string',
-          description: 'Rights offering identifier from sandbox_get_rights',
-        },
-        pricing_option_id: {
-          type: 'string',
-          description: 'Selected pricing option from the rights offering',
-        },
+        rights_id: { type: 'string', description: 'Rights offering identifier from get_rights' },
+        pricing_option_id: { type: 'string', description: 'Selected pricing option' },
         buyer: {
           type: 'object',
-          properties: {
-            domain: { type: 'string' },
-            brand_id: { type: 'string' },
-          },
+          properties: { domain: { type: 'string' }, brand_id: { type: 'string' } },
           required: ['domain'],
           description: 'Buyer brand identity',
         },
         campaign: {
           type: 'object',
           properties: {
-            description: { type: 'string', description: 'How the rights will be used' },
-            uses: { type: 'array', items: { type: 'string' }, description: 'Rights uses for this campaign' },
-            countries: { type: 'array', items: { type: 'string' }, description: 'Campaign countries' },
-            estimated_impressions: { type: 'integer', description: 'Estimated total impressions' },
-            start_date: { type: 'string', description: 'Campaign start date (YYYY-MM-DD)' },
-            end_date: { type: 'string', description: 'Campaign end date (YYYY-MM-DD)' },
+            description: { type: 'string' },
+            uses: { type: 'array', items: { type: 'string' } },
+            countries: { type: 'array', items: { type: 'string' } },
+            estimated_impressions: { type: 'integer' },
+            start_date: { type: 'string' },
+            end_date: { type: 'string' },
           },
           required: ['description', 'uses'],
           description: 'Campaign details for rights clearance',
@@ -536,13 +477,13 @@ export const BRAND_SANDBOX_TOOLS: AddieTool[] = [
     },
   },
   {
-    name: 'sandbox_update_rights',
-    description: 'Update an existing rights grant — extend dates, adjust impression caps, or pause/resume. Sandbox version for certification exercises.',
-    usage_hints: 'use during certification brand protocol exercises to demonstrate update_rights, rights lifecycle management',
-    input_schema: {
-      type: 'object',
+    name: 'update_rights',
+    description: 'Update an existing rights grant — extend dates, adjust impression caps, or pause/resume.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: 'object' as const,
       properties: {
-        rights_id: { type: 'string', description: 'Rights grant identifier from sandbox_acquire_rights' },
+        rights_id: { type: 'string', description: 'Rights grant identifier from acquire_rights' },
         end_date: { type: 'string', description: 'New end date (must be >= current end date)' },
         impression_cap: { type: 'number', description: 'New impression cap (must be >= current)' },
         paused: { type: 'boolean', description: 'Pause or resume the grant' },
@@ -552,29 +493,30 @@ export const BRAND_SANDBOX_TOOLS: AddieTool[] = [
   },
 ];
 
-// =====================================================
-// HANDLERS
-// =====================================================
+// ── Handlers ──────────────────────────────────────────────────────
 
-type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
+function getTalentName(talent: TalentEntry): string {
+  return talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id;
+}
 
-function handleGetBrandIdentity(args: Record<string, unknown>): string {
+export function handleGetBrandIdentity(
+  args: Record<string, unknown>,
+  _ctx: TrainingContext,
+): Record<string, unknown> {
   const brandId = args.brand_id as string;
   const fields = args.fields as string[] | undefined;
   const authorized = args.authorized as boolean ?? false;
 
   const talent = TALENT_MAP.get(brandId);
   if (!talent) {
-    return JSON.stringify({
-      errors: [{ code: 'brand_not_found', message: `No brand with id '${brandId}'` }],
-    });
+    return { errors: [{ code: 'brand_not_found', message: `No brand with id '${brandId}'` }] };
   }
 
-  // Core fields always returned
   const response: Record<string, unknown> = {
     brand_id: talent.brand_id,
     house: talent.house,
     names: talent.names,
+    sandbox: true,
   };
 
   const requested = fields ?? [...ALL_FIELDS];
@@ -593,7 +535,6 @@ function handleGetBrandIdentity(args: Record<string, unknown>): string {
           response[field] = value;
         }
       } else {
-        // Only list in available_fields if the talent actually has this data
         const value = (talent as unknown as Record<string, unknown>)[field];
         if (value !== undefined) {
           withheld.push(field);
@@ -606,11 +547,8 @@ function handleGetBrandIdentity(args: Record<string, unknown>): string {
     response.available_fields = withheld;
   }
 
-  return JSON.stringify(response);
+  return response;
 }
-
-// Keywords that indicate meat/steakhouse — used for van Dijk exclusion
-const MEAT_KEYWORDS = ['steakhouse', 'steak', 'meat', 'burger', 'bbq', 'barbecue', 'grill'];
 
 function computeMatchScore(
   talent: TalentEntry,
@@ -618,14 +556,12 @@ function computeMatchScore(
   requestedUses: string[],
   requestedCountries?: string[],
 ): number {
-  let score = 0.2; // base score
+  let score = 0.2;
 
-  // Country overlap
   if (requestedCountries && requestedCountries.length > 0) {
     const overlap = requestedCountries.filter(c => talent.rights.countries.includes(c));
     if (overlap.length > 0) score += 0.3;
   } else {
-    // Check query for country names/codes
     const countryHints: Record<string, string[]> = {
       NL: ['dutch', 'netherlands', 'amsterdam', 'rotterdam', 'nl'],
       MX: ['mexican', 'mexico', 'mx'],
@@ -640,14 +576,12 @@ function computeMatchScore(
     }
   }
 
-  // Use overlap
   const availableUses = talent.rights.available_uses;
   const useOverlap = requestedUses.filter(u => availableUses.includes(u));
   if (requestedUses.length > 0) {
     score += 0.3 * (useOverlap.length / requestedUses.length);
   }
 
-  // Budget fit — check if query mentions a budget and a flat_rate fits
   const budgetMatch = queryLower.match(/(\d+)\s*(eur|usd|€|\$)/);
   if (budgetMatch) {
     const budget = parseInt(budgetMatch[1], 10);
@@ -667,7 +601,6 @@ function buildMatchReasons(
 ): string[] {
   const reasons: string[] = [];
 
-  // Country match
   const countries = talent.rights.countries.join(', ');
   if (queryLower.includes('dutch') || queryLower.includes('netherlands') || queryLower.includes('amsterdam')) {
     if (talent.rights.countries.includes('NL')) {
@@ -681,14 +614,12 @@ function buildMatchReasons(
     reasons.push(`Available in ${countries}`);
   }
 
-  // Use match
   const availableUses = talent.rights.available_uses;
   const matched = requestedUses.filter(u => availableUses.includes(u));
   if (matched.length > 0) {
     reasons.push(`Supports requested uses: ${matched.join(', ')}`);
   }
 
-  // Budget fit
   const budgetMatch = queryLower.match(/(\d+)\s*(eur|usd|€|\$)/);
   if (budgetMatch) {
     const budget = parseInt(budgetMatch[1], 10);
@@ -698,7 +629,6 @@ function buildMatchReasons(
     }
   }
 
-  // Category relevance from query
   if (queryLower.includes('restaurant') || queryLower.includes('food') || queryLower.includes('steakhouse')) {
     reasons.push('Available for food/restaurant brands');
   }
@@ -709,7 +639,10 @@ function buildMatchReasons(
   return reasons;
 }
 
-function handleGetRights(args: Record<string, unknown>): string {
+export function handleGetRights(
+  args: Record<string, unknown>,
+  _ctx: TrainingContext,
+): Record<string, unknown> {
   const query = (args.query as string) || '';
   const uses = (args.uses as string[]) || [];
   const countries = args.countries as string[] | undefined;
@@ -718,27 +651,22 @@ function handleGetRights(args: Record<string, unknown>): string {
 
   const queryLower = query.toLowerCase();
 
-  // Filter talent
   let candidates = brandId ? TALENT.filter(t => t.brand_id === brandId) : [...TALENT];
 
-  // Filter by countries
   if (countries && countries.length > 0) {
     candidates = candidates.filter(t =>
       countries.some(c => t.rights.countries.includes(c))
     );
   }
 
-  // Filter by uses
   candidates = candidates.filter(t =>
     uses.some(u => t.rights.available_uses.includes(u))
   );
 
-  // Separate excluded (lifestyle conflicts based on query keywords)
-  const rights: unknown[] = [];
-  const excluded: unknown[] = [];
+  const rights: Record<string, unknown>[] = [];
+  const excluded: Record<string, unknown>[] = [];
 
   for (const talent of candidates) {
-    // Check if this talent should be excluded based on query keywords
     let excludeRule: { reason: string; suggestions?: string[] } | null = null;
     if (talent.exclusion_reasons) {
       for (const [keyword, rule] of Object.entries(talent.exclusion_reasons)) {
@@ -753,7 +681,7 @@ function handleGetRights(args: Record<string, unknown>): string {
       if (includeExcluded) {
         excluded.push({
           brand_id: talent.brand_id,
-          name: talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id,
+          name: getTalentName(talent),
           reason: excludeRule.reason,
           ...(excludeRule.suggestions ? { suggestions: excludeRule.suggestions } : {}),
         });
@@ -768,7 +696,7 @@ function handleGetRights(args: Record<string, unknown>): string {
       rights.push({
         rights_id: offering.rights_id,
         brand_id: talent.brand_id,
-        name: talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id,
+        name: getTalentName(talent),
         description: talent.description,
         right_type: offering.right_type,
         match_score: Math.round(matchScore * 100) / 100,
@@ -783,18 +711,20 @@ function handleGetRights(args: Record<string, unknown>): string {
     }
   }
 
-  // Sort by match score descending
-  (rights as Array<{ match_score: number }>).sort((a, b) => b.match_score - a.match_score);
+  rights.sort((a, b) => (b.match_score as number) - (a.match_score as number));
 
-  const response: Record<string, unknown> = { rights };
+  const response: Record<string, unknown> = { rights, sandbox: true };
   if (includeExcluded && excluded.length > 0) {
     response.excluded = excluded;
   }
 
-  return JSON.stringify(response);
+  return response;
 }
 
-function handleAcquireRights(args: Record<string, unknown>): string {
+export function handleAcquireRights(
+  args: Record<string, unknown>,
+  _ctx: TrainingContext,
+): Record<string, unknown> {
   const rightsId = args.rights_id as string;
   const pricingOptionId = args.pricing_option_id as string;
   const buyer = args.buyer as { domain: string; brand_id?: string } | undefined;
@@ -808,10 +738,9 @@ function handleAcquireRights(args: Record<string, unknown>): string {
   };
 
   if (!buyer) {
-    return JSON.stringify({ errors: [{ code: 'invalid_request', message: 'buyer is required' }] });
+    return { errors: [{ code: 'invalid_request', message: 'buyer is required' }] };
   }
 
-  // Find the talent and offering
   let talent: TalentEntry | undefined;
   let offering: RightsOffering | undefined;
   for (const t of TALENT) {
@@ -824,57 +753,50 @@ function handleAcquireRights(args: Record<string, unknown>): string {
   }
 
   if (!talent || !offering) {
-    return JSON.stringify({
-      errors: [{ code: 'rights_not_found', message: `No rights offering with id '${rightsId}'` }],
-    });
+    return { errors: [{ code: 'rights_not_found', message: `No rights offering with id '${rightsId}'` }] };
   }
 
-  // Validate pricing option
   const pricingOption = offering.pricing_options.find(p => p.pricing_option_id === pricingOptionId);
   if (!pricingOption) {
-    return JSON.stringify({
-      errors: [{ code: 'invalid_pricing_option', message: `No pricing option '${pricingOptionId}' in offering '${rightsId}'` }],
-    });
+    return { errors: [{ code: 'invalid_pricing_option', message: `No pricing option '${pricingOptionId}' in offering '${rightsId}'` }] };
   }
 
-  // Determine status from campaign description keywords
   const descLower = campaign.description.toLowerCase();
   const behavior = talent.acquire_behavior;
 
-  // Check rejected first
   for (const [keyword, rule] of Object.entries(behavior.rejected)) {
     if (descLower.includes(keyword)) {
       const isStructured = typeof rule === 'object';
-      return JSON.stringify({
+      return {
         rights_id: rightsId,
         status: 'rejected',
         brand_id: talent.brand_id,
         reason: isStructured ? rule.reason : rule,
         ...(isStructured && rule.suggestions ? { suggestions: rule.suggestions } : {}),
-      });
+        sandbox: true,
+      };
     }
   }
 
-  // Check pending_approval
   for (const keyword of behavior.pending_approval) {
     if (descLower.includes(keyword)) {
-      const talentName = talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id;
-      return JSON.stringify({
+      const talentName = getTalentName(talent);
+      return {
         rights_id: rightsId,
         status: 'pending_approval',
         brand_id: talent.brand_id,
         detail: `${talentName}'s management requires review for ${keyword} category campaigns. Request submitted for talent approval.`,
         estimated_response_time: '48h',
-      });
+        sandbox: true,
+      };
     }
   }
 
-  // Default: acquired
-  const talentName = talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id;
+  const talentName = getTalentName(talent);
   const startDate = campaign.start_date || '2026-04-01';
   const endDate = campaign.end_date || '2026-06-30';
 
-  const generationCredentials: unknown[] = [];
+  const generationCredentials: Record<string, unknown>[] = [];
   const campaignUses = campaign.uses || pricingOption.uses;
 
   if (campaignUses.includes('likeness')) {
@@ -895,7 +817,7 @@ function handleAcquireRights(args: Record<string, unknown>): string {
     });
   }
 
-  return JSON.stringify({
+  return {
     rights_id: rightsId,
     status: 'acquired',
     brand_id: talent.brand_id,
@@ -942,16 +864,19 @@ function handleAcquireRights(args: Record<string, unknown>): string {
       },
     },
     usage_reporting_url: `https://sandbox.lotientertainment.com/rights/${rightsId}/usage`,
-  });
+    sandbox: true,
+  };
 }
 
-function handleUpdateRights(args: Record<string, unknown>): string {
+export function handleUpdateRights(
+  args: Record<string, unknown>,
+  _ctx: TrainingContext,
+): Record<string, unknown> {
   const rightsId = args.rights_id as string;
   const endDate = args.end_date as string | undefined;
   const impressionCap = args.impression_cap as number | undefined;
   const paused = args.paused as boolean | undefined;
 
-  // Find the talent and offering by rights_id
   let talent: TalentEntry | undefined;
   let offering: RightsOffering | undefined;
   for (const t of TALENT) {
@@ -964,37 +889,28 @@ function handleUpdateRights(args: Record<string, unknown>): string {
   }
 
   if (!talent || !offering) {
-    return JSON.stringify({
-      errors: [{ code: 'rights_not_found', message: `No active grant with id '${rightsId}'` }],
-    });
+    return { errors: [{ code: 'rights_not_found', message: `No active grant with id '${rightsId}'` }] };
   }
 
-  // Validate end_date (sandbox assumes current end date is 2026-06-30, start is 2026-04-01)
   const currentEndDate = '2026-06-30';
   const currentStartDate = '2026-04-01';
   if (endDate && endDate < currentEndDate) {
-    return JSON.stringify({
-      errors: [{ code: 'invalid_update', message: 'New end_date must be >= current end_date' }],
-    });
+    return { errors: [{ code: 'invalid_update', message: 'New end_date must be >= current end_date' }] };
   }
 
-  // Validate impression_cap (simulate 50000 already delivered)
   const deliveredImpressions = 50000;
   if (impressionCap !== undefined && impressionCap < deliveredImpressions) {
-    return JSON.stringify({
-      errors: [{ code: 'invalid_update', message: `New impression_cap (${impressionCap}) must be >= impressions already delivered (${deliveredImpressions})` }],
-    });
+    return { errors: [{ code: 'invalid_update', message: `New impression_cap (${impressionCap}) must be >= impressions already delivered (${deliveredImpressions})` }] };
   }
 
   const pricingOption = offering.pricing_options[0];
   const effectiveEndDate = endDate || currentEndDate;
   const effectiveImpressionCap = impressionCap ?? pricingOption.impression_cap;
 
-  const talentName = talent.names[0]?.[Object.keys(talent.names[0])[0]] || talent.brand_id;
+  const talentName = getTalentName(talent);
   const campaignUses = pricingOption.uses;
 
-  // Build generation credentials (re-issued with updated expiration)
-  const generationCredentials: unknown[] = [];
+  const generationCredentials: Record<string, unknown>[] = [];
 
   if (campaignUses.includes('likeness')) {
     generationCredentials.push({
@@ -1044,26 +960,12 @@ function handleUpdateRights(args: Record<string, unknown>): string {
       verification_url: `https://sandbox.lotientertainment.com/rights/${rightsId}/verify`,
     },
     implementation_date: new Date().toISOString(),
+    sandbox: true,
   };
 
   if (paused !== undefined) {
     response.paused = paused;
   }
 
-  return JSON.stringify(response);
-}
-
-// =====================================================
-// EXPORTS
-// =====================================================
-
-export function createBrandSandboxToolHandlers(): Map<string, ToolHandler> {
-  const handlers = new Map<string, ToolHandler>();
-
-  handlers.set('sandbox_get_brand_identity', async (args) => handleGetBrandIdentity(args));
-  handlers.set('sandbox_get_rights', async (args) => handleGetRights(args));
-  handlers.set('sandbox_acquire_rights', async (args) => handleAcquireRights(args));
-  handlers.set('sandbox_update_rights', async (args) => handleUpdateRights(args));
-
-  return handlers;
+  return response;
 }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -43,6 +43,13 @@ import {
   handleReportPlanOutcome,
   handleGetPlanAuditLogs,
 } from './governance-handlers.js';
+import {
+  BRAND_TOOLS,
+  handleGetBrandIdentity,
+  handleGetRights,
+  handleAcquireRights,
+  handleUpdateRights,
+} from './brand-handlers.js';
 import { PUBLISHERS } from './publishers.js';
 
 /** Wire-format error shared by all training agent responses. */
@@ -436,6 +443,7 @@ const TOOLS = [
     },
   },
   ...GOVERNANCE_TOOLS,
+  ...BRAND_TOOLS,
   {
     name: 'get_adcp_capabilities',
     description: 'Discover the capabilities of this AdCP agent — supported tasks, features, and protocol version. Call once per session; capabilities are static.',
@@ -1563,6 +1571,10 @@ const HANDLER_MAP: Record<string, ToolHandler> = {
   check_governance: handleCheckGovernance,
   report_plan_outcome: handleReportPlanOutcome,
   get_plan_audit_logs: handleGetPlanAuditLogs,
+  get_brand_identity: handleGetBrandIdentity,
+  get_rights: handleGetRights,
+  acquire_rights: handleAcquireRights,
+  update_rights: handleUpdateRights,
   get_adcp_capabilities: handleGetAdcpCapabilities,
 };
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -702,8 +702,12 @@ describe('createTrainingAgentServer', () => {
     expect(toolNames).toContain('check_governance');
     expect(toolNames).toContain('report_plan_outcome');
     expect(toolNames).toContain('get_plan_audit_logs');
+    expect(toolNames).toContain('get_brand_identity');
+    expect(toolNames).toContain('get_rights');
+    expect(toolNames).toContain('acquire_rights');
+    expect(toolNames).toContain('update_rights');
     expect(toolNames).toContain('get_adcp_capabilities');
-    expect(toolNames).toHaveLength(16);
+    expect(toolNames).toHaveLength(20);
   });
 
   it('returns error for unknown tool', async () => {

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -1,46 +1,48 @@
-import { createBrandSandboxToolHandlers, BRAND_SANDBOX_TOOLS } from '../../server/src/addie/mcp/brand-sandbox-tools.js';
+import { describe, it, expect } from '@jest/globals';
+import {
+  handleGetBrandIdentity,
+  handleGetRights,
+  handleAcquireRights,
+  handleUpdateRights,
+} from '../../server/src/training-agent/brand-handlers.js';
 
-const handlers = createBrandSandboxToolHandlers();
+const ctx = { mode: 'training' as const };
 
-describe('brand sandbox tools', () => {
+type Handler = (args: Record<string, unknown>, ctx: { mode: string }) => Record<string, unknown>;
 
-  describe('tool definitions', () => {
-    it('exports four tools', () => {
-      expect(BRAND_SANDBOX_TOOLS).toHaveLength(4);
-      const names = BRAND_SANDBOX_TOOLS.map(t => t.name);
-      expect(names).toEqual([
-        'sandbox_get_brand_identity',
-        'sandbox_get_rights',
-        'sandbox_acquire_rights',
-        'sandbox_update_rights',
-      ]);
-    });
+const handlers: Record<string, Handler> = {
+  get_brand_identity: handleGetBrandIdentity,
+  get_rights: handleGetRights,
+  acquire_rights: handleAcquireRights,
+  update_rights: handleUpdateRights,
+};
 
-    it('registers four handlers', () => {
-      expect(handlers.size).toBe(4);
-    });
-  });
+function call(tool: string, args: Record<string, unknown>) {
+  return handlers[tool](args, ctx);
+}
 
-  describe('sandbox_get_brand_identity', () => {
-    const handler = handlers.get('sandbox_get_brand_identity')!;
+describe('brand protocol tools (training agent)', () => {
 
-    it('returns core fields for a valid brand', async () => {
-      const result = JSON.parse(await handler({ brand_id: 'daan_janssen' }));
+  describe('get_brand_identity', () => {
+
+    it('returns core fields for a valid brand', () => {
+      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.brand_id).toBe('daan_janssen');
       expect(result.house).toEqual({ domain: 'lotientertainment.com', name: 'Loti Entertainment' });
       expect(result.names).toEqual([{ en: 'Daan Janssen' }]);
+      expect(result.sandbox).toBe(true);
     });
 
-    it('returns public fields without authorization', async () => {
-      const result = JSON.parse(await handler({ brand_id: 'daan_janssen' }));
+    it('returns public fields without authorization', () => {
+      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.description).toBe('Dutch Olympic speed skater, 2x gold medalist');
       expect(result.industry).toBe('sports');
       expect(result.tagline).toBe('Speed is a choice');
       expect(result.logos).toBeDefined();
     });
 
-    it('withholds authorized fields and lists them in available_fields', async () => {
-      const result = JSON.parse(await handler({ brand_id: 'daan_janssen' }));
+    it('withholds authorized fields and lists them in available_fields', () => {
+      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.colors).toBeUndefined();
       expect(result.tone).toBeUndefined();
       expect(result.voice_synthesis).toBeUndefined();
@@ -50,8 +52,8 @@ describe('brand sandbox tools', () => {
       );
     });
 
-    it('returns authorized fields with authorized=true', async () => {
-      const result = JSON.parse(await handler({ brand_id: 'daan_janssen', authorized: true }));
+    it('returns authorized fields with authorized=true', () => {
+      const result = call('get_brand_identity', { brand_id: 'daan_janssen', authorized: true });
       expect(result.colors).toBeDefined();
       expect(result.tone).toBeDefined();
       expect(result.voice_synthesis).toBeDefined();
@@ -59,118 +61,118 @@ describe('brand sandbox tools', () => {
       expect(result.available_fields).toBeUndefined();
     });
 
-    it('returns only requested fields', async () => {
-      const result = JSON.parse(await handler({
+    it('returns only requested fields', () => {
+      const result = call('get_brand_identity', {
         brand_id: 'daan_janssen',
         fields: ['description', 'tagline'],
-      }));
+      });
       expect(result.description).toBeDefined();
       expect(result.tagline).toBeDefined();
       expect(result.industry).toBeUndefined();
       expect(result.logos).toBeUndefined();
     });
 
-    it('returns error for unknown brand', async () => {
-      const result = JSON.parse(await handler({ brand_id: 'nonexistent' }));
+    it('returns error for unknown brand', () => {
+      const result = call('get_brand_identity', { brand_id: 'nonexistent' });
       expect(result.errors).toBeDefined();
-      expect(result.errors[0].code).toBe('brand_not_found');
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('brand_not_found');
     });
 
-    it('omits available_fields when talent lacks the requested authorized field', async () => {
-      const result = JSON.parse(await handler({
+    it('omits available_fields when talent lacks the requested authorized field', () => {
+      const result = call('get_brand_identity', {
         brand_id: 'sofia_reyes',
         fields: ['voice_synthesis'],
-      }));
+      });
       expect(result.voice_synthesis).toBeUndefined();
       expect(result.available_fields).toBeUndefined();
     });
   });
 
-  describe('sandbox_get_rights', () => {
-    const handler = handlers.get('sandbox_get_rights')!;
+  describe('get_rights', () => {
 
-    it('returns Daan Janssen as top match for Amsterdam steakhouse', async () => {
-      const result = JSON.parse(await handler({
+    it('returns Daan Janssen as top match for Amsterdam steakhouse', () => {
+      const result = call('get_rights', {
         query: 'Dutch athlete for restaurant brand in Amsterdam',
         uses: ['likeness'],
-      }));
-      expect(result.rights.length).toBeGreaterThan(0);
-      expect(result.rights[0].brand_id).toBe('daan_janssen');
+      });
+      expect((result.rights as Array<{ brand_id: string }>).length).toBeGreaterThan(0);
+      expect((result.rights as Array<{ brand_id: string }>)[0].brand_id).toBe('daan_janssen');
     });
 
-    it('excludes van Dijk for steakhouse queries', async () => {
-      const result = JSON.parse(await handler({
+    it('excludes van Dijk for steakhouse queries', () => {
+      const result = call('get_rights', {
         query: 'Dutch athlete for steakhouse in Amsterdam',
         uses: ['likeness'],
-      }));
-      const brandIds = result.rights.map((r: { brand_id: string }) => r.brand_id);
+      });
+      const brandIds = (result.rights as Array<{ brand_id: string }>).map(r => r.brand_id);
       expect(brandIds).not.toContain('pieter_van_dijk');
     });
 
-    it('shows exclusion reasons with include_excluded=true and includes suggestions', async () => {
-      const result = JSON.parse(await handler({
+    it('shows exclusion reasons with include_excluded=true and includes suggestions', () => {
+      const result = call('get_rights', {
         query: 'Dutch athlete for steakhouse in Amsterdam',
         uses: ['likeness'],
         include_excluded: true,
-      }));
+      });
       expect(result.excluded).toBeDefined();
-      expect(result.excluded[0].brand_id).toBe('pieter_van_dijk');
-      expect(result.excluded[0].reason).toContain('lifestyle conflict');
-      expect(result.excluded[0].suggestions).toBeDefined();
-      expect(result.excluded[0].suggestions[0]).toContain('plant-based');
+      const excluded = result.excluded as Array<{ brand_id: string; reason: string; suggestions?: string[] }>;
+      expect(excluded[0].brand_id).toBe('pieter_van_dijk');
+      expect(excluded[0].reason).toContain('lifestyle conflict');
+      expect(excluded[0].suggestions).toBeDefined();
+      expect(excluded[0].suggestions![0]).toContain('plant-based');
     });
 
-    it('filters by country', async () => {
-      const result = JSON.parse(await handler({
+    it('filters by country', () => {
+      const result = call('get_rights', {
         query: 'athlete for food brand',
         uses: ['likeness'],
         countries: ['JP'],
-      }));
-      const brandIds = result.rights.map((r: { brand_id: string }) => r.brand_id);
+      });
+      const brandIds = (result.rights as Array<{ brand_id: string }>).map(r => r.brand_id);
       expect(brandIds).toContain('yuki_tanaka');
       expect(brandIds).not.toContain('daan_janssen');
     });
 
-    it('filters by specific brand_id', async () => {
-      const result = JSON.parse(await handler({
+    it('filters by specific brand_id', () => {
+      const result = call('get_rights', {
         query: 'athlete',
         uses: ['likeness'],
         brand_id: 'sofia_reyes',
-      }));
-      expect(result.rights).toHaveLength(1);
-      expect(result.rights[0].brand_id).toBe('sofia_reyes');
+      });
+      expect((result.rights as unknown[]).length).toBe(1);
+      expect((result.rights as Array<{ brand_id: string }>)[0].brand_id).toBe('sofia_reyes');
     });
 
-    it('includes pricing options', async () => {
-      const result = JSON.parse(await handler({
+    it('includes pricing options', () => {
+      const result = call('get_rights', {
         query: 'Dutch athlete for food brand',
         uses: ['likeness'],
-      }));
-      const janssen = result.rights.find((r: { brand_id: string }) => r.brand_id === 'daan_janssen');
-      expect(janssen.pricing_options.length).toBeGreaterThan(0);
-      const cpm = janssen.pricing_options.find((p: { model: string }) => p.model === 'cpm');
-      expect(cpm.price).toBe(3.50);
-      expect(cpm.currency).toBe('EUR');
+      });
+      const janssen = (result.rights as Array<{ brand_id: string; pricing_options: Array<{ model: string; price: number; currency: string }> }>)
+        .find(r => r.brand_id === 'daan_janssen');
+      expect(janssen!.pricing_options.length).toBeGreaterThan(0);
+      const cpm = janssen!.pricing_options.find(p => p.model === 'cpm');
+      expect(cpm!.price).toBe(3.50);
+      expect(cpm!.currency).toBe('EUR');
     });
 
-    it('sorts by match score descending', async () => {
-      const result = JSON.parse(await handler({
+    it('sorts by match score descending', () => {
+      const result = call('get_rights', {
         query: 'Dutch athlete for food brand in Netherlands, budget 400 EUR',
         uses: ['likeness'],
-      }));
-      const scores = result.rights.map((r: { match_score: number }) => r.match_score);
+      });
+      const scores = (result.rights as Array<{ match_score: number }>).map(r => r.match_score);
       for (let i = 1; i < scores.length; i++) {
         expect(scores[i]).toBeLessThanOrEqual(scores[i - 1]);
       }
     });
   });
 
-  describe('sandbox_acquire_rights', () => {
-    const handler = handlers.get('sandbox_acquire_rights')!;
+  describe('acquire_rights', () => {
     const baseBuyer = { domain: 'bistro-oranje.nl', brand_id: 'bistro_oranje' };
 
-    it('auto-approves food category for Daan Janssen', async () => {
-      const result = JSON.parse(await handler({
+    it('auto-approves food category for Daan Janssen', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -179,15 +181,16 @@ describe('brand sandbox tools', () => {
           uses: ['likeness'],
           countries: ['NL'],
         },
-      }));
+      });
       expect(result.status).toBe('acquired');
-      expect(result.generation_credentials.length).toBeGreaterThan(0);
-      expect(result.disclosure.required).toBe(true);
+      expect((result.generation_credentials as unknown[]).length).toBeGreaterThan(0);
+      expect((result.disclosure as { required: boolean }).required).toBe(true);
       expect(result.rights_constraint).toBeDefined();
+      expect(result.sandbox).toBe(true);
     });
 
-    it('returns pending_approval for alcohol campaigns', async () => {
-      const result = JSON.parse(await handler({
+    it('returns pending_approval for alcohol campaigns', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         buyer: { domain: 'brouwerij-test.nl' },
@@ -195,13 +198,13 @@ describe('brand sandbox tools', () => {
           description: 'Craft alcohol brand campaign in Amsterdam',
           uses: ['likeness'],
         },
-      }));
+      });
       expect(result.status).toBe('pending_approval');
       expect(result.estimated_response_time).toBe('48h');
     });
 
-    it('rejects sportswear campaigns for Janssen with actionable suggestions', async () => {
-      const result = JSON.parse(await handler({
+    it('rejects sportswear campaigns for Janssen with actionable suggestions', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         buyer: { domain: 'sportswear-test.com' },
@@ -209,15 +212,15 @@ describe('brand sandbox tools', () => {
           description: 'New sportswear line campaign',
           uses: ['likeness'],
         },
-      }));
+      });
       expect(result.status).toBe('rejected');
       expect(result.reason).toContain('exclusivity');
       expect(result.suggestions).toBeDefined();
-      expect(result.suggestions.length).toBeGreaterThan(0);
+      expect((result.suggestions as string[]).length).toBeGreaterThan(0);
     });
 
-    it('rejects confidential rule violations without suggestions', async () => {
-      const result = JSON.parse(await handler({
+    it('rejects confidential rule violations without suggestions', () => {
+      const result = call('acquire_rights', {
         rights_id: 'vandijk_likeness',
         pricing_option_id: 'cpm_likeness',
         buyer: baseBuyer,
@@ -225,14 +228,14 @@ describe('brand sandbox tools', () => {
           description: 'New meat brand campaign',
           uses: ['likeness'],
         },
-      }));
+      });
       expect(result.status).toBe('rejected');
       expect(result.reason).toBe('This conflicts with our talent lifestyle guidelines');
       expect(result.suggestions).toBeUndefined();
     });
 
-    it('includes voice credentials when voice is requested and talent has voice_synthesis', async () => {
-      const result = JSON.parse(await handler({
+    it('includes voice credentials when voice is requested and talent has voice_synthesis', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -240,15 +243,15 @@ describe('brand sandbox tools', () => {
           description: 'Restaurant food campaign',
           uses: ['likeness', 'voice'],
         },
-      }));
+      });
       expect(result.status).toBe('acquired');
-      const providers = result.generation_credentials.map((c: { provider: string }) => c.provider);
+      const providers = (result.generation_credentials as Array<{ provider: string }>).map(c => c.provider);
       expect(providers).toContain('midjourney');
       expect(providers).toContain('elevenlabs');
     });
 
-    it('generation credentials match schema (uses, not scope)', async () => {
-      const result = JSON.parse(await handler({
+    it('generation credentials match schema (uses, not scope)', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -256,8 +259,8 @@ describe('brand sandbox tools', () => {
           description: 'Restaurant food campaign',
           uses: ['likeness'],
         },
-      }));
-      const cred = result.generation_credentials[0];
+      });
+      const cred = (result.generation_credentials as Array<Record<string, unknown>>)[0];
       expect(cred.uses).toEqual(['likeness']);
       expect(cred.scope).toBeUndefined();
       expect(cred.credential_type).toBeUndefined();
@@ -265,8 +268,8 @@ describe('brand sandbox tools', () => {
       expect(cred.expires_at).toMatch(/T\d{2}:\d{2}:\d{2}Z$/);
     });
 
-    it('approval_webhook uses push-notification-config with authentication', async () => {
-      const result = JSON.parse(await handler({
+    it('approval_webhook uses push-notification-config with authentication', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -274,16 +277,17 @@ describe('brand sandbox tools', () => {
           description: 'Restaurant food campaign',
           uses: ['likeness'],
         },
-      }));
-      expect(result.approval_webhook).toBeDefined();
-      expect(result.approval_webhook.url).toMatch(/^https:\/\//);
-      expect(result.approval_webhook.authentication).toBeDefined();
-      expect(result.approval_webhook.authentication.schemes).toEqual(['Bearer']);
-      expect(result.approval_webhook.authentication.credentials.length).toBeGreaterThanOrEqual(32);
+      });
+      const webhook = result.approval_webhook as { url: string; authentication: { schemes: string[]; credentials: string } };
+      expect(webhook).toBeDefined();
+      expect(webhook.url).toMatch(/^https:\/\//);
+      expect(webhook.authentication).toBeDefined();
+      expect(webhook.authentication.schemes).toEqual(['Bearer']);
+      expect(webhook.authentication.credentials.length).toBeGreaterThanOrEqual(32);
     });
 
-    it('rights_constraint includes verification_url', async () => {
-      const result = JSON.parse(await handler({
+    it('rights_constraint includes verification_url', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -291,13 +295,14 @@ describe('brand sandbox tools', () => {
           description: 'Restaurant food campaign',
           uses: ['likeness'],
         },
-      }));
-      expect(result.rights_constraint.verification_url).toMatch(/^https:\/\//);
-      expect(result.rights_constraint.verification_url).toContain('/verify');
+      });
+      const constraint = result.rights_constraint as { verification_url: string };
+      expect(constraint.verification_url).toMatch(/^https:\/\//);
+      expect(constraint.verification_url).toContain('/verify');
     });
 
-    it('rights_constraint uses date-time format', async () => {
-      const result = JSON.parse(await handler({
+    it('rights_constraint uses date-time format', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -307,42 +312,43 @@ describe('brand sandbox tools', () => {
           start_date: '2026-04-01',
           end_date: '2026-06-30',
         },
-      }));
-      expect(result.rights_constraint.valid_from).toBe('2026-04-01T00:00:00Z');
-      expect(result.rights_constraint.valid_until).toBe('2026-06-30T23:59:59Z');
+      });
+      const constraint = result.rights_constraint as { valid_from: string; valid_until: string };
+      expect(constraint.valid_from).toBe('2026-04-01T00:00:00Z');
+      expect(constraint.valid_until).toBe('2026-06-30T23:59:59Z');
     });
 
-    it('returns error for unknown rights_id', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error for unknown rights_id', () => {
+      const result = call('acquire_rights', {
         rights_id: 'nonexistent',
         pricing_option_id: 'cpm_endorsement',
         buyer: baseBuyer,
         campaign: { description: 'test', uses: ['likeness'] },
-      }));
-      expect(result.errors[0].code).toBe('rights_not_found');
+      });
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('rights_not_found');
     });
 
-    it('returns error for invalid pricing option', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error for invalid pricing option', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'nonexistent',
         buyer: baseBuyer,
         campaign: { description: 'test', uses: ['likeness'] },
-      }));
-      expect(result.errors[0].code).toBe('invalid_pricing_option');
+      });
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_pricing_option');
     });
 
-    it('returns error when buyer is missing', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error when buyer is missing', () => {
+      const result = call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         campaign: { description: 'test', uses: ['likeness'] },
-      }));
-      expect(result.errors[0].code).toBe('invalid_request');
+      });
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_request');
     });
 
-    it('rejects cosmetics for Yuki Tanaka', async () => {
-      const result = JSON.parse(await handler({
+    it('rejects cosmetics for Yuki Tanaka', () => {
+      const result = call('acquire_rights', {
         rights_id: 'tanaka_likeness_voice',
         pricing_option_id: 'cpm_voice',
         buyer: { domain: 'beauty-test.jp' },
@@ -350,98 +356,98 @@ describe('brand sandbox tools', () => {
           description: 'Premium cosmetics brand campaign',
           uses: ['voice'],
         },
-      }));
+      });
       expect(result.status).toBe('rejected');
       expect(result.reason).toContain('cosmetics');
     });
   });
 
-  describe('sandbox_update_rights', () => {
-    const handler = handlers.get('sandbox_update_rights')!;
+  describe('update_rights', () => {
 
-    it('returns updated terms with extended end_date', async () => {
-      const result = JSON.parse(await handler({
+    it('returns updated terms with extended end_date', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
-      }));
+      });
       expect(result.rights_id).toBe('janssen_likeness_voice');
-      expect(result.terms.end_date).toBe('2026-09-30');
+      expect((result.terms as { end_date: string }).end_date).toBe('2026-09-30');
     });
 
-    it('returns updated impression cap', async () => {
-      const result = JSON.parse(await handler({
+    it('returns updated impression cap', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         impression_cap: 200000,
-      }));
-      expect(result.terms.impression_cap).toBe(200000);
-      expect(result.rights_constraint.impression_cap).toBe(200000);
+      });
+      expect((result.terms as { impression_cap: number }).impression_cap).toBe(200000);
+      expect((result.rights_constraint as { impression_cap: number }).impression_cap).toBe(200000);
     });
 
-    it('returns re-issued generation credentials', async () => {
-      const result = JSON.parse(await handler({
+    it('returns re-issued generation credentials', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
-      }));
-      expect(result.generation_credentials.length).toBeGreaterThan(0);
-      const cred = result.generation_credentials[0];
-      expect(cred.expires_at).toBe('2026-09-30T23:59:59Z');
-      expect(cred.rights_key).toMatch(/^rk_mj_sandbox_/);
+      });
+      const creds = result.generation_credentials as Array<{ expires_at: string; rights_key: string }>;
+      expect(creds.length).toBeGreaterThan(0);
+      expect(creds[0].expires_at).toBe('2026-09-30T23:59:59Z');
+      expect(creds[0].rights_key).toMatch(/^rk_mj_sandbox_/);
     });
 
-    it('returns updated rights_constraint', async () => {
-      const result = JSON.parse(await handler({
+    it('returns updated rights_constraint', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
         impression_cap: 200000,
-      }));
-      expect(result.rights_constraint.valid_until).toBe('2026-09-30T23:59:59Z');
-      expect(result.rights_constraint.impression_cap).toBe(200000);
-      expect(result.rights_constraint.rights_id).toBe('janssen_likeness_voice');
+      });
+      const constraint = result.rights_constraint as { valid_until: string; impression_cap: number; rights_id: string };
+      expect(constraint.valid_until).toBe('2026-09-30T23:59:59Z');
+      expect(constraint.impression_cap).toBe(200000);
+      expect(constraint.rights_id).toBe('janssen_likeness_voice');
     });
 
-    it('returns paused state', async () => {
-      const result = JSON.parse(await handler({
+    it('returns paused state', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         paused: true,
-      }));
+      });
       expect(result.paused).toBe(true);
     });
 
-    it('omits paused when not provided', async () => {
-      const result = JSON.parse(await handler({
+    it('omits paused when not provided', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
-      }));
+      });
       expect(result.paused).toBeUndefined();
     });
 
-    it('returns error for unknown rights_id', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error for unknown rights_id', () => {
+      const result = call('update_rights', {
         rights_id: 'nonexistent',
-      }));
+      });
       expect(result.errors).toBeDefined();
-      expect(result.errors[0].code).toBe('rights_not_found');
-      expect(result.errors[0].message).toContain('nonexistent');
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('rights_not_found');
+      expect((result.errors as Array<{ message: string }>)[0].message).toContain('nonexistent');
     });
 
-    it('returns error for impression_cap below delivered', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error for impression_cap below delivered', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         impression_cap: 10000,
-      }));
+      });
       expect(result.errors).toBeDefined();
-      expect(result.errors[0].code).toBe('invalid_update');
-      expect(result.errors[0].message).toContain('10000');
-      expect(result.errors[0].message).toContain('50000');
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_update');
+      expect((result.errors as Array<{ message: string }>)[0].message).toContain('10000');
+      expect((result.errors as Array<{ message: string }>)[0].message).toContain('50000');
     });
 
-    it('returns error for end_date before current', async () => {
-      const result = JSON.parse(await handler({
+    it('returns error for end_date before current', () => {
+      const result = call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2025-01-01',
-      }));
+      });
       expect(result.errors).toBeDefined();
-      expect(result.errors[0].code).toBe('invalid_update');
-      expect(result.errors[0].message).toContain('end_date');
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_update');
+      expect((result.errors as Array<{ message: string }>)[0].message).toContain('end_date');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Brand sandbox tools (`sandbox_get_brand_identity`, `sandbox_get_rights`, `sandbox_acquire_rights`, `sandbox_update_rights`) were custom Addie tools with a bespoke interface that didn't match the AdCP protocol surface
- Refactors them into standard AdCP tools (`get_brand_identity`, `get_rights`, `acquire_rights`, `update_rights`) that route through the training agent via `agent_url`, matching the pattern used by media buy, creative, signals, and governance tools
- Learners now use the same tools they'll use in production, just pointed at a sandbox agent — one tool surface, two backends

## Changes
- **New:** `server/src/training-agent/brand-handlers.ts` — seed data + handlers (ported from deleted file)
- **New:** `server/src/db/migrations/313_c2_brand_tools_rename.sql` — renames tool refs in C2 exercises
- **Modified:** `adcp-tools.ts` — adds `ADCP_BRAND_PROTOCOL_TOOLS` with `agent_url` routing
- **Modified:** `task-handlers.ts` — wires brand handlers into training agent dispatch
- **Modified:** `tool-sets.ts` — updates certification + adcp_operations sets
- **Deleted:** `brand-sandbox-tools.ts` + all references in bolt-app.ts, register-baseline-tools.ts
- **Bonus:** fixes in-process shortcut hostname check (security review finding)

## Test plan
- [x] 36 brand handler tests pass (Jest)
- [x] 179 training agent unit tests pass (vitest)
- [x] Full suite: 499 tests pass
- [x] Typecheck clean
- [x] Code review: all Must Fix and Should Fix items addressed
- [x] Security review: all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)