### PR TITLE
fix: retry portrait generation on Gemini abort errors

### DIFF
--- a/.changeset/jolly-views-allow.md
+++ b/.changeset/jolly-views-allow.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: retry portrait generation on Gemini API abort/timeout errors

--- a/server/src/routes/portraits.ts
+++ b/server/src/routes/portraits.ts
@@ -251,7 +251,13 @@ export function createPortraitRouter(config: PortraitRoutesConfig): Router {
       });
     } catch (err) {
       logger.error({ err }, 'Portrait generation failed');
-      res.status(500).json({ error: 'Portrait generation failed' });
+      const isTransient =
+        err instanceof Error &&
+        (err.name === 'AbortError' || err.message.includes('aborted') || err.message.includes('503'));
+      res.status(isTransient ? 503 : 500).json({
+        error: 'Portrait generation failed',
+        retryable: isTransient,
+      });
     }
   });
 

--- a/server/src/services/portrait-generator.ts
+++ b/server/src/services/portrait-generator.ts
@@ -85,7 +85,7 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
         responseModalities: ['TEXT', 'IMAGE'],
       },
     },
-    { timeout: 120_000 },
+    { timeout: 180_000 },
   );
 
   // Build content parts
@@ -106,7 +106,7 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
 
   const result = await withGeminiRetry(
     () => model.generateContent(parts),
-    undefined,
+    { initialDelayMs: 5000, maxDelayMs: 30000 },
     'generatePortrait',
   );
   const response = result.response;

--- a/server/src/utils/gemini-retry.ts
+++ b/server/src/utils/gemini-retry.ts
@@ -37,7 +37,9 @@ function isRetryableGeminiError(error: unknown): boolean {
     msg.includes('fetch failed') ||
     msg.includes('ECONNRESET') ||
     msg.includes('ETIMEDOUT') ||
-    msg.includes('ENOTFOUND')
+    msg.includes('ENOTFOUND') ||
+    msg.includes('aborted') ||
+    error.name === 'AbortError'
   );
 }
 


### PR DESCRIPTION
## Summary
- Portrait generation was failing with `AbortError` when the Gemini API request timed out, because the retry utility didn't recognize abort errors as retryable
- Added `aborted` / `AbortError` to the retryable error list in `gemini-retry.ts`
- Bumped image generation timeout from 120s to 180s and increased retry backoff delays (5s initial, 30s max) to give the API more recovery time
- Route now returns `503` with `retryable: true` for transient failures instead of generic 500

## Test plan
- [x] All 597 unit tests pass
- [x] TypeScript type-check passes
- [ ] Verify portrait generation succeeds after transient Gemini timeouts in staging
- [ ] Confirm client receives 503 + retryable flag on timeout (can trigger via short timeout in dev)