### PR TITLE
fix: resolve DB connection churn causing worker timeouts

### DIFF
--- a/.changeset/slick-hands-ask.md
+++ b/.changeset/slick-hands-ask.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: resolve DB connection churn causing enrichment and committee summary timeouts

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -52,12 +52,12 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
   for (const agent of agentsDue) {
     const startTime = Date.now();
     try {
-      // Use the owning org's saved credentials from agent_contexts.
-      // These are credentials the owner saved when connecting through Addie.
-      const auth = await complianceDb.resolveOwnerAuth(agent.agent_url);
-
-      // Pass platform_type for coherence reporting
-      const metadata = await complianceDb.getRegistryMetadata(agent.agent_url);
+      // Batch DB reads before the external HTTP call to avoid holding
+      // pool connections during the up-to-60s comply() request.
+      const [auth, metadata] = await Promise.all([
+        complianceDb.resolveOwnerAuth(agent.agent_url),
+        complianceDb.getRegistryMetadata(agent.agent_url),
+      ]);
       const platformType = metadata?.platform_type as PlatformType | undefined;
 
       const complyOptions: ComplyOptions = {

--- a/server/src/addie/jobs/scheduler.ts
+++ b/server/src/addie/jobs/scheduler.ts
@@ -156,6 +156,32 @@ class JobScheduler {
   /** Only notify Slack after this many consecutive failures. */
   private static readonly FAILURE_THRESHOLD = 2;
 
+  private static readonly MAX_CONCURRENCY = 5;
+  private activeJobs = 0;
+  private waitQueue: Array<() => void> = [];
+
+  private acquireSlot(): Promise<void> {
+    if (this.activeJobs < JobScheduler.MAX_CONCURRENCY) {
+      this.activeJobs++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(() => {
+        this.activeJobs++;
+        resolve();
+      });
+    });
+  }
+
+  private releaseSlot(): void {
+    const next = this.waitQueue.shift();
+    if (next) {
+      next();
+    } else {
+      this.activeJobs--;
+    }
+  }
+
   /**
    * Register a job configuration
    */
@@ -200,6 +226,7 @@ class JobScheduler {
         return;
       }
 
+      await this.acquireSlot();
       job.executing = true;
       const startTime = Date.now();
       try {
@@ -232,6 +259,7 @@ class JobScheduler {
           });
         }
       } finally {
+        this.releaseSlot();
         job.executing = false;
         job.lastRunAt = new Date();
         job.lastDurationMs = Date.now() - startTime;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -11,6 +11,7 @@ export interface DatabaseConfig {
   ssl?: boolean | { rejectUnauthorized: boolean };
   maxPoolSize?: number;
   connectionTimeoutMillis?: number;
+  idleTimeoutMillis?: number;
 }
 
 /**
@@ -42,5 +43,8 @@ export function getDatabaseConfig(): DatabaseConfig | null {
     connectionTimeoutMillis: process.env.DATABASE_CONNECTION_TIMEOUT_MS
       ? parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS, 10)
       : 10000,
+    idleTimeoutMillis: process.env.DATABASE_IDLE_TIMEOUT_MS
+      ? parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS, 10)
+      : 30000,
   };
 }

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -33,11 +33,12 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
     user: config.user,
     password: config.password,
     ssl: config.ssl,
-    // PgBouncer handles connection pooling on the server side. This Pool
-    // only limits concurrency — connections are closed immediately after use
-    // (idleTimeoutMillis: 1) so we never hold stale PgBouncer sessions.
+    // PgBouncer handles connection pooling on the server side, but we still
+    // keep connections alive in the local pool to avoid connection churn.
+    // Previously idleTimeoutMillis was 1ms which forced a new PgBouncer
+    // connection for every query — hammering PgBouncer under load.
     max: config.maxPoolSize || 10,
-    idleTimeoutMillis: 1,
+    idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
     connectionTimeoutMillis: config.connectionTimeoutMillis || 10000,
     allowExitOnIdle: true,
   });

--- a/server/src/routes/catalog-api.ts
+++ b/server/src/routes/catalog-api.ts
@@ -358,7 +358,7 @@ export function createCatalogApiRouter(config: CatalogApiConfig): Router {
           await client.query('COMMIT');
           return idx;
         } catch (err) {
-          await client.query('ROLLBACK');
+          await client.query('ROLLBACK').catch(() => {});
           throw err;
         } finally {
           client.release();
@@ -415,7 +415,7 @@ export function createCatalogApiRouter(config: CatalogApiConfig): Router {
           await client.query('COMMIT');
           return propIdx;
         } catch (err) {
-          await client.query('ROLLBACK');
+          await client.query('ROLLBACK').catch(() => {});
           throw err;
         } finally {
           client.release();
@@ -506,7 +506,7 @@ export function createCatalogApiRouter(config: CatalogApiConfig): Router {
           await client.query('COMMIT');
           return propIdx;
         } catch (err) {
-          await client.query('ROLLBACK');
+          await client.query('ROLLBACK').catch(() => {});
           throw err;
         } finally {
           client.release();

--- a/server/src/services/brand-enrichment.ts
+++ b/server/src/services/brand-enrichment.ts
@@ -26,6 +26,17 @@ import type { BrandClassification } from './brand-classifier.js';
 
 const logger = createLogger('brand-enrichment');
 
+const _backgroundWork = new Set<Promise<unknown>>();
+
+export function trackBackground(p: Promise<unknown>): void {
+  _backgroundWork.add(p);
+  p.finally(() => _backgroundWork.delete(p));
+}
+
+export function drainBackgroundWork(): Promise<unknown[]> {
+  return Promise.allSettled([..._backgroundWork]);
+}
+
 // Generic page titles that Brandfetch sometimes returns instead of brand names
 const GENERIC_NAMES = new Set([
   'about', 'home', 'welcome', 'homepage', 'contact', 'products', 'services',
@@ -614,10 +625,10 @@ export async function expandHouse(houseDomain: string, options: {
         'Background enrichment complete'
       );
     };
-    // Fire and forget — don't await
-    enrichInBackground().catch(err => {
+    const bgPromise = enrichInBackground().catch(err => {
       logger.error({ err, houseDomain }, 'Background enrichment crashed');
     });
+    trackBackground(bgPromise);
   }
 
   logger.info(

--- a/server/src/services/enrichment.ts
+++ b/server/src/services/enrichment.ts
@@ -6,7 +6,7 @@
  * don't need to manage enrichment manually.
  */
 
-import { getPool } from '../db/client.js';
+import { getPool, getClient } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import {
   getLushaClient,
@@ -26,6 +26,9 @@ const ENRICHMENT_STALE_DAYS = 30;
 
 // Maximum number of enrichments per batch to avoid rate limits
 const MAX_BATCH_SIZE = 10;
+
+// Statement timeout for enrichment queries (ms) to prevent connection hogging
+const ENRICHMENT_QUERY_TIMEOUT_MS = 8000;
 
 export interface EnrichmentResult {
   success: boolean;
@@ -64,7 +67,6 @@ async function saveEnrichmentToOrg(
   orgId: string,
   enrichmentData: LushaCompanyData
 ): Promise<void> {
-  const pool = getPool();
   const suggestedCompanyType = mapIndustryToCompanyType(
     enrichmentData.mainIndustry,
     enrichmentData.subIndustry
@@ -73,44 +75,55 @@ async function saveEnrichmentToOrg(
     enrichmentData.revenueRange || formatRevenueRange(enrichmentData.revenue);
   const suggestedRevenueTier = mapRevenueToTier(enrichmentData.revenue);
 
-  await pool.query(
-    `UPDATE organizations SET
-      enrichment_data = $1,
-      enrichment_source = 'lusha',
-      enrichment_at = NOW(),
-      enrichment_revenue = $2,
-      enrichment_revenue_range = $3,
-      enrichment_employee_count = $4,
-      enrichment_employee_count_range = $5,
-      enrichment_industry = $6,
-      enrichment_sub_industry = $7,
-      enrichment_founded_year = $8,
-      enrichment_country = $9,
-      enrichment_city = $10,
-      enrichment_linkedin_url = $11,
-      enrichment_description = $12,
-      company_type = COALESCE(company_type, $13),
-      revenue_tier = COALESCE(revenue_tier, $14),
-      updated_at = NOW()
-    WHERE workos_organization_id = $15`,
-    [
-      JSON.stringify(enrichmentData),
-      enrichmentData.revenue || null,
-      revenueRange,
-      enrichmentData.employeeCount || null,
-      enrichmentData.employeeCountRange || null,
-      enrichmentData.mainIndustry || null,
-      enrichmentData.subIndustry || null,
-      enrichmentData.foundedYear || null,
-      enrichmentData.country || null,
-      enrichmentData.city || null,
-      enrichmentData.linkedinUrl || null,
-      enrichmentData.description || null,
-      suggestedCompanyType,
-      suggestedRevenueTier,
-      orgId,
-    ]
-  );
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL statement_timeout = '${ENRICHMENT_QUERY_TIMEOUT_MS}ms'`);
+    await client.query(
+      `UPDATE organizations SET
+        enrichment_data = $1,
+        enrichment_source = 'lusha',
+        enrichment_at = NOW(),
+        enrichment_revenue = $2,
+        enrichment_revenue_range = $3,
+        enrichment_employee_count = $4,
+        enrichment_employee_count_range = $5,
+        enrichment_industry = $6,
+        enrichment_sub_industry = $7,
+        enrichment_founded_year = $8,
+        enrichment_country = $9,
+        enrichment_city = $10,
+        enrichment_linkedin_url = $11,
+        enrichment_description = $12,
+        company_type = COALESCE(company_type, $13),
+        revenue_tier = COALESCE(revenue_tier, $14),
+        updated_at = NOW()
+      WHERE workos_organization_id = $15`,
+      [
+        JSON.stringify(enrichmentData),
+        enrichmentData.revenue || null,
+        revenueRange,
+        enrichmentData.employeeCount || null,
+        enrichmentData.employeeCountRange || null,
+        enrichmentData.mainIndustry || null,
+        enrichmentData.subIndustry || null,
+        enrichmentData.foundedYear || null,
+        enrichmentData.country || null,
+        enrichmentData.city || null,
+        enrichmentData.linkedinUrl || null,
+        enrichmentData.description || null,
+        suggestedCompanyType,
+        suggestedRevenueTier,
+        orgId,
+      ]
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
 
   logger.info(
     { orgId, companyName: enrichmentData.companyName, suggestedCompanyType, suggestedRevenueTier },
@@ -199,11 +212,14 @@ async function saveEnrichmentToOrg(
     );
   }
 
-  // Fire and forget - don't block enrichment on knowledge writes
+  // Await knowledge writes so pool connections are released before returning.
+  // Previously these were fire-and-forget, which leaked pool connections under load.
   if (knowledgeWrites.length > 0) {
-    Promise.all(knowledgeWrites).catch(err => {
+    try {
+      await Promise.all(knowledgeWrites);
+    } catch (err) {
       logger.warn({ err, orgId }, 'Failed to write enrichment data to org_knowledge');
-    });
+    }
   }
 }
 
@@ -225,33 +241,44 @@ export async function enrichOrganization(
 
   const pool = getPool();
 
-  // Check if already enriched and not stale
-  const existingResult = await pool.query(
-    `SELECT enrichment_at, enrichment_data, enrichment_industry, enrichment_revenue,
-            enrichment_revenue_range, enrichment_employee_count, company_type
-     FROM organizations WHERE workos_organization_id = $1`,
-    [orgId]
-  );
+  // Check if already enriched and not stale (with statement timeout to avoid holding connections)
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL statement_timeout = '${ENRICHMENT_QUERY_TIMEOUT_MS}ms'`);
+    const existingResult = await client.query(
+      `SELECT enrichment_at, enrichment_data, enrichment_industry, enrichment_revenue,
+              enrichment_revenue_range, enrichment_employee_count, company_type
+       FROM organizations WHERE workos_organization_id = $1`,
+      [orgId]
+    );
+    await client.query('COMMIT');
 
-  if (existingResult.rows.length > 0) {
-    const existing = existingResult.rows[0];
-    if (!isEnrichmentStale(existing.enrichment_at)) {
-      // Return cached data
-      return {
-        success: true,
-        domain,
-        enriched: true,
-        cached: true,
-        data: {
-          companyName: existing.enrichment_data?.companyName,
-          employeeCount: existing.enrichment_employee_count,
-          revenue: existing.enrichment_revenue,
-          revenueRange: existing.enrichment_revenue_range,
-          industry: existing.enrichment_industry,
-          suggestedCompanyType: existing.company_type,
-        },
-      };
+    if (existingResult.rows.length > 0) {
+      const existing = existingResult.rows[0];
+      if (!isEnrichmentStale(existing.enrichment_at)) {
+        // Return cached data
+        return {
+          success: true,
+          domain,
+          enriched: true,
+          cached: true,
+          data: {
+            companyName: existing.enrichment_data?.companyName,
+            employeeCount: existing.enrichment_employee_count,
+            revenue: existing.enrichment_revenue,
+            revenueRange: existing.enrichment_revenue_range,
+            industry: existing.enrichment_industry,
+            suggestedCompanyType: existing.company_type,
+          },
+        };
+      }
     }
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
   }
 
   // Fetch fresh enrichment data
@@ -516,24 +543,37 @@ export async function enrichMissingOrganizations(
 
   // Find organizations without enrichment data that have a domain
   // Priority: accounts with users first, then prospects
-  const result = await pool.query(`
-    SELECT o.workos_organization_id, o.name, o.email_domain,
-           CASE WHEN om.workos_organization_id IS NOT NULL THEN true ELSE false END as has_users
-    FROM organizations o
-    LEFT JOIN (
-      SELECT DISTINCT workos_organization_id FROM organization_memberships
-    ) om ON om.workos_organization_id = o.workos_organization_id
-    WHERE o.enrichment_at IS NULL
-      AND o.email_domain IS NOT NULL
-      AND o.email_domain != ''
-      ${includeEmptyProspects ? '' : 'AND om.workos_organization_id IS NOT NULL'}
-    ORDER BY
-      -- Prioritize accounts with users
-      CASE WHEN om.workos_organization_id IS NOT NULL THEN 0 ELSE 1 END,
-      o.last_activity_at DESC NULLS LAST,
-      o.created_at DESC
-    LIMIT $1
-  `, [limit]);
+  // Use a dedicated client with statement timeout to avoid hogging connections
+  const batchClient = await getClient();
+  let result;
+  try {
+    await batchClient.query('BEGIN');
+    await batchClient.query(`SET LOCAL statement_timeout = '${ENRICHMENT_QUERY_TIMEOUT_MS}ms'`);
+    result = await batchClient.query(`
+      SELECT o.workos_organization_id, o.name, o.email_domain,
+             CASE WHEN om.workos_organization_id IS NOT NULL THEN true ELSE false END as has_users
+      FROM organizations o
+      LEFT JOIN (
+        SELECT DISTINCT workos_organization_id FROM organization_memberships
+      ) om ON om.workos_organization_id = o.workos_organization_id
+      WHERE o.enrichment_at IS NULL
+        AND o.email_domain IS NOT NULL
+        AND o.email_domain != ''
+        ${includeEmptyProspects ? '' : 'AND om.workos_organization_id IS NOT NULL'}
+      ORDER BY
+        -- Prioritize accounts with users
+        CASE WHEN om.workos_organization_id IS NOT NULL THEN 0 ELSE 1 END,
+        o.last_activity_at DESC NULLS LAST,
+        o.created_at DESC
+      LIMIT $1
+    `, [limit]);
+    await batchClient.query('COMMIT');
+  } catch (err) {
+    await batchClient.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    batchClient.release();
+  }
 
   let enriched = 0;
   let failed = 0;
@@ -557,10 +597,21 @@ export async function enrichMissingOrganizations(
         });
       } else if (enrichResult.error === 'Company not found') {
         // Mark as attempted so we don't keep re-querying Lusha for the same domain
-        await pool.query(
-          `UPDATE organizations SET enrichment_at = NOW(), enrichment_source = 'lusha_not_found' WHERE workos_organization_id = $1`,
-          [org.workos_organization_id]
-        );
+        const notFoundClient = await getClient();
+        try {
+          await notFoundClient.query('BEGIN');
+          await notFoundClient.query(`SET LOCAL statement_timeout = '${ENRICHMENT_QUERY_TIMEOUT_MS}ms'`);
+          await notFoundClient.query(
+            `UPDATE organizations SET enrichment_at = NOW(), enrichment_source = 'lusha_not_found' WHERE workos_organization_id = $1`,
+            [org.workos_organization_id]
+          );
+          await notFoundClient.query('COMMIT');
+        } catch (err) {
+          await notFoundClient.query('ROLLBACK').catch(() => {});
+          throw err;
+        } finally {
+          notFoundClient.release();
+        }
         skipped++;
         details.push({
           orgId: org.workos_organization_id,

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -9,7 +9,7 @@ import { getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import { WorkOS, DomainDataState } from '@workos-inc/node';
 import { resolveOrgByDomain } from '../db/domain-resolution-db.js';
-import { researchDomain } from './brand-enrichment.js';
+import { researchDomain, trackBackground } from './brand-enrichment.js';
 import { enrichOrganization } from './enrichment.js';
 import { isLushaConfigured } from './lusha.js';
 import { COMPANY_TYPE_VALUES } from '../config/company-types.js';
@@ -198,13 +198,13 @@ export async function createProspect(
         [workosOrg.id, normalizedDomain]
       );
 
-      // Auto-enrich in background (brand registry + firmographics)
-      researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
+      const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
         logger.warn(
           { err, domain: normalizedDomain, orgId: workosOrg.id },
           'Background research failed for new prospect'
         );
       });
+      trackBackground(bgPromise);
     }
 
     return {


### PR DESCRIPTION
## Summary

Holistic fix for DB connection timeouts hitting enrichment workers, committee summary generator, and health checks.

**Root cause**: `idleTimeoutMillis` was hardcoded to `1ms` in the connection pool, destroying every connection immediately after use. This forced a new PgBouncer handshake for every single query — under load, hundreds of connect/disconnect cycles per second exhausted PgBouncer's server-side pool, causing `client_idle_timeout` kills and cascading health check failures.

### Commit 1: Connection churn fix
- Make `idleTimeoutMillis` configurable via `DATABASE_IDLE_TIMEOUT_MS` (default 30s, matching `.env.local.example` which was previously ignored by the code)
- Await fire-and-forget knowledge writes in enrichment service to prevent pool connection leaks
- Use `BEGIN/SET LOCAL/COMMIT` for statement timeouts to prevent settings leaking across PgBouncer sessions

### Commit 2: Broader DB connection audit fixes
- **Job concurrency limiter** — cap concurrent background jobs to 5 via scheduler semaphore (previously all 23 jobs could run simultaneously against 20-connection pool)
- **Compliance heartbeat** — batch DB reads with `Promise.all()` before 60s external HTTP call so pool connections aren't held during network I/O
- **Background work tracking** — fire-and-forget DB work in brand-enrichment and prospect services now tracked via `trackBackground()` for graceful shutdown visibility
- **ROLLBACK safety** — add `.catch()` to 3 ROLLBACK calls in catalog-api so a dead connection during rollback doesn't mask the original error

## Test plan
- [x] Unit tests pass (597/597)
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [ ] Monitor worker logs for `client_idle_timeout` and `Connection terminated due to connection timeout` errors after deploy
- [ ] Verify health check endpoint responds consistently under load
- [ ] Confirm enrichment and committee summary jobs complete without connection errors