### PR TITLE
fix: per-item errors use error.json ref instead of bare strings

### DIFF
--- a/.changeset/sync-item-error-refs.md
+++ b/.changeset/sync-item-error-refs.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Per-item errors in sync_catalogs, sync_creatives, and sync_event_sources responses now reference error.json instead of bare strings, matching the operation-level errors pattern.

--- a/static/schemas/source/creative/sync-creatives-response.json
+++ b/static/schemas/source/creative/sync-creatives-response.json
@@ -47,7 +47,7 @@
                 "type": "array",
                 "description": "Validation or processing errors (only present when action='failed')",
                 "items": {
-                  "type": "string"
+                  "$ref": "/schemas/core/error.json"
                 }
               },
               "warnings": {

--- a/static/schemas/source/media-buy/sync-catalogs-response.json
+++ b/static/schemas/source/media-buy/sync-catalogs-response.json
@@ -99,7 +99,7 @@
                 "type": "array",
                 "description": "Validation or processing errors (only present when action='failed')",
                 "items": {
-                  "type": "string"
+                  "$ref": "/schemas/core/error.json"
                 }
               },
               "warnings": {

--- a/static/schemas/source/media-buy/sync-event-sources-response.json
+++ b/static/schemas/source/media-buy/sync-event-sources-response.json
@@ -77,7 +77,7 @@
                 "type": "array",
                 "description": "Errors for this event source (only present when action='failed')",
                 "items": {
-                  "type": "string"
+                  "$ref": "/schemas/core/error.json"
                 }
               }
             },


### PR DESCRIPTION
## Summary
- Per-item `errors` arrays in `sync-catalogs-response`, `sync-creatives-response`, and `sync-event-sources-response` used `"type": "string"` for items instead of `$ref` to `error.json`
- Agents return structured error objects (`{ "code": "...", "message": "..." }`), causing Zod validation failures in adcp-client
- Updated all three source schemas to use `"$ref": "/schemas/core/error.json"`, matching the operation-level errors pattern already used in the same files

Closes #2059

## Test plan
- [x] `npm run build:schemas` — dist schemas regenerated correctly with versioned `$ref` paths
- [x] `npm run test:schemas` — 7/7 pass (cross-references resolve, examples validate)
- [x] `npm run test:examples` — 29/29 pass
- [x] `npm run test:unit` — 565/565 pass
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)