### PR TITLE
fix: restore sales agent type to enum

### DIFF
--- a/.changeset/restore-sales-agent-type.md
+++ b/.changeset/restore-sales-agent-type.md
@@ -1,5 +1,5 @@
 ---
-"@anthropic/adcp": patch
+"adcontextprotocol": patch
 ---
 
 Restore `sales` agent type to the enum. Migration 387 incorrectly renamed sales→buying, but they are distinct types: sales agents sell inventory (SSPs, publishers), buying agents buy inventory (DSPs, buyer platforms).

--- a/.changeset/restore-sales-agent-type.md
+++ b/.changeset/restore-sales-agent-type.md
@@ -1,0 +1,5 @@
+---
+"@anthropic/adcp": patch
+---
+
+Restore `sales` agent type to the enum. Migration 387 incorrectly renamed sales→buying, but they are distinct types: sales agents sell inventory (SSPs, publishers), buying agents buy inventory (DSPs, buyer platforms).

--- a/server/src/addie/mcp/directory-tools.ts
+++ b/server/src/addie/mcp/directory-tools.ts
@@ -76,7 +76,7 @@ export const DIRECTORY_TOOLS: AddieTool[] = [
       properties: {
         type: {
           type: 'string',
-          enum: ['brand', 'rights', 'measurement', 'governance', 'creative', 'buying', 'signals'],
+          enum: ['brand', 'rights', 'measurement', 'governance', 'creative', 'sales', 'buying', 'signals'],
           description: 'Filter by agent type',
         },
       },

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto';
 // TYPES
 // =====================================================
 
-export type AgentType = 'brand' | 'rights' | 'measurement' | 'governance' | 'creative' | 'buying' | 'signals' | 'unknown';
+export type AgentType = 'brand' | 'rights' | 'measurement' | 'governance' | 'creative' | 'sales' | 'buying' | 'signals' | 'unknown';
 export type Protocol = 'mcp' | 'a2a';
 export type AuthType = 'bearer' | 'basic';
 

--- a/server/src/db/migrations/392_restore_sales_agent_type.sql
+++ b/server/src/db/migrations/392_restore_sales_agent_type.sql
@@ -1,0 +1,7 @@
+-- Restore 'sales' agent type that was incorrectly dropped in migration 387.
+-- Sales agents (sell-side) and buying agents (buy-side) are distinct types.
+
+ALTER TABLE agent_contexts DROP CONSTRAINT IF EXISTS agent_contexts_agent_type_check;
+
+ALTER TABLE agent_contexts ADD CONSTRAINT agent_contexts_agent_type_check
+  CHECK (agent_type IN ('brand', 'rights', 'measurement', 'governance', 'creative', 'sales', 'buying', 'signals', 'unknown'));

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -518,7 +518,7 @@ registry.registerPath({
   tags: ["Agent Discovery"],
   request: {
     query: z.object({
-      type: z.enum(["brand", "rights", "measurement", "governance", "creative", "buying", "signals", "unknown"]).optional(),
+      type: z.enum(["brand", "rights", "measurement", "governance", "creative", "sales", "buying", "signals", "unknown"]).optional(),
       health: z.enum(["true"]).optional(),
       capabilities: z.enum(["true"]).optional(),
       properties: z.enum(["true"]).optional(),

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -269,6 +269,7 @@ export const FederatedAgentWithDetailsSchema = z
       "measurement",
       "governance",
       "creative",
+      "sales",
       "buying",
       "signals",
       "unknown",
@@ -442,7 +443,7 @@ const AgentAuthorizationSummarySchema = z.object({
 const OperatorAgentSchema = z.object({
   url: z.string(),
   name: z.string(),
-  type: z.enum(["brand", "rights", "measurement", "governance", "creative", "buying", "signals", "unknown"]),
+  type: z.enum(["brand", "rights", "measurement", "governance", "creative", "sales", "buying", "signals", "unknown"]),
   authorized_by: z.array(AgentAuthorizationSummarySchema),
 });
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,10 +1,10 @@
-export type AgentType = "brand" | "rights" | "measurement" | "governance" | "creative" | "buying" | "signals" | "unknown";
+export type AgentType = "brand" | "rights" | "measurement" | "governance" | "creative" | "sales" | "buying" | "signals" | "unknown";
 
 /**
  * Valid agent type values for runtime validation.
  * Matches the brand-agent-type.json schema enum (plus "unknown" for unclassified).
  */
-export const VALID_AGENT_TYPES: readonly AgentType[] = ["brand", "rights", "measurement", "governance", "creative", "buying", "signals", "unknown"] as const;
+export const VALID_AGENT_TYPES: readonly AgentType[] = ["brand", "rights", "measurement", "governance", "creative", "sales", "buying", "signals", "unknown"] as const;
 
 /**
  * Type guard to check if a string is a valid AgentType

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -330,6 +330,7 @@ components:
             - measurement
             - governance
             - creative
+            - sales
             - buying
             - signals
             - unknown
@@ -2400,6 +2401,7 @@ paths:
               - measurement
               - governance
               - creative
+              - sales
               - buying
               - signals
               - unknown

--- a/static/schemas/source/enums/brand-agent-type.json
+++ b/static/schemas/source/enums/brand-agent-type.json
@@ -10,6 +10,7 @@
     "measurement",
     "governance",
     "creative",
+    "sales",
     "buying",
     "signals"
   ],
@@ -19,6 +20,7 @@
     "measurement": "Provides campaign measurement, attribution, and reporting services",
     "governance": "Enforces brand safety, compliance, and policy rules",
     "creative": "Manages creative asset generation, review, and approval",
+    "sales": "Sells inventory on behalf of publishers and media owners",
     "buying": "Executes media buying on behalf of the brand",
     "signals": "Provides audience signal discovery and activation"
   }

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -594,7 +594,7 @@
         },
         "brand-agent-type": {
           "$ref": "/schemas/enums/brand-agent-type.json",
-          "description": "Agent types declarable in brand.json (brand, rights, measurement, governance, creative, buying, signals)"
+          "description": "Agent types declarable in brand.json (brand, rights, measurement, governance, creative, sales, buying, signals)"
         },
         "right-use": {
           "$ref": "/schemas/enums/right-use.json",


### PR DESCRIPTION
## Summary
- Restores `sales` to the agent type enum across all surfaces (TypeScript types, Zod schemas, OpenAPI spec, JSON schema, DB constraint)
- Migration 387 incorrectly renamed `sales` → `buying`, but they are distinct types: sales agents sell inventory (SSPs, publishers), buying agents buy inventory (DSPs, buyer platforms)
- Adds migration 392 to re-allow `sales` in the `agent_contexts` CHECK constraint

Fixes #2123

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 597 unit tests pass
- [x] Schema build succeeds (`npm run build:schemas`)
- [x] Pre-push hooks pass (version sync, Mintlify validation, link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)