### PR TITLE
fix: allow authors to view their own draft perspectives

### DIFF
--- a/.changeset/draft-access-fix.md
+++ b/.changeset/draft-access-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: allow authors to view their own draft perspectives at the article URL

--- a/server/public/perspectives/article.html
+++ b/server/public/perspectives/article.html
@@ -881,7 +881,7 @@
       }
 
       try {
-        const response = await fetch(`/api/perspectives/${slug}`);
+        const response = await fetch(`/api/perspectives/${slug}`, { credentials: 'same-origin' });
 
         if (!response.ok) {
           showError();
@@ -954,6 +954,17 @@
             document.getElementById('authorTitle').textContent = `, ${article.author_title}`;
           }
           document.getElementById('authorInfo').style.display = 'block';
+        }
+
+        // Show draft banner for unpublished content
+        if (article.status && article.status !== 'published') {
+          const banner = document.createElement('div');
+          banner.style.cssText = 'background:#fef3c7;border:1px solid #f59e0b;color:#92400e;padding:12px 24px;text-align:center;font-weight:500;font-size:14px;';
+          banner.textContent = article.status === 'draft'
+            ? 'Draft — not publicly visible'
+            : 'Pending review — not publicly visible';
+          const hero = document.getElementById('heroSection');
+          hero.parentNode.insertBefore(banner, hero);
         }
 
         // Show content

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4996,11 +4996,14 @@ Disallow: /api/admin/
       }
     });
 
-    // GET /api/perspectives/:slug - Get single published perspective by slug
-    this.app.get('/api/perspectives/:slug', async (req, res) => {
+    // GET /api/perspectives/:slug - Get perspective by slug
+    // Published perspectives are public; drafts are visible to their author/co-authors
+    this.app.get('/api/perspectives/:slug', optionalAuth, async (req, res) => {
       try {
         const { slug } = req.params;
         const pool = getPool();
+        const userId = req.user?.id ?? null;
+
         const result = await pool.query(
           `SELECT
             p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt,
@@ -5009,23 +5012,33 @@ Disallow: /api/admin/
             u.slug as author_slug,
             u.avatar_url as author_avatar_url,
             u.headline as author_headline,
-            p.published_at, p.tags, p.metadata, p.like_count, p.updated_at
+            p.status, p.published_at, p.tags, p.metadata, p.like_count, p.updated_at
           FROM perspectives p
           LEFT JOIN users u ON u.workos_user_id = p.author_user_id AND u.is_public = true
           LEFT JOIN working_groups wg ON wg.id = p.working_group_id
-          WHERE p.slug = $1 AND p.status = 'published'
-            AND (p.working_group_id IS NULL OR wg.slug = 'editorial')`,
-          [slug]
+          WHERE p.slug = $1
+            AND (
+              (p.status = 'published' AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
+              OR ($2::text IS NOT NULL AND p.status IN ('draft', 'pending_review') AND (
+                p.author_user_id = $2
+                OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $2)
+              ))
+            )`,
+          [slug, userId]
         );
 
         if (result.rows.length === 0) {
           return res.status(404).json({
             error: 'Perspective not found',
-            message: `No published perspective found with slug ${slug}`
           });
         }
 
-        res.json(result.rows[0]);
+        const row = result.rows[0];
+        // Only expose status to authenticated authors viewing their own draft
+        if (!userId || row.status === 'published') {
+          delete row.status;
+        }
+        res.json(row);
       } catch (error) {
         logger.error({ err: error }, 'Get perspective by slug error:');
         res.status(500).json({
@@ -5092,17 +5105,24 @@ Disallow: /api/admin/
       'image/gif': 'image/gif',
       'application/pdf': 'application/pdf',
     };
-    this.app.get('/api/perspectives/:slug/assets/:filename', async (req, res) => {
+    this.app.get('/api/perspectives/:slug/assets/:filename', optionalAuth, async (req, res) => {
       try {
         const { slug, filename } = req.params;
         const pool = getPool();
+        const userId = req.user?.id ?? null;
 
         const perspResult = await pool.query(
           `SELECT p.id FROM perspectives p
            LEFT JOIN working_groups wg ON wg.id = p.working_group_id
-           WHERE p.slug = $1 AND p.status = 'published'
-             AND (p.working_group_id IS NULL OR wg.slug = 'editorial')`,
-          [slug]
+           WHERE p.slug = $1
+             AND (
+               (p.status = 'published' AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
+               OR ($2::text IS NOT NULL AND p.status IN ('draft', 'pending_review') AND (
+                 p.author_user_id = $2
+                 OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $2)
+               ))
+             )`,
+          [slug, userId]
         );
         if (perspResult.rows.length === 0) {
           return res.status(404).send('Not found');


### PR DESCRIPTION
## Summary
- Authors visiting their draft article URL (`/perspectives/:slug`) got a 404 even when logged in, because the API endpoint only returned published content
- Added `optionalAuth` middleware to the perspective slug and asset endpoints so authenticated authors/co-authors can view their own drafts and pending_review content
- Frontend sends session cookie with the fetch and shows a "Draft — not publicly visible" banner for unpublished articles

Resolves escalation #194 (B. Masse / Triton Digital — cannot access draft at `/perspectives/signals-planning-sleeper-use-case`).

## Security
- Unauthenticated users cannot see draft content (`$2::text IS NOT NULL` guard)
- Only the author or co-authors (via `content_authors` table) can view drafts
- `status` field is stripped from the response for public/published articles
- Error messages do not reflect user input

## Test plan
- [ ] Log in as B. Masse (or the article's author), visit `/perspectives/signals-planning-sleeper-use-case` — should see the draft with a yellow banner
- [ ] Visit the same URL logged out — should get 404
- [ ] Visit as a different logged-in user who is not the author — should get 404
- [ ] Published perspectives still load normally without auth
- [ ] Draft articles with embedded images/assets load correctly for the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)