### PR TITLE
fix: lazy-load agreement text to speed up admin page

### DIFF
--- a/.changeset/lazy-load-agreements.md
+++ b/.changeset/lazy-load-agreements.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: lazy-load agreement text to speed up /admin/agreements page

--- a/server/public/admin-agreements.html
+++ b/server/public/admin-agreements.html
@@ -383,10 +383,24 @@
       document.getElementById('agreementModal').style.display = 'flex';
     }
 
-    // Edit agreement
-    function editAgreement(id) {
-      editingAgreement = agreements.find(a => a.id === id);
-      if (!editingAgreement) return;
+    // Edit agreement — fetches full text on demand
+    async function editAgreement(id) {
+      const stub = agreements.find(a => a.id === id);
+      if (!stub) return;
+
+      document.getElementById('modalTitle').textContent = 'Loading...';
+      document.getElementById('agreementModal').style.display = 'flex';
+
+      try {
+        const response = await fetch(`/api/admin/agreements/${id}`);
+        if (!response.ok) throw new Error('Failed to load agreement');
+        editingAgreement = await response.json();
+      } catch (error) {
+        console.error('Error loading agreement:', error);
+        alert('Failed to load agreement text');
+        closeModal();
+        return;
+      }
 
       document.getElementById('modalTitle').textContent = 'Edit Agreement';
       document.getElementById('agreementType').value = editingAgreement.agreement_type;
@@ -394,7 +408,6 @@
       document.getElementById('agreementEffectiveDate').value = editingAgreement.effective_date.split('T')[0];
       document.getElementById('agreementText').value = editingAgreement.text;
       updatePreview();
-      document.getElementById('agreementModal').style.display = 'flex';
     }
 
     // Close modal

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4414,7 +4414,7 @@ export class HTTPServer {
       try {
         const pool = getPool();
         const result = await pool.query(
-          'SELECT * FROM agreements ORDER BY agreement_type, effective_date DESC'
+          'SELECT id, agreement_type, version, effective_date, created_at FROM agreements ORDER BY agreement_type, effective_date DESC'
         );
 
         res.json(result.rows);
@@ -4422,6 +4422,33 @@ export class HTTPServer {
         logger.error({ err: error }, 'Get all agreements error:');
         res.status(500).json({
           error: 'Failed to get agreements',
+        });
+      }
+    });
+
+    // GET /api/admin/agreements/:id - Get single agreement with full text
+    this.app.get('/api/admin/agreements/:id', requireAuth, requireAdmin, async (req, res) => {
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(req.params.id)) {
+        return res.status(400).json({ error: 'Invalid agreement ID format' });
+      }
+
+      try {
+        const pool = getPool();
+        const result = await pool.query(
+          'SELECT id, agreement_type, version, text, effective_date, created_at FROM agreements WHERE id = $1',
+          [req.params.id]
+        );
+
+        if (result.rows.length === 0) {
+          return res.status(404).json({ error: 'Agreement not found' });
+        }
+
+        res.json(result.rows[0]);
+      } catch (error) {
+        logger.error({ err: error }, 'Get agreement error:');
+        res.status(500).json({
+          error: 'Failed to get agreement',
         });
       }
     });

--- a/server/tests/integration/admin-endpoints.test.ts
+++ b/server/tests/integration/admin-endpoints.test.ts
@@ -128,7 +128,7 @@ describe('Admin Endpoints Integration Tests', () => {
   });
 
   describe('GET /api/admin/agreements', () => {
-    it('should list all agreements', async () => {
+    it('should list all agreements without text', async () => {
       // Create a test agreement
       await pool.query(
         `INSERT INTO agreements (agreement_type, version, text, effective_date)
@@ -143,7 +143,38 @@ describe('Admin Endpoints Integration Tests', () => {
       expect(response.body).toBeInstanceOf(Array);
       expect(response.body.length).toBeGreaterThan(0);
       expect(response.body[0]).toHaveProperty('version');
-      expect(response.body[0]).toHaveProperty('text');
+      expect(response.body[0]).not.toHaveProperty('text');
+    });
+  });
+
+  describe('GET /api/admin/agreements/:id', () => {
+    it('should return a single agreement with full text', async () => {
+      const result = await pool.query(
+        `INSERT INTO agreements (agreement_type, version, text, effective_date)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id`,
+        ['membership', '1.0', 'Full agreement text here', new Date()]
+      );
+      const id = result.rows[0].id;
+
+      const response = await request(app)
+        .get(`/api/admin/agreements/${id}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('text', 'Full agreement text here');
+      expect(response.body).toHaveProperty('version', '1.0');
+    });
+
+    it('should return 404 for non-existent agreement', async () => {
+      await request(app)
+        .get('/api/admin/agreements/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+    });
+
+    it('should return 400 for invalid id format', async () => {
+      await request(app)
+        .get('/api/admin/agreements/not-a-uuid')
+        .expect(400);
     });
   });
 


### PR DESCRIPTION
## Summary
- The `/admin/agreements` page was slow because `GET /api/admin/agreements` returned `SELECT *` including full markdown legal document text for every agreement version
- Changed list endpoint to return only metadata columns (`id`, `agreement_type`, `version`, `effective_date`, `created_at`)
- Added `GET /api/admin/agreements/:id` endpoint to fetch a single agreement with full text on demand
- Frontend `editAgreement()` now fetches text lazily when the edit modal opens, with a "Loading..." state

## Test plan
- [x] Unit tests pass (563/563)
- [x] Type-check passes
- [x] New integration tests for `GET /api/admin/agreements/:id` (happy path, 404 for missing UUID, 400 for invalid format)
- [x] Existing list test updated to assert `text` is NOT in list response
- [x] Code review: addressed UUID validation, input reflection in error messages, explicit column list
- [x] Security review: no Must Fix findings; all Should Fix items addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)