### PR TITLE
fix: unblock org edit page from slow billing API calls

### DIFF
--- a/.changeset/fix-org-edit-page-load.md
+++ b/.changeset/fix-org-edit-page-load.md
@@ -1,0 +1,7 @@
+---
+---
+
+Fix organization edit page failing to load when billing API is slow. Get
+is_personal from /api/me (already fetched) instead of blocking on the
+heavy billing endpoint. Add 15s fetch timeouts to prevent pages hanging
+indefinitely on slow API responses.

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -804,12 +804,20 @@
       window.location.href = '/auth/login?return_to=/organization';
     }
 
+    // Fetch with a timeout to prevent hanging on slow API responses
+    function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      return fetch(url, { ...options, signal: controller.signal })
+        .finally(() => clearTimeout(timer));
+    }
+
     document.addEventListener('DOMContentLoaded', loadHub);
 
     async function loadHub() {
       try {
         // Fetch user data first to resolve which org to show
-        const meRes = await fetch('/api/me', { credentials: 'include' });
+        const meRes = await fetchWithTimeout('/api/me', { credentials: 'include' });
         if (!meRes.ok) {
           if (meRes.status === 401) {
             window.location.href = '/auth/login?return_to=/organization';
@@ -828,9 +836,9 @@
         // Now fetch engagement + profile + health scoped to the selected org
         const orgParam = currentOrg?.id ? `?org=${encodeURIComponent(currentOrg.id)}` : '';
         const [engRes, profileRes, healthRes] = await Promise.all([
-          fetch(`/api/me/engagement${orgParam}`, { credentials: 'include' }),
-          fetch(`/api/me/member-profile${orgParam}`, { credentials: 'include' }),
-          fetch('/api/me/org-health', { credentials: 'include' }),
+          fetchWithTimeout(`/api/me/engagement${orgParam}`, { credentials: 'include' }),
+          fetchWithTimeout(`/api/me/member-profile${orgParam}`, { credentials: 'include' }),
+          fetchWithTimeout('/api/me/org-health', { credentials: 'include' }),
         ]);
 
         if (!engRes.ok) {
@@ -874,7 +882,7 @@
         let certSummary = null;
         if (currentOrg?.id) {
           try {
-            const certRes = await fetch(`/api/organizations/${currentOrg.id}/certification-summary`, { credentials: 'include' });
+            const certRes = await fetchWithTimeout(`/api/organizations/${currentOrg.id}/certification-summary`, { credentials: 'include' });
             if (certRes.ok) certSummary = await certRes.json();
           } catch (e) { /* ignore cert fetch errors */ }
         }
@@ -885,8 +893,18 @@
         renderHub(data, profileData?.profile || null, currentOrgId, certSummary, healthData, currentOrg?.role || 'member');
       } catch (err) {
         console.error('Hub load error:', err);
-        document.getElementById('hub-loading').innerHTML =
-          '<p>Failed to load. <a href="/organization">Try again</a></p>';
+        const msg = err.name === 'AbortError'
+          ? 'The server is taking too long to respond. Please try again in a moment.'
+          : 'Failed to load.';
+        const loadingEl = document.getElementById('hub-loading');
+        loadingEl.textContent = '';
+        const p = document.createElement('p');
+        p.textContent = msg + ' ';
+        const a = document.createElement('a');
+        a.href = '/organization';
+        a.textContent = 'Try again';
+        p.appendChild(a);
+        loadingEl.appendChild(p);
       }
     }
 

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1150,6 +1150,14 @@
     let currentOrgId = null;
     let currentOrgName = null;
 
+    // Fetch with a timeout to prevent hanging on slow API responses
+    function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      return fetch(url, { ...options, signal: controller.signal })
+        .finally(() => clearTimeout(timer));
+    }
+
     // Get org ID from query parameter
     function getOrgIdFromUrl() {
       const params = new URLSearchParams(window.location.search);
@@ -1199,7 +1207,7 @@
     async function loadProfile() {
       try {
         // Fetch user info first - needed for org selection and sidebar
-        const meResponse = await fetch('/api/me', { credentials: 'include' });
+        const meResponse = await fetchWithTimeout('/api/me', { credentials: 'include' });
         if (meResponse.status === 401) {
           const returnUrl = encodeURIComponent(window.location.pathname + window.location.search);
           window.location.href = `/auth/login?redirect=${returnUrl}`;
@@ -1224,7 +1232,7 @@
         }
 
         const apiUrl = orgId ? `/api/me/member-profile?org=${encodeURIComponent(orgId)}` : '/api/me/member-profile';
-        const response = await fetch(apiUrl, {
+        const response = await fetchWithTimeout(apiUrl, {
           credentials: 'include'
         });
 
@@ -1260,19 +1268,9 @@
         currentOrgName = data.organization_name;
         hasActiveSubscription = data.has_active_subscription || false;
 
-        // Get billing info for sidebar
-        let isSubscribed = false;
-        let isPersonal = false;
-        try {
-          const billingResponse = await fetch(`/api/organizations/${currentOrgId}/billing`, { credentials: 'include' });
-          if (billingResponse.ok) {
-            const billingData = await billingResponse.json();
-            isSubscribed = billingData.subscription?.status === 'active';
-            isPersonal = billingData.is_personal || false;
-          }
-        } catch (e) {
-          console.warn('Could not load billing info for sidebar:', e);
-        }
+        // Determine is_personal from /api/me org data (already fetched, no extra call)
+        const currentOrgInfo = meData?.organizations?.find(o => o.id === currentOrgId);
+        const isPersonal = currentOrgInfo?.is_personal || false;
 
         // Individual accounts use the community profile as their single profile
         if (isPersonal) {
@@ -1280,15 +1278,27 @@
           return;
         }
 
-        // Initialize dashboard sidebar
+        // Initialize dashboard sidebar immediately (don't block on billing)
         if (typeof DashboardNav !== 'undefined') {
           DashboardNav.init({
             showOrgSwitcher: false,
             currentOrgName: currentOrgName || 'Organization',
             isPersonal: isPersonal,
-            isSubscribed: isSubscribed,
+            isSubscribed: false,
             showAdmin: isAdmin
           });
+        }
+
+        // Fetch billing info in the background for sidebar subscription badge
+        if (currentOrgId) {
+          fetchWithTimeout(`/api/organizations/${currentOrgId}/billing`, { credentials: 'include' }, 30000)
+            .then(r => r.ok ? r.json() : null)
+            .then(billingData => {
+              if (billingData?.subscription?.status === 'active' && typeof DashboardNav !== 'undefined') {
+                DashboardNav.setOrgStatus({ isPersonal, isSubscribed: true });
+              }
+            })
+            .catch(() => { /* billing info is non-critical for profile editing */ });
         }
 
         document.getElementById('loading').style.display = 'none';
@@ -1325,7 +1335,10 @@
       } catch (error) {
         console.error('Load profile error:', error);
         document.getElementById('loading').style.display = 'none';
-        showError('Failed to load your profile. Please try again.');
+        const msg = error.name === 'AbortError'
+          ? 'The server is taking too long to respond. Please try again in a moment.'
+          : 'Failed to load your profile. Please try again.';
+        showError(msg);
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix organization edit page (`/member-profile`) failing to load when the billing API is slow or hanging
- Get `is_personal` from `/api/me` (already fetched) instead of blocking on `GET /api/organizations/{id}/billing` which does Stripe customer creation/session setup
- Move billing fetch to background (fire-and-forget) since it only updates sidebar subscription badge
- Add 15s `AbortController` timeouts to all critical fetch calls on both member-profile and organization dashboard pages
- Show actionable timeout error messages instead of leaving pages stuck on "Loading..."

## Root cause
The member-profile page awaited the billing endpoint before showing any content. That endpoint calls `getOrCreateStripeCustomer` and `createCustomerSession`, which can hang when Stripe is slow or DB connections are scarce (related to recent pool exhaustion fixes in #2146, #2151).

## Test plan
- [x] 597 unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Load `/member-profile?org=...` — page should render immediately without waiting for billing
- [ ] Verify personal org users still redirect to `/account`
- [ ] Verify sidebar subscription badge updates after billing loads in background
- [ ] Simulate slow API (e.g. throttle network) — page should show timeout error after 15s instead of hanging

Closes #2147

🤖 Generated with [Claude Code](https://claude.com/claude-code)