### PR TITLE
feat: normative extraction specs for MCP, A2A, and webhooks

### DIFF
--- a/.changeset/a2a-response-extraction.md
+++ b/.changeset/a2a-response-extraction.md
@@ -1,0 +1,4 @@
+---
+---
+
+Proposal: A2A response extraction — normative algorithm with test vectors.

--- a/.changeset/mcp-response-extraction.md
+++ b/.changeset/mcp-response-extraction.md
@@ -1,0 +1,4 @@
+---
+---
+
+Proposal: MCP success response extraction — normative algorithm with test vectors.

--- a/.changeset/webhook-payload-extraction.md
+++ b/.changeset/webhook-payload-extraction.md
@@ -1,0 +1,4 @@
+---
+---
+
+Proposal: webhook payload extraction — format detection, unified extraction algorithm, test vectors, and fix A2A completed data location in webhooks.mdx.

--- a/docs.json
+++ b/docs.json
@@ -131,6 +131,8 @@
                       "docs/building/implementation/orchestrator-design",
                       "docs/building/implementation/error-handling",
                       "docs/building/implementation/transport-errors",
+                      "docs/building/implementation/mcp-response-extraction",
+                      "docs/building/implementation/a2a-response-extraction",
                       "docs/building/implementation/security",
                       "docs/building/implementation/seller-integration"
                     ]
@@ -575,6 +577,8 @@
                   "docs/building/implementation/orchestrator-design",
                   "docs/building/implementation/error-handling",
                   "docs/building/implementation/transport-errors",
+                  "docs/building/implementation/mcp-response-extraction",
+                  "docs/building/implementation/a2a-response-extraction",
                   "docs/building/implementation/security",
                   "docs/building/implementation/seller-integration"
                 ]

--- a/docs/building/implementation/a2a-response-extraction.mdx
+++ b/docs/building/implementation/a2a-response-extraction.mdx
@@ -1,0 +1,203 @@
+---
+title: A2A Response Extraction
+description: "How to extract AdCP response data from A2A Task objects: status-based branching, last-DataPart authority, wrapper rejection, and client implementation requirements."
+"og:title": "AdCP — A2A Response Extraction"
+---
+
+This page defines the normative algorithm for extracting AdCP response data from A2A Task objects and TaskStatusUpdateEvents. For the canonical response structure that sellers must produce, see [A2A Response Format](/docs/building/integration/a2a-response-format). For error-specific extraction, see [Transport Error Mapping](/docs/building/implementation/transport-errors).
+
+## Status-Based Extraction
+
+The extraction location depends on the task's status:
+
+| Status | Type | Data Location | DataPart Selection |
+|---|---|---|---|
+| `completed` | Final | `.artifacts[0].parts[]` | Last DataPart |
+| `failed` | Final | `.artifacts[0].parts[]` | Last DataPart |
+| `canceled` | Final | `.artifacts[0].parts[]` | Last DataPart (typically none) |
+| `working` | Interim | `status.message.parts[]` | First DataPart |
+| `submitted` | Interim | `status.message.parts[]` | First DataPart |
+| `input-required` | Interim | `status.message.parts[]` | First DataPart |
+
+Canceled tasks rarely carry data — the extraction returns null when no DataPart is present, which is the expected case.
+
+## Extraction Algorithm
+
+Clients MUST extract AdCP data from A2A responses using these steps:
+
+1. **Read `status.state`.** If absent, return null.
+2. **Final states** (`completed`, `failed`, `canceled`):
+   a. Look in `artifacts[0].parts[]` for DataParts (`kind === 'data'` with non-null object `.data`).
+   b. Use the **last** DataPart as authoritative (see [Last-DataPart Authority](#last-datapart-authority)).
+   c. **Reject wrappers**: If the DataPart's `.data` has a single key `response` containing an object, this is a framework wrapper bug. Throw or log an error.
+   d. Return `.data`.
+   e. **Fallback**: If no artifacts or no DataPart in artifacts, check `status.message.parts[]` using step 3.
+3. **Interim states** (`working`, `submitted`, `input-required`):
+   a. Look in `status.message.parts[]` for DataParts.
+   b. Use the **first** DataPart.
+   c. Return `.data`, or null if no DataPart found.
+4. **Unknown states**: Return null. Forward-compatible clients SHOULD NOT throw on unrecognized status values.
+
+<CodeGroup>
+```javascript A2A Client
+function extractAdcpResponseFromA2A(task) {
+  const state = task.status?.state;
+  if (!state) return null;
+
+  const FINAL = ['completed', 'failed', 'canceled'];
+  const INTERIM = ['working', 'submitted', 'input-required'];
+
+  if (FINAL.includes(state)) {
+    // Final: last DataPart from artifacts[0]
+    const artifact = task.artifacts?.[0];
+    if (artifact?.parts) {
+      const dataParts = artifact.parts.filter(p => p.kind === 'data'
+        && p.data != null && typeof p.data === 'object' && !Array.isArray(p.data));
+      if (dataParts.length > 0) {
+        const last = dataParts[dataParts.length - 1];
+        // Reject framework wrappers
+        const keys = Object.keys(last.data);
+        if (keys.length === 1 && keys[0] === 'response' && typeof last.data.response === 'object') {
+          throw new Error(
+            'Invalid response format: DataPart contains wrapper object {response: {...}}. ' +
+            'This is a server-side bug.'
+          );
+        }
+        return last.data;
+      }
+    }
+    // Fallback to status.message.parts
+    return extractFromMessage(task);
+  }
+
+  if (INTERIM.includes(state)) {
+    return extractFromMessage(task);
+  }
+
+  return null; // Unknown state
+}
+
+function extractFromMessage(task) {
+  const parts = task.status?.message?.parts;
+  if (!Array.isArray(parts)) return null;
+  const dataPart = parts.find(p => p.kind === 'data' && p.data != null);
+  return dataPart?.data ?? null;
+}
+```
+</CodeGroup>
+
+## Last-DataPart Authority
+
+For final states, the **last** DataPart in `artifacts[0].parts[]` is authoritative. During streaming, intermediate DataParts may contain stale progress data that gets superseded by the final result:
+
+```json
+{
+  "status": {"state": "completed"},
+  "artifacts": [{
+    "parts": [
+      {"kind": "text", "text": "Found products"},
+      {"kind": "data", "data": {"progress": 25}},
+      {"kind": "data", "data": {"products": [...], "total": 12}}
+    ]
+  }]
+}
+```
+
+The extracted data is `{"products": [...], "total": 12}`, not `{"progress": 25}`.
+
+For interim states, the **first** DataPart is used because interim updates are single-event snapshots, not accumulated.
+
+## Wrapper Rejection
+
+Clients MUST reject DataParts where `.data` is wrapped in a framework-specific object:
+
+```json
+// REJECTED: wrapper detected
+{"kind": "data", "data": {"response": {"products": [...]}}}
+
+// ACCEPTED: direct payload
+{"kind": "data", "data": {"products": [...]}}
+```
+
+The detection rule: if `.data` has exactly one key named `response` whose value is an object, it is a wrapper. This is a server-side bug — clients should throw or log an error, not silently unwrap.
+
+Wrapper detection applies to **final states only** (artifacts). Interim status messages are lightweight progress snapshots — wrapper detection is not required for `status.message.parts`.
+
+**Exception**: A `.data` object that has `response` alongside other keys is NOT a wrapper:
+```json
+// NOT a wrapper — response is one of several keys
+{"kind": "data", "data": {"response": {...}, "status": "completed", "errors": []}}
+```
+
+## Relationship to Error Extraction
+
+This algorithm extracts *any* AdCP data from A2A responses, including error payloads (`adcp_error`). Error-specific extraction ([Transport Error Mapping](/docs/building/implementation/transport-errors)) is a specialization that checks for the `adcp_error` key in the extracted data.
+
+The transport-errors spec provides its own `extractAdcpErrorFromA2A` function that scans all artifacts for `adcp_error`. That function is optimized for error detection (scanning all parts for the error key). This function is the general-purpose extractor (last DataPart from first artifact). For failed tasks with a single `adcp_error` DataPart, both produce equivalent results.
+
+Typical client flow:
+
+```javascript
+function handleA2aResponse(task) {
+  const data = extractAdcpResponseFromA2A(task);
+
+  // Check if the extracted data is an error
+  if (data?.adcp_error) {
+    return handleError(data.adcp_error);
+  }
+
+  return handleSuccess(data);
+}
+```
+
+## Security Considerations
+
+### Seller-Controlled Data
+
+All data in `.artifacts[].parts[].data` and `status.message.parts[].data` is seller-controlled. The prompt injection, data boundary, and size limit requirements from [Transport Error Mapping](/docs/building/implementation/transport-errors#security-considerations) apply.
+
+### Prototype Pollution
+
+Clients MUST NOT merge extracted DataPart payloads into application state via `Object.assign` or spread without filtering keys. Validate against the expected task response schema before merging.
+
+### FilePart URI Validation
+
+A2A responses may include FileParts (`kind: 'file'`). Clients MUST validate that `uri` uses the `https` scheme, contains no userinfo component, and matches an expected domain allowlist. Reject `javascript:`, `data:`, `file:`, and `http:` URIs.
+
+### Size Limits
+
+Clients SHOULD enforce a maximum DataPart size (e.g., 1MB) before schema validation. Unlike error payloads (capped at 4096 bytes), success payloads can be larger but still need bounds.
+
+### Intermediary Injection
+
+The last-DataPart convention assumes the artifact is received intact from a single trusted sender. In multi-hop scenarios (buyer → orchestrator → seller), an intermediary could inject additional parts. Clients operating through intermediaries SHOULD validate that the artifact part count matches expectations.
+
+## Client Library Requirements
+
+Client libraries that implement this spec MUST:
+
+1. **Branch on `status.state`.** Final states use artifacts; interim states use `status.message.parts`.
+2. **Use last DataPart for final states.** Skip DataParts with null `.data`.
+3. **Use first DataPart for interim states.**
+4. **Detect and reject wrappers.** Single-key `{response: {...}}` payloads are bugs.
+5. **Fall back gracefully.** If artifacts are empty for a final state, check `status.message.parts`.
+6. **Handle unknown states.** Return null, do not throw.
+
+## Test Vectors
+
+Machine-readable test vectors are available at [`/static/test-vectors/a2a-response-extraction.json`](https://adcontextprotocol.org/test-vectors/a2a-response-extraction.json). Each vector contains:
+
+- `status`: the A2A task status
+- `path`: extraction path (`artifact`, `status_message`, or `none`)
+- `response`: the A2A Task or TaskStatusUpdateEvent
+- `expected_data`: the AdCP data that should be extracted (or `null`)
+- `expected_error_type`: if present, the extraction should throw (e.g., `wrapper_detected`)
+
+Client libraries SHOULD validate their extraction logic against these vectors.
+
+## See Also
+
+- [A2A Response Format](/docs/building/integration/a2a-response-format) — canonical response structure for sellers
+- [Transport Error Mapping](/docs/building/implementation/transport-errors) — error extraction from MCP and A2A
+- [MCP Response Extraction](/docs/building/implementation/mcp-response-extraction) — equivalent spec for MCP
+- [A2A Guide](/docs/building/integration/a2a-guide) — A2A transport integration

--- a/docs/building/implementation/mcp-response-extraction.mdx
+++ b/docs/building/implementation/mcp-response-extraction.mdx
@@ -1,0 +1,163 @@
+---
+title: MCP Response Extraction
+description: "How to extract AdCP success response data from MCP tool results: structuredContent, text fallback, and client implementation requirements."
+"og:title": "AdCP — MCP Response Extraction"
+---
+
+This page defines the normative algorithm for extracting AdCP success response data from MCP tool results. For error extraction, see [Transport Error Mapping](/docs/building/implementation/transport-errors).
+
+## Layer Separation
+
+| Path | When | Data Source |
+|---|---|---|
+| Success extraction (this page) | `isError` absent or `false` | `structuredContent` or `content[].text` |
+| Error extraction ([transport-errors](/docs/building/implementation/transport-errors)) | `isError: true` | `structuredContent.adcp_error` or text fallback |
+
+Clients MUST check `isError` before deciding which extraction path to use. A response with `isError: true` MUST NOT be processed as a success response, even if it contains `structuredContent` with non-error data.
+
+## Extraction Algorithm
+
+Clients MUST extract AdCP data from MCP tool results in this order:
+
+1. **Guard: reject error responses.** If `isError` is truthy, return null. Error extraction is a separate path.
+2. **`structuredContent`** — If present and is a non-array object, return it. If the only key is `adcp_error`, return null (this is an error response missing the `isError` flag).
+3. **Text fallback** — Iterate `content[]` items in array order. For each item where `type === 'text'`, enforce a 1MB size limit, then attempt `JSON.parse`. If the result is a non-array object, return it. Skip items that fail to parse, parse as non-objects, or contain only an `adcp_error` key.
+4. **No structured data found** — Return null. The response is plain text with no machine-readable AdCP data.
+
+<CodeGroup>
+```javascript MCP Client
+function extractAdcpResponseFromMcp(response) {
+  // 1. Error responses go through transport-errors extraction
+  if (response.isError) return null;
+
+  // 2. structuredContent (preferred — MCP 2025-03-26+)
+  if (response.structuredContent != null
+      && typeof response.structuredContent === 'object'
+      && !Array.isArray(response.structuredContent)) {
+    const sc = response.structuredContent;
+    // adcp_error-only structuredContent is an error missing isError flag
+    const keys = Object.keys(sc);
+    if (keys.length === 1 && keys[0] === 'adcp_error') return null;
+    return sc;
+  }
+
+  // 3. Text fallback — JSON.parse content[].text
+  if (response.content && Array.isArray(response.content)) {
+    for (const item of response.content) {
+      if (item.type === 'text' && item.text) {
+        if (item.text.length > 1_048_576) continue; // 1MB size limit
+        try {
+          const parsed = JSON.parse(item.text);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            // Skip adcp_error-only payloads (error missing isError flag)
+            const keys = Object.keys(parsed);
+            if (keys.length === 1 && keys[0] === 'adcp_error') continue;
+            return parsed;
+          }
+        } catch { /* not JSON */ }
+      }
+    }
+  }
+
+  return null;
+}
+```
+</CodeGroup>
+
+## Extraction Paths
+
+### structuredContent (Preferred)
+
+MCP 2025-03-26 introduced `structuredContent` for typed tool results. AdCP servers return the full response payload here:
+
+```json
+{
+  "content": [{"type": "text", "text": "Found 3 products matching your brief."}],
+  "structuredContent": {
+    "status": "completed",
+    "message": "Found 3 products",
+    "products": [
+      {"product_id": "ctv_sports_premium", "name": "Premium Sports CTV"},
+      {"product_id": "ctv_news_standard", "name": "Standard News CTV"}
+    ]
+  }
+}
+```
+
+The `structuredContent` object IS the AdCP response — task-specific fields (`products`, `media_buy_id`, `status`, etc.) are at the top level, not nested.
+
+### Text Fallback
+
+Older MCP servers (pre-2025-03-26) serialize the response as JSON in `content[].text`:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "{\"status\":\"completed\",\"products\":[{\"product_id\":\"ctv_premium\"}]}"}
+  ]
+}
+```
+
+Clients parse the first text item that yields a JSON object. When both `structuredContent` and text JSON exist, `structuredContent` takes precedence.
+
+## Relationship to Error Extraction
+
+Success and error extraction are complementary:
+
+```javascript
+function handleMcpResponse(response) {
+  // Try error extraction first (only runs if isError is true)
+  const error = extractAdcpErrorFromMcp(response);
+  if (error) return handleError(error);
+
+  // Then try success extraction
+  const data = extractAdcpResponseFromMcp(response);
+  if (data) return handleSuccess(data);
+
+  // Plain text response — no structured data
+  return handlePlainText(response.content);
+}
+```
+
+## Security Considerations
+
+### Seller-Controlled Data
+
+All data in `structuredContent` and `content[].text` is seller-controlled. The same prompt injection and data boundary requirements from [Transport Error Mapping](/docs/building/implementation/transport-errors#security-considerations) apply.
+
+### Size Limits
+
+Clients SHOULD enforce a maximum payload size before processing. A recommended limit is 1MB for `structuredContent`. For text fallback, apply the limit before `JSON.parse` to prevent memory exhaustion from oversized payloads.
+
+### Prototype Pollution
+
+Clients MUST NOT merge extracted response objects into application state via `Object.assign` or spread without filtering keys. Seller-controlled keys like `__proto__` or `constructor` can trigger prototype pollution. Validate against the expected task response schema before merging.
+
+### Type Confusion
+
+Clients MUST check `isError` before success extraction. Without this guard, a client could process an error response as success data, leading to incorrect business logic (e.g., treating a `RATE_LIMITED` error as product data).
+
+## Client Library Requirements
+
+Client libraries that implement this spec MUST:
+
+1. **Check `isError` before extraction.** Return null for error responses.
+2. **Prefer `structuredContent`.** Only fall back to text parsing when `structuredContent` is absent.
+3. **Validate parsed text.** Only accept non-array objects from `JSON.parse`. Reject arrays, strings, numbers, booleans, and null.
+4. **Handle `adcp_error`-only `structuredContent`.** When `structuredContent` contains only an `adcp_error` key, return null — this is an error response that may be missing the `isError` flag.
+
+## Test Vectors
+
+Machine-readable test vectors are available at [`/static/test-vectors/mcp-response-extraction.json`](https://adcontextprotocol.org/test-vectors/mcp-response-extraction.json). Each vector contains:
+
+- `path`: extraction path (`structuredContent` or `text_fallback`)
+- `response`: the MCP tool result envelope
+- `expected_data`: the AdCP data that should be extracted (or `null`)
+
+Client libraries SHOULD validate their extraction logic against these vectors.
+
+## See Also
+
+- [Transport Error Mapping](/docs/building/implementation/transport-errors) — error extraction from MCP and A2A
+- [A2A Response Extraction](/docs/building/implementation/a2a-response-extraction) — equivalent spec for A2A
+- [MCP Guide](/docs/building/integration/mcp-guide) — MCP transport integration

--- a/docs/building/implementation/webhooks.mdx
+++ b/docs/building/implementation/webhooks.mdx
@@ -162,7 +162,7 @@ If the task completes synchronously (initial response is already `completed` or 
 
 ### A2A
 
-A2A sends a `Task` object (for final states) or `TaskStatusUpdateEvent` (for progress). The AdCP result data is in `status.message.parts[].data`:
+A2A sends a `Task` object (for final states) or `TaskStatusUpdateEvent` (for progress). For final states (`completed`, `failed`), AdCP result data is in `.artifacts[0].parts[]`. For interim states (`working`, `input-required`), data is in `status.message.parts[]`.
 
 ```json
 {
@@ -170,23 +170,23 @@ A2A sends a `Task` object (for final states) or `TaskStatusUpdateEvent` (for pro
   "contextId": "ctx_123",
   "status": {
     "state": "completed",
-    "message": {
-      "role": "agent",
-      "parts": [
-        { "kind": "text", "text": "Media buy created successfully" },
-        {
-          "kind": "data",
-          "data": {
-            "media_buy_id": "mb_12345",
-            "packages": [
-              { "package_id": "pkg_001", "context": { "line_item": "li_ctv_sports" } }
-            ]
-          }
-        }
-      ]
-    },
     "timestamp": "2025-01-22T10:30:00Z"
-  }
+  },
+  "artifacts": [{
+    "artifactId": "result",
+    "parts": [
+      { "kind": "text", "text": "Media buy created successfully" },
+      {
+        "kind": "data",
+        "data": {
+          "media_buy_id": "mb_12345",
+          "packages": [
+            { "package_id": "pkg_001", "context": { "line_item": "li_ctv_sports" } }
+          ]
+        }
+      }
+    ]
+  }]
 }
 ```
 
@@ -196,7 +196,7 @@ A2A sends a `Task` object (for final states) or `TaskStatusUpdateEvent` (for pro
 |---|---|---|
 | **Config field** | `push_notification_config` (in task args) | `configuration.pushNotificationConfig` (separate from skill params) |
 | **Envelope** | `mcp-webhook-payload.json` | Native `Task` / `TaskStatusUpdateEvent` |
-| **Result location** | `result` field | `status.message.parts[].data` |
+| **Result location** | `result` field | `.artifacts[0].parts[].data` (final) / `status.message.parts[].data` (interim) |
 | **Data schemas** | Identical AdCP schemas | Identical AdCP schemas |
 
 ### Status-specific result data
@@ -363,6 +363,51 @@ async function processWebhook(payload) {
 4. **Acknowledge immediately** — return `200` before doing any heavy processing to avoid publisher timeouts and unnecessary retries
 5. **Don't rely on URL structure** — use `operation_id` from the payload for routing, not URL parsing
 6. **Use HMAC-SHA256 in production** — Bearer tokens are simpler but don't protect against payload tampering
+
+## Payload extraction
+
+Webhook receivers need to detect the format and extract AdCP data. The buyer typically knows the format because it configured the transport, but defensive detection is useful for multi-format receivers.
+
+### Format detection
+
+| Signal | Format |
+|---|---|
+| `status` is a string, `task_id` present | MCP |
+| `status` is an object with `.state` | A2A |
+
+### Extraction
+
+**MCP webhooks:** Extract data from the `result` field directly.
+
+**A2A webhooks:** Use the [A2A response extraction](/docs/building/implementation/a2a-response-extraction) algorithm — final states extract from `.artifacts[0].parts[]` (last DataPart), interim states from `status.message.parts[]` (first DataPart).
+
+```javascript
+function extractAdcpResponseFromWebhook(payload, knownFormat) {
+  const format = knownFormat || detectFormat(payload);
+
+  if (format === 'mcp') return payload.result ?? null;
+  if (format === 'a2a') return extractAdcpResponseFromA2A(payload);
+  return null;
+}
+
+function detectFormat(payload) {
+  if (payload.status && typeof payload.status === 'object'
+      && !Array.isArray(payload.status) && payload.status.state) return 'a2a';
+  if (typeof payload.status === 'string' && payload.task_id) return 'mcp';
+  return null;
+}
+```
+
+### Security requirements
+
+- **Content-Type validation**: Publishers MUST send `application/json`. Receivers MUST reject other types before HMAC verification.
+- **Payload size limit**: Receivers SHOULD enforce a 1MB limit. Reject before HMAC computation — computing HMAC over large payloads is a DoS vector. Return `413 Payload Too Large`.
+- **Deduplication**: `task_id` + `timestamp` dedup provides defense-in-depth against replay attacks within the timestamp window.
+- **Format detection**: Auto-detection is a defensive fallback. Receivers SHOULD use the known format from their transport configuration (`knownFormat` parameter) rather than relying solely on payload inspection. A compromised intermediary could craft an ambiguous payload that routes extraction to the wrong path.
+
+### Test vectors
+
+Machine-readable test vectors are available at [`/static/test-vectors/webhook-payload-extraction.json`](https://adcontextprotocol.org/test-vectors/webhook-payload-extraction.json). Client libraries SHOULD validate their format detection and extraction logic against these vectors.
 
 ## Reporting webhooks
 

--- a/docs/building/integration/a2a-response-format.mdx
+++ b/docs/building/integration/a2a-response-format.mdx
@@ -192,8 +192,11 @@ function extractDataPartFromArtifacts(response) {
   const lastDataPart = dataParts[dataParts.length - 1];
   const payload = lastDataPart.data;
 
-  // CRITICAL: Payload MUST be direct AdCP response
-  if (payload.response !== undefined && typeof payload.response === 'object') {
+  // CRITICAL: Payload MUST be direct AdCP response, not a framework wrapper.
+  // A wrapper is a single-key object { response: {...} } — reject it.
+  // Objects that have 'response' alongside other keys are NOT wrappers.
+  const keys = Object.keys(payload);
+  if (keys.length === 1 && keys[0] === 'response' && typeof payload.response === 'object') {
     throw new Error(
       'Invalid response format: DataPart contains wrapper object. ' +
       'Expected direct AdCP payload (e.g., {products: [...]}) ' +

--- a/static/test-vectors/a2a-response-extraction.json
+++ b/static/test-vectors/a2a-response-extraction.json
@@ -1,0 +1,441 @@
+{
+  "version": 1,
+  "description": "Test vectors for extracting AdCP responses from A2A Task objects. Each vector contains an A2A response and the expected extracted AdCP data.",
+  "vectors": [
+    {
+      "id": "completed-single-datapart",
+      "description": "Completed task — single artifact, single DataPart (happy path)",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_001",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:30:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "text", "text": "Found 3 products matching your brief."},
+            {
+              "kind": "data",
+              "data": {
+                "status": "completed",
+                "products": [
+                  {"product_id": "ctv_sports_premium", "name": "Premium Sports CTV"},
+                  {"product_id": "ctv_news_standard", "name": "Standard News CTV"},
+                  {"product_id": "display_ros", "name": "Run of Site Display"}
+                ]
+              }
+            }
+          ]
+        }]
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [
+          {"product_id": "ctv_sports_premium", "name": "Premium Sports CTV"},
+          {"product_id": "ctv_news_standard", "name": "Standard News CTV"},
+          {"product_id": "display_ros", "name": "Run of Site Display"}
+        ]
+      }
+    },
+    {
+      "id": "completed-multiple-dataparts",
+      "description": "Completed task — multiple DataParts, last one wins",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_002",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:35:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "text", "text": "Found products"},
+            {"kind": "data", "data": {"progress": 25}},
+            {
+              "kind": "data",
+              "data": {
+                "status": "completed",
+                "products": [{"product_id": "ctv_final"}],
+                "total": 1
+              }
+            }
+          ]
+        }]
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [{"product_id": "ctv_final"}],
+        "total": 1
+      }
+    },
+    {
+      "id": "failed-adcp-error",
+      "description": "Failed task — adcp_error in artifact DataPart",
+      "status": "failed",
+      "path": "artifact",
+      "response": {
+        "id": "task_003",
+        "status": {
+          "state": "failed",
+          "timestamp": "2025-01-22T10:40:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "error-result",
+          "parts": [
+            {"kind": "text", "text": "Rate limit exceeded."},
+            {
+              "kind": "data",
+              "data": {
+                "adcp_error": {
+                  "code": "RATE_LIMITED",
+                  "message": "Request rate exceeded",
+                  "recovery": "transient",
+                  "retry_after": 5
+                }
+              }
+            }
+          ]
+        }]
+      },
+      "expected_data": {
+        "adcp_error": {
+          "code": "RATE_LIMITED",
+          "message": "Request rate exceeded",
+          "recovery": "transient",
+          "retry_after": 5
+        }
+      }
+    },
+    {
+      "id": "working-status-message",
+      "description": "Working status — progress data in status.message.parts",
+      "status": "working",
+      "path": "status_message",
+      "response": {
+        "id": "task_004",
+        "status": {
+          "state": "working",
+          "timestamp": "2025-01-22T10:31:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Processing inventory search..."},
+              {"kind": "data", "data": {"percentage": 45, "current_step": "analyzing_inventory"}}
+            ]
+          }
+        }
+      },
+      "expected_data": {"percentage": 45, "current_step": "analyzing_inventory"}
+    },
+    {
+      "id": "input-required-status-message",
+      "description": "Input-required status — reason data in status.message.parts",
+      "status": "input-required",
+      "path": "status_message",
+      "response": {
+        "id": "task_005",
+        "status": {
+          "state": "input-required",
+          "timestamp": "2025-01-22T10:32:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Media buy exceeds auto-approval limit ($100K). Please approve."},
+              {
+                "kind": "data",
+                "data": {
+                  "reason": "budget_approval",
+                  "media_buy_id": "mb_pending_456",
+                  "total_budget": 150000
+                }
+              }
+            ]
+          }
+        }
+      },
+      "expected_data": {
+        "reason": "budget_approval",
+        "media_buy_id": "mb_pending_456",
+        "total_budget": 150000
+      }
+    },
+    {
+      "id": "completed-no-artifacts",
+      "description": "Completed task — no artifacts, fallback to status.message.parts",
+      "status": "completed",
+      "path": "status_message",
+      "response": {
+        "id": "task_006",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:33:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Task completed."},
+              {"kind": "data", "data": {"status": "completed", "products": []}}
+            ]
+          }
+        }
+      },
+      "expected_data": {"status": "completed", "products": []}
+    },
+    {
+      "id": "completed-empty-artifacts",
+      "description": "Completed task — empty artifacts array, fallback to status.message.parts",
+      "status": "completed",
+      "path": "status_message",
+      "response": {
+        "id": "task_007",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:34:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "data", "data": {"status": "completed", "media_buy_id": "mb_789"}}
+            ]
+          }
+        },
+        "artifacts": []
+      },
+      "expected_data": {"status": "completed", "media_buy_id": "mb_789"}
+    },
+    {
+      "id": "wrapper-rejected",
+      "description": "Completed task — wrapper object {response: {...}} is rejected",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_008",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:35:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {
+              "kind": "data",
+              "data": {
+                "response": {
+                  "products": [{"product_id": "ctv_001"}]
+                }
+              }
+            }
+          ]
+        }]
+      },
+      "expected_data": null,
+      "expected_error_type": "wrapper_detected"
+    },
+    {
+      "id": "text-only-no-datapart",
+      "description": "Task with TextPart only, no DataPart — returns null",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_009",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:36:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "text", "text": "Operation completed successfully."}
+          ]
+        }]
+      },
+      "expected_data": null
+    },
+    {
+      "id": "multiple-artifacts",
+      "description": "Multiple artifacts — first artifact used",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_010",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:37:00Z"
+        },
+        "artifacts": [
+          {
+            "artifactId": "primary",
+            "parts": [
+              {"kind": "data", "data": {"products": [{"product_id": "primary_001"}]}}
+            ]
+          },
+          {
+            "artifactId": "secondary",
+            "parts": [
+              {"kind": "data", "data": {"report": "trafficking_report.pdf"}}
+            ]
+          }
+        ]
+      },
+      "expected_data": {"products": [{"product_id": "primary_001"}]}
+    },
+    {
+      "id": "datapart-null-data",
+      "description": "DataPart with null data — skip to next DataPart",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_011",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:38:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "data", "data": null},
+            {"kind": "data", "data": {"status": "completed", "products": [{"product_id": "ctv_real"}]}}
+          ]
+        }]
+      },
+      "expected_data": {"status": "completed", "products": [{"product_id": "ctv_real"}]}
+    },
+    {
+      "id": "submitted-minimal",
+      "description": "Submitted status — minimal acknowledgment data",
+      "status": "submitted",
+      "path": "status_message",
+      "response": {
+        "id": "task_012",
+        "status": {
+          "state": "submitted",
+          "timestamp": "2025-01-22T10:39:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Task queued for processing."},
+              {"kind": "data", "data": {"queue_position": 3}}
+            ]
+          }
+        }
+      },
+      "expected_data": {"queue_position": 3}
+    },
+    {
+      "id": "failed-no-artifacts-no-message",
+      "description": "Failed task — no artifacts, no status message data — returns null",
+      "status": "failed",
+      "path": "none",
+      "response": {
+        "id": "task_013",
+        "status": {
+          "state": "failed",
+          "timestamp": "2025-01-22T10:40:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Authentication failed: Invalid API token"}
+            ]
+          }
+        }
+      },
+      "expected_data": null
+    },
+    {
+      "id": "working-no-datapart",
+      "description": "Working status — text only, no DataPart — returns null",
+      "status": "working",
+      "path": "status_message",
+      "response": {
+        "id": "task_014",
+        "status": {
+          "state": "working",
+          "timestamp": "2025-01-22T10:41:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Processing..."}
+            ]
+          }
+        }
+      },
+      "expected_data": null
+    },
+    {
+      "id": "canceled-no-data",
+      "description": "Canceled task — no data to extract, returns null",
+      "status": "canceled",
+      "path": "none",
+      "response": {
+        "id": "task_015",
+        "status": {
+          "state": "canceled",
+          "timestamp": "2025-01-22T10:42:00Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Task canceled by user."}
+            ]
+          }
+        }
+      },
+      "expected_data": null
+    },
+    {
+      "id": "proto-pollution-payload",
+      "description": "Payload containing __proto__ key — extraction succeeds but clients MUST NOT merge via Object.assign",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_016",
+        "status": {"state": "completed", "timestamp": "2025-01-22T10:43:00Z"},
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [{
+            "kind": "data",
+            "data": {"products": [], "__proto__": {"isAdmin": true}}
+          }]
+        }]
+      },
+      "expected_data": {"products": [], "__proto__": {"isAdmin": true}}
+    },
+    {
+      "id": "datapart-non-object-data",
+      "description": "DataPart with non-object data (number) — skip, must be object",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_017",
+        "status": {"state": "completed", "timestamp": "2025-01-22T10:44:00Z"},
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "data", "data": 42},
+            {"kind": "data", "data": {"products": [{"product_id": "real_data"}]}}
+          ]
+        }]
+      },
+      "expected_data": {"products": [{"product_id": "real_data"}]}
+    },
+    {
+      "id": "datapart-string-data",
+      "description": "DataPart with string data — skip, must be object",
+      "status": "completed",
+      "path": "artifact",
+      "response": {
+        "id": "task_018",
+        "status": {"state": "completed", "timestamp": "2025-01-22T10:45:00Z"},
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "data", "data": "not an object"}
+          ]
+        }]
+      },
+      "expected_data": null
+    }
+  ]
+}

--- a/static/test-vectors/mcp-response-extraction.json
+++ b/static/test-vectors/mcp-response-extraction.json
@@ -1,0 +1,244 @@
+{
+  "version": 1,
+  "description": "Test vectors for extracting AdCP success responses from MCP tool results. Each vector contains an MCP response and the expected extracted AdCP data.",
+  "vectors": [
+    {
+      "id": "structured-content-products",
+      "description": "structuredContent with product catalog (happy path)",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Found 3 products matching your brief."}],
+        "structuredContent": {
+          "status": "completed",
+          "message": "Found 3 products",
+          "products": [
+            {"product_id": "ctv_sports_premium", "name": "Premium Sports CTV", "cpm": 35.00},
+            {"product_id": "ctv_news_standard", "name": "Standard News CTV", "cpm": 22.50},
+            {"product_id": "display_run_of_site", "name": "Run of Site Display", "cpm": 8.00}
+          ]
+        }
+      },
+      "expected_data": {
+        "status": "completed",
+        "message": "Found 3 products",
+        "products": [
+          {"product_id": "ctv_sports_premium", "name": "Premium Sports CTV", "cpm": 35.00},
+          {"product_id": "ctv_news_standard", "name": "Standard News CTV", "cpm": 22.50},
+          {"product_id": "display_run_of_site", "name": "Run of Site Display", "cpm": 8.00}
+        ]
+      }
+    },
+    {
+      "id": "structured-content-media-buy",
+      "description": "structuredContent with media buy response",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Media buy created successfully."}],
+        "structuredContent": {
+          "status": "completed",
+          "media_buy_id": "mb_12345",
+          "packages": [
+            {"package_id": "pkg_001", "status": "active"}
+          ],
+          "creative_deadline": "2025-02-01T23:59:59Z"
+        }
+      },
+      "expected_data": {
+        "status": "completed",
+        "media_buy_id": "mb_12345",
+        "packages": [
+          {"package_id": "pkg_001", "status": "active"}
+        ],
+        "creative_deadline": "2025-02-01T23:59:59Z"
+      }
+    },
+    {
+      "id": "text-fallback-json",
+      "description": "No structuredContent — JSON in content[].text (older MCP servers)",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "{\"status\":\"completed\",\"products\":[{\"product_id\":\"ctv_premium\",\"name\":\"Premium CTV\"}]}"}]
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [{"product_id": "ctv_premium", "name": "Premium CTV"}]
+      }
+    },
+    {
+      "id": "plain-text-no-json",
+      "description": "Plain text response with no structured data",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "Found 3 products matching your brief for pet food campaigns."}]
+      },
+      "expected_data": null
+    },
+    {
+      "id": "is-error-true",
+      "description": "isError: true response — MUST NOT extract as success (error path handles this)",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Rate limit exceeded."}],
+        "isError": true,
+        "structuredContent": {
+          "adcp_error": {
+            "code": "RATE_LIMITED",
+            "message": "Request rate exceeded",
+            "recovery": "transient"
+          }
+        }
+      },
+      "expected_data": null
+    },
+    {
+      "id": "is-error-true-no-structured",
+      "description": "isError: true with text fallback — MUST NOT extract as success",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "{\"adcp_error\":{\"code\":\"RATE_LIMITED\",\"recovery\":\"transient\"}}"}],
+        "isError": true
+      },
+      "expected_data": null
+    },
+    {
+      "id": "empty-structured-content",
+      "description": "Empty structuredContent object — returns empty object",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "No data available."}],
+        "structuredContent": {}
+      },
+      "expected_data": {}
+    },
+    {
+      "id": "multiple-text-items",
+      "description": "Multiple text content items — first valid JSON wins",
+      "path": "text_fallback",
+      "response": {
+        "content": [
+          {"type": "text", "text": "Found products for your campaign."},
+          {"type": "text", "text": "{\"status\":\"completed\",\"products\":[{\"product_id\":\"vid_001\"}]}"}
+        ]
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [{"product_id": "vid_001"}]
+      }
+    },
+    {
+      "id": "text-not-json",
+      "description": "Text content is not valid JSON — returns null",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "This is not JSON {invalid"}]
+      },
+      "expected_data": null
+    },
+    {
+      "id": "text-parses-as-array",
+      "description": "Text parses as JSON array — MUST NOT extract (must be object)",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "[{\"product_id\":\"ctv_001\"},{\"product_id\":\"ctv_002\"}]"}]
+      },
+      "expected_data": null
+    },
+    {
+      "id": "structured-content-adcp-error-only",
+      "description": "structuredContent with only adcp_error (no success data) — returns null",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Error occurred."}],
+        "structuredContent": {
+          "adcp_error": {
+            "code": "BUDGET_TOO_LOW",
+            "message": "Budget is below the seller's minimum",
+            "recovery": "correctable"
+          }
+        }
+      },
+      "expected_data": null
+    },
+    {
+      "id": "structured-content-wins-over-text",
+      "description": "Both structuredContent and text JSON present — structuredContent takes precedence",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "{\"status\":\"completed\",\"products\":[{\"product_id\":\"old_data\"}]}"}],
+        "structuredContent": {
+          "status": "completed",
+          "products": [{"product_id": "ctv_premium", "name": "Premium CTV"}]
+        }
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [{"product_id": "ctv_premium", "name": "Premium CTV"}]
+      }
+    },
+    {
+      "id": "working-status",
+      "description": "Working status with progress data in structuredContent",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Processing your request..."}],
+        "structuredContent": {
+          "status": "working",
+          "percentage": 45,
+          "current_step": "analyzing_inventory"
+        }
+      },
+      "expected_data": {
+        "status": "working",
+        "percentage": 45,
+        "current_step": "analyzing_inventory"
+      }
+    },
+    {
+      "id": "input-required-status",
+      "description": "Input-required status with reason data",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "Need approval for budget over $100K."}],
+        "structuredContent": {
+          "status": "input-required",
+          "message": "Media buy exceeds auto-approval limit",
+          "media_buy_id": "mb_pending_456",
+          "packages": [{"package_id": "pkg_001", "status": "pending_approval"}]
+        }
+      },
+      "expected_data": {
+        "status": "input-required",
+        "message": "Media buy exceeds auto-approval limit",
+        "media_buy_id": "mb_pending_456",
+        "packages": [{"package_id": "pkg_001", "status": "pending_approval"}]
+      }
+    },
+    {
+      "id": "text-fallback-adcp-error-only",
+      "description": "Text fallback with adcp_error-only JSON (error response missing isError) — returns null",
+      "path": "text_fallback",
+      "response": {
+        "content": [{"type": "text", "text": "{\"adcp_error\":{\"code\":\"RATE_LIMITED\",\"message\":\"Rate exceeded\",\"recovery\":\"transient\"}}"}]
+      },
+      "expected_data": null
+    },
+    {
+      "id": "proto-pollution-structured",
+      "description": "structuredContent with __proto__ key — extraction succeeds but clients MUST NOT merge via Object.assign",
+      "path": "structuredContent",
+      "response": {
+        "content": [{"type": "text", "text": "OK"}],
+        "structuredContent": {
+          "status": "completed",
+          "products": [],
+          "__proto__": {"isAdmin": true}
+        }
+      },
+      "expected_data": {
+        "status": "completed",
+        "products": [],
+        "__proto__": {"isAdmin": true}
+      }
+    }
+  ]
+}

--- a/static/test-vectors/webhook-payload-extraction.json
+++ b/static/test-vectors/webhook-payload-extraction.json
@@ -1,0 +1,271 @@
+{
+  "version": 1,
+  "description": "Test vectors for extracting AdCP data from webhook payloads. Each vector contains a webhook payload and the expected extracted AdCP data. Covers both MCP flat envelope and A2A native Task formats.",
+  "vectors": [
+    {
+      "id": "mcp-completed",
+      "description": "MCP webhook — completed with result data",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_001",
+        "task_type": "create_media_buy",
+        "domain": "media-buy",
+        "status": "completed",
+        "timestamp": "2025-01-22T10:30:00Z",
+        "message": "Media buy created successfully",
+        "result": {
+          "media_buy_id": "mb_12345",
+          "packages": [
+            {"package_id": "pkg_001", "status": "active"}
+          ]
+        }
+      },
+      "expected_format": "mcp",
+      "expected_data": {
+        "media_buy_id": "mb_12345",
+        "packages": [
+          {"package_id": "pkg_001", "status": "active"}
+        ]
+      }
+    },
+    {
+      "id": "mcp-failed-adcp-error",
+      "description": "MCP webhook — failed with adcp_error in result",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_002",
+        "status": "failed",
+        "timestamp": "2025-01-22T10:31:00Z",
+        "message": "Rate limit exceeded",
+        "result": {
+          "adcp_error": {
+            "code": "RATE_LIMITED",
+            "message": "Request rate exceeded",
+            "recovery": "transient",
+            "retry_after": 5
+          }
+        }
+      },
+      "expected_format": "mcp",
+      "expected_data": {
+        "adcp_error": {
+          "code": "RATE_LIMITED",
+          "message": "Request rate exceeded",
+          "recovery": "transient",
+          "retry_after": 5
+        }
+      }
+    },
+    {
+      "id": "mcp-working",
+      "description": "MCP webhook — working status with progress data",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_003",
+        "status": "working",
+        "timestamp": "2025-01-22T10:30:15Z",
+        "message": "Processing inventory search...",
+        "result": {
+          "percentage": 45,
+          "current_step": "analyzing_inventory"
+        }
+      },
+      "expected_format": "mcp",
+      "expected_data": {
+        "percentage": 45,
+        "current_step": "analyzing_inventory"
+      }
+    },
+    {
+      "id": "mcp-input-required",
+      "description": "MCP webhook — input-required status",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_004",
+        "status": "input-required",
+        "timestamp": "2025-01-22T10:30:30Z",
+        "message": "Budget exceeds auto-approval limit",
+        "result": {
+          "reason": "budget_approval",
+          "total_budget": 150000
+        }
+      },
+      "expected_format": "mcp",
+      "expected_data": {
+        "reason": "budget_approval",
+        "total_budget": 150000
+      }
+    },
+    {
+      "id": "a2a-completed-artifacts",
+      "description": "A2A webhook — completed Task with data in artifacts",
+      "format": "a2a",
+      "payload": {
+        "id": "task_005",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:30:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "text", "text": "Media buy created successfully"},
+            {
+              "kind": "data",
+              "data": {
+                "media_buy_id": "mb_12345",
+                "packages": [
+                  {"package_id": "pkg_001", "status": "active"}
+                ]
+              }
+            }
+          ]
+        }]
+      },
+      "expected_format": "a2a",
+      "expected_data": {
+        "media_buy_id": "mb_12345",
+        "packages": [
+          {"package_id": "pkg_001", "status": "active"}
+        ]
+      }
+    },
+    {
+      "id": "a2a-failed-adcp-error",
+      "description": "A2A webhook — failed Task with adcp_error in artifacts",
+      "format": "a2a",
+      "payload": {
+        "id": "task_006",
+        "status": {
+          "state": "failed",
+          "timestamp": "2025-01-22T10:31:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "error-result",
+          "parts": [
+            {"kind": "text", "text": "Rate limit exceeded."},
+            {
+              "kind": "data",
+              "data": {
+                "adcp_error": {
+                  "code": "RATE_LIMITED",
+                  "message": "Request rate exceeded",
+                  "recovery": "transient"
+                }
+              }
+            }
+          ]
+        }]
+      },
+      "expected_format": "a2a",
+      "expected_data": {
+        "adcp_error": {
+          "code": "RATE_LIMITED",
+          "message": "Request rate exceeded",
+          "recovery": "transient"
+        }
+      }
+    },
+    {
+      "id": "a2a-working-event",
+      "description": "A2A webhook — TaskStatusUpdateEvent for working status",
+      "format": "a2a",
+      "payload": {
+        "id": "task_007",
+        "status": {
+          "state": "working",
+          "timestamp": "2025-01-22T10:30:15Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Processing..."},
+              {"kind": "data", "data": {"percentage": 60, "current_step": "matching"}}
+            ]
+          }
+        }
+      },
+      "expected_format": "a2a",
+      "expected_data": {"percentage": 60, "current_step": "matching"}
+    },
+    {
+      "id": "mcp-missing-result",
+      "description": "MCP webhook — missing result field returns null",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_008",
+        "status": "completed",
+        "timestamp": "2025-01-22T10:30:00Z",
+        "message": "Done"
+      },
+      "expected_format": "mcp",
+      "expected_data": null
+    },
+    {
+      "id": "mcp-null-result",
+      "description": "MCP webhook — null result field returns null",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_009",
+        "status": "completed",
+        "timestamp": "2025-01-22T10:30:00Z",
+        "result": null
+      },
+      "expected_format": "mcp",
+      "expected_data": null
+    },
+    {
+      "id": "a2a-completed-no-datapart",
+      "description": "A2A webhook — completed but text-only artifacts, no DataPart",
+      "format": "a2a",
+      "payload": {
+        "id": "task_010",
+        "status": {
+          "state": "completed",
+          "timestamp": "2025-01-22T10:30:00Z"
+        },
+        "artifacts": [{
+          "artifactId": "result",
+          "parts": [
+            {"kind": "text", "text": "Task completed."}
+          ]
+        }]
+      },
+      "expected_format": "a2a",
+      "expected_data": null
+    },
+    {
+      "id": "mcp-canceled",
+      "description": "MCP webhook — canceled status with no result",
+      "format": "mcp",
+      "payload": {
+        "task_id": "task_011",
+        "status": "canceled",
+        "timestamp": "2025-01-22T10:30:00Z",
+        "message": "Task canceled by user"
+      },
+      "expected_format": "mcp",
+      "expected_data": null
+    },
+    {
+      "id": "a2a-input-required-event",
+      "description": "A2A webhook — input-required with reason data",
+      "format": "a2a",
+      "payload": {
+        "id": "task_012",
+        "status": {
+          "state": "input-required",
+          "timestamp": "2025-01-22T10:30:30Z",
+          "message": {
+            "role": "agent",
+            "parts": [
+              {"kind": "text", "text": "Approval needed for budget over $100K."},
+              {"kind": "data", "data": {"reason": "budget_approval", "amount": 150000}}
+            ]
+          }
+        }
+      },
+      "expected_format": "a2a",
+      "expected_data": {"reason": "budget_approval", "amount": 150000}
+    }
+  ]
+}

--- a/tests/a2a-response-extraction.test.cjs
+++ b/tests/a2a-response-extraction.test.cjs
@@ -1,0 +1,290 @@
+/**
+ * Validates A2A response extraction test vectors.
+ *
+ * Tests that the extraction logic for A2A responses produces the
+ * expected AdCP data from Task objects and TaskStatusUpdateEvents.
+ * Client libraries should also validate against these vectors.
+ */
+const fs = require('fs');
+const path = require('path');
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const vectorsPath = path.join(__dirname, '..', 'static', 'test-vectors', 'a2a-response-extraction.json');
+const data = JSON.parse(fs.readFileSync(vectorsPath, 'utf8'));
+
+const FINAL_STATES = ['completed', 'failed', 'canceled'];
+const INTERIM_STATES = ['working', 'submitted', 'input-required'];
+
+/**
+ * Extract the last DataPart with non-null data from an array of parts.
+ */
+function lastDataPart(parts) {
+  if (!Array.isArray(parts)) return null;
+  const dataParts = parts.filter(p => p.kind === 'data' && p.data != null
+    && typeof p.data === 'object' && !Array.isArray(p.data));
+  return dataParts.length > 0 ? dataParts[dataParts.length - 1] : null;
+}
+
+/**
+ * Extract the first DataPart with non-null data from an array of parts.
+ */
+function firstDataPart(parts) {
+  if (!Array.isArray(parts)) return null;
+  return parts.find(p => p.kind === 'data' && p.data != null
+    && typeof p.data === 'object' && !Array.isArray(p.data)) || null;
+}
+
+/**
+ * Detect framework wrapper objects.
+ * Returns true if the payload is wrapped in { response: {...} }.
+ */
+function isWrapped(data) {
+  if (!data || typeof data !== 'object') return false;
+  const keys = Object.keys(data);
+  return keys.length === 1 && keys[0] === 'response' && typeof data.response === 'object';
+}
+
+/**
+ * Reference extraction implementation matching the spec.
+ *
+ * Extracts AdCP response data from an A2A Task or TaskStatusUpdateEvent.
+ * Returns the extracted data, or null if no DataPart is found.
+ * Throws if a wrapper object is detected (server-side bug).
+ */
+function extractAdcpResponseFromA2A(task) {
+  const state = task.status?.state;
+  if (!state) return null;
+
+  // Final states: extract from artifacts[0].parts[] (last DataPart)
+  if (FINAL_STATES.includes(state)) {
+    const artifact = task.artifacts?.[0];
+    if (artifact?.parts) {
+      const part = lastDataPart(artifact.parts);
+      if (part) {
+        if (isWrapped(part.data)) {
+          throw new Error(
+            'Invalid response format: DataPart contains wrapper object. ' +
+            'Expected direct AdCP payload but received {response: {...}}. ' +
+            'This is a server-side bug that must be fixed.'
+          );
+        }
+        return part.data;
+      }
+    }
+    // Fallback: check status.message.parts for final states too
+    const msgPart = firstDataPart(task.status?.message?.parts);
+    return msgPart?.data ?? null;
+  }
+
+  // Interim states: extract from status.message.parts[] (first DataPart)
+  if (INTERIM_STATES.includes(state)) {
+    const msgPart = firstDataPart(task.status?.message?.parts);
+    return msgPart?.data ?? null;
+  }
+
+  return null;
+}
+
+describe('A2A response extraction test vectors', () => {
+  it('should have a valid structure', () => {
+    assert.equal(typeof data.version, 'number');
+    assert.ok(Array.isArray(data.vectors));
+    assert.ok(data.vectors.length > 0, 'must have at least one vector');
+
+    for (const vector of data.vectors) {
+      assert.ok(vector.id, 'each vector must have an id');
+      assert.ok(vector.description, 'each vector must have a description');
+      assert.ok(vector.status, 'each vector must have a status');
+      assert.ok(vector.response, 'each vector must have a response');
+      assert.ok('expected_data' in vector, 'each vector must have expected_data (can be null)');
+    }
+  });
+
+  for (const vector of data.vectors) {
+    it(`should extract correctly: ${vector.description} [${vector.id}]`, () => {
+      if (vector.expected_error_type === 'wrapper_detected') {
+        assert.throws(
+          () => extractAdcpResponseFromA2A(vector.response),
+          /wrapper/i,
+          `Expected wrapper detection error for ${vector.id}`
+        );
+        return;
+      }
+
+      const extracted = extractAdcpResponseFromA2A(vector.response);
+
+      if (vector.expected_data === null) {
+        assert.equal(extracted, null,
+          `Expected null but got: ${JSON.stringify(extracted)}`);
+      } else {
+        assert.ok(extracted !== null,
+          `Expected data but extraction returned null`);
+        assert.deepStrictEqual(extracted, vector.expected_data,
+          `Extracted data does not match expected for ${vector.id}`);
+      }
+    });
+  }
+
+  it('should cover all status types', () => {
+    const statuses = new Set(data.vectors.map(v => v.status));
+    assert.ok(statuses.has('completed'), 'must have completed vector');
+    assert.ok(statuses.has('failed'), 'must have failed vector');
+    assert.ok(statuses.has('working'), 'must have working vector');
+    assert.ok(statuses.has('input-required'), 'must have input-required vector');
+    assert.ok(statuses.has('submitted'), 'must have submitted vector');
+    assert.ok(statuses.has('canceled'), 'must have canceled vector');
+  });
+
+  it('should cover both extraction paths', () => {
+    const paths = new Set(data.vectors.map(v => v.path));
+    assert.ok(paths.has('artifact'), 'must have artifact path vector');
+    assert.ok(paths.has('status_message'), 'must have status_message path vector');
+  });
+
+  it('should have null-extraction vectors', () => {
+    const nullVectors = data.vectors.filter(
+      v => v.expected_data === null && !v.expected_error_type
+    );
+    assert.ok(nullVectors.length >= 2,
+      `must have at least 2 null-extraction vectors, got ${nullVectors.length}`);
+  });
+
+  it('should have wrapper detection vector', () => {
+    const wrapperVectors = data.vectors.filter(v => v.expected_error_type === 'wrapper_detected');
+    assert.ok(wrapperVectors.length >= 1, 'must have at least 1 wrapper detection vector');
+  });
+});
+
+describe('Validation and safety', () => {
+  it('should use last DataPart as authoritative for final states', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'completed' },
+      artifacts: [{
+        parts: [
+          { kind: 'data', data: { progress: 50 } },
+          { kind: 'data', data: { products: [{ product_id: 'final' }] } }
+        ]
+      }]
+    });
+    assert.deepStrictEqual(result, { products: [{ product_id: 'final' }] });
+  });
+
+  it('should use first DataPart for interim states', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: {
+        state: 'working',
+        message: {
+          role: 'agent',
+          parts: [
+            { kind: 'data', data: { percentage: 25 } },
+            { kind: 'data', data: { percentage: 75 } }
+          ]
+        }
+      }
+    });
+    assert.deepStrictEqual(result, { percentage: 25 });
+  });
+
+  it('should skip DataParts with null data', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'completed' },
+      artifacts: [{
+        parts: [
+          { kind: 'data', data: null },
+          { kind: 'data', data: { products: [] } }
+        ]
+      }]
+    });
+    assert.deepStrictEqual(result, { products: [] });
+  });
+
+  it('should throw on wrapper detection', () => {
+    assert.throws(
+      () => extractAdcpResponseFromA2A({
+        status: { state: 'completed' },
+        artifacts: [{
+          parts: [
+            { kind: 'data', data: { response: { products: [] } } }
+          ]
+        }]
+      }),
+      /wrapper/i
+    );
+  });
+
+  it('should NOT throw on data that happens to have a response key among others', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'completed' },
+      artifacts: [{
+        parts: [
+          { kind: 'data', data: { response: { products: [] }, status: 'completed' } }
+        ]
+      }]
+    });
+    assert.ok(result !== null, 'should extract when response is not the only key');
+  });
+
+  it('should return null for unknown status', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'unknown_future_status' },
+      artifacts: [{
+        parts: [{ kind: 'data', data: { foo: 'bar' } }]
+      }]
+    });
+    assert.equal(result, null);
+  });
+
+  it('should return null when no status present', () => {
+    const result = extractAdcpResponseFromA2A({});
+    assert.equal(result, null);
+  });
+
+  it('should fall back to status.message.parts when completed but no artifacts', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: {
+        state: 'completed',
+        message: {
+          role: 'agent',
+          parts: [{ kind: 'data', data: { products: [] } }]
+        }
+      }
+    });
+    assert.deepStrictEqual(result, { products: [] });
+  });
+
+  it('should not allow prototype pollution', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'completed' },
+      artifacts: [{
+        parts: [{
+          kind: 'data',
+          data: {
+            products: [],
+            __proto__: { isAdmin: true }
+          }
+        }]
+      }]
+    });
+    assert.ok(result !== null);
+    assert.equal(({}).isAdmin, undefined, '__proto__ must not pollute Object prototype');
+  });
+
+  it('should handle artifacts with no parts array', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: { state: 'completed' },
+      artifacts: [{ artifactId: 'empty' }]
+    });
+    assert.equal(result, null);
+  });
+
+  it('should handle status.message with no parts array', () => {
+    const result = extractAdcpResponseFromA2A({
+      status: {
+        state: 'working',
+        message: { role: 'agent' }
+      }
+    });
+    assert.equal(result, null);
+  });
+});

--- a/tests/mcp-response-extraction.test.cjs
+++ b/tests/mcp-response-extraction.test.cjs
@@ -1,0 +1,224 @@
+/**
+ * Validates MCP response extraction test vectors.
+ *
+ * Tests that the extraction logic for MCP success responses produces the
+ * expected AdCP data from the tool result envelope. Client libraries
+ * should also validate against these vectors.
+ */
+const fs = require('fs');
+const path = require('path');
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const vectorsPath = path.join(__dirname, '..', 'static', 'test-vectors', 'mcp-response-extraction.json');
+const data = JSON.parse(fs.readFileSync(vectorsPath, 'utf8'));
+
+/**
+ * Reference extraction implementation matching the spec.
+ *
+ * Extracts AdCP success response data from an MCP tool result.
+ * Returns null for error responses (isError: true) — those go through
+ * the transport error extraction path instead.
+ */
+function extractAdcpResponseFromMcp(response) {
+  // Error responses are handled by extractAdcpErrorFromMcp (transport-errors.mdx)
+  if (response.isError) return null;
+
+  // 1. structuredContent (preferred — MCP 2025-03-26+)
+  if (response.structuredContent != null && typeof response.structuredContent === 'object'
+      && !Array.isArray(response.structuredContent)) {
+    const sc = response.structuredContent;
+
+    // If structuredContent contains only adcp_error and nothing else,
+    // this is an error response missing isError flag — return null
+    const keys = Object.keys(sc);
+    if (keys.length === 1 && keys[0] === 'adcp_error') return null;
+
+    return sc;
+  }
+
+  // 2. Text fallback — JSON.parse content[].text
+  if (response.content && Array.isArray(response.content)) {
+    for (const item of response.content) {
+      if (item.type === 'text' && item.text) {
+        if (item.text.length > 1_048_576) continue; // 1MB size limit
+        try {
+          const parsed = JSON.parse(item.text);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            // Skip adcp_error-only payloads (error response missing isError flag)
+            const keys = Object.keys(parsed);
+            if (keys.length === 1 && keys[0] === 'adcp_error') continue;
+            return parsed;
+          }
+        } catch {
+          // Not JSON, continue
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+describe('MCP response extraction test vectors', () => {
+  it('should have a valid structure', () => {
+    assert.equal(typeof data.version, 'number');
+    assert.ok(Array.isArray(data.vectors));
+    assert.ok(data.vectors.length > 0, 'must have at least one vector');
+
+    for (const vector of data.vectors) {
+      assert.ok(vector.id, 'each vector must have an id');
+      assert.ok(vector.description, 'each vector must have a description');
+      assert.ok(vector.path, 'each vector must have a path');
+      assert.ok(vector.response, 'each vector must have a response');
+      assert.ok('expected_data' in vector, 'each vector must have expected_data (can be null)');
+    }
+  });
+
+  for (const vector of data.vectors) {
+    it(`should extract correctly: ${vector.description} [${vector.id}]`, () => {
+      const extracted = extractAdcpResponseFromMcp(vector.response);
+
+      if (vector.expected_data === null) {
+        assert.equal(extracted, null,
+          `Expected null but got: ${JSON.stringify(extracted)}`);
+      } else {
+        assert.ok(extracted !== null,
+          `Expected data but extraction returned null`);
+        assert.deepStrictEqual(extracted, vector.expected_data,
+          `Extracted data does not match expected for ${vector.id}`);
+      }
+    });
+  }
+
+  it('should cover both extraction paths', () => {
+    const paths = new Set(data.vectors.map(v => v.path));
+    assert.ok(paths.has('structuredContent'), 'must have structuredContent vector');
+    assert.ok(paths.has('text_fallback'), 'must have text fallback vector');
+  });
+
+  it('should have null-extraction vectors for error responses', () => {
+    const errorVectors = data.vectors.filter(
+      v => v.expected_data === null && v.response.isError
+    );
+    assert.ok(errorVectors.length >= 1, 'must have at least 1 isError null-extraction vector');
+  });
+
+  it('should have null-extraction vectors for non-JSON text', () => {
+    const nonJsonVectors = data.vectors.filter(
+      v => v.expected_data === null && !v.response.isError && !v.response.structuredContent
+    );
+    assert.ok(nonJsonVectors.length >= 1, 'must have at least 1 non-JSON null-extraction vector');
+  });
+});
+
+describe('Validation and safety', () => {
+  it('should not extract from isError: true responses', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'Error' }],
+      isError: true,
+      structuredContent: { products: [{ product_id: 'ctv_001' }] }
+    });
+    assert.equal(result, null, 'must not extract from error responses');
+  });
+
+  it('should not extract from isError: false responses via error path', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'Success' }],
+      isError: false,
+      structuredContent: { products: [{ product_id: 'ctv_001' }] }
+    });
+    assert.ok(result !== null, 'isError: false is a success response');
+    assert.deepStrictEqual(result.products, [{ product_id: 'ctv_001' }]);
+  });
+
+  it('should not extract when text parses as array', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: '[{"product_id":"ctv_001"}]' }]
+    });
+    assert.equal(result, null, 'array parse result must not extract');
+  });
+
+  it('should not extract when text parses as string', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: '"just a string"' }]
+    });
+    assert.equal(result, null, 'string parse result must not extract');
+  });
+
+  it('should not extract when text parses as number', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: '42' }]
+    });
+    assert.equal(result, null, 'number parse result must not extract');
+  });
+
+  it('should return null for structuredContent with only adcp_error', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'Error.' }],
+      structuredContent: {
+        adcp_error: { code: 'RATE_LIMITED', recovery: 'transient' }
+      }
+    });
+    assert.equal(result, null, 'adcp_error-only structuredContent must return null');
+  });
+
+  it('should extract structuredContent that has adcp_error alongside other data', () => {
+    // Edge case: completed response with partial errors
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'Partial results.' }],
+      structuredContent: {
+        status: 'completed',
+        products: [{ product_id: 'ctv_001' }],
+        errors: [{ code: 'NO_DATA_IN_REGION' }]
+      }
+    });
+    assert.ok(result !== null, 'should extract when other data present');
+    assert.deepStrictEqual(result.products, [{ product_id: 'ctv_001' }]);
+  });
+
+  it('should handle null structuredContent', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'Hello' }],
+      structuredContent: null
+    });
+    assert.equal(result, null);
+  });
+
+  it('should handle missing content array', () => {
+    const result = extractAdcpResponseFromMcp({});
+    assert.equal(result, null);
+  });
+
+  it('should handle empty content array', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: []
+    });
+    assert.equal(result, null);
+  });
+
+  it('should not allow prototype pollution via __proto__ in structuredContent', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: 'OK' }],
+      structuredContent: {
+        status: 'completed',
+        products: [],
+        __proto__: { isAdmin: true }
+      }
+    });
+    assert.ok(result !== null);
+    assert.equal(({}).isAdmin, undefined, '__proto__ must not pollute Object prototype');
+  });
+
+  it('should prefer structuredContent over text JSON', () => {
+    const result = extractAdcpResponseFromMcp({
+      content: [{ type: 'text', text: '{"status":"completed","products":[{"product_id":"old"}]}' }],
+      structuredContent: {
+        status: 'completed',
+        products: [{ product_id: 'new' }]
+      }
+    });
+    assert.deepStrictEqual(result.products, [{ product_id: 'new' }],
+      'structuredContent must take precedence');
+  });
+});

--- a/tests/webhook-payload-extraction.test.cjs
+++ b/tests/webhook-payload-extraction.test.cjs
@@ -1,0 +1,260 @@
+/**
+ * Validates webhook payload extraction test vectors.
+ *
+ * Tests format detection (MCP vs A2A) and data extraction from webhook
+ * payloads. MCP webhooks use a flat envelope with a `result` field.
+ * A2A webhooks use native Task/TaskStatusUpdateEvent objects and delegate
+ * to the A2A response extraction algorithm.
+ */
+const fs = require('fs');
+const path = require('path');
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const vectorsPath = path.join(__dirname, '..', 'static', 'test-vectors', 'webhook-payload-extraction.json');
+const data = JSON.parse(fs.readFileSync(vectorsPath, 'utf8'));
+
+// --- A2A extraction (reused from a2a-response-extraction) ---
+
+const FINAL_STATES = ['completed', 'failed', 'canceled'];
+const INTERIM_STATES = ['working', 'submitted', 'input-required'];
+
+function lastDataPart(parts) {
+  if (!Array.isArray(parts)) return null;
+  const dataParts = parts.filter(p => p.kind === 'data' && p.data != null
+    && typeof p.data === 'object' && !Array.isArray(p.data));
+  return dataParts.length > 0 ? dataParts[dataParts.length - 1] : null;
+}
+
+function firstDataPart(parts) {
+  if (!Array.isArray(parts)) return null;
+  return parts.find(p => p.kind === 'data' && p.data != null
+    && typeof p.data === 'object' && !Array.isArray(p.data)) || null;
+}
+
+function extractAdcpResponseFromA2A(task) {
+  const state = task.status?.state;
+  if (!state) return null;
+
+  if (FINAL_STATES.includes(state)) {
+    const artifact = task.artifacts?.[0];
+    if (artifact?.parts) {
+      const part = lastDataPart(artifact.parts);
+      if (part) {
+        // Reject framework wrappers (single-key {response: {...}})
+        const keys = Object.keys(part.data);
+        if (keys.length === 1 && keys[0] === 'response' && typeof part.data.response === 'object') {
+          throw new Error('Wrapper object detected in webhook A2A payload');
+        }
+        return part.data;
+      }
+    }
+    const msgPart = firstDataPart(task.status?.message?.parts);
+    return msgPart?.data ?? null;
+  }
+
+  if (INTERIM_STATES.includes(state)) {
+    const msgPart = firstDataPart(task.status?.message?.parts);
+    return msgPart?.data ?? null;
+  }
+
+  return null;
+}
+
+// --- Format detection ---
+
+/**
+ * Detect whether a webhook payload is MCP or A2A format.
+ *
+ * Primary: the buyer knows the format because it configured the transport.
+ * Defensive fallback for when format is unknown:
+ *   - `status.state` (object with state) → A2A
+ *   - `status` (string) with `task_id` → MCP
+ */
+function detectWebhookFormat(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+
+  // A2A: status is an object with a state field
+  if (payload.status && typeof payload.status === 'object'
+      && !Array.isArray(payload.status) && payload.status.state) {
+    return 'a2a';
+  }
+
+  // MCP: status is a string, task_id present
+  if (typeof payload.status === 'string' && payload.task_id) {
+    return 'mcp';
+  }
+
+  return null;
+}
+
+// --- Webhook extraction ---
+
+/**
+ * Extract AdCP response data from a webhook payload.
+ *
+ * For MCP webhooks: data is in the `result` field.
+ * For A2A webhooks: delegates to A2A extraction algorithm.
+ */
+function extractAdcpResponseFromWebhook(payload, knownFormat) {
+  const format = knownFormat || detectWebhookFormat(payload);
+
+  if (format === 'mcp') {
+    return payload.result ?? null;
+  }
+
+  if (format === 'a2a') {
+    return extractAdcpResponseFromA2A(payload);
+  }
+
+  return null;
+}
+
+describe('Webhook payload extraction test vectors', () => {
+  it('should have a valid structure', () => {
+    assert.equal(typeof data.version, 'number');
+    assert.ok(Array.isArray(data.vectors));
+    assert.ok(data.vectors.length > 0, 'must have at least one vector');
+
+    for (const vector of data.vectors) {
+      assert.ok(vector.id, 'each vector must have an id');
+      assert.ok(vector.description, 'each vector must have a description');
+      assert.ok(vector.format, 'each vector must have a format');
+      assert.ok(vector.payload, 'each vector must have a payload');
+      assert.ok('expected_data' in vector, 'each vector must have expected_data (can be null)');
+      assert.ok(vector.expected_format, 'each vector must have expected_format');
+    }
+  });
+
+  for (const vector of data.vectors) {
+    it(`should detect format correctly: ${vector.id}`, () => {
+      const detected = detectWebhookFormat(vector.payload);
+      assert.equal(detected, vector.expected_format,
+        `Expected format ${vector.expected_format} but detected ${detected} for ${vector.id}`);
+    });
+
+    it(`should extract correctly: ${vector.description} [${vector.id}]`, () => {
+      const extracted = extractAdcpResponseFromWebhook(vector.payload);
+
+      if (vector.expected_data === null) {
+        assert.equal(extracted, null,
+          `Expected null but got: ${JSON.stringify(extracted)}`);
+      } else {
+        assert.ok(extracted !== null,
+          `Expected data but extraction returned null`);
+        assert.deepStrictEqual(extracted, vector.expected_data,
+          `Extracted data does not match expected for ${vector.id}`);
+      }
+    });
+  }
+
+  it('should cover both webhook formats', () => {
+    const formats = new Set(data.vectors.map(v => v.format));
+    assert.ok(formats.has('mcp'), 'must have MCP webhook vector');
+    assert.ok(formats.has('a2a'), 'must have A2A webhook vector');
+  });
+
+  it('should have null-extraction vectors', () => {
+    const nullVectors = data.vectors.filter(v => v.expected_data === null);
+    assert.ok(nullVectors.length >= 2,
+      `must have at least 2 null-extraction vectors, got ${nullVectors.length}`);
+  });
+
+  it('should cover multiple statuses per format', () => {
+    const mcpStatuses = new Set(
+      data.vectors.filter(v => v.format === 'mcp').map(v => v.payload.status)
+    );
+    const a2aStatuses = new Set(
+      data.vectors.filter(v => v.format === 'a2a').map(v => v.payload.status?.state)
+    );
+    assert.ok(mcpStatuses.size >= 3, `must have at least 3 MCP statuses, got ${mcpStatuses.size}`);
+    assert.ok(a2aStatuses.size >= 3, `must have at least 3 A2A statuses, got ${a2aStatuses.size}`);
+  });
+});
+
+describe('Format detection', () => {
+  it('should detect MCP format from string status + task_id', () => {
+    assert.equal(detectWebhookFormat({
+      task_id: 'task_001',
+      status: 'completed',
+      result: {}
+    }), 'mcp');
+  });
+
+  it('should detect A2A format from object status with state', () => {
+    assert.equal(detectWebhookFormat({
+      id: 'task_001',
+      status: { state: 'completed' }
+    }), 'a2a');
+  });
+
+  it('should return null for unrecognized format', () => {
+    assert.equal(detectWebhookFormat({ foo: 'bar' }), null);
+  });
+
+  it('should return null for null payload', () => {
+    assert.equal(detectWebhookFormat(null), null);
+  });
+
+  it('should return null for non-object payload', () => {
+    assert.equal(detectWebhookFormat('string'), null);
+  });
+});
+
+describe('Extraction with known format', () => {
+  it('should extract MCP data when format is known', () => {
+    const result = extractAdcpResponseFromWebhook(
+      { task_id: 'task_001', status: 'completed', result: { products: [] } },
+      'mcp'
+    );
+    assert.deepStrictEqual(result, { products: [] });
+  });
+
+  it('should extract A2A data when format is known', () => {
+    const result = extractAdcpResponseFromWebhook(
+      {
+        id: 'task_001',
+        status: { state: 'completed' },
+        artifacts: [{ parts: [{ kind: 'data', data: { products: [] } }] }]
+      },
+      'a2a'
+    );
+    assert.deepStrictEqual(result, { products: [] });
+  });
+
+  it('should return null for unknown format', () => {
+    const result = extractAdcpResponseFromWebhook({ foo: 'bar' }, null);
+    assert.equal(result, null);
+  });
+});
+
+describe('Validation and safety', () => {
+  it('should handle MCP payload with undefined result', () => {
+    const result = extractAdcpResponseFromWebhook(
+      { task_id: 'task_001', status: 'completed' },
+      'mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  it('should handle A2A payload with no artifacts or message', () => {
+    const result = extractAdcpResponseFromWebhook(
+      { id: 'task_001', status: { state: 'completed' } },
+      'a2a'
+    );
+    assert.equal(result, null);
+  });
+
+  it('should not allow prototype pollution via MCP result', () => {
+    const result = extractAdcpResponseFromWebhook(
+      {
+        task_id: 'task_001',
+        status: 'completed',
+        result: { products: [], __proto__: { isAdmin: true } }
+      },
+      'mcp'
+    );
+    assert.ok(result !== null);
+    assert.equal(({}).isAdmin, undefined, '__proto__ must not pollute Object prototype');
+  });
+});


### PR DESCRIPTION
## Summary

- **MCP success response extraction** (#1577): normative algorithm for extracting AdCP data from `structuredContent` and `content[].text` fallback, with 17 test vectors
- **A2A response extraction** (#1571): normative algorithm with status-based branching, last-DataPart authority, wrapper rejection, and 18 test vectors
- **Webhook payload extraction** (#1572): format detection (MCP vs A2A), unified extraction algorithm, and 12 test vectors
- **Fix**: `webhooks.mdx` A2A completed data location corrected from `status.message.parts` to `.artifacts[].parts[]`
- **Fix**: `a2a-response-format.mdx` wrapper detection narrowed to single-key check for consistency with new extraction spec

Follows the three-file pattern from transport error mapping (#1560): spec MDX + test vectors JSON + reference test CJS.

Closes #1577, closes #1571, closes #1572.

## Test plan

- [x] `node --test tests/mcp-response-extraction.test.cjs` — 32 tests pass
- [x] `node --test tests/a2a-response-extraction.test.cjs` — 33 tests pass
- [x] `node --test tests/webhook-payload-extraction.test.cjs` — 42 tests pass
- [x] `node --test tests/transport-error-mapping.test.cjs` — existing 81 tests still pass
- [x] Full `npm test` suite passes (188 extraction tests + all existing tests)
- [x] No broken links in docs navigation
- [x] Code review and security review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)