### PR TITLE
fix: split profile tools into personal profile and company listing

### DIFF
--- a/.changeset/profile-listing-split.md
+++ b/.changeset/profile-listing-split.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Split Addie's profile tools into personal profile (the person) and company listing (the org's directory entry). Guard sync from overwriting independently customized taglines. Include personal org listings in Addie's ambient context. Add offerings to company listing tool.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -459,13 +459,13 @@ export const MEMBER_TOOLS: AddieTool[] = [
   },
 
   // ============================================
-  // MEMBER PROFILE (user-scoped only)
+  // PERSONAL PROFILE (the person)
   // ============================================
   {
     name: 'get_my_profile',
     description:
-      "Get the current user's member profile. Shows their public profile information, organization details, and any published agents or properties.",
-    usage_hints: 'use for "what\'s my profile?", account/membership questions',
+      "Get the current user's personal profile — who they are as a person. Shows headline, bio, expertise, interests, and social links.",
+    usage_hints: 'use for "what\'s my profile?", "my bio", "my headline"',
     input_schema: {
       type: 'object',
       properties: {},
@@ -475,17 +475,61 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'update_my_profile',
     description:
-      "Update the current user's member profile. Can update headline, bio, focus areas, website, LinkedIn, and other profile fields. Only updates fields that are provided - omitted fields are unchanged.",
-    usage_hints: 'use when user wants to update their profile information',
+      "Update the current user's personal profile — who they are as a person. Can update headline, bio, expertise, interests, location, and social links. Only updates fields that are provided.",
+    usage_hints: 'use when user wants to update their personal info, headline, bio, or expertise',
     input_schema: {
       type: 'object',
       properties: {
-        headline: { type: 'string', description: 'Short headline/title' },
+        headline: { type: 'string', description: 'Short headline (e.g., "VP of Programmatic at Acme Corp")' },
         bio: { type: 'string', description: 'Bio in markdown' },
-        focus_areas: { type: 'array', items: { type: 'string' }, description: 'Areas of focus' },
-        website: { type: 'string', description: 'Website URL' },
-        linkedin: { type: 'string', description: 'LinkedIn URL' },
-        location: { type: 'string', description: 'Location' },
+        expertise: { type: 'array', items: { type: 'string' }, description: 'Areas of expertise' },
+        interests: { type: 'array', items: { type: 'string' }, description: 'Professional interests' },
+        city: { type: 'string', description: 'City/location' },
+        linkedin_url: { type: 'string', description: 'LinkedIn profile URL' },
+        twitter_url: { type: 'string', description: 'Twitter/X profile URL' },
+      },
+      required: [],
+    },
+  },
+
+  // ============================================
+  // COMPANY LISTING (the org's directory entry)
+  // ============================================
+  {
+    name: 'get_company_listing',
+    description:
+      "Get the company's directory listing — how the organization appears in the member directory and to Addie. Shows tagline, description, offerings, headquarters, and contact info.",
+    usage_hints: 'use for "what\'s our company listing?", "our tagline", "company profile", "our directory entry"',
+    input_schema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'update_company_listing',
+    description:
+      "Update the company's directory listing — how the organization appears in the member directory and to Addie. Can update tagline, description, contact info, social links, and headquarters. Only updates fields that are provided.",
+    usage_hints: 'use when user wants to update company tagline, description, contact info, or directory listing',
+    input_schema: {
+      type: 'object',
+      properties: {
+        tagline: { type: 'string', description: 'Short tagline shown on directory card and used by Addie for search matching. Omit to leave unchanged.' },
+        description: { type: 'string', description: 'Longer company description' },
+        offerings: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['buyer_agent', 'sales_agent', 'creative_agent', 'signals_agent', 'si_agent', 'governance_agent', 'publisher', 'data_provider', 'consulting', 'other'],
+          },
+          description: 'Service offerings (replaces existing list)',
+        },
+        contact_email: { type: 'string', description: 'Contact email address' },
+        contact_website: { type: 'string', description: 'Company website URL' },
+        contact_phone: { type: 'string', description: 'Contact phone number' },
+        linkedin_url: { type: 'string', description: 'LinkedIn company page URL' },
+        twitter_url: { type: 'string', description: 'Twitter/X profile URL' },
+        headquarters: { type: 'string', description: 'Headquarters location (e.g., "New York, NY")' },
       },
       required: [],
     },
@@ -1376,56 +1420,60 @@ export function createMemberToolHandlers(
   });
 
   // ============================================
-  // MEMBER PROFILE
+  // PERSONAL PROFILE (the person)
   // ============================================
   handlers.set('get_my_profile', async () => {
     if (!memberContext?.workos_user?.workos_user_id) {
       return 'You need to be logged in to see your profile. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    const result = await callApi('GET', '/api/me/member-profile', memberContext);
+    const result = await callApi('GET', '/api/me/community/hub', memberContext);
 
     if (!result.ok) {
-      if (result.status === 404) {
-        return "You don't have a member profile yet. Visit https://agenticadvertising.org/member-profile to create one!";
-      }
       return `Failed to fetch your profile: ${result.error}`;
     }
 
     const data = result.data as { profile: {
-      name: string;
-      slug: string;
+      slug?: string;
       headline?: string;
       bio?: string;
-      focus_areas?: string[];
-      website?: string;
-      linkedin?: string;
-      location?: string;
-      is_visible: boolean;
-    } | null; organization_name?: string };
+      expertise?: string[];
+      interests?: string[];
+      city?: string;
+      country?: string;
+      linkedin_url?: string;
+      twitter_url?: string;
+      is_public?: boolean;
+      first_name?: string;
+      last_name?: string;
+    } | null };
 
     if (!data.profile) {
-      return "You don't have a member profile yet. Visit https://agenticadvertising.org/member-profile to create one!";
+      return "You don't have a profile yet. Visit https://agenticadvertising.org/community/profile/edit to create one!";
     }
 
-    const profile = data.profile;
+    const p = data.profile;
+    const name = [p.first_name, p.last_name].filter(Boolean).join(' ') || 'Member';
 
-    let response = `## Your Member Profile\n\n`;
-    response += `**Name:** ${profile.name}\n`;
-    response += `**Profile URL:** https://agenticadvertising.org/members/${profile.slug}\n`;
-    response += `**Visibility:** ${profile.is_visible ? '🌐 Public' : '🔒 Hidden'}\n\n`;
+    let response = `## Your Profile\n\n`;
+    response += `**Name:** ${name}\n`;
+    if (p.slug) response += `**Profile URL:** https://agenticadvertising.org/community/people/${p.slug}\n`;
+    if (p.is_public !== undefined) response += `**Visibility:** ${p.is_public ? 'Public' : 'Hidden'}\n`;
 
-    if (profile.headline) response += `**Headline:** ${profile.headline}\n`;
-    if (profile.location) response += `**Location:** ${profile.location}\n`;
-    if (profile.website) response += `**Website:** ${profile.website}\n`;
-    if (profile.linkedin) response += `**LinkedIn:** ${profile.linkedin}\n`;
+    if (p.headline) response += `**Headline:** ${p.headline}\n`;
+    if (p.city) response += `**Location:** ${p.city}${p.country ? `, ${p.country}` : ''}\n`;
+    if (p.linkedin_url) response += `**LinkedIn:** ${p.linkedin_url}\n`;
+    if (p.twitter_url) response += `**Twitter:** ${p.twitter_url}\n`;
 
-    if (profile.focus_areas && profile.focus_areas.length > 0) {
-      response += `**Focus Areas:** ${profile.focus_areas.join(', ')}\n`;
+    if (p.expertise && p.expertise.length > 0) {
+      response += `**Expertise:** ${p.expertise.join(', ')}\n`;
+    }
+    if (p.interests && p.interests.length > 0) {
+      response += `**Interests:** ${p.interests.join(', ')}\n`;
     }
 
-    if (profile.bio) {
-      response += `\n### Bio\n${profile.bio}\n`;
+    if (p.bio) {
+      response += `\n### Bio\n${p.bio}\n`;
     }
 
     return response;
@@ -1436,30 +1484,129 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to update your profile. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    // Only include fields that were provided
     const updates: Record<string, unknown> = {};
-    if (input.headline !== undefined) updates.headline = input.headline;
-    if (input.bio !== undefined) updates.bio = input.bio;
-    if (input.focus_areas !== undefined) updates.focus_areas = input.focus_areas;
-    if (input.website !== undefined) updates.website = input.website;
-    if (input.linkedin !== undefined) updates.linkedin = input.linkedin;
-    if (input.location !== undefined) updates.location = input.location;
+    const stringFields = ['headline', 'bio', 'city', 'linkedin_url', 'twitter_url'] as const;
+    for (const field of stringFields) {
+      if (input[field] !== undefined) {
+        updates[field] = (input[field] as string) || null;
+      }
+    }
+    const arrayFields = ['expertise', 'interests'] as const;
+    for (const field of arrayFields) {
+      if (input[field] !== undefined) {
+        updates[field] = input[field];
+      }
+    }
 
     if (Object.keys(updates).length === 0) {
-      return 'No fields to update. Provide at least one field (headline, bio, focus_areas, website, linkedin, or location).';
+      return 'No fields to update. Provide at least one field (headline, bio, expertise, interests, city, linkedin_url, or twitter_url).';
+    }
+
+    const result = await callApi('PUT', '/api/me/community-profile', memberContext, updates);
+
+    if (!result.ok) {
+      return `Failed to update profile: ${result.error}`;
+    }
+
+    const updatedFields = Object.keys(updates).join(', ');
+    return `Profile updated! Updated: ${updatedFields}\n\nEdit at https://agenticadvertising.org/community/profile/edit`;
+  });
+
+  // ============================================
+  // COMPANY LISTING (the org's directory entry)
+  // ============================================
+  handlers.set('get_company_listing', async () => {
+    if (!memberContext?.workos_user?.workos_user_id) {
+      return 'You need to be logged in to see your company listing. Please log in at https://agenticadvertising.org/dashboard first.';
+    }
+
+    const result = await callApi('GET', '/api/me/member-profile', memberContext);
+
+    if (!result.ok) {
+      if (result.status === 404) {
+        return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one!";
+      }
+      return `Failed to fetch company listing: ${result.error}`;
+    }
+
+    const data = result.data as { profile: {
+      display_name: string;
+      slug: string;
+      tagline?: string;
+      description?: string;
+      contact_email?: string;
+      contact_website?: string;
+      contact_phone?: string;
+      linkedin_url?: string;
+      twitter_url?: string;
+      headquarters?: string;
+      offerings?: string[];
+      is_public: boolean;
+    } | null; organization_name?: string };
+
+    if (!data.profile) {
+      return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one!";
+    }
+
+    const listing = data.profile;
+
+    let response = `## Company Listing\n\n`;
+    response += `**Name:** ${listing.display_name}\n`;
+    response += `**Directory URL:** https://agenticadvertising.org/members/${listing.slug}\n`;
+    response += `**Visibility:** ${listing.is_public ? 'Public' : 'Hidden'}\n\n`;
+
+    if (listing.tagline) response += `**Tagline:** ${listing.tagline}\n`;
+    if (listing.headquarters) response += `**Headquarters:** ${listing.headquarters}\n`;
+    if (listing.contact_website) response += `**Website:** ${listing.contact_website}\n`;
+    if (listing.contact_email) response += `**Email:** ${listing.contact_email}\n`;
+    if (listing.linkedin_url) response += `**LinkedIn:** ${listing.linkedin_url}\n`;
+    if (listing.twitter_url) response += `**Twitter:** ${listing.twitter_url}\n`;
+
+    if (listing.offerings && listing.offerings.length > 0) {
+      response += `**Offerings:** ${listing.offerings.join(', ')}\n`;
+    }
+
+    if (listing.description) {
+      response += `\n### Description\n${listing.description}\n`;
+    }
+
+    return response;
+  });
+
+  handlers.set('update_company_listing', async (input) => {
+    if (!memberContext?.workos_user?.workos_user_id) {
+      return 'You need to be logged in to update your company listing. Please log in at https://agenticadvertising.org/dashboard first.';
+    }
+
+    const updates: Record<string, unknown> = {};
+    const stringFields = [
+      'tagline', 'description', 'contact_email', 'contact_website',
+      'contact_phone', 'linkedin_url', 'twitter_url', 'headquarters',
+    ] as const;
+    for (const field of stringFields) {
+      if (input[field] !== undefined) {
+        updates[field] = (input[field] as string) || null;
+      }
+    }
+    if (input.offerings !== undefined) {
+      updates.offerings = input.offerings;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return 'No fields to update. Provide at least one field (tagline, description, offerings, contact_email, contact_website, contact_phone, linkedin_url, twitter_url, or headquarters).';
     }
 
     const result = await callApi('PUT', '/api/me/member-profile', memberContext, updates);
 
     if (!result.ok) {
       if (result.status === 404) {
-        return "You don't have a member profile yet. Visit https://agenticadvertising.org/member-profile to create one first!";
+        return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one first!";
       }
-      return `Failed to update profile: ${result.error}`;
+      return `Failed to update company listing: ${result.error}`;
     }
 
     const updatedFields = Object.keys(updates).join(', ');
-    return `✅ Profile updated successfully! Updated fields: ${updatedFields}\n\nView your profile at https://agenticadvertising.org/members/`;
+    return `Company listing updated! Updated: ${updatedFields}\n\nView at https://agenticadvertising.org/members/`;
   });
 
   // ============================================

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -221,6 +221,7 @@ export interface MemberContext {
     logo_url?: string;
     offerings: string[];
     headquarters?: string;
+    listing_type: 'personal' | 'company';
   };
 
   /** Subscription details */
@@ -489,14 +490,15 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
       }
     }
 
-    // Process member profile (only for non-personal workspaces)
-    if (profile && !org?.is_personal) {
+    // Process member profile / directory listing
+    if (profile) {
       context.member_profile = {
         display_name: profile.display_name,
         tagline: profile.tagline,
         logo_url: profile.resolved_brand?.logo_url,
         offerings: profile.offerings,
         headquarters: profile.headquarters,
+        listing_type: org?.is_personal ? 'personal' : 'company',
       };
     }
 
@@ -778,15 +780,16 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
       }
     }
 
-    // Step 6: Get member profile if exists (only for non-personal workspaces)
+    // Step 6: Get member profile / directory listing if exists
     const profile = await memberDb.getProfileByOrgId(organizationId);
-    if (profile && !org?.is_personal) {
+    if (profile) {
       context.member_profile = {
         display_name: profile.display_name,
         tagline: profile.tagline,
         logo_url: profile.resolved_brand?.logo_url,
         offerings: profile.offerings,
         headquarters: profile.headquarters,
+        listing_type: org?.is_personal ? 'personal' : 'company',
       };
     }
 

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -77,9 +77,13 @@ You have access to these tools to help users:
 **Member Journey:**
 - get_member_engagement: Get the current member's journey stage, engagement score, persona/archetype, milestone completion, and persona-based working group recommendations. Call this tool when: (1) the member asks what to do next, how to get more involved, or what their next step is; (2) they ask about their archetype, persona, or organization type; (3) they ask about working group recommendations. The result includes assessment_completed (bool) — if false, surface the assessment_url to invite them to discover their agentic archetype. If milestones show gaps (e.g. has_working_groups: false), suggest one specific action to address it. Surface one recommendation at a time, not a list.
 
-**Member Profile:**
-- get_my_profile: Show user's profile
-- update_my_profile: Update profile fields
+**Personal Profile (the person):**
+- get_my_profile: Show user's personal profile (headline, bio, expertise)
+- update_my_profile: Update personal profile fields
+
+**Company Listing (the org's directory entry):**
+- get_company_listing: Show the company's directory listing (tagline, description, offerings)
+- update_company_listing: Update the company's directory listing (tagline, description, contact info)
 
 **Member Directory (searchable vendor/partner directory):**
 The member directory lists AgenticAdvertising.org member ORGANIZATIONS (companies). Use it to find companies that offer specific services — not individual people. When users ask about vendors, implementation partners, consultants, or service providers, search with the user's actual need as the query (e.g., "CTV measurement", "creative optimization") — do NOT use generic terms like "partner".

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -158,7 +158,7 @@ export const ROUTING_RULES = {
     },
     membership: {
       patterns: ['member', 'join', 'signup', 'account', 'profile', 'working group', 'api key', 'api keys', 'api token'],
-      tools: ['get_my_profile', 'list_working_groups', 'join_working_group'],
+      tools: ['get_my_profile', 'update_my_profile', 'get_company_listing', 'update_company_listing', 'list_working_groups', 'join_working_group'],
       description: 'AgenticAdvertising.org membership and API key management',
     },
     find_help: {
@@ -191,7 +191,12 @@ export const ROUTING_RULES = {
     community_directory: {
       patterns: ['community directory', 'community profile', 'people directory', 'community hub', 'coffee chat', 'connection request', 'connect with'],
       tools: ['get_my_profile', 'update_my_profile'],
-      description: 'Community directory, people profiles, connections, and coffee chats',
+      description: 'Community directory, personal profiles, connections, and coffee chats',
+    },
+    company_listing: {
+      patterns: ['company listing', 'company tagline', 'company profile', 'directory listing', 'our tagline', 'company description', 'company offerings'],
+      tools: ['get_company_listing', 'update_company_listing'],
+      description: 'Company directory listing — tagline, description, offerings, contact info',
     },
     community: {
       patterns: ['community', 'discussion', 'slack', 'chat history', 'what did', 'who said'],

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -78,6 +78,8 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     tools: [
       'get_my_profile',
       'update_my_profile',
+      'get_company_listing',
+      'update_company_listing',
       'list_working_groups',
       'get_working_group',
       'join_working_group',

--- a/server/src/routes/community.ts
+++ b/server/src/routes/community.ts
@@ -422,8 +422,6 @@ async function syncIndividualMemberProfile(
   // Build mapped fields for member_profiles
   const memberUpdates: Record<string, unknown> = {
     display_name: displayName,
-    tagline: communityProfile.headline || null,
-    description: communityProfile.bio || null,
     logo_url: communityProfile.avatar_url || null,
     linkedin_url: communityProfile.linkedin_url || null,
     twitter_url: communityProfile.twitter_url || null,
@@ -436,6 +434,20 @@ async function syncIndividualMemberProfile(
   const existingProfile = await memberDb.getProfileByOrgId(user.primary_organization_id);
 
   if (existingProfile) {
+    // Only sync headline→tagline and bio→description if the listing field hasn't been
+    // independently customized (i.e., it's empty or already matches the community value).
+    const newTagline = communityProfile.headline || null;
+    const currentTagline = existingProfile.tagline || null;
+    if (!currentTagline || currentTagline === newTagline) {
+      memberUpdates.tagline = newTagline;
+    }
+
+    const newDescription = communityProfile.bio || null;
+    const currentDescription = existingProfile.description || null;
+    if (!currentDescription || currentDescription === newDescription) {
+      memberUpdates.description = newDescription;
+    }
+
     // Merge offerings: the form only edits individual-relevant offerings (consulting, other).
     // Preserve any other offerings the existing profile has (e.g. data_provider).
     if (memberFields.offerings !== undefined) {

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -61,21 +61,34 @@ describe('MEMBER_TOOLS definitions', () => {
     expect(tool).toBeDefined();
   });
 
-  it('has get_my_profile tool', () => {
+  it('has get_my_profile tool for personal profile', () => {
     const tool = MEMBER_TOOLS.find(t => t.name === 'get_my_profile');
     expect(tool).toBeDefined();
   });
 
-  it('has update_my_profile tool with optional fields', () => {
+  it('has update_my_profile tool with community profile fields', () => {
     const tool = MEMBER_TOOLS.find(t => t.name === 'update_my_profile');
     expect(tool).toBeDefined();
     expect(tool?.input_schema.properties).toHaveProperty('headline');
     expect(tool?.input_schema.properties).toHaveProperty('bio');
-    expect(tool?.input_schema.properties).toHaveProperty('focus_areas');
-    expect(tool?.input_schema.properties).toHaveProperty('website');
-    expect(tool?.input_schema.properties).toHaveProperty('linkedin');
-    expect(tool?.input_schema.properties).toHaveProperty('location');
-    // All fields are optional
+    expect(tool?.input_schema.properties).toHaveProperty('expertise');
+    expect(tool?.input_schema.properties).toHaveProperty('city');
+    expect(tool?.input_schema.required).toEqual([]);
+  });
+
+  it('has get_company_listing tool for org directory entry', () => {
+    const tool = MEMBER_TOOLS.find(t => t.name === 'get_company_listing');
+    expect(tool).toBeDefined();
+  });
+
+  it('has update_company_listing tool with member profile fields', () => {
+    const tool = MEMBER_TOOLS.find(t => t.name === 'update_company_listing');
+    expect(tool).toBeDefined();
+    expect(tool?.input_schema.properties).toHaveProperty('tagline');
+    expect(tool?.input_schema.properties).toHaveProperty('description');
+    expect(tool?.input_schema.properties).toHaveProperty('offerings');
+    expect(tool?.input_schema.properties).toHaveProperty('contact_website');
+    expect(tool?.input_schema.properties).toHaveProperty('headquarters');
     expect(tool?.input_schema.required).toEqual([]);
   });
 
@@ -344,6 +357,8 @@ describe('createMemberToolHandlers', () => {
       'get_my_working_groups',
       'get_my_profile',
       'update_my_profile',
+      'get_company_listing',
+      'update_company_listing',
       'create_working_group_post',
     ];
 


### PR DESCRIPTION
## Summary

- Split Addie's ambiguous `get_my_profile` / `update_my_profile` into two clear tool pairs:
  - **Personal Profile** (`get_my_profile` / `update_my_profile`) — the person (headline, bio, expertise, city) via community profile API
  - **Company Listing** (`get_company_listing` / `update_company_listing`) — the org's directory entry (tagline, description, offerings) via member profile API
- Guard `syncIndividualMemberProfile` from overwriting tagline/description when independently customized via `update_company_listing`
- Include personal org listings in Addie's ambient context (previously skipped), with `listing_type` discriminator
- Add all 10 offering types to `update_company_listing` (previously only consulting + other available to individuals)

## Context

Bryan Szekely tried to update his company's tagline via Addie but Addie said the company had no tagline. Root cause: the profile tools conflated person and org — sending community profile field names (`headline`, `bio`) to the member profile API (which expects `tagline`, `description`).

## Test plan

- [x] TypeScript compiles clean
- [x] All 383 addie tests pass (43 member-tools tests, 11 member-context tests)
- [x] Full pre-commit suite passes (829 tests)
- [x] Code review: addressed tagline clear description, routing gap, variable naming
- [x] Security review: no Must Fix or Should Fix findings (self-injection risk noted as pre-existing, low impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)