### PR TITLE
Add buyer and seller specific contexts to media-buy

### DIFF
--- a/.changeset/new-plants-grow.md
+++ b/.changeset/new-plants-grow.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(schemas): add buyer_context and seller_context to media-buy tasks while retaining legacy context for minor-version compatibility.

--- a/static/schemas/source/core/context.json
+++ b/static/schemas/source/core/context.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/context.json",
   "title": "Context Object",
-  "description": "Opaque correlation data that is echoed unchanged in responses. Used for internal tracking, UI session IDs, trace IDs, and other caller-specific identifiers that don't affect protocol behavior. Context data is never parsed by AdCP agents - it's simply preserved and returned.",
+  "description": "Opaque correlation data echoed unchanged in responses, used to maintain context for both buyers and sellers—for example internal tracking, UI session IDs, trace IDs, and other party-specific identifiers that do not affect protocol behavior. Context data is never parsed by AdCP agents; it is simply preserved and returned.",
   "type": "object",
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/build-creative-async-response-input-required.json
+++ b/static/schemas/source/media-buy/build-creative-async-response-input-required.json
@@ -21,6 +21,12 @@
         "$ref": "/schemas/core/error.json"
       }
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/build-creative-async-response-submitted.json
+++ b/static/schemas/source/media-buy/build-creative-async-response-submitted.json
@@ -5,6 +5,12 @@
   "description": "Payload acknowledging the build_creative task is queued.",
   "type": "object",
   "properties": {
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/build-creative-async-response-working.json
+++ b/static/schemas/source/media-buy/build-creative-async-response-working.json
@@ -25,6 +25,12 @@
       "minimum": 1,
       "description": "Current step number"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/build-creative-request.json
+++ b/static/schemas/source/media-buy/build-creative-request.json
@@ -103,6 +103,12 @@
         "type": "string"
       }
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -110,5 +116,15 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "oneOf": [
+    {
+      "required": ["target_format_id"],
+      "properties": { "target_format_ids": false }
+    },
+    {
+      "required": ["target_format_ids"],
+      "properties": { "target_format_id": false }
+    }
+  ],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/build-creative-response.json
+++ b/static/schemas/source/media-buy/build-creative-response.json
@@ -99,6 +99,12 @@
           "$ref": "/schemas/core/error.json",
           "description": "When include_preview was true in the request but preview generation failed. Uses the standard error structure with code, message, and recovery classification. Distinguishes 'agent does not support inline preview' (preview and preview_error both absent) from 'preview generation failed' (preview absent, preview_error present). Omitted when preview succeeded or was not requested."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -214,6 +220,12 @@
           "$ref": "/schemas/core/error.json",
           "description": "When include_preview was true in the request but preview generation failed. Uses the standard error structure with code, message, and recovery classification. Omitted when preview succeeded or was not requested."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -238,6 +250,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/create-media-buy-async-response-input-required.json
+++ b/static/schemas/source/media-buy/create-media-buy-async-response-input-required.json
@@ -20,6 +20,12 @@
         "$ref": "/schemas/core/error.json"
       }
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/create-media-buy-async-response-submitted.json
+++ b/static/schemas/source/media-buy/create-media-buy-async-response-submitted.json
@@ -5,6 +5,12 @@
   "description": "Payload acknowledging the task is queued. Usually empty or just context.",
   "type": "object",
   "properties": {
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/create-media-buy-async-response-working.json
+++ b/static/schemas/source/media-buy/create-media-buy-async-response-working.json
@@ -25,6 +25,12 @@
       "minimum": 1,
       "description": "Current step number"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -147,6 +147,12 @@
       ],
       "additionalProperties": true
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -46,6 +46,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -77,6 +83,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/get-media-buy-delivery-request.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-request.json
@@ -181,6 +181,12 @@
       },
       "additionalProperties": true
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -644,6 +644,12 @@
       "type": "boolean",
       "description": "When true, this response contains simulated data from sandbox mode."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-media-buys-request.json
+++ b/static/schemas/source/media-buy/get-media-buys-request.json
@@ -49,6 +49,12 @@
       "$ref": "/schemas/core/pagination-request.json",
       "description": "Cursor-based pagination controls. Strongly recommended when querying broad scopes (for example, all active media buys in an account)."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -263,6 +263,12 @@
       "type": "boolean",
       "description": "When true, this response contains simulated data from sandbox mode."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-products-async-response-input-required.json
+++ b/static/schemas/source/media-buy/get-products-async-response-input-required.json
@@ -27,6 +27,12 @@
         "type": "string"
       }
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-products-async-response-submitted.json
+++ b/static/schemas/source/media-buy/get-products-async-response-submitted.json
@@ -10,6 +10,12 @@
       "format": "date-time",
       "description": "Estimated completion time for the search"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-products-async-response-working.json
+++ b/static/schemas/source/media-buy/get-products-async-response-working.json
@@ -23,6 +23,12 @@
       "type": "integer",
       "description": "Current step number (1-indexed)"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/get-products-request.json
+++ b/static/schemas/source/media-buy/get-products-request.json
@@ -170,6 +170,12 @@
     "pagination": {
       "$ref": "/schemas/core/pagination-request.json"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -183,6 +189,44 @@
     }
   },
   "required": ["buying_mode"],
+  "oneOf": [
+    {
+      "properties": {
+        "buying_mode": {
+          "const": "brief"
+        },
+        "refine": false
+      },
+      "required": [
+        "buying_mode",
+        "brief"
+      ]
+    },
+    {
+      "properties": {
+        "buying_mode": {
+          "const": "wholesale"
+        },
+        "brief": false,
+        "refine": false
+      },
+      "required": [
+        "buying_mode"
+      ]
+    },
+    {
+      "properties": {
+        "buying_mode": {
+          "const": "refine"
+        },
+        "brief": false
+      },
+      "required": [
+        "buying_mode",
+        "refine"
+      ]
+    }
+  ],
   "dependencies": {
     "catalog": ["brand"]
   },

--- a/static/schemas/source/media-buy/get-products-response.json
+++ b/static/schemas/source/media-buy/get-products-response.json
@@ -95,6 +95,12 @@
       "type": "boolean",
       "description": "When true, this response contains simulated data from sandbox mode."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/list-creative-formats-request.json
+++ b/static/schemas/source/media-buy/list-creative-formats-request.json
@@ -90,6 +90,12 @@
     "pagination": {
       "$ref": "/schemas/core/pagination-request.json"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/list-creative-formats-response.json
+++ b/static/schemas/source/media-buy/list-creative-formats-response.json
@@ -54,6 +54,12 @@
       "type": "boolean",
       "description": "When true, this response contains simulated data from sandbox mode."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/log-event-request.json
+++ b/static/schemas/source/media-buy/log-event-request.json
@@ -22,6 +22,12 @@
       "minItems": 1,
       "maxItems": 10000
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/log-event-response.json
+++ b/static/schemas/source/media-buy/log-event-response.json
@@ -60,6 +60,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -85,6 +91,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/provide-performance-feedback-request.json
+++ b/static/schemas/source/media-buy/provide-performance-feedback-request.json
@@ -44,6 +44,12 @@
       "description": "Source of the performance data",
       "default": "buyer_attribution"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/provide-performance-feedback-response.json
+++ b/static/schemas/source/media-buy/provide-performance-feedback-response.json
@@ -19,6 +19,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -48,6 +54,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/sync-audiences-request.json
+++ b/static/schemas/source/media-buy/sync-audiences-request.json
@@ -76,6 +76,12 @@
       "default": false,
       "description": "When true, buyer-managed audiences on the account not included in this sync will be removed. Does not affect seller-managed audiences. Do not combine with an omitted audiences array or all buyer-managed audiences will be deleted."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-audiences-response.json
+++ b/static/schemas/source/media-buy/sync-audiences-response.json
@@ -79,6 +79,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -104,6 +110,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/sync-catalogs-async-response-input-required.json
+++ b/static/schemas/source/media-buy/sync-catalogs-async-response-input-required.json
@@ -15,6 +15,12 @@
       ],
       "description": "Reason code indicating why buyer input is needed. APPROVAL_REQUIRED: platform requires explicit approval before activating the catalog. FEED_VALIDATION: feed URL returned unexpected format or schema errors. ITEM_REVIEW: platform flagged items for manual review. FEED_ACCESS: platform cannot access the feed URL (authentication, CORS, etc.)."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-catalogs-async-response-submitted.json
+++ b/static/schemas/source/media-buy/sync-catalogs-async-response-submitted.json
@@ -5,6 +5,12 @@
   "description": "Payload acknowledging sync_catalogs task is queued for processing.",
   "type": "object",
   "properties": {
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-catalogs-async-response-working.json
+++ b/static/schemas/source/media-buy/sync-catalogs-async-response-working.json
@@ -45,6 +45,12 @@
       "minimum": 0,
       "description": "Total number of catalog items to process across all catalogs"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-catalogs-request.json
+++ b/static/schemas/source/media-buy/sync-catalogs-request.json
@@ -46,6 +46,12 @@
       "$ref": "/schemas/core/push-notification-config.json",
       "description": "Optional webhook configuration for async sync notifications. Publisher will send webhook when sync completes if operation takes longer than immediate response time (common for large feeds requiring platform review)."
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-catalogs-response.json
+++ b/static/schemas/source/media-buy/sync-catalogs-response.json
@@ -121,6 +121,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -150,6 +156,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/sync-event-sources-request.json
+++ b/static/schemas/source/media-buy/sync-event-sources-request.json
@@ -52,6 +52,12 @@
       "default": false,
       "description": "When true, event sources not included in this sync will be removed"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/sync-event-sources-response.json
+++ b/static/schemas/source/media-buy/sync-event-sources-response.json
@@ -85,6 +85,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -110,6 +116,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/media-buy/update-media-buy-async-response-input-required.json
+++ b/static/schemas/source/media-buy/update-media-buy-async-response-input-required.json
@@ -13,6 +13,12 @@
       ],
       "description": "Reason code indicating why input is needed"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/update-media-buy-async-response-submitted.json
+++ b/static/schemas/source/media-buy/update-media-buy-async-response-submitted.json
@@ -5,6 +5,12 @@
   "description": "Payload acknowledging update_media_buy task is queued for processing.",
   "type": "object",
   "properties": {
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/update-media-buy-async-response-working.json
+++ b/static/schemas/source/media-buy/update-media-buy-async-response-working.json
@@ -25,6 +25,12 @@
       "minimum": 1,
       "description": "Current step number"
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -47,6 +47,12 @@
       "minLength": 8,
       "maxLength": 255
     },
+    "buyer_context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "seller_context": {
+      "$ref": "/schemas/core/context.json"
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -37,6 +37,12 @@
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
         },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
+        },
         "context": {
           "$ref": "/schemas/core/context.json"
         },
@@ -67,6 +73,12 @@
             "$ref": "/schemas/core/error.json"
           },
           "minItems": 1
+        },
+        "buyer_context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "seller_context": {
+          "$ref": "/schemas/core/context.json"
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/tests/addie/adcp-tool-schema-drift.test.ts
+++ b/tests/addie/adcp-tool-schema-drift.test.ts
@@ -36,7 +36,7 @@ const TOOL_SCHEMA_MAP: Record<string, string> = {
 };
 
 /** Protocol metadata fields — not useful for LLM tool schemas */
-const PROTOCOL_ONLY = new Set(['ext', 'context']);
+const PROTOCOL_ONLY = new Set(['ext', 'context', 'buyer_context', 'seller_context']);
 
 /** Addie-specific routing fields — not in protocol schemas */
 const ADDIE_ONLY = new Set(['agent_url', 'debug']);


### PR DESCRIPTION
This maintains existing contexts for backwards compatibility, but this allows the seller agent to also maintain it's own context.

The generic context should be depricated and removed in future releases.