### PR TITLE
test: json-schema validator handles AdCP macros in URI fields

### DIFF
--- a/.changeset/macro-uri-validation.md
+++ b/.changeset/macro-uri-validation.md
@@ -1,0 +1,4 @@
+---
+---
+
+test: json-schema validator handles AdCP macros in URI fields

--- a/docs/creative/creative-manifests.mdx
+++ b/docs/creative/creative-manifests.mdx
@@ -124,7 +124,7 @@ Here's a complete creative manifest showing the current structure without redund
       "content": "Made with real chicken and wholesome grains"
     },
     "clickthrough_url": {
-      "url": "https://example.com/products/premium-dog-food",
+      "url": "https://acmecorp.example.com/products/premium-dog-food?campaign={MEDIA_BUY_ID}",
       "description": "Product landing page"
     }
   }

--- a/docs/creative/provenance.mdx
+++ b/docs/creative/provenance.mdx
@@ -209,7 +209,7 @@ A creative where the image is AI-generated but the copy is human-written. The ma
       "content": "Nutrition dogs love"
     },
     "clickthrough_url": {
-      "url": "https://novabrands.example.com/products"
+      "url": "https://novabrands.example.com/products?campaign={MEDIA_BUY_ID}"
     }
   }
 }

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -666,7 +666,7 @@ Transform an existing 728x90 leaderboard to a 300x250 banner:
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/spring"
+        "url": "https://mybrand.example.com/spring?campaign={MEDIA_BUY_ID}"
       }
     }
   },
@@ -699,7 +699,7 @@ Transform an existing 728x90 leaderboard to a 300x250 banner:
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/spring"
+        "url": "https://mybrand.example.com/spring?campaign={MEDIA_BUY_ID}"
       }
     }
   }
@@ -769,7 +769,7 @@ Adapt a creative for mobile with specific design changes:
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/new"
+        "url": "https://mybrand.example.com/new?campaign={MEDIA_BUY_ID}"
       }
     }
   }

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -189,7 +189,7 @@ Retrieve a creative from the agent's library and resolve it into a manifest with
         "content": "<script src=\"https://cdn.example.com/frameworks/js/sdk.js\"></script><script>AdSDK.createBanner({clickTag:'https://publisher.example.com/click/abc123',width:300,height:250,id:'ft_88201_{CACHEBUSTER}'});</script>"
       },
       "clickthrough_url": {
-        "url": "https://acmecorp.example.com/holiday-sale"
+        "url": "https://acmecorp.example.com/holiday-sale?campaign={MEDIA_BUY_ID}"
       }
     }
   }
@@ -251,7 +251,7 @@ Generate creatives for multiple formats in a single call using `target_format_id
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://acmecorp.com/spring"
+        "url": "https://acmecorp.example.com/spring?campaign={MEDIA_BUY_ID}"
       }
     }
   }
@@ -279,7 +279,7 @@ The response uses `creative_manifests` (array) instead of `creative_manifest` (s
           "height": 250
         },
         "headline": { "asset_type": "text", "content": "Spring Collection Now Available" },
-        "clickthrough_url": { "asset_type": "url", "url": "https://acmecorp.com/spring" }
+        "clickthrough_url": { "asset_type": "url", "url": "https://acmecorp.example.com/spring?campaign={MEDIA_BUY_ID}" }
       }
     },
     {
@@ -404,7 +404,7 @@ When the request uses `target_format_id`, the response contains a single creativ
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/winter-sale"
+        "url": "https://mybrand.example.com/winter-sale?campaign={MEDIA_BUY_ID}"
       }
     }
   }
@@ -633,7 +633,7 @@ Generate a creative from scratch using a generative format:
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/winter-sale"
+        "url": "https://mybrand.example.com/winter-sale?campaign={MEDIA_BUY_ID}"
       }
     }
   }
@@ -1224,7 +1224,7 @@ To refine, pass the previous response's `creative_manifest` back as input with a
       },
       "clickthrough_url": {
         "asset_type": "url",
-        "url": "https://mybrand.com/winter-sale"
+        "url": "https://mybrand.example.com/winter-sale?campaign={MEDIA_BUY_ID}"
       }
     }
   }

--- a/tests/json-schema-validation.test.cjs
+++ b/tests/json-schema-validation.test.cjs
@@ -221,6 +221,28 @@ function findDocFiles() {
 }
 
 /**
+ * Replace AdCP macro placeholders ({MACRO_NAME}) with dummy values so that
+ * AJV's URI format validation can check the surrounding URL structure.
+ * Only replaces patterns that look like AdCP macros: {UPPER_CASE_WITH_UNDERSCORES}.
+ */
+function replaceMacros(obj) {
+  if (typeof obj === 'string') {
+    return obj.replace(/\{([A-Z][A-Z0-9_]*)\}/g, (_, name) => `__${name.toLowerCase()}__`);
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(replaceMacros);
+  }
+  if (obj !== null && typeof obj === 'object') {
+    const result = {};
+    for (const key of Object.keys(obj)) {
+      result[key] = replaceMacros(obj[key]);
+    }
+    return result;
+  }
+  return obj;
+}
+
+/**
  * Validate a JSON block against its declared schema
  */
 async function validateJsonBlock(ajv, block) {
@@ -258,9 +280,8 @@ async function validateJsonBlock(ajv, block) {
     };
   }
 
-  // Strip $schema from the data before validating
-  // (the $schema field itself isn't part of the data schema)
-  const dataToValidate = { ...block.parsed };
+  // Strip $schema and replace AdCP macros before validating
+  const dataToValidate = replaceMacros(JSON.parse(JSON.stringify(block.parsed)));
   delete dataToValidate.$schema;
 
   const valid = validate(dataToValidate);

--- a/tests/json-schema-validation.test.cjs
+++ b/tests/json-schema-validation.test.cjs
@@ -221,13 +221,113 @@ function findDocFiles() {
 }
 
 /**
- * Replace AdCP macro placeholders ({MACRO_NAME}) with dummy values so that
- * AJV's URI format validation can check the surrounding URL structure.
- * Only replaces patterns that look like AdCP macros: {UPPER_CASE_WITH_UNDERSCORES}.
+ * Realistic dummy values for AdCP macros, sourced from docs/creative/universal-macros.mdx.
+ * URL-valued macros use valid URIs so standalone URI fields pass format validation.
+ * All other values are URI-safe so they work inside query parameters too.
+ */
+const MACRO_DUMMY_VALUES = {
+  // Common
+  MEDIA_BUY_ID: 'mb_spring_2025',
+  PACKAGE_ID: 'pkg_ctv_prime',
+  CREATIVE_ID: 'cr_video_30s',
+  CACHEBUSTER: '87654321',
+  TIMESTAMP: '1704067200000',
+  CLICK_URL: 'https://click.example.com/track',
+  // Privacy
+  GDPR: '1',
+  GDPR_CONSENT: 'CPc7TgPPc7TgPAGABCENB',
+  US_PRIVACY: '1YNN',
+  GPP_STRING: 'DBABMA',
+  GPP_SID: '7',
+  IP_ADDRESS: '203.0.113.42',
+  LIMIT_AD_TRACKING: '0',
+  // Device
+  DEVICE_TYPE: 'desktop',
+  OS: 'iOS',
+  OS_VERSION: '17.2',
+  DEVICE_MAKE: 'Apple',
+  DEVICE_MODEL: 'iPhone15',
+  USER_AGENT: 'Mozilla',
+  APP_BUNDLE: 'com.publisher.app',
+  APP_NAME: 'Publisher_News',
+  // Geo
+  COUNTRY: 'US',
+  REGION: 'NY',
+  CITY: 'New_York',
+  ZIP: '10001',
+  DMA: '501',
+  LAT: '40.7128',
+  LONG: '-74.0060',
+  // Identity
+  DEVICE_ID: 'ABC-123-DEF-456',
+  DEVICE_ID_TYPE: 'idfa',
+  // Web context
+  DOMAIN: 'publisher.example.com',
+  PAGE_URL: 'https%3A%2F%2Fpublisher.example.com%2Farticle',
+  REFERRER: 'https://search.example.com',
+  KEYWORDS: 'business,finance',
+  // Placement
+  PLACEMENT_ID: '12345678',
+  FOLD_POSITION: 'above_fold',
+  AD_WIDTH: '300',
+  AD_HEIGHT: '250',
+  // Video
+  VIDEO_ID: 'vid_12345',
+  VIDEO_TITLE: 'Breaking_News',
+  VIDEO_DURATION: '600',
+  VIDEO_CATEGORY: 'IAB1',
+  CONTENT_GENRE: 'news',
+  CONTENT_RATING: 'TV-14',
+  PLAYER_WIDTH: '1920',
+  PLAYER_HEIGHT: '1080',
+  // Ad pod
+  POD_POSITION: '1',
+  POD_SIZE: '3',
+  AD_BREAK_ID: 'break_mid_1',
+  // Audio
+  STATION_ID: 'WXYZ-FM',
+  COLLECTION_NAME: 'Morning_Drive',
+  INSTALLMENT_ID: 'ep_2025_01_15',
+  AUDIO_DURATION: '3600',
+  // Legacy
+  AXEM: 'eyJjb250ZXh0IjoiLi4uIn0',
+  // Catalog
+  CATALOG_ID: 'gmc-primary',
+  SKU: 'SKU-12345',
+  GTIN: '00013000006040',
+  OFFERING_ID: 'summer-sale',
+  JOB_ID: 'vacancy-42',
+  HOTEL_ID: 'grand-amsterdam',
+  FLIGHT_ID: 'AMS-BCN-2025-06',
+  VEHICLE_ID: 'VIN-1234',
+  LISTING_ID: 'prop-01',
+  STORE_ID: 'amsterdam-flagship',
+  PROGRAM_ID: 'mba-2025',
+  DESTINATION_ID: 'barcelona',
+  CREATIVE_VARIANT_ID: 'variant_a',
+  APP_ITEM_ID: 'app_12345',
+  // DOOH
+  SCREEN_ID: 'screen_001',
+  VENUE_TYPE: 'airport',
+  PLAY_TIMESTAMP: '1704067200',
+  VENUE_LAT: '40.7128',
+  VENUE_LONG: '-74.0060',
+  // Carousel
+  CAROUSEL_INDEX: '0',
+  CAROUSEL_TOTAL: '5',
+};
+
+/**
+ * Replace AdCP macro placeholders ({MACRO_NAME}) with realistic dummy values
+ * so that AJV's URI format validation can check the surrounding URL structure.
+ * Known macros get values from MACRO_DUMMY_VALUES; unknown macros get a
+ * URI-safe fallback.
  */
 function replaceMacros(obj) {
   if (typeof obj === 'string') {
-    return obj.replace(/\{([A-Z][A-Z0-9_]*)\}/g, (_, name) => `__${name.toLowerCase()}__`);
+    return obj.replace(/\{([A-Z][A-Z0-9_]*)\}/g, (_, name) =>
+      MACRO_DUMMY_VALUES[name] || `__${name.toLowerCase()}__`
+    );
   }
   if (Array.isArray(obj)) {
     return obj.map(replaceMacros);


### PR DESCRIPTION
## Summary
- Adds `replaceMacros` pre-processing to `tests/json-schema-validation.test.cjs` that replaces `{MACRO_NAME}` patterns with realistic dummy values before AJV URI format validation
- Dummy values sourced from the universal macros spec — URL macros like `{CLICK_URL}` get valid URIs, IDs get realistic prefixed values, numbers get actual numbers
- Allows doc examples with AdCP macro-containing URLs (e.g., `https://track.brand.example/imp?buy={MEDIA_BUY_ID}&cb={CACHEBUSTER}`) to pass schema validation while still checking the surrounding URL structure
- Enriches clickthrough URLs in `creative-manifests.mdx`, `build_creative.mdx`, and `provenance.mdx` with `?campaign={MEDIA_BUY_ID}` where macros would naturally appear

Closes #2049

## Test plan
- [x] `npm run test:json-schema` — all 219 schema-validated blocks pass
- [x] `npm test` — full suite passes (565 unit tests, all CI checks)
- [x] Code review: addressed all Should Fix (immutable object branch, missed URLs)
- [x] Security review: clean bill of health, no ReDoS, no validation bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)