### PR TITLE
feat: gate newsletter sends on explicit marketing opt-in

### DIFF
--- a/.changeset/true-brooms-think.md
+++ b/.changeset/true-brooms-think.md
@@ -1,0 +1,4 @@
+---
+---
+
+Gate newsletter email sends on explicit marketing opt-in consent. Add consent collection via Slack join DM, event registration, and strengthened opt-in copy. Add admin visibility for opt-in status and stats.

--- a/server/public/admin-newsletter.html
+++ b/server/public/admin-newsletter.html
@@ -18,6 +18,7 @@
     .status-approved { background: #d1fae5; color: #065f46; }
     .status-sent { background: #dbeafe; color: #1e40af; }
     .recipient-count { font-size: 13px; color: #666; padding: 4px 10px; background: #f1f5f9; border-radius: 12px; }
+    .optin-stats { font-size: 12px; color: #666; margin-top: 4px; text-align: right; }
 
     .section { background: var(--color-bg-card, #fff); border-radius: 8px; padding: 20px; margin-bottom: 16px; box-shadow: var(--shadow-xs, 0 1px 2px rgba(0,0,0,0.05)); position: relative; }
     .section.hidden-section { opacity: 0.5; }
@@ -269,12 +270,23 @@
       const hidden = new Set(c.hiddenSections || []);
 
       // Header
-      const badge = recipientCount ? `<span class="recipient-count">${recipientCount.emailCount} recipients</span>` : '';
+      const optIn = recipientCount?.optInStats;
+      const badge = recipientCount
+        ? `<span class="recipient-count">${esc(String(recipientCount.emailCount))} recipients</span>`
+        : '';
+      const optInBar = optIn
+        ? `<div class="optin-stats">${esc(String(optIn.opted_in))} opted in · ${esc(String(optIn.opted_out))} opted out · ${esc(String(optIn.not_asked))} not yet asked</div>`
+        : '';
       document.getElementById('headerActions').innerHTML = `
-        ${badge}
-        <span class="status-badge status-${esc(status)}">${esc(status)}</span>
-        ${status === 'draft' ? `<button class="btn btn-nl" onclick="sendTest()">Send Test</button>` : ''}
-        ${status === 'draft' ? `<button class="btn btn-success" onclick="approveEdition()">Approve & Queue</button>` : ''}
+        <div>
+          <div style="display: flex; align-items: center; gap: 8px; justify-content: flex-end;">
+            ${badge}
+            <span class="status-badge status-${esc(status)}">${esc(status)}</span>
+            ${status === 'draft' ? `<button class="btn btn-nl" onclick="sendTest()">Send Test</button>` : ''}
+            ${status === 'draft' ? `<button class="btn btn-success" onclick="approveEdition()">Approve & Queue</button>` : ''}
+          </div>
+          ${optInBar}
+        </div>
       `;
 
       // Subject

--- a/server/public/admin-users.html
+++ b/server/public/admin-users.html
@@ -124,6 +124,9 @@
     }
 
     /* Users Table */
+    #usersTableContainer {
+      overflow-x: auto;
+    }
     .users-table {
       width: 100%;
       border-collapse: collapse;
@@ -336,6 +339,19 @@
       background: var(--color-gray-200);
       color: var(--color-text-secondary);
     }
+
+    /* Email opt-in badges */
+    .optin-badge {
+      display: inline-block;
+      padding: 2px var(--space-2);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-xs);
+      font-weight: var(--font-medium);
+      white-space: nowrap;
+    }
+    .optin-yes { background: var(--color-success-100); color: var(--color-success-700); }
+    .optin-no { background: var(--color-error-100); color: var(--color-error-700); }
+    .optin-unknown { background: var(--color-gray-100); color: var(--color-gray-600); }
 
     /* Source indicator */
     .source-icon {
@@ -934,6 +950,7 @@
                 <th>Stage</th>
                 <th>Lifecycle</th>
                 <th>Goal</th>
+                <th>Email Opt-in</th>
                 <th>Actions</th>
               </tr>
             </thead>
@@ -1699,6 +1716,13 @@
           ? `<span class="goal-badge goal-${user.goal_key}">${escapeHtml(user.goal_name || formatGoalKey(user.goal_key))}</span>`
           : '<span class="score-na">—</span>';
 
+        // Marketing opt-in display
+        const optInHtml = user.marketing_opt_in === true
+          ? '<span class="optin-badge optin-yes">Opted in</span>'
+          : user.marketing_opt_in === false
+            ? '<span class="optin-badge optin-no">Opted out</span>'
+            : '<span class="optin-badge optin-unknown">Not asked</span>';
+
         // Actions based on status
         let actions = '';
 
@@ -1748,6 +1772,9 @@
             </td>
             <td>
               ${goalHtml}
+            </td>
+            <td>
+              ${optInHtml}
             </td>
             <td class="action-cell">
               ${actions}

--- a/server/public/join.html
+++ b/server/public/join.html
@@ -372,7 +372,7 @@
           <label style="display: flex; align-items: flex-start; gap: var(--space-3); background: var(--color-gray-50); border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); padding: var(--space-4); font-size: var(--text-sm); cursor: pointer;" onclick="document.getElementById('marketingOptIn').click(); event.stopPropagation();">
             <input type="checkbox" id="marketingOptIn" style="width: 18px; height: 18px; margin-top: 2px; cursor: pointer; flex-shrink: 0;" onclick="event.stopPropagation();">
             <span style="cursor: pointer; line-height: var(--leading-normal);" onclick="event.stopPropagation();">
-              Keep me updated on news, events, and workshops (optional)
+              Receive The Prompt, The Build, and event notifications via email (optional)
             </span>
           </label>
         </div>

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -1433,7 +1433,7 @@
             <div class="milestone-icon">📬</div>
             <div class="milestone-body">
               <div class="milestone-title">Stay in the loop?</div>
-              <div class="milestone-detail">Get updates on news, events, and workshops from AgenticAdvertising.org.</div>
+              <div class="milestone-detail">Receive The Prompt, The Build, and event notifications from AgenticAdvertising.org.</div>
               <div class="milestone-actions">
                 <button class="btn btn-primary btn-sm" onclick="setMarketingOptIn(true)">Yes, keep me updated</button>
                 <button class="btn btn-ghost btn-sm" onclick="setMarketingOptIn(false)">No thanks</button>

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -726,7 +726,7 @@
           <div class="agreements-checkbox" onclick="document.getElementById('marketingOptIn').click(); event.stopPropagation();">
             <input type="checkbox" id="marketingOptIn" onclick="event.stopPropagation();">
             <label for="marketingOptIn" onclick="event.stopPropagation();">
-              Keep me updated on news, events, and workshops (optional)
+              Receive The Prompt, The Build, and event notifications via email (optional)
             </label>
           </div>
           <button type="submit" class="btn" id="createBtn">Register Company</button>
@@ -792,7 +792,7 @@
         <div class="agreements-checkbox" onclick="document.getElementById('marketingOptInIndividual').click(); event.stopPropagation();">
           <input type="checkbox" id="marketingOptInIndividual" onclick="event.stopPropagation();">
           <label for="marketingOptInIndividual" onclick="event.stopPropagation();">
-            Keep me updated on news, events, and workshops (optional)
+            Receive The Prompt, The Build, and event notifications via email (optional)
           </label>
         </div>
         <button class="btn" id="individualBtn" onclick="createIndividualWorkspace()">Join as Individual</button>

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -31,6 +31,8 @@ import { logger } from '../logger.js';
 import { captureEvent } from '../utils/posthog.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
 import { AddieDatabase } from '../db/addie-db.js';
+import { SlackDatabase } from '../db/slack-db.js';
+import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
 import { getPool } from '../db/client.js';
 import {
   isKnowledgeReady,
@@ -695,6 +697,10 @@ export async function initializeAddieBolt(): Promise<{ app: InstanceType<typeof 
   // Register alias match action handlers
   boltApp.action('alias_confirm', handleAliasConfirm);
   boltApp.action('alias_reject', handleAliasReject);
+
+  // Register marketing opt-in action handlers (from Slack join DM)
+  boltApp.action('marketing_optin_yes', handleMarketingOptIn);
+  boltApp.action('marketing_optin_no', handleMarketingOptIn);
 
   // Register reaction handler for thumbs up/down confirmations
   boltApp.event('reaction_added', handleReactionAdded);
@@ -2642,6 +2648,86 @@ async function handleAliasReject({ ack, body, client }: any): Promise<void> {
       user: userId,
       text: 'Failed to dismiss alias. Please try again.',
     });
+  }
+}
+
+/**
+ * Handle marketing opt-in button clicks from Slack DM.
+ * Both yes and no route here — we distinguish by action_id.
+ */
+async function handleMarketingOptIn({ ack, body, client }: any): Promise<void> {
+  await ack();
+
+  const actionId = body.actions?.[0]?.action_id;
+  const slackUserId = body.user?.id;
+  const channelId = body.channel?.id;
+  const messageTs = body.message?.ts;
+  const optIn = actionId === 'marketing_optin_yes';
+
+  if (!slackUserId) {
+    logger.warn({ actionId }, 'Addie Bolt: Marketing opt-in missing user ID');
+    return;
+  }
+
+  try {
+    const slackDb = new SlackDatabase();
+    const mapping = await slackDb.getBySlackUserId(slackUserId);
+
+    if (mapping?.workos_user_id) {
+      // User is mapped to a web account — record preference if not already set
+      if (!mapping.slack_email) {
+        logger.warn({ slackUserId }, 'Cannot record marketing opt-in: no email on Slack mapping, storing as pending');
+        await slackDb.setPendingMarketingOptIn(slackUserId, optIn);
+      } else {
+        const emailPrefsDb = new EmailPreferencesDatabase();
+        const wasSet = await emailPrefsDb.setMarketingOptInIfNotSet({
+          workos_user_id: mapping.workos_user_id,
+          email: mapping.slack_email,
+          optIn,
+        });
+        if (wasSet) {
+          logger.info({ slackUserId, workosUserId: mapping.workos_user_id, optIn }, 'Marketing opt-in recorded via Slack');
+        } else {
+          logger.debug({ slackUserId, workosUserId: mapping.workos_user_id }, 'Skipping marketing opt-in — user already has explicit preference');
+        }
+      }
+    } else {
+      // Not mapped yet — store as pending preference
+      await slackDb.setPendingMarketingOptIn(slackUserId, optIn);
+      logger.info({ slackUserId, optIn }, 'Pending marketing opt-in stored for unmapped Slack user');
+    }
+
+    // Update the message to replace buttons with confirmation
+    const confirmText = optIn
+      ? "You're all set — you'll receive The Prompt, The Build, and event notifications via email."
+      : "No problem — you won't receive marketing emails from us.";
+
+    if (channelId && messageTs) {
+      try {
+        await client.chat.update({
+          channel: channelId,
+          ts: messageTs,
+          text: confirmText,
+          blocks: [
+            {
+              type: 'section',
+              text: { type: 'mrkdwn', text: confirmText },
+            },
+          ],
+        });
+      } catch (updateErr) {
+        logger.warn({ error: updateErr }, 'Addie Bolt: Failed to update marketing opt-in message');
+      }
+    }
+  } catch (error) {
+    logger.error({ error, slackUserId, actionId }, 'Addie Bolt: Error handling marketing opt-in');
+    if (channelId) {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: slackUserId,
+        text: 'Something went wrong recording your preference. Please try again.',
+      });
+    }
   }
 }
 

--- a/server/src/db/build-db.ts
+++ b/server/src/db/build-db.ts
@@ -262,6 +262,11 @@ export async function getBuildRecipients(): Promise<Array<{
          WHERE uep.workos_user_id = u.workos_user_id
            AND uep.global_unsubscribe = TRUE
        )
+       AND EXISTS (
+         SELECT 1 FROM user_email_preferences uep
+         WHERE uep.workos_user_id = u.workos_user_id
+           AND uep.marketing_opt_in = TRUE
+       )
      ORDER BY u.workos_user_id, om.created_at ASC`,
   );
   return result.rows;

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -553,6 +553,11 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
          SELECT 1 FROM user_email_preferences uep
          WHERE uep.workos_user_id = u.workos_user_id
            AND uep.global_unsubscribe = TRUE
+       )
+       AND EXISTS (
+         SELECT 1 FROM user_email_preferences uep
+         WHERE uep.workos_user_id = u.workos_user_id
+           AND uep.marketing_opt_in = TRUE
        )`,
   );
   return result.rows;

--- a/server/src/db/email-preferences-db.ts
+++ b/server/src/db/email-preferences-db.ts
@@ -1,6 +1,17 @@
 import { query } from './client.js';
 import crypto from 'crypto';
 
+/**
+ * Email categories that require explicit marketing opt-in (marketing_opt_in = true).
+ * Transactional emails bypass this check entirely.
+ */
+export const MARKETING_EMAIL_CATEGORIES = [
+  'the_prompt',
+  'weekly_digest',
+  'the_build',
+  'newsletter',
+];
+
 export interface EmailCategory {
   id: string;
   name: string;
@@ -269,7 +280,8 @@ export class EmailPreferencesDatabase {
   }
 
   /**
-   * Check if a user wants to receive a specific category of email
+   * Check if a user wants to receive a specific category of email.
+   * Marketing categories require explicit marketing_opt_in = true.
    */
   async shouldSendEmail(data: {
     workos_user_id: string;
@@ -277,8 +289,11 @@ export class EmailPreferencesDatabase {
   }): Promise<boolean> {
     const userPrefs = await this.getUserPreferencesByUserId(data.workos_user_id);
 
-    // If no preferences exist, use category default
+    // If no preferences exist and this is a marketing category, block send
     if (!userPrefs) {
+      if (MARKETING_EMAIL_CATEGORIES.includes(data.category_id)) {
+        return false;
+      }
       const category = await this.getCategoryById(data.category_id);
       return category?.default_enabled ?? true;
     }
@@ -286,6 +301,13 @@ export class EmailPreferencesDatabase {
     // Check global unsubscribe first
     if (userPrefs.global_unsubscribe) {
       return false;
+    }
+
+    // Marketing categories require explicit opt-in
+    if (MARKETING_EMAIL_CATEGORIES.includes(data.category_id)) {
+      if (userPrefs.marketing_opt_in !== true) {
+        return false;
+      }
     }
 
     // Check category-specific preference
@@ -596,6 +618,23 @@ export class EmailPreferencesDatabase {
    * table are marketing — transactional emails bypass this system entirely).
    * If optIn is true, removes any category overrides so defaults apply.
    */
+  /**
+   * Set marketing opt-in only if the user has no existing explicit preference.
+   * Returns true if the preference was set, false if it was already set.
+   */
+  async setMarketingOptInIfNotSet(data: {
+    workos_user_id: string;
+    email: string;
+    optIn: boolean;
+  }): Promise<boolean> {
+    const existing = await this.getUserPreferencesByUserId(data.workos_user_id);
+    if (existing && existing.marketing_opt_in !== null) {
+      return false;
+    }
+    await this.setMarketingOptIn(data);
+    return true;
+  }
+
   async setMarketingOptIn(data: {
     workos_user_id: string;
     email: string;

--- a/server/src/db/migrations/394_slack_pending_marketing_optin.sql
+++ b/server/src/db/migrations/394_slack_pending_marketing_optin.sql
@@ -1,0 +1,5 @@
+-- Store marketing opt-in preference for Slack users who respond to the DM
+-- before being mapped to a web account. Applied when mapping occurs.
+ALTER TABLE slack_user_mappings
+  ADD COLUMN IF NOT EXISTS pending_marketing_opt_in BOOLEAN,
+  ADD COLUMN IF NOT EXISTS pending_marketing_opt_in_at TIMESTAMP WITH TIME ZONE;

--- a/server/src/db/slack-db.ts
+++ b/server/src/db/slack-db.ts
@@ -934,4 +934,29 @@ export class SlackDatabase {
     };
   }
 
+  /**
+   * Store a pending marketing opt-in preference for a Slack user
+   * who hasn't been mapped to a web account yet.
+   */
+  async setPendingMarketingOptIn(slackUserId: string, optIn: boolean): Promise<void> {
+    await query(
+      `UPDATE slack_user_mappings
+       SET pending_marketing_opt_in = $2, pending_marketing_opt_in_at = NOW(), updated_at = NOW()
+       WHERE slack_user_id = $1`,
+      [slackUserId, optIn]
+    );
+  }
+
+  /**
+   * Clear pending marketing opt-in after it has been applied to the web account.
+   */
+  async clearPendingMarketingOptIn(slackUserId: string): Promise<void> {
+    await query(
+      `UPDATE slack_user_mappings
+       SET pending_marketing_opt_in = NULL, pending_marketing_opt_in_at = NULL, updated_at = NOW()
+       WHERE slack_user_id = $1`,
+      [slackUserId]
+    );
+  }
+
 }

--- a/server/src/newsletters/admin-routes.ts
+++ b/server/src/newsletters/admin-routes.ts
@@ -13,6 +13,7 @@ import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import type { NewsletterConfig, CustomSection } from './config.js';
 import { generateCoverForEdition } from './cover.js';
 import { sendMarketingEmail } from '../notifications/email.js';
+import { query } from '../db/client.js';
 
 const logger = createLogger('newsletter-admin');
 
@@ -334,10 +335,34 @@ export function createNewsletterAdminRoutes(config: NewsletterConfig): Router {
 
   router.get('/recipients/count', requireAuth, requireAdmin, async (_req: Request, res: Response) => {
     try {
-      const recipients = await config.db.getRecipients();
+      const [recipients, optInStats] = await Promise.all([
+        config.db.getRecipients(),
+        query<{ status: string; count: string }>(`
+          SELECT
+            CASE
+              WHEN marketing_opt_in = TRUE THEN 'opted_in'
+              WHEN marketing_opt_in = FALSE THEN 'opted_out'
+              ELSE 'not_asked'
+            END AS status,
+            COUNT(*)::text AS count
+          FROM user_email_preferences
+          GROUP BY status
+        `),
+      ]);
       const emailCount = recipients.length;
       const slackCount = recipients.filter(r => r.has_slack).length;
-      res.json({ emailCount, slackCount, total: emailCount });
+
+      const statsMap = Object.fromEntries(optInStats.rows.map(r => [r.status, parseInt(r.count, 10)]));
+      res.json({
+        emailCount,
+        slackCount,
+        total: emailCount,
+        optInStats: {
+          opted_in: statsMap.opted_in || 0,
+          opted_out: statsMap.opted_out || 0,
+          not_asked: statsMap.not_asked || 0,
+        },
+      });
     } catch (err) {
       logger.error({ error: err, newsletterId: config.id }, 'Failed to get recipient count');
       res.status(500).json({ error: 'Failed to get recipient count' });

--- a/server/src/notifications/marketing-optin-dm.ts
+++ b/server/src/notifications/marketing-optin-dm.ts
@@ -1,0 +1,58 @@
+/**
+ * Marketing Opt-In DM
+ *
+ * Sends new Slack members a DM asking if they'd like to receive
+ * email newsletters (The Prompt, The Build) and event notifications.
+ *
+ * Fires on team_join after the welcome social posts DM.
+ */
+
+import { createLogger } from '../logger.js';
+import { sendDirectMessage } from '../slack/client.js';
+import type { SlackBlockMessage } from '../slack/types.js';
+
+const logger = createLogger('marketing-optin-dm');
+
+export async function sendMarketingOptInDM(slackUserId: string): Promise<boolean> {
+  const message: SlackBlockMessage = {
+    text: 'Would you like to receive The Prompt, The Build, and event notifications via email?',
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Would you like to receive our newsletters and event notifications via email?*\n\nWe publish _The Prompt_ (industry news) and _The Build_ (contributor updates), plus event invitations. You can manage preferences any time from your dashboard.',
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Yes, keep me updated', emoji: true },
+            style: 'primary',
+            action_id: 'marketing_optin_yes',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'No thanks', emoji: true },
+            action_id: 'marketing_optin_no',
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const result = await sendDirectMessage(slackUserId, message);
+    if (result.ok) {
+      logger.info({ slackUserId }, 'Marketing opt-in DM sent');
+      return true;
+    }
+    logger.warn({ slackUserId, error: result.error }, 'Marketing opt-in DM failed');
+    return false;
+  } catch (err) {
+    logger.error({ err, slackUserId }, 'Marketing opt-in DM error');
+    return false;
+  }
+}

--- a/server/src/routes/admin/users.ts
+++ b/server/src/routes/admin/users.ts
@@ -57,6 +57,7 @@ export function createAdminUsersRouter(): Router {
         goal_key: string | null;
         goal_name: string | null;
         last_activity_at: Date | null;
+        marketing_opt_in: boolean | null;
       }>(`
         SELECT DISTINCT ON (om.workos_user_id)
           om.workos_user_id,
@@ -71,13 +72,15 @@ export function createAdminUsersRouter(): Router {
           pr.stage AS relationship_stage,
           uc.goal_key,
           uc.goal_name,
-          GREATEST(sm.last_slack_activity_at, u.updated_at) as last_activity_at
+          GREATEST(sm.last_slack_activity_at, u.updated_at) as last_activity_at,
+          ep.marketing_opt_in
         FROM organization_memberships om
         INNER JOIN organizations o ON om.workos_organization_id = o.workos_organization_id
         LEFT JOIN users u ON u.workos_user_id = om.workos_user_id
         LEFT JOIN person_relationships pr ON pr.workos_user_id = om.workos_user_id
         LEFT JOIN unified_contacts_with_goals uc ON uc.workos_user_id = om.workos_user_id
         LEFT JOIN slack_user_mappings sm ON sm.workos_user_id = om.workos_user_id
+        LEFT JOIN user_email_preferences ep ON ep.workos_user_id = om.workos_user_id
         LEFT JOIN (
           SELECT workos_user_id, SUM(points) AS total_points
           FROM community_points
@@ -152,6 +155,7 @@ export function createAdminUsersRouter(): Router {
         goal_key: string | null;
         goal_name: string | null;
         last_activity_at: Date | null;
+        marketing_opt_in: boolean | null;
       };
 
       const unifiedUsers: UnifiedUser[] = [];
@@ -240,6 +244,7 @@ export function createAdminUsersRouter(): Router {
           goal_key: user.goal_key,
           goal_name: user.goal_name,
           last_activity_at: user.last_activity_at,
+          marketing_opt_in: user.marketing_opt_in ?? null,
         });
       }
 
@@ -338,6 +343,7 @@ export function createAdminUsersRouter(): Router {
           goal_key: engagement?.goal_key ?? null,
           goal_name: engagement?.goal_name ?? null,
           last_activity_at: engagement?.last_activity_at ?? null,
+          marketing_opt_in: slackUser.pending_marketing_opt_in ?? null,
         });
       }
 

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -37,6 +37,7 @@ import type {
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { createChannel, setChannelPurpose, sendDirectMessage } from "../slack/client.js";
 import { SlackDatabase } from "../db/slack-db.js";
+import { EmailPreferencesDatabase } from "../db/email-preferences-db.js";
 
 /**
  * Zoom participant report CSV row structure.
@@ -1831,6 +1832,21 @@ export function createEventsRouter(): {
         { registrationId: registration.id, eventId: event.id, userId: user.id },
         "User registered for event"
       );
+
+      // Record marketing opt-in if provided and user hasn't previously chosen
+      const { marketing_opt_in } = req.body || {};
+      if (typeof marketing_opt_in === 'boolean') {
+        try {
+          const emailPrefsDb = new EmailPreferencesDatabase();
+          await emailPrefsDb.setMarketingOptInIfNotSet({
+            workos_user_id: user.id,
+            email: user.email,
+            optIn: marketing_opt_in,
+          });
+        } catch (err) {
+          logger.error({ err, userId: user.id }, 'Failed to record marketing opt-in from event registration');
+        }
+      }
 
       // Award community points + check badges (fire-and-forget)
       const communityDb = new CommunityDatabase();

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -1274,7 +1274,7 @@ export function createOrganizationsRouter(): Router {
             // Record marketing communications opt-in choice (best-effort, don't block signup)
             if (typeof marketing_opt_in === 'boolean') {
               try {
-                await emailPrefsDb.setMarketingOptIn({
+                await emailPrefsDb.setMarketingOptInIfNotSet({
                   workos_user_id: user.id,
                   email: user.email,
                   optIn: marketing_opt_in,
@@ -1440,7 +1440,7 @@ export function createOrganizationsRouter(): Router {
       // Record marketing communications opt-in choice (best-effort, don't block signup)
       if (typeof marketing_opt_in === 'boolean') {
         try {
-          await emailPrefsDb.setMarketingOptIn({
+          await emailPrefsDb.setMarketingOptInIfNotSet({
             workos_user_id: user.id,
             email: user.email,
             optIn: marketing_opt_in,

--- a/server/src/routes/referrals.ts
+++ b/server/src/routes/referrals.ts
@@ -140,7 +140,7 @@ export function createReferralsRouter(): Router {
       // Record marketing communications opt-in choice (best-effort, don't block referral acceptance)
       if (typeof marketing_opt_in === 'boolean') {
         try {
-          await emailPrefsDb.setMarketingOptIn({
+          await emailPrefsDb.setMarketingOptInIfNotSet({
             workos_user_id: userId,
             email: req.user!.email,
             optIn: marketing_opt_in,

--- a/server/src/slack/events.ts
+++ b/server/src/slack/events.ts
@@ -27,6 +27,7 @@ import {
 } from '../addie/index.js';
 import { triageAndCreateProspect } from '../services/prospect-triage.js';
 import { sendWelcomeSocialPosts } from '../notifications/welcome-social-posts.js';
+import { sendMarketingOptInDM } from '../notifications/marketing-optin-dm.js';
 
 const slackDb = new SlackDatabase();
 const addieDb = new AddieDatabase();
@@ -171,6 +172,13 @@ export async function handleTeamJoin(event: SlackTeamJoinEvent): Promise<void> {
       }).catch(err => {
         logger.error({ err, userId: user.id }, 'Welcome social posts DM failed');
       });
+
+      // Send marketing opt-in DM after a delay so welcome posts arrive first
+      setTimeout(() => {
+        sendMarketingOptInDM(user.id).catch(err => {
+          logger.error({ err, userId: user.id }, 'Marketing opt-in DM failed');
+        });
+      }, 10_000);
     }
 
     // Fire-and-forget prospect triage for business emails
@@ -283,6 +291,29 @@ async function tryAutoMapByEmail(slackUserId: string, email: string): Promise<vo
     });
 
     logger.info({ slackUserId, workosUserId, email }, 'Auto-mapped Slack user to web account by email');
+
+    // Apply any pending marketing opt-in preference captured via Slack DM
+    // Only apply if the user hasn't already made an explicit choice on the web
+    if (existingSlackMapping?.pending_marketing_opt_in != null) {
+      try {
+        const { EmailPreferencesDatabase } = await import('../db/email-preferences-db.js');
+        const emailPrefsDb = new EmailPreferencesDatabase();
+        const wasSet = await emailPrefsDb.setMarketingOptInIfNotSet({
+          workos_user_id: workosUserId,
+          email,
+          optIn: existingSlackMapping.pending_marketing_opt_in,
+        });
+        // Clear the pending flag now that it's been processed
+        await slackDb.clearPendingMarketingOptIn(slackUserId);
+        if (wasSet) {
+          logger.info({ slackUserId, workosUserId, optIn: existingSlackMapping.pending_marketing_opt_in }, 'Applied pending marketing opt-in from Slack DM');
+        } else {
+          logger.debug({ slackUserId, workosUserId }, 'Skipping pending marketing opt-in — user already has explicit preference');
+        }
+      } catch (err) {
+        logger.error({ err, slackUserId, workosUserId }, 'Failed to apply pending marketing opt-in');
+      }
+    }
 
     // Sync user to chapters based on their Slack channel memberships
     const chapterSyncResult = await syncUserToChaptersFromSlackChannels(workosUserId, slackUserId);

--- a/server/src/slack/types.ts
+++ b/server/src/slack/types.ts
@@ -34,6 +34,9 @@ export interface SlackUserMapping {
   slack_tz_offset: number | null;
   // Organization ID for unmapped users discovered via domain (from migration 160)
   pending_organization_id: string | null;
+  // Marketing opt-in captured via Slack DM before web account mapping
+  pending_marketing_opt_in: boolean | null;
+  pending_marketing_opt_in_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }


### PR DESCRIPTION
## Summary

- **Gate newsletter email sends on `marketing_opt_in = true`** — newsletters were being sent to all users who hadn't explicitly opted OUT of a category. Now they require explicit opt-in, meeting CAN-SPAM/GDPR requirements.
- **Add consent collection touchpoints** — Slack join DM with buttons, event registration opt-in, strengthened copy across all forms ("Receive The Prompt, The Build, and event notifications via email")
- **Add admin visibility** — Email Opt-in column on admin users page, opt-in stats breakdown on newsletter admin page
- **Protect existing preferences** — `setMarketingOptInIfNotSet()` helper ensures no write path overwrites an explicit prior choice
- **Migration 394** — `pending_marketing_opt_in` on `slack_user_mappings` for Slack users not yet mapped to web accounts

## Context

Mary flagged in the working group that we may not have CAN-SPAM/GDPR permissions to email blast all members + non-members. The `marketing_opt_in` field existed but was never checked during newsletter sends. Users with NULL (never asked) or FALSE preferences could still receive emails.

## Files Changed (20)

| Area | Files |
|------|-------|
| Compliance gate | `email-preferences-db.ts`, `digest-db.ts`, `build-db.ts` |
| Consent collection | `marketing-optin-dm.ts`, `bolt-app.ts`, `slack/events.ts`, `events.ts` |
| Preference guards | `organizations.ts`, `referrals.ts` |
| Copy updates | `onboarding.html`, `join.html`, `hub.html` |
| Admin visibility | `admin-users.html`, `admin/users.ts`, `admin-newsletter.html`, `admin-routes.ts` |
| Schema | `slack/types.ts`, `slack-db.ts`, migration `394` |

## Test plan

- [x] Unit tests pass (597/597)
- [x] Typecheck passes
- [x] Code review — addressed all Must Fix and Should Fix
- [x] Security review — no blocking findings, defense-in-depth `esc()` added
- [x] CSS review — overflow-x fix, class extraction for inline styles
- [ ] Verify on staging: `SELECT COUNT(*), marketing_opt_in FROM user_email_preferences GROUP BY marketing_opt_in` to see opt-in distribution
- [ ] Verify newsletter admin shows correct recipient count (should drop to only opted-in users)
- [ ] Test Slack join DM by inviting a test user
- [ ] Verify hub banner still shows for NULL-preference users

🤖 Generated with [Claude Code](https://claude.com/claude-code)