### PR TITLE
fix: prevent ownerless orgs via webhook safety net

### DIFF
--- a/.changeset/fix-org-no-owner.md
+++ b/.changeset/fix-org-no-owner.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: prevent ownerless orgs via webhook safety net, owner-leaves promotion, and merge role preservation

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -4760,6 +4760,7 @@ Use add_committee_leader to assign a leader.`;
         // Step 1: Get users from secondary org in WorkOS before merge
         let workosUsersToMigrate: string[] = [];
         let workosErrors: string[] = [];
+        let secondaryRoles = new Map<string, string>();
 
         try {
           // Get all memberships from the secondary org in WorkOS
@@ -4780,9 +4781,11 @@ Use add_committee_leader to assign a leader.`;
           });
           const primaryUserIds = new Set(primaryMemberships.data.map(m => m.userId));
 
-          workosUsersToMigrate = memberships.data
-            .filter(m => m.status === 'active' && !primaryUserIds.has(m.userId))
-            .map(m => m.userId);
+          const usersToMigrate = memberships.data
+            .filter(m => m.status === 'active' && !primaryUserIds.has(m.userId));
+          workosUsersToMigrate = usersToMigrate.map(m => m.userId);
+          // Preserve roles from secondary org so owners/admins keep their role
+          secondaryRoles = new Map(usersToMigrate.map(m => [m.userId, m.role?.slug || 'member']));
 
           logger.info({ count: workosUsersToMigrate.length, secondaryOrgId }, 'Found WorkOS users to migrate');
         } catch (err) {
@@ -4806,10 +4809,11 @@ Use add_committee_leader to assign a leader.`;
 
         for (const userId of workosUsersToMigrate) {
           try {
+            const roleSlug = secondaryRoles.get(userId) || 'member';
             await workos.userManagement.createOrganizationMembership({
               userId,
               organizationId: primaryOrgId,
-              roleSlug: 'member', // Default to member role
+              roleSlug,
             });
             workosAdded++;
             logger.debug({ userId, primaryOrgId }, 'Added user to primary org in WorkOS');

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -1271,13 +1271,21 @@ export function createOrganizationsRouter(): Router {
         logger.info({ orgId: workosOrgId, name: trimmedName }, 'WorkOS organization created');
 
         // Add user as organization owner (since they created it)
-        await workos!.userManagement.createOrganizationMembership({
+        const ownerMembership = await workos!.userManagement.createOrganizationMembership({
           userId: user.id,
           organizationId: workosOrgId,
           roleSlug: 'owner',
         });
 
         logger.info({ userId: user.id, orgId: workosOrgId }, 'User added as organization owner');
+
+        // Mirror membership locally so the owner is visible immediately
+        // (rather than waiting for the webhook)
+        await pool.query(`
+          INSERT INTO organization_memberships (workos_user_id, workos_organization_id, workos_membership_id, email, role, seat_type, created_at, updated_at, synced_at)
+          VALUES ($1, $2, $3, $4, 'owner', 'contributor', NOW(), NOW(), NOW())
+          ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET role = 'owner', workos_membership_id = $3, updated_at = NOW()
+        `, [user.id, workosOrgId, ownerMembership.id, user.email]);
       }
 
       // Create organization record in our database

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -123,7 +123,11 @@ async function upsertMembership(
   const hasExplicitSeatType = seatResult.rows.length > 0;
   const seatType = seatResult.rows[0]?.seat_type || 'contributor';
 
-  await pool.query(
+  // Atomically determine the role: if the incoming role is 'member' and the
+  // org has no admin/owner, promote to 'owner'. The subquery makes this
+  // race-safe — concurrent inserts will see each other's rows.
+  const effectiveRole = role === 'member' ? '__auto__' : role;
+  const result = await pool.query<{ role: string }>(
     `INSERT INTO organization_memberships (
       workos_user_id,
       workos_organization_id,
@@ -134,7 +138,20 @@ async function upsertMembership(
       role,
       seat_type,
       synced_at
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6,
+      CASE
+        WHEN $7 = '__auto__' AND NOT EXISTS (
+          SELECT 1 FROM organization_memberships
+          WHERE workos_organization_id = $2
+            AND role IN ('admin', 'owner')
+            AND workos_user_id != $1
+        ) THEN 'owner'
+        WHEN $7 = '__auto__' THEN 'member'
+        ELSE $7
+      END,
+      $8, NOW()
+    )
     ON CONFLICT (workos_user_id, workos_organization_id)
     DO UPDATE SET
       workos_membership_id = EXCLUDED.workos_membership_id,
@@ -147,7 +164,8 @@ async function upsertMembership(
         ELSE organization_memberships.seat_type
       END,
       synced_at = NOW(),
-      updated_at = NOW()`,
+      updated_at = NOW()
+    RETURNING role`,
     [
       membership.user_id,
       membership.organization_id,
@@ -155,11 +173,38 @@ async function upsertMembership(
       userData.email,
       userData.first_name,
       userData.last_name,
-      role,
+      effectiveRole,
       seatType,
       hasExplicitSeatType,
     ]
   );
+
+  const assignedRole = result.rows[0]?.role || role;
+
+  // If the DB promoted this member to owner, sync the change to WorkOS
+  if (assignedRole === 'owner' && role === 'member') {
+    try {
+      await workos.userManagement.updateOrganizationMembership(membership.id, {
+        roleSlug: 'owner',
+      });
+      logger.info({
+        membershipId: membership.id,
+        userId: membership.user_id,
+        orgId: membership.organization_id,
+      }, 'Promoted member to owner — org had no admin');
+    } catch (err) {
+      // Roll back local promotion to stay in sync with WorkOS
+      await pool.query(
+        `UPDATE organization_memberships SET role = 'member', updated_at = NOW()
+         WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+        [membership.user_id, membership.organization_id]
+      ).catch((rollbackErr) => {
+        logger.error({ err: rollbackErr, orgId: membership.organization_id },
+          'Failed to roll back local owner promotion — local/WorkOS role divergence');
+      });
+      logger.warn({ err, orgId: membership.organization_id }, 'Failed to promote member to owner in WorkOS, rolled back local role');
+    }
+  }
 
   // Set primary_organization_id if not already set (prefer paying orgs)
   const preferredOrg = await resolvePreferredOrganization(membership.user_id);
@@ -171,6 +216,7 @@ async function upsertMembership(
     membershipId: membership.id,
     userId: membership.user_id,
     orgId: membership.organization_id,
+    role: assignedRole,
   }, 'Upserted organization membership');
 }
 
@@ -180,17 +226,84 @@ async function upsertMembership(
 async function deleteMembership(membership: OrganizationMembershipData): Promise<void> {
   const pool = getPool();
 
-  await pool.query(
+  const deleted = await pool.query<{ role: string }>(
     `DELETE FROM organization_memberships
-     WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+     WHERE workos_user_id = $1 AND workos_organization_id = $2
+     RETURNING role`,
     [membership.user_id, membership.organization_id]
   );
+
+  const deletedRole = deleted.rows[0]?.role;
 
   logger.info({
     membershipId: membership.id,
     userId: membership.user_id,
     orgId: membership.organization_id,
+    role: deletedRole,
   }, 'Deleted organization membership');
+
+  // If an admin/owner was removed, check if the org still has one.
+  // Promote the longest-tenured remaining member to prevent ownerless orgs.
+  // Single atomic query: returns a row only when no admin/owner remains.
+  if (deletedRole === 'admin' || deletedRole === 'owner') {
+    try {
+      const successor = await pool.query<{ workos_user_id: string; workos_membership_id: string | null }>(
+        `SELECT workos_user_id, workos_membership_id FROM organization_memberships
+         WHERE workos_organization_id = $1
+           AND NOT EXISTS (
+             SELECT 1 FROM organization_memberships
+             WHERE workos_organization_id = $1 AND role IN ('admin', 'owner')
+           )
+         ORDER BY created_at ASC
+         LIMIT 1`,
+        [membership.organization_id]
+      );
+      if (successor.rows.length > 0) {
+        const target = successor.rows[0];
+        // Promote in WorkOS first, then mirror locally
+        let promotedInWorkos = false;
+        if (target.workos_membership_id) {
+          await workos.userManagement.updateOrganizationMembership(
+            target.workos_membership_id,
+            { roleSlug: 'owner' }
+          );
+          promotedInWorkos = true;
+        } else {
+          // No cached membership ID — look it up from WorkOS
+          const memberships = await workos.userManagement.listOrganizationMemberships({
+            organizationId: membership.organization_id,
+            userId: target.workos_user_id,
+          });
+          if (memberships.data.length > 0) {
+            await workos.userManagement.updateOrganizationMembership(
+              memberships.data[0].id,
+              { roleSlug: 'owner' }
+            );
+            promotedInWorkos = true;
+          } else {
+            logger.warn({
+              orgId: membership.organization_id,
+              userId: target.workos_user_id,
+            }, 'Successor has no WorkOS membership — cannot promote, org may be ownerless');
+          }
+        }
+        if (promotedInWorkos) {
+          await pool.query(
+            `UPDATE organization_memberships SET role = 'owner', updated_at = NOW()
+             WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+            [target.workos_user_id, membership.organization_id]
+          );
+          logger.info({
+            orgId: membership.organization_id,
+            promotedUserId: target.workos_user_id,
+            previousOwnerId: membership.user_id,
+          }, 'Promoted longest-tenured member to owner after admin/owner removal');
+        }
+      }
+    } catch (err) {
+      logger.warn({ err, orgId: membership.organization_id }, 'Failed to promote successor after owner removal');
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds atomic owner-promotion in the WorkOS webhook handler (`upsertMembership`) — when a member joins an org with no admin/owner, they're automatically promoted to owner using a race-safe SQL `CASE/NOT EXISTS` subquery, then synced to WorkOS
- Adds owner-succession in `deleteMembership` — when an admin/owner is removed, the longest-tenured remaining member is promoted (WorkOS-first, local mirror on success)
- Mirrors owner membership to local DB immediately during org creation instead of waiting for webhook
- Preserves original roles during org merge instead of hardcoding all migrated users to 'member'

## Test plan
- [ ] Create a new org — verify owner membership appears immediately in local DB
- [ ] Run audit-admins endpoint — verify count decreases after deploying
- [ ] Add a member to an ownerless prospect org — verify they get promoted to owner
- [ ] Remove the sole owner from an org — verify successor is promoted
- [ ] Merge two orgs where secondary has an owner — verify role is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)