### PR TITLE
fix: reorder migration to update data before CHECK constraint

### DIFF
--- a/server/src/db/migrations/387_align_agent_types.sql
+++ b/server/src/db/migrations/387_align_agent_types.sql
@@ -2,18 +2,18 @@
 -- Renames: sales → buying, si → brand
 -- Adds: brand, rights, measurement, buying
 
--- Update agent_contexts CHECK constraint
-ALTER TABLE agent_contexts DROP CONSTRAINT IF EXISTS agent_contexts_agent_type_check;
-ALTER TABLE agent_contexts ADD CONSTRAINT agent_contexts_agent_type_check
-  CHECK (agent_type IN ('brand', 'rights', 'measurement', 'governance', 'creative', 'buying', 'signals', 'unknown'));
-
--- Migrate existing data
+-- Migrate existing data before changing constraints
 UPDATE agent_contexts SET agent_type = 'buying' WHERE agent_type = 'sales';
 UPDATE agent_contexts SET agent_type = 'brand' WHERE agent_type = 'si';
 
 -- Migrate discovered agents in federated index
 UPDATE discovered_agents SET agent_type = 'buying' WHERE agent_type = 'sales';
 UPDATE discovered_agents SET agent_type = 'brand' WHERE agent_type = 'si';
+
+-- Now safe to update the CHECK constraint
+ALTER TABLE agent_contexts DROP CONSTRAINT IF EXISTS agent_contexts_agent_type_check;
+ALTER TABLE agent_contexts ADD CONSTRAINT agent_contexts_agent_type_check
+  CHECK (agent_type IN ('brand', 'rights', 'measurement', 'governance', 'creative', 'buying', 'signals', 'unknown'));
 
 -- Migrate agent types stored in member_profiles.agents JSONB array
 UPDATE member_profiles


### PR DESCRIPTION
## Summary
- Migration `387_align_agent_types.sql` was adding a CHECK constraint **before** updating existing `'sales'`/`'si'` rows, causing deploys to fail
- Swapped the order: UPDATE data first, then add the constraint

## Test plan
- [x] Unit tests pass (597/597)
- [ ] Deploy succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)