### PR TITLE
feat: content sampling gaps — move sampling to buy time, add content_standards_detail

### DIFF
--- a/.changeset/6xz37fozu0qa74mq.md
+++ b/.changeset/6xz37fozu0qa74mq.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove `sampling` parameter from `get_media_buy_artifacts` request — sampling is configured at media buy creation time, not at retrieval time. Replace `sampling_info` with `collection_info` in the response. Add `failures_only` boolean filter for retrieving only locally-failed artifacts. Add `content_standards_detail` to `get_adcp_capabilities` for pre-buy visibility into local evaluation and artifact delivery capabilities. Add podcast, CTV, and AI-generated content artifact examples to documentation.

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -26,6 +26,8 @@ Artifacts are identified by `property_id` + `artifact_id` - the property defines
 
 **Schema**: [artifact.json](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json)
 
+Web article:
+
 ```json
 {
   "property_id": {"type": "domain", "value": "reddit.com"},
@@ -34,6 +36,35 @@ Artifacts are identified by `property_id` + `artifact_id` - the property defines
     {"type": "text", "role": "title", "content": "Best protein sources for muscle building", "language": "en"},
     {"type": "text", "role": "paragraph", "content": "Looking for recommendations on high-quality protein sources...", "language": "en"},
     {"type": "image", "url": "https://cdn.reddit.com/fitness-image.jpg", "alt_text": "Person lifting weights"}
+  ]
+}
+```
+
+Podcast segment (note: no `url` — the property is identified by `apple_podcast_id`, and the audio asset uses a secured URL):
+
+```json
+{
+  "property_id": {"type": "apple_podcast_id", "value": "1234567890"},
+  "artifact_id": "episode_42_segment_3",
+  "assets": [
+    {"type": "text", "role": "title", "content": "The Future of Running Shoes", "language": "en"},
+    {"type": "audio", "url": "https://cdn.example.com/secured/ep42_seg3.mp3", "transcript": "Today we're talking to Dr. Chen about biomechanics research...", "duration_ms": 480000}
+  ],
+  "metadata": {
+    "json_ld": [{"@type": "PodcastEpisode", "episodeNumber": 42}]
+  }
+}
+```
+
+CTV scene (the artifact_id encodes show, season, episode, and scene):
+
+```json
+{
+  "property_id": {"type": "app_id", "value": "com.streamingservice.tv"},
+  "artifact_id": "show_running_s2e5_scene_14",
+  "assets": [
+    {"type": "text", "role": "title", "content": "Championship Race - Final Stretch", "language": "en"},
+    {"type": "video", "url": "https://cdn.streaming.example.com/secured/s2e5_scene14.mp4", "transcript": "The runners round the final corner as the crowd erupts...", "duration_ms": 120000}
   ]
 }
 ```

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -83,7 +83,7 @@ sequenceDiagram
         Note over Seller: Local model evaluates artifacts
     end
 
-    Buyer->>Seller: get_media_buy_artifacts (sampled)
+    Buyer->>Seller: get_media_buy_artifacts
     Seller-->>Buyer: Content artifacts
     Buyer->>Verifier: validate_content_delivery
     Verifier-->>Buyer: Validation results
@@ -157,7 +157,7 @@ Sampling rate is negotiated in the media buy:
 }
 ```
 
-Higher sampling rates typically cost more but provide stronger guarantees. The seller is responsible for implementing the agreed sampling rate and reporting actual coverage.
+Higher sampling rates typically cost more but provide stronger guarantees. The seller is responsible for implementing the agreed sampling rate and reporting actual coverage. Buyers retrieve collected artifacts via [get_media_buy_artifacts](./tasks/get_media_buy_artifacts) (pull) or receive them via `artifact_webhook` (push) — both deliver artifacts sampled per the buy agreement.
 
 ## Validation Thresholds
 

--- a/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
+++ b/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
@@ -18,13 +18,13 @@ sequenceDiagram
     participant Seller as Seller Agent
     participant Verifier as Verification Agent
 
-    Buyer->>Seller: get_media_buy_artifacts (sampled or full)
-    Seller-->>Buyer: Artifacts with content
+    Buyer->>Seller: get_media_buy_artifacts
+    Seller-->>Buyer: Collected artifacts
     Buyer->>Verifier: validate_content_delivery
     Verifier-->>Buyer: Validation results
 ```
 
-The buyer requests artifacts from the seller using the same media buy parameters. The seller returns content samples based on the agreed sampling rate. The buyer then validates these against the verification agent.
+The buyer retrieves artifacts the seller has collected per the sampling configuration agreed at buy creation time. Sellers may also push artifacts via webhook — `get_media_buy_artifacts` is the pull-based alternative. The buyer forwards artifacts to the verification agent for validation.
 
 ## Request
 
@@ -35,27 +35,13 @@ The buyer requests artifacts from the seller using the same media buy parameters
 | `account` | [account-ref](/docs/building/integration/accounts-and-agents#account-references) | No | Account reference. Pass `{ "account_id": "..." }` or `{ "brand": {...}, "operator": "..." }` if the seller supports implicit resolution. Only returns artifacts for media buys belonging to this account. When omitted, returns artifacts across all accessible accounts. |
 | `media_buy_id` | string | Yes | Media buy to get artifacts from |
 | `package_ids` | array | No | Filter to specific packages |
-| `sampling` | object | No | Sampling parameters (defaults to media buy agreement) |
+| `failures_only` | boolean | No | Only return artifacts where the seller's local model returned `local_verdict: "fail"` (see [behavior with unevaluated records](#failures_only-and-unevaluated-records)) |
 | `time_range` | object | No | Filter to specific time period |
 | `pagination` | object | No | Pagination parameters (see below) |
 
-### Sampling Options
-
-```json
-{
-  "sampling": {
-    "rate": 0.25,
-    "method": "random"
-  }
-}
-```
-
-| Method | Description |
-|--------|-------------|
-| `random` | Random sample across all deliveries |
-| `stratified` | Sample proportionally across packages/properties |
-| `recent` | Most recent deliveries first |
-| `failures_only` | Only artifacts that failed local evaluation |
+<Info>
+**Sampling is configured at buy creation time**, not at retrieval time. The sampling rate, method, and per-channel configuration are part of the media buy's `governance.content_standards` agreement. `get_media_buy_artifacts` retrieves artifacts that the seller has already collected per that agreement. For push-based delivery, configure `artifact_webhook` in `create_media_buy`.
+</Info>
 
 ### Pagination
 
@@ -113,11 +99,11 @@ Uses higher limits than standard pagination because artifact result sets can be 
       "local_verdict": "fail"
     }
   ],
-  "sampling_info": {
+  "collection_info": {
     "total_deliveries": 100000,
-    "sampled_count": 1000,
-    "effective_rate": 0.01,
-    "method": "random"
+    "total_collected": 1000,
+    "returned_count": 1000,
+    "effective_rate": 0.01
   },
   "pagination": {
     "cursor": "eyJvZmZzZXQiOjEwMDB9",
@@ -132,21 +118,20 @@ Uses higher limits than standard pagination because artifact result sets can be 
 |-------|-------------|
 | `artifacts` | Array of delivery records with full artifact content |
 | `artifacts[].country` | ISO 3166-1 alpha-2 country code where delivery occurred |
-| `artifacts[].channel` | Channel type (display, video, audio, social) |
+| `artifacts[].channel` | Channel type (display, olv, ctv, podcast, social, etc.) |
 | `artifacts[].brand_context` | Brand/SKU information for policy evaluation (schema TBD) |
 | `artifacts[].local_verdict` | Seller's local model verdict (pass/fail/unevaluated) |
-| `sampling_info` | How the sample was generated |
+| `collection_info` | Artifact collection statistics — what the seller collected per the buy agreement |
 | `pagination` | Cursor for fetching more results |
 
 ## Use Cases
 
-### Validate Sample Against Standards
+### Validate Collected Artifacts
 
 ```python
-# Get artifacts from seller
+# Get artifacts from seller (sampling was configured at buy creation time)
 artifacts_response = seller_agent.get_media_buy_artifacts(
-    media_buy_id="mb_nike_reddit_q1",
-    sampling={"rate": 0.25, "method": "random"}
+    media_buy_id="mb_nike_reddit_q1"
 )
 
 # Convert to validation records
@@ -183,7 +168,7 @@ for i, result in enumerate(validation["results"]):
 # Get only artifacts that failed local evaluation
 failures = seller_agent.get_media_buy_artifacts(
     media_buy_id="mb_nike_reddit_q1",
-    sampling={"method": "failures_only"},
+    failures_only=True,
     pagination={"max_results": 100}
 )
 
@@ -198,6 +183,90 @@ validation = verification_agent.validate_content_delivery(
 false_positives = sum(1 for r in validation["results"] if r["verdict"] == "pass")
 print(f"False positive rate: {false_positives / len(failures['artifacts']):.1%}")
 ```
+
+## failures_only and Unevaluated Records
+
+When a seller does not run a local evaluation model, all records have `local_verdict: "unevaluated"`. In this case, `failures_only` returns an empty result set — there are no failures to return.
+
+Governance agents receiving validation results where every `local_verdict` is `"unevaluated"` should treat this as **no local enforcement**. The validation still works — the verification agent evaluates the artifacts normally — but there is no drift comparison to perform. Buyers can check `content_standards_detail.supports_local_evaluation` in [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities#content_standards_detail) to know whether `failures_only` will be useful before creating a buy.
+
+| `local_verdict` | `failures_only` returns? | Drift comparison possible? |
+|-----------------|--------------------------|---------------------------|
+| `fail` | Yes | Yes |
+| `pass` | No | N/A (not in result set) |
+| `unevaluated` | No | No — omit `failures_only` to retrieve all collected artifacts |
+
+## Non-Web Artifact Examples
+
+### Podcast
+
+```json
+{
+  "record_id": "imp_podcast_001",
+  "timestamp": "2025-02-10T08:00:00Z",
+  "package_id": "pkg_mid_roll",
+  "artifact": {
+    "property_id": {"type": "apple_podcast_id", "value": "1234567890"},
+    "artifact_id": "episode_42_segment_3",
+    "assets": [
+      {"type": "text", "role": "title", "content": "The Future of Running Shoes", "language": "en"},
+      {"type": "audio", "url": "https://cdn.example.com/secured/ep42_seg3.mp3", "transcript": "Today we're talking to Dr. Chen about biomechanics research and how it's changing shoe design for marathon runners...", "duration_ms": 480000}
+    ],
+    "metadata": {
+      "json_ld": [{"@type": "PodcastEpisode", "episodeNumber": 42, "name": "The Future of Running Shoes"}]
+    }
+  },
+  "country": "US",
+  "channel": "podcast",
+  "brand_context": {"brand_id": "nike_global", "sku_id": "vaporfly_next"},
+  "local_verdict": "pass"
+}
+```
+
+### CTV
+
+```json
+{
+  "record_id": "imp_ctv_001",
+  "timestamp": "2025-02-10T20:15:00Z",
+  "package_id": "pkg_premium_ctv",
+  "artifact": {
+    "property_id": {"type": "app_id", "value": "com.streamingservice.tv"},
+    "artifact_id": "show_running_s2e5_scene_14",
+    "assets": [
+      {"type": "text", "role": "title", "content": "Championship Race - Final Stretch", "language": "en"},
+      {"type": "video", "url": "https://cdn.streaming.example.com/secured/s2e5_scene14.mp4", "transcript": "The runners round the final corner as the crowd erupts. Commentary: 'And she's pulling ahead now, this is going to be close...'", "duration_ms": 120000}
+    ]
+  },
+  "country": "US",
+  "channel": "ctv",
+  "brand_context": {"brand_id": "nike_global"},
+  "local_verdict": "pass"
+}
+```
+
+### AI-Generated Content
+
+```json
+{
+  "record_id": "imp_ai_001",
+  "timestamp": "2025-02-10T14:22:00Z",
+  "package_id": "pkg_conversational",
+  "artifact": {
+    "property_id": {"type": "domain", "value": "chat.example.com"},
+    "artifact_id": "session_x7k9_turn_15",
+    "assets": [
+      {"type": "text", "role": "paragraph", "content": "Based on your training schedule, I'd recommend increasing your long run distance by 10% each week. Here's a 12-week half-marathon plan...", "language": "en"}
+    ]
+  },
+  "country": "GB",
+  "channel": "display",
+  "brand_context": {"brand_id": "nike_global", "sku_id": "pegasus_41"},
+  "local_verdict": "unevaluated"
+}
+```
+
+Note: The AI-generated content example has `local_verdict: "unevaluated"` because the content is ephemeral and the platform relies on post-delivery validation rather than a local model.
 
 ## Delivery vs Artifacts
 

--- a/docs/governance/content-standards/tasks/validate_content_delivery.mdx
+++ b/docs/governance/content-standards/tasks/validate_content_delivery.mdx
@@ -20,8 +20,8 @@ sequenceDiagram
     participant Seller as Seller Agent
     participant Verifier as Verification Agent
 
-    Buyer->>Seller: get_media_buy_artifacts (sampled)
-    Seller-->>Buyer: Artifacts with content
+    Buyer->>Seller: get_media_buy_artifacts
+    Seller-->>Buyer: Collected artifacts
     Buyer->>Verifier: validate_content_delivery
     Verifier-->>Buyer: Validation results
 ```

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -100,8 +100,35 @@ Optional media-buy features. **If declared true, seller MUST honor requests usin
 |---------|-------------|
 | `inline_creative_management` | Accepts creatives inline in `create_media_buy` requests |
 | `property_list_filtering` | Honors `property_list` parameter in `get_products` |
-| `content_standards` | Full support for content standards configuration |
+| `content_standards` | Full support for content standards configuration (see `content_standards_detail` for specifics) |
 | `audience_targeting` | Support for audience targeting and ingestion, including `sync_audiences` |
+
+#### content_standards_detail
+
+When `features.content_standards` is `true`, sellers can provide additional detail about their content standards implementation. This gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `supports_local_evaluation` | boolean | Whether the seller runs a local evaluation model. When `false`, `local_verdict` will always be `unevaluated` and the `failures_only` filter on `get_media_buy_artifacts` is not useful. |
+| `supported_channels` | string[] | Channels for which the seller can provide content artifacts. Helps buyers understand which parts of a mixed-channel buy will have content standards coverage. |
+| `supports_webhook_delivery` | boolean | Whether the seller supports push-based artifact delivery via `artifact_webhook` configured at buy creation time. |
+
+**Example:**
+
+```json
+{
+  "features": {
+    "content_standards": true
+  },
+  "content_standards_detail": {
+    "supports_local_evaluation": true,
+    "supported_channels": ["display", "olv", "podcast"],
+    "supports_webhook_delivery": true
+  }
+}
+```
+
+If `supports_local_evaluation` is `false`, the `failures_only` filter on `get_media_buy_artifacts` will return an empty result set — all verdicts will be `unevaluated`.
 
 #### execution
 

--- a/server/src/db/migrations/344_addie_spec_feedback_behavior.sql
+++ b/server/src/db/migrations/344_addie_spec_feedback_behavior.sql
@@ -1,0 +1,46 @@
+-- Addie: when community members give spec feedback or suggest features,
+-- take a position and close the loop — don't just validate and hand back homework.
+
+-- 1. Deactivate the old "GitHub and Bug Reports" rule which contradicts
+--    draft_github_issue usage (says "you cannot create GitHub issues directly").
+--    The "GitHub Issue Drafting" rule (updated in migration 155) already covers
+--    the same ground correctly.
+UPDATE addie_rules
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE name = 'GitHub and Bug Reports'
+  AND rule_type = 'behavior'
+  AND is_active = TRUE;
+
+-- 2. Add spec feedback behavior rule
+INSERT INTO addie_rules (rule_type, name, description, content, priority, created_by) VALUES
+(
+  'behavior',
+  'Spec Feedback Response Pattern',
+  'How to respond when community members suggest protocol changes or report spec gaps',
+  'This pattern applies in technical channels (#adcp-dev, #protocol-*, wg-*) or when the caller is clearly doing structured spec review (multiple specific points, references to spec sections, comparison with other standards). In #general or casual contexts, default to a lighter response: verify the gap, share what you find, and offer to draft an issue if they want to pursue it. Do not auto-draft issues from casual remarks.
+
+When someone shares spec feedback, feature requests, or gap analysis about the AdCP protocol:
+
+1. VERIFY first. Use search_docs and get_schema to check whether the gap is real. Do not take the caller''s characterization at face value — the spec may already address their concern, or the concern may reflect a misunderstanding. If the spec already handles it, say so with a citation.
+
+2. TAKE A POSITION. Do not agree with every point. Evaluate each suggestion on its merits:
+   - Is this the right architectural layer for this change?
+   - Does this add implementation burden that isn''t justified?
+   - Is this buyer-side logic being pushed into the protocol?
+   - Does the spec already handle this differently than the caller assumes?
+   Say "this is buyer-side logic, not a protocol concern" or "this belongs at buy creation time, not query time" when that''s true. A protocol advisor who agrees with everything is not adding value.
+   If after searching you are genuinely unsure whether the caller''s point is valid, say so. "I found X in the spec which might address this, but I''m not sure it fully covers your case" is better than a confident pushback that turns out to be wrong.
+
+3. CLOSE THE LOOP. Do not end with "you should file an issue" — use draft_github_issue to create a pre-filled issue link for each actionable item. If the caller has a linked account, draft the issue directly. Structure the issue body with: the gap description, the proposed change, and which spec files are affected. One issue per distinct change, not one mega-issue.
+
+4. CITE THE SPEC. When referencing protocol behavior, link to the specific doc page or schema file. "The sampling object takes a rate and a method" is not useful without pointing to where.
+
+Anti-patterns:
+- Restating all N points back to the caller with "you''re right" on each one
+- Ending with "I''d suggest filing them as spec issues" (that is YOUR job)
+- Proposing compromises that add protocol complexity without clear justification
+- Saying "worth writing up as a spec issue" without drafting it',
+  215,
+  'system'
+);

--- a/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
+++ b/static/schemas/source/content-standards/get-media-buy-artifacts-request.json
@@ -19,22 +19,10 @@
       "minItems": 1,
       "description": "Filter to specific packages within the media buy"
     },
-    "sampling": {
-      "type": "object",
-      "description": "Sampling parameters. Defaults to the sampling rate agreed in the media buy.",
-      "properties": {
-        "rate": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "Sampling rate (0-1). 1.0 = all deliveries, 0.25 = 25% sample."
-        },
-        "method": {
-          "type": "string",
-          "enum": ["random", "stratified", "recent", "failures_only"],
-          "description": "How to select the sample"
-        }
-      }
+    "failures_only": {
+      "type": "boolean",
+      "description": "When true, only return artifacts where the seller's local model returned local_verdict: 'fail'. Useful for auditing false positives. Not useful when the seller does not run a local evaluation model (all verdicts are 'unevaluated').",
+      "default": false
     },
     "time_range": {
       "type": "object",

--- a/static/schemas/source/content-standards/get-media-buy-artifacts-response.json
+++ b/static/schemas/source/content-standards/get-media-buy-artifacts-response.json
@@ -67,26 +67,25 @@
             "required": ["record_id", "artifact"]
           }
         },
-        "sampling_info": {
+        "collection_info": {
           "type": "object",
-          "description": "Information about how the sample was generated",
+          "description": "Information about artifact collection for this media buy. Sampling is configured at buy creation time — this reports what was actually collected.",
           "properties": {
             "total_deliveries": {
               "type": "integer",
-              "description": "Total deliveries in the time range"
+              "description": "Total deliveries in the requested time range"
             },
-            "sampled_count": {
+            "total_collected": {
               "type": "integer",
-              "description": "Number of artifacts in this response"
+              "description": "Total artifacts collected (per the buy's sampling configuration)"
+            },
+            "returned_count": {
+              "type": "integer",
+              "description": "Number of artifacts in this response (may be less than total_collected due to pagination or filters)"
             },
             "effective_rate": {
               "type": "number",
-              "description": "Actual sampling rate achieved"
-            },
-            "method": {
-              "type": "string",
-              "enum": ["random", "stratified", "recent", "failures_only"],
-              "description": "Sampling method used"
+              "description": "Actual collection rate achieved (total_collected / total_deliveries)"
             }
           }
         },

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -477,6 +477,28 @@
           },
           "additionalProperties": true
         },
+        "content_standards_detail": {
+          "type": "object",
+          "description": "Content standards implementation details. Only meaningful when features.content_standards is true. Gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.",
+          "properties": {
+            "supports_local_evaluation": {
+              "type": "boolean",
+              "description": "Whether the seller runs a local evaluation model. When false, all artifacts will have local_verdict: 'unevaluated' and the failures_only filter on get_media_buy_artifacts is not useful."
+            },
+            "supported_channels": {
+              "type": "array",
+              "description": "Channels for which the seller can provide content artifacts. Helps buyers understand which parts of a mixed-channel buy will have content standards coverage.",
+              "items": {
+                "$ref": "/schemas/enums/channels.json"
+              },
+              "minItems": 1
+            },
+            "supports_webhook_delivery": {
+              "type": "boolean",
+              "description": "Whether the seller supports push-based artifact delivery via artifact_webhook configured at buy creation time."
+            }
+          }
+        },
         "portfolio": {
           "type": "object",
           "description": "Information about the seller's media inventory portfolio",


### PR DESCRIPTION
## Summary

Community feedback identified gaps in how content standards sampling works for non-web inventory (podcast, CTV, AI surfaces). The key architectural insight: **sampling is a buy-time configuration, not a retrieval-time parameter.**

- **Remove `sampling` from `get_media_buy_artifacts`** — replaced with `failures_only` boolean filter. Sampling rate/method are configured at `create_media_buy` time (via `governance.content_standards` or `artifact_webhook`). The task is now purely retrieval.
- **Replace `sampling_info` with `collection_info` in response** — reports what the seller collected per the buy agreement (total_deliveries, total_collected, returned_count, effective_rate)
- **Add `content_standards_detail` to `get_adcp_capabilities`** — pre-buy visibility into `supports_local_evaluation`, `supported_channels`, and `supports_webhook_delivery`
- **Add non-web artifact examples** — podcast (apple_podcast_id + transcript), CTV (app_id + video), AI-generated content (unevaluated verdict)
- **Clarify `failures_only` + unevaluated** — truth table for what gets returned and when drift comparison is possible
- **Addie behavior rule** — when community members share spec feedback: verify the gap, take a position, draft GitHub issues (don't hand back homework)

## Test plan

- [x] Schema validation tests pass (451 schemas)
- [x] Tool schema drift tests pass (16 tests)
- [x] Server unit tests pass (1010 tests)
- [x] Docs navigation validation pass
- [x] Mintlify broken link check pass
- [x] Pre-push version sync + accessibility checks pass
- [ ] Review `content_standards_detail` shape with governance WG
- [ ] Verify Addie behavior rule works in Slack (spec feedback trigger, scope guard for casual channels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)