### PR TITLE
feat: invoice backdating and payment terms

### DIFF
--- a/.changeset/stripe-invoice-backdating.md
+++ b/.changeset/stripe-invoice-backdating.md
@@ -1,0 +1,4 @@
+---
+---
+
+Billing tools: add invoice backdating (invoice_date, due_date) and configurable payment terms (net-30/45/60/90) to send_invoice and confirm_send_invoice. Fixes timezone bug where midnight UTC rendered as previous day on Stripe invoice PDFs.

--- a/scripts/backdate-salesforce-invoice.ts
+++ b/scripts/backdate-salesforce-invoice.ts
@@ -1,22 +1,50 @@
 /**
- * One-off script: Create a backdated March 1 invoice for Salesforce with net-60 terms.
+ * One-off script: Create a backdated invoice with configurable terms.
  *
  * Usage:
+ *   STRIPE_SECRET_KEY=sk_... \
+ *   CUSTOMER_EMAIL=user@example.com \
+ *   COMPANY_NAME="Acme Inc" \
+ *   CONTACT_NAME="Jane Doe" \
+ *   INVOICE_DATE=2026-03-01 \
+ *   DUE_DATE=2026-04-30 \
  *   npx tsx scripts/backdate-salesforce-invoice.ts [--dry-run]
  *
- * Requires STRIPE_SECRET_KEY in environment.
+ * Environment variables:
+ *   STRIPE_SECRET_KEY  - Stripe API key (required)
+ *   CUSTOMER_EMAIL     - Customer email (required)
+ *   COMPANY_NAME       - Company name for the invoice (required)
+ *   CONTACT_NAME       - Contact person name (required)
+ *   INVOICE_DATE       - Invoice date as YYYY-MM-DD (required)
+ *   DUE_DATE           - Due date as YYYY-MM-DD (required)
+ *   LOOKUP_KEY         - Stripe price lookup key (default: aao_membership_leader_50000)
+ *   DAYS_UNTIL_DUE     - Payment terms in days (default: 60)
  */
 
 import Stripe from 'stripe';
 
-// ─── Configuration ───────────────────────────────────────────────────────────
-const CUSTOMER_EMAIL = 'gjoynt@salesforce.com';
-const COMPANY_NAME = 'Salesforce';
-const CONTACT_NAME = 'Gabe Joynt';
-const LOOKUP_KEY = 'aao_membership_leader_50000';
-const DAYS_UNTIL_DUE = 60; // net-60
-const INVOICE_DATE = new Date('2026-03-01T12:00:00Z');
-const DUE_DATE = new Date('2026-04-30T12:00:00Z'); // March 1 + 60 days
+// ─── Configuration from environment ─────────────────────────────────────────
+const CUSTOMER_EMAIL = process.env.CUSTOMER_EMAIL;
+const COMPANY_NAME = process.env.COMPANY_NAME;
+const CONTACT_NAME = process.env.CONTACT_NAME;
+const LOOKUP_KEY = process.env.LOOKUP_KEY || 'aao_membership_leader_50000';
+const DAYS_UNTIL_DUE = parseInt(process.env.DAYS_UNTIL_DUE || '60', 10);
+const INVOICE_DATE_STR = process.env.INVOICE_DATE;
+const DUE_DATE_STR = process.env.DUE_DATE;
+
+if (!CUSTOMER_EMAIL || !COMPANY_NAME || !CONTACT_NAME || !INVOICE_DATE_STR || !DUE_DATE_STR) {
+  console.error('Required env vars: CUSTOMER_EMAIL, COMPANY_NAME, CONTACT_NAME, INVOICE_DATE, DUE_DATE');
+  process.exit(1);
+}
+
+// Use noon UTC to avoid timezone rendering issues on Stripe invoice PDFs
+const INVOICE_DATE = new Date(`${INVOICE_DATE_STR}T12:00:00Z`);
+const DUE_DATE = new Date(`${DUE_DATE_STR}T12:00:00Z`);
+
+if (isNaN(INVOICE_DATE.getTime()) || isNaN(DUE_DATE.getTime())) {
+  console.error('Invalid date format. Use YYYY-MM-DD.');
+  process.exit(1);
+}
 // ─────────────────────────────────────────────────────────────────────────────
 
 const dryRun = process.argv.includes('--dry-run');
@@ -72,7 +100,7 @@ async function main() {
     console.log(`\nCreated customer: ${customer.id}`);
   }
 
-  // 3. Create subscription with backdated start and net-60
+  // 3. Create subscription with backdated start and custom terms
   const invoiceDateUnix = Math.floor(INVOICE_DATE.getTime() / 1000);
 
   const subscription = await stripe.subscriptions.create({
@@ -84,7 +112,7 @@ async function main() {
     metadata: {
       lookup_key: LOOKUP_KEY,
       contact_name: CONTACT_NAME,
-      note: 'Backdated invoice per Salesforce procurement requirement',
+      note: 'Backdated invoice created via script',
     },
   });
 

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -531,9 +531,10 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       });
     } catch (error) {
       logger.error({ error }, 'Addie: Error sending invoice');
+      const message = error instanceof Error ? error.message : 'Failed to send invoice. Please try again.';
       return JSON.stringify({
         success: false,
-        error: 'Failed to send invoice. Please try again.',
+        error: message,
       });
     }
   });

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -945,6 +945,13 @@ export async function createAndSendInvoice(
       }
     }
 
+    // Validate payment terms
+    const allowedTerms = [30, 45, 60, 90];
+    const daysUntilDue = data.daysUntilDue ?? 30;
+    if (!allowedTerms.includes(daysUntilDue)) {
+      throw new Error(`Invalid payment terms: ${daysUntilDue}. Allowed: ${allowedTerms.join(', ')}`);
+    }
+
     // Validate date inputs if provided
     // Use noon UTC to avoid timezone issues — midnight UTC renders as the
     // previous day in US timezones on Stripe invoice PDFs.
@@ -955,14 +962,25 @@ export async function createAndSendInvoice(
       ? Math.floor(new Date(`${data.dueDate}T12:00:00Z`).getTime() / 1000)
       : undefined;
 
+    if (data.invoiceDate && (!invoiceDateUnix || isNaN(invoiceDateUnix))) {
+      throw new Error(`Invalid invoice_date format: "${data.invoiceDate}". Use YYYY-MM-DD.`);
+    }
+    if (data.dueDate && (!dueDateUnix || isNaN(dueDateUnix))) {
+      throw new Error(`Invalid due_date format: "${data.dueDate}". Use YYYY-MM-DD.`);
+    }
+
     if (invoiceDateUnix && invoiceDateUnix > Math.floor(Date.now() / 1000)) {
-      logger.error({ invoiceDate: data.invoiceDate }, 'createAndSendInvoice: invoiceDate cannot be in the future');
-      return null;
+      throw new Error('invoice_date cannot be in the future. Provide a past date in YYYY-MM-DD format.');
+    }
+
+    const maxBackdateDays = 180;
+    const minInvoiceDate = Math.floor(Date.now() / 1000) - (maxBackdateDays * 86400);
+    if (invoiceDateUnix && invoiceDateUnix < minInvoiceDate) {
+      throw new Error(`invoice_date cannot be more than ${maxBackdateDays} days in the past.`);
     }
 
     if (dueDateUnix && invoiceDateUnix && dueDateUnix <= invoiceDateUnix) {
-      logger.error({ invoiceDate: data.invoiceDate, dueDate: data.dueDate }, 'createAndSendInvoice: dueDate must be after invoiceDate');
-      return null;
+      throw new Error('due_date must be after invoice_date.');
     }
 
     // Create subscription with invoice billing
@@ -972,7 +990,7 @@ export async function createAndSendInvoice(
       customer: customer.id,
       items: [{ price: priceId }],
       collection_method: 'send_invoice',
-      days_until_due: data.daysUntilDue ?? 30,
+      days_until_due: daysUntilDue,
       // Backdate subscription start if invoice date is in the past
       ...(invoiceDateUnix && { backdate_start_date: invoiceDateUnix }),
       // Apply coupon if validated


### PR DESCRIPTION
## Summary
- Add `invoice_date`, `due_date`, and `payment_terms` parameters to `send_invoice` and `confirm_send_invoice` billing tools so Addie and admins can handle procurement requirements (e.g. Salesforce needing a March 1 invoice date) without developer intervention
- Fix timezone bug: use noon UTC instead of midnight to prevent Stripe rendering dates as the previous day in US timezones
- Validate dates (NaN, future, >180 days back), payment terms (30/45/60/90 only), and surface descriptive errors to the agent

## Context
Salesforce (gjoynt@salesforce.com) rejected our invoice because it showed Feb 28 instead of March 1. The Stripe UI doesn't support backdating, but the API does via `backdate_start_date` and `effective_at`. Voided XUQR69S9-0002, reissued as XUQR69S9-0003 with the correct date.

## Test plan
- [ ] Verify existing billing tool tests still pass (they do — 1010 passed)
- [ ] Confirm Salesforce received the corrected invoice (XUQR69S9-0003, March 1 date, due April 30)
- [ ] Test invalid date formats return descriptive errors (not silent no-ops)
- [ ] Test future dates and >180 day backdates are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)