### PR TITLE
feat: event tools for all users, Luma sync fixes

### DIFF
--- a/.changeset/event-tools-for-all.md
+++ b/.changeset/event-tools-for-all.md
@@ -1,5 +1,5 @@
 ---
-"@anthropic/adcp-server": patch
+"adcontextprotocol": patch
 ---
 
 Give all authenticated users access to read-only event tools (list events, get details, register interest). Admin event tools remain gated. Fix dashboard upcoming events to match by email for Luma-synced registrations. Map Luma pending_approval to waitlisted. Sync Luma hosts as registered attendees.

--- a/.changeset/event-tools-for-all.md
+++ b/.changeset/event-tools-for-all.md
@@ -1,0 +1,5 @@
+---
+"@anthropic/adcp-server": patch
+---
+
+Give all authenticated users access to read-only event tools (list events, get details, register interest). Admin event tools remain gated. Fix dashboard upcoming events to match by email for Luma-synced registrations. Map Luma pending_approval to waitlisted. Sync Luma hosts as registered attendees.

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -331,6 +331,10 @@
     .badge-participant { background: var(--color-gray-200); color: var(--color-gray-700); }
     .invite-row { display: flex; gap: var(--space-2); margin-top: var(--space-4); padding-top: var(--space-4); border-top: 1px solid var(--color-gray-200); }
     .invite-row input { flex: 1; padding: var(--space-2); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); font-size: var(--text-sm); }
+
+    /* TipTap editor: inner ProseMirror element must fill the wrapper */
+    #recapEditorEl { display: flex; flex-direction: column; }
+    #recapEditorEl .ProseMirror { flex: 1; min-height: 180px; outline: none; }
   </style>
 </head>
 <body>
@@ -688,6 +692,20 @@
             </div>
           </div>
 
+          <div id="eventGroupNotExists" style="display: none;">
+            <button type="button" class="btn btn-primary" onclick="createEventGroup()">
+              Create Attendee Group + Slack Channel
+            </button>
+            <p style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-2);">
+              This will create a public Slack channel for attendees to join.
+            </p>
+          </div>
+
+          <div id="eventGroupLoading" style="display: none; color: var(--color-text-secondary); font-size: var(--text-sm);">
+            Loading attendee group info...
+          </div>
+        </div>
+
         <!-- Recap (shown for existing events) -->
         <div class="section-divider" id="recapSection" style="display: none;">
           <div class="section-title">Event Recap</div>
@@ -710,20 +728,6 @@
               <button type="button" class="btn btn-secondary" style="padding: 4px 8px; font-size: 12px;" onclick="recapEditor?.chain().focus().toggleOrderedList().run()" title="Numbered List">1. List</button>
             </div>
             <div id="recapEditorEl" style="border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-3); min-height: 200px; background: var(--color-bg-card);"></div>
-          </div>
-        </div>
-
-          <div id="eventGroupNotExists" style="display: none;">
-            <button type="button" class="btn btn-primary" onclick="createEventGroup()">
-              Create Attendee Group + Slack Channel
-            </button>
-            <p style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-2);">
-              This will create a public Slack channel for attendees to join.
-            </p>
-          </div>
-
-          <div id="eventGroupLoading" style="display: none; color: var(--color-text-secondary); font-size: var(--text-sm);">
-            Loading attendee group info...
           </div>
         </div>
 

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -48,7 +48,8 @@ import {
   isSlackUserAAOAdmin,
 } from './mcp/admin-tools.js';
 import {
-  EVENT_TOOLS,
+  EVENT_READONLY_TOOLS,
+  EVENT_ADMIN_TOOLS,
   createEventToolHandlers,
   canCreateEvents,
 } from './mcp/event-tools.js';
@@ -907,15 +908,23 @@ async function createUserScopedTools(
     logger.debug({ slackUserId }, 'Addie Bolt: User is NOT an admin — admin tools withheld');
   }
 
-  // Add event tools if user can create events (admin or committee lead)
+  // Event tools: readonly for all users, admin tools gated behind canCreateEvents
+  const eventHandlers = createEventToolHandlers(memberContext, slackUserId);
+  allTools.push(...EVENT_READONLY_TOOLS);
+  for (const tool of EVENT_READONLY_TOOLS) {
+    const handler = eventHandlers.get(tool.name);
+    if (handler) allHandlers.set(tool.name, handler);
+  }
+  logger.debug('Addie Bolt: Event read-only tools enabled');
+
   const canCreate = slackUserId ? await canCreateEvents(slackUserId) : userIsAdmin;
   if (canCreate) {
-    const eventHandlers = createEventToolHandlers(memberContext, slackUserId);
-    allTools.push(...EVENT_TOOLS);
-    for (const [name, handler] of eventHandlers) {
-      allHandlers.set(name, handler);
+    allTools.push(...EVENT_ADMIN_TOOLS);
+    for (const tool of EVENT_ADMIN_TOOLS) {
+      const handler = eventHandlers.get(tool.name);
+      if (handler) allHandlers.set(tool.name, handler);
     }
-    logger.debug('Addie Bolt: Event tools enabled for this user');
+    logger.debug('Addie Bolt: Event admin tools enabled for this user');
   }
 
   // Add meeting tools if user can schedule meetings (admin or committee leader)

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -37,7 +37,8 @@ import {
   createMemberToolHandlers,
 } from './mcp/member-tools.js';
 import {
-  EVENT_TOOLS,
+  EVENT_READONLY_TOOLS,
+  EVENT_ADMIN_TOOLS,
   createEventToolHandlers,
   canCreateEvents,
 } from './mcp/event-tools.js';
@@ -354,15 +355,22 @@ async function createUserScopedTools(
     logger.debug('Addie: Admin tools enabled for this user');
   }
 
-  // Add event tools if user can create events (admin or committee lead)
+  // Event tools: readonly for all users, admin tools gated behind canCreateEvents
+  const eventHandlers = createEventToolHandlers(memberContext, slackUserId);
+  allTools.push(...EVENT_READONLY_TOOLS);
+  for (const tool of EVENT_READONLY_TOOLS) {
+    const handler = eventHandlers.get(tool.name);
+    if (handler) allHandlers.set(tool.name, handler);
+  }
+
   const canCreate = slackUserId ? await canCreateEvents(slackUserId) : userIsAdmin;
   if (canCreate) {
-    const eventHandlers = createEventToolHandlers(memberContext, slackUserId);
-    allTools.push(...EVENT_TOOLS);
-    for (const [name, handler] of eventHandlers) {
-      allHandlers.set(name, handler);
+    allTools.push(...EVENT_ADMIN_TOOLS);
+    for (const tool of EVENT_ADMIN_TOOLS) {
+      const handler = eventHandlers.get(tool.name);
+      if (handler) allHandlers.set(tool.name, handler);
     }
-    logger.debug('Addie: Event tools enabled for this user');
+    logger.debug('Addie: Event admin tools enabled for this user');
   }
 
   // Add meeting tools if user can schedule meetings (admin or committee leader)

--- a/server/src/addie/mcp/event-tools.ts
+++ b/server/src/addie/mcp/event-tools.ts
@@ -1184,6 +1184,12 @@ export function createEventToolHandlers(
       return `❌ Event not found: "${eventSlug}"`;
     }
 
+    // Non-admin users can only register interest in published events
+    const isAdmin = slackUserId ? await canCreateEvents(slackUserId) : (memberContext?.org_membership?.role === 'admin');
+    if (!isAdmin && !['published', 'completed'].includes(event.status)) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+
     const email = memberContext?.workos_user?.email ?? memberContext?.slack_user?.email ?? null;
     if (!email) {
       return `I don't have your email address on file. Could you share it so I can add you to the interest list?`;

--- a/server/src/addie/mcp/event-tools.ts
+++ b/server/src/addie/mcp/event-tools.ts
@@ -351,9 +351,79 @@ function formatTime(date: Date, timezone = 'America/New_York'): string {
 }
 
 /**
- * Event tool definitions
+ * Read-only event tools available to all authenticated users.
+ * These let any member check their registrations and browse upcoming events.
  */
-export const EVENT_TOOLS: AddieTool[] = [
+export const EVENT_READONLY_TOOLS: AddieTool[] = [
+  {
+    name: 'list_events',
+    description: `List AAO events personalized for the user. Shows:
+- Events the user is already registered for
+- Events in regional chapters they're a member of
+- Events at industry gatherings they've indicated interest in (CES, Cannes Lions, etc.)
+- Major global summits (open to all members)
+
+Does NOT include virtual webinars (those are educational content).
+
+When asked about past events, set include_past=true.
+When asked about upcoming events or what's happening soon, use the defaults.
+
+If the user isn't in any regional chapters or hasn't indicated interest in any industry events,
+the response will suggest they share their location or join industry gathering groups.`,
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        event_type: {
+          type: 'string',
+          enum: ['summit', 'meetup', 'workshop', 'conference', 'other'],
+          description: 'Filter by event type (webinar excluded)',
+        },
+        include_past: {
+          type: 'boolean',
+          description: 'Include past/completed events (default: false, only shows upcoming)',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of events to return (default: 10)',
+        },
+      },
+    },
+  },
+  {
+    name: 'get_event_details',
+    description: `Get details about a specific event including registration count and waitlist. Use this when someone asks about a specific event.`,
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        event_slug: {
+          type: 'string',
+          description: 'Event slug (URL identifier) or event ID',
+        },
+      },
+      required: ['event_slug'],
+    },
+  },
+  {
+    name: 'register_event_interest',
+    description: `Register the current user's interest in an event. Use when someone asks to be notified about an event, added to a waitlist, or wants to express interest without formally registering.`,
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        event_slug: {
+          type: 'string',
+          description: 'Event slug or ID',
+        },
+      },
+      required: ['event_slug'],
+    },
+  },
+];
+
+/**
+ * Admin/committee-lead event tools for creating and managing events.
+ * Gated behind canCreateEvents() permission check.
+ */
+export const EVENT_ADMIN_TOOLS: AddieTool[] = [
   {
     name: 'create_event',
     description: `Create a new AAO event. Use this when someone asks to create a meetup, webinar, summit, or workshop.
@@ -436,54 +506,6 @@ Optional: description, end_time, timezone, location details, virtual_url, max_at
     },
   },
   {
-    name: 'list_events',
-    description: `List AAO events personalized for the user. Shows:
-- Events the user is already registered for
-- Events in regional chapters they're a member of
-- Events at industry gatherings they've indicated interest in (CES, Cannes Lions, etc.)
-- Major global summits (open to all members)
-
-Does NOT include virtual webinars (those are educational content).
-
-When asked about past events, set include_past=true.
-When asked about upcoming events or what's happening soon, use the defaults.
-
-If the user isn't in any regional chapters or hasn't indicated interest in any industry events,
-the response will suggest they share their location or join industry gathering groups.`,
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        event_type: {
-          type: 'string',
-          enum: ['summit', 'meetup', 'workshop', 'conference', 'other'],
-          description: 'Filter by event type (webinar excluded)',
-        },
-        include_past: {
-          type: 'boolean',
-          description: 'Include past/completed events (default: false, only shows upcoming)',
-        },
-        limit: {
-          type: 'number',
-          description: 'Maximum number of events to return (default: 10)',
-        },
-      },
-    },
-  },
-  {
-    name: 'get_event_details',
-    description: `Get details about a specific event including registration count and waitlist. Use this when someone asks about a specific event.`,
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        event_slug: {
-          type: 'string',
-          description: 'Event slug (URL identifier) or event ID',
-        },
-      },
-      required: ['event_slug'],
-    },
-  },
-  {
     name: 'manage_event_registrations',
     description: `Manage event registrations - view registrations, approve waitlisted attendees, or export attendee list.`,
     input_schema: {
@@ -554,20 +576,6 @@ the response will suggest they share their location or join industry gathering g
     },
   },
   {
-    name: 'register_event_interest',
-    description: `Register the current user's interest in an event. Use when someone asks to be notified about an event, added to a waitlist, or wants to express interest without formally registering.`,
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        event_slug: {
-          type: 'string',
-          description: 'Event slug or ID',
-        },
-      },
-      required: ['event_slug'],
-    },
-  },
-  {
     name: 'check_person_event_status',
     description: `Look up a specific person's status at an event. Use when someone asks "Is [person] invited to [event]?", "Did [person] attend [event]?", "What's [person]'s RSVP status?", etc.
 
@@ -620,6 +628,11 @@ The invitation is recorded immediately; the outreach message is a draft for the 
     },
   },
 ];
+
+/**
+ * All event tools combined (for backward compatibility).
+ */
+export const EVENT_TOOLS: AddieTool[] = [...EVENT_READONLY_TOOLS, ...EVENT_ADMIN_TOOLS];
 
 /**
  * Event tool handler implementations
@@ -904,6 +917,12 @@ export function createEventToolHandlers(
     }
 
     if (!event) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+
+    // Non-admin users can only see published/completed events
+    const isAdmin = slackUserId ? await canCreateEvents(slackUserId) : (memberContext?.org_membership?.role === 'admin');
+    if (!isAdmin && !['published', 'completed'].includes(event.status)) {
       return `❌ Event not found: "${eventSlug}"`;
     }
 

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -390,7 +390,9 @@ ${ctx.source === 'channel' && !explicitlyNamedAddie ? 'These guidelines apply ON
 - Content workflows, GitHub issues, proposals → ["content"]
 - Questions about working group documents, brand guidelines, uploaded files → ["knowledge", "member"]
 - Billing, invoices, payment links, resending invoices → ["billing"]
-- Scheduling meetings, events, calendar, RSVPs, covering topics, joining a call, meeting agendas → ["meetings"]
+- Upcoming events, event registrations, "am I registered", event details, register interest → ["events"]
+- Who is coming to an event, attendee lists, invite someone to an event, create/update events → ["events", "admin"]
+- Scheduling meetings, calendar, covering topics, joining a call, meeting agendas → ["meetings"]
 - Listing all members with payment/product/invoice status → ["admin"]
 - Task management, marking tasks done, checking tasks, reminders, logging conversations → ["admin"]
 - Escalations, pending requests, user role changes, merging orgs → ["admin"]
@@ -435,7 +437,7 @@ ${ctx.source === 'channel' && !explicitlyNamedAddie ? `
 
 3. {"action": "respond", "tool_sets": ["set1", "set2"], "confidence": "high", "requires_depth": false, "reason": "brief reason"}
    - When you can help - select the tool SET(S) that will be needed
-   - Valid sets: knowledge, member, directory, agent_testing, adcp_operations, content, billing, meetings${isAAOAdmin ? ', admin' : ''}
+   - Valid sets: knowledge, member, directory, agent_testing, adcp_operations, content, billing, events, meetings${isAAOAdmin ? ', admin' : ''}
    - Empty array [] means respond without tools (general knowledge)
    - **confidence** (required): How sure you are that Addie's tools will return a DEFINITIVE answer:
      - "high": Addie's docs/tools contain the answer. Schema questions, documented protocol flows, membership actions, directory lookups — things where the answer EXISTS in our systems.

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -247,6 +247,16 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     requiresPrecision: true,
   },
 
+  events: {
+    name: 'events',
+    description: 'Browse upcoming events, check event registrations, get event details, and register interest in events — available to all members',
+    tools: [
+      'list_events',
+      'get_event_details',
+      'register_event_interest',
+    ],
+  },
+
   meetings: {
     name: 'meetings',
     description: 'Schedule, list, update, and cancel meetings - add or remove attendees, RSVP, manage recurring series, handle calendar invites and Zoom links',
@@ -279,8 +289,14 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   admin: {
     name: 'admin',
-    description: 'Administrative operations - manage prospects, organizations, feeds, escalations, user roles, committee/working group leadership, member insights and engagement analytics, community-wide engagement ranking (admin only)',
+    description: 'Administrative operations - manage prospects, organizations, feeds, escalations, user roles, committee/working group leadership, event management (create/update events, manage registrations, invites, attendee lists), member insights and engagement analytics, community-wide engagement ranking (admin only)',
     tools: [
+      // Event management (admin)
+      'create_event',
+      'update_event',
+      'manage_event_registrations',
+      'check_person_event_status',
+      'invite_to_event',
       'list_pending_invoices',
       'get_account',
       'add_prospect',

--- a/server/src/db/community-db.ts
+++ b/server/src/db/community-db.ts
@@ -879,10 +879,10 @@ export class CommunityDatabase {
 
   async getHubData(userId: string): Promise<HubData> {
     // Fetch user profile
-    const profileResult = await query<CommunityProfile & { first_name: string; last_name: string; city: string | null; country: string | null }>(
+    const profileResult = await query<CommunityProfile & { first_name: string; last_name: string; city: string | null; country: string | null; email: string | null }>(
       `SELECT workos_user_id, slug, headline, bio, avatar_url, expertise, interests,
               linkedin_url, twitter_url, github_username, is_public, open_to_coffee_chat, open_to_intros,
-              first_name, last_name, city, country
+              first_name, last_name, city, country, email
        FROM users WHERE workos_user_id = $1`,
       [userId]
     );
@@ -907,7 +907,7 @@ export class CommunityDatabase {
       this.getUserBadges(userId),
       this.getSuggestedConnections(userId, 4),
       this.getRecentPublicProfiles(5),
-      this.getUpcomingEvents(userId),
+      this.getUpcomingEvents(userId, profile.email ?? undefined),
       this.getUserWorkingGroupsWithCount(userId),
       this.getConnectionCount(userId),
       this.getPendingRequestCount(userId),
@@ -928,19 +928,27 @@ export class CommunityDatabase {
     };
   }
 
-  private async getUpcomingEvents(userId: string): Promise<{ id: string; title: string; start_time: string; co_attendee_count: number }[]> {
+  private async getUpcomingEvents(userId: string, userEmail?: string): Promise<{ id: string; title: string; start_time: string; co_attendee_count: number }[]> {
+    // Match registrations by workos_user_id OR email (Luma-synced registrations only have email)
+    const userMatch = userEmail
+      ? `(er.workos_user_id = $1 OR LOWER(er.email) = LOWER($2))`
+      : `er.workos_user_id = $1`;
+    const params = userEmail ? [userId, userEmail] : [userId];
+
     const result = await query<{ id: string; title: string; start_time: string; co_attendee_count: number }>(
-      `SELECT e.id, e.title, e.start_time,
+      `SELECT DISTINCT e.id, e.title, e.start_time,
               (SELECT COUNT(*) FROM event_registrations er2
-               WHERE er2.event_id = e.id AND er2.workos_user_id != $1) as co_attendee_count
+               WHERE er2.event_id = e.id AND er2.workos_user_id != $1
+                 AND er2.registration_status IN ('registered', 'waitlisted')) as co_attendee_count
        FROM events e
        JOIN event_registrations er ON er.event_id = e.id
-       WHERE er.workos_user_id = $1
+       WHERE ${userMatch}
+         AND er.registration_status IN ('registered', 'waitlisted')
          AND e.start_time > NOW()
          AND e.status = 'published'
        ORDER BY e.start_time ASC
        LIMIT 5`,
-      [userId]
+      params
     );
     return result.rows;
   }

--- a/server/src/db/community-db.ts
+++ b/server/src/db/community-db.ts
@@ -933,12 +933,15 @@ export class CommunityDatabase {
     const userMatch = userEmail
       ? `(er.workos_user_id = $1 OR LOWER(er.email) = LOWER($2))`
       : `er.workos_user_id = $1`;
+    const excludeSelf = userEmail
+      ? `AND er2.workos_user_id != $1 AND LOWER(er2.email) != LOWER($2)`
+      : `AND er2.workos_user_id != $1`;
     const params = userEmail ? [userId, userEmail] : [userId];
 
     const result = await query<{ id: string; title: string; start_time: string; co_attendee_count: number }>(
       `SELECT DISTINCT e.id, e.title, e.start_time,
               (SELECT COUNT(*) FROM event_registrations er2
-               WHERE er2.event_id = e.id AND er2.workos_user_id != $1
+               WHERE er2.event_id = e.id ${excludeSelf}
                  AND er2.registration_status IN ('registered', 'waitlisted')) as co_attendee_count
        FROM events e
        JOIN event_registrations er ON er.event_id = e.id

--- a/server/src/luma/client.ts
+++ b/server/src/luma/client.ts
@@ -305,6 +305,30 @@ export async function getEventGuests(eventId: string): Promise<LumaGuest[]> {
 }
 
 /**
+ * Get hosts for an event.
+ * Luma hosts are separate from guests — they don't appear in getEventGuests.
+ */
+export async function getEventHosts(eventId: string): Promise<Array<{ email: string; name: string | null }>> {
+  try {
+    const response = await lumaFetch<{
+      entries: Array<{
+        name: string | null;
+        email: string;
+        api_id: string;
+        type: string;
+      }>;
+    }>(`/event/get-hosts?event_api_id=${encodeURIComponent(eventId)}`);
+
+    return (response.entries || [])
+      .filter(h => h.email)
+      .map(h => ({ email: h.email, name: h.name }));
+  } catch (error) {
+    logger.debug({ err: error, eventId }, 'Could not fetch Luma event hosts');
+    return [];
+  }
+}
+
+/**
  * Get a single guest registration
  */
 export async function getGuest(guestId: string): Promise<LumaGuest | null> {

--- a/server/src/luma/sync.ts
+++ b/server/src/luma/sync.ts
@@ -67,7 +67,7 @@ function inferCityFromTitle(title: string): string | null {
 /**
  * Map Luma guest approval_status to AAO registration_status.
  */
-function mapLumaApprovalStatus(approvalStatus: string): 'registered' | 'waitlisted' | 'cancelled' {
+export function mapLumaApprovalStatus(approvalStatus: string): 'registered' | 'waitlisted' | 'cancelled' {
   switch (approvalStatus?.toLowerCase()) {
     case 'approved':
       return 'registered';

--- a/server/src/luma/sync.ts
+++ b/server/src/luma/sync.ts
@@ -13,6 +13,7 @@ import {
   listCalendars,
   listCalendarEvents,
   getEventGuests,
+  getEventHosts,
   isLumaEnabled,
   type LumaEvent,
 } from './client.js';
@@ -61,6 +62,24 @@ function inferCityFromTitle(title: string): string | null {
   const colonMatch = title.match(/:\s*([A-Z][a-z]+(?:\s[A-Z][a-z]+)?)/);
   if (colonMatch) return colonMatch[1];
   return null;
+}
+
+/**
+ * Map Luma guest approval_status to AAO registration_status.
+ */
+function mapLumaApprovalStatus(approvalStatus: string): 'registered' | 'waitlisted' | 'cancelled' {
+  switch (approvalStatus?.toLowerCase()) {
+    case 'approved':
+      return 'registered';
+    case 'pending_approval':
+    case 'waitlist':
+      return 'waitlisted';
+    case 'declined':
+    case 'cancelled':
+      return 'cancelled';
+    default:
+      return 'registered';
+  }
 }
 
 /**
@@ -188,7 +207,7 @@ export async function syncEventRegistrations(eventId: string, lumaEventId: strin
         );
         if (existing.rows.length > 0) continue;
 
-        const status = guest.approval_status === 'declined' ? 'cancelled' as const : 'registered' as const;
+        const status = mapLumaApprovalStatus(guest.approval_status);
         await eventsDb.createRegistration({
           event_id: eventId,
           email: guest.user_email,
@@ -228,6 +247,44 @@ export async function syncEventRegistrations(eventId: string, lumaEventId: strin
   } catch (err) {
     logger.warn({ err, eventId, lumaEventId }, 'Could not sync registrations from Luma');
   }
+
+  // Sync hosts as registered attendees (Luma hosts are separate from guests)
+  try {
+    const hosts = await getEventHosts(lumaEventId);
+    for (const host of hosts) {
+      if (!host.email) continue;
+      try {
+        const pool = getPool();
+        const existing = await pool.query(
+          `SELECT id FROM event_registrations
+           WHERE event_id = $1 AND LOWER(email) = LOWER($2)`,
+          [eventId, host.email]
+        );
+        if (existing.rows.length > 0) continue;
+
+        await eventsDb.createRegistration({
+          event_id: eventId,
+          email: host.email,
+          name: host.name || undefined,
+          registration_source: 'luma',
+          registration_status: 'registered',
+        });
+
+        try {
+          await eventsDb.addInvites(eventId, [host.email]);
+        } catch {
+          // Duplicate invite — safe to ignore
+        }
+
+        synced++;
+      } catch {
+        // Duplicate or other error — skip
+      }
+    }
+  } catch (err) {
+    logger.debug({ err, eventId, lumaEventId }, 'Could not sync hosts from Luma');
+  }
+
   return synced;
 }
 

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -51,7 +51,8 @@ import {
   isWebUserAAOAdmin,
 } from "../addie/mcp/admin-tools.js";
 import {
-  EVENT_TOOLS,
+  EVENT_READONLY_TOOLS,
+  EVENT_ADMIN_TOOLS,
   createEventToolHandlers,
 } from "../addie/mcp/event-tools.js";
 import {
@@ -539,11 +540,19 @@ export async function prepareRequestWithMemberTools(
       }
     }
 
-    // Event creation: admin only (matches canCreateEvents in event-tools.ts)
+    // Event tools: readonly for all users, admin tools for admins only
+    const eventHandlers = createEventToolHandlers(memberContext);
+    allTools.push(...EVENT_READONLY_TOOLS);
+    for (const tool of EVENT_READONLY_TOOLS) {
+      const handler = eventHandlers.get(tool.name);
+      if (handler) combinedHandlers.set(tool.name, handler);
+    }
+
     if (userIsAdmin) {
-      allTools.push(...EVENT_TOOLS);
-      for (const [name, handler] of createEventToolHandlers(memberContext)) {
-        combinedHandlers.set(name, handler);
+      allTools.push(...EVENT_ADMIN_TOOLS);
+      for (const tool of EVENT_ADMIN_TOOLS) {
+        const handler = eventHandlers.get(tool.name);
+        if (handler) combinedHandlers.set(tool.name, handler);
       }
     }
 

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -148,7 +148,7 @@ function mapLumaStatus(lumaStatus: string): RegistrationStatus {
     case 'approved':
       return 'registered';
     case 'pending_approval':
-      return 'registered'; // Treat pending as registered for historical imports
+      return 'waitlisted';
     case 'waitlist':
       return 'waitlisted';
     case 'declined':

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -17,7 +17,7 @@ import { OrganizationDatabase } from "../db/organization-db.js";
 import { upsertEmailContact } from "../db/contacts-db.js";
 import { CommunityDatabase } from "../db/community-db.js";
 import { getEventBySlug as getLumaEventBySlug, extractLumaSlug, getEventGuests, isLumaEnabled } from "../luma/client.js";
-import { createEventFromLuma } from "../luma/sync.js";
+import { createEventFromLuma, mapLumaApprovalStatus } from "../luma/sync.js";
 import { notifyUser } from "../notifications/notification-service.js";
 import {
   createCheckoutSession,
@@ -33,7 +33,6 @@ import type {
   EventStatus,
   EventType,
   EventFormat,
-  RegistrationStatus,
 } from "../types.js";
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { createChannel, setChannelPurpose, sendDirectMessage } from "../slack/client.js";
@@ -140,24 +139,7 @@ function parseDate(dateStr: string | undefined): Date | undefined {
   return date;
 }
 
-/**
- * Map Luma approval_status to our registration_status
- */
-function mapLumaStatus(lumaStatus: string): RegistrationStatus {
-  switch (lumaStatus.toLowerCase()) {
-    case 'approved':
-      return 'registered';
-    case 'pending_approval':
-      return 'waitlisted';
-    case 'waitlist':
-      return 'waitlisted';
-    case 'declined':
-    case 'cancelled':
-      return 'cancelled';
-    default:
-      return 'registered';
-  }
-}
+// Luma status mapping is shared — see mapLumaApprovalStatus in luma/sync.ts
 
 const orgDb = new OrganizationDatabase();
 const workingGroupDb = new WorkingGroupDatabase();
@@ -935,7 +917,7 @@ export function createEventsRouter(): {
             }
 
             const name = row.name || `${row.first_name || ''} ${row.last_name || ''}`.trim();
-            const registrationStatus = mapLumaStatus(row.approval_status);
+            const registrationStatus = mapLumaApprovalStatus(row.approval_status);
             const checkedInAt = parseDate(row.checked_in_at);
             const attended = !!checkedInAt;
 

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -41,7 +41,8 @@ import {
   isWebUserAAOAdmin,
 } from "../addie/mcp/admin-tools.js";
 import {
-  EVENT_TOOLS,
+  EVENT_READONLY_TOOLS,
+  EVENT_ADMIN_TOOLS,
   createEventToolHandlers,
 } from "../addie/mcp/event-tools.js";
 import {
@@ -247,14 +248,23 @@ async function buildVoiceRequestTools(
     workingGroupDb.getCommitteesLedByUser(userId),
   ]);
 
+  // Event tools: readonly for all users, admin tools for admins only
+  const eventHandlers = createEventToolHandlers(memberContext);
+  allTools.push(...EVENT_READONLY_TOOLS);
+  for (const tool of EVENT_READONLY_TOOLS) {
+    const handler = eventHandlers.get(tool.name);
+    if (handler) combinedHandlers.set(tool.name, handler);
+  }
+
   if (userIsAdmin) {
     allTools.push(...ADMIN_TOOLS);
     for (const [name, handler] of createAdminToolHandlers(memberContext)) {
       combinedHandlers.set(name, handler);
     }
-    allTools.push(...EVENT_TOOLS);
-    for (const [name, handler] of createEventToolHandlers(memberContext)) {
-      combinedHandlers.set(name, handler);
+    allTools.push(...EVENT_ADMIN_TOOLS);
+    for (const tool of EVENT_ADMIN_TOOLS) {
+      const handler = eventHandlers.get(tool.name);
+      if (handler) combinedHandlers.set(tool.name, handler);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Event tools for all users**: Split `EVENT_TOOLS` into read-only (list_events, get_event_details, register_event_interest) available to all authenticated users and admin tools (create, update, manage registrations, invites) gated behind permissions. Added `events` tool set to the Haiku router.
- **Dashboard "Upcoming events" fix**: Query now matches by email in addition to workos_user_id, so Luma-synced registrations appear. Also filters by active registration_status only.
- **Luma status mapping fix**: `pending_approval` now correctly maps to `waitlisted` (was `registered`) in both CSV import and API sync paths.
- **Luma host sync**: Added `getEventHosts()` to Luma client and sync hosts as registered attendees during event sync.
- **Admin events UI fixes**: TipTap editor height (ProseMirror element fills container), Event Recap section moved out of Attendee Group (was incorrectly nested).
- **Security**: Added visibility check to `get_event_details` so non-admin users cannot access draft/cancelled events.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 114 router + tool-sets + luma-sync unit tests pass
- [x] Full test suite: 2099 tests pass (24 pre-existing migration failures unrelated)
- [x] Pre-commit hooks pass (unit tests + typecheck)
- [x] HTML structure verified (nesting, CSS)
- [x] Code review: addressed double handler instantiation
- [x] Security review: addressed get_event_details visibility check

🤖 Generated with [Claude Code](https://claude.com/claude-code)