### PR TITLE
fix: add missing route for /dashboard-membership

### DIFF
--- a/.changeset/fix-membership-route.md
+++ b/.changeset/fix-membership-route.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add missing route handler for /dashboard-membership to fix "Cannot GET" errors

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1610,6 +1610,7 @@ export class HTTPServer {
 
     this.app.get('/organization', (req, res) => serveDashboardPage(req, res, 'dashboard-organization.html'));
     this.app.get('/account', (req, res) => serveDashboardPage(req, res, 'dashboard-settings.html'));
+    this.app.get('/dashboard-membership', (req, res) => serveDashboardPage(req, res, 'dashboard-membership.html'));
     this.app.get('/dashboard/organization', (req, res) => {
       const query = req.url.includes('?') ? req.url.substring(req.url.indexOf('?')) : '';
       res.redirect(301, `/organization${query}`);


### PR DESCRIPTION
## Summary
- Adds the missing Express route handler for `/dashboard-membership` to serve `dashboard-membership.html`
- PR #1837 changed upgrade buttons to link to `/dashboard-membership` (hyphenated) instead of `/dashboard/membership` (slashed), but did not add the corresponding server route
- This caused "Cannot GET /dashboard-membership" errors for users trying to upgrade their membership

Issue: 
<img width="892" height="375" alt="Screenshot 2026-04-02 at 10 58 10 AM" src="https://github.com/user-attachments/assets/3fb3454c-6dcd-4bc9-8ed7-4c7b071ed7e2" />

## Test plan
- [ ] Visit `https://agenticadvertising.org/dashboard-membership?org=<orgId>` and confirm the checkout page loads
- [ ] Click "Upgrade" button from membership CTA and confirm it navigates to the checkout page
- [ ] Verify `/dashboard/membership` still redirects to `/organization#membership`