### PR TITLE
fix: correct salesagent repo URL to prebid org

### DIFF
--- a/.changeset/fix-salesagent-repo-url.md
+++ b/.changeset/fix-salesagent-repo-url.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix salesagent repo URL from adcontextprotocol to prebid org
+
+The salesagent repo lives at github.com/prebid/salesagent, not
+adcontextprotocol/salesagent. The incorrect URL caused Addie to
+wrongly "correct" a community member who shared the right link.
+
+Updated in Dockerfile, docs/intro.mdx, and external-repos.ts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY <<'CLONE' /repos/clone.sh
 set -e
 pids=""
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp.git adcp & pids="$pids $!"
-git clone --depth=1 --branch main https://github.com/adcontextprotocol/salesagent.git salesagent & pids="$pids $!"
+git clone --depth=1 --branch main https://github.com/prebid/salesagent.git salesagent & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/signals-agent.git signals-agent & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp-client.git adcp-client & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp-client-python.git adcp-client-python & pids="$pids $!"

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -673,7 +673,7 @@ pip install adcp
 ## Reference implementations
 
 - [Signals Agent](https://github.com/adcontextprotocol/signals-agent)
-- [Sales Agent](https://github.com/adcontextprotocol/salesagent)
+- [Sales Agent](https://github.com/prebid/salesagent)
 
 ## Organization
 

--- a/server/src/addie/mcp/external-repos.ts
+++ b/server/src/addie/mcp/external-repos.ts
@@ -80,7 +80,7 @@ const EXTERNAL_REPOS: ExternalRepo[] = [
   },
   {
     id: 'salesagent',
-    url: 'https://github.com/adcontextprotocol/salesagent',
+    url: 'https://github.com/prebid/salesagent',
     name: 'AdCP Sales Agent',
     description: 'Reference implementation of an AdCP sales agent for publishers',
     indexPatterns: ['README.md', 'docs/**/*.md', 'CHANGELOG.md'],


### PR DESCRIPTION
## Summary
- Salesagent repo URL was pointing to `adcontextprotocol/salesagent` but the repo actually lives at `prebid/salesagent`
- This caused Addie to incorrectly "correct" a community member (Timothy Whitfield) who shared the right link after filing [prebid/salesagent#1155](https://github.com/prebid/salesagent/issues/1155)
- Updated Dockerfile, docs/intro.mdx, and external-repos.ts

## Test plan
- [x] Build passes
- [x] 808 unit tests pass
- [x] Typecheck passes
- [x] No broken doc links
- [x] Code review: clean
- [x] Security review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)