### PR TITLE
feat: generic agents array in brand.json

### DIFF
--- a/.changeset/brand-agents-array.md
+++ b/.changeset/brand-agents-array.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add generic `agents` array to brand.json for brand and house objects. Replaces the pattern of adding named agent fields (`brand_agent`, `rights_agent`) with a typed array that supports brand, rights, measurement, governance, creative, buying, and signals agent types. Deprecates `brand_agent` and `rights_agent` fields.

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -414,13 +414,19 @@
           "$ref": "#/definitions/visual_guidelines",
           "description": "Structured visual rules for generative creative systems"
         },
+        "agents": {
+          "$ref": "#/definitions/agents",
+          "description": "Agents authorized to act on behalf of this brand. Overrides house-level agents of the same type."
+        },
         "brand_agent": {
           "$ref": "#/definitions/brand_agent",
-          "description": "Brand agent that provides dynamic brand data via MCP"
+          "description": "Deprecated: use agents array with type 'brand' instead. Brand agent that provides dynamic brand data via MCP.",
+          "deprecated": true
         },
         "rights_agent": {
           "$ref": "#/definitions/rights_agent",
-          "description": "Rights licensing agent for this brand"
+          "description": "Deprecated: use agents array with type 'rights' instead. Rights licensing agent for this brand.",
+          "deprecated": true
         },
         "contact": {
           "type": "object",
@@ -484,6 +490,10 @@
           "type": "string",
           "enum": ["branded_house", "house_of_brands", "hybrid"],
           "description": "Brand architecture model: branded_house (Google), house_of_brands (P&G), hybrid (Nike)"
+        },
+        "agents": {
+          "$ref": "#/definitions/agents",
+          "description": "House-level agents that apply to all brands unless overridden at the brand level"
         }
       },
       "required": ["domain", "name"],
@@ -546,6 +556,61 @@
       },
       "required": ["url", "id", "available_uses"],
       "additionalProperties": true
+    },
+    "brand_agent_entry": {
+      "type": "object",
+      "description": "An agent declared by a brand or house. Each entry identifies one agent endpoint and its functional role in the advertising ecosystem.",
+      "properties": {
+        "type": {
+          "$ref": "/schemas/enums/brand-agent-type.json",
+          "description": "Functional role of this agent"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://",
+          "description": "Agent endpoint URL (MCP or A2A)"
+        },
+        "id": {
+          "type": "string",
+          "description": "Agent identifier (useful for logging, multi-tenant platforms)",
+          "pattern": "^[a-z0-9_]+$",
+          "maxLength": 100
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this agent's capabilities or scope",
+          "maxLength": 500
+        },
+        "available_uses": {
+          "type": "array",
+          "description": "For rights agents: rights uses available for licensing",
+          "items": { "$ref": "/schemas/enums/right-use.json" },
+          "minItems": 1
+        },
+        "right_types": {
+          "type": "array",
+          "description": "For rights agents: types of rights available",
+          "items": { "$ref": "/schemas/enums/right-type.json" },
+          "minItems": 1
+        },
+        "countries": {
+          "type": "array",
+          "description": "ISO 3166-1 alpha-2 country codes where this agent operates. Omit for global scope.",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z]{2}$"
+          }
+        }
+      },
+      "required": ["type", "url", "id"],
+      "additionalProperties": true
+    },
+    "agents": {
+      "type": "array",
+      "description": "Agents declared by this brand or house. One agent per type.",
+      "items": { "$ref": "#/definitions/brand_agent_entry" },
+      "maxItems": 20
     },
     "authorized_operator": {
       "type": "object",
@@ -1213,15 +1278,22 @@
     {
       "type": "object",
       "title": "Brand Agent",
-      "description": "Brand with an agent that provides brand info via MCP",
+      "description": "Brand represented by agents that provide brand info via MCP",
       "properties": {
         "$schema": { "type": "string" },
         "version": { "type": "string" },
-        "brand_agent": { "$ref": "#/definitions/brand_agent" },
+        "agents": { "$ref": "#/definitions/agents" },
+        "brand_agent": {
+          "$ref": "#/definitions/brand_agent",
+          "deprecated": true
+        },
         "contact": { "$ref": "#/definitions/contact" },
         "last_updated": { "type": "string", "format": "date-time" }
       },
-      "required": ["brand_agent"],
+      "anyOf": [
+        { "required": ["agents"] },
+        { "required": ["brand_agent"] }
+      ],
       "additionalProperties": false
     },
     {
@@ -1276,10 +1348,13 @@
     {
       "$schema": "/schemas/brand.json",
       "version": "1.0",
-      "brand_agent": {
-        "url": "https://agent.acme.com/mcp",
-        "id": "acme_brand_agent"
-      }
+      "agents": [
+        {
+          "type": "brand",
+          "url": "https://agent.acme.com/mcp",
+          "id": "acme_brand"
+        }
+      ]
     },
     {
       "$schema": "/schemas/brand.json",
@@ -1287,7 +1362,15 @@
       "house": {
         "domain": "pg.com",
         "name": "Procter & Gamble",
-        "architecture": "house_of_brands"
+        "architecture": "house_of_brands",
+        "agents": [
+          {
+            "type": "governance",
+            "url": "https://agents.pg.com/governance",
+            "id": "pg_governance",
+            "description": "Brand safety and compliance for all P&G brands"
+          }
+        ]
       },
       "brands": [
         {

--- a/static/schemas/source/enums/brand-agent-type.json
+++ b/static/schemas/source/enums/brand-agent-type.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/brand-agent-type.json",
+  "title": "Brand Agent Type",
+  "description": "Functional roles for agents declared in brand.json. Each type represents a distinct capability that a brand or house can expose via an agent endpoint.",
+  "type": "string",
+  "enum": [
+    "brand",
+    "rights",
+    "measurement",
+    "governance",
+    "creative",
+    "buying",
+    "signals"
+  ],
+  "enumDescriptions": {
+    "brand": "Provides brand identity data (logos, colors, tone, guidelines) via MCP",
+    "rights": "Handles rights discovery, pricing, and acquisition for licensable assets",
+    "measurement": "Provides campaign measurement, attribution, and reporting services",
+    "governance": "Enforces brand safety, compliance, and policy rules",
+    "creative": "Manages creative asset generation, review, and approval",
+    "buying": "Executes media buying on behalf of the brand",
+    "signals": "Provides audience signal discovery and activation"
+  }
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -584,6 +584,10 @@
           "$ref": "/schemas/enums/adcp-domain.json",
           "description": "AdCP protocol domains (media-buy, signals, governance, creative, brand)"
         },
+        "brand-agent-type": {
+          "$ref": "/schemas/enums/brand-agent-type.json",
+          "description": "Agent types declarable in brand.json (brand, rights, measurement, governance, creative, buying, signals)"
+        },
         "right-use": {
           "$ref": "/schemas/enums/right-use.json",
           "description": "Types of rights usage (likeness, voice, endorsement, sync, etc.)"


### PR DESCRIPTION
## Summary

- Adds a generic `agents` array to brand.json for both house and brand objects, replacing the pattern of adding named agent fields per agent type
- New `brand-agent-type` enum: brand, rights, measurement, governance, creative, buying, signals
- Deprecates `brand_agent` and `rights_agent` named fields (backward compatible — both still validate)
- Establishes brand.json as the canonical source for public agent discovery

## Design decisions

- **No independent AAO registry** — assembled from crawled brand.json files and community-hosted brand.json
- **One agent per type** — no "primary" flag; filter by type to find the right agent
- **Sales agents stay in adagents.json** — publisher authorization, not brand declaration
- **Buying agents in brand.json** — "here's my media buying agent"
- **House-level agents** — apply to all brands unless overridden at brand level

## What's NOT in this PR

This is part 1 of #1972. Part 2 (measurement agent task interface — live rate queries) depends on this.

Server-side changes (crawler, registry, brand-manager) to consume the new `agents` array are a follow-up.

## Test plan

- [ ] `npm run test:schemas` passes — all 452 schemas valid, refs resolve
- [ ] `npm run test:json-schema` passes — all 218 schema examples validate
- [ ] Existing brand.json examples with `brand_agent` still validate (backward compat)
- [ ] New example with `agents` array validates against variant 3
- [ ] House portfolio example with house-level agents validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)