### PR TITLE
fix: DB connection leak, org-merge race condition, and storyboard resilience

### DIFF
--- a/.changeset/fix-db-connection-leak-merge-race.md
+++ b/.changeset/fix-db-connection-leak-merge-race.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix DB connection leak in org adoption path, add FOR UPDATE to org merge to prevent stripe_customer_id race condition, and wrap storyboard upsert in SAVEPOINT for resilience when migration 390 is pending.

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -264,6 +264,8 @@ export class ComplianceDatabase {
       );
 
       // 5. Batch upsert per-storyboard statuses (single query, not N+1)
+      // Uses a SAVEPOINT so a missing table (pre-migration) doesn't roll back
+      // the entire compliance run — the run and status update still commit.
       if (input.storyboard_statuses?.length) {
         // Validate status values before sending to Postgres to surface typos
         // as clear errors instead of cryptic constraint violations inside unnest
@@ -278,37 +280,44 @@ export class ComplianceDatabase {
         const sbStepsPassed = input.storyboard_statuses.map(s => s.steps_passed);
         const sbStepsTotal = input.storyboard_statuses.map(s => s.steps_total);
 
-        await client.query(
-          `INSERT INTO agent_storyboard_status (
-            agent_url, storyboard_id, status, last_tested_at,
-            last_passed_at, last_failed_at, run_id,
-            steps_passed, steps_total, triggered_by, updated_at
-          )
-          SELECT
-            $1, sb_id, sb_status, NOW(),
-            CASE WHEN sb_status = 'passing' THEN NOW() ELSE NULL END,
-            CASE WHEN sb_status IN ('failing', 'partial') THEN NOW() ELSE NULL END,
-            $4, sb_passed, sb_total, $7, NOW()
-          FROM unnest($2::text[], $3::text[], $5::int[], $6::int[])
-            AS t(sb_id, sb_status, sb_passed, sb_total)
-          ON CONFLICT (agent_url, storyboard_id) DO UPDATE SET
-            status = EXCLUDED.status,
-            last_tested_at = NOW(),
-            last_passed_at = CASE
-              WHEN EXCLUDED.status = 'passing' THEN NOW()
-              ELSE agent_storyboard_status.last_passed_at
-            END,
-            last_failed_at = CASE
-              WHEN EXCLUDED.status IN ('failing', 'partial') THEN NOW()
-              ELSE agent_storyboard_status.last_failed_at
-            END,
-            run_id = EXCLUDED.run_id,
-            steps_passed = EXCLUDED.steps_passed,
-            steps_total = EXCLUDED.steps_total,
-            triggered_by = EXCLUDED.triggered_by,
-            updated_at = NOW()`,
-          [input.agent_url, sbIds, sbStatuses, run.id, sbStepsPassed, sbStepsTotal, input.triggered_by ?? 'heartbeat'],
-        );
+        await client.query('SAVEPOINT storyboard_upsert');
+        try {
+          await client.query(
+            `INSERT INTO agent_storyboard_status (
+              agent_url, storyboard_id, status, last_tested_at,
+              last_passed_at, last_failed_at, run_id,
+              steps_passed, steps_total, triggered_by, updated_at
+            )
+            SELECT
+              $1, sb_id, sb_status, NOW(),
+              CASE WHEN sb_status = 'passing' THEN NOW() ELSE NULL END,
+              CASE WHEN sb_status IN ('failing', 'partial') THEN NOW() ELSE NULL END,
+              $4, sb_passed, sb_total, $7, NOW()
+            FROM unnest($2::text[], $3::text[], $5::int[], $6::int[])
+              AS t(sb_id, sb_status, sb_passed, sb_total)
+            ON CONFLICT (agent_url, storyboard_id) DO UPDATE SET
+              status = EXCLUDED.status,
+              last_tested_at = NOW(),
+              last_passed_at = CASE
+                WHEN EXCLUDED.status = 'passing' THEN NOW()
+                ELSE agent_storyboard_status.last_passed_at
+              END,
+              last_failed_at = CASE
+                WHEN EXCLUDED.status IN ('failing', 'partial') THEN NOW()
+                ELSE agent_storyboard_status.last_failed_at
+              END,
+              run_id = EXCLUDED.run_id,
+              steps_passed = EXCLUDED.steps_passed,
+              steps_total = EXCLUDED.steps_total,
+              triggered_by = EXCLUDED.triggered_by,
+              updated_at = NOW()`,
+            [input.agent_url, sbIds, sbStatuses, run.id, sbStepsPassed, sbStepsTotal, input.triggered_by ?? 'heartbeat'],
+          );
+          await client.query('RELEASE SAVEPOINT storyboard_upsert');
+        } catch (sbErr) {
+          await client.query('ROLLBACK TO SAVEPOINT storyboard_upsert');
+          logger.warn({ err: sbErr, agentUrl: input.agent_url }, 'Storyboard status upsert failed (table may not exist yet)');
+        }
       }
 
       await client.query('COMMIT');

--- a/server/src/db/org-merge-db.ts
+++ b/server/src/db/org-merge-db.ts
@@ -79,7 +79,9 @@ export async function mergeOrganizations(
       'Starting organization merge'
     );
 
-    // Validate both organizations exist and fetch all needed fields
+    // Validate both organizations exist and fetch all needed fields.
+    // FOR UPDATE prevents concurrent Stripe webhooks or other merges from
+    // modifying these rows (especially stripe_customer_id) mid-transaction.
     const orgsResult = await client.query(
       `SELECT workos_organization_id, name, is_personal, prospect_notes,
               stripe_customer_id,
@@ -87,7 +89,8 @@ export async function mergeOrganizations(
               enrichment_employee_count, enrichment_revenue, enrichment_revenue_range,
               enrichment_country, enrichment_city, enrichment_description
        FROM organizations
-       WHERE workos_organization_id = ANY($1)`,
+       WHERE workos_organization_id = ANY($1)
+       FOR UPDATE`,
       [[primaryOrgId, secondaryOrgId]]
     );
 

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -1193,7 +1193,6 @@ export function createOrganizationsRouter(): Router {
 
             if (!isAdoptable) {
               await client.query('ROLLBACK');
-              client.release();
               return res.status(409).json({
                 error: 'Organization exists',
                 message: `An organization for ${verifiedDomain} already exists: "${existingOrgName}". Please search for it and request to join instead of creating a new one.`,
@@ -1271,7 +1270,6 @@ export function createOrganizationsRouter(): Router {
             });
 
             await client.query('COMMIT');
-            client.release();
 
             // Record marketing communications opt-in choice (best-effort, don't block signup)
             if (typeof marketing_opt_in === 'boolean') {
@@ -1294,11 +1292,11 @@ export function createOrganizationsRouter(): Router {
           }
 
           await client.query('ROLLBACK');
-          client.release();
         } catch (adoptError) {
           await client.query('ROLLBACK').catch(() => {});
-          client.release();
           throw adoptError;
+        } finally {
+          client.release();
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes two production system errors and adds resilience for a third that's already addressed by #2104.

### New fixes

- **Connection pool exhaustion** (`organizations.ts`): The org adoption path (`POST /api/organizations`) used manual `client.release()` calls instead of a `finally` block. If WorkOS API calls or `recordAuditLog` threw between acquiring the client and releasing it, the connection leaked. With a pool max of 10, this cascaded into health-check timeouts, job-scheduler failures, and database-pool errors.

- **Org merge `stripe_customer_id` unique constraint violation** (`org-merge-db.ts`): `mergeOrganizations` read both orgs without `FOR UPDATE`, allowing concurrent Stripe webhooks to modify `stripe_customer_id` mid-transaction. Added row-level locking to prevent the race.

### Defense-in-depth (complements #2104)

- **Storyboard upsert kills compliance runs** (`compliance-db.ts`): `recordComplianceRun` inserted into `agent_storyboard_status` inside the main transaction. If the table doesn't exist yet (migration 390 from #2104 pending), the entire compliance run rolls back — silently losing the status update. Wrapped the upsert in a `SAVEPOINT` so it fails gracefully. Once #2104's migration deploys and creates the table, the SAVEPOINT becomes a no-op.

### Already resolved upstream

- The `domain_verified` ambiguous column error was fixed in #2112. Our branch rebased on top of it — no duplicate change.

## Test plan

- [x] 597 unit tests pass
- [x] TypeScript type check passes
- [ ] Verify org adoption flow releases connections when WorkOS calls fail
- [ ] Verify org merge with concurrent Stripe webhook doesn't hit unique constraint
- [ ] Verify compliance heartbeats still record status when `agent_storyboard_status` table is missing