### PR TITLE
fix: deprecate testing.adcontextprotocol.org

### DIFF
--- a/.changeset/deprecate-testing-hostname.md
+++ b/.changeset/deprecate-testing-hostname.md
@@ -1,0 +1,4 @@
+---
+---
+
+Deprecate testing.adcontextprotocol.org — 301 redirect to validation guide, update frozen docs, teach Addie

--- a/dist/docs/2.5.3/intro.mdx
+++ b/dist/docs/2.5.3/intro.mdx
@@ -164,8 +164,8 @@ Each AdCP protocol operates within this ecosystem:
 
 Want to try AdCP right now?
 
-### 🚀 [**Interactive Testing Platform**](https://testing.adcontextprotocol.org)
-Test all AdCP tasks in your browser - no code required.
+### Interactive Testing Platform (Deprecated February 2026)
+See the [current Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for getting-started instructions.
 
 ### 📋 [**AdAgents.json Builder**](https://adcontextprotocol.org/adagents)
 Validate your publisher's adagents.json file or create a new one with guided validation and agent card verification.
@@ -265,7 +265,7 @@ Learn more in the [Protocols section](/dist/docs/2.5.3/protocols/getting-started
 
 ### Getting Started
 - 🚀 **New to AdCP?** Start with the [**Quickstart Guide**](/dist/docs/2.5.3/quickstart)
-- 🧪 **Want to test?** Try the [**Interactive Testing Platform**](https://testing.adcontextprotocol.org)
+- 🧪 **Want to test?** See the [current Quickstart](https://docs.adcontextprotocol.org/docs/quickstart)
 - 📚 **Building an integration?** Choose [MCP](/dist/docs/2.5.3/protocols/mcp-guide) or [A2A](/dist/docs/2.5.3/protocols/a2a-guide) protocol guide
 
 ### By Role

--- a/dist/docs/2.5.3/protocols/mcp-guide.mdx
+++ b/dist/docs/2.5.3/protocols/mcp-guide.mdx
@@ -9,7 +9,7 @@ Transport-specific guide for integrating AdCP using the Model Context Protocol. 
 
 ## Testing AdCP via MCP
 
-You can test AdCP tasks using the reference implementation at [testing.adcontextprotocol.org](https://testing.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
+You can test AdCP tasks using the reference implementation at [test-agent.adcontextprotocol.org](https://test-agent.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
 
 ## Tool Call Patterns
 

--- a/dist/docs/2.5.3/quickstart.mdx
+++ b/dist/docs/2.5.3/quickstart.mdx
@@ -9,7 +9,7 @@ Get started with AdCP in 5 minutes using our public test agent.
 
 ## Interactive Testing
 
-Try AdCP without writing code: **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+> The interactive testing platform (`testing.adcontextprotocol.org`) was deprecated in February 2026. Use the [Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for current getting-started instructions.
 
 ## Code Examples
 
@@ -95,7 +95,7 @@ Now that you've seen basic product discovery, explore:
 
 ## Need Help?
 
-- Try examples at **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+- See the [current Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for testing examples
 - Read the **[Introduction](/dist/docs/2.5.3/intro)** for concepts
 - Check **[Authentication](/dist/docs/2.5.3/reference/authentication)** for production setup
 

--- a/dist/docs/3.0.0-beta.3/building/integration/mcp-guide.mdx
+++ b/dist/docs/3.0.0-beta.3/building/integration/mcp-guide.mdx
@@ -9,7 +9,7 @@ Transport-specific guide for integrating AdCP using the Model Context Protocol. 
 
 ## Testing AdCP via MCP
 
-You can test AdCP tasks using the reference implementation at [testing.adcontextprotocol.org](https://testing.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
+You can test AdCP tasks using the reference implementation at [test-agent.adcontextprotocol.org](https://test-agent.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
 
 ## Tool Call Patterns
 

--- a/dist/docs/3.0.0-beta.3/intro.mdx
+++ b/dist/docs/3.0.0-beta.3/intro.mdx
@@ -232,8 +232,8 @@ AdCP covers multiple advertising domains:
 ## Quick Start
 
 <CardGroup cols={2}>
-  <Card title="Interactive Testing" icon="flask" href="https://testing.adcontextprotocol.org">
-    Test all AdCP tasks in your browser—no code required
+  <Card title="Interactive Testing (Deprecated)" icon="flask" href="https://docs.adcontextprotocol.org/docs/quickstart">
+    Deprecated February 2026. See the current Quickstart.
   </Card>
   <Card title="AdAgents.json Builder" icon="hammer" href="https://adcontextprotocol.org/adagents">
     Validate or create your publisher's adagents.json file

--- a/dist/docs/3.0.0-beta.3/quickstart.mdx
+++ b/dist/docs/3.0.0-beta.3/quickstart.mdx
@@ -9,7 +9,7 @@ Get started with AdCP in 5 minutes using our public test agent.
 
 ## Interactive Testing
 
-Try AdCP without writing code: **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+> The interactive testing platform (`testing.adcontextprotocol.org`) was deprecated in February 2026. Use the [Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for current getting-started instructions.
 
 ## Code Examples
 
@@ -95,7 +95,7 @@ Now that you've seen basic product discovery, explore:
 
 ## Need Help?
 
-- Try examples at **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+- See the [current Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for testing examples
 - Read the **[Introduction](/dist/docs/3.0.0-beta.3/intro)** for concepts
 - Check **[Authentication](/dist/docs/3.0.0-beta.3/building/integration/authentication)** for production setup
 

--- a/dist/docs/3.0.0-rc.1/building/integration/mcp-guide.mdx
+++ b/dist/docs/3.0.0-rc.1/building/integration/mcp-guide.mdx
@@ -9,7 +9,7 @@ Transport-specific guide for integrating AdCP using the Model Context Protocol. 
 
 ## Testing AdCP via MCP
 
-You can test AdCP tasks using the reference implementation at [testing.adcontextprotocol.org](https://testing.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
+You can test AdCP tasks using the reference implementation at [test-agent.adcontextprotocol.org](https://test-agent.adcontextprotocol.org). This endpoint implements all AdCP tasks as MCP tools and is useful for development and integration testing.
 
 ## Tool Call Patterns
 

--- a/dist/docs/3.0.0-rc.1/quickstart.mdx
+++ b/dist/docs/3.0.0-rc.1/quickstart.mdx
@@ -9,7 +9,7 @@ Get started with AdCP in 5 minutes using our public test agent.
 
 ## Interactive Testing
 
-Try AdCP without writing code: **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+> The interactive testing platform (`testing.adcontextprotocol.org`) was deprecated in February 2026. Use the [Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for current getting-started instructions.
 
 ## Code Examples
 
@@ -94,7 +94,7 @@ Now that you've seen basic product discovery, explore:
 
 ## Need Help?
 
-- Try examples at **[testing.adcontextprotocol.org](https://testing.adcontextprotocol.org)**
+- See the [current Quickstart](https://docs.adcontextprotocol.org/docs/quickstart) for testing examples
 - Read the **[Introduction](/dist/docs/3.0.0-rc.1/intro)** for concepts
 - Check **[Authentication](/dist/docs/3.0.0-rc.1/building/integration/authentication)** for production setup
 

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -388,6 +388,9 @@ Common issues to understand:
 - RESELLER means the publisher has authorized another entity to sell on their behalf
 - A seller claiming DIRECT when the relationship is through an intermediary is a misrepresentation
 
+## Deprecated URLs
+The interactive testing platform at `testing.adcontextprotocol.org` was deprecated in February 2026 and no longer works. It was a browser-based UI for trying AdCP without code. If someone asks about it or reports it as down, explain that it was deprecated in February 2026 and point them to the Validate Your Agent guide at https://docs.adcontextprotocol.org/docs/building/validate-your-agent instead. The URL now redirects there automatically. Do not link to or reference `testing.adcontextprotocol.org`. Note: `test-agent.adcontextprotocol.org` is a separate, active MCP-based test agent — it is not a replacement for the interactive testing UI.
+
 ## Official Libraries and Developer Resources
 Recommend the official AdCP libraries for development:
 - JavaScript/TypeScript: @adcp/client (npm)

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -103,7 +103,7 @@ import { createApiKeysRouter } from "./routes/api-keys.js";
 import { createAccountLinkingRouter, handleEmailLinkVerification } from "./routes/account-linking.js";
 import { createBrandLogoRouter } from "./routes/brand-logos.js";
 import { createTrainingAgentRouter } from "./training-agent/index.js";
-import { TRAINING_AGENT_HOSTNAMES } from "./training-agent/config.js";
+import { TRAINING_AGENT_HOSTNAMES, TRAINING_AGENT_HOSTNAME_DEPRECATED } from "./training-agent/config.js";
 import { createCreativeAgentRouter } from "./creative-agent/index.js";
 import { sendWelcomeEmail, sendUserSignupEmail, emailDb } from "./notifications/email.js";
 import { emailPrefsDb } from "./db/email-preferences-db.js";
@@ -1246,6 +1246,10 @@ export class HTTPServer {
 
     // Host-based routing: serve embedded agents at root for legacy standalone URLs
     this.app.use((req, res, next) => {
+      if (req.hostname === TRAINING_AGENT_HOSTNAME_DEPRECATED) {
+        logger.info({ path: req.path, ua: req.headers['user-agent'] }, 'deprecated testing hostname hit');
+        return res.redirect(301, 'https://docs.adcontextprotocol.org/docs/building/validate-your-agent');
+      }
       if (TRAINING_AGENT_HOSTNAMES.has(req.hostname)) {
         return trainingAgentRouter(req, res, next);
       }

--- a/server/src/training-agent/config.ts
+++ b/server/src/training-agent/config.ts
@@ -2,13 +2,12 @@
 export const TRAINING_AGENT_HOSTNAME = 'test-agent.adcontextprotocol.org';
 export const TRAINING_AGENT_URL = `https://${TRAINING_AGENT_HOSTNAME}`;
 
-/** DNS alias — some published docs reference this hostname. */
-export const TRAINING_AGENT_HOSTNAME_LEGACY = 'testing.adcontextprotocol.org';
+/** Deprecated hostname — redirects to the validation guide. */
+export const TRAINING_AGENT_HOSTNAME_DEPRECATED = 'testing.adcontextprotocol.org';
 
 /** All hostnames that resolve to the training agent. */
 export const TRAINING_AGENT_HOSTNAMES = new Set([
   TRAINING_AGENT_HOSTNAME,
-  TRAINING_AGENT_HOSTNAME_LEGACY,
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- `testing.adcontextprotocol.org` was deprecated in Feb 2026 but still routed to the training agent, causing CSRF errors for visitors who found it via old docs
- Now returns a 301 redirect to the [Validate Your Agent](https://docs.adcontextprotocol.org/docs/building/validate-your-agent) guide
- Removed from `TRAINING_AGENT_HOSTNAMES` set so it no longer hits the MCP router
- Added logging for observability on deprecated hostname hits
- Updated frozen docs (2.5.3, 3.0.0-beta.3, 3.0.0-rc.1): deprecation notices for interactive testing links, correct `test-agent` URL for MCP-specific references
- Taught Addie about the deprecation so she explains the situation instead of escalating

## Test plan
- [x] All 597 unit tests pass
- [x] TypeScript typecheck clean
- [x] Pre-push hooks pass (doc validation, link check, accessibility)
- [x] Code review: addressed all Should Fix items (observability logging, consistent redirect target in Addie knowledge)
- [x] Security review: no issues found — hardcoded redirect target, exact hostname match, net reduction in attack surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)