### PR TITLE
Add CI migration smoke test

### DIFF
--- a/.changeset/tiny-lizards-shop.md
+++ b/.changeset/tiny-lizards-shop.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds a CI smoke test that runs built database migrations against PostgreSQL.

--- a/.github/workflows/migration-smoke-test.yml
+++ b/.github/workflows/migration-smoke-test.yml
@@ -1,0 +1,69 @@
+name: Migration Smoke Test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/migration-smoke-test.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'server/src/db/**'
+      - 'server/src/config.ts'
+      - 'server/tsconfig.json'
+      - 'Dockerfile'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/migration-smoke-test.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'server/src/db/**'
+      - 'server/src/config.ts'
+      - 'server/tsconfig.json'
+      - 'Dockerfile'
+
+jobs:
+  migrate:
+    name: Built migrations against Postgres
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: adcp_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d adcp_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+      - name: Build
+        run: npm run build
+
+      - name: Stage migrations into dist
+        run: |
+          mkdir -p dist/db
+          cp -R server/src/db/migrations dist/db/migrations
+
+      - name: Run built migrations
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/adcp_test
+        run: node dist/db/migrate.js


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to run built database migrations against PostgreSQL
- stage `server/src/db/migrations` into `dist/db/migrations` so the CI path matches the Fly release artifact
- trigger the smoke test on migration, DB runner, build, and workflow changes

## Validation
- staged `dist/db/migrations` locally to mirror the deploy artifact
- ran `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55434/adcp_test2 node dist/db/migrate.js` against a disposable Postgres instance
- verified the run completed successfully through `340_purpose_mission_vision.sql`
