### PR TITLE
fix!: revert geo capability flattening for 3.0 stability

### DIFF
--- a/.changeset/revert-geo-flattening.md
+++ b/.changeset/revert-geo-flattening.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": major
+---
+
+Revert geo capability flattening from #2143. Restore `geo_countries`, `geo_regions` (booleans) and `geo_metros`, `geo_postal_areas` (typed objects with `additionalProperties: false`) as primary geo capability fields. Remove `supported_geo_levels`, `supported_metro_systems`, `supported_postal_systems` arrays. Typed objects provide better static type safety and match what beta/RC users have already implemented against.

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -195,9 +195,10 @@ Buyers discover AXE support via `get_adcp_capabilities` and filter products to A
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `supported_geo_levels` | string[] | Geographic targeting levels: `countries`, `regions`, `metros`, `postal_areas` |
-| `supported_metro_systems` | string[] | Metro area systems: `nielsen_dma`, `uk_itl1`, `uk_itl2`, `eurostat_nuts2` |
-| `supported_postal_systems` | string[] | Postal code systems: `us_zip`, `us_zip_plus_four`, `gb_outward`, `gb_full`, `ca_fsa`, `ca_full`, `de_plz`, `fr_code_postal`, `au_postcode`, `ch_plz`, `at_plz` |
+| `geo_countries` | boolean | Country-level targeting using ISO 3166-1 alpha-2 codes |
+| `geo_regions` | boolean | Region/state-level targeting using ISO 3166-2 codes (e.g., `US-NY`, `GB-SCT`) |
+| `geo_metros` | object | Metro area targeting with system-specific support |
+| `geo_postal_areas` | object | Postal area targeting with country and precision support |
 | `age_restriction` | object | Age restriction capabilities with `supported` flag and `verification_methods` |
 | `language` | boolean | Language targeting (ISO 639-1 codes) |
 | `keyword_targets` | object | Keyword targeting with `supported_match_types` array (`broad`, `phrase`, `exact`). Presence indicates support. |
@@ -205,10 +206,6 @@ Buyers discover AXE support via `get_adcp_capabilities` and filter products to A
 | `geo_proximity` | object | Proximity targeting from arbitrary coordinates (see below) |
 
 Device platform and device type targeting are implied by `media_buy` support. Audience include/exclude targeting is implied by the presence of the `audience_targeting` capabilities object.
-
-:::note
-The per-field booleans `geo_countries`, `geo_regions` and the nested objects `geo_metros`, `geo_postal_areas` are deprecated in 3.0. Use the flattened array fields above instead.
-:::
 
 Sellers that support a geographic targeting level SHOULD support both inclusion and exclusion at that level. For example, `geo_metros.nielsen_dma: true` SHOULD mean the seller supports both `geo_metros` and `geo_metros_exclude` with Nielsen DMA codes. If a seller only supports one direction (e.g., inclusion but not exclusion), it MUST return a validation error for unsupported fields rather than silently ignoring them. See [Targeting Overlays](/docs/media-buy/advanced-topics/targeting) for exclusion semantics.
 
@@ -221,7 +218,7 @@ Sellers that support a geographic targeting level SHOULD support both inclusion 
 | `geometry` | boolean | Pre-computed GeoJSON geometry (buyer provides the polygon) |
 | `transport_modes` | string[] | Transport modes supported for isochrones: `driving`, `walking`, `cycling`, `public_transport` |
 
-**supported_metro_systems** values:
+**geo_metros** specifies which metro classification systems are supported:
 
 | System | Description |
 |--------|-------------|
@@ -230,7 +227,7 @@ Sellers that support a geographic targeting level SHOULD support both inclusion 
 | `uk_itl2` | UK ITL Level 2 regions |
 | `eurostat_nuts2` | Eurostat NUTS Level 2 regions (EU) |
 
-**supported_postal_systems** values:
+**geo_postal_areas** specifies which postal code systems are supported:
 
 | System | Description |
 |--------|-------------|
@@ -410,8 +407,8 @@ This tells buyers:
 
 **If a capability is declared, the seller MUST honor it.**
 
-- `"postal_areas"` in `supported_geo_levels` + `"us_zip"` in `supported_postal_systems` → Buyer can send US ZIP codes, seller MUST honor them
-- `"metros"` in `supported_geo_levels` + `"nielsen_dma"` in `supported_metro_systems` → Buyer can send DMA codes, seller MUST honor them
+- `media_buy.execution.targeting.geo_postal_areas.us_zip: true` → Buyer can send US ZIP codes, seller MUST honor them
+- `media_buy.execution.targeting.geo_metros.nielsen_dma: true` → Buyer can send DMA codes, seller MUST honor them
 - `media_buy.content_standards` object present → Seller MUST apply content standards when provided
 - `media_buy.audience_targeting` object present → Seller MUST support `sync_audiences` and audience targeting overlays
 - `media_buy.conversion_tracking` object present → Seller MUST support `sync_event_sources` and `log_event`
@@ -454,7 +451,7 @@ if (result.supported_protocols.includes('media_buy')) {
   }
 
   // Check geo targeting
-  if (mediaBuy.execution?.targeting?.supported_postal_systems?.includes('us_zip')) {
+  if (mediaBuy.execution?.targeting?.geo_postal_areas?.us_zip) {
     console.log('US ZIP code targeting supported');
   }
 
@@ -508,7 +505,7 @@ async function findCompatibleSellers(sellers, requirements) {
 
     // Check geo targeting requirement
     if (requirements.postalCodeTargeting) {
-      if (!mediaBuy.execution?.targeting?.supported_postal_systems?.includes('us_zip')) {
+      if (!mediaBuy.execution?.targeting?.geo_postal_areas?.us_zip) {
         continue;
       }
     }
@@ -579,7 +576,7 @@ const buy = await client.createMediaBuy({
     targeting_overlay: {
       geo_countries: ['US'],
       // Only specify ZIP targeting if seller supports it
-      ...(mediaBuy.execution?.targeting?.supported_postal_systems?.includes('us_zip') && {
+      ...(mediaBuy.execution?.targeting?.geo_postal_areas?.us_zip && {
         geo_postal_areas: [{
           system: 'us_zip',
           values: ['10001', '10002', '10003', '10004', '10005']
@@ -662,9 +659,16 @@ const buy = await client.createMediaBuy({
         "simid": true
       },
       "targeting": {
-        "supported_geo_levels": ["countries", "regions", "metros", "postal_areas"],
-        "supported_metro_systems": ["nielsen_dma"],
-        "supported_postal_systems": ["us_zip", "gb_outward", "ca_fsa"],
+        "geo_countries": true,
+        "geo_regions": true,
+        "geo_metros": {
+          "nielsen_dma": true
+        },
+        "geo_postal_areas": {
+          "us_zip": true,
+          "gb_outward": true,
+          "ca_fsa": true
+        },
         "language": true,
         "keyword_targets": {
           "supported_match_types": ["broad", "phrase", "exact"]

--- a/docs/reference/migration/geo-targeting.mdx
+++ b/docs/reference/migration/geo-targeting.mdx
@@ -132,20 +132,21 @@ Before sending geo targeting, buyers should verify the seller supports the reque
   "media_buy": {
     "execution": {
       "targeting": {
-        "supported_geo_levels": ["countries", "regions", "metros", "postal_areas"],
-        "supported_metro_systems": ["nielsen_dma"],
-        "supported_postal_systems": ["us_zip"]
+        "geo_countries": true,
+        "geo_regions": true,
+        "geo_metros": {
+          "nielsen_dma": true
+        },
+        "geo_postal_areas": {
+          "us_zip": true
+        }
       }
     }
   }
 }
 ```
 
-The `supported_geo_levels` array declares which geographic targeting levels the seller supports. `supported_metro_systems` and `supported_postal_systems` specify which classification systems are accepted within those levels. If you request a system the seller doesn't declare, expect a validation error.
-
-:::note
-The per-field booleans `geo_countries`, `geo_regions` and nested objects `geo_metros`, `geo_postal_areas` are deprecated in 3.0 and will be removed in 4.0. Use the flat array fields above instead.
-:::
+The `geo_metros` and `geo_postal_areas` objects use boolean properties to indicate which systems are supported. If you request a system the seller doesn't declare, expect a validation error.
 
 ## Full targeting example
 

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1934,9 +1934,10 @@ function handleGetAdcpCapabilities(_args: ToolArgs, _ctx: TrainingContext): Reco
       },
       execution: {
         targeting: {
-          supported_geo_levels: ['countries', 'regions', 'metros', 'postal_areas'],
-          supported_metro_systems: ['nielsen_dma'],
-          supported_postal_systems: ['us_zip'],
+          geo_countries: true,
+          geo_regions: true,
+          geo_metros: { nielsen_dma: true },
+          geo_postal_areas: { us_zip: true },
           language: true,
           keyword_targets: { supported_match_types: ['broad', 'phrase', 'exact'] },
           negative_keywords: { supported_match_types: ['broad', 'phrase', 'exact'] },

--- a/server/tests/unit/luma-sync.test.ts
+++ b/server/tests/unit/luma-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { LumaEvent } from '../../src/luma/client.js';
 
 // Mock dependencies before importing the module under test
@@ -50,11 +50,16 @@ describe('Luma Sync', () => {
   let mockPool: { query: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    vi.useFakeTimers({ now: new Date('2026-04-10T12:00:00Z') });
     vi.clearAllMocks();
     mockPool = {
       query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     };
     vi.mocked(clientModule.getPool).mockReturnValue(mockPool as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('createEventFromLuma', () => {

--- a/server/tests/unit/set-primary-email.test.ts
+++ b/server/tests/unit/set-primary-email.test.ts
@@ -53,13 +53,10 @@ describe('Set primary email endpoint', () => {
     expect(source).toMatch(/FOR UPDATE/);
   });
 
-  it('does DB swap before WorkOS update so rollback is clean', () => {
-    // WorkOS updateUser must appear after the DB operations but before COMMIT
-    const beginIdx = source.indexOf("'BEGIN'");
+  it('does WorkOS update after DB transaction to avoid holding connections during network calls', () => {
     const commitIdx = source.indexOf("'COMMIT'");
-    const workosIdx = source.indexOf('workos.userManagement.updateUser', beginIdx);
-    expect(workosIdx).toBeGreaterThan(beginIdx);
-    expect(workosIdx).toBeLessThan(commitIdx);
+    const workosIdx = source.indexOf('workos.userManagement.updateUser');
+    expect(workosIdx).toBeGreaterThan(commitIdx);
   });
 
   it('rolls back on error', () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -864,7 +864,12 @@ describe('createTrainingAgentServer', () => {
     expect(toolNames).toContain('sync_event_sources');
     expect(toolNames).toContain('log_event');
     expect(toolNames).toContain('provide_performance_feedback');
-    expect(toolNames).toHaveLength(43);
+    expect(toolNames).toContain('create_collection_list');
+    expect(toolNames).toContain('get_collection_list');
+    expect(toolNames).toContain('update_collection_list');
+    expect(toolNames).toContain('list_collection_lists');
+    expect(toolNames).toContain('delete_collection_list');
+    expect(toolNames).toHaveLength(48);
   });
 
   it('get_adcp_capabilities response uses 3.0 capability model', async () => {
@@ -892,12 +897,13 @@ describe('createTrainingAgentServer', () => {
     expect(targeting).not.toHaveProperty('audience_include');
     expect(targeting).not.toHaveProperty('audience_exclude');
 
-    // Flattened geo targeting
-    expect(targeting.supported_geo_levels).toBeDefined();
-    expect(targeting.supported_metro_systems).toBeDefined();
-    expect(targeting.supported_postal_systems).toBeDefined();
-    expect(targeting).not.toHaveProperty('geo_countries');
-    expect(targeting).not.toHaveProperty('geo_regions');
+    // Geo targeting uses typed objects (not flattened arrays)
+    expect(targeting.geo_countries).toBe(true);
+    expect(targeting.geo_regions).toBe(true);
+    expect(targeting.geo_metros).toBeDefined();
+    expect((targeting.geo_metros as Record<string, unknown>).nielsen_dma).toBe(true);
+    expect(targeting.geo_postal_areas).toBeDefined();
+    expect((targeting.geo_postal_areas as Record<string, unknown>).us_zip).toBe(true);
 
     // Removed seller-level reporting (product-level is source of truth)
     expect(mediaBuy).not.toHaveProperty('reporting');

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -157,47 +157,17 @@
               "type": "object",
               "description": "Targeting capabilities. If declared true/supported, buyer can use these targeting parameters and seller MUST honor them.",
               "properties": {
-                "supported_geo_levels": {
-                  "type": "array",
-                  "description": "Geographic targeting levels this seller supports.",
-                  "items": {
-                    "type": "string",
-                    "enum": ["countries", "regions", "metros", "postal_areas"]
-                  },
-                  "uniqueItems": true
-                },
-                "supported_metro_systems": {
-                  "type": "array",
-                  "description": "Metro area classification systems this seller supports. Only meaningful when supported_geo_levels includes 'metros'.",
-                  "items": {
-                    "type": "string",
-                    "enum": ["nielsen_dma", "uk_itl1", "uk_itl2", "eurostat_nuts2"]
-                  },
-                  "uniqueItems": true
-                },
-                "supported_postal_systems": {
-                  "type": "array",
-                  "description": "Postal code systems this seller supports. Only meaningful when supported_geo_levels includes 'postal_areas'.",
-                  "items": {
-                    "type": "string",
-                    "enum": ["us_zip", "us_zip_plus_four", "gb_outward", "gb_full", "ca_fsa", "ca_full", "de_plz", "fr_code_postal", "au_postcode", "ch_plz", "at_plz"]
-                  },
-                  "uniqueItems": true
-                },
                 "geo_countries": {
                   "type": "boolean",
-                  "description": "Deprecated in 3.0, will be removed in 4.0. Use supported_geo_levels instead.",
-                  "deprecated": true
+                  "description": "Country-level targeting using ISO 3166-1 alpha-2 codes"
                 },
                 "geo_regions": {
                   "type": "boolean",
-                  "description": "Deprecated in 3.0, will be removed in 4.0. Use supported_geo_levels instead.",
-                  "deprecated": true
+                  "description": "Region/state-level targeting using ISO 3166-2 codes (e.g., US-NY, GB-SCT)"
                 },
                 "geo_metros": {
                   "type": "object",
-                  "description": "Deprecated in 3.0, will be removed in 4.0. Use supported_metro_systems instead.",
-                  "deprecated": true,
+                  "description": "Metro area targeting. Properties indicate which classification systems are supported.",
                   "properties": {
                     "nielsen_dma": { "type": "boolean" },
                     "uk_itl1": { "type": "boolean" },
@@ -208,8 +178,7 @@
                 },
                 "geo_postal_areas": {
                   "type": "object",
-                  "description": "Deprecated in 3.0, will be removed in 4.0. Use supported_postal_systems instead.",
-                  "deprecated": true,
+                  "description": "Postal area targeting. Properties indicate which postal code systems are supported.",
                   "properties": {
                     "us_zip": { "type": "boolean" },
                     "us_zip_plus_four": { "type": "boolean" },


### PR DESCRIPTION
## Summary

- Reverts the geo targeting flattening from #2143. Restores `geo_countries`, `geo_regions` (booleans) and `geo_metros`, `geo_postal_areas` (typed objects with `additionalProperties: false`) as the primary geo capability fields
- Removes `supported_geo_levels`, `supported_metro_systems`, `supported_postal_systems` flat arrays
- Fixes three pre-existing test failures (training-agent tool count, luma-sync date rot, set-primary-email ordering)

**Why:** Typed objects provide better static type safety at consumption sites. Beta/RC users already implemented against the object shape — changing it right before 3.0 GA would break them for marginal benefit. The "too many false fields" argument was invalid: optional properties don't need to be listed.

The rest of #2143 (removing boolean gates, object-presence-as-signal, required `reporting_capabilities`) is intentionally kept.

## Test plan

- [x] Schema build succeeds
- [x] 597 unit tests pass (pre-commit hook)
- [x] 61 server test files pass, 0 failures
- [x] TypeScript typecheck passes
- [x] Mintlify doc validation passes (no broken links)
- [x] No remaining references to `supported_geo_levels`, `supported_metro_systems`, or `supported_postal_systems` in repo
- [x] Code review: no Must Fix or Should Fix items
- [x] Security review: no findings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)