### PR TITLE
fix: retry transient network errors in Gemini API calls

### DIFF
--- a/.changeset/many-flies-allow.md
+++ b/.changeset/many-flies-allow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Retry transient network errors (fetch failed, ECONNRESET, ETIMEDOUT, ENOTFOUND) in Gemini API calls. Add 120s timeout for image generation and 30s for validation.

--- a/server/src/services/illustration-generator.ts
+++ b/server/src/services/illustration-generator.ts
@@ -128,13 +128,16 @@ export async function generateIllustration(options: GenerateIllustrationOptions)
   }
 
   const ai = getGenAI();
-  const model = ai.getGenerativeModel({
-    model: 'gemini-3.1-flash-image-preview',
-    generationConfig: {
-      // @ts-expect-error - responseModalities not in SDK types yet
-      responseModalities: ['TEXT', 'IMAGE'],
+  const model = ai.getGenerativeModel(
+    {
+      model: 'gemini-3.1-flash-image-preview',
+      generationConfig: {
+        // @ts-expect-error - responseModalities not in SDK types yet
+        responseModalities: ['TEXT', 'IMAGE'],
+      },
     },
-  });
+    { timeout: 120_000 },
+  );
 
   logger.info({ title, hasAuthorDirection: !!authorDescription }, 'Generating illustration');
 

--- a/server/src/services/portrait-generator.ts
+++ b/server/src/services/portrait-generator.ts
@@ -113,6 +113,10 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
 
   for (const part of response.candidates?.[0]?.content?.parts ?? []) {
     if (part.inlineData) {
+      const mimeType = part.inlineData.mimeType || 'image/png';
+      if (!mimeType.startsWith('image/')) {
+        throw new Error(`Gemini returned non-image content: ${mimeType}`);
+      }
       const imageBuffer = Buffer.from(part.inlineData.data, 'base64');
       logger.info({ sizeKB: (imageBuffer.length / 1024).toFixed(0) }, 'Portrait generated');
       return { imageBuffer, promptUsed: prompt };
@@ -143,15 +147,19 @@ export async function validatePortrait(imageBuffer: Buffer): Promise<{
     `{ "valid": true/false, "issues": ["issue 1", "issue 2"] }`;
 
   try {
-    const result = await model.generateContent([
-      {
-        inlineData: {
-          mimeType: 'image/png',
-          data: imageBuffer.toString('base64'),
+    const result = await withGeminiRetry(
+      () => model.generateContent([
+        {
+          inlineData: {
+            mimeType: 'image/png',
+            data: imageBuffer.toString('base64'),
+          },
         },
-      },
-      validationPrompt,
-    ]);
+        validationPrompt,
+      ]),
+      undefined,
+      'validatePortrait',
+    );
 
     const text = result.response.text().trim();
     const jsonStr = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');

--- a/server/src/services/portrait-generator.ts
+++ b/server/src/services/portrait-generator.ts
@@ -77,13 +77,16 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
   prompt += `Do not include any text, words, labels, or logos in the image. Square aspect ratio.`;
 
   const ai = getGenAI();
-  const model = ai.getGenerativeModel({
-    model: 'gemini-3.1-flash-image-preview',
-    generationConfig: {
-      // @ts-expect-error - responseModalities not in SDK types yet
-      responseModalities: ['TEXT', 'IMAGE'],
+  const model = ai.getGenerativeModel(
+    {
+      model: 'gemini-3.1-flash-image-preview',
+      generationConfig: {
+        // @ts-expect-error - responseModalities not in SDK types yet
+        responseModalities: ['TEXT', 'IMAGE'],
+      },
     },
-  });
+    { timeout: 120_000 },
+  );
 
   // Build content parts
   const parts: Array<{ text: string } | { inlineData: { mimeType: string; data: string } }> = [];
@@ -129,7 +132,7 @@ export async function validatePortrait(imageBuffer: Buffer): Promise<{
   issues: string[];
 }> {
   const ai = getGenAI();
-  const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash' }, { timeout: 30_000 });
 
   const validationPrompt =
     `Analyze this portrait illustration for quality. Check: ` +

--- a/server/src/utils/gemini-retry.ts
+++ b/server/src/utils/gemini-retry.ts
@@ -33,7 +33,11 @@ function isRetryableGeminiError(error: unknown): boolean {
     msg.includes('Resource has been exhausted') ||
     msg.includes('high demand') ||
     msg.includes('UNAVAILABLE') ||
-    msg.includes('RESOURCE_EXHAUSTED')
+    msg.includes('RESOURCE_EXHAUSTED') ||
+    msg.includes('fetch failed') ||
+    msg.includes('ECONNRESET') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('ENOTFOUND')
   );
 }
 

--- a/server/tests/unit/gemini-retry.test.ts
+++ b/server/tests/unit/gemini-retry.test.ts
@@ -12,7 +12,8 @@ describe('withGeminiRetry', () => {
   });
 
   it.each([
-    '503 Service Unavailable',
+    '503 Bad Gateway',
+    'Service Unavailable',
     '429 Too Many Requests',
     'Resource has been exhausted',
     'The model is overloaded due to high demand',

--- a/server/tests/unit/gemini-retry.test.ts
+++ b/server/tests/unit/gemini-retry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withGeminiRetry } from '../../src/utils/gemini-retry.js';
+
+const FAST_CONFIG = { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 1, backoffMultiplier: 1 };
+
+describe('withGeminiRetry', () => {
+  it('returns result on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await withGeminiRetry(fn, FAST_CONFIG);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    '503 Service Unavailable',
+    '429 Too Many Requests',
+    'Resource has been exhausted',
+    'The model is overloaded due to high demand',
+    'UNAVAILABLE: server not ready',
+    'RESOURCE_EXHAUSTED',
+    'fetch failed',
+    'read ECONNRESET',
+    'connect ETIMEDOUT',
+    'getaddrinfo ENOTFOUND generativelanguage.googleapis.com',
+  ])('retries on "%s"', async (message) => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error(message))
+      .mockResolvedValue('ok');
+    const result = await withGeminiRetry(fn, FAST_CONFIG);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('Invalid API key'));
+    await expect(withGeminiRetry(fn, FAST_CONFIG)).rejects.toThrow('Invalid API key');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry when a non-Error value is thrown', async () => {
+    const fn = vi.fn().mockRejectedValue('string error');
+    await expect(withGeminiRetry(fn, FAST_CONFIG)).rejects.toBe('string error');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('503'));
+    await expect(withGeminiRetry(fn, FAST_CONFIG)).rejects.toThrow('503');
+    expect(fn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+});


### PR DESCRIPTION
## Summary
- Add `fetch failed`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND` to retryable error patterns in `withGeminiRetry` — portrait generation was failing immediately on transient network errors instead of retrying
- Add 120s request timeout for image generation (`portrait-generator`, `illustration-generator`) and 30s for portrait validation to prevent indefinite hangs
- Add comprehensive test coverage for the retry utility (14 tests covering all retryable patterns, non-retryable errors, non-Error values, and retry exhaustion)

## Test plan
- [x] All 597 unit tests pass
- [x] TypeScript compiles cleanly
- [x] New `gemini-retry.test.ts` covers all 10 retryable error patterns via parameterized tests
- [ ] Verify portrait generation succeeds in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)