### PR TITLE
feat: v3 readiness checklist and comply hard-fail for v2 agents

### DIFF
--- a/.changeset/wide-regions-lay.md
+++ b/.changeset/wide-regions-lay.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add v3 readiness checklist doc and comply hard-fail for v2 agents.

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
                     "expanded": false,
                     "pages": [
                       "docs/reference/whats-new-in-v3",
+                      "docs/reference/migration/v3-readiness",
                       "docs/reference/migration/index",
                       "docs/reference/migration/prerelease-upgrades",
                       "docs/reference/migration/channels",
@@ -553,6 +554,7 @@
                 "expanded": false,
                 "pages": [
                   "docs/reference/whats-new-in-v3",
+                  "docs/reference/migration/v3-readiness",
                   "docs/reference/migration/index",
                   "docs/reference/migration/prerelease-upgrades",
                   "docs/reference/migration/channels",

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -9,6 +9,10 @@ description: "A complete guide to migrating AdCP integrations from v2.x to v3.0,
 
 This page covers every breaking change when upgrading from AdCP 2.x to 3.0, with effort estimates and links to detailed migration pages. For new features see [What's new in v3](/docs/reference/whats-new-in-v3); for release-candidate deltas see [prerelease upgrade notes](/docs/reference/migration/prerelease-upgrades).
 
+<Info>
+**Starting from v2?** See the [v3 readiness checklist](/docs/reference/migration/v3-readiness) for the 7 minimum requirements to pass comply testing before working through this full migration.
+</Info>
+
 ## Migration checklist
 
 Each row is a breaking change. **Effort** indicates the typical work involved:

--- a/docs/reference/migration/v3-readiness.mdx
+++ b/docs/reference/migration/v3-readiness.mdx
@@ -1,0 +1,132 @@
+---
+title: "v3 readiness checklist"
+sidebarTitle: Readiness checklist
+description: "The 7 minimum requirements for seller agents to pass AdCP v3 integration testing. Comply testing will fail without these."
+"og:title": "AdCP — v3 readiness checklist"
+---
+
+# v3 readiness checklist
+
+AdCP comply testing requires v3 protocol support. Agents that only support v2 will fail. This page covers the minimum changes to unblock integration testing with v3 buyers — not the full migration. For the complete list, see the [migration guide](/docs/reference/migration).
+
+<Warning>
+Comply testing will hard-fail any agent that does not declare v3 support. Complete these 7 items first, then work through the [full migration checklist](/docs/reference/migration).
+</Warning>
+
+---
+
+## 1. Implement `get_adcp_capabilities`
+
+v3 buyers call this task first to discover what your agent supports. Without it, buyers cannot determine your protocol version, supported channels, pricing models, or features.
+
+This is the single most important change — it's how buyers (and comply testing) distinguish v3 agents from v2.
+
+Return at minimum: `major_versions: [3]`, `supported_protocols`, and your `features` object.
+
+<Card title="get_adcp_capabilities reference" icon="arrow-right" href="/docs/protocol/get_adcp_capabilities">
+  Task specification and response schema.
+</Card>
+
+---
+
+## 2. Update channel taxonomy
+
+v3 replaces v2's 9 channels with 20 planning-oriented channels. Buyers send v3 channel values — your agent must recognize them.
+
+| Common v2 value | v3 replacement |
+|-----------------|----------------|
+| `video` | `olv`, `linear_tv`, or `cinema` |
+| `audio` | `radio` or `streaming_audio` |
+| `native` | Removed — native inventory is now part of `display` |
+| `retail` | `retail_media` |
+
+`display`, `social`, `ctv`, `podcast`, and `dooh` are unchanged.
+
+<Card title="Channel migration" icon="arrow-right" href="/docs/reference/migration/channels">
+  Complete mapping table and examples.
+</Card>
+
+---
+
+## 3. Rename pricing fields
+
+Two field renames — same semantics, different names:
+
+| v2 field | v3 field |
+|----------|----------|
+| `fixed_rate` | `fixed_price` |
+| `price_guidance.floor` | `floor_price` (top-level) |
+
+Buyers validate against v3 schemas. The old field names cause schema validation failures.
+
+<Card title="Pricing migration" icon="arrow-right" href="/docs/reference/migration/pricing">
+  Before/after examples and price guidance restructuring.
+</Card>
+
+---
+
+## 4. Support `creative_assignments`
+
+`creative_ids` (string array) is replaced by `creative_assignments` (object array) with delivery weighting and placement targeting.
+
+```json
+// v2
+{ "creative_ids": ["cr_001", "cr_002"] }
+
+// v3
+{ "creative_assignments": [
+    { "creative_id": "cr_001", "weight": 70 },
+    { "creative_id": "cr_002", "weight": 30 }
+  ]
+}
+```
+
+<Card title="Creatives migration" icon="arrow-right" href="/docs/reference/migration/creatives">
+  Weighted assignments, placement targeting, and asset discovery.
+</Card>
+
+---
+
+## 5. Accept `brand` ref instead of `brand_manifest`
+
+Buyers pass brand identity as a reference (`{ domain, brand_id }`) instead of an inline manifest. Your agent resolves brand data from `brand.json` or the registry at execution time.
+
+```json
+// v2
+{ "brand_manifest": { "name": "Acme", "logo": "..." } }
+
+// v3
+{ "brand": { "domain": "acme.example.com", "brand_id": "acme_main" } }
+```
+
+<Card title="Brand identity migration" icon="arrow-right" href="/docs/reference/migration/brand-identity">
+  BrandRef schema, resolution flow, and migration steps.
+</Card>
+
+---
+
+## 6. Handle `buying_mode` on `get_products`
+
+`buying_mode` is now required on every `get_products` request. Your agent must accept and handle it. The three modes are `browse`, `brief`, and `refine`.
+
+<Card title="get_products reference" icon="arrow-right" href="/docs/media-buy/task-reference/get_products">
+  Full request schema including buying_mode.
+</Card>
+
+---
+
+## 7. Implement `sync_accounts`
+
+v3 buyers establish billing relationships before placing buys. Your agent must accept `sync_accounts` calls and return an account reference that buyers include on subsequent requests.
+
+<Card title="Accounts Protocol" icon="arrow-right" href="/docs/accounts/overview">
+  Account provisioning, lifecycle, and the sync_accounts task.
+</Card>
+
+---
+
+## After these 7 items
+
+Once these are in place, run comply testing against your agent. The existing tracks (products, media buy, creative) validate v3 schemas in detail and will surface any remaining field-level issues.
+
+For the complete migration — including geo targeting, optimization goals, signals, audiences, and attribution — see the [full migration guide](/docs/reference/migration).

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -74,7 +74,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       // Derive overall status from track counts
       const { tracks_passed, tracks_failed, tracks_partial } = complianceResult.summary;
       let overallStatus: OverallRunStatus;
-      if (tracks_failed === 0 && tracks_partial === 0) {
+      if (tracks_failed === 0 && tracks_partial === 0 && !complianceResult.v3_gate_failed) {
         overallStatus = 'passing';
       } else if (tracks_passed > 0 || tracks_partial > 0) {
         overallStatus = 'partial';

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2929,7 +2929,7 @@ export function createMemberToolHandlers(
             await agentContextDb.recordTest({
               agent_context_id: context.id,
               scenario: 'quality_evaluation',
-              overall_passed: result.summary.tracks_failed === 0,
+              overall_passed: result.summary.tracks_failed === 0 && !result.v3_gate_failed,
               steps_passed: result.summary.tracks_passed,
               steps_failed: result.summary.tracks_failed,
               total_duration_ms: result.total_duration_ms,

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -101,6 +101,7 @@ export interface ComplyResult {
   total_duration_ms: number;
   dry_run: boolean;
   platform_coherence?: PlatformCoherence;
+  v3_gate_failed?: boolean;
 }
 
 const TRACK_LABELS: Record<ComplianceTrack, string> = {
@@ -424,19 +425,36 @@ export async function comply(agentUrl: string, options: ComplyOptions = {}): Pro
   const tracks_partial = trackResults.filter((track) => track.status === 'partial').length;
   const tracks_skipped = trackResults.filter((track) => track.status === 'skip').length;
 
+  const observations = buildObservations(trackResults);
+  const headline = `${tracks_passed} track${tracks_passed === 1 ? '' : 's'} passed, ${tracks_failed} failed, ${tracks_partial} partial, ${tracks_skipped} skipped`;
+
+  // Hard-fail agents that do not support v3
+  const agentVersion = suite.agent_profile.adcp_version;
+  const v3GateFailed = !agentVersion || agentVersion === 'v2';
+  if (v3GateFailed) {
+    observations.push({
+      severity: 'error',
+      category: 'v3_readiness',
+      message:
+        'Agent does not support AdCP v3. Comply testing requires v3 protocol support. See the v3 readiness checklist: https://adcontextprotocol.org/docs/reference/migration/v3-readiness',
+      evidence: { detected_version: agentVersion ?? 'unknown' },
+    });
+  }
+
   return {
     agent_profile: suite.agent_profile,
     tracks: trackResults,
     summary: {
-      headline: `${tracks_passed} track${tracks_passed === 1 ? '' : 's'} passed, ${tracks_failed} failed, ${tracks_partial} partial, ${tracks_skipped} skipped`,
+      headline: v3GateFailed ? `v3 required — ${headline}` : headline,
       tracks_passed,
       tracks_failed,
       tracks_partial,
       tracks_skipped,
     },
-    observations: buildObservations(trackResults),
+    observations,
     total_duration_ms: suite.total_duration_ms,
     dry_run: suite.dry_run,
     platform_coherence: buildPlatformCoherence(options.platform_type, trackResults),
+    v3_gate_failed: v3GateFailed || undefined,
   };
 }


### PR DESCRIPTION
## Summary

- Adds a concise **v3 readiness checklist** doc (`docs/reference/migration/v3-readiness.mdx`) with the 7 minimum requirements for seller agents to pass integration testing
- **Comply testing now hard-fails v2 agents** — sets `v3_gate_failed` on `ComplyResult` and adds an error-severity observation linking to the checklist
- Cross-links from the existing migration guide index page
- Updates both downstream consumers (`member-tools`, `compliance-heartbeat`) to check the v3 gate

## Context

Lots of 2.5 seller agents are asking "what do I need to upgrade for integration testing?" The existing migration docs have 30+ checklist items but don't answer this specific question. Meanwhile, comply testing was happily passing v2 agents.

## The 7 minimum requirements

1. `get_adcp_capabilities` — runtime discovery
2. Channel taxonomy — 20 channels, not 9
3. Pricing field renames — `fixed_rate` → `fixed_price`, `price_guidance.floor` → `floor_price`
4. `creative_assignments` — replaces `creative_ids`
5. `brand` ref — replaces `brand_manifest`
6. `buying_mode` — now required on `get_products`
7. `sync_accounts` — formal account provisioning

## Test plan

- [x] `npm test` — 1161 tests pass, 44 test files pass
- [x] `npm run typecheck` — clean
- [x] Pre-commit hooks pass (docs nav validation, schema validation, broken link check, accessibility)
- [x] Pre-push hooks pass (version sync, Mintlify validation)
- [ ] Verify doc renders correctly on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)