### PR TITLE
fix: weekly digest collaborative flow

### DIFF
--- a/.changeset/digest-collab-flow.md
+++ b/.changeset/digest-collab-flow.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+fix: weekly digest stays collaborative — no auto-skip, edits revive skipped digests, late approvals send immediately

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -112,7 +112,7 @@ import {
 } from './services/community-articles.js';
 import { isRetriesExhaustedError } from '../utils/anthropic-retry.js';
 import { WorkingGroupDatabase } from '../db/working-group-db.js';
-import { getDigestByReviewMessage, approveDigest, updateDigestContent } from '../db/digest-db.js';
+import { getDigestByReviewMessage, approveDigest, updateDigestContent, revertToDraft } from '../db/digest-db.js';
 import { applyDigestEdit } from './services/digest-editor.js';
 import { renderDigestReview } from './templates/weekly-digest.js';
 import * as relationshipDb from '../db/relationship-db.js';
@@ -3802,18 +3802,7 @@ async function handleDigestEditReply(
     return false;
   }
 
-  if (digest.status !== 'draft') {
-    if (boltApp) {
-      await boltApp.client.chat.postMessage({
-        channel: channelId,
-        thread_ts: threadTs,
-        text: `This digest has already been ${digest.status}. Edits can only be made to drafts.`,
-      });
-    }
-    return true;
-  }
-
-  // Verify editor is an Editorial working group leader or member
+  // Verify editor is an Editorial working group leader or member before any state changes
   const editorial = await workingGroupDb.getWorkingGroupBySlug('editorial');
   if (!editorial) {
     logger.warn('Editorial working group not found for digest edit');
@@ -3829,6 +3818,37 @@ async function handleDigestEditReply(
         channel: channelId,
         thread_ts: threadTs,
         text: 'Only Editorial working group members can edit the digest.',
+      });
+    }
+    return true;
+  }
+
+  if (digest.status === 'skipped') {
+    // Revive skipped digest so editorial can continue collaborating
+    const revived = await revertToDraft(digest.id);
+    if (!revived) {
+      if (boltApp) {
+        await boltApp.client.chat.postMessage({
+          channel: channelId,
+          thread_ts: threadTs,
+          text: `Could not reopen this digest. It may have already been sent.`,
+        });
+      }
+      return true;
+    }
+    if (boltApp) {
+      await boltApp.client.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadTs,
+        text: `Digest reopened as a draft. Applying your edit...`,
+      });
+    }
+  } else if (digest.status !== 'draft') {
+    if (boltApp) {
+      await boltApp.client.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadTs,
+        text: `This digest has already been sent. Edits can only be made to drafts.`,
       });
     }
     return true;
@@ -3908,11 +3928,11 @@ async function handleDigestRegenerate(
   messageTs: string,
 ): Promise<boolean> {
   const digest = await getDigestByReviewMessage(channelId, messageTs);
-  if (!digest || digest.status !== 'draft') {
+  if (!digest || (digest.status !== 'draft' && digest.status !== 'skipped')) {
     return false;
   }
 
-  // Verify reactor is an Editorial working group leader or member
+  // Verify reactor is an Editorial working group leader or member before any state changes
   const editorial = await workingGroupDb.getWorkingGroupBySlug('editorial');
   if (!editorial) {
     logger.warn('Editorial working group not found for digest regenerate');
@@ -3933,7 +3953,7 @@ async function handleDigestRegenerate(
     return true;
   }
 
-  // Delegate to applyDigestEdit which handles regeneration and edit history
+  // Delegate to handleDigestEditReply which handles revert, regeneration, and edit history
   return handleDigestEditReply(channelId, messageTs, 'regenerate', reactingUserId);
 }
 
@@ -3948,7 +3968,7 @@ async function handleDigestApproval(
   messageTs: string,
 ): Promise<boolean> {
   const digest = await getDigestByReviewMessage(channelId, messageTs);
-  if (!digest || digest.status !== 'draft') {
+  if (!digest || (digest.status !== 'draft' && digest.status !== 'skipped')) {
     return false;
   }
 
@@ -3977,6 +3997,12 @@ async function handleDigestApproval(
     return true;
   }
 
+  // Revive skipped digest before approving
+  if (digest.status === 'skipped') {
+    const revived = await revertToDraft(digest.id);
+    if (!revived) return false;
+  }
+
   // Store canonical (WorkOS) user ID for audit trail
   const approverUserId = matchedLeader.canonical_user_id || reactingUserId;
   const approved = await approveDigest(digest.id, approverUserId);
@@ -3986,11 +4012,32 @@ async function handleDigestApproval(
     const resolved = await resolveSlackUserDisplayName(reactingUserId);
     const name = resolved?.display_name || 'An editor';
 
-    await boltApp.client.chat.postMessage({
-      channel: channelId,
-      thread_ts: messageTs,
-      text: `Approved by ${name}! Will send at 10am ET.`,
-    });
+    // If approved after the normal 10am send window, send immediately
+    const { getETHour, sendDigest } = await import('./jobs/weekly-digest.js');
+    const etHour = getETHour();
+
+    if (etHour >= 10) {
+      await boltApp.client.chat.postMessage({
+        channel: channelId,
+        thread_ts: messageTs,
+        text: `Approved by ${name}! Sending now...`,
+      });
+
+      const sendResult = await sendDigest(approved);
+      if (sendResult.sent === 0) {
+        await boltApp.client.chat.postMessage({
+          channel: channelId,
+          thread_ts: messageTs,
+          text: `Delivery failed — nothing was sent. The digest is still approved and will retry on the next scheduled check.`,
+        });
+      }
+    } else {
+      await boltApp.client.chat.postMessage({
+        channel: channelId,
+        thread_ts: messageTs,
+        text: `Approved by ${name}! Will send at 10am ET.`,
+      });
+    }
 
     logger.info(
       { digestId: digest.id, approvedBy: approverUserId },

--- a/server/src/addie/jobs/weekly-digest.ts
+++ b/server/src/addie/jobs/weekly-digest.ts
@@ -5,9 +5,9 @@ import {
   getDigestByDate,
   setReviewMessage,
   markSent,
-  markSkipped,
   getDigestEmailRecipients,
   getUserWorkingGroupMap,
+  type DigestRecord,
   type DigestSendStats,
 } from '../../db/digest-db.js';
 import { WorkingGroupDatabase } from '../../db/working-group-db.js';
@@ -31,7 +31,7 @@ interface WeeklyDigestResult {
 /**
  * Get the current hour in US Eastern time
  */
-function getETHour(): number {
+export function getETHour(): number {
   const now = new Date();
   const etString = now.toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', hour12: false });
   return parseInt(etString, 10);
@@ -54,7 +54,7 @@ function getTodayEditionDate(): string {
  * Main weekly digest job runner.
  * Runs hourly. On Tuesdays:
  * - 7-8am ET: Generates a draft and posts to Editorial channel for review
- * - 10-11am ET: Sends the digest if approved, or marks it skipped
+ * - 10am+ ET: Sends the digest if approved, or nudges at 10am if still waiting
  */
 export async function runWeeklyDigestJob(): Promise<WeeklyDigestResult> {
   const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
@@ -74,9 +74,9 @@ export async function runWeeklyDigestJob(): Promise<WeeklyDigestResult> {
     return generateDraft(editionDate);
   }
 
-  // Phase 2: Send if approved (10-11am ET)
-  if (etHour >= 10 && etHour < 11) {
-    return sendApprovedDigest(editionDate);
+  // Phase 2: Send if approved, or nudge at 10am (rest of Tuesday)
+  if (etHour >= 10) {
+    return sendApprovedDigest(editionDate, etHour);
   }
 
   return result;
@@ -134,9 +134,11 @@ async function generateDraft(editionDate: string): Promise<WeeklyDigestResult> {
 }
 
 /**
- * Send the approved digest to all segments, or mark as skipped
+ * Check if the approved digest is ready to send, or nudge if still waiting.
+ * No longer auto-skips — the draft stays editable until someone approves or
+ * a new edition is generated next week.
  */
-async function sendApprovedDigest(editionDate: string): Promise<WeeklyDigestResult> {
+async function sendApprovedDigest(editionDate: string, etHour: number): Promise<WeeklyDigestResult> {
   const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
 
   const digest = await getDigestByDate(editionDate);
@@ -149,24 +151,34 @@ async function sendApprovedDigest(editionDate: string): Promise<WeeklyDigestResu
     return result;
   }
 
-  // Not approved yet - skip
+  // Still a draft — nudge once at 10am, then leave it alone
   if (digest.status === 'draft') {
-    await markSkipped(digest.id);
-    result.skipped = true;
-
-    // Notify Editorial channel
-    if (digest.review_channel_id && digest.review_message_ts) {
+    if (etHour >= 10 && etHour < 11 && digest.review_channel_id && digest.review_message_ts) {
       await sendChannelMessage(digest.review_channel_id, {
-        text: `This week's digest was not approved in time and has been skipped.`,
+        text: `This week's digest is still waiting for approval. React with :white_check_mark: to send now, or reply in this thread with edits.`,
         thread_ts: digest.review_message_ts,
       });
     }
-
-    logger.info({ editionDate }, 'Digest skipped - no approval received');
     return result;
   }
 
   // Status is 'approved' - send it
+  const sendResult = await sendDigest(digest);
+  result.sent = sendResult.sent;
+  return result;
+}
+
+/**
+ * Deliver an approved digest via email and Slack.
+ * Called from the scheduled job and from the approval handler (for late approvals).
+ */
+export async function sendDigest(digest: DigestRecord): Promise<{ sent: number }> {
+  if (digest.status !== 'approved') {
+    logger.error({ digestId: digest.id, status: digest.status }, 'sendDigest called on non-approved digest');
+    return { sent: 0 };
+  }
+
+  const editionDate = new Date(digest.edition_date).toISOString().split('T')[0];
   const stats: DigestSendStats = { email_count: 0, slack_count: 0, by_segment: {} };
 
   // Post to Slack #announcements
@@ -217,7 +229,6 @@ async function sendApprovedDigest(editionDate: string): Promise<WeeklyDigestResu
   // Only mark as sent if at least something was delivered
   if (stats.email_count > 0 || stats.slack_count > 0) {
     await markSent(digest.id, stats);
-    result.sent = stats.email_count + stats.slack_count;
   } else {
     logger.error({ editionDate, batchResult }, 'Digest delivery failed - nothing delivered, leaving as approved for retry');
   }
@@ -235,5 +246,5 @@ async function sendApprovedDigest(editionDate: string): Promise<WeeklyDigestResu
     });
   }
 
-  return result;
+  return { sent: stats.email_count + stats.slack_count };
 }

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -170,13 +170,15 @@ export async function setReviewMessage(
 /**
  * Mark a digest as sent with stats
  */
-export async function markSent(id: number, stats: DigestSendStats): Promise<void> {
-  await query(
+export async function markSent(id: number, stats: DigestSendStats): Promise<boolean> {
+  const result = await query(
     `UPDATE weekly_digests
      SET status = 'sent', sent_at = NOW(), send_stats = $2
-     WHERE id = $1`,
+     WHERE id = $1 AND status = 'approved'
+     RETURNING id`,
     [id, JSON.stringify(stats)],
   );
+  return result.rows.length > 0;
 }
 
 /**
@@ -187,6 +189,20 @@ export async function markSkipped(id: number): Promise<void> {
     `UPDATE weekly_digests SET status = 'skipped' WHERE id = $1`,
     [id],
   );
+}
+
+/**
+ * Revert a skipped digest back to draft so it can be edited and re-approved.
+ */
+export async function revertToDraft(id: number): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `UPDATE weekly_digests
+     SET status = 'draft', approved_by = NULL, approved_at = NULL
+     WHERE id = $1 AND status = 'skipped'
+     RETURNING *`,
+    [id],
+  );
+  return result.rows[0] || null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **No more auto-skip**: At 10am, if the digest isn't approved, Addie posts a nudge instead of killing it. The draft stays editable all day.
- **Edits revive skipped digests**: Replying to a skipped digest thread reopens it as a draft and applies the edit. Same for the 🔄 regenerate reaction.
- **Late approvals send immediately**: Approving after 10am ET triggers delivery right away instead of waiting for the next cron cycle.
- **Authorization before state changes**: Membership checks now run before any revert operations (security review finding).
- **Double-send protection**: `sendDigest()` requires `approved` status, `markSent()` uses `WHERE status = 'approved'` to prevent race conditions.

Addresses the UX issue where B. Masse gave good feedback on a digest but was blocked by "edits can only be made to drafts" after auto-skip.

## Test plan

- [ ] Generate a digest draft, don't approve by 10am — verify nudge posted instead of skip
- [ ] Reply to a skipped digest thread with edit instructions — verify it reopens and applies
- [ ] Approve a digest after 10am — verify it sends immediately
- [ ] Non-Editorial member tries to edit a skipped digest — verify rejection without state change
- [ ] Two concurrent approval/send paths — verify only one delivery via `markSent` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)