### PR TITLE
feat: WG meeting minutes, Google Docs error reporting, admin doc access

### DIFF
--- a/.changeset/creative-wg-minutes.md
+++ b/.changeset/creative-wg-minutes.md
@@ -1,0 +1,10 @@
+---
+---
+
+feat: Show meeting minutes on working group pages and fix Google Docs permission debugging
+
+- Added "Meeting Minutes" section to working group detail pages showing past meetings with Zoom-generated summaries
+- Added `?past=true` parameter to public meetings API to support fetching past meetings
+- Upgraded Google Docs API error logging from debug to warn level with actual error details from Google
+- Fixed reindexDocument returning success even when indexing fails (access_denied was silently swallowed)
+- Show document management UI (retry indexing, manage docs button) for site admins, not just WG members

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1207,6 +1207,14 @@
       <div id="meetingsList" class="meetings-list"></div>
     </div>
 
+    <!-- Meeting Minutes Section -->
+    <div id="minutesSection" class="content-section" style="display: none;">
+      <div class="section-header">
+        <h2 class="section-title">Meeting Minutes</h2>
+      </div>
+      <div id="minutesList" class="meetings-list"></div>
+    </div>
+
     <!-- Members Section -->
     <div id="membersSection" class="content-section" style="display: none;">
       <div class="section-header">
@@ -1356,6 +1364,7 @@
     let currentGroup = null;
     let isMember = false;
     let isLeader = false;
+    let isAdmin = false;
     let currentSlug = '';
     let postsData = [];
 
@@ -1382,6 +1391,7 @@
         if (response.ok) {
           const config = await response.json();
           currentUser = config.user || null;
+          isAdmin = config.user?.isAdmin || false;
         }
       } catch (err) {
         console.debug('Auth check failed:', err);
@@ -1421,7 +1431,7 @@
         }
 
         // Load meetings for all committee types
-        loadMeetings();
+        Promise.all([loadMeetings(), loadMinutes()]);
 
       } catch (error) {
         console.error('Error loading working group:', error);
@@ -1769,6 +1779,51 @@
       `;
     }
 
+    async function loadMinutes() {
+      try {
+        const response = await fetch(`/api/meetings?working_group_id=${currentGroup.id}&past=true&limit=20`);
+        if (!response.ok) return;
+
+        const data = await response.json();
+        const pastMeetings = (data.meetings || []).filter(m => m.summary);
+
+        if (pastMeetings.length === 0) return;
+
+        const minutesSection = document.getElementById('minutesSection');
+        const minutesList = document.getElementById('minutesList');
+
+        minutesSection.style.display = 'block';
+        minutesList.innerHTML = pastMeetings.map(meeting => {
+          const startDate = new Date(meeting.start_time);
+          const tz = meeting.timezone || 'America/New_York';
+          const month = startDate.toLocaleDateString('en-US', { month: 'short', timeZone: tz });
+          const day = parseInt(startDate.toLocaleDateString('en-US', { day: 'numeric', timeZone: tz }), 10);
+          const dateStr = startDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: tz });
+
+          // Truncate summary for preview
+          const summaryPreview = meeting.summary.length > 300
+            ? meeting.summary.substring(0, 300) + '...'
+            : meeting.summary;
+
+          return `
+            <a href="/meetings#meeting-${meeting.id}" class="meeting-card">
+              <div class="meeting-date-badge">
+                <div class="meeting-date-month">${month}</div>
+                <div class="meeting-date-day">${day}</div>
+              </div>
+              <div class="meeting-info">
+                <div class="meeting-title">${escapeHtml(meeting.title)}</div>
+                <div class="meeting-meta"><span>${dateStr}</span></div>
+                <div class="document-summary" style="margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted);">${escapeHtml(summaryPreview)}</div>
+              </div>
+            </a>
+          `;
+        }).join('');
+      } catch (error) {
+        console.error('Error loading minutes:', error);
+      }
+    }
+
     async function loadDocuments() {
       try {
         const response = await fetch(`/api/working-groups/${currentSlug}/documents`);
@@ -1780,15 +1835,15 @@
         const documentsSection = document.getElementById('documentsSection');
         const documentsList = document.getElementById('documentsList');
 
-        // Show manage button for members
-        if (isMember || isLeader) {
+        // Show manage button for members and admins
+        if (isMember || isLeader || isAdmin) {
           const manageDocsBtn = document.getElementById('manageDocsBtn');
           manageDocsBtn.href = `/working-groups/${currentSlug}/manage?tab=documents`;
           manageDocsBtn.style.display = 'inline-flex';
         }
 
-        // Only show the section if there are documents or user is a member
-        if (documents.length === 0 && !isMember && !isLeader) {
+        // Only show the section if there are documents or user is a member/admin
+        if (documents.length === 0 && !isMember && !isLeader && !isAdmin) {
           return;
         }
 
@@ -1826,7 +1881,7 @@
                   ${doc.index_status !== 'success' ? `<span class="document-status ${statusClass}">${formatIndexStatus(doc.index_status)}</span>` : ''}
                 </div>
                 ${doc.document_summary ? `<div class="document-summary">${escapeHtml(doc.document_summary)}</div>` : ''}
-                ${doc.index_status === 'access_denied' && isMember ? `
+                ${doc.index_status === 'access_denied' && (isMember || isAdmin) ? `
                   <div class="document-fix-banner">
                     <p>Addie can't read this document. To fix it:</p>
                     <ol>

--- a/server/src/addie/jobs/committee-document-indexer.ts
+++ b/server/src/addie/jobs/committee-document-indexer.ts
@@ -980,7 +980,10 @@ export async function reindexDocument(documentId: string): Promise<{
   }
 
   try {
-    await indexDocument(doc);
+    const result = await indexDocument(doc);
+    if (result.error) {
+      return { success: false, error: result.error };
+    }
     return { success: true };
   } catch (error) {
     return {

--- a/server/src/addie/mcp/google-docs.ts
+++ b/server/src/addie/mcp/google-docs.ts
@@ -185,7 +185,12 @@ async function readViaDocsApi(
   );
 
   if (!response.ok) {
-    logger.debug({ status: response.status, docId }, 'Google Docs API: request failed, will try Drive API');
+    let errorDetail = '';
+    try {
+      const body = await response.json() as { error?: { message?: string; status?: string } };
+      errorDetail = body.error?.message || body.error?.status || '';
+    } catch { /* ignore parse errors */ }
+    logger.warn({ status: response.status, docId, errorDetail }, 'Google Docs API: request failed, will try Drive API');
     return null;
   }
 
@@ -229,7 +234,12 @@ async function readViaSheetsApi(
   );
 
   if (!metaResponse.ok) {
-    logger.debug({ status: metaResponse.status, spreadsheetId }, 'Google Sheets API: metadata request failed, will try Drive API');
+    let errorDetail = '';
+    try {
+      const body = await metaResponse.json() as { error?: { message?: string; status?: string } };
+      errorDetail = body.error?.message || body.error?.status || '';
+    } catch { /* ignore parse errors */ }
+    logger.warn({ status: metaResponse.status, spreadsheetId, errorDetail }, 'Google Sheets API: metadata request failed, will try Drive API');
     return null;
   }
 
@@ -388,15 +398,20 @@ async function readGoogleDoc(
 
     if (!metadataResponse.ok) {
       if (metadataResponse.status === 404 || metadataResponse.status === 403) {
+        let driveError = '';
+        try {
+          const body = await metadataResponse.json() as { error?: { message?: string; errors?: Array<{ reason?: string }> } };
+          driveError = body.error?.message || body.error?.errors?.[0]?.reason || '';
+        } catch { /* ignore parse errors */ }
         // Drive API may be blocked for unverified OAuth apps. Try direct APIs
         // as a fallback before telling the user we can't access the document.
-        logger.debug({ status: metadataResponse.status, docId }, 'Google Docs: Drive API inaccessible, trying direct APIs');
+        logger.warn({ status: metadataResponse.status, docId, driveError }, 'Google Docs: Drive API inaccessible, trying direct APIs');
         const docsResult = await readViaDocsApi(docId, accessToken);
         if (docsResult !== null) return docsResult;
         const sheetsResult = await readViaSheetsApi(docId, accessToken);
         if (sheetsResult !== null) return sheetsResult;
 
-        logger.warn({ status: metadataResponse.status, docId }, 'Google Docs: document inaccessible via all APIs');
+        logger.warn({ status: metadataResponse.status, docId, driveError }, 'Google Docs: document inaccessible via all APIs');
         return `I don't have access to this document. Please share it with ${ADDIE_EMAIL} (Viewer access is fine) and let me know when you've done that.`;
       }
       const error = await metadataResponse.text();

--- a/server/src/routes/meetings.ts
+++ b/server/src/routes/meetings.ts
@@ -738,10 +738,10 @@ export function createMeetingRouters(): {
   // PUBLIC API ROUTES (/api/meetings)
   // =========================================================================
 
-  // GET /api/meetings - List upcoming meetings (public)
+  // GET /api/meetings - List meetings (public)
   publicApiRouter.get('/', optionalAuth, async (req: Request, res: Response) => {
     try {
-      const { working_group_id, limit } = req.query;
+      const { working_group_id, limit, past } = req.query;
 
       // Validate working_group_id if provided
       if (working_group_id && !isValidUuid(working_group_id as string)) {
@@ -751,9 +751,12 @@ export function createMeetingRouters(): {
         });
       }
 
+      const isPast = past === 'true';
+
       const meetings = await meetingsDb.listMeetings({
         working_group_id: working_group_id as string,
-        upcoming_only: true,
+        upcoming_only: !isPast,
+        past_only: isPast,
         limit: limit ? Math.min(parseInt(limit as string, 10), 500) : undefined,
       });
 


### PR DESCRIPTION
## Summary
- Add "Meeting Minutes" section to working group detail pages showing past meetings with Zoom-generated summaries
- Add `?past=true` param to public meetings API for fetching past meetings
- Upgrade Google Docs/Drive/Sheets API error logging from debug to warn with actual Google error details (helps diagnose access_denied issues)
- Fix `reindexDocument` silently returning success when indexing fails (access_denied was swallowed)
- Show retry indexing banner and manage docs button for site admins, not just WG members

## Test plan
- [x] TypeScript compiles clean
- [x] All 567 unit tests pass
- [x] All 1278 server unit tests pass
- [ ] Verify meeting minutes section appears on WG pages with past meetings that have summaries
- [ ] Verify admin can see retry indexing button on access_denied documents
- [ ] Verify Google error details appear in server logs on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)