### PR TITLE
fix: qualify ambiguous domain_verified in registry query

### DIFF
--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -557,7 +557,7 @@ export class BrandDatabase {
         COALESCE(brand_json->>'name', brand_json->'house'->>'name', brand_domain) as brand_name,
         'hosted' as source,
         true as has_manifest,
-        domain_verified as verified,
+        hosted_brands.domain_verified as verified,
         db.house_domain,
         COALESCE(db.keller_type, 'master') as keller_type,
         COALESCE(brand_json->'logos'->0->>'url', brand_json->'brands'->0->'logos'->0->>'url') as logo_url,


### PR DESCRIPTION
## Summary
- The `getAllBrandsForRegistry` query joins `hosted_brands` with `discovered_brands`, both of which now have a `domain_verified` column after the brand table merge migration (#2097)
- Prefixed with `hosted_brands.` to resolve the ambiguous column reference that was causing 500 errors on the registry API

## Test plan
- [x] All 597 unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify `/registry/brands` endpoint returns results without error in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)