### PR TITLE
docs: registry feed, agent search, crawl-request

### DIFF
--- a/.changeset/registry-api-docs.md
+++ b/.changeset/registry-api-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document registry change feed, agent search, and crawl-request endpoints. Add OpenAPI registrations for all three. Fix OpenAPI spec link in docs.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -15,7 +15,7 @@ https://agenticadvertising.org
 
 Most endpoints are **public and require no authentication**. [Authenticated endpoints](#authenticated-endpoints) require a Bearer token.
 
-The full [OpenAPI 3.1 specification](https://adcontextprotocol.org/openapi/registry.yaml) is available for code generation and tooling.
+The full [OpenAPI 3.1 specification](https://agenticadvertising.org/openapi/registry.yaml) is available for code generation and tooling.
 
 ## Quick Start
 
@@ -64,6 +64,7 @@ print(brand["brand_name"], brand["canonical_domain"])
 |----------|-------|
 | Bulk resolve (`/api/brands/resolve/bulk`, `/api/properties/resolve/bulk`) | 20 requests/minute per IP |
 | Save endpoints (`/api/brands/save`, `/api/properties/save`) | 60 requests/hour per user |
+| Crawl request (`/api/registry/crawl-request`) | 5 minutes per domain, 30 requests/hour per user |
 | All other endpoints | No limit |
 
 Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded.
@@ -78,7 +79,10 @@ Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded
     Resolve publisher domains to property information, validate adagents.json, and browse properties.
   </Card>
   <Card title="Agent Discovery" icon="robot" href="/docs/registry/index#agent-discovery">
-    List registered and discovered agents, publishers, and view registry statistics.
+    List, search, and filter agents by inventory profile. Browse publishers and view registry statistics.
+  </Card>
+  <Card title="Change Feed" icon="clock-rotate-left" href="/docs/registry/index#change-feed">
+    Poll a cursor-based feed of registry changes for local sync.
   </Card>
   <Card title="Lookups & Authorization" icon="shield-check" href="/docs/registry/index#lookups--authorization">
     Look up agents by domain, validate product authorization, and check property authorization in real time.
@@ -123,8 +127,17 @@ All sources produce the same resolution response structure. To get full brand id
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/registry/agents` | List all agents (filter by type, with enrichment) |
+| GET | `/api/registry/agents/search` | Search agents by inventory profile (auth required) |
 | GET | `/api/registry/publishers` | List all publishers |
 | GET | `/api/registry/stats` | Registry statistics |
+| POST | `/api/registry/crawl-request` | Request re-crawl of a publisher domain (auth required) |
+
+### Change Feed
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/registry/feed` | Poll cursor-based registry change feed (auth required) |
+
 
 ### Lookups & Authorization
 
@@ -210,7 +223,7 @@ Authorization: Bearer sk_...
 
 ### Authenticated endpoints
 
-These endpoints require a valid API key. Rate-limited to 60 requests per hour per user.
+These endpoints require a valid API key.
 
 #### Save brand
 
@@ -384,6 +397,242 @@ result = requests.post(
 }
 ```
 
+#### Change feed
+
+`GET /api/registry/feed`
+
+Poll a cursor-based feed of registry changes. Use this to keep a local copy of the registry in sync without re-fetching the full dataset. Events are ordered by UUID v7 `event_id`, providing monotonic cursor progression. The feed retains events for 90 days — expired cursors return `410 Gone`.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cursor` | UUID | — | Resume after this event ID. Omit for the earliest available events. |
+| `types` | string | — | Comma-separated event type filters. Supports glob patterns (e.g. `property.*`). |
+| `limit` | number | 100 | Max events per page (1–10,000). |
+
+**Event types:**
+
+| Type | Description |
+|------|-------------|
+| `property.created` | A new property was added to the registry |
+| `property.updated` | Property metadata changed |
+| `property.merged` | Two property records were merged |
+| `property.stale` | Property failed re-crawl validation |
+| `property.reactivated` | A stale property passed re-crawl |
+| `agent.discovered` | A new agent was found via adagents.json |
+| `agent.removed` | An agent was removed from the registry |
+| `agent.profile_updated` | Agent inventory profile changed |
+| `publisher.adagents_changed` | A publisher's adagents.json was updated |
+| `authorization.granted` | An agent was authorized for a property |
+| `authorization.revoked` | An authorization was removed |
+
+<CodeGroup>
+
+```bash cURL
+curl "https://agenticadvertising.org/api/registry/feed?types=property.*&limit=50" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```javascript JavaScript
+const res = await fetch(
+  "https://agenticadvertising.org/api/registry/feed?types=property.*&limit=50",
+  { headers: { Authorization: "Bearer YOUR_API_KEY" } }
+);
+const feed = await res.json();
+// Store feed.cursor for next poll
+```
+
+```python Python
+import requests
+
+feed = requests.get(
+    "https://agenticadvertising.org/api/registry/feed",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"types": "property.*", "limit": 50},
+).json()
+# Store feed["cursor"] for next poll
+```
+
+</CodeGroup>
+
+```json Response
+{
+  "events": [
+    {
+      "event_id": "019539a0-1234-7000-8000-000000000001",
+      "event_type": "property.created",
+      "entity_type": "property",
+      "entity_id": "019539a0-b1c2-7000-8000-000000000002",
+      "payload": {},
+      "actor": "crawler",
+      "created_at": "2026-03-31T10:00:00.000Z"
+    }
+  ],
+  "cursor": "019539a0-1234-7000-8000-000000000001",
+  "has_more": true
+}
+```
+
+When `has_more` is `true`, pass the returned `cursor` value in the next request to continue polling. When `false`, you've reached the end of the current feed — poll again later with the same cursor to pick up new events.
+
+If the cursor has expired (older than 90 days or not found), the response is `410 Gone`:
+
+```json 410 Gone
+{
+  "error": "cursor_expired",
+  "message": "Cursor is older than 90-day retention window. Re-bootstrap from /registry/agents/search and /catalog/sync."
+}
+```
+
+#### Agent search
+
+`GET /api/registry/agents/search`
+
+Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by a relevance score based on filter match breadth, inventory depth, and TMP support.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channels` | CSV | — | Filter by channel (e.g. `ctv,olv,display`) |
+| `property_types` | CSV | — | Filter by property type (e.g. `ctv_app,website`) |
+| `markets` | CSV | — | Filter by market/country code (e.g. `US,GB`) |
+| `categories` | CSV | — | Filter by IAB content category (e.g. `IAB-7,IAB-7-1`) |
+| `tags` | CSV | — | Filter by tag (e.g. `premium,brand_safe`) |
+| `delivery_types` | CSV | — | Filter by delivery type (e.g. `guaranteed,programmatic`) |
+| `has_tmp` | boolean | — | Require TMP support (`true` or `false`) |
+| `min_properties` | number | — | Minimum number of properties in inventory |
+| `cursor` | string | — | Pagination cursor from a previous response |
+| `limit` | number | 50 | Max results per page (1–200) |
+
+Each CSV parameter accepts up to 100 values.
+
+<CodeGroup>
+
+```bash cURL
+curl "https://agenticadvertising.org/api/registry/agents/search?channels=ctv,olv&markets=US&has_tmp=true" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```javascript JavaScript
+const res = await fetch(
+  "https://agenticadvertising.org/api/registry/agents/search?channels=ctv,olv&markets=US&has_tmp=true",
+  { headers: { Authorization: "Bearer YOUR_API_KEY" } }
+);
+const agents = await res.json();
+```
+
+```python Python
+import requests
+
+agents = requests.get(
+    "https://agenticadvertising.org/api/registry/agents/search",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"channels": "ctv,olv", "markets": "US", "has_tmp": "true"},
+).json()
+```
+
+</CodeGroup>
+
+```json Response
+{
+  "results": [
+    {
+      "agent_url": "https://ads.streamhaus.example.com",
+      "channels": ["ctv", "olv"],
+      "property_types": ["ctv_app", "website"],
+      "markets": ["US", "GB", "CA"],
+      "categories": ["IAB-7", "IAB-7-1"],
+      "tags": ["premium"],
+      "delivery_types": ["guaranteed"],
+      "format_ids": [],
+      "property_count": 42,
+      "publisher_count": 3,
+      "has_tmp": true,
+      "category_taxonomy": null,
+      "relevance_score": 0.92,
+      "matched_filters": ["channels", "markets"],
+      "updated_at": "2026-03-31T10:00:00.000Z"
+    }
+  ],
+  "cursor": "MC45Mjpodh...",
+  "has_more": false
+}
+```
+
+The `matched_filters` array shows which filter dimensions matched, useful for understanding why a result was returned. The `relevance_score` combines filter match breadth, `ln(property_count + 1)` weighted at 0.1, and a 0.05 boost for TMP support.
+
+#### Crawl request
+
+`POST /api/registry/crawl-request`
+
+Request an immediate re-crawl of a publisher domain. Use this after updating an `adagents.json` file so the registry picks up changes without waiting for the next scheduled crawl. The crawl runs asynchronously — the endpoint returns `202 Accepted` immediately.
+
+Rate-limited to one request per domain every 5 minutes and 30 requests per user per hour.
+
+**Request body:**
+
+```json
+{
+  "domain": "examplepub.com"
+}
+```
+
+`domain` is required. Domains are normalized (lowercased, trimmed). The endpoint validates the domain format and performs a DNS lookup to reject private/reserved IP addresses.
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST "https://agenticadvertising.org/api/registry/crawl-request" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"domain":"examplepub.com"}'
+```
+
+```javascript JavaScript
+const res = await fetch(
+  "https://agenticadvertising.org/api/registry/crawl-request",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer YOUR_API_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ domain: "examplepub.com" }),
+  }
+);
+const result = await res.json(); // 202
+```
+
+```python Python
+import requests
+
+result = requests.post(
+    "https://agenticadvertising.org/api/registry/crawl-request",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    json={"domain": "examplepub.com"},
+).json()
+```
+
+</CodeGroup>
+
+```json 202 Accepted
+{
+  "message": "Crawl request accepted",
+  "domain": "examplepub.com"
+}
+```
+
+```json 429 Too Many Requests
+{
+  "error": "Rate limit exceeded for this domain",
+  "retry_after": 245
+}
+```
+
+`retry_after` is the number of seconds to wait before retrying.
+
 #### Submit brand (legacy)
 
 `POST /api/brands/discovered/community`
@@ -397,7 +646,8 @@ Submit a brand for review. This endpoint predates `/api/brands/save` — prefer 
 | 400 | Missing required fields or invalid domain |
 | 401 | Missing or invalid API key |
 | 409 | Cannot edit an authoritative brand/property (managed via `brand.json` or `adagents.json`) |
-| 429 | Rate limit exceeded (60 requests/hour) |
+| 410 | Cursor expired (change feed — older than 90-day retention window) |
+| 429 | Rate limit exceeded |
 
 ## Protocol vs REST API
 

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -26,16 +26,14 @@ const doc = generator.generateDocument({
   info: {
     title: "AgenticAdvertising.org Registry API",
     description: [
-      "Public REST API for the AgenticAdvertising.org registry. Resolve brands,",
+      "REST API for the AgenticAdvertising.org registry. Resolve brands,",
       "discover properties, look up agents, and validate authorization in the",
       "AdCP ecosystem.",
       "",
-      "All endpoints listed here are public and require no authentication.",
+      "Most endpoints are public and require no authentication. Endpoints marked",
+      "with a lock icon require a Bearer token — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).",
       "",
       "**Base URL:** `https://agenticadvertising.org`",
-      "",
-      "**Rate limits:** Bulk resolve endpoints are limited to 20 requests per minute",
-      "per IP address. All other endpoints are unmetered.",
     ].join("\n"),
     version: "1.0.0",
     contact: {
@@ -50,13 +48,23 @@ const doc = generator.generateDocument({
     },
   ],
   security: [],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        description: "API key issued to an AgenticAdvertising.org member organization.",
+      },
+    },
+  },
 });
 
 // Tag descriptions for the generated spec
 const TAG_DESCRIPTIONS: Record<string, string> = {
   "Brand Resolution": "Resolve advertiser domains to canonical brand identities.",
   "Property Resolution": "Resolve publisher domains to their property configurations and authorized agents.",
-  "Agent Discovery": "Browse the federated agent network, publisher index, and registry statistics.",
+  "Agent Discovery": "Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.",
+  "Change Feed": "Poll cursor-based registry change events for local sync.",
   "Lookups & Authorization": "Look up agents by domain or property, and validate ad-serving authorization.",
   "Validation Tools": "Validate publisher adagents.json files and generate compliant configurations.",
   "Search": "Cross-entity search across brands, publishers, agents, and properties.",

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -982,6 +982,165 @@ registry.registerPath({
   },
 });
 
+// Change Feed & Sync
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/feed",
+  operationId: "getRegistryFeed",
+  summary: "Registry change feed",
+  description:
+    "Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.\n\nType filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.",
+  tags: ["Change Feed"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      cursor: z.string().uuid().optional().openapi({ description: "Resume after this event ID" }),
+      types: z.string().optional().openapi({ description: "Comma-separated event type filters with glob support (e.g. property.*)", example: "property.*,agent.*" }),
+      limit: z.coerce.number().int().min(1).max(10000).optional().openapi({ description: "Max events per page (default 100, max 10,000)" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Feed page",
+      content: {
+        "application/json": {
+          schema: z.object({
+            events: z.array(z.object({
+              event_id: z.string().uuid(),
+              event_type: z.string().openapi({ example: "property.created" }),
+              entity_type: z.string().openapi({ example: "property" }),
+              entity_id: z.string(),
+              payload: z.record(z.string(), z.unknown()),
+              actor: z.string(),
+              created_at: z.string().datetime(),
+            })),
+            cursor: z.string().uuid().nullable().openapi({ description: "Pass as cursor in the next request to continue polling" }),
+            has_more: z.boolean(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid cursor format or type filter", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    410: {
+      description: "Cursor expired (older than 90-day retention window)",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.literal("cursor_expired"),
+            message: z.string(),
+          }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/agents/search",
+  operationId: "searchAgentProfiles",
+  summary: "Search agent inventory profiles",
+  description:
+    "Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.",
+  tags: ["Agent Discovery"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      channels: z.string().optional().openapi({ description: "Comma-separated channel filter", example: "ctv,olv" }),
+      property_types: z.string().optional().openapi({ description: "Comma-separated property type filter", example: "ctv_app,website" }),
+      markets: z.string().optional().openapi({ description: "Comma-separated market/country code filter", example: "US,GB" }),
+      categories: z.string().optional().openapi({ description: "Comma-separated IAB content category filter", example: "IAB-7,IAB-7-1" }),
+      tags: z.string().optional().openapi({ description: "Comma-separated tag filter", example: "premium" }),
+      delivery_types: z.string().optional().openapi({ description: "Comma-separated delivery type filter", example: "guaranteed,programmatic" }),
+      has_tmp: z.enum(["true", "false"]).optional().openapi({ description: "Require TMP support" }),
+      min_properties: z.coerce.number().int().min(0).optional().openapi({ description: "Minimum number of properties in inventory" }),
+      cursor: z.string().optional().openapi({ description: "Pagination cursor from a previous response" }),
+      limit: z.coerce.number().int().min(1).max(200).optional().openapi({ description: "Max results per page (default 50, max 200)" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Search results ranked by relevance",
+      content: {
+        "application/json": {
+          schema: z.object({
+            results: z.array(z.object({
+              agent_url: z.string().url(),
+              channels: z.array(z.string()),
+              property_types: z.array(z.string()),
+              markets: z.array(z.string()),
+              categories: z.array(z.string()),
+              tags: z.array(z.string()),
+              delivery_types: z.array(z.string()),
+              format_ids: z.array(z.unknown()).openapi({ description: "Creative format identifiers supported by this agent" }),
+              property_count: z.number().int(),
+              publisher_count: z.number().int(),
+              has_tmp: z.boolean(),
+              category_taxonomy: z.string().nullable(),
+              relevance_score: z.number(),
+              matched_filters: z.array(z.string()),
+              updated_at: z.string().datetime(),
+            })),
+            cursor: z.string().nullable(),
+            has_more: z.boolean(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid cursor or parameter", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/crawl-request",
+  operationId: "requestCrawl",
+  summary: "Request domain re-crawl",
+  description:
+    "Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
+  tags: ["Agent Discovery"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            domain: z.string().openapi({ example: "examplepub.com", description: "Publisher domain to re-crawl" }),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    202: {
+      description: "Crawl request accepted",
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.literal("Crawl request accepted"),
+            domain: z.string(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    429: {
+      description: "Rate limit exceeded",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            retry_after: z.number().int().openapi({ description: "Seconds to wait before retrying" }),
+          }),
+        },
+      },
+    },
+  },
+});
+
 // ── Router factory ──────────────────────────────────────────────
 
 export function createRegistryApiRouter(config: RegistryApiConfig): Router {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2,16 +2,14 @@ openapi: 3.1.0
 info:
   title: AgenticAdvertising.org Registry API
   description: |-
-    Public REST API for the AgenticAdvertising.org registry. Resolve brands,
+    REST API for the AgenticAdvertising.org registry. Resolve brands,
     discover properties, look up agents, and validate authorization in the
     AdCP ecosystem.
 
-    All endpoints listed here are public and require no authentication.
+    Most endpoints are public and require no authentication. Endpoints marked
+    with a lock icon require a Bearer token — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
 
     **Base URL:** `https://agenticadvertising.org`
-
-    **Rate limits:** Bulk resolve endpoints are limited to 20 requests per minute
-    per IP address. All other endpoints are unmetered.
   version: 1.0.0
   contact:
     name: AgenticAdvertising.org
@@ -3053,13 +3051,396 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/registry/feed:
+    get:
+      operationId: getRegistryFeed
+      summary: Registry change feed
+      description: |-
+        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.
+
+        Type filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: property.*,agent.*
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per page (default 100, max 10,000)
+          required: false
+          description: Max events per page (default 100, max 10,000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Feed page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        event_id:
+                          type: string
+                          format: uuid
+                        event_type:
+                          type: string
+                          example: property.created
+                        entity_type:
+                          type: string
+                          example: property
+                        entity_id:
+                          type: string
+                        payload:
+                          type: object
+                          additionalProperties: {}
+                        actor:
+                          type: string
+                        created_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - event_id
+                        - event_type
+                        - entity_type
+                        - entity_id
+                        - payload
+                        - actor
+                        - created_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                    format: uuid
+                    description: Pass as cursor in the next request to continue polling
+                  has_more:
+                    type: boolean
+                required:
+                  - events
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor format or type filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Cursor expired (older than 90-day retention window)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/agents/search:
+    get:
+      operationId: searchAgentProfiles
+      summary: Search agent inventory profiles
+      description: Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated channel filter
+            example: ctv,olv
+          required: false
+          description: Comma-separated channel filter
+          name: channels
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated property type filter
+            example: ctv_app,website
+          required: false
+          description: Comma-separated property type filter
+          name: property_types
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated market/country code filter
+            example: US,GB
+          required: false
+          description: Comma-separated market/country code filter
+          name: markets
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated IAB content category filter
+            example: IAB-7,IAB-7-1
+          required: false
+          description: Comma-separated IAB content category filter
+          name: categories
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated tag filter
+            example: premium
+          required: false
+          description: Comma-separated tag filter
+          name: tags
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated delivery type filter
+            example: guaranteed,programmatic
+          required: false
+          description: Comma-separated delivery type filter
+          name: delivery_types
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Require TMP support
+          required: false
+          description: Require TMP support
+          name: has_tmp
+          in: query
+        - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            description: Minimum number of properties in inventory
+          required: false
+          description: Minimum number of properties in inventory
+          name: min_properties
+          in: query
+        - schema:
+            type: string
+            description: Pagination cursor from a previous response
+          required: false
+          description: Pagination cursor from a previous response
+          name: cursor
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            description: Max results per page (default 50, max 200)
+          required: false
+          description: Max results per page (default 50, max 200)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results ranked by relevance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent_url:
+                          type: string
+                          format: uri
+                        channels:
+                          type: array
+                          items:
+                            type: string
+                        property_types:
+                          type: array
+                          items:
+                            type: string
+                        markets:
+                          type: array
+                          items:
+                            type: string
+                        categories:
+                          type: array
+                          items:
+                            type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        delivery_types:
+                          type: array
+                          items:
+                            type: string
+                        format_ids:
+                          type: array
+                          items: {}
+                          description: Creative format identifiers supported by this agent
+                        property_count:
+                          type: integer
+                        publisher_count:
+                          type: integer
+                        has_tmp:
+                          type: boolean
+                        category_taxonomy:
+                          type:
+                            - string
+                            - "null"
+                        relevance_score:
+                          type: number
+                        matched_filters:
+                          type: array
+                          items:
+                            type: string
+                        updated_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - agent_url
+                        - channels
+                        - property_types
+                        - markets
+                        - categories
+                        - tags
+                        - delivery_types
+                        - format_ids
+                        - property_count
+                        - publisher_count
+                        - has_tmp
+                        - category_taxonomy
+                        - relevance_score
+                        - matched_filters
+                        - updated_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                  has_more:
+                    type: boolean
+                required:
+                  - results
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor or parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/crawl-request:
+    post:
+      operationId: requestCrawl
+      summary: Request domain re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplepub.com
+                  description: Publisher domain to re-crawl
+              required:
+                - domain
+      responses:
+        "202":
+          description: Crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
 tags:
   - name: Brand Resolution
     description: Resolve advertiser domains to canonical brand identities.
   - name: Property Resolution
     description: Resolve publisher domains to their property configurations and authorized agents.
   - name: Agent Discovery
-    description: Browse the federated agent network, publisher index, and registry statistics.
+    description: Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.
+  - name: Change Feed
+    description: Poll cursor-based registry change events for local sync.
   - name: Lookups & Authorization
     description: Look up agents by domain or property, and validate ad-serving authorization.
   - name: Validation Tools


### PR DESCRIPTION
## Summary
- Add documentation for `/api/registry/feed`, `/api/registry/agents/search`, and `/api/registry/crawl-request` — the three endpoints introduced in #1807 that were missing from docs
- Add OpenAPI `registerPath()` registrations with Zod schemas for all three, regenerate `static/openapi/registry.yaml`
- Fix broken OpenAPI spec link (`adcontextprotocol.org` → `agenticadvertising.org`)
- Add `bearerAuth` security scheme and `Change Feed` tag to the OpenAPI spec

## Test plan
- [x] `npm run build:openapi` succeeds
- [x] `npm run test:openapi` passes (spec matches generated output)
- [x] All pre-commit tests pass
- [x] Mintlify link checker passes (no broken links)
- [ ] Verify docs render correctly on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)