### PR TITLE
feat: availability forecasts for guaranteed inventory

### DIFF
--- a/.changeset/availability-forecasts.md
+++ b/.changeset/availability-forecasts.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": minor
+---
+
+Support availability forecasts for guaranteed and direct-sold inventory
+
+- Make `budget` optional on `ForecastPoint` — when omitted, the point represents total available inventory for the requested targeting and dates
+- Add `availability` value to `forecast-range-unit` enum for forecasts where metrics express what exists, not what a given spend level buys
+- Guaranteed products now include availability forecasts with `metrics.spend` expressing estimated cost
+- Update delivery forecast documentation with availability forecast examples and buyer-side underdelivery calculation guidance

--- a/docs/learning/specialist/media-buy.mdx
+++ b/docs/learning/specialist/media-buy.mdx
@@ -75,7 +75,7 @@ Passing earns the **AdCP specialist — Media buy** credential.
 During the module, Addie will guide you through hands-on exercises:
 
 1. **Product discovery and evaluation** — Query multiple sandbox agents, compare products, evaluate pricing
-2. **Proposal and forecasting** — Request proposals with budget points, analyze delivery forecasts
+2. **Proposal and forecasting** — Request proposals, analyze delivery forecasts (spend curves and availability)
 3. **Campaign creation and optimization** — Create a media buy, monitor delivery, execute updates
 4. **Lifecycle management** — Check `valid_actions`, cancel a package, handle `NOT_CANCELLABLE`, use `revision` for concurrency
 5. **Multi-agent orchestration** — Manage campaigns across multiple sellers simultaneously

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -796,7 +796,7 @@ Proposals are optional — publishers may return only products if allocation gui
 
 Publishers can attach delivery forecasts to proposals and individual allocations to help buyers evaluate expected performance before committing budget.
 
-Each forecast contains a `points` array of one or more ForecastPoints, each pairing a budget level with metric ranges (low/mid/high). A single point is a standard forecast; multiple points ordered by ascending budget show how metrics scale with spend.
+Each forecast contains a `points` array of one or more ForecastPoints. For spend curves, each point pairs a budget level with metric ranges (low/mid/high) — multiple points at ascending budgets show how delivery scales with spend. For availability forecasts, points omit budget and express total available inventory for the requested targeting and dates.
 
 Metric keys come from two vocabularies:
 - **Delivery/engagement**: `forecastable-metric` enum values (impressions, reach, clicks, spend, views, completed_views, grps, etc.)
@@ -813,6 +813,7 @@ This lets sellers forecast both delivery ("1.2M impressions") and outcomes ("1,8
 The `forecast_range_unit` field tells consumers how to interpret the points array — what axis the curve represents:
 
 - **`spend`** (default) — points at ascending budget levels. Standard budget curve.
+- **`availability`** — each point represents total available inventory for the requested targeting and dates. Budget is omitted; use `metrics.spend` to express estimated cost. Typical for guaranteed and direct-sold inventory.
 - **`reach_freq`** — points at ascending reach/frequency targets. Used in broadcast planning where the publisher shows how cost scales with frequency goals.
 - **`weekly`** / **`daily`** — metrics are per-period values. Budget refers to total campaign spend. A frequency of 3.2 with `weekly` means 3.2 exposures per week.
 - **`clicks`** / **`conversions`** — points at ascending outcome targets. Used in goal-based planning (e.g., "tell me your conversion goal, I'll tell you the budget").
@@ -868,6 +869,29 @@ Multiple forecast points at ascending budget levels show how metrics scale with 
 ```
 
 The curve reveals diminishing returns — doubling budget from \$50K to \$100K increases reach by ~56%, not 2x. Buyers can use this to negotiate or reallocate budget across publishers.
+
+#### Availability Forecast
+
+For guaranteed and direct-sold inventory, the forecast is an availability check — how much inventory exists on this placement with this targeting in this flight window. Budget is omitted because available inventory doesn't depend on how much the buyer wants to spend. The seller can include `metrics.spend` to express the estimated cost of the available inventory:
+
+```json
+{
+  "points": [
+    {
+      "metrics": {
+        "impressions": { "low": 320000, "mid": 400000, "high": 480000 },
+        "reach": { "low": 200000, "mid": 260000, "high": 300000 },
+        "spend": { "low": 6400, "mid": 8000, "high": 9600 }
+      }
+    }
+  ],
+  "forecast_range_unit": "availability",
+  "method": "guaranteed",
+  "currency": "USD"
+}
+```
+
+The buyer agent can compare available impressions against budget requirements to identify underdelivery. If the buyer needs 500,000 impressions at a \$20 CPM to spend their full \$10K budget, and the forecast shows 400,000 mid available, the buyer knows \$2K of budget must be allocated elsewhere.
 
 #### CTV with GRP Demographics
 

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -400,12 +400,34 @@ function buildProduct(
     }
   }
 
-  // Build forecast for non-guaranteed products
+  // Build forecast
   let forecast: Product['forecast'];
-  if (template.deliveryType === 'non_guaranteed') {
-    const baseCpm = effectivePricing[0]?.floorPrice || effectivePricing[0]?.fixedPrice || 10;
-    const impressionsPer1k = Math.round(1000 / baseCpm * 1000);
+  const baseCpm = effectivePricing[0]?.floorPrice || effectivePricing[0]?.fixedPrice || 10;
+  const impressionsPer1k = Math.round(1000 / baseCpm * 1000);
+  const currency = effectivePricing[0]?.currency || 'USD';
 
+  if (template.deliveryType === 'guaranteed') {
+    // Availability forecast — total inventory available, no budget input.
+    // Cast needed until @adcp/client types are regenerated with optional budget
+    // and the 'availability' forecast_range_unit value.
+    const availableImpressions = impressionsPer1k * 30;
+    const estimatedSpend = Math.round(availableImpressions * baseCpm / 1000);
+    forecast = {
+      points: [
+        {
+          metrics: {
+            impressions: { low: Math.round(availableImpressions * 0.85), mid: availableImpressions, high: Math.round(availableImpressions * 1.1) },
+            reach: { low: Math.round(availableImpressions * 0.5), mid: Math.round(availableImpressions * 0.65), high: Math.round(availableImpressions * 0.75) },
+            spend: { low: Math.round(estimatedSpend * 0.85), mid: estimatedSpend, high: Math.round(estimatedSpend * 1.1) },
+          },
+        },
+      ],
+      forecast_range_unit: 'availability',
+      method: 'guaranteed',
+      currency,
+    } as unknown as Product['forecast'];
+  } else {
+    // Spend curve — metrics at ascending budget levels
     forecast = {
       points: [
         {
@@ -424,7 +446,7 @@ function buildProduct(
         },
       ],
       method: 'modeled',
-      currency: effectivePricing[0]?.currency || 'USD',
+      currency,
     };
   }
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -2132,7 +2132,7 @@ describe('time pricing model', () => {
 });
 
 describe('forecast data', () => {
-  it('non-guaranteed products have forecast field', () => {
+  it('non-guaranteed products have modeled spend-curve forecasts', () => {
     const catalog = buildCatalog();
     const nonGuaranteed = catalog.filter(cp =>
       cp.product.delivery_type === 'non_guaranteed',
@@ -2142,19 +2142,43 @@ describe('forecast data', () => {
       expect(cp.product.forecast).toBeDefined();
       const forecast = cp.product.forecast as Record<string, unknown>;
       expect(forecast.method).toBe('modeled');
+      expect(forecast.currency).toBeDefined();
       const points = forecast.points as Array<Record<string, unknown>>;
       expect(points.length).toBe(2);
+      // Spend curve points have budget and metric ranges
+      for (const point of points) {
+        expect(point.budget).toBeDefined();
+        expect(typeof point.budget).toBe('number');
+        const metrics = point.metrics as Record<string, Record<string, number>>;
+        expect(metrics.impressions.mid).toBeGreaterThan(0);
+        expect(metrics.impressions.low).toBeLessThanOrEqual(metrics.impressions.mid);
+      }
     }
   });
 
-  it('guaranteed products do not have forecast', () => {
+  it('guaranteed products have availability forecasts', () => {
     const catalog = buildCatalog();
     const guaranteed = catalog.filter(cp =>
       cp.product.delivery_type === 'guaranteed',
     );
     expect(guaranteed.length).toBeGreaterThan(0);
     for (const cp of guaranteed) {
-      expect(cp.product.forecast).toBeUndefined();
+      expect(cp.product.forecast).toBeDefined();
+      const forecast = cp.product.forecast as Record<string, unknown>;
+      expect(forecast.method).toBe('guaranteed');
+      expect(forecast.forecast_range_unit).toBe('availability');
+      expect(forecast.currency).toBeDefined();
+      const points = forecast.points as Array<Record<string, unknown>>;
+      expect(points.length).toBe(1);
+      // Availability points have no budget — metrics express what exists
+      const point = points[0];
+      expect(point.budget).toBeUndefined();
+      const metrics = point.metrics as Record<string, Record<string, number>>;
+      expect(metrics.impressions).toBeDefined();
+      expect(metrics.impressions.mid).toBeGreaterThan(0);
+      expect(metrics.impressions.low).toBeLessThanOrEqual(metrics.impressions.mid);
+      expect(metrics.spend).toBeDefined();
+      expect(metrics.spend.mid).toBeGreaterThan(0);
     }
   });
 });

--- a/static/schemas/source/core/delivery-forecast.json
+++ b/static/schemas/source/core/delivery-forecast.json
@@ -7,7 +7,7 @@
   "properties": {
     "points": {
       "type": "array",
-      "description": "Forecasted delivery at one or more budget levels. A single point is a standard forecast; multiple points ordered by ascending budget form a curve showing how metrics scale with spend. Each point pairs a budget with metric ranges.",
+      "description": "Forecasted delivery data points. For spend curves (default), points at ascending budget levels show how metrics scale with spend. For availability forecasts, points represent total available inventory independent of budget. See forecast_range_unit for interpretation.",
       "items": {
         "$ref": "/schemas/core/forecast-point.json"
       },
@@ -15,7 +15,7 @@
     },
     "forecast_range_unit": {
       "$ref": "/schemas/enums/forecast-range-unit.json",
-      "description": "How to interpret the points array. 'spend' (default when omitted): points at ascending budget levels. 'reach_freq': points at ascending reach/frequency targets. 'weekly'/'daily': metrics are per-period values. 'clicks'/'conversions': points at ascending outcome targets."
+      "description": "How to interpret the points array. 'spend' (default when omitted): points at ascending budget levels. 'availability': total available inventory, budget omitted. 'reach_freq': points at ascending reach/frequency targets. 'weekly'/'daily': metrics are per-period values. 'clicks'/'conversions': points at ascending outcome targets."
     },
     "method": {
       "$ref": "/schemas/enums/forecast-method.json",

--- a/static/schemas/source/core/forecast-point.json
+++ b/static/schemas/source/core/forecast-point.json
@@ -2,17 +2,17 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/forecast-point.json",
   "title": "Forecast Point",
-  "description": "A forecast at a specific budget level. A single point represents a standard forecast; multiple points ordered by ascending budget form a curve showing how delivery metrics scale with spend.",
+  "description": "A forecast data point. When budget is present, the point pairs a spend level with expected delivery — multiple points at ascending budgets form a curve. When budget is omitted, the point represents total available inventory for the requested targeting and dates, independent of spend.",
   "type": "object",
   "properties": {
     "budget": {
       "type": "number",
-      "description": "Budget amount for this forecast point. For allocation-level forecasts, this is the absolute budget for that allocation (not the percentage). For proposal-level forecasts, this is the total proposal budget.",
+      "description": "Budget amount for this forecast point. Required for spend curves; omit for availability forecasts where the metrics represent total available inventory. For allocation-level forecasts, this is the absolute budget for that allocation (not the percentage). For proposal-level forecasts, this is the total proposal budget. When omitted, use metrics.spend to express the estimated cost of the available inventory.",
       "minimum": 0
     },
     "metrics": {
       "type": "object",
-      "description": "Forecasted metric values at this budget level. Keys are forecastable-metric enum values for delivery/engagement or event-type enum values for outcomes. Values are ForecastRange objects (low/mid/high). Use { \"mid\": value } for point estimates. Include spend when the platform predicts it will differ from budget. Additional keys beyond the documented properties are allowed for event-type values (purchase, lead, app_install, etc.).",
+      "description": "Forecasted metric values. Keys are forecastable-metric enum values for delivery/engagement or event-type enum values for outcomes. Values are ForecastRange objects (low/mid/high). Use { \"mid\": value } for point estimates. When budget is present, these are the expected metrics at that spend level. When budget is omitted, these represent total available inventory — use spend to express the estimated cost. Additional keys beyond the documented properties are allowed for event-type values (purchase, lead, app_install, etc.).",
       "properties": {
         "audience_size": { "$ref": "/schemas/core/forecast-range.json" },
         "reach": { "$ref": "/schemas/core/forecast-range.json" },
@@ -33,6 +33,6 @@
       }
     }
   },
-  "required": ["budget", "metrics"],
+  "required": ["metrics"],
   "additionalProperties": true
 }

--- a/static/schemas/source/enums/forecast-range-unit.json
+++ b/static/schemas/source/enums/forecast-range-unit.json
@@ -4,9 +4,10 @@
   "title": "Forecast Range Unit",
   "description": "Describes how to interpret the points array in a DeliveryForecast — what axis the curve represents",
   "type": "string",
-  "enum": ["spend", "reach_freq", "weekly", "daily", "clicks", "conversions"],
+  "enum": ["spend", "availability", "reach_freq", "weekly", "daily", "clicks", "conversions"],
   "enumDescriptions": {
     "spend": "Points at ascending budget levels. Standard budget curve showing how delivery metrics scale with spend. Default when field is omitted.",
+    "availability": "Each point represents total available inventory for the requested targeting and dates. Budget is omitted — metrics express what exists, not what a given spend level buys. Use metrics.spend to express the estimated cost. Typical for guaranteed and direct-sold inventory where the forecast is an availability check.",
     "reach_freq": "Points at ascending reach/frequency targets. Used in broadcast planning where the publisher shows how cost scales with frequency goals.",
     "weekly": "Metrics are per-week values. Budget refers to total campaign spend. Frequency of 3.2 means 3.2 exposures per week.",
     "daily": "Metrics are per-day values. Budget refers to total campaign spend.",


### PR DESCRIPTION
## Summary

Addresses #1740 — the current forecast model assumes budget as the independent variable, which doesn't work for guaranteed/direct-sold inventory where the forecast is an availability check.

- Make `budget` optional on `ForecastPoint` — when omitted, the point represents total available inventory for the requested targeting and dates
- Add `availability` value to `forecast-range-unit` enum for forecasts where metrics express what exists, not what a given spend level buys
- Sellers use `metrics.spend` to express the estimated cost of available inventory
- Guaranteed products in the training agent now include availability forecasts
- No `underdelivery` object — that's derived data belonging in buyer-side logic, not the protocol

### Design decisions

**Why no `underdelivery` fields?** The issue proposed `budget_at_risk` and `impressions_shortfall`. These require the publisher to know the buyer's budget to compute, which contradicts the premise that availability forecasts are budget-independent. The buyer agent can trivially compute shortfall from available impressions + CPM + their budget.

**Why `forecast_range_unit: "availability"` instead of just omitting budget?** Gives consuming agents an explicit discriminator for how to interpret the points array, rather than requiring inference from the absence of `budget`.

**Why `metrics.spend` for cost?** A seller returning an availability forecast may still want to say "this inventory costs roughly $X." The existing `spend` metric in the metrics map serves this purpose without needing new fields.

## Test plan

- [x] All 218 training-agent unit tests pass
- [x] Schema validation passes (449 schemas)
- [x] TypeScript typecheck passes
- [x] Pre-commit hooks pass (all test suites, linting, schema builds)
- [x] Pre-push hooks pass (Mintlify docs, broken links, accessibility)
- [ ] Verify availability forecast example renders correctly in docs preview
- [ ] @LukasGoTom review: does this address the guaranteed inventory forecasting gap?

🤖 Generated with [Claude Code](https://claude.com/claude-code)