### PR TITLE
docs: skill-based agent quickstart

### DIFF
--- a/.changeset/gentle-foxes-learn.md
+++ b/.changeset/gentle-foxes-learn.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add skill-based agent quickstart page

--- a/docs.json
+++ b/docs.json
@@ -108,7 +108,7 @@
                     ]
                   },
                   "docs/building/schemas-and-sdks",
-                  "docs/building/build-with-js-ts",
+                  "docs/building/build-an-agent",
                   {
                     "group": "Foundations",
                     "pages": [
@@ -584,7 +584,7 @@
                 ]
               },
               "docs/building/schemas-and-sdks",
-              "docs/building/build-with-js-ts",
+              "docs/building/build-an-agent",
               {
                 "group": "Foundations",
                 "pages": [

--- a/docs.json
+++ b/docs.json
@@ -108,6 +108,7 @@
                     ]
                   },
                   "docs/building/schemas-and-sdks",
+                  "docs/building/build-with-js-ts",
                   {
                     "group": "Foundations",
                     "pages": [
@@ -583,6 +584,7 @@
                 ]
               },
               "docs/building/schemas-and-sdks",
+              "docs/building/build-with-js-ts",
               {
                 "group": "Foundations",
                 "pages": [

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -7,27 +7,17 @@ description: "Use AdCP SDK skill files to generate storyboard-compliant agents w
 
 The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from an AdCP SDK. Each skill produces a working, storyboard-validated agent in 2–8 minutes.
 
-## Install an SDK
+## Install the SDK
 
-<Tabs>
-  <Tab title="JavaScript / TypeScript">
-    ```bash
-    npm install @adcp/client
-    ```
+```bash
+npm install @adcp/client
+```
 
-    Skills and storyboards are available in the [adcp-client repository](https://github.com/adcontextprotocol/adcp-client).
-  </Tab>
-  <Tab title="Python (coming soon)">
-    ```bash
-    pip install adcp
-    ```
+This installs the client library and the `adcp` CLI used for storyboard validation. Skill files are not included in the package — you'll fetch them from GitHub in the next step.
 
-    Skill files are being ported to the [Python SDK](https://github.com/adcontextprotocol/adcp-client-python). The `adcp` package is available now for client usage — see [Schemas and SDKs](/docs/building/schemas-and-sdks).
-  </Tab>
-  <Tab title="Go (coming soon)">
-    The [Go SDK](https://github.com/adcontextprotocol/adcp-go) currently focuses on the Trusted Match Protocol (TMP) for real-time activation. Skill-based agent generation is planned.
-  </Tab>
-</Tabs>
+<Info>
+Skill-based agent generation is currently available for JavaScript/TypeScript. Ports to [Python](https://github.com/adcontextprotocol/adcp-client-python) and [Go](https://github.com/adcontextprotocol/adcp-go) are planned. See [Schemas and SDKs](/docs/building/schemas-and-sdks) for all available SDKs.
+</Info>
 
 ## Choose a skill
 
@@ -62,20 +52,9 @@ In Cursor or Windsurf, download the skill file and include it as context with yo
 
 Once the agent is running, configure it in your `adcp.config.json` and validate it against the matching storyboard:
 
-<Tabs>
-  <Tab title="JavaScript / TypeScript">
-    ```bash
-    adcp storyboard run my-agent media_buy_seller --json
-    ```
-  </Tab>
-  <Tab title="Python (coming soon)">
-    ```bash
-    adcp storyboard run my-agent media_buy_seller --json
-    ```
-
-    The Python CLI uses the same command syntax.
-  </Tab>
-</Tabs>
+```bash
+adcp storyboard run my-agent media_buy_seller --json
+```
 
 Storyboards exercise every required tool call and validate response shapes. A passing run means your agent is protocol-compliant.
 

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -1,17 +1,33 @@
 ---
-title: Build an Agent with JS/TS
-sidebarTitle: Build with JS/TS
-description: "Use the @adcp/client SDK and skill files to generate storyboard-compliant AdCP agents with a coding agent in minutes."
-"og:title": "AdCP — Build an Agent with JS/TS"
+title: Build an Agent
+sidebarTitle: Build an Agent
+description: "Use AdCP SDK skill files to generate storyboard-compliant agents with a coding agent in minutes."
+"og:title": "AdCP — Build an Agent"
 ---
 
-The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from the [`@adcp/client`](https://github.com/adcontextprotocol/adcp-client) SDK. Each skill produces a working, storyboard-validated agent in 2–8 minutes.
+The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from an AdCP SDK. Each skill produces a working, storyboard-validated agent in 2–8 minutes.
 
-## Install the SDK
+## Install an SDK
 
-```bash
-npm install @adcp/client
-```
+<Tabs>
+  <Tab title="JavaScript / TypeScript">
+    ```bash
+    npm install @adcp/client
+    ```
+
+    Skills and storyboards are available in the [adcp-client repository](https://github.com/adcontextprotocol/adcp-client).
+  </Tab>
+  <Tab title="Python (coming soon)">
+    ```bash
+    pip install adcp
+    ```
+
+    Skill files are being ported to the [Python SDK](https://github.com/adcontextprotocol/adcp-client-python). The `adcp` package is available now for client usage — see [Schemas and SDKs](/docs/building/schemas-and-sdks).
+  </Tab>
+  <Tab title="Go (coming soon)">
+    The [Go SDK](https://github.com/adcontextprotocol/adcp-go) currently focuses on the Trusted Match Protocol (TMP) for real-time activation. Skill-based agent generation is planned.
+  </Tab>
+</Tabs>
 
 ## Choose a skill
 
@@ -44,11 +60,22 @@ In Cursor or Windsurf, download the skill file and include it as context with yo
 
 ## Validate with storyboards
 
-Once the agent is running, configure it as an agent in your `adcp.config.json` and validate it against the matching storyboard:
+Once the agent is running, configure it in your `adcp.config.json` and validate it against the matching storyboard:
 
-```bash
-adcp storyboard run my-agent media_buy_seller --json
-```
+<Tabs>
+  <Tab title="JavaScript / TypeScript">
+    ```bash
+    adcp storyboard run my-agent media_buy_seller --json
+    ```
+  </Tab>
+  <Tab title="Python (coming soon)">
+    ```bash
+    adcp storyboard run my-agent media_buy_seller --json
+    ```
+
+    The Python CLI uses the same command syntax.
+  </Tab>
+</Tabs>
 
 Storyboards exercise every required tool call and validate response shapes. A passing run means your agent is protocol-compliant.
 
@@ -76,7 +103,7 @@ media_buy_seller (9 steps)
 
 ## Additional resources
 
-The SDK includes documentation designed for both humans and coding agents:
+Each SDK includes documentation designed for both humans and coding agents:
 
 | Resource | Location | Purpose |
 |----------|----------|---------|

--- a/docs/building/build-with-js-ts.mdx
+++ b/docs/building/build-with-js-ts.mdx
@@ -1,0 +1,92 @@
+---
+title: Build an Agent with JS/TS
+sidebarTitle: Build with JS/TS
+description: "Use the @adcp/client SDK and skill files to generate storyboard-compliant AdCP agents with a coding agent in minutes."
+"og:title": "AdCP — Build an Agent with JS/TS"
+---
+
+The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from the [`@adcp/client`](https://github.com/adcontextprotocol/adcp-client) SDK. Each skill produces a working, storyboard-validated agent in 2–8 minutes.
+
+## Install the SDK
+
+```bash
+npm install @adcp/client
+```
+
+## Choose a skill
+
+Each skill targets a specific agent type. Pick the one that matches what you're building:
+
+| Skill | You are building... | Storyboard |
+|-------|---------------------|------------|
+| `build-seller-agent` | Publisher, SSP, or media network selling inventory | `media_buy_seller` |
+| `build-generative-seller-agent` | AI ad network generating ads from briefs | `media_buy_generative_seller` |
+| `build-retail-media-agent` | Retail media network with catalog-driven creative | `media_buy_catalog_creative` |
+| `build-signals-agent` | CDP or data provider serving audience segments | `signal_owned`, `signal_marketplace` |
+| `build-creative-agent` | Ad server or CMP rendering creatives | `creative_lifecycle` |
+
+Skill files are in the [adcp-client repository](https://github.com/adcontextprotocol/adcp-client/tree/main/skills) at `skills/<skill-name>/SKILL.md`.
+
+## Build the agent
+
+Point your coding agent at the skill file for your agent type. In Claude Code:
+
+```
+Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skills/build-seller-agent/SKILL.md, then build a seller agent for a premium sports news publisher with guaranteed CTV and OLV inventory.
+```
+
+In Cursor or Windsurf, download the skill file and include it as context with your prompt. Each skill walks the coding agent through:
+
+1. Business model decisions (what you sell, how you price, approval workflow)
+2. Tool registration with correct schemas
+3. Response shapes that pass storyboard validation
+4. Error handling and edge cases
+
+## Validate with storyboards
+
+Once the agent is running, configure it as an agent in your `adcp.config.json` and validate it against the matching storyboard:
+
+```bash
+adcp storyboard run my-agent media_buy_seller --json
+```
+
+Storyboards exercise every required tool call and validate response shapes. A passing run means your agent is protocol-compliant.
+
+<Tip>
+Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, proposal mode, and more. Run `adcp storyboard list` to see all available storyboards.
+</Tip>
+
+### Reading storyboard output
+
+Pass `--json` for machine-readable results. Without it, you get a step-by-step summary:
+
+```
+media_buy_seller (9 steps)
+  ✓ get_adcp_capabilities
+  ✓ sync_accounts
+  ✓ get_products
+  ✓ create_media_buy
+  ✓ list_creative_formats
+  ✓ sync_creatives
+  ✓ list_creatives
+  ✓ get_media_buy_delivery
+  ✓ provide_performance_feedback
+  9/9 passed
+```
+
+## Additional resources
+
+The SDK includes documentation designed for both humans and coding agents:
+
+| Resource | Location | Purpose |
+|----------|----------|---------|
+| Protocol spec | `node_modules/@adcp/client/docs/llms.txt` | Full protocol in one file — tools, types, error codes, examples |
+| Server guide | `node_modules/@adcp/client/docs/guides/BUILD-AN-AGENT.md` | Server-side implementation patterns |
+| Examples | [GitHub](https://github.com/adcontextprotocol/adcp-client/tree/main/examples) | Working examples covering multi-agent, A2A, MCP, and async patterns |
+
+## What's next
+
+- **[Schemas and SDKs](/docs/building/schemas-and-sdks)** — Schema access, CLI tools, and SDK package exports
+- **[MCP integration guide](/docs/building/integration/mcp-guide)** — Transport, sessions, and auth details
+- **[Task lifecycle](/docs/building/implementation/task-lifecycle)** — Status values, transitions, and polling
+- **[Error handling](/docs/building/implementation/error-handling)** — Error categories, codes, and recovery

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -25,7 +25,7 @@ This section provides everything you need to understand, integrate, and build ro
 
 **Want a coding agent to build it for you?**
 
-- [Build with JS/TS](/docs/building/build-with-js-ts) - Point a coding agent at a skill file, get a storyboard-compliant agent in minutes
+- [Build an Agent](/docs/building/build-an-agent) - Point a coding agent at a skill file, get a storyboard-compliant agent in minutes
 
 **Already know which protocol you're using?**
 

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -23,6 +23,10 @@ This section provides everything you need to understand, integrate, and build ro
 
 ## Quick Start
 
+**Want a coding agent to build it for you?**
+
+- [Build with JS/TS](/docs/building/build-with-js-ts) - Point a coding agent at a skill file, get a storyboard-compliant agent in minutes
+
 **Already know which protocol you're using?**
 
 - [MCP Integration Guide](/docs/building/integration/mcp-guide) - For Claude, AI assistants, and MCP-compatible tools

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -271,7 +271,7 @@ console.log(result.data.products);
 
 ## What's next
 
-- **[Build an agent](/docs/building/build-an-agent)** — use skill files to generate a storyboard-compliant agent with a coding agent
+- **[Build an Agent](/docs/building/build-an-agent)** — use skill files to generate a storyboard-compliant agent with a coding agent
 - **[MCP integration guide](/docs/building/integration/mcp-guide)** — transport, sessions, auth details
 - **[A2A integration guide](/docs/building/integration/a2a-guide)** — streaming, artifacts, push notifications
 - **[Task reference](/docs/media-buy/task-reference)** — all available tasks with testable examples

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -271,7 +271,7 @@ console.log(result.data.products);
 
 ## What's next
 
-- **[Build an agent with JS/TS](/docs/building/build-with-js-ts)** — use skill files to generate a storyboard-compliant agent with a coding agent
+- **[Build an agent](/docs/building/build-an-agent)** — use skill files to generate a storyboard-compliant agent with a coding agent
 - **[MCP integration guide](/docs/building/integration/mcp-guide)** — transport, sessions, auth details
 - **[A2A integration guide](/docs/building/integration/a2a-guide)** — streaming, artifacts, push notifications
 - **[Task reference](/docs/media-buy/task-reference)** — all available tasks with testable examples

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -271,6 +271,7 @@ console.log(result.data.products);
 
 ## What's next
 
+- **[Build an agent with JS/TS](/docs/building/build-with-js-ts)** — use skill files to generate a storyboard-compliant agent with a coding agent
 - **[MCP integration guide](/docs/building/integration/mcp-guide)** — transport, sessions, auth details
 - **[A2A integration guide](/docs/building/integration/a2a-guide)** — streaming, artifacts, push notifications
 - **[Task reference](/docs/media-buy/task-reference)** — all available tasks with testable examples


### PR DESCRIPTION
## Summary

- Add language-agnostic "Build an Agent" docs page documenting how to use SDK skill files to generate storyboard-compliant AdCP agents with coding agents (Claude Code, Codex, Cursor, Windsurf)
- Uses Mintlify `<Tabs>` for SDK-specific sections (install, storyboard CLI) — JS/TS active now, Python and Go tabs ready for when skills are ported
- Link from quickstart "What's next" and building overview "Quick Start" sections
- Nav entry in both 3.0-rc and latest version sections

Closes #2044

## Test plan

- [ ] Verify Mintlify renders the new page correctly at `/docs/building/build-an-agent`
- [ ] Verify `<Tabs>` component renders JS/TS, Python, and Go tabs
- [ ] Verify nav entry appears after "Schemas and SDKs" in sidebar
- [ ] Verify all internal links resolve (pre-push hook confirmed no broken links)
- [ ] Verify skill file GitHub links are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)