### PR TITLE
Add ext fields to remaining task-level schemas

### DIFF
--- a/.changeset/ext-remaining-schemas.md
+++ b/.changeset/ext-remaining-schemas.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add ext extension fields to remaining task-level schemas (governance, content-standards, TMP) for consistency with the rest of the protocol.

--- a/static/schemas/source/content-standards/calibrate-content-request.json
+++ b/static/schemas/source/content-standards/calibrate-content-request.json
@@ -24,6 +24,9 @@
       "description": "Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.",
       "minLength": 16,
       "maxLength": 255
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/governance/check-governance-request.json
+++ b/static/schemas/source/governance/check-governance-request.json
@@ -180,6 +180,9 @@
     "invoice_recipient": {
       "$ref": "/schemas/core/business-entity.json",
       "description": "Invoice recipient from the purchase request. MUST be present when the tool payload includes invoice_recipient, so the governance agent can validate billing changes."
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -126,6 +126,9 @@
       "minLength": 1,
       "maxLength": 4096,
       "pattern": "^[\\x20-\\x7E]+$"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/governance/get-plan-audit-logs-request.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-request.json
@@ -47,6 +47,9 @@
       "type": "boolean",
       "description": "Include the full audit trail. Default: false.",
       "default": false
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "anyOf": [

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -399,6 +399,9 @@
         ],
         "additionalProperties": false
       }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/governance/report-plan-outcome-request.json
+++ b/static/schemas/source/governance/report-plan-outcome-request.json
@@ -142,6 +142,9 @@
       "minLength": 1,
       "maxLength": 4096,
       "pattern": "^[\\x20-\\x7E]+$"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/governance/report-plan-outcome-response.json
+++ b/static/schemas/source/governance/report-plan-outcome-response.json
@@ -60,6 +60,9 @@
         }
       },
       "additionalProperties": false
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": ["outcome_id", "status"],

--- a/static/schemas/source/governance/sync-plans-response.json
+++ b/static/schemas/source/governance/sync-plans-response.json
@@ -76,6 +76,9 @@
         "required": ["plan_id", "status", "version"],
         "additionalProperties": false
       }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": ["plans"],

--- a/static/schemas/source/tmp/context-match-request.json
+++ b/static/schemas/source/tmp/context-match-request.json
@@ -206,6 +206,9 @@
       },
       "minItems": 1,
       "maxItems": 500
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/tmp/context-match-response.json
+++ b/static/schemas/source/tmp/context-match-response.json
@@ -62,6 +62,9 @@
         }
       },
       "additionalProperties": true
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/tmp/identity-match-request.json
+++ b/static/schemas/source/tmp/identity-match-request.json
@@ -68,6 +68,9 @@
         "type": "string"
       },
       "minItems": 1
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [

--- a/static/schemas/source/tmp/identity-match-response.json
+++ b/static/schemas/source/tmp/identity-match-response.json
@@ -26,6 +26,9 @@
       "description": "How long the router should cache this response, in seconds. The router returns cached eligibility without re-querying the buyer during this window. A value of 0 means do not cache.",
       "minimum": 0,
       "maximum": 86400
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
   },
   "required": [


### PR DESCRIPTION
## Summary

- Adds optional `ext` extension field (`$ref` to `core/ext.json`) to 12 task-level request/response schemas that were missing it
- Completes the extension field coverage started in #214
- Governance schemas (7), content-standards (1), and TMP match schemas (4)
- Pagination helper schemas intentionally excluded (embedded sub-objects, not task-level schemas)

## Test Plan

- [x] All 20 extension field tests pass (`node tests/extension-fields.test.cjs`)
- [x] All 597 unit tests pass (`npm run test:unit`)
- [x] TypeScript compilation succeeds
- [x] All JSON schemas validate as valid JSON
- [x] Verified no request/response schemas missing `ext` (except pagination helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)