### PR TITLE
fix: resolve DB health check timeouts under load

### DIFF
--- a/.changeset/common-forks-open.md
+++ b/.changeset/common-forks-open.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: resolve DB health check timeouts by switching all rate limiters to CachedPostgresStore and using a dedicated connection for health checks

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -1,7 +1,8 @@
-import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
+import { Client, Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { DatabaseConfig } from "../config.js";
 
 let pool: Pool | null = null;
+let dbConfig: DatabaseConfig | null = null;
 
 /** Callback invoked on pool-level errors (set via onPoolError). */
 let poolErrorCallback: ((err: Error) => void) | null = null;
@@ -21,6 +22,8 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
   if (pool) {
     return pool;
   }
+
+  dbConfig = config;
 
   pool = new Pool({
     connectionString: config.connectionString,
@@ -76,6 +79,34 @@ export async function query<T extends QueryResultRow = any>(
 export async function getClient(): Promise<PoolClient> {
   const pool = getPool();
   return pool.connect();
+}
+
+/**
+ * Perform a health check using a dedicated connection (not from the pool).
+ * This ensures health checks succeed even when the pool is fully occupied.
+ */
+export async function healthCheck(timeoutMs = 5000): Promise<void> {
+  if (!dbConfig) {
+    throw new Error("Database not initialized. Call initializeDatabase() first.");
+  }
+
+  const client = new Client({
+    connectionString: dbConfig.connectionString,
+    host: dbConfig.host,
+    port: dbConfig.port,
+    database: dbConfig.database,
+    user: dbConfig.user,
+    password: dbConfig.password,
+    ssl: dbConfig.ssl,
+    connectionTimeoutMillis: timeoutMs,
+  });
+
+  try {
+    await client.connect();
+    await client.query('SELECT 1');
+  } finally {
+    await client.end().catch(() => {});
+  }
 }
 
 /**

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -18,7 +18,7 @@ import { CapabilityDiscovery } from "./capabilities.js";
 import { PublisherTracker } from "./publishers.js";
 import { PropertiesService } from "./properties.js";
 import { AdAgentsManager } from "./adagents-manager.js";
-import { closeDatabase, getPool } from "./db/client.js";
+import { closeDatabase, getPool, healthCheck } from "./db/client.js";
 import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
 import type { Agent, AgentType, AgentWithStats, Company } from "./types.js";
 import { isValidAgentType, VALID_MEMBER_OFFERINGS, VALID_LEGAL_DOCUMENT_TYPES } from "./types.js";
@@ -2001,23 +2001,9 @@ export class HTTPServer {
       let dbError: string | null = null;
 
       try {
-        const pool = getPool();
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const queryPromise = pool.query('SELECT 1');
-        // Prevent unhandled rejection when the timeout wins the race
-        queryPromise.catch(() => {});
-        try {
-          await Promise.race([
-            queryPromise,
-            new Promise((_, reject) => {
-              // Must exceed pool connectionTimeoutMillis (10s) to avoid
-              // false negatives when all connections are busy but the DB is healthy.
-              timer = setTimeout(() => reject(new Error('db health timeout')), 12000);
-            }),
-          ]);
-        } finally {
-          if (timer) clearTimeout(timer);
-        }
+        // Use a dedicated connection (not from the pool) so health checks
+        // succeed even when the pool is fully occupied under load.
+        await healthCheck(5000);
         checks.database = true;
       } catch (dbErr) {
         checks.database = false;

--- a/server/src/mcp/routes.ts
+++ b/server/src/mcp/routes.ts
@@ -20,7 +20,7 @@ import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import rateLimit from 'express-rate-limit';
 import { createLogger } from '../logger.js';
-import { PostgresStore } from '../middleware/pg-rate-limit-store.js';
+import { CachedPostgresStore } from '../middleware/pg-rate-limit-store.js';
 import { createUnifiedMCPServer } from './server.js';
 import { createOAuthProvider, MCP_AUTH_ENABLED } from './oauth-provider.js';
 import {
@@ -52,7 +52,7 @@ const mcpRateLimiter = rateLimit({
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('mcp:'),
+  store: new CachedPostgresStore('mcp:'),
   keyGenerator: (req: MCPAuthenticatedRequest) => {
     return `user:${req.mcpAuth?.sub || 'anonymous'}`;
   },

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,7 +1,7 @@
 import rateLimit from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
-import { PostgresStore, CachedPostgresStore } from './pg-rate-limit-store.js';
+import { CachedPostgresStore } from './pg-rate-limit-store.js';
 
 const logger = createLogger('rate-limit');
 
@@ -37,7 +37,7 @@ export const invitationRateLimiter = rateLimit({
   max: 10, // 10 requests per window
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('invite:'),
+  store: new CachedPostgresStore('invite:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -67,7 +67,7 @@ export const orgCreationRateLimiter = rateLimit({
   skipSuccessfulRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('org:'),
+  store: new CachedPostgresStore('org:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -94,7 +94,7 @@ export const brandCreationRateLimiter = rateLimit({
   max: 60,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('brand:'),
+  store: new CachedPostgresStore('brand:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -154,7 +154,7 @@ export const storyboardEvalRateLimiter = rateLimit({
   skipFailedRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('storyboard:'),
+  store: new CachedPostgresStore('storyboard:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -182,7 +182,7 @@ export const storyboardStepRateLimiter = rateLimit({
   skipFailedRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('storyboard-step:'),
+  store: new CachedPostgresStore('storyboard-step:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -209,7 +209,7 @@ export const bulkResolveRateLimiter = rateLimit({
   max: 20,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('resolve:'),
+  store: new CachedPostgresStore('resolve:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -231,7 +231,7 @@ export const emailPrefsRateLimiter = rateLimit({
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('emailprefs:'),
+  store: new CachedPostgresStore('emailprefs:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -258,7 +258,7 @@ export const adminContentWriteRateLimiter = rateLimit({
   max: 30,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('admin-content:'),
+  store: new CachedPostgresStore('admin-content:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -285,7 +285,7 @@ export const logoUploadRateLimiter = rateLimit({
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('logo:'),
+  store: new CachedPostgresStore('logo:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -7,7 +7,7 @@ import { query, getPool } from '../db/client.js';
 import { mergeUsers } from '../db/user-merge-db.js';
 import { sendEmailLinkVerification } from '../notifications/email.js';
 import { workos } from '../auth/workos-client.js';
-import { PostgresStore } from '../middleware/pg-rate-limit-store.js';
+import { CachedPostgresStore } from '../middleware/pg-rate-limit-store.js';
 
 const logger = createLogger('account-linking');
 
@@ -19,7 +19,7 @@ const sendVerificationLimiter = rateLimit({
   max: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('link-email-send:'),
+  store: new CachedPostgresStore('link-email-send:'),
   keyGenerator: (req) => req.user?.id || req.ip || 'unknown',
   validate: { keyGeneratorIpFallback: false },
 });
@@ -30,7 +30,7 @@ const verifyViewLimiter = rateLimit({
   max: 30,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('verify-email-view:'),
+  store: new CachedPostgresStore('verify-email-view:'),
   keyGenerator: (req) => req.ip || 'unknown',
   validate: { keyGeneratorIpFallback: false },
 });
@@ -41,7 +41,7 @@ const verifyExecuteLimiter = rateLimit({
   max: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new PostgresStore('verify-email-exec:'),
+  store: new CachedPostgresStore('verify-email-exec:'),
   keyGenerator: (req) => req.ip || 'unknown',
   validate: { keyGeneratorIpFallback: false },
 });

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -13,7 +13,7 @@ import { validate as uuidValidate } from "uuid";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import cors from "cors";
 import { createLogger } from "../logger.js";
-import { PostgresStore } from "../middleware/pg-rate-limit-store.js";
+import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
@@ -308,7 +308,7 @@ interface ConversationMessage {
 const chatRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 20, // 20 messages per minute per IP
-  store: new PostgresStore('chat:'),
+  store: new CachedPostgresStore('chat:'),
   message: { error: "Too many requests", message: "Please try again later" },
   standardHeaders: true,
   legacyHeaders: false,
@@ -322,7 +322,7 @@ const chatRateLimiter = rateLimit({
 const anonymousDailyLimiter = rateLimit({
   windowMs: 24 * 60 * 60 * 1000, // 24 hours
   max: 50, // 50 messages per day for anonymous users
-  store: new PostgresStore('anon-daily:'),
+  store: new CachedPostgresStore('anon-daily:'),
   skip: (req) => !!(req as any).user?.id, // Authenticated users bypass
   keyGenerator: (req) => ipKeyGenerator(req.ip || ''),
   message: {

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -74,7 +74,7 @@ import {
   createPropertyToolHandlers,
 } from "../addie/mcp/property-tools.js";
 import { AddieModelConfig } from "../config/models.js";
-import { PostgresStore } from "../middleware/pg-rate-limit-store.js";
+import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { sanitizeInput } from "../addie/security.js";
 import { getThreadService } from "../addie/thread-service.js";
 import { optionalAuth } from "../middleware/auth.js";
@@ -304,7 +304,7 @@ async function buildVoiceRequestTools(
 const llmRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 200,
-  store: new PostgresStore("tavus-llm:"),
+  store: new CachedPostgresStore("tavus-llm:"),
   keyGenerator: (req) => ipKeyGenerator(req.ip || ""),
   message: { error: { message: "Too many requests" } },
   standardHeaders: true,
@@ -316,7 +316,7 @@ const llmRateLimiter = rateLimit({
 const sessionRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 5,
-  store: new PostgresStore("tavus-session:"),
+  store: new CachedPostgresStore("tavus-session:"),
   keyGenerator: (req) => (req as Request & { user?: { id: string } }).user?.id || ipKeyGenerator(req.ip || ""),
   message: { error: "Too many requests" },
   standardHeaders: true,


### PR DESCRIPTION
## Summary

- Switched all 15 remaining `PostgresStore`-backed rate limiters to `CachedPostgresStore` (memory-first, periodic DB sync every 15s). Each `PostgresStore` was executing a DB query on every HTTP request, saturating the connection pool under load.
- Added a dedicated `healthCheck()` function in `db/client.ts` that opens a fresh `pg.Client` connection (bypasses the pool) so `/health` succeeds even when the pool is fully occupied.
- Removed the complex `Promise.race` + 12s timeout pattern from the health endpoint in favor of the simpler dedicated-connection approach with a 5s timeout.

## Files changed

- `server/src/db/client.ts` — new `healthCheck()` using dedicated `pg.Client`
- `server/src/http.ts` — simplified `/health` endpoint to use `healthCheck()`
- `server/src/middleware/rate-limit.ts` — all 8 limiters → `CachedPostgresStore`
- `server/src/routes/tavus.ts` — 2 limiters → `CachedPostgresStore`
- `server/src/routes/addie-chat.ts` — 2 limiters → `CachedPostgresStore`
- `server/src/mcp/routes.ts` — 1 limiter → `CachedPostgresStore`
- `server/src/routes/account-linking.ts` — 3 limiters → `CachedPostgresStore`

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 597 unit tests pass
- [ ] Verify health check returns 200 in staging
- [ ] Monitor DB connection pool utilization after deploy — expect significant drop
- [ ] Confirm rate limiting still works correctly (approximate cross-pod enforcement via 15s sync)