### PR TITLE
fix: eliminate DB pool exhaustion from N+1 queries and untracked background work

### DIFF
--- a/.changeset/fix-db-pool-exhaustion.md
+++ b/.changeset/fix-db-pool-exhaustion.md
@@ -1,5 +1,9 @@
 ---
-"adcontextprotocol": patch
 ---
 
-fix: switch notification rate limiter to in-memory store and increase default DB pool size from 10 to 20 to prevent connection pool exhaustion under load
+fix: eliminate DB pool exhaustion from N+1 queries and untracked background work
+
+- Batch brand lookups in carousel and members endpoints into single `WHERE IN` queries instead of one query per profile
+- Batch credential lookups in members endpoint into single query instead of one per org
+- Wrap all fire-and-forget enrichOrganization/researchDomain/triageAndNotify calls in trackBackground()
+- Drain tracked background work during graceful shutdown before closing DB pool

--- a/.changeset/fluffy-grapes-fetch.md
+++ b/.changeset/fluffy-grapes-fetch.md
@@ -1,4 +1,0 @@
----
----
-
-fix: track all fire-and-forget background promises and drain on shutdown

--- a/.changeset/fluffy-grapes-fetch.md
+++ b/.changeset/fluffy-grapes-fetch.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: track all fire-and-forget background promises and drain on shutdown

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -368,6 +368,25 @@ export class BrandDatabase {
   }
 
   /**
+   * Batch-fetch discovered brands for multiple domains in a single query.
+   * Returns a Map keyed by lowercase domain.
+   */
+  async getDiscoveredBrandsByDomains(domains: string[]): Promise<Map<string, DiscoveredBrand>> {
+    if (domains.length === 0) return new Map();
+    const lower = domains.map(d => d.toLowerCase());
+    const placeholders = lower.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await query<DiscoveredBrand>(
+      `SELECT * FROM brands WHERE domain IN (${placeholders})`,
+      lower
+    );
+    const map = new Map<string, DiscoveredBrand>();
+    for (const row of result.rows) {
+      map.set(row.domain, this.deserializeDiscoveredBrand(row));
+    }
+    return map;
+  }
+
+  /**
    * Get discovered brand by domain + optional brand_id (brand reference lookup).
    * If brand_id is provided, looks for a brand with that brand_id under the domain.
    * If no brand_id, falls back to getDiscoveredBrandByDomain.

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -738,6 +738,32 @@ export async function getOrgMemberCredentials(workosOrgId: string): Promise<Publ
   return result.rows;
 }
 
+/**
+ * Batch-fetch earned credentials for multiple organizations in a single query.
+ * Returns a Map keyed by workos_organization_id.
+ */
+export async function getOrgMemberCredentialsBatch(orgIds: string[]): Promise<Map<string, PublicUserCredential[]>> {
+  const map = new Map<string, PublicUserCredential[]>();
+  if (orgIds.length === 0) return map;
+  const placeholders = orgIds.map((_, i) => `$${i + 1}`).join(', ');
+  const result = await query<PublicUserCredential & { workos_organization_id: string }>(
+    `SELECT DISTINCT ON (om.workos_organization_id, cc.tier)
+       om.workos_organization_id, uc.credential_id, cc.name AS credential_name, cc.tier, uc.awarded_at
+     FROM user_credentials uc
+     JOIN certification_credentials cc ON cc.id = uc.credential_id
+     JOIN organization_memberships om ON om.workos_user_id = uc.workos_user_id
+     WHERE om.workos_organization_id IN (${placeholders})
+     ORDER BY om.workos_organization_id, cc.tier DESC, uc.awarded_at DESC`,
+    orgIds
+  );
+  for (const row of result.rows) {
+    const existing = map.get(row.workos_organization_id) || [];
+    existing.push({ credential_id: row.credential_id, credential_name: row.credential_name, tier: row.tier, awarded_at: row.awarded_at });
+    map.set(row.workos_organization_id, existing);
+  }
+  return map;
+}
+
 // =====================================================
 // ORGANIZATION CERTIFICATION SUMMARY
 // =====================================================

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7616,10 +7616,22 @@ Disallow: /api/admin/
           offset: offset ? parseInt(offset as string, 10) : 0,
         });
 
-        // Resolve brand data and credentials in parallel for all profiles
-        await Promise.all(profiles.map(async (profile) => {
+        // Batch-fetch all brand data and credentials in two queries instead of N+1
+        const brandDomains = profiles
+          .map(p => p.primary_brand_domain)
+          .filter((d): d is string => !!d);
+        const orgIds = profiles.map(p => p.workos_organization_id);
+
+        const [brandsMap, credentialsMap] = await Promise.all([
+          this.brandDb.getDiscoveredBrandsByDomains(brandDomains),
+          import('./db/certification-db.js')
+            .then(({ getOrgMemberCredentialsBatch }) => getOrgMemberCredentialsBatch(orgIds))
+            .catch(() => new Map<string, any[]>()),
+        ]);
+
+        for (const profile of profiles) {
           if (profile.primary_brand_domain) {
-            const brand = await this.brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+            const brand = brandsMap.get(profile.primary_brand_domain.toLowerCase());
             if (brand?.brand_manifest) {
               profile.resolved_brand = resolveBrandFromJson(
                 profile.primary_brand_domain,
@@ -7628,12 +7640,11 @@ Disallow: /api/admin/
               );
             }
           }
-          // Add earned credentials for org members
-          try {
-            const { getOrgMemberCredentials } = await import('./db/certification-db.js');
-            (profile as any).credentials = await getOrgMemberCredentials(profile.workos_organization_id);
-          } catch { /* credentials optional */ }
-        }));
+          const creds = credentialsMap.get(profile.workos_organization_id);
+          if (creds) {
+            (profile as any).credentials = creds;
+          }
+        }
 
         res.json({ members: profiles });
       } catch (error) {
@@ -7649,11 +7660,16 @@ Disallow: /api/admin/
       try {
         const profiles = await memberDb.getCarouselProfiles();
 
-        // Resolve brand data for carousel profiles
+        // Batch-fetch all brand data in a single query to avoid pool exhaustion
         // codeql[js/user-controlled-bypass] - brand domains come from server-side DB, not user input
-        await Promise.all(profiles.map(async (profile) => {
+        const brandDomains = profiles
+          .map(p => p.primary_brand_domain)
+          .filter((d): d is string => !!d);
+        const brandsMap = await this.brandDb.getDiscoveredBrandsByDomains(brandDomains);
+
+        for (const profile of profiles) {
           if (profile.primary_brand_domain) {
-            const brand = await this.brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+            const brand = brandsMap.get(profile.primary_brand_domain.toLowerCase());
             if (brand?.brand_manifest) {
               profile.resolved_brand = resolveBrandFromJson(
                 profile.primary_brand_domain,
@@ -7662,7 +7678,7 @@ Disallow: /api/admin/
               );
             }
           }
-        }));
+        }
 
         res.json({ members: profiles });
       } catch (error) {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -8340,6 +8340,12 @@ Disallow: /api/admin/
       }).catch(() => {});
     }
 
+    // Drain tracked background work before closing connections
+    const { drainBackgroundWork } = await import('./services/brand-enrichment.js');
+    logger.info('Draining background work');
+    await drainBackgroundWork();
+    logger.info('Background work drained');
+
     // Close HTTP server
     if (this.server) {
       await new Promise<void>((resolve, reject) => {

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -10,6 +10,7 @@ import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { SlackDatabase } from "../../db/slack-db.js";
 import { enrichOrganization } from "../../services/enrichment.js";
+import { trackBackground } from "../../services/brand-enrichment.js";
 import {
   addPersonalDomain,
   removePersonalDomain,
@@ -280,9 +281,11 @@ export function setupDomainRoutes(
         );
 
         // Auto-enrich the new organization in the background
-        enrichOrganization(workosOrg.id, domain).catch((err) => {
-          logger.warn({ err, domain, orgId: workosOrg.id }, "Background enrichment failed");
-        });
+        trackBackground(
+          enrichOrganization(workosOrg.id, domain).catch((err) => {
+            logger.warn({ err, domain, orgId: workosOrg.id }, "Background enrichment failed");
+          })
+        );
 
         // Link the unmapped Slack users to this new prospect
         const linkResult = await slackDb.linkSlackUsersByDomain(domain, workosOrg.id);
@@ -458,9 +461,11 @@ export function setupDomainRoutes(
             );
 
             // Auto-enrich in background
-            enrichOrganization(workosOrg.id, normalizedDomain).catch((err) => {
-              logger.warn({ err, domain: normalizedDomain, orgId: workosOrg.id }, "Background enrichment failed");
-            });
+            trackBackground(
+              enrichOrganization(workosOrg.id, normalizedDomain).catch((err) => {
+                logger.warn({ err, domain: normalizedDomain, orgId: workosOrg.id }, "Background enrichment failed");
+              })
+            );
 
             // Link unmapped Slack users to this new prospect (same as single-create)
             if (source === 'slack') {
@@ -746,9 +751,11 @@ export function setupDomainRoutes(
         );
 
         // Auto-enrich the new organization in the background
-        enrichOrganization(workosOrg.id, domain).catch((err) => {
-          logger.warn({ err, domain, orgId: workosOrg.id }, "Background enrichment failed");
-        });
+        trackBackground(
+          enrichOrganization(workosOrg.id, domain).catch((err) => {
+            logger.warn({ err, domain, orgId: workosOrg.id }, "Background enrichment failed");
+          })
+        );
 
         res.status(201).json({
           ...result.rows[0],

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -25,7 +25,7 @@ import { workos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { tryAutoLinkWebsiteUserToSlack } from '../slack/sync.js';
 import { triageAndNotify } from '../services/prospect-triage.js';
-import { researchDomain } from '../services/brand-enrichment.js';
+import { researchDomain, trackBackground } from '../services/brand-enrichment.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
 import { resolvePreferredOrganization, backfillPrimaryOrganization } from '../db/users-db.js';
 import { notifySystemError } from '../addie/error-notifier.js';
@@ -781,17 +781,21 @@ export function createWorkOSWebhooksRouter(): Router {
                 // Assess prospect value and notify Slack
                 if (process.env.ANTHROPIC_API_KEY) {
                   const name = [user.first_name, user.last_name].filter(Boolean).join(' ') || undefined;
-                  triageAndNotify(domain, { name, email: user.email, source: 'inbound' }).catch(err => {
-                    logger.error({ err, domain }, 'Prospect triage failed for new website user');
-                  });
+                  trackBackground(
+                    triageAndNotify(domain, { name, email: user.email, source: 'inbound' }).catch(err => {
+                      logger.error({ err, domain }, 'Prospect triage failed for new website user');
+                    })
+                  );
                 }
                 // Classify brand hierarchy before the user finishes onboarding
                 const isValidDomain = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(domain)
                   && !(/^\d+\.\d+\.\d+\.\d+$/.test(domain));
                 if (isValidDomain && !isFreeEmailDomain(domain)) {
-                  researchDomain(domain).catch(err => {
-                    logger.warn({ err, domain }, 'Background domain research failed for new user');
-                  });
+                  trackBackground(
+                    researchDomain(domain).catch(err => {
+                      logger.warn({ err, domain }, 'Background domain research failed for new user');
+                    })
+                  );
                 }
               }
             }
@@ -821,9 +825,11 @@ export function createWorkOSWebhooksRouter(): Router {
             // Auto-research the primary domain for brand registry coverage
             const primaryDomain = newOrg.domains.length > 0 ? newOrg.domains[0].domain : null;
             if (primaryDomain) {
-              researchDomain(primaryDomain, { org_id: newOrg.id }).catch(err => {
-                logger.warn({ err, orgId: newOrg.id, domain: primaryDomain }, 'Background research failed for new org');
-              });
+              trackBackground(
+                researchDomain(primaryDomain, { org_id: newOrg.id }).catch(err => {
+                  logger.warn({ err, orgId: newOrg.id, domain: primaryDomain }, 'Background research failed for new org');
+                })
+              );
             }
             break;
           }

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -410,9 +410,11 @@ export async function updateProspect(
 
   // Trigger enrichment if domain changed
   if (input.triggerEnrichment && input.fields.email_domain && isLushaConfigured()) {
-    enrichOrganization(orgId, input.fields.email_domain as string).catch(err => {
-      logger.warn({ err, orgId }, 'Background enrichment failed after update');
-    });
+    trackBackground(
+      enrichOrganization(orgId, input.fields.email_domain as string).catch(err => {
+        logger.warn({ err, orgId }, 'Background enrichment failed after update');
+      })
+    );
   }
 
   return {


### PR DESCRIPTION
## What changed?

**N+1 query elimination (the main fix for pool timeouts):**
- Carousel endpoint (`GET /api/members/carousel`) was firing a separate `SELECT * FROM brands` for every profile via `Promise.all(profiles.map(...))`. With 15+ profiles, this grabbed 15+ pool connections simultaneously from a 20-connection pool.
- Members endpoint (`GET /api/members`) was even worse — 2 queries per profile (brand + credentials), up to 500 profiles = 1000 concurrent connection attempts.
- Both endpoints now use batch `WHERE domain IN (...)` queries — **2 total connections regardless of profile count**.

**Background promise tracking:**
- Wrapped all fire-and-forget `enrichOrganization()`, `researchDomain()`, and `triageAndNotify()` calls in `trackBackground()` across 4 files (6 call sites).
- Added `drainBackgroundWork()` to graceful shutdown before `closeDatabase()`.

## Why?

The N+1 pattern was the primary cause of `timeout exceeded when trying to connect` errors on both web and worker processes. When 15+ carousel profiles each grab a pool connection concurrently, the 20-connection pool is exhausted — and any other concurrent request (including health checks) times out waiting for a connection. The DB server itself gets overwhelmed, causing even dedicated health check connections to fail.

## Files changed

- **`server/src/db/brand-db.ts`** — Added `getDiscoveredBrandsByDomains()` batch method
- **`server/src/db/certification-db.ts`** — Added `getOrgMemberCredentialsBatch()` batch method
- **`server/src/http.ts`** — Replaced N+1 `Promise.all(map)` with batch queries in both endpoints; added `drainBackgroundWork()` to shutdown
- **`server/src/services/prospect.ts`** — Wrapped `enrichOrganization()` in `trackBackground()`
- **`server/src/routes/admin/domains.ts`** — Wrapped 3 `enrichOrganization()` calls in `trackBackground()`
- **`server/src/routes/workos-webhooks.ts`** — Wrapped `triageAndNotify()` + 2 `researchDomain()` calls in `trackBackground()`

## Test plan

- [x] Unit tests pass (597/597)
- [x] TypeScript compiles cleanly
- [ ] Deploy to staging and confirm `database-pool` and `health-check` errors stop
- [ ] Verify carousel and members endpoints return correct brand/credential data
- [ ] Verify graceful shutdown completes without orphaned connections