### PR TITLE
fix: Addie can access working group documents in Slack

### DIFF
--- a/.changeset/fix-addie-wg-doc-access.md
+++ b/.changeset/fix-addie-wg-doc-access.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: Addie can now access working group documents when asked in Slack

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -27,7 +27,7 @@ import { ROUTING_RULES } from './router.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.03.5';
+export const CODE_VERSION = '2026.03.6';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -169,7 +169,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
         },
         category: {
           type: 'string',
-          description: 'Optional category filter (media-buy, signals, creative, intro, reference)',
+          description: 'Optional category filter. Protocol docs: media-buy, signals, creative, intro, reference. Working group docs: "working group: <name>" (e.g., "working group: marketing").',
         },
         limit: {
           type: 'number',

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -346,6 +346,7 @@ IMPORTANT: Select tool SETS based on the user's INTENT:
 - Testing/validating AdCP agent implementations → ["agent_testing"]
 - Actually executing AdCP operations (media buys, creatives, signals) → ["adcp_operations"]
 - Content workflows, GitHub issues, proposals → ["content"]
+- Questions about working group documents, brand guidelines, uploaded files → ["knowledge", "member"]
 - Billing, invoices, payment links, resending invoices → ["billing"]
 - Scheduling meetings, events, calendar, RSVPs, covering topics, joining a call, meeting agendas → ["meetings"]
 - Escalations, pending requests, user role changes, merging orgs → ["admin"]

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -74,7 +74,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   member: {
     name: 'member',
-    description: 'Manage member profile, working groups, committees, content proposals, and account settings',
+    description: 'Manage member profile, working groups, committees, content proposals, and account settings. Includes listing working group documents.',
     tools: [
       'get_my_profile',
       'update_my_profile',
@@ -92,6 +92,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'bookmark_resource',
       'set_outreach_preference',
       'draft_social_posts',
+      'list_committee_documents',
     ],
   },
 
@@ -195,7 +196,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   content: {
     name: 'content',
-    description: 'Manage content workflows - draft GitHub issues, propose news sources, handle content approvals, manage committee documents',
+    description: 'Manage content workflows - draft GitHub issues, propose news sources, handle content approvals, add or update committee documents (admin actions)',
     tools: [
       'draft_github_issue',
       'propose_news_source',
@@ -203,7 +204,6 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'approve_content',
       'reject_content',
       'add_committee_document',
-      'list_committee_documents',
       'update_committee_document',
       'delete_committee_document',
     ],

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -20,6 +20,7 @@ import { notifyUser } from "../notifications/notification-service.js";
 import { decodeHtmlEntities } from "../utils/html-entities.js";
 import { validateFetchUrl, validateRedirectTarget, sanitizeUrl } from "../utils/url-security.js";
 import { reindexDocument } from "../addie/jobs/committee-document-indexer.js";
+import { refreshWorkingGroupDocs } from "../addie/mcp/docs-indexer.js";
 import { createChannel, setChannelPurpose, sendChannelMessage, inviteToChannel, isSlackConfigured } from "../slack/client.js";
 import { SlackDatabase } from "../db/slack-db.js";
 import { CommunityDatabase } from "../db/community-db.js";
@@ -1815,6 +1816,11 @@ export function createCommitteeRouters(): {
       }
 
       res.status(201).json({ document });
+
+      // Index immediately so Addie can reference the document right away
+      reindexDocument(document.id)
+        .then(() => refreshWorkingGroupDocs())
+        .catch(err => logger.warn({ err, documentId: document.id }, 'Background indexing after document creation failed'));
     } catch (error) {
       logger.error({ err: error }, 'Create committee document error');
       res.status(500).json({
@@ -1921,6 +1927,11 @@ export function createCommitteeRouters(): {
       }
 
       res.status(201).json({ document });
+
+      // Index immediately so Addie can reference the document right away
+      reindexDocument(document.id)
+        .then(() => refreshWorkingGroupDocs())
+        .catch(err => logger.warn({ err, documentId: document.id }, 'Background indexing after file upload failed'));
     } catch (error) {
       logger.error({ err: error }, 'Upload committee document error');
       res.status(500).json({
@@ -2013,6 +2024,10 @@ export function createCommitteeRouters(): {
       });
 
       res.json({ document });
+
+      // Refresh in-memory search index so Addie sees updated metadata
+      refreshWorkingGroupDocs()
+        .catch(err => logger.warn({ err, documentId }, 'Background refresh after document update failed'));
     } catch (error) {
       logger.error({ err: error }, 'Update committee document error');
       res.status(500).json({
@@ -2067,6 +2082,9 @@ export function createCommitteeRouters(): {
         });
       }
 
+      // Refresh in-memory search index so Addie sees updated content
+      await refreshWorkingGroupDocs();
+
       // Fetch the updated document
       const updatedDoc = await workingGroupDb.getDocumentById(documentId);
 
@@ -2117,6 +2135,10 @@ export function createCommitteeRouters(): {
       logger.info({ documentId, groupSlug: slug }, 'Committee document deleted');
 
       res.json({ success: true });
+
+      // Remove from in-memory search index
+      refreshWorkingGroupDocs()
+        .catch(err => logger.warn({ err, documentId }, 'Background refresh after document delete failed'));
     } catch (error) {
       logger.error({ err: error }, 'Delete committee document error');
       res.status(500).json({


### PR DESCRIPTION
## Summary
- Moved `list_committee_documents` from the `content` tool set to `member` so it's available when members ask about WG docs
- Added explicit router guideline: WG document questions route to `["knowledge", "member"]`
- Trigger immediate indexing + in-memory refresh after document creation, upload, update, and delete (was waiting up to 60min for the periodic job)
- Updated `search_docs` category filter to document WG doc category format
- Bumped CODE_VERSION to 2026.03.6

## Context
Escalation #130 from Pia Malovrh (Celtra): Addie told her "I don't have access to working group documents or the member dashboard right now — those tools aren't available in this conversation."

Root cause: The Haiku router classified WG document questions as "knowledge" or "member" but `list_committee_documents` lived in the `content` tool set. The unavailable-sets hint told Addie "content: manage committee documents" wasn't available, so she refused. Meanwhile `search_docs` (in `knowledge`) already indexes WG document content — she just didn't know to use it.

## Test plan
- [x] Reproduced locally: sent 4 WG document queries through the router, 3/4 failed pre-fix
- [x] All 4 pass post-fix (router selects knowledge+member, both search_docs and list_committee_documents available)
- [x] TypeScript compiles clean
- [x] All existing tests pass (precommit hook)
- [ ] Deploy and verify Pia can ask Addie about marketing WG branding docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)