### PR TITLE
fix: replace N+1 query in listAllAgents with bulk fetch

### DIFF
--- a/.changeset/yellow-heads-go.md
+++ b/.changeset/yellow-heads-go.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: replace N+1 query in listAllAgents with bulk fetch to eliminate DB pool exhaustion

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -126,6 +126,35 @@ export class FederatedIndexDatabase {
   }
 
   /**
+   * Bulk-fetch first authorization for multiple agents in a single query.
+   * Returns a Map from agent_url to its first AgentPublisherAuthorization.
+   */
+  async bulkGetFirstAuthForAgents(agentUrls: string[]): Promise<Map<string, AgentPublisherAuthorization>> {
+    if (agentUrls.length === 0) return new Map();
+
+    const map = new Map<string, AgentPublisherAuthorization>();
+    const BATCH_SIZE = 1000;
+
+    for (let i = 0; i < agentUrls.length; i += BATCH_SIZE) {
+      const batch = agentUrls.slice(i, i + BATCH_SIZE);
+      // DISTINCT ON picks first row per agent_url.
+      // ORDER BY source ASC ensures adagents_json (alphabetically first) is preferred over agent_claim.
+      const result = await query<AgentPublisherAuthorization>(
+        `SELECT DISTINCT ON (agent_url)
+           agent_url, publisher_domain, authorized_for, property_ids, source, discovered_at, last_validated
+         FROM agent_publisher_authorizations
+         WHERE agent_url = ANY($1)
+         ORDER BY agent_url, source, publisher_domain`,
+        [batch]
+      );
+      for (const row of result.rows) {
+        map.set(row.agent_url, row);
+      }
+    }
+    return map;
+  }
+
+  /**
    * Check whether a publisher domain has a valid adagents.json (from crawl data).
    * Returns true if any record for this domain has has_valid_adagents = true,
    * null if the domain has never been discovered.

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -52,14 +52,9 @@ export class FederatedIndexService {
     // Get discovered agents
     const discoveredAgents = await this.db.getAllDiscoveredAgents(type);
 
-    // Get authorizations to find which domain discovered each agent
-    const allAuths = new Map<string, AgentPublisherAuthorization>();
-    for (const agent of discoveredAgents) {
-      const auths = await this.db.getDomainsForAgent(agent.agent_url);
-      if (auths.length > 0) {
-        allAuths.set(agent.agent_url, auths[0]); // Use first authorization as source
-      }
-    }
+    // Bulk-fetch first authorization for all discovered agents in a single query
+    const agentUrls = discoveredAgents.map(a => a.agent_url);
+    const allAuths = await this.db.bulkGetFirstAuthForAgents(agentUrls);
 
     // Merge: registered takes precedence
     const result: FederatedAgent[] = Array.from(registeredAgents.values());


### PR DESCRIPTION
## Summary
- **Root cause**: `listAllAgents()` in `federated-index.ts` made an individual `SELECT` per discovered agent to fetch authorizations — a sequential N+1 query. With hundreds of agents, this caused `/registry/agents` to take 500+ seconds, exhausting the DB connection pool (20 connections).
- **Cascade**: Pool exhaustion caused health check failures, `card.png` timeouts, background task connection errors, and monotonically climbing VM concurrency on Fly.io.
- **Fix**: Added `bulkGetFirstAuthForAgents()` — a single `SELECT DISTINCT ON (agent_url) ... WHERE agent_url = ANY($1)` query, batched in chunks of 1000 to stay within PostgreSQL parameter limits.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 597 unit tests pass (1 pre-existing failure in luma-sync unrelated to this change)
- [x] Code review: no Must Fix items
- [x] Security review: no Must Fix items, Should Fix (batching) addressed
- [ ] Deploy and verify `/registry/agents` response time drops from 500s to sub-second
- [ ] Verify VM Service Concurrency stabilizes on Fly.io metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)