### PR TITLE
fix: migration docs

### DIFF
--- a/.changeset/migration-guide-comply-gaps.md
+++ b/.changeset/migration-guide-comply-gaps.md
@@ -5,5 +5,5 @@
 Fix migration guide missing comply-blocking requirements
 
 - Add `buying_mode` as a required field on all `get_products` requests to the breaking changes table
-- Add warning callout flagging `buying_mode` and `sync_accounts` as comply-blocking
-- Correct `sync_accounts` requirement: required for all sellers, not conditional on `require_operator_auth`
+- Add warning callout for `buying_mode` comply-blocking requirement
+- Fix Accounts protocol row: protocol is required for all buyers, `require_operator_auth` determines which task (`sync_accounts` vs `list_accounts`) to call

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -51,7 +51,7 @@ These capabilities are new in v3. None existed in v2, so there's nothing to migr
 
 | Capability | Required? | Who needs it |
 |---|---|---|
-| Accounts protocol (`sync_accounts`, `list_accounts`) | Required if `require_operator_auth: true` on any seller you connect to | All buyers working with walled gardens (AI platforms, social, retail media) |
+| Accounts protocol (`sync_accounts`, `list_accounts`) | Required for all buyers — use `sync_accounts` when `require_operator_auth: false` (implicit accounts), `list_accounts` when `true` (explicit accounts) | All buyers — the seller's `require_operator_auth` flag determines which task to call, not whether accounts are needed |
 | Brand Protocol (`brand.json`) | Recommended | All buyers — provides brand identity for creative generation |
 | Governance (content standards, property lists) | Optional | Buyers who need brand suitability enforcement |
 | Sponsored Intelligence | Optional | Buyers working with AI platforms that support conversational handoffs |


### PR DESCRIPTION
## Summary
- Add `buying_mode` as a required field on `get_products` to the breaking changes table
- Add comply-blocking warning callout for the `buying_mode` requirement
- Fix Accounts protocol row: protocol is required for all buyers — `require_operator_auth` determines which task to call (`sync_accounts` for implicit, `list_accounts` for explicit), not whether accounts are needed

## Test plan
- [ ] Verify migration index page renders correctly with the new table row and warning callout
- [ ] Confirm links to `get_products` reference and v3 readiness checklist resolve properly
- [ ] Verify Accounts protocol row accurately reflects the docs at `/docs/accounts/overview`