### PR TITLE
fix: echo caller context in test agent responses

### DIFF
--- a/.changeset/echo-context-test-agent.md
+++ b/.changeset/echo-context-test-agent.md
@@ -1,0 +1,4 @@
+---
+---
+
+Echo caller's context object in all test agent tool responses

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -46,12 +46,15 @@ function escapeHtmlAttr(s: string): string {
 }
 
 /** Build a structured MCP error response for tool calls (L3 error compliance). */
-function adcpError(code: string, opts: { message: string; details?: unknown; recovery?: string; field?: string }) {
+function adcpError(code: string, opts: { message: string; details?: unknown; recovery?: string; field?: string }, context?: unknown) {
   const errorObj = { code, ...opts };
+  const body = context !== undefined
+    ? { adcp_error: errorObj, context }
+    : { adcp_error: errorObj };
   return {
     isError: true,
-    content: [{ type: 'text' as const, text: JSON.stringify({ adcp_error: errorObj }) }],
-    structuredContent: { adcp_error: errorObj },
+    content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+    structuredContent: body,
   };
 }
 
@@ -2829,17 +2832,23 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
 
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args } = request.params;
+
+    // Extract and strip context before passing args to handlers (AdCP requirement:
+    // echo caller's context object back unchanged in every response).
+    const rawArgs = (args as Record<string, unknown> | undefined) ?? {};
+    const { context: callerContext, ...handlerArgs } = rawArgs;
+
     const handler = HANDLER_MAP[name];
 
     if (!handler) {
-      return adcpError('INVALID_REQUEST', { message: `Unknown tool: ${name}` });
+      return adcpError('INVALID_REQUEST', { message: `Unknown tool: ${name}` }, callerContext);
     }
 
     // Check for task-augmented request (explicit `task` field in params).
     // Dry-run requests always return synchronously — there's no reason to
     // async a dry-run operation, and clients expect immediate results.
     const taskField = (request.params as { task?: { ttl?: number } }).task;
-    const isDryRun = (args as Record<string, unknown> | undefined)?.dry_run === true;
+    const isDryRun = rawArgs.dry_run === true;
     const isTaskRequest = taskField !== undefined && !isDryRun;
     if (isTaskRequest && !toolSupportsTask(name)) {
       throw new Error(`Tool "${name}" does not support task augmentation`);
@@ -2849,7 +2858,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     let toolResult: CallToolResult;
     let isError = false;
     try {
-      const result = await Promise.resolve(handler((args as ToolArgs) || {}, ctx));
+      const result = await Promise.resolve(handler((handlerArgs as ToolArgs) || {}, ctx));
       const resultObj = result as { errors?: Array<{ code: string; message: string; field?: string }> };
       const hasErrors = resultObj.errors && resultObj.errors.length > 0;
       if (hasErrors) {
@@ -2861,10 +2870,13 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           details: resultObj.errors!.length > 1
             ? { all_errors: resultObj.errors }
             : undefined,
-        });
+        }, callerContext);
       } else {
+        const response = callerContext !== undefined
+          ? { ...result as object, context: callerContext }
+          : result;
         toolResult = {
-          content: [{ type: 'text', text: JSON.stringify(result) }],
+          content: [{ type: 'text', text: JSON.stringify(response) }],
         };
       }
     } catch (error) {
@@ -2873,7 +2885,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       toolResult = adcpError('SERVICE_UNAVAILABLE', {
         message: error instanceof Error ? error.message : 'Unknown error',
         recovery: 'transient',
-      });
+      }, callerContext);
     }
 
     // If not task-augmented, return result directly

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -5621,3 +5621,86 @@ describe('storyboard governance sample_requests accepted by training agent', () 
     expect(result.status).toBe('denied');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Context echo — AdCP requirement: echo caller context unchanged in responses
+// ---------------------------------------------------------------------------
+
+/** Raw call that preserves the full response envelope (context, adcp_error). */
+async function simulateCallToolRaw(
+  server: ReturnType<typeof createTrainingAgentServer>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ parsed: Record<string, unknown>; isError?: boolean }> {
+  const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+  const handler = requestHandlers.get('tools/call');
+  if (!handler) throw new Error('CallTool handler not found');
+  const response = await handler(
+    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    {},
+  );
+  const text = response.content?.[0]?.text;
+  return { parsed: text ? JSON.parse(text) : {}, isError: response.isError };
+}
+
+describe('context echo', () => {
+  const DEFAULT_CTX: TrainingContext = { mode: 'open' };
+  const TEST_CONTEXT = { correlation_id: 'test-123', custom: { nested: true } };
+
+  beforeEach(() => {
+    clearSessions();
+    invalidateCache();
+    clearTaskStore();
+  });
+
+  it('echoes context in success responses', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_adcp_capabilities', {
+      context: TEST_CONTEXT,
+    });
+    expect(isError).toBeFalsy();
+    expect(parsed.context).toEqual(TEST_CONTEXT);
+  });
+
+  it('omits context when not provided', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed } = await simulateCallToolRaw(server, 'get_adcp_capabilities', {});
+    expect(parsed).not.toHaveProperty('context');
+  });
+
+  it('echoes context in error responses (unknown tool)', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'nonexistent_tool', {
+      context: TEST_CONTEXT,
+    });
+    expect(isError).toBe(true);
+    expect(parsed.adcp_error).toBeDefined();
+    expect(parsed.context).toEqual(TEST_CONTEXT);
+  });
+
+  it('echoes context in validation error responses', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    // create_media_buy with missing required fields triggers a validation error
+    const { parsed, isError } = await simulateCallToolRaw(server, 'create_media_buy', {
+      context: TEST_CONTEXT,
+      account: { brand: { domain: 'acmeoutdoor.com' } },
+      // missing required fields: start_time, end_time, packages
+    });
+    expect(isError).toBe(true);
+    expect(parsed.context).toEqual(TEST_CONTEXT);
+  });
+
+  it('does not pass context to handlers as part of args', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    // get_products returns product data — if context leaked into args it wouldn't
+    // affect the response, but the key should not appear in the result body
+    // except as the echoed context field
+    const { parsed } = await simulateCallToolRaw(server, 'get_products', {
+      context: TEST_CONTEXT,
+      account: { brand: { domain: 'acmeoutdoor.com' } },
+    });
+    expect(parsed.context).toEqual(TEST_CONTEXT);
+    // The products field should exist (handler ran successfully)
+    expect(parsed.products).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Echoes the caller's `context` object back unchanged in all test agent tool responses (success, error, and exception paths)
- Extracts context at the centralized response-wrapping level rather than modifying each of the ~50 individual handlers
- Strips `context` from args before passing to handlers to prevent accidental leakage

Fixes #2155

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All unit tests pass (pre-commit hook)
- [ ] Run updated storyboards from `bokelley/context-ext-storyboards` (adcp-client) against deployed test agent to verify context echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>