### PR TITLE
fix: SQL param bug in send_payment_request, better billing error messages

### DIFF
--- a/.changeset/fix-billing-errors.md
+++ b/.changeset/fix-billing-errors.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix SQL parameter indexing bug in send_payment_request and improve billing lookup key error messages

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -2814,6 +2814,13 @@ export function createAdminToolHandlers(
 
     // Step 1: Find the organization
     const searchPattern = `%${companyName}%`;
+    const searchParams: string[] = [searchPattern];
+    let paramIdx = 2;
+    const domainClause = domain ? `OR LOWER(email_domain) LIKE LOWER($${paramIdx++})` : '';
+    if (domain) searchParams.push(`%${domain}%`);
+    const exactIdx = paramIdx++;
+    const prefixIdx = paramIdx++;
+    searchParams.push(companyName, `${companyName}%`);
     const searchResult = await pool.query(
       `SELECT workos_organization_id, name, is_personal, company_type, revenue_tier,
               prospect_contact_email, prospect_contact_name,
@@ -2821,15 +2828,13 @@ export function createAdminToolHandlers(
               discount_percent, discount_amount_cents, stripe_coupon_id, stripe_promotion_code
        FROM organizations
        WHERE is_personal = false
-         AND (LOWER(name) LIKE LOWER($1) ${domain ? 'OR LOWER(email_domain) LIKE LOWER($2)' : ''})
+         AND (LOWER(name) LIKE LOWER($1) ${domainClause})
        ORDER BY
-         CASE WHEN LOWER(name) = LOWER($3) THEN 0
-              WHEN LOWER(name) LIKE LOWER($4) THEN 1
+         CASE WHEN LOWER(name) = LOWER($${exactIdx}) THEN 0
+              WHEN LOWER(name) LIKE LOWER($${prefixIdx}) THEN 1
               ELSE 2 END
        LIMIT 5`,
-      domain
-        ? [searchPattern, `%${domain}%`, companyName, `${companyName}%`]
-        : [searchPattern, companyName, `${companyName}%`]
+      searchParams
     );
 
     if (searchResult.rows.length === 0) {
@@ -2953,7 +2958,8 @@ export function createAdminToolHandlers(
         );
       }
       if (!selectedProduct) {
-        return `❌ Product not found for lookup_key: "${lookupKey}". Use find_membership_products to get valid lookup keys.`;
+        const validKeys = products.map(p => p.lookup_key).filter(Boolean);
+        return `❌ Product not found for lookup_key: "${lookupKey}". Valid keys: ${validKeys.join(', ')}`;
       }
     }
 

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -317,7 +317,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       if (!priceId) {
         return JSON.stringify({
           success: false,
-          error: `Product not found for lookup key: ${lookupKey}`,
+          error: `No product matches lookup_key "${lookupKey}". Call find_membership_products first, then pass the exact lookup_key from the result.`,
         });
       }
 

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -270,7 +270,6 @@ export async function getPriceByLookupKey(lookupKey: string): Promise<string | n
     return null;
   }
 
-  // First check our cached products - this is faster and more reliable
   const cachedProducts = await getBillingProducts();
   const cachedProduct = cachedProducts.find(p => p.lookup_key === lookupKey);
   if (cachedProduct) {
@@ -278,8 +277,7 @@ export async function getPriceByLookupKey(lookupKey: string): Promise<string | n
     return cachedProduct.price_id;
   }
 
-  // Fallback to direct Stripe query if not in cache
-  logger.info({ lookupKey }, 'getPriceByLookupKey: Not in cache, querying Stripe directly');
+  // Direct Stripe lookup as fallback when cache doesn't have the key
   try {
     const prices = await stripe.prices.list({
       lookup_keys: [lookupKey],
@@ -287,25 +285,18 @@ export async function getPriceByLookupKey(lookupKey: string): Promise<string | n
       limit: 1,
     });
 
-    if (prices.data.length === 0) {
-      // Log available lookup keys for debugging
-      const allPrices = await stripe.prices.list({ active: true, limit: 100 });
-      const availableLookupKeys = allPrices.data
-        .filter(p => p.lookup_key?.startsWith('aao_'))
-        .map(p => p.lookup_key);
-      logger.error({
-        lookupKey,
-        availableLookupKeys,
-      }, 'getPriceByLookupKey: No price found for lookup key in Stripe');
-      return null;
+    if (prices.data.length > 0) {
+      logger.info({ lookupKey, priceId: prices.data[0].id }, 'getPriceByLookupKey: Found price via direct Stripe lookup');
+      return prices.data[0].id;
     }
-
-    logger.info({ lookupKey, priceId: prices.data[0].id }, 'getPriceByLookupKey: Found price in Stripe');
-    return prices.data[0].id;
   } catch (error) {
-    logger.error({ err: error, lookupKey }, 'getPriceByLookupKey: Error fetching price');
-    return null;
+    logger.error({ err: error, lookupKey }, 'getPriceByLookupKey: Error in direct Stripe lookup');
   }
+
+  const availableLookupKeys = cachedProducts.map(p => p.lookup_key).filter(Boolean);
+  logger.error({ lookupKey, availableLookupKeys },
+    `getPriceByLookupKey: No price found for lookup key "${lookupKey}". Available: ${availableLookupKeys.join(', ')}`);
+  return null;
 }
 
 /**

--- a/tests/addie/billing-tools.test.ts
+++ b/tests/addie/billing-tools.test.ts
@@ -376,8 +376,9 @@ describe('billing-tools', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.success).toBe(false);
-      expect(parsed.error).toContain('Product not found');
+      expect(parsed.error).toContain('No product matches lookup_key');
       expect(parsed.error).toContain('invalid_key');
+      expect(parsed.error).toContain('find_membership_products');
     });
 
     test('returns error when Stripe session creation fails', async () => {


### PR DESCRIPTION
## Summary
- **Fixed SQL parameter indexing bug** in `send_payment_request` org search query. When `domain` was absent, the ORDER BY clause hardcoded `$3`/`$4` but only 3 params were passed — `$2` was unreferenced, causing PostgreSQL's "could not determine data type of parameter $2" error. Parameter indices are now computed dynamically.
- **Improved billing error messages** so Addie can self-correct when a lookup key doesn't match: `create_payment_link` now directs the LLM to call `find_membership_products`, `send_payment_request` surfaces valid keys inline, and `getPriceByLookupKey` logs include the key and available keys in the message text (visible in Slack notifications).

## Test plan
- [x] All 565 unit tests pass
- [x] Typecheck passes
- [x] Updated billing-tools test to match new error message format
- [x] Code review: no must-fix or should-fix findings
- [x] Security review: no findings — SQL remains parameterized, no injection risk, lookup keys are non-sensitive product identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)