### PR TITLE
feat: streaming/audio delivery metrics and reach_unit

### DIFF
--- a/.changeset/streaming-delivery-metrics.md
+++ b/.changeset/streaming-delivery-metrics.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": minor
+---
+
+Add native streaming/audio metrics to delivery schema.
+
+- Broadens `views` description to cover audio/podcast stream starts
+- Renames `video_completions` to `completed_views` in aggregated_totals
+- Adds `views`, `completion_rate`, `reach`, `reach_unit`, `frequency` to aggregated_totals
+- Adds `reach_unit` field to `delivery-metrics.json` referencing existing `reach-unit.json` enum with `dependencies` co-occurrence constraint (reach requires reach_unit)
+- Aggregated reach/frequency omitted when media buys have heterogeneous reach units
+- Updates `frequency` description from "per individual" to "per reach unit"
+- Training agent: channel-specific completion rates (podcast 87%, streaming audio 72%, CTV 82%), `views` at package level, audio/video metrics rolled up into totals, `reach_unit` emission (accounts for streaming, devices for CTV/OLV)

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -46,7 +46,7 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 | `reporting_period` | Date range for report (start/end timestamps) |
 | `currency` | ISO 4217 currency code (USD, EUR, GBP, etc.) |
 | `attribution_window` | Attribution methodology: `post_click` and `post_view` (duration objects), and `model` (last_touch, first_touch, linear, time_decay, data_driven) |
-| `aggregated_totals` | Combined metrics across all media buys (impressions, spend, clicks, video_completions, conversions, conversion_value, roas, new_to_brand_rate, cost_per_acquisition, media_buy_count) |
+| `aggregated_totals` | Combined metrics across all media buys (impressions, spend, clicks, views, completed_views, conversions, conversion_value, roas, new_to_brand_rate, cost_per_acquisition, completion_rate, reach, reach_unit, frequency, media_buy_count) |
 | `media_buy_deliveries` | Array of delivery data per media buy |
 
 ### Media Buy Delivery Object
@@ -487,13 +487,18 @@ asyncio.run(main())
 | **Spend** | Amount spent in specified currency |
 | **Clicks** | Number of ad clicks (if available) |
 | **CTR** | Click-through rate (clicks/impressions) |
-| **Video Completions** | Videos watched to completion |
-| **Completion Rate** | Video completions/video impressions |
-| **Conversions** | Attributed conversions/orders |
+| **Views** | Content engagements at the billable view threshold — video views, audio/podcast stream starts, or format-specific view events |
+| **Completed Views** | Audio/video completions (at threshold or 100%) |
+| **Completion Rate** | Completion rate (completed_views/impressions) |
+| **Conversions** | Attributed conversions (purchases, new listeners, app installs, etc.) |
 | **Conversion Value** | Total monetary value of attributed conversions |
 | **ROAS** | Return on ad spend (conversion_value / spend) |
 | **New-to-Brand Rate** | Fraction of conversions from first-time brand buyers (0-1) |
 | **Cost per Acquisition** | Cost per conversion (spend / conversions) |
+| **Reach** | Unique users reached (see `reach_unit` for measurement unit: individuals, households, devices, accounts, cookies) |
+| **Reach Unit** | Unit of measurement for reach — required when reach is present |
+| **Frequency** | Average ad exposures per reach unit |
+| **Follows** | New followers, subscribes, or page likes attributed to delivery |
 | **Pacing Index** | Actual vs. expected delivery rate (1.0 = on track, &lt;1.0 = behind, &gt;1.0 = ahead) |
 | **CPM** | Cost per thousand impressions (spend/impressions * 1000) |
 
@@ -522,8 +527,10 @@ asyncio.run(main())
 
 ### Metric Availability
 - **Universal**: Impressions, spend (available on all platforms)
-- **Format-dependent**: Clicks, video completions (depends on inventory type and platform capabilities)
-- **Commerce attribution**: Conversions, conversion_value, roas, new_to_brand_rate (available on commerce media platforms)
+- **Format-dependent**: Clicks, completed_views, completion_rate (depends on inventory type and platform capabilities)
+- **Audience**: Reach, frequency (available on platforms with deduplicated measurement)
+- **Commerce attribution**: Conversions, conversion_value, roas, new_to_brand_rate (available on commerce media and streaming platforms)
+- **Engagement**: Follows, saves, engagements, profile_visits (available on social and streaming platforms)
 - **Attribution window**: `attribution_window` describes the lookback windows and model used for conversion attribution (e.g., 14-day click, 1-day view, last_touch)
 - **Package-level**: All metrics broken down by package with pacing_index
 

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1063,6 +1063,10 @@ function handleGetMediaBuyDelivery(args: Record<string, unknown>, ctx: TrainingC
   let totalImpressions = 0;
   let totalSpend = 0;
   let totalClicks = 0;
+  let totalCompletedViews = 0;
+  let totalViews = 0;
+  let totalReach = 0;
+  let totalReachUnit: string | undefined;
 
   const byPackage = mb.packages.map(pkg => {
     // Paused or canceled packages stop accruing delivery
@@ -1106,11 +1110,48 @@ function handleGetMediaBuyDelivery(args: Record<string, unknown>, ctx: TrainingC
     totalSpend += spend;
     totalClicks += clicks;
 
+    // Audio/video metrics — completion rates vary by channel
+    // Accumulators for totals rollup are updated after audioMetrics is built
+    const isAudioVideo = channels?.some(c =>
+      ['streaming_audio', 'podcast', 'radio', 'ctv', 'linear_tv', 'olv'].includes(c),
+    );
+    let completionRate = 0.65;
+    if (channels?.some(c => ['podcast'].includes(c))) completionRate = 0.87;
+    else if (channels?.some(c => ['streaming_audio', 'radio'].includes(c))) completionRate = 0.72;
+    else if (channels?.some(c => ['ctv', 'linear_tv'].includes(c))) completionRate = 0.82;
+
+    const reachUnit = channels?.some(c => ['streaming_audio', 'podcast'].includes(c)) ? 'accounts' as const : 'devices' as const;
+    const audioMetrics = isAudioVideo && impressions > 0
+      ? {
+        views: Math.round(impressions * 0.9),
+        completed_views: Math.round(impressions * completionRate),
+        completion_rate: completionRate,
+        reach: Math.round(impressions * 0.72),
+        reach_unit: reachUnit,
+        frequency: +(impressions / Math.round(impressions * 0.72)).toFixed(1),
+        ...(channels?.some(c => ['streaming_audio', 'podcast'].includes(c))
+          ? {
+            follows: Math.round(impressions * 0.002),
+            conversions: Math.round(impressions * 0.006),
+          }
+          : {}),
+      }
+      : {};
+
+    if (isAudioVideo && impressions > 0) {
+      totalCompletedViews += Math.round(impressions * completionRate);
+      totalViews += Math.round(impressions * 0.9);
+      totalReach += Math.round(impressions * 0.72);
+      if (!totalReachUnit) totalReachUnit = reachUnit;
+      else if (totalReachUnit !== reachUnit) totalReachUnit = 'mixed';
+    }
+
     return {
       package_id: pkg.packageId,
       spend,
       impressions,
       clicks,
+      ...audioMetrics,
       pricing_model: pricingModel,
       model: pricingModel, // #1525: alias for @adcp/client < 4.11.0
       rate,
@@ -1133,6 +1174,16 @@ function handleGetMediaBuyDelivery(args: Record<string, unknown>, ctx: TrainingC
         impressions: totalImpressions,
         spend: Math.round(totalSpend * 100) / 100,
         clicks: totalClicks,
+        ...(totalCompletedViews > 0 ? {
+          views: totalViews,
+          completed_views: totalCompletedViews,
+          completion_rate: +(totalCompletedViews / totalImpressions).toFixed(3),
+        } : {}),
+        ...(totalReach > 0 && totalReachUnit && totalReachUnit !== 'mixed' ? {
+          reach: totalReach,
+          reach_unit: totalReachUnit,
+          frequency: +(totalImpressions / totalReach).toFixed(1),
+        } : {}),
       },
       by_package: byPackage,
     }],

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -28,7 +28,7 @@
     },
     "views": {
       "type": "number",
-      "description": "Views at threshold (for CPV)",
+      "description": "Content engagements counted toward the billable view threshold. For video this is a platform-defined view event (e.g., 30 seconds or video midpoint); for audio/podcast it is a stream start; for other formats it follows the pricing model's view definition. When the package uses CPV pricing, spend = views × rate.",
       "minimum": 0
     },
     "completed_views": {
@@ -112,17 +112,21 @@
     },
     "reach": {
       "type": "number",
-      "description": "Unique reach - units depend on measurement provider (e.g., individuals, households, devices, cookies). See delivery_measurement.provider for methodology.",
+      "description": "Unique reach in the units specified by reach_unit. When reach_unit is omitted, units are unspecified — do not compare reach values across packages or media buys without a common reach_unit.",
       "minimum": 0
+    },
+    "reach_unit": {
+      "allOf": [{ "$ref": "/schemas/enums/reach-unit.json" }],
+      "description": "Unit of measurement for the reach field. Aligns with the reach_unit declared on optimization goals and delivery forecasts. Required when reach is present to enable cross-platform comparison."
     },
     "frequency": {
       "type": "number",
-      "description": "Average frequency per individual (typically measured over campaign duration, but can vary by measurement provider)",
+      "description": "Average frequency per reach unit (typically measured over campaign duration, but can vary by measurement provider). When reach_unit is 'households', this is average exposures per household; when 'accounts', per logged-in account; etc.",
       "minimum": 0
     },
     "quartile_data": {
       "type": "object",
-      "description": "Video quartile completion data",
+      "description": "Audio/video quartile completion data",
       "properties": {
         "q1_views": {
           "type": "number",
@@ -310,6 +314,9 @@
         "additionalProperties": true
       }
     }
+  },
+  "dependencies": {
+    "reach": ["reach_unit"]
   },
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -83,9 +83,14 @@
           "description": "Total clicks across all media buys (if applicable)",
           "minimum": 0
         },
-        "video_completions": {
+        "completed_views": {
           "type": "number",
-          "description": "Total video completions across all media buys (if applicable)",
+          "description": "Total audio/video completions across all media buys (if applicable)",
+          "minimum": 0
+        },
+        "views": {
+          "type": "number",
+          "description": "Total views across all media buys (if applicable)",
           "minimum": 0
         },
         "conversions": {
@@ -112,6 +117,26 @@
         "cost_per_acquisition": {
           "type": "number",
           "description": "Aggregate cost per conversion across all media buys (total spend / total conversions)",
+          "minimum": 0
+        },
+        "completion_rate": {
+          "type": "number",
+          "description": "Aggregate completion rate across all media buys (weighted by impressions, not a simple average of per-buy rates)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "reach": {
+          "type": "number",
+          "description": "Deduplicated reach across all media buys (if the seller can deduplicate across buys; otherwise sum of per-buy reach). Only present when all media buys share the same reach_unit. Omitted when reach units are heterogeneous — use per-buy reach values instead.",
+          "minimum": 0
+        },
+        "reach_unit": {
+          "allOf": [{ "$ref": "/schemas/enums/reach-unit.json" }],
+          "description": "Unit of measurement for reach. Only present when all aggregated media buys use the same reach_unit."
+        },
+        "frequency": {
+          "type": "number",
+          "description": "Average frequency per reach unit across all media buys (impressions / reach when cross-buy deduplication is available). Only present when reach is present.",
           "minimum": 0
         },
         "media_buy_count": {


### PR DESCRIPTION
## Summary

Closes #1671. Makes delivery metrics usable for cross-platform streaming/audio campaign optimization by autonomous agents.

- Broadens `views` to cover audio/podcast stream starts (the CPV billable unit)
- Adds `reach_unit` field (referencing existing `reach-unit.json` enum) with JSON Schema `dependencies` constraint — `reach` requires `reach_unit` for cross-platform comparison
- Renames `video_completions` → `completed_views` in `aggregated_totals`
- Adds `views`, `completion_rate`, `reach`, `reach_unit`, `frequency` to `aggregated_totals` (omitted when reach units are heterogeneous across media buys)
- Updates `frequency` description from "per individual" to "per reach unit"
- Training agent: channel-specific completion rates (podcast 87%, streaming 72%, CTV 82%), `views` at package level, audio/video metrics rolled up into totals, `reach_unit` emission

**Design decision: dropped `new_conversions`** — redundant with `new_to_brand_rate * conversions`, and cross-platform comparison of "new listener" vs "new subscriber" vs "first purchase" is misleading without additional context.

## Test plan

- [x] Schema build passes (`npm run build:schemas`)
- [x] All 192 training agent unit tests pass
- [x] Full pre-commit hook passes (schema validation, docs nav, broken links, accessibility, type checking)
- [ ] Verify training agent emits `reach_unit` and `views` for streaming/podcast products
- [ ] Verify `aggregated_totals` omits `reach`/`reach_unit`/`frequency` when packages have mixed reach units

🤖 Generated with [Claude Code](https://claude.com/claude-code)