### PR TITLE
fix: replace dots with underscores in CSS custom property names

### DIFF
--- a/.changeset/fix-css-variable-dots.md
+++ b/.changeset/fix-css-variable-dots.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix CSS custom property names containing dots (replace with underscores).
+
+CSS custom properties cannot contain dots per spec. Renamed `--space-0.5`, `--space-1.5`, `--space-2.5`, and `--space-3.5` to `--space-0_5`, `--space-1_5`, `--space-2_5`, and `--space-3_5` in `design-system.css` and all usages across public HTML/JS files.

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -304,7 +304,7 @@
       }
 
       .identifier-entry .btn {
-        padding: var(--space-1.5) var(--space-2.5);
+        padding: var(--space-1_5) var(--space-2_5);
         font-size: var(--text-xs);
       }
 
@@ -387,7 +387,7 @@
 
       .dashboard-card-tags {
         display: flex;
-        gap: var(--space-1.5);
+        gap: var(--space-1_5);
         flex-wrap: wrap;
         margin-top: var(--space-2);
       }
@@ -396,7 +396,7 @@
         font-size: var(--text-xs);
         background: var(--color-gray-100);
         color: var(--color-gray-600);
-        padding: var(--space-1) var(--space-2.5);
+        padding: var(--space-1) var(--space-2_5);
         border-radius: var(--radius-full);
         font-weight: var(--font-semibold);
       }
@@ -531,7 +531,7 @@
       .form-group select,
       .form-group textarea {
         width: 100%;
-        padding: var(--space-2.5) var(--space-3);
+        padding: var(--space-2_5) var(--space-3);
         border: var(--border-2) solid var(--color-border);
         border-radius: var(--radius-md);
         font-size: var(--text-sm);
@@ -617,7 +617,7 @@
       }
 
       .identifier-item .btn {
-        padding: var(--space-2.5) var(--space-3.5);
+        padding: var(--space-2_5) var(--space-3_5);
         font-size: var(--text-xs);
       }
 
@@ -670,14 +670,14 @@
         position: absolute;
         top: var(--space-3);
         right: var(--space-3);
-        padding: var(--space-1.5) var(--space-3);
+        padding: var(--space-1_5) var(--space-3);
         font-size: var(--text-xs);
       }
 
       /* Responsive Design */
       @media (max-width: 768px) {
         .main-content {
-          padding: var(--space-5) var(--space-2.5);
+          padding: var(--space-5) var(--space-2_5);
         }
 
         .page-header h1 {
@@ -702,7 +702,7 @@
         }
 
         .nav-link {
-          padding: var(--space-1.5) var(--space-3);
+          padding: var(--space-1_5) var(--space-3);
           font-size: var(--text-xs);
         }
       }
@@ -718,7 +718,7 @@
         }
 
         .btn {
-          padding: var(--space-2.5) var(--space-4);
+          padding: var(--space-2_5) var(--space-4);
           font-size: var(--text-xs);
         }
       }

--- a/server/public/adagents-landing.html
+++ b/server/public/adagents-landing.html
@@ -81,7 +81,7 @@
     }
     .hero--adagents .hero-description code {
       background: rgba(255, 255, 255, 0.15);
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
       font-size: var(--text-sm);
@@ -231,7 +231,7 @@
     }
     .quickstart-note code {
       background: var(--color-gray-100);
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
       font-size: var(--text-sm);

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -3108,7 +3108,7 @@
             <div style="font-weight: var(--font-semibold); margin-bottom: var(--space-2);">${escapeHtml(member)}</div>
             ${insights.map(insight => `
               <div style="display: flex; gap: var(--space-2); padding: var(--space-1) 0; font-size: var(--text-sm);">
-                <span style="background: var(--color-primary-100); color: var(--color-primary-700); padding: var(--space-0.5) var(--space-1.5); border-radius: var(--radius-sm); font-size: var(--text-xs); font-weight: var(--font-medium);">
+                <span style="background: var(--color-primary-100); color: var(--color-primary-700); padding: var(--space-0_5) var(--space-1_5); border-radius: var(--radius-sm); font-size: var(--text-xs); font-weight: var(--font-medium);">
                   ${escapeHtml(insight.insight_type)}
                 </span>
                 <span>${escapeHtml(insight.value)}</span>

--- a/server/public/admin-accounts.html
+++ b/server/public/admin-accounts.html
@@ -236,7 +236,7 @@
     .unmapped-badge {
       display: inline-block;
       font-size: var(--text-xs);
-      padding: 0 var(--space-1.5);
+      padding: 0 var(--space-1_5);
       border-radius: var(--radius-full);
       background: var(--color-warning-100);
       color: var(--color-warning-700);
@@ -699,7 +699,7 @@
     }
     .modal-actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-4);
@@ -721,7 +721,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -30,7 +30,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
 
     /* Stats row */
@@ -116,7 +116,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -159,7 +159,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
     }
     .interaction-content {
@@ -217,7 +217,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -263,7 +263,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -286,7 +286,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -452,7 +452,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }

--- a/server/public/admin-api-keys.html
+++ b/server/public/admin-api-keys.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle {
       color: var(--color-text-secondary);
       font-size: var(--text-sm);
@@ -42,7 +42,7 @@
     }
     .info-box code {
       background: var(--color-primary-100);
-      padding: var(--space-0.5) var(--space-1);
+      padding: var(--space-0_5) var(--space-1);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
     }
@@ -96,7 +96,7 @@
     }
     .permissions-list li code {
       background: var(--color-gray-100);
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
       font-size: var(--text-xs);

--- a/server/public/admin-bans.html
+++ b/server/public/admin-bans.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-lg); }
     .header-bar {
       display: flex;
@@ -45,7 +45,7 @@
       color: var(--color-text-heading);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       margin-left: var(--space-2);
       min-width: 24px;
@@ -59,7 +59,7 @@
       border-bottom: var(--border-1) solid var(--color-gray-200);
     }
     .filter-tab {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       font-size: var(--text-sm);
       font-weight: var(--font-medium);
       color: var(--color-text-secondary);
@@ -142,7 +142,7 @@
       cursor: pointer;
       transition: all 0.15s ease;
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -173,7 +173,7 @@
     .form-group input,
     .form-group select {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -205,7 +205,7 @@
 
     /* Status messages */
     .status-message {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -100,7 +100,7 @@
 
     .badge {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
@@ -124,7 +124,7 @@
       align-items: center;
     }
     .link-form input {
-      padding: var(--space-1.5) var(--space-2);
+      padding: var(--space-1_5) var(--space-2);
       border: var(--border-1) solid var(--color-gray-300);
       border-radius: var(--radius-sm);
       font-size: var(--text-sm);
@@ -137,7 +137,7 @@
     }
 
     .btn {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: none;
       border-radius: var(--radius-sm);
       font-size: var(--text-sm);

--- a/server/public/admin-brands.html
+++ b/server/public/admin-brands.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
     .filters {
       display: grid;
@@ -53,11 +53,11 @@
     }
     .actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .btn {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -152,7 +152,7 @@
       color: var(--color-text-secondary);
     }
     .btn-icon {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: var(--border-1) solid var(--color-gray-200);
       background: var(--color-bg-card);
       border-radius: var(--radius-sm);
@@ -253,7 +253,7 @@
     }
     .modal-actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-5);
       padding-top: var(--space-4);
@@ -386,7 +386,7 @@
           </div>
         </div>
 
-        <div id="brandsCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2.5);">
+        <div id="brandsCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2_5);">
           Showing 0 brands
         </div>
 

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
 
     .filters {
       display: flex;

--- a/server/public/admin-data-cleanup.html
+++ b/server/public/admin-data-cleanup.html
@@ -32,7 +32,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
 
     /* Breadcrumb */
@@ -103,7 +103,7 @@
       background: var(--color-error-600);
     }
     .btn-sm {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       font-size: var(--text-xs);
     }
     .btn:disabled {
@@ -154,7 +154,7 @@
     .issue-suggestion {
       font-size: var(--text-xs);
       color: var(--color-text-muted);
-      margin-top: var(--space-0.5);
+      margin-top: var(--space-0_5);
     }
 
     /* Empty/loading states */
@@ -227,7 +227,7 @@
     .markdown-content ul, .markdown-content ol { margin: var(--space-2) 0; padding-left: var(--space-5); }
     .markdown-content li { margin-bottom: var(--space-1); }
     .markdown-content strong { font-weight: var(--font-semibold); }
-    .markdown-content code { background: var(--color-bg-subtle); padding: var(--space-0.5) var(--space-1); border-radius: var(--radius-sm); font-size: 0.9em; }
+    .markdown-content code { background: var(--color-bg-subtle); padding: var(--space-0_5) var(--space-1); border-radius: var(--radius-sm); font-size: 0.9em; }
 
     /* Action panels */
     .action-panel {

--- a/server/public/admin-domain-discovery.html
+++ b/server/public/admin-domain-discovery.html
@@ -31,7 +31,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
 
     /* Breadcrumb */
@@ -117,7 +117,7 @@
       background: var(--color-gray-300);
     }
     .btn-sm {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       font-size: var(--text-xs);
     }
 
@@ -165,7 +165,7 @@
     /* Source badges */
     .source-badge {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);

--- a/server/public/admin-domain-health.html
+++ b/server/public/admin-domain-health.html
@@ -79,7 +79,7 @@
     .section-badge {
       background: var(--color-error-100);
       color: var(--color-error-700);
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -133,12 +133,12 @@
     .user-list li {
       font-size: var(--text-xs);
       color: var(--color-text-secondary);
-      padding: var(--space-0.5) 0;
+      padding: var(--space-0_5) 0;
     }
     .claimed-tag {
       display: inline-block;
       margin-left: var(--space-1);
-      padding: var(--space-0.5) var(--space-1);
+      padding: var(--space-0_5) var(--space-1);
       background: var(--color-warning-100);
       color: var(--color-warning-700);
       border-radius: var(--radius-sm);
@@ -151,7 +151,7 @@
     .personal-tag {
       display: inline-block;
       margin-left: var(--space-1);
-      padding: var(--space-0.5) var(--space-1);
+      padding: var(--space-0_5) var(--space-1);
       background: var(--color-gray-100);
       color: var(--color-text-muted);
       border-radius: var(--radius-sm);
@@ -160,7 +160,7 @@
     .user-count {
       background: var(--color-gray-100);
       color: var(--color-text-secondary);
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -168,7 +168,7 @@
 
     /* Action Buttons */
     .btn {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-xs);
@@ -230,7 +230,7 @@
     /* Status Badges */
     .status-badge {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
@@ -247,7 +247,7 @@
     /* Signal badges for Review Relationships */
     .signal-badge {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -411,7 +411,7 @@
               <div style="flex: 1;">
                 <div style="font-weight: var(--font-semibold); color: var(--color-text-heading);">
                   Backfill Slack User Links
-                  <span id="backfillCount" style="margin-left: var(--space-2); padding: var(--space-0.5) var(--space-2); background: var(--color-gray-100); color: var(--color-text-secondary); border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: var(--font-normal);">loading...</span>
+                  <span id="backfillCount" style="margin-left: var(--space-2); padding: var(--space-0_5) var(--space-2); background: var(--color-gray-100); color: var(--color-text-secondary); border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: var(--font-normal);">loading...</span>
                 </div>
                 <div style="font-size: var(--text-sm); color: var(--color-text-secondary);">Link unmapped Slack users to existing organizations based on their email domain</div>
               </div>
@@ -427,7 +427,7 @@
               <div style="flex: 1;">
                 <div style="font-weight: var(--font-semibold); color: var(--color-text-heading);">
                   Auto-Add Domain Users as Members
-                  <span id="memberBackfillCount" style="margin-left: var(--space-2); padding: var(--space-0.5) var(--space-2); background: var(--color-gray-100); color: var(--color-text-secondary); border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: var(--font-normal);">loading...</span>
+                  <span id="memberBackfillCount" style="margin-left: var(--space-2); padding: var(--space-0_5) var(--space-2); background: var(--color-gray-100); color: var(--color-text-secondary); border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: var(--font-normal);">loading...</span>
                 </div>
                 <div style="font-size: var(--text-sm); color: var(--color-text-secondary);">Add users with verified domain emails directly as organization members (they have accounts but aren't members yet)</div>
               </div>

--- a/server/public/admin-escalations.html
+++ b/server/public/admin-escalations.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .header-bar {
       display: flex;
       justify-content: space-between;

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -30,7 +30,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .events-list {
       display: grid;
@@ -57,7 +57,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -89,7 +89,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -133,7 +133,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -166,7 +166,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -184,7 +184,7 @@
     }
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .filter-bar select {

--- a/server/public/admin-feeds.html
+++ b/server/public/admin-feeds.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .header-bar {
       display: flex;
@@ -127,7 +127,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -170,7 +170,7 @@
     .form-group input,
     .form-group select {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -193,7 +193,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -201,13 +201,13 @@
     }
     .url-input-group {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
     }
     .url-input-group input {
       flex: 1;
     }
     .status-message {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);

--- a/server/public/admin-manifest-refs.html
+++ b/server/public/admin-manifest-refs.html
@@ -90,7 +90,7 @@
     }
     .badge {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);

--- a/server/public/admin-meetings.html
+++ b/server/public/admin-meetings.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .header-bar {
       display: flex;
@@ -39,7 +39,7 @@
     }
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
       flex-wrap: wrap;
     }
@@ -96,7 +96,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -124,7 +124,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -168,7 +168,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -196,7 +196,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -214,7 +214,7 @@
       margin-bottom: var(--space-5);
     }
     .tab {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       cursor: pointer;
       border: 2px solid transparent;
       border-bottom: none;

--- a/server/public/admin-members.html
+++ b/server/public/admin-members.html
@@ -39,7 +39,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
     .filters {
       display: grid;
@@ -67,11 +67,11 @@
     }
     .actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .btn {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -162,7 +162,7 @@
       color: var(--color-text-secondary);
     }
     .btn-icon {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: var(--border-1) solid var(--color-gray-200);
       background: var(--color-bg-card);
       border-radius: var(--radius-sm);
@@ -232,7 +232,7 @@
     }
     .payment-item {
       padding: var(--space-4);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
       border-left: 4px solid var(--color-brand);
       background: var(--color-gray-50);
       border-radius: var(--radius-sm);
@@ -386,7 +386,7 @@
           </div>
         </div>
 
-        <div id="membersCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2.5);">
+        <div id="membersCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2_5);">
           Showing 0 members
         </div>
 

--- a/server/public/admin-notification-channels.html
+++ b/server/public/admin-notification-channels.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .header-bar {
       display: flex;
@@ -130,7 +130,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -176,7 +176,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -226,14 +226,14 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
       border-top: var(--border-1) solid var(--color-gray-200);
     }
     .status-message {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);

--- a/server/public/admin-people.html
+++ b/server/public/admin-people.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle {
       color: var(--color-text-secondary);
       font-size: var(--text-sm);
@@ -72,7 +72,7 @@
     /* Filters */
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
       flex-wrap: wrap;
       align-items: center;

--- a/server/public/admin-policies.html
+++ b/server/public/admin-policies.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
     .filters {
       display: grid;
@@ -115,7 +115,7 @@
     }
     .jurisdiction-tag {
       display: inline-block;
-      padding: 1px var(--space-1.5);
+      padding: 1px var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: var(--text-xs);
       background: var(--color-gray-100);

--- a/server/public/admin-products.html
+++ b/server/public/admin-products.html
@@ -37,7 +37,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
     .filters {
       display: grid;
@@ -65,11 +65,11 @@
     }
     .actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .btn {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -136,7 +136,7 @@
     }
     .tag {
       display: inline-block;
-      padding: 2px var(--space-1.5);
+      padding: 2px var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: 10px;
       background: var(--color-gray-100);
@@ -150,7 +150,7 @@
       color: var(--color-text-secondary);
     }
     .btn-icon {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: var(--border-1) solid var(--color-gray-200);
       background: var(--color-bg-card);
       border-radius: var(--radius-sm);
@@ -221,7 +221,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -261,7 +261,7 @@
     }
     .modal-actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -352,7 +352,7 @@
           </div>
         </div>
 
-        <div id="productsCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2.5);">
+        <div id="productsCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2_5);">
           Showing 0 products
         </div>
 

--- a/server/public/admin-properties.html
+++ b/server/public/admin-properties.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-5); }
     .filters {
       display: grid;
@@ -53,11 +53,11 @@
     }
     .actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .btn {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -134,7 +134,7 @@
       color: var(--color-text-secondary);
     }
     .btn-icon {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border: var(--border-1) solid var(--color-gray-200);
       background: var(--color-bg-card);
       border-radius: var(--radius-sm);
@@ -235,7 +235,7 @@
     }
     .modal-actions {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-5);
       padding-top: var(--space-4);
@@ -328,7 +328,7 @@
           </div>
         </div>
 
-        <div id="propertiesCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2.5);">
+        <div id="propertiesCount" style="color: var(--color-text-secondary); margin-bottom: var(--space-2_5);">
           Showing 0 properties
         </div>
 

--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -25,7 +25,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .subtitle {
       color: var(--color-text-secondary);
@@ -67,7 +67,7 @@
     .field select,
     .field input {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -85,7 +85,7 @@
       font-size: var(--text-xs);
     }
     .btn {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       border: none;
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -117,7 +117,7 @@
       color: var(--color-text-secondary);
     }
     .status-message {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);

--- a/server/public/admin-simulations.html
+++ b/server/public/admin-simulations.html
@@ -18,7 +18,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     h3 { margin-bottom: var(--space-3); color: var(--color-text-heading); font-size: var(--text-lg); }
     .subtitle { color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-6); }

--- a/server/public/admin-users.html
+++ b/server/public/admin-users.html
@@ -27,7 +27,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     .subtitle {
       color: var(--color-text-secondary);
       font-size: var(--text-sm);
@@ -42,7 +42,7 @@
     }
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
       flex-wrap: wrap;
       align-items: center;
@@ -69,7 +69,7 @@
       align-items: center;
       gap: var(--space-2);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-secondary { background: var(--color-gray-200); color: var(--color-text-heading); }

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -27,7 +27,7 @@
       margin-bottom: var(--space-5);
       box-shadow: var(--shadow-xs);
     }
-    h1 { margin-bottom: var(--space-2.5); color: var(--color-text-heading); }
+    h1 { margin-bottom: var(--space-2_5); color: var(--color-text-heading); }
     h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
     .groups-list {
       display: grid;
@@ -54,7 +54,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -89,7 +89,7 @@
       cursor: pointer;
       transition: var(--transition-all);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -133,7 +133,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -160,7 +160,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -178,7 +178,7 @@
     }
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
     }
     .filter-bar select {
@@ -220,7 +220,7 @@
       display: block;
     }
     .user-search-item {
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       cursor: pointer;
       border-bottom: var(--border-1) solid var(--color-gray-100);
     }
@@ -240,7 +240,7 @@
     }
     .selected-user {
       background: var(--color-gray-50);
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border-radius: var(--radius-md);
       display: flex;
       justify-content: space-between;
@@ -277,7 +277,7 @@
       margin-bottom: var(--space-5);
     }
     .tab {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       cursor: pointer;
       border: 2px solid transparent;
       border-bottom: none;

--- a/server/public/brand-landing.html
+++ b/server/public/brand-landing.html
@@ -70,7 +70,7 @@
     }
     .hero--brand .hero-description code {
       background: rgba(255, 255, 255, 0.15);
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
       font-size: var(--text-sm);
@@ -183,7 +183,7 @@
     .quick-start-note code {
       background: var(--color-primary-50);
       color: var(--color-brand);
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);
       font-size: var(--text-sm);

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -57,7 +57,7 @@
 
       .keller-badge {
         font-size: var(--text-xs);
-        padding: var(--space-0.5) var(--space-2);
+        padding: var(--space-0_5) var(--space-2);
         border-radius: var(--radius-full);
         background: var(--color-gray-100);
         color: var(--color-text-muted);
@@ -176,7 +176,7 @@
 
       .logo-tag {
         font-size: var(--text-xs);
-        padding: var(--space-0.5) var(--space-2);
+        padding: var(--space-0_5) var(--space-2);
         border-radius: var(--radius-full);
         background: var(--color-primary-100);
         color: var(--color-brand);
@@ -225,7 +225,7 @@
         font-weight: var(--font-semibold);
         color: var(--color-text-heading);
         text-transform: capitalize;
-        margin-bottom: var(--space-0.5);
+        margin-bottom: var(--space-0_5);
       }
 
       .swatch-hex {
@@ -406,7 +406,7 @@
         display: inline-flex;
         align-items: center;
         gap: var(--space-1);
-        padding: var(--space-0.5) var(--space-2);
+        padding: var(--space-0_5) var(--space-2);
         border-radius: var(--radius-full);
         background: var(--color-gray-100);
         color: var(--color-gray-600);

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -177,7 +177,7 @@
     .brand-card__domain {
       font-size: var(--text-sm);
       color: var(--color-text-muted);
-      margin-top: var(--space-0.5);
+      margin-top: var(--space-0_5);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -207,7 +207,7 @@
     .brand-card__detail-item {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
     }
     .brand-card__color-dot {
       width: 14px;
@@ -219,7 +219,7 @@
     }
     .brand-card__tag {
       display: inline-block;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       background: var(--color-primary-50);
       color: var(--color-primary-700);
       border-radius: var(--radius-full);
@@ -243,7 +243,7 @@
     .brand-card__meta-item {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       font-size: var(--text-xs);
       color: var(--color-text-muted);
     }
@@ -299,7 +299,7 @@
       flex-wrap: wrap;
     }
     .claim-brand-cta__primary {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       background: var(--color-brand);
       color: white;
       border-radius: var(--radius-lg);
@@ -315,7 +315,7 @@
       outline-offset: 2px;
     }
     .claim-brand-cta__secondary {
-      padding: var(--space-2.5) var(--space-5);
+      padding: var(--space-2_5) var(--space-5);
       background: var(--color-bg-card);
       color: var(--color-brand);
       border: 1px solid var(--color-primary-200);

--- a/server/public/community/connections.html
+++ b/server/public/community/connections.html
@@ -73,7 +73,7 @@
       justify-content: center;
       min-width: 20px;
       height: 20px;
-      padding: 0 var(--space-1.5);
+      padding: 0 var(--space-1_5);
       font-size: var(--text-xs);
       font-weight: var(--font-bold);
       border-radius: var(--radius-full);

--- a/server/public/community/hub.html
+++ b/server/public/community/hub.html
@@ -420,9 +420,9 @@
     .group-rec-item { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) 0; border-bottom: var(--border-1) solid var(--color-border); }
     .group-rec-item:last-child { border-bottom: none; }
     .group-rec-info { flex: 1; min-width: 0; }
-    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0.5); }
+    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0_5); }
     .group-rec-reason { font-size: var(--text-xs); color: var(--color-text-muted); }
-    .group-rec-badge { display: inline-flex; padding: var(--space-0.5) var(--space-2); border-radius: var(--badge-radius); font-size: 10px; font-weight: var(--font-semibold); text-transform: uppercase; letter-spacing: var(--tracking-wide); background: var(--color-gray-100); color: var(--color-gray-600); flex-shrink: 0; }
+    .group-rec-badge { display: inline-flex; padding: var(--space-0_5) var(--space-2); border-radius: var(--badge-radius); font-size: 10px; font-weight: var(--font-semibold); text-transform: uppercase; letter-spacing: var(--tracking-wide); background: var(--color-gray-100); color: var(--color-gray-600); flex-shrink: 0; }
     .group-rec-link { font-size: var(--text-xs); color: var(--color-brand); text-decoration: none; font-weight: var(--font-medium); white-space: nowrap; flex-shrink: 0; }
     .group-rec-link:hover { text-decoration: underline; }
 

--- a/server/public/community/people.html
+++ b/server/public/community/people.html
@@ -58,7 +58,7 @@
     }
 
     .filter-select {
-      padding: var(--space-2.5) var(--space-3.5);
+      padding: var(--space-2_5) var(--space-3_5);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
@@ -75,7 +75,7 @@
     }
 
     .filter-input {
-      padding: var(--space-2.5) var(--space-3.5);
+      padding: var(--space-2_5) var(--space-3_5);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
@@ -121,7 +121,7 @@
       justify-content: center;
       min-width: 22px;
       height: 22px;
-      padding: 0 var(--space-1.5);
+      padding: 0 var(--space-1_5);
       background: var(--color-brand);
       color: white;
       border-radius: var(--radius-full);

--- a/server/public/community/person-card.js
+++ b/server/public/community/person-card.js
@@ -232,7 +232,7 @@ function injectPersonCardStyles() {
       font-size: var(--text-xs);
       color: var(--color-success-700);
       background: var(--color-success-100);
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-full);
       font-weight: var(--font-medium);
       white-space: nowrap;
@@ -274,7 +274,7 @@ function injectPersonCardStyles() {
 
     .pc-tag {
       font-size: var(--text-xs);
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       background: var(--color-primary-100);
       color: var(--color-brand);
       border-radius: var(--radius-sm);

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -128,7 +128,7 @@
     .profile-meta-item {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
     }
 
     .profile-meta-item svg {
@@ -154,8 +154,8 @@
     .social-link {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-1.5) var(--space-3);
+      gap: var(--space-1_5);
+      padding: var(--space-1_5) var(--space-3);
       background: var(--color-gray-100);
       border-radius: var(--radius-md);
       color: var(--color-text-body);
@@ -186,8 +186,8 @@
     .open-to-badge {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-1.5) var(--space-3);
+      gap: var(--space-1_5);
+      padding: var(--space-1_5) var(--space-3);
       background: var(--color-success-50);
       color: var(--color-success-700);
       border-radius: var(--radius-full);
@@ -227,7 +227,7 @@
     }
 
     .profile-tag {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
@@ -624,7 +624,7 @@
     .progress-bar-label {
       display: flex;
       justify-content: space-between;
-      margin-bottom: var(--space-1.5);
+      margin-bottom: var(--space-1_5);
     }
 
     .progress-bar-label span {

--- a/server/public/community/profile-edit.html
+++ b/server/public/community/profile-edit.html
@@ -196,7 +196,7 @@
       width: 44px;
       height: 24px;
       flex-shrink: 0;
-      margin-top: var(--space-0.5);
+      margin-top: var(--space-0_5);
     }
 
     .toggle-switch input {
@@ -614,8 +614,8 @@
                   <div>
                     <div style="font-size: var(--text-sm); font-weight: var(--font-medium); color: var(--color-text-heading); margin-bottom: var(--space-2);">How does this look?</div>
                     <div style="display: flex; gap: var(--space-2);">
-                      <button type="button" id="portrait-approve-btn" style="padding: var(--space-1.5) var(--space-3); background: var(--color-success-600); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Use this</button>
-                      <button type="button" id="portrait-retry-btn" style="padding: var(--space-1.5) var(--space-3); background: var(--color-bg-card); color: var(--color-text-body); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Try again</button>
+                      <button type="button" id="portrait-approve-btn" style="padding: var(--space-1_5) var(--space-3); background: var(--color-success-600); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Use this</button>
+                      <button type="button" id="portrait-retry-btn" style="padding: var(--space-1_5) var(--space-3); background: var(--color-bg-card); color: var(--color-text-body); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Try again</button>
                     </div>
                   </div>
                 </div>

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -467,12 +467,12 @@
     .group-rec-item:last-child { border-bottom: none; }
 
     .group-rec-info { flex: 1; min-width: 0; }
-    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0.5); }
+    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0_5); }
     .group-rec-reason { font-size: var(--text-xs); color: var(--color-text-muted); }
 
     .group-rec-badge {
       display: inline-flex;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--badge-radius);
       font-size: 10px; font-weight: var(--font-semibold);
       text-transform: uppercase; letter-spacing: var(--tracking-wide);
@@ -607,7 +607,7 @@
     }
 
     .timeline-date { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-1); }
-    .timeline-transition { font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium); margin-bottom: var(--space-0.5); }
+    .timeline-transition { font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium); margin-bottom: var(--space-0_5); }
     .timeline-trigger { font-size: var(--text-xs); color: var(--color-text-secondary); }
     .timeline-empty { font-size: var(--text-sm); color: var(--color-text-muted); text-align: center; padding: var(--space-6) 0; }
 
@@ -636,7 +636,7 @@
 
     .status-badge {
       display: inline-flex;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--badge-radius);
       font-size: 10px; font-weight: var(--font-semibold);
       text-transform: uppercase; letter-spacing: var(--tracking-wide);
@@ -696,7 +696,7 @@
       font-size: var(--text-sm); font-weight: var(--font-medium); color: var(--color-text-heading);
     }
     .welcome-checklist-item .wc-desc {
-      font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-0.5);
+      font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-0_5);
     }
 
     /* Upgrade teaser card */
@@ -768,7 +768,7 @@
       .content-table, .content-table tbody, .content-table tr, .content-table td { display: block; }
       .content-table tr { padding: var(--space-3) 0; border-bottom: var(--border-1) solid var(--color-border); }
       .content-table td { padding: var(--space-1) var(--space-3); border-bottom: none; }
-      .content-table td::before { content: attr(data-label); font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: var(--tracking-wide); display: block; margin-bottom: var(--space-0.5); }
+      .content-table td::before { content: attr(data-label); font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: var(--tracking-wide); display: block; margin-bottom: var(--space-0_5); }
 
       .health-score-layout { flex-direction: column; align-items: flex-start; }
       .health-signal-grid { grid-template-columns: repeat(2, 1fr); }
@@ -777,7 +777,7 @@
       .people-table, .people-table tbody, .people-table tr, .people-table td { display: block; }
       .people-table tr { padding: var(--space-3) 0; border-bottom: var(--border-1) solid var(--color-border); }
       .people-table td { padding: var(--space-1) var(--space-3); border-bottom: none; }
-      .people-table td::before { content: attr(data-label); font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: var(--tracking-wide); display: block; margin-bottom: var(--space-0.5); }
+      .people-table td::before { content: attr(data-label); font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: var(--tracking-wide); display: block; margin-bottom: var(--space-0_5); }
 
       .champion-grid { grid-template-columns: 1fr; }
     }

--- a/server/public/dashboard-settings.html
+++ b/server/public/dashboard-settings.html
@@ -182,7 +182,7 @@
       width: 44px;
       height: 24px;
       flex-shrink: 0;
-      margin-top: var(--space-0.5);
+      margin-top: var(--space-0_5);
     }
 
     .toggle-switch input {
@@ -794,8 +794,8 @@
                   <div>
                     <div style="font-size: var(--text-sm); font-weight: var(--font-medium); color: var(--color-text-heading); margin-bottom: var(--space-2);">How does this look?</div>
                     <div style="display: flex; gap: var(--space-2);">
-                      <button type="button" id="portrait-approve-btn" style="padding: var(--space-1.5) var(--space-3); background: var(--color-success-600); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Use this</button>
-                      <button type="button" id="portrait-retry-btn" style="padding: var(--space-1.5) var(--space-3); background: var(--color-bg-card); color: var(--color-text-body); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Try again</button>
+                      <button type="button" id="portrait-approve-btn" style="padding: var(--space-1_5) var(--space-3); background: var(--color-success-600); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Use this</button>
+                      <button type="button" id="portrait-retry-btn" style="padding: var(--space-1_5) var(--space-3); background: var(--color-bg-card); color: var(--color-text-body); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Try again</button>
                     </div>
                   </div>
                 </div>

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -38,7 +38,7 @@
 
     h1 {
       color: var(--color-text-heading);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
       font-size: var(--text-4xl);
     }
 

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -202,13 +202,13 @@
 :root {
   --space-0:   0;
   --space-px:  1px;
-  --space-0.5: 0.125rem;   /* 2px */
+  --space-0_5: 0.125rem;   /* 2px */
   --space-1:   0.25rem;    /* 4px */
-  --space-1.5: 0.375rem;   /* 6px */
+  --space-1_5: 0.375rem;   /* 6px */
   --space-2:   0.5rem;     /* 8px - base unit */
-  --space-2.5: 0.625rem;   /* 10px */
+  --space-2_5: 0.625rem;   /* 10px */
   --space-3:   0.75rem;    /* 12px */
-  --space-3.5: 0.875rem;   /* 14px */
+  --space-3_5: 0.875rem;   /* 14px */
   --space-4:   1rem;       /* 16px */
   --space-5:   1.25rem;    /* 20px */
   --space-6:   1.5rem;     /* 24px */
@@ -361,7 +361,7 @@
      8.1 Buttons
      ----------------------------------------------------------------------------- */
   --btn-padding-x: var(--space-5);
-  --btn-padding-y: var(--space-2.5);
+  --btn-padding-y: var(--space-2_5);
   --btn-padding-x-sm: var(--space-3);
   --btn-padding-y-sm: var(--space-2);
   --btn-padding-x-lg: var(--space-8);
@@ -1732,7 +1732,7 @@ html {
   .btn-sm,
   .ds-btn-sm {
     min-height: 40px;
-    padding: var(--space-2.5) var(--space-4);
+    padding: var(--space-2_5) var(--space-4);
     font-size: var(--text-sm);
   }
 

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -35,7 +35,7 @@
     }
     h1 {
       color: var(--color-text-heading);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
       font-size: var(--text-3xl);
     }
     h2 {
@@ -43,7 +43,7 @@
       margin-bottom: var(--space-4);
       font-size: var(--text-xl);
       border-bottom: var(--border-2) solid var(--color-success-500);
-      padding-bottom: var(--space-2.5);
+      padding-bottom: var(--space-2_5);
     }
     .subtitle {
       color: var(--color-text-secondary);
@@ -56,7 +56,7 @@
       display: block;
       color: var(--color-text-heading);
       font-weight: var(--font-semibold);
-      margin-bottom: var(--space-1.5);
+      margin-bottom: var(--space-1_5);
     }
     .form-group .hint {
       font-size: var(--text-sm);
@@ -167,7 +167,7 @@
       display: flex;
       align-items: center;
       gap: var(--space-2);
-      padding: var(--space-2) var(--space-3.5);
+      padding: var(--space-2) var(--space-3_5);
       background: var(--color-gray-50);
       border: var(--border-2) solid var(--color-gray-200);
       border-radius: var(--radius-md);
@@ -191,7 +191,7 @@
       display: flex;
       flex-direction: column;
       gap: var(--space-4);
-      margin-top: var(--space-2.5);
+      margin-top: var(--space-2_5);
     }
     .toggle-item {
       display: flex;
@@ -307,8 +307,8 @@
     .gravatar-note {
       font-size: var(--text-xs);
       color: var(--color-text-secondary);
-      margin-top: var(--space-2.5);
-      padding: var(--space-2.5);
+      margin-top: var(--space-2_5);
+      padding: var(--space-2_5);
       background: var(--color-bg-card);
       border-radius: var(--radius-md);
       border-left: 3px solid var(--color-success-500);
@@ -325,7 +325,7 @@
     .logo-input-group .upload-filename {
       flex: 1;
       min-width: 100px;
-      padding: var(--space-2.5) var(--space-3.5);
+      padding: var(--space-2_5) var(--space-3_5);
       border: var(--border-2) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -345,7 +345,7 @@
       color: var(--color-success-700);
     }
     .logo-input-group .btn-upload {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       background: var(--color-gray-100);
       border: var(--border-2) solid var(--color-gray-200);
       border-radius: var(--radius-md);
@@ -360,7 +360,7 @@
       border-color: var(--color-success-500);
     }
     .logo-input-group .btn-clear {
-      padding: var(--space-2.5) var(--space-3);
+      padding: var(--space-2_5) var(--space-3);
       background: var(--color-error-50);
       border: var(--border-2) solid var(--color-error-200);
       border-radius: var(--radius-md);
@@ -447,7 +447,7 @@
       gap: 0;
     }
     .slug-prefix {
-      padding: var(--space-2.5) var(--space-3.5);
+      padding: var(--space-2_5) var(--space-3_5);
       background: var(--color-gray-100);
       border: var(--border-2) solid var(--color-gray-200);
       border-right: none;
@@ -459,7 +459,7 @@
       border-radius: 0 var(--radius-md) var(--radius-md) 0 !important;
     }
     .slug-status {
-      margin-left: var(--space-2.5);
+      margin-left: var(--space-2_5);
       font-size: var(--text-sm);
     }
     .slug-status.available { color: var(--color-success-500); }
@@ -481,7 +481,7 @@
       display: inline-flex;
       align-items: center;
       gap: var(--space-1);
-      padding: var(--space-1) var(--space-2.5);
+      padding: var(--space-1) var(--space-2_5);
       background: var(--color-info-100);
       color: var(--color-info-700);
       border-radius: var(--radius-md);
@@ -514,8 +514,8 @@
     .status-badge {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-2) var(--space-3.5);
+      gap: var(--space-1_5);
+      padding: var(--space-2) var(--space-3_5);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
@@ -581,7 +581,7 @@
       color: var(--color-text-secondary);
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       flex-wrap: wrap;
     }
     .agent-type-badge {
@@ -611,7 +611,7 @@
     }
     .protocol-badge {
       display: inline-block;
-      padding: 2px var(--space-1.5);
+      padding: 2px var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: 10px;
       font-weight: var(--font-semibold);
@@ -621,7 +621,7 @@
     .agent-url-status {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       font-size: var(--text-xs);
       white-space: nowrap;
     }
@@ -641,7 +641,7 @@
       gap: var(--space-2);
     }
     .agent-url-actions button {
-      padding: var(--space-1.5) var(--space-2.5);
+      padding: var(--space-1_5) var(--space-2_5);
       border: none;
       border-radius: var(--radius-sm);
       font-size: var(--text-xs);
@@ -659,12 +659,12 @@
       display: flex;
       align-items: center;
       gap: var(--space-2);
-      padding: var(--space-1.5) 0;
+      padding: var(--space-1_5) 0;
     }
     .agent-visibility label {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       cursor: pointer;
       font-size: var(--text-xs);
       color: var(--color-text-secondary);
@@ -698,7 +698,7 @@
       display: none;
     }
     .visibility-badge-small {
-      padding: 2px var(--space-1.5);
+      padding: 2px var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: 10px;
       font-weight: var(--font-medium);
@@ -967,13 +967,13 @@
               <div style="margin-bottom: var(--space-4);">
                 <div class="form-group" style="margin-bottom: var(--space-3);">
                   <label for="brand_logo_url_new" style="font-size: var(--text-sm); font-weight: var(--font-medium); color: var(--color-text-heading); display: block; margin-bottom: var(--space-1);">Logo URL</label>
-                  <input type="url" id="brand_logo_url_new" placeholder="https://example.com/logo.png" style="width: 100%; padding: var(--space-2.5) var(--space-4); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); background: var(--color-bg-card); color: var(--color-text); box-sizing: border-box;">
+                  <input type="url" id="brand_logo_url_new" placeholder="https://example.com/logo.png" style="width: 100%; padding: var(--space-2_5) var(--space-4); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); background: var(--color-bg-card); color: var(--color-text); box-sizing: border-box;">
                 </div>
                 <div class="form-group" style="margin-bottom: var(--space-3);">
                   <label for="brand_color_input_new" style="font-size: var(--text-sm); font-weight: var(--font-medium); color: var(--color-text-heading); display: block; margin-bottom: var(--space-1);">Brand color</label>
                   <div style="display: flex; align-items: center; gap: var(--space-3);">
                     <input type="color" id="brand_color_input_new" value="#667eea" style="width: 40px; height: 36px; padding: 2px; border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); cursor: pointer; background: var(--color-bg-card);">
-                    <input type="text" id="brand_color_hex_new" placeholder="#667eea" maxlength="7" style="width: 100px; padding: var(--space-2.5) var(--space-4); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); font-family: monospace; background: var(--color-bg-card); color: var(--color-text);">
+                    <input type="text" id="brand_color_hex_new" placeholder="#667eea" maxlength="7" style="width: 100px; padding: var(--space-2_5) var(--space-4); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); font-family: monospace; background: var(--color-bg-card); color: var(--color-text);">
                   </div>
                 </div>
                 <div style="display: flex; align-items: center; gap: var(--space-3);">
@@ -984,7 +984,7 @@
 
               <div style="text-align: center; color: var(--color-text-muted); font-size: var(--text-sm); margin-bottom: var(--space-3);">or use the full brand builder for more options</div>
               <div style="text-align: center;">
-                <a href="/brand/builder" style="display: inline-block; padding: var(--space-2.5) var(--space-5); background: var(--color-primary-50); color: var(--color-primary-700); border: 1px solid var(--color-primary-200); border-radius: var(--radius-md); text-decoration: none; font-weight: var(--font-medium);">Brand builder</a>
+                <a href="/brand/builder" style="display: inline-block; padding: var(--space-2_5) var(--space-5); background: var(--color-primary-50); color: var(--color-primary-700); border: 1px solid var(--color-primary-200); border-radius: var(--radius-md); text-decoration: none; font-weight: var(--font-medium);">Brand builder</a>
               </div>
             </div>
           </div>
@@ -2351,7 +2351,7 @@
       injectAgentCardStyles();
 
       if (agents.length === 0) {
-        container.innerHTML = '<div style="color: var(--color-text-secondary); font-size: var(--text-sm); padding: var(--space-2.5);">No agents registered yet.</div>';
+        container.innerHTML = '<div style="color: var(--color-text-secondary); font-size: var(--text-sm); padding: var(--space-2_5);">No agents registered yet.</div>';
         return;
       }
 
@@ -2448,7 +2448,7 @@
       injectPublisherCardStyles();
 
       if (publishers.length === 0) {
-        container.innerHTML = '<div style="color: var(--color-text-secondary); font-size: var(--text-sm); padding: var(--space-2.5);">No publishers registered yet.</div>';
+        container.innerHTML = '<div style="color: var(--color-text-secondary); font-size: var(--text-sm); padding: var(--space-2_5);">No publishers registered yet.</div>';
         return;
       }
 

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -70,7 +70,7 @@
     }
 
     .market-filter {
-      padding: var(--space-2.5) var(--space-3.5);
+      padding: var(--space-2_5) var(--space-3_5);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
@@ -189,7 +189,7 @@
     .back-link {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       color: var(--color-brand);
       text-decoration: none;
       font-family: inherit;
@@ -221,8 +221,8 @@
     .intro-btn-style {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-2.5) var(--space-4);
+      gap: var(--space-1_5);
+      padding: var(--space-2_5) var(--space-4);
       background: var(--color-brand);
       color: white;
       border: none;
@@ -241,8 +241,8 @@
     .share-btn {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-2.5) var(--space-4);
+      gap: var(--space-1_5);
+      padding: var(--space-2_5) var(--space-4);
       background: var(--color-bg-card);
       border: var(--border-1) solid var(--color-border);
       color: var(--color-text-muted);
@@ -390,8 +390,8 @@
     .detail-social-link {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-2.5) var(--space-4);
+      gap: var(--space-1_5);
+      padding: var(--space-2_5) var(--space-4);
       background: var(--color-gray-100);
       border-radius: var(--radius-md);
       color: var(--color-text-body);
@@ -432,7 +432,7 @@
       gap: var(--space-2);
     }
     .detail-offerings .offering-tag {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       font-size: var(--text-sm);
     }
     .detail-tags {
@@ -441,7 +441,7 @@
       gap: var(--space-2);
     }
     .tag {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       background: var(--color-gray-100);
       color: var(--color-text-body);
       border-radius: var(--radius-md);
@@ -508,7 +508,7 @@
       margin-top: var(--space-2);
     }
     .capability-tag {
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       background: var(--color-primary-100);
       color: var(--color-primary-800);
       border-radius: var(--radius-sm);
@@ -518,9 +518,9 @@
     .agent-status {
       display: flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
       font-size: var(--text-xs);
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border-radius: var(--radius-md);
       flex-shrink: 0;
     }
@@ -797,7 +797,7 @@
       top: var(--space-2);
       right: var(--space-2);
       background: rgba(255, 255, 255, 0.95);
-      padding: var(--space-1) var(--space-2.5);
+      padding: var(--space-1) var(--space-2_5);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -850,7 +850,7 @@
     .format-card-generative-badge {
       background: var(--color-brand);
       color: white;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--radius-lg);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -905,7 +905,7 @@
       line-height: var(--leading-tight);
     }
     .product-card-type {
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       background: var(--color-purple-100);
       color: var(--color-purple-700);
       border-radius: var(--radius-sm);
@@ -931,13 +931,13 @@
       font-size: var(--text-xs);
     }
     .product-card-tag {
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       background: var(--color-gray-200);
       color: var(--color-text-body);
       border-radius: var(--radius-sm);
     }
     .product-card-price {
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       background: var(--color-primary-100);
       color: var(--color-brand);
       border-radius: var(--radius-sm);
@@ -974,7 +974,7 @@
       flex-wrap: wrap;
     }
     .publisher-card-stat {
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       background: var(--color-primary-100);
       color: var(--color-primary-800);
       border-radius: var(--radius-sm);
@@ -988,7 +988,7 @@
       flex-wrap: wrap;
     }
     .publisher-type-badge {
-      padding: var(--space-0.5) var(--space-1.5);
+      padding: var(--space-0_5) var(--space-1_5);
       background: var(--color-warning-100);
       color: var(--color-warning-800);
       border-radius: var(--radius-sm);
@@ -1043,7 +1043,7 @@
       gap: var(--space-2);
     }
     .channel-badge {
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       background: var(--color-purple-100);
       color: var(--color-purple-700);
       border-radius: var(--radius-full);
@@ -1073,8 +1073,8 @@
     .working-group-link {
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
-      padding: var(--space-1.5) var(--space-3);
+      gap: var(--space-1_5);
+      padding: var(--space-1_5) var(--space-3);
       background: var(--color-gray-100);
       border-radius: var(--radius-md);
       font-size: var(--text-xs);

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -810,12 +810,12 @@
     .group-rec-item:last-child { border-bottom: none; }
 
     .group-rec-info { flex: 1; min-width: 0; }
-    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0.5); }
+    .group-rec-name { font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-0_5); }
     .group-rec-reason { font-size: var(--text-xs); color: var(--color-text-muted); }
 
     .group-rec-badge {
       display: inline-flex;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--badge-radius);
       font-size: 10px; font-weight: var(--font-semibold);
       text-transform: uppercase; letter-spacing: var(--tracking-wide);
@@ -976,7 +976,7 @@
     }
 
     .timeline-date { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-1); }
-    .timeline-transition { font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium); margin-bottom: var(--space-0.5); }
+    .timeline-transition { font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium); margin-bottom: var(--space-0_5); }
     .timeline-trigger { font-size: var(--text-xs); color: var(--color-text-secondary); }
     .timeline-empty { font-size: var(--text-sm); color: var(--color-text-muted); text-align: center; padding: var(--space-6) 0; }
 
@@ -1230,7 +1230,7 @@
 
     .status-badge {
       display: inline-flex;
-      padding: var(--space-0.5) var(--space-2);
+      padding: var(--space-0_5) var(--space-2);
       border-radius: var(--badge-radius);
       font-size: 10px; font-weight: var(--font-semibold);
       text-transform: uppercase; letter-spacing: var(--tracking-wide);

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -180,7 +180,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
       margin-bottom: var(--space-2);
@@ -234,9 +234,9 @@
       text-decoration: none;
       display: inline-flex;
       align-items: center;
-      gap: var(--space-1.5);
+      gap: var(--space-1_5);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -264,7 +264,7 @@
       display: inline-flex;
       align-items: center;
       gap: var(--space-1);
-      padding: var(--space-1.5) var(--space-3);
+      padding: var(--space-1_5) var(--space-3);
       border-radius: var(--radius-full);
       border: var(--border-1) solid var(--color-border);
       background: white;
@@ -288,7 +288,7 @@
     }
     .filter-bar {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-5);
       flex-wrap: wrap;
     }
@@ -341,7 +341,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -375,7 +375,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -383,7 +383,7 @@
     }
     .type-toggle {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-6);
     }
     .type-toggle button {
@@ -403,7 +403,7 @@
     }
     .url-input-group {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
     }
     .url-input-group input { flex: 1; }
     .markdown-editor-container {
@@ -445,9 +445,9 @@
       color: var(--color-gray-400);
       font-style: italic;
     }
-    .preview-pane h1 { font-size: var(--text-2xl); margin-top: var(--space-5); margin-bottom: var(--space-2.5); }
+    .preview-pane h1 { font-size: var(--text-2xl); margin-top: var(--space-5); margin-bottom: var(--space-2_5); }
     .preview-pane h1:first-child { margin-top: 0; }
-    .preview-pane h2 { font-size: var(--text-xl); margin-top: var(--space-5); margin-bottom: var(--space-2.5); }
+    .preview-pane h2 { font-size: var(--text-xl); margin-top: var(--space-5); margin-bottom: var(--space-2_5); }
     .preview-pane p { margin-bottom: var(--space-3); line-height: var(--leading-relaxed); }
     .char-count {
       font-size: var(--text-xs);

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -29,7 +29,7 @@
     }
     h1 {
       color: var(--color-text-heading);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
       font-size: var(--text-3xl);
     }
     .subtitle {
@@ -120,7 +120,7 @@
       background: var(--color-bg-card);
       padding: var(--space-3) var(--space-4);
       border-radius: var(--radius-md);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
     }
     .invitation-item:last-child {
       margin-bottom: 0;
@@ -189,7 +189,7 @@
     }
     .btn {
       width: 100%;
-      padding: var(--space-3.5);
+      padding: var(--space-3_5);
       background: var(--gradient-primary);
       color: white;
       border: none;
@@ -318,7 +318,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       margin-bottom: var(--space-4);
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       background: var(--color-gray-100);
       border-radius: var(--radius-md);
     }
@@ -591,7 +591,7 @@
 
           <div class="form-group">
             <label>What type of company are you? *</label>
-            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2.5);">
+            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2_5);">
               <label class="radio-option" style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-colors);">
                 <input type="radio" name="companyType" value="brand" required style="width: 18px; height: 18px; flex-shrink: 0;">
                 <div>
@@ -646,7 +646,7 @@
 
           <div class="form-group">
             <label>Annual Revenue *</label>
-            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2.5);">
+            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2_5);">
               <label class="radio-option" style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-colors);">
                 <input type="radio" name="revenueTier" value="under_1m" required style="width: 18px; height: 18px; flex-shrink: 0;">
                 <div>
@@ -689,7 +689,7 @@
           <!-- Membership Tier Selection -->
           <div class="form-group" id="companyTierGroup">
             <label>Select your membership tier</label>
-            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2.5);">
+            <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2_5);">
               <label class="radio-option" style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-colors);">
                 <input type="radio" name="companyTier" value="" checked style="width: 18px; height: 18px; flex-shrink: 0;">
                 <div style="flex: 1;">
@@ -750,7 +750,7 @@
         <!-- Membership Tier Selection -->
         <div class="form-group">
           <label>Select your membership tier</label>
-          <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2.5);">
+          <div class="radio-group" style="display: flex; flex-direction: column; gap: var(--space-2_5);">
             <label class="radio-option" style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-colors);">
               <input type="radio" name="individualTier" value="" checked style="width: 18px; height: 18px; flex-shrink: 0;">
               <div style="flex: 1;">

--- a/server/public/policies.html
+++ b/server/public/policies.html
@@ -209,7 +209,7 @@
     }
     .policy-card__meta-sep {
       display: inline;
-      margin: 0 var(--space-1.5);
+      margin: 0 var(--space-1_5);
     }
 
     /* Community CTA */

--- a/server/public/study-guide.html
+++ b/server/public/study-guide.html
@@ -297,7 +297,7 @@
     .card-title-group {
       display: flex;
       flex-direction: column;
-      gap: var(--space-0.5);
+      gap: var(--space-0_5);
     }
 
     .card-level-label {
@@ -363,7 +363,7 @@
     .meta-item {
       display: flex;
       flex-direction: column;
-      gap: var(--space-0.5);
+      gap: var(--space-0_5);
     }
 
     .meta-label {
@@ -486,7 +486,7 @@
     }
 
     .tab-btn {
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       font-size: var(--text-sm);
       font-weight: var(--font-medium);
       color: var(--sg-text-muted);

--- a/server/public/team.html
+++ b/server/public/team.html
@@ -92,7 +92,7 @@
     }
     .role-badge {
       display: inline-block;
-      padding: var(--space-1) var(--space-2.5);
+      padding: var(--space-1) var(--space-2_5);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
@@ -111,7 +111,7 @@
     }
     .status-badge {
       display: inline-block;
-      padding: var(--space-1) var(--space-2.5);
+      padding: var(--space-1) var(--space-2_5);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
@@ -171,7 +171,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-top: var(--space-5);
       justify-content: flex-end;
     }
@@ -187,7 +187,7 @@
     .form-group input,
     .form-group select {
       width: 100%;
-      padding: var(--space-2.5) var(--space-3);
+      padding: var(--space-2_5) var(--space-3);
       border: var(--border-1) solid var(--color-gray-300);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -206,7 +206,7 @@
     .error-message {
       background: var(--color-error-50);
       color: var(--color-error-600);
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);
@@ -214,7 +214,7 @@
     .success-message {
       background: var(--color-success-100);
       color: var(--color-success-700);
-      padding: var(--space-2.5) var(--space-4);
+      padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);
@@ -254,13 +254,13 @@
     }
     .domain-section h3 {
       font-size: var(--text-base);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
       color: var(--color-text-heading);
     }
     .domain-section p {
       color: var(--color-text-secondary);
       font-size: var(--text-sm);
-      margin-bottom: var(--space-2.5);
+      margin-bottom: var(--space-2_5);
     }
   </style>
 </head>

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -217,7 +217,7 @@
       font-size: var(--text-sm);
       color: var(--color-brand);
       font-weight: var(--font-medium);
-      margin-bottom: var(--space-0.5);
+      margin-bottom: var(--space-0_5);
     }
 
     .leader-org {

--- a/server/public/working-groups/manage.html
+++ b/server/public/working-groups/manage.html
@@ -76,7 +76,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -110,7 +110,7 @@
       align-items: center;
       gap: var(--space-2);
     }
-    .btn-small { padding: var(--space-1.5) var(--space-3); font-size: var(--text-xs); }
+    .btn-small { padding: var(--space-1_5) var(--space-3); font-size: var(--text-xs); }
     .btn-primary { background: var(--color-brand); color: white; }
     .btn-primary:hover { background: var(--color-primary-700); }
     .btn-primary:disabled { background: var(--color-gray-400); cursor: not-allowed; }
@@ -154,7 +154,7 @@
     .form-group select,
     .form-group textarea {
       width: 100%;
-      padding: var(--space-2.5);
+      padding: var(--space-2_5);
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -186,7 +186,7 @@
     }
     .modal-buttons {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       justify-content: flex-end;
       margin-top: var(--space-6);
       padding-top: var(--space-5);
@@ -194,7 +194,7 @@
     }
     .type-toggle {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       margin-bottom: var(--space-6);
     }
     .type-toggle button {
@@ -214,7 +214,7 @@
     }
     .url-input-group {
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
     }
     .url-input-group input {
       flex: 1;
@@ -337,7 +337,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
     }
@@ -394,7 +394,7 @@
       font-size: var(--text-sm);
       color: var(--color-text-secondary);
       display: flex;
-      gap: var(--space-2.5);
+      gap: var(--space-2_5);
       flex-wrap: wrap;
       align-items: center;
       margin-bottom: var(--space-2);


### PR DESCRIPTION
## Summary

- CSS custom properties (variables) cannot contain dots in their names per the CSS spec
- Renamed `--space-0.5`, `--space-1.5`, `--space-2.5`, and `--space-3.5` to `--space-0_5`, `--space-1_5`, `--space-2_5`, and `--space-3_5`
- Updated the declarations in `design-system.css` and all 50 usages across public HTML/JS files

### Before

<img width="986" height="268" alt="image" src="https://github.com/user-attachments/assets/28c81fca-de85-41cf-be4c-25b16fd0ee9b" />

### After

<img width="997" height="282" alt="image" src="https://github.com/user-attachments/assets/e285ba78-eb11-48db-a3b2-87386290d8ad" />


## Test plan

- [ ] Verify spacing visually unchanged across pages (values are identical, only variable names changed)
- [ ] Confirm no remaining `--space-*.5` patterns: `grep -r '\-\-space-[0-9]*\.[0-9]' server/public/` should return nothing
