### PR TITLE
docs: deprecate X-Dry-Run header, standardize on sandbox mode

### DIFF
--- a/.changeset/deprecate-x-dry-run.md
+++ b/.changeset/deprecate-x-dry-run.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Deprecate X-Dry-Run HTTP header in favor of sandbox mode. Add explicit deprecation notices to sandbox docs and protocol compliance section. Upgrade seller sandbox requirements to RFC 2119 MUST/MUST NOT language. Update agent building and validation pages to document sandbox as the default testing mechanism. Update SKILL.md testing section to remove X-Dry-Run reference.

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -108,7 +108,7 @@ go run main.go &
 npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
-Storyboards exercise every required tool call and validate response shapes. A passing run means your agent is protocol-compliant.
+Storyboards exercise every required tool call and validate response shapes. The storyboard runner uses sandbox mode by default — your agent receives `sandbox: true` on all account references and should return simulated data without real platform calls. A passing run means your agent is protocol-compliant.
 
 ```
 media_buy_seller (9 steps)

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -31,6 +31,8 @@ The mechanism for provisioning sandbox credentials is seller-specific and out of
 
 The storyboard runner SHOULD verify that `comply_test_controller` is absent from `tools/list` on a production connection as a basic safety check.
 
+If a `comply_test_controller` call references a non-sandbox account, the controller MUST return `FORBIDDEN`. Sandbox gating is enforced per-request on the account reference, not just at tool registration time — the tool may be listed in a sandbox connection, but the caller could still reference a production account in the params.
+
 ## Tool definition
 
 **Schemas**: [`comply-test-controller-request.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-request.json) | [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-response.json)

--- a/docs/building/validate-your-agent.mdx
+++ b/docs/building/validate-your-agent.mdx
@@ -126,6 +126,24 @@ Share an insertion order with Addie. She'll extract the line items, match them a
 
 Each step builds confidence. Storyboards prove protocol compliance. RFP and IO testing prove business readiness.
 
+## Sandbox mode
+
+All storyboard runs use sandbox mode by default. The storyboard runner sets `sandbox: true` on every account reference, so your agent processes requests without real platform calls or spend.
+
+Your agent should declare sandbox support in `get_adcp_capabilities`:
+
+```json
+{
+  "account": {
+    "sandbox": true
+  }
+}
+```
+
+When a request references a sandbox account, your agent MUST NOT persist production state or cause real-world side effects — no real orders, no real billing, no real ad platform API calls. Return realistic response shapes with simulated data and include `sandbox: true` in success responses.
+
+See [Sandbox mode](/docs/media-buy/advanced-topics/sandbox) for full implementation details and the two account model paths (implicit vs explicit).
+
 ## The build-validate-fix loop
 
 The typical development workflow:

--- a/docs/contributing/testable-snippets.md
+++ b/docs/contributing/testable-snippets.md
@@ -135,22 +135,25 @@ const products = await client.getProducts({
 });
 ```
 
-### 3. Use Dry Run Mode
+### 3. Use sandbox accounts
 
-When demonstrating operations that modify state (create, update, delete), use dry run mode:
+When demonstrating operations that modify state (create, update, delete), use a sandbox account reference:
 
 ```javascript
-// Example showing dry run mode usage
+// Example using sandbox account — no real campaign created
 const mediaBuy = await client.createMediaBuy({
+  account: {
+    brand: { domain: 'acme-corp.com' },
+    operator: 'acme-corp.com',
+    sandbox: true
+  },
   product_id: 'prod_123',
   budget: 10000,
   start_date: '2025-11-01',
   end_date: '2025-11-30'
-}, {
-  dryRun: true  // No actual campaign created
 });
 
-console.log('Dry run successful');
+console.log('Sandbox media buy created:', mediaBuy.media_buy_id);
 ```
 
 ### 4. Handle Async Operations

--- a/docs/media-buy/advanced-topics/sandbox.mdx
+++ b/docs/media-buy/advanced-topics/sandbox.mdx
@@ -204,24 +204,33 @@ The seller returns simulated delivery metrics — impressions, spend, pacing —
 
 ## Sandbox vs dry run
 
-Some tasks (e.g., `sync_creatives`) also support a `dry_run` parameter. These serve different purposes:
+Some sync tasks (`sync_creatives`, `sync_catalogs`) support a `dry_run` parameter. These serve different purposes:
 
 | | Sandbox account | `dry_run` |
 |---|---|---|
 | **Meaning** | Nothing is real | Preview changes without applying |
-| **Scope** | All tasks | sync_creatives only |
+| **Scope** | All tasks on the account | Sync tasks only |
 | **Side effects** | None (simulated) | None (preview only) |
-| **Use case** | Test the full lifecycle | Check what a sync would change |
+| **Use case** | Test the full lifecycle | Check what a sync would change before committing |
+
+You can combine them — `dry_run: true` on a sandbox account previews the sync without even updating sandbox state.
+
+<Warning>
+The `X-Dry-Run`, `X-Test-Session-ID`, and `X-Mock-Time` HTTP headers are **deprecated**. Sandbox mode replaces them as a protocol-level parameter.
+
+- **Sellers MUST NOT** alter behavior based on these headers. Sandbox mode is determined solely by the account reference. Sellers SHOULD ignore the headers entirely and MAY log a deprecation warning to help buyers identify stale integrations.
+- **Buyers MUST NOT** rely on these headers to prevent production side effects. Only `sandbox: true` on the account reference guarantees sandbox semantics.
+</Warning>
 
 ## Seller implementation
 
-When a request references a sandbox account (either via `sandbox: true` in the natural key or via a sandbox `account_id`):
+When a request references a sandbox account (either via `sandbox: true` in the natural key or via a sandbox `account_id`), agents MUST NOT persist production state or cause real-world side effects:
 
-- **Do not** make real ad platform API calls (no real orders, line items, etc.)
-- **Do not** charge real money or create real billing records
-- **Do** validate inputs the same way as production (reject invalid budgets, bad dates, etc.)
-- **Do** return realistic response shapes with simulated data
-- **Should** include `sandbox: true` in success responses
+- **MUST NOT** make real ad platform API calls (no real orders, line items, etc.)
+- **MUST NOT** charge real money or create real billing records
+- **MUST** validate inputs the same way as production (reject invalid budgets, bad dates, etc.)
+- **MUST** return realistic response shapes with simulated data
+- **SHOULD** include `sandbox: true` in success responses
 
 Sandbox errors are real validation errors. If a buyer sends an invalid budget using a sandbox account, return a real error — don't simulate fake errors.
 
@@ -235,6 +244,7 @@ Sellers that declare `account.sandbox: true` in capabilities MUST:
 
 - Accept sandbox accounts appropriate to their account model
 - Apply sandbox semantics to all requests referencing a sandbox account
+- NOT persist production state or cause real-world side effects when processing sandbox requests
 - Apply normal input validation (sandbox does not bypass validation)
 
 Sellers SHOULD include `sandbox: true` in success responses when processing a sandbox account request.

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -573,6 +573,9 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
 | `report_usage.kind` and `report_usage.operator_id` | Removed |
 | `catalog` (singular) on Package | `catalogs` (array) |
 | `account_resolution` capability | `require_operator_auth` determines account model |
+| `X-Dry-Run` HTTP header | `sandbox: true` on account reference |
+| `X-Test-Session-ID` HTTP header | Removed — sandbox accounts provide test isolation |
+| `X-Mock-Time` HTTP header | Removed |
 | `delete_content_standards` task | Archive via `update_content_standards` instead |
 | `get_property_features` task | Property list filters + `get_adcp_capabilities` for feature discovery |
 | `tone` as string on brand.json | Object only: `{ voice, attributes, dos, donts }` |
@@ -615,6 +618,7 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
     - [ ] Migrate brand `tone` from string to object format (`{ voice, attributes, dos, donts }`)
     - [ ] Remove `account_resolution` reads — use `require_operator_auth` instead
     - [ ] Read sandbox support from `account.sandbox` instead of `media_buy.features.sandbox`
+    - [ ] Remove `X-Dry-Run`, `X-Test-Session-ID`, and `X-Mock-Time` header handling — use `sandbox: true` on account references instead
     - [ ] Add `type: "dooh"` inside `flat_rate.parameters` when DOOH parameters are provided
     - [ ] Treat `list_creatives` and `sync_creatives` as Creative Protocol operations
     - [ ] Remove `delete_content_standards` calls — archive via `update_content_standards`
@@ -641,6 +645,7 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
     - [ ] Declare `supported_pricing_models` in `get_adcp_capabilities`
     - [ ] Support `time_budget` on `get_products` and return `incomplete` when work cannot finish in budget
     - [ ] Declare sandbox support in `account.sandbox`, not `media_buy.features.sandbox`
+    - [ ] Stop checking for `X-Dry-Run` header — honor `sandbox: true` on account references instead
     - [ ] Support `preferred_delivery_types`, `exclusivity`, optional `delivery_measurement`, and package-level `start_time` / `end_time`
   </Accordion>
 

--- a/skills/adcp-media-buy/SKILL.md
+++ b/skills/adcp-media-buy/SKILL.md
@@ -323,9 +323,28 @@ Error responses include:
 
 ## Testing Mode
 
-For testing without real transactions, agents may support:
-- `X-Dry-Run: true` header - Preview without side effects
-- Test products with `test: true` flag
-- Sandbox environments
+Use **sandbox mode** for testing without real transactions. Sandbox is account-level — once a request references a sandbox account, the entire request is treated as sandbox with no real platform calls or spend.
 
-Ask the agent about testing capabilities before creating real campaigns.
+Check whether the agent supports sandbox via `get_adcp_capabilities`:
+```json
+{
+  "account": {
+    "sandbox": true
+  }
+}
+```
+
+To enter sandbox mode, set `sandbox: true` on the account reference:
+```json
+{
+  "account": {
+    "brand": { "domain": "acme-corp.com" },
+    "operator": "acme-corp.com",
+    "sandbox": true
+  }
+}
+```
+
+Some sync tasks (`sync_creatives`, `sync_catalogs`) also support a `dry_run` parameter that previews changes without applying them. This is orthogonal to sandbox — you can use `dry_run` in both sandbox and production accounts.
+
+See [Sandbox mode](https://docs.adcontextprotocol.org/docs/media-buy/advanced-topics/sandbox) for full details.


### PR DESCRIPTION
## Summary

- Deprecate `X-Dry-Run`, `X-Test-Session-ID`, and `X-Mock-Time` HTTP headers in favor of account-level `sandbox: true`
- Add normative MUST/MUST NOT requirements for both sellers (must not alter behavior based on deprecated headers) and buyers (must not rely on headers for sandbox semantics)
- Update agent building and validation pages to document sandbox as the default testing mechanism
- Add deprecated headers to "Removed in v3" table and migration checklists
- Fix stale `dryRun` example in contributor docs
- Add per-request sandbox gate requirement to comply-test-controller spec

Closes #2087

## Test plan

- [x] All 597 unit tests pass
- [x] TypeScript typecheck clean
- [x] Mintlify link checker passes (no broken links)
- [x] Code review: no Must Fix findings
- [x] Security review: all Should Fix items addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)