### PR TITLE
fix: list_paying_members returns all active members

### DIFF
--- a/.changeset/slimy-paths-beam.md
+++ b/.changeset/slimy-paths-beam.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Add list_paying_members admin tool and infer membership tier from subscription amount in get_account.
+Fix list_paying_members returning incomplete results: raise default limit from 50 to 200 (max 500), add truncation warning when results are capped.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -1093,7 +1093,7 @@ Roles: member (default), admin (can manage team), owner (full control)`,
         },
         limit: {
           type: 'number',
-          description: 'Maximum results (default: 50)',
+          description: 'Maximum results (default: 200, max: 500)',
         },
       },
     },
@@ -6610,7 +6610,7 @@ Use add_committee_leader to assign a leader.`;
     try {
       const pool = getPool();
       const includeIndividual = input.include_individual !== false;
-      const limit = Math.min(Math.max((input.limit as number) || 50, 1), 100);
+      const limit = Math.min(Math.max((input.limit as number) || 200, 1), 500);
 
       const result = await pool.query(
         `SELECT
@@ -6694,6 +6694,7 @@ Use add_committee_leader to assign a leader.`;
       let response = `## Active Members\n\n`;
       response += `**${result.rows.length} active member${result.rows.length !== 1 ? 's' : ''}**`;
       if (!includeIndividual) response += ` (corporate only)`;
+      if (result.rows.length >= limit) response += ` (results truncated at ${limit} — increase limit for full list)`;
       response += `\n\n`;
 
       if (groups.icl.length > 0) {


### PR DESCRIPTION
## Summary
- Raised `list_paying_members` default limit from 50 to 200 (max 500) so the tool returns all ~132 active members instead of silently truncating
- Added truncation warning when results hit the limit, so Addie knows to request more
- Updated limit parameter description to document the max cap

Fixes the issue where Addie reported only 58 members when asked for the full membership list — the default limit of 50 was silently capping results.

## Test plan
- [ ] Ask Addie "show me all paying members" — should return ~132 members (not 58)
- [ ] Verify truncation warning appears when limit < total members
- [ ] Confirm `include_individual: false` still filters to corporate-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)