### PR TITLE
fix: use Docs and Sheets APIs directly instead of Drive API

### DIFF
--- a/.changeset/gdoc-direct-api.md
+++ b/.changeset/gdoc-direct-api.md
@@ -1,0 +1,8 @@
+---
+---
+
+Use Google Docs and Sheets APIs directly instead of routing all reads through
+the Drive API. The drive.readonly OAuth scope is a Google "restricted" scope
+that is silently blocked for unverified apps, causing all file operations to
+return 404. The documents.readonly and spreadsheets.readonly scopes are
+"sensitive" scopes that work without app verification.

--- a/scripts/google-oauth-setup.ts
+++ b/scripts/google-oauth-setup.ts
@@ -22,7 +22,7 @@ const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/callback`;
 const SCOPES = [
   'https://www.googleapis.com/auth/calendar',
   'https://www.googleapis.com/auth/documents.readonly',
-  'https://www.googleapis.com/auth/drive.readonly',
+  'https://www.googleapis.com/auth/spreadsheets.readonly',
 ];
 
 if (!CLIENT_ID || !CLIENT_SECRET) {

--- a/server/src/addie/mcp/google-docs.ts
+++ b/server/src/addie/mcp/google-docs.ts
@@ -126,6 +126,171 @@ function isValidDocId(id: string): boolean {
 }
 
 /**
+ * Check if a URL points to a Google Docs document (not a Drive file, Sheet, etc.)
+ */
+function isGoogleDocUrl(urlOrId: string): boolean {
+  try {
+    const url = new URL(urlOrId);
+    return url.hostname === 'docs.google.com' && url.pathname.includes('/document/d/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a URL points to a Google Sheets spreadsheet
+ */
+function isGoogleSheetsUrl(urlOrId: string): boolean {
+  try {
+    const url = new URL(urlOrId);
+    return url.hostname === 'docs.google.com' && url.pathname.includes('/spreadsheets/d/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract plain text from a Google Docs API document response
+ */
+function extractTextFromDocsResponse(doc: {
+  title?: string;
+  body?: { content?: Array<{
+    paragraph?: { elements?: Array<{ textRun?: { content?: string } }> };
+  }> };
+}): string {
+  const parts: string[] = [];
+  for (const item of doc.body?.content ?? []) {
+    for (const elem of item.paragraph?.elements ?? []) {
+      const text = elem.textRun?.content;
+      if (text) parts.push(text);
+    }
+  }
+  return parts.join('');
+}
+
+/**
+ * Read a Google Doc using the Docs API (docs.googleapis.com).
+ * This works even when the Drive API is restricted.
+ */
+async function readViaDocsApi(
+  docId: string,
+  accessToken: string,
+): Promise<string | null> {
+  const response = await fetch(
+    `https://docs.googleapis.com/v1/documents/${docId}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    },
+  );
+
+  if (!response.ok) {
+    logger.debug({ status: response.status, docId }, 'Google Docs API: request failed, will try Drive API');
+    return null;
+  }
+
+  const doc = await response.json() as {
+    title?: string;
+    body?: { content?: Array<{
+      paragraph?: { elements?: Array<{ textRun?: { content?: string } }> };
+    }> };
+  };
+
+  const title = doc.title || 'Untitled';
+  const text = extractTextFromDocsResponse(doc);
+
+  if (!text.trim()) {
+    return `**${title}**\n\n(Document is empty)`;
+  }
+
+  if (text.length > MAX_CONTENT_SIZE) {
+    return `**${title}**\n\n${text.substring(0, MAX_CONTENT_SIZE)}\n\n[Content truncated to ${MAX_CONTENT_SIZE / 1024}KB]`;
+  }
+
+  return `**${title}**\n\n${text}`;
+}
+
+/**
+ * Read a Google Sheet using the Sheets API (sheets.googleapis.com).
+ * Returns the sheet data as CSV text.
+ * Requires the spreadsheets.readonly scope and the Sheets API enabled in the GCP project.
+ */
+async function readViaSheetsApi(
+  spreadsheetId: string,
+  accessToken: string,
+): Promise<string | null> {
+  // Get spreadsheet metadata and first sheet name
+  const metaResponse = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}?fields=properties.title,sheets.properties.title`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    },
+  );
+
+  if (!metaResponse.ok) {
+    logger.debug({ status: metaResponse.status, spreadsheetId }, 'Google Sheets API: metadata request failed, will try Drive API');
+    return null;
+  }
+
+  const meta = await metaResponse.json() as {
+    properties?: { title?: string };
+    sheets?: Array<{ properties?: { title?: string } }>;
+  };
+
+  const title = meta.properties?.title || 'Untitled Spreadsheet';
+  const sheetNames = (meta.sheets ?? []).map(s => s.properties?.title).filter(Boolean) as string[];
+
+  if (sheetNames.length === 0) {
+    return `**${title}**\n\n(Spreadsheet has no sheets)`;
+  }
+
+  // Read all values from the first sheet
+  const firstSheet = sheetNames[0];
+  const valuesResponse = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(firstSheet)}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    },
+  );
+
+  if (!valuesResponse.ok) {
+    logger.debug({ status: valuesResponse.status, spreadsheetId }, 'Google Sheets API: values request failed');
+    return null;
+  }
+
+  const valuesData = await valuesResponse.json() as {
+    values?: string[][];
+  };
+
+  const rows = valuesData.values ?? [];
+  if (rows.length === 0) {
+    return `**${title}**\n\n(Sheet "${firstSheet}" is empty)`;
+  }
+
+  // Convert to CSV
+  const csv = rows
+    .map(row => row.map(cell => {
+      const str = String(cell ?? '');
+      return str.includes(',') || str.includes('"') || str.includes('\n')
+        ? `"${str.replace(/"/g, '""')}"`
+        : str;
+    }).join(','))
+    .join('\n');
+
+  const sheetInfo = sheetNames.length > 1
+    ? `\n\n(Showing sheet "${firstSheet}" — ${sheetNames.length} sheets total: ${sheetNames.join(', ')})`
+    : '';
+
+  if (csv.length > MAX_CONTENT_SIZE) {
+    return `**${title}** (csv)\n\n${csv.substring(0, MAX_CONTENT_SIZE)}\n\n[Content truncated to ${MAX_CONTENT_SIZE / 1024}KB]${sheetInfo}`;
+  }
+
+  return `**${title}** (csv)\n\n${csv}${sheetInfo}`;
+}
+
+/**
  * Extract Google Doc/Drive ID from various URL formats
  *
  * Supports:
@@ -196,7 +361,23 @@ async function readGoogleDoc(
     const auth = getAuthManager(config);
     const accessToken = await auth.getAccessToken();
 
-    // First, check what type of file this is using Drive API
+    // Try direct APIs first (Docs, Sheets) before Drive API.
+    // These use sensitive scopes (documents.readonly, spreadsheets.readonly) that work
+    // even when the restricted drive.readonly scope is silently blocked by Google
+    // for unverified OAuth apps.
+    if (isGoogleDocUrl(urlOrId)) {
+      const docsResult = await readViaDocsApi(docId, accessToken);
+      if (docsResult !== null) {
+        return docsResult;
+      }
+    } else if (isGoogleSheetsUrl(urlOrId)) {
+      const sheetsResult = await readViaSheetsApi(docId, accessToken);
+      if (sheetsResult !== null) {
+        return sheetsResult;
+      }
+    }
+
+    // Fall through to Drive API for Drive file links, raw IDs, or if direct APIs failed
     const metadataResponse = await fetch(
       `https://www.googleapis.com/drive/v3/files/${docId}?fields=name,mimeType,capabilities`,
       {
@@ -207,7 +388,15 @@ async function readGoogleDoc(
 
     if (!metadataResponse.ok) {
       if (metadataResponse.status === 404 || metadataResponse.status === 403) {
-        logger.warn({ status: metadataResponse.status, docId }, 'Google Docs: document inaccessible');
+        // Drive API may be blocked for unverified OAuth apps. Try direct APIs
+        // as a fallback before telling the user we can't access the document.
+        logger.debug({ status: metadataResponse.status, docId }, 'Google Docs: Drive API inaccessible, trying direct APIs');
+        const docsResult = await readViaDocsApi(docId, accessToken);
+        if (docsResult !== null) return docsResult;
+        const sheetsResult = await readViaSheetsApi(docId, accessToken);
+        if (sheetsResult !== null) return sheetsResult;
+
+        logger.warn({ status: metadataResponse.status, docId }, 'Google Docs: document inaccessible via all APIs');
         return `I don't have access to this document. Please share it with ${ADDIE_EMAIL} (Viewer access is fine) and let me know when you've done that.`;
       }
       const error = await metadataResponse.text();


### PR DESCRIPTION
## Summary
- The `drive.readonly` OAuth scope is a Google "restricted" scope that gets silently blocked for unverified OAuth apps — Drive API returns 200 with empty results or 404 for shared files
- Add `readViaDocsApi` and `readViaSheetsApi` that use `documents.readonly` and `spreadsheets.readonly` (Google "sensitive" scopes that work without app verification)
- Try direct APIs first for docs/sheets URLs, fall back to Drive API for other file types
- When Drive returns 404/403, try direct APIs before telling the user access is denied
- Update OAuth setup script: drop `drive.readonly`, add `spreadsheets.readonly`

## Context
Mary Mason shared a Google Doc with Addie but Addie kept reporting "I don't have access." Investigation showed the OAuth token was valid and scopes were present, but Drive API returned empty results for all files — the signature of a restricted scope being silently downgraded for an unverified app.

## Test plan
- [ ] Verify Addie can read Google Docs shared with her (the Mary doc that triggered this)
- [ ] Verify Addie can read Google Sheets shared with her
- [ ] Verify Drive file links still fall through to Drive API (with direct API fallback on 404)
- [ ] Update production refresh token via `fly secrets set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)