### PR TITLE
fix: normalize Slack smart quotes in router quickMatch

### DIFF
--- a/.changeset/bold-chefs-cross.md
+++ b/.changeset/bold-chefs-cross.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: normalize Slack smart quotes in router quickMatch so event attendee patterns match

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -630,7 +630,10 @@ export class AddieRouter {
    */
   quickMatch(ctx: RoutingContext): ExecutionPlan | null {
     const startTime = Date.now();
-    const text = ctx.message.toLowerCase().trim();
+    // Normalize smart quotes (Slack converts ' to \u2018/\u2019 and " to \u201C/\u201D)
+    const text = ctx.message.toLowerCase().trim()
+      .replace(/[\u2018\u2019]/g, "'")
+      .replace(/[\u201C\u201D]/g, '"');
 
     // In threads, brief messages ("yes", "done", "ok") are responses to
     // something Addie said — let the LLM router see them with thread context.

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -331,6 +331,17 @@ describe('AddieRouter.quickMatch', () => {
       expect(plan!.action).toBe('respond');
     });
 
+    it('should match Slack smart quotes in "who\u2019s coming to"', () => {
+      const plan = router.quickMatch(
+        makeCtx({ message: "who\u2019s coming to the amsterdam meetup tonight" }),
+      );
+      expect(plan).not.toBeNull();
+      expect(plan!.action).toBe('respond');
+      if (plan!.action === 'respond') {
+        expect(plan!.tool_sets).toEqual(['events']);
+      }
+    });
+
     it('should NOT match "who is going to fix this bug"', () => {
       const plan = router.quickMatch(
         makeCtx({ message: 'who is going to fix this bug?' }),


### PR DESCRIPTION
## Summary
- Slack auto-converts straight quotes to smart quotes (U+2018/U+2019), which broke regex patterns in the router's `quickMatch` — event attendee queries like "who's coming to the amsterdam meetup" were silently falling through to the LLM router
- Added smart quote normalization (single + double) at the top of `quickMatch` so all existing patterns match regardless of quote style
- Added a test case for the smart quote variant

## Test plan
- [x] New unit test: smart quote `who\u2019s coming to` matches events tool set
- [x] All 597 existing tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)