### PR TITLE
fix: stop double-pooling — let PgBouncer own connection pooling

### DIFF
--- a/.changeset/ready-plants-warn.md
+++ b/.changeset/ready-plants-warn.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: lower Node pool idleTimeoutMillis from 30s to 10s to prevent PgBouncer client_idle_timeout errors

--- a/.changeset/ready-sides-fail.md
+++ b/.changeset/ready-sides-fail.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: reduce idle timeout and enable TCP keepalive to prevent PgBouncer client_idle_timeout errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -815,6 +816,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2849,7 +2851,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -3536,7 +3537,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/prebuild/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4644,7 +4646,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/scraping/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4867,7 +4870,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -5170,7 +5172,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -5190,6 +5191,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5546,6 +5548,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5859,8 +5862,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
       "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6606,6 +6608,7 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -8527,7 +8530,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
       "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8740,6 +8742,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -8867,6 +8870,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9213,6 +9217,7 @@
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9281,6 +9286,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10403,8 +10409,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "4.2.0",
@@ -11007,8 +11012,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "6.2.1",
@@ -11386,7 +11390,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12300,6 +12305,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14216,6 +14222,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14505,6 +14512,7 @@
       "integrity": "sha512-2CbJAa7XeziZYe6pDS5RVLirRY28iSGMQuEV8jRU5NQsONQNfcR/BZHHc9vkMg2lGYTHTM2pskxC1YmY28p6bQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.0",
         "ansi-escapes": "^7.0.0",
@@ -15568,6 +15576,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -16203,7 +16212,6 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -18776,6 +18784,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19025,6 +19034,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20690,6 +20700,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20828,8 +20839,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -22346,6 +22356,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22530,6 +22541,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -22703,6 +22715,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22786,6 +22799,7 @@
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -23244,6 +23258,7 @@
       "integrity": "sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -23984,6 +23999,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -39,12 +39,12 @@ export function getDatabaseConfig(): DatabaseConfig | null {
     ssl,
     maxPoolSize: process.env.DATABASE_MAX_POOL_SIZE
       ? parseInt(process.env.DATABASE_MAX_POOL_SIZE, 10)
-      : 20,
+      : 3,
     connectionTimeoutMillis: process.env.DATABASE_CONNECTION_TIMEOUT_MS
       ? parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS, 10)
       : 10000,
     idleTimeoutMillis: process.env.DATABASE_IDLE_TIMEOUT_MS
       ? parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS, 10)
-      : 10000,
+      : 1000,
   };
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -45,6 +45,6 @@ export function getDatabaseConfig(): DatabaseConfig | null {
       : 10000,
     idleTimeoutMillis: process.env.DATABASE_IDLE_TIMEOUT_MS
       ? parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS, 10)
-      : 30000,
+      : 10000,
   };
 }

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -67,6 +67,11 @@ export function getPool(): Pool {
   return pool;
 }
 
+// PgBouncer can kill idle connections between pool checkout and query execution.
+// When this happens pg destroys the dead connection internally, so a single
+// retry on a fresh connection is safe for standalone queries (NOT transactions).
+const RETRYABLE_RE = /client_idle_timeout|Connection terminated|ECONNRESET|EPIPE|connection reset/i;
+
 /**
  * Execute a parameterized query. All callers must use $1, $2, etc. placeholders
  * with the params array -- never concatenate user input into the text argument.
@@ -76,7 +81,15 @@ export async function query<T extends QueryResultRow = any>(
   params?: any[]
 ): Promise<QueryResult<T>> {
   const pool = getPool();
-  return pool.query<T>(text, params);
+  try {
+    return await pool.query<T>(text, params);
+  } catch (err) {
+    if (err instanceof Error && RETRYABLE_RE.test(err.message)) {
+      console.warn("Retrying query after transient PgBouncer disconnect:", err.message);
+      return pool.query<T>(text, params);
+    }
+    throw err;
+  }
 }
 
 /**

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -34,10 +34,18 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
     // keep connections alive in the local pool to avoid connection churn.
     // Previously idleTimeoutMillis was 1ms which forced a new PgBouncer
     // connection for every query — hammering PgBouncer under load.
+    // idleTimeoutMillis MUST be shorter than PgBouncer's client_idle_timeout
+    // so the Node pool proactively closes idle connections before PgBouncer
+    // kills them (which causes client_idle_timeout errors on reuse).
     max: config.maxPoolSize || 10,
-    idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
+    idleTimeoutMillis: config.idleTimeoutMillis ?? 10000,
     connectionTimeoutMillis: config.connectionTimeoutMillis || 10000,
     allowExitOnIdle: true,
+    // TCP keepalive detects dead peers (crashed machines, network partitions)
+    // but does NOT prevent PgBouncer's client_idle_timeout — that tracks
+    // protocol-level activity, not TCP-level.
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10000,
   });
 
   pool.on("error", (err) => {

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -30,22 +30,16 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
     user: config.user,
     password: config.password,
     ssl: config.ssl,
-    // PgBouncer handles connection pooling on the server side, but we still
-    // keep connections alive in the local pool to avoid connection churn.
-    // Previously idleTimeoutMillis was 1ms which forced a new PgBouncer
-    // connection for every query — hammering PgBouncer under load.
-    // idleTimeoutMillis MUST be shorter than PgBouncer's client_idle_timeout
-    // so the Node pool proactively closes idle connections before PgBouncer
-    // kills them (which causes client_idle_timeout errors on reuse).
-    max: config.maxPoolSize || 10,
-    idleTimeoutMillis: config.idleTimeoutMillis ?? 10000,
+    // PgBouncer owns connection pooling — we do NOT pool here.
+    // We use pg.Pool only as a connection manager: it gives us pool.query()
+    // (atomic connect → query → release) and pool.connect() (checkout/release
+    // for transactions). With max: 3 and a 1 s idle timeout, this is just a
+    // thin TCP cache — connections are reused briefly within request bursts
+    // then closed well before PgBouncer's client_idle_timeout can fire.
+    max: config.maxPoolSize || 3,
+    idleTimeoutMillis: config.idleTimeoutMillis ?? 1000,
     connectionTimeoutMillis: config.connectionTimeoutMillis || 10000,
     allowExitOnIdle: true,
-    // TCP keepalive detects dead peers (crashed machines, network partitions)
-    // but does NOT prevent PgBouncer's client_idle_timeout — that tracks
-    // protocol-level activity, not TCP-level.
-    keepAlive: true,
-    keepAliveInitialDelayMillis: 10000,
   });
 
   pool.on("error", (err) => {
@@ -67,11 +61,6 @@ export function getPool(): Pool {
   return pool;
 }
 
-// PgBouncer can kill idle connections between pool checkout and query execution.
-// When this happens pg destroys the dead connection internally, so a single
-// retry on a fresh connection is safe for standalone queries (NOT transactions).
-const RETRYABLE_RE = /client_idle_timeout|Connection terminated|ECONNRESET|EPIPE|connection reset/i;
-
 /**
  * Execute a parameterized query. All callers must use $1, $2, etc. placeholders
  * with the params array -- never concatenate user input into the text argument.
@@ -81,15 +70,7 @@ export async function query<T extends QueryResultRow = any>(
   params?: any[]
 ): Promise<QueryResult<T>> {
   const pool = getPool();
-  try {
-    return await pool.query<T>(text, params);
-  } catch (err) {
-    if (err instanceof Error && RETRYABLE_RE.test(err.message)) {
-      console.warn("Retrying query after transient PgBouncer disconnect:", err.message);
-      return pool.query<T>(text, params);
-    }
-    throw err;
-  }
+  return pool.query<T>(text, params);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stop double-pooling: the Node.js `pg.Pool` was configured as a real connection pool (`max: 20`, `idleTimeoutMillis: 30s`) sitting in front of PgBouncer, which already handles connection pooling on the Fly Postgres side
- PgBouncer's `client_idle_timeout` was killing idle connections that the Node pool thought were still alive, causing `client_idle_timeout` errors in the document indexer and `timeout expired` errors on health checks
- Reconfigure `pg.Pool` as a thin connection manager (`max: 3`, `idleTimeoutMillis: 1s`) — just enough to cache TCP sockets for burst reuse, while letting PgBouncer own all real connection pooling

## Changes
| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `max` | 20 | **3** | Connection cache, not a pool — PgBouncer owns pooling |
| `idleTimeoutMillis` | 30000 (30s) | **1000** (1s) | Release connections before PgBouncer's `client_idle_timeout` fires |

## Test plan
- [x] Typecheck passes
- [x] 597/597 unit tests pass
- [ ] Deploy and monitor Slack for `client_idle_timeout` and `timeout expired` errors
- [ ] Confirm `/health` endpoint responds reliably under load