### PR TITLE
feat: add list_event_attendees tool for all members

### DIFF
--- a/.changeset/addie-event-attendees.md
+++ b/.changeset/addie-event-attendees.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add list_event_attendees tool so any member can see who's coming to an event

--- a/server/src/addie/mcp/event-tools.ts
+++ b/server/src/addie/mcp/event-tools.ts
@@ -934,9 +934,12 @@ export function createEventToolHandlers(
       return `❌ Event not found: "${eventSlug}"`;
     }
 
-    // Non-admin users can only see published/completed events
+    // Non-admin users can only see published/completed public events
     const isAdmin = slackUserId ? await canCreateEvents(slackUserId) : (memberContext?.org_membership?.role === 'admin');
     if (!isAdmin && !['published', 'completed'].includes(event.status)) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+    if (!isAdmin && event.visibility === 'invite_unlisted') {
       return `❌ Event not found: "${eventSlug}"`;
     }
 
@@ -1198,9 +1201,12 @@ export function createEventToolHandlers(
       return `❌ Event not found: "${eventSlug}"`;
     }
 
-    // Non-admin users can only register interest in published events
+    // Non-admin users can only register interest in published public events
     const isAdmin = slackUserId ? await canCreateEvents(slackUserId) : (memberContext?.org_membership?.role === 'admin');
     if (!isAdmin && !['published', 'completed'].includes(event.status)) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+    if (!isAdmin && event.visibility === 'invite_unlisted') {
       return `❌ Event not found: "${eventSlug}"`;
     }
 
@@ -1264,9 +1270,9 @@ export function createEventToolHandlers(
       return `❌ Event not found: "${eventSlug}"`;
     }
 
-    const registrations = await eventsDb.getEventRegistrations(event.id);
-    const registered = registrations.filter(r => r.registration_status === 'registered');
-    const waitlisted = registrations.filter(r => r.registration_status === 'waitlisted');
+    const attendees = await eventsDb.getEventAttendeeSummary(event.id);
+    const registered = attendees.filter(r => r.registration_status === 'registered');
+    const waitlisted = attendees.filter(r => r.registration_status === 'waitlisted');
 
     if (registered.length === 0 && waitlisted.length === 0) {
       return `No one has registered for **${event.title}** yet.`;

--- a/server/src/addie/mcp/event-tools.ts
+++ b/server/src/addie/mcp/event-tools.ts
@@ -417,6 +417,20 @@ the response will suggest they share their location or join industry gathering g
       required: ['event_slug'],
     },
   },
+  {
+    name: 'list_event_attendees',
+    description: `List who is registered for an event. Use when someone asks "who's coming to [event]?", "who's registered?", "attendee list", or "who will be there?". Shows names of registered attendees for published events.`,
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        event_slug: {
+          type: 'string',
+          description: 'Event slug (URL identifier) or event ID',
+        },
+      },
+      required: ['event_slug'],
+    },
+  },
 ];
 
 /**
@@ -1227,6 +1241,69 @@ export function createEventToolHandlers(
     logger.info({ eventId: event.id, email, contactId: contact.contactId }, 'Event interest registered via Addie');
 
     return `✅ You're on the interest list for **${event.title}**. We'll keep you posted on updates.`;
+  });
+
+  // List event attendees (available to all members)
+  handlers.set('list_event_attendees', async (input) => {
+    const eventSlug = input.event_slug as string;
+
+    let event = await eventsDb.getEventBySlug(eventSlug);
+    if (!event) {
+      event = await eventsDb.getEventById(eventSlug);
+    }
+    if (!event) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+
+    // Non-admin users can only see attendees for published/completed public events
+    const isAdmin = slackUserId ? await canCreateEvents(slackUserId) : (memberContext?.org_membership?.role === 'admin');
+    if (!isAdmin && !['published', 'completed'].includes(event.status)) {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+    if (!isAdmin && event.visibility === 'invite_unlisted') {
+      return `❌ Event not found: "${eventSlug}"`;
+    }
+
+    const registrations = await eventsDb.getEventRegistrations(event.id);
+    const registered = registrations.filter(r => r.registration_status === 'registered');
+    const waitlisted = registrations.filter(r => r.registration_status === 'waitlisted');
+
+    if (registered.length === 0 && waitlisted.length === 0) {
+      return `No one has registered for **${event.title}** yet.`;
+    }
+
+    const MAX_DISPLAY = 30;
+    let response = `## Who's coming to ${event.title}\n\n`;
+
+    if (registered.length > 0) {
+      response += `**Registered (${registered.length})**\n`;
+      for (const reg of registered.slice(0, MAX_DISPLAY)) {
+        const name = isAdmin
+          ? (reg.name || reg.email?.split('@')[0] || 'Unknown')
+          : (reg.name || 'Attendee');
+        const checkMark = isAdmin && reg.attended ? ' ✅' : '';
+        response += `• ${name}${checkMark}\n`;
+      }
+      if (registered.length > MAX_DISPLAY) {
+        response += `_...and ${registered.length - MAX_DISPLAY} more_\n`;
+      }
+      response += '\n';
+    }
+
+    if (waitlisted.length > 0) {
+      response += `**Waitlisted (${waitlisted.length})**\n`;
+      for (const reg of waitlisted.slice(0, MAX_DISPLAY)) {
+        const name = isAdmin
+          ? (reg.name || reg.email?.split('@')[0] || 'Unknown')
+          : (reg.name || 'Attendee');
+        response += `• ${name}\n`;
+      }
+      if (waitlisted.length > MAX_DISPLAY) {
+        response += `_...and ${waitlisted.length - MAX_DISPLAY} more_\n`;
+      }
+    }
+
+    return response;
   });
 
   // Check person's event status

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -390,8 +390,8 @@ ${ctx.source === 'channel' && !explicitlyNamedAddie ? 'These guidelines apply ON
 - Content workflows, GitHub issues, proposals → ["content"]
 - Questions about working group documents, brand guidelines, uploaded files → ["knowledge", "member"]
 - Billing, invoices, payment links, resending invoices → ["billing"]
-- Upcoming events, event registrations, "am I registered", event details, register interest → ["events"]
-- Who is coming to an event, attendee lists, invite someone to an event, create/update events → ["events", "admin"]
+- Upcoming events, event registrations, "am I registered", event details, register interest, who's coming/attending → ["events"]
+- Invite someone to an event, create/update events, manage registrations → ["events", "admin"]
 - Scheduling meetings, calendar, covering topics, joining a call, meeting agendas → ["meetings"]
 - Listing all members with payment/product/invoice status → ["admin"]
 - Task management, marking tasks done, checking tasks, reminders, logging conversations → ["admin"]
@@ -647,6 +647,21 @@ export class AddieRouter {
           };
         }
       }
+    }
+
+    // Event attendee queries - "who's coming to X", "attendee list for X"
+    const eventAttendeePattern =
+      /who(?:'s|\s+is)\s+(coming\s+to|going\s+to\s+(?:the|cannes|ces|dmexco)|registered\s+for|attending|signed\s+up\s+for)|attendee\s+list|guest\s+list|who\s+will\s+be\s+(?:at\s+the|there\s+(?:at|for)|coming\s+to)/i;
+    if (eventAttendeePattern.test(text)) {
+      const toolSets = ctx.isAAOAdmin ? ['events', 'admin'] : ['events'];
+      return {
+        action: 'respond',
+        tool_sets: toolSets,
+        confidence: 'high',
+        reason: 'Event attendee query',
+        decision_method: 'quick_match',
+        latency_ms: Date.now() - startTime,
+      };
     }
 
     // Admin engagement/analytics queries - route to admin tools

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -249,10 +249,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   events: {
     name: 'events',
-    description: 'Browse upcoming events, check event registrations, get event details, and register interest in events — available to all members',
+    description: 'Browse upcoming events, check event registrations, get event details, see who is coming, and register interest in events — available to all members',
     tools: [
       'list_events',
       'get_event_details',
+      'list_event_attendees',
       'register_event_interest',
     ],
   },

--- a/server/src/db/events-db.ts
+++ b/server/src/db/events-db.ts
@@ -534,6 +534,31 @@ export class EventsDatabase {
   }
 
   /**
+   * Get attendee summary for an event (name, status, attended only).
+   * Use this instead of getEventRegistrations when full registration data is not needed.
+   */
+  async getEventAttendeeSummary(eventId: string): Promise<Array<{
+    name: string | null;
+    email: string | null;
+    registration_status: string;
+    attended: boolean;
+  }>> {
+    const result = await query<{
+      name: string | null;
+      email: string | null;
+      registration_status: string;
+      attended: boolean;
+    }>(
+      `SELECT name, email, registration_status, attended
+       FROM event_registrations
+       WHERE event_id = $1
+       ORDER BY registered_at ASC`,
+      [eventId]
+    );
+    return result.rows;
+  }
+
+  /**
    * Get registrations by user (matches by workos_user_id OR by user's email)
    * This allows registrations created via Luma import (which only have email)
    * to be associated with a user who later signs up with that email.

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -276,6 +276,76 @@ describe('AddieRouter.quickMatch', () => {
     });
   });
 
+  describe('event attendee quick-match', () => {
+    it('should route "who\'s coming to the amsterdam meetup" to events for non-admin', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: "who's coming to the amsterdam meetup tonight" }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+      if (plan!.action === 'respond') {
+        expect(plan!.tool_sets).toEqual(['events']);
+      }
+    });
+
+    it('should route "who\'s coming" to events + admin for admins', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: "who's coming to the amsterdam meetup tonight", isAAOAdmin: true }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+      if (plan!.action === 'respond') {
+        expect(plan!.tool_sets).toEqual(['events', 'admin']);
+      }
+    });
+
+    it('should route "who is registered for the summit" to events', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'who is registered for the summit?' }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+    });
+
+    it('should route "attendee list for the NYC meetup" to events', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'attendee list for the NYC meetup' }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+    });
+
+    it('should route "who will be at the meetup" to events', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'who will be at the meetup tomorrow?' }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+    });
+
+    it('should route "who is going to Cannes" to events', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'who is going to Cannes?' }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+    });
+
+    it('should NOT match "who is going to fix this bug"', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'who is going to fix this bug?' }),
+      );
+      expect(plan).toBeNull();
+    });
+
+    it('should NOT match "who is going to handle the deployment"', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: 'who is going to handle the deployment?' }),
+      );
+      expect(plan).toBeNull();
+    });
+  });
+
   describe('substantive messages fall through to LLM router', () => {
     it('should return null for protocol questions', () => {
       const plan = router.quickMatch(


### PR DESCRIPTION
## Summary
- Adds `list_event_attendees` tool to the `events` tool set so any authenticated member can see who's registered for published events (previously admin-only via `manage_event_registrations`)
- Adds quick-match router pattern so "who's coming to [event]" queries reliably route to event tools instead of falling through to the LLM router
- Privacy: non-admins see names only (no email fallback), `invite_unlisted` events are hidden, output capped at 30 entries, attended checkmarks admin-only

## Test plan
- [x] All 597 unit tests pass (103 router tests including 8 new ones)
- [x] TypeScript compiles clean
- [x] Pre-push hooks pass (docs validation, link checking)
- [ ] Verify in Slack DM: "who's coming to the amsterdam meetup tonight" routes to events and returns attendee list
- [ ] Verify non-admin member sees names but not email-derived identifiers
- [ ] Verify invite_unlisted events return "not found" for non-admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)