### PR TITLE
fix: enforce GOVERNANCE_DENIED in create_media_buy

### DIFF
--- a/.changeset/fix-governance-denied-enforcement.md
+++ b/.changeset/fix-governance-denied-enforcement.md
@@ -1,0 +1,4 @@
+---
+---
+
+Enforce governance in create_media_buy: return GOVERNANCE_DENIED error when governance check denied the purchase, budget exceeds plan limits, or governance_context is unrecognized.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1022,6 +1022,69 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
     }
   }
 
+  // Enforce governance: if governance plans exist, validate the buy budget.
+  // Deny-on-any-plan: without a governance_context there is no way to know
+  // which plan the buy targets, so a conservative deny teaches buyers to call
+  // check_governance first.
+  const rawGovCtx = (req as unknown as Record<string, unknown>).governance_context;
+  const govCtx = typeof rawGovCtx === 'string' && rawGovCtx ? rawGovCtx : undefined;
+  if (govCtx) {
+    // Find the latest check for this governance_context (Map iterates in insertion order)
+    let latestCheck: { status: string; explanation: string } | undefined;
+    for (const check of session.governanceChecks.values()) {
+      if (check.governanceContext === govCtx) {
+        latestCheck = check;
+      }
+    }
+    if (latestCheck?.status === 'denied') {
+      return {
+        errors: [{
+          code: 'GOVERNANCE_DENIED',
+          message: latestCheck.explanation || 'Governance check denied this purchase.',
+        }] as TaskError[],
+      };
+    }
+    // governance_context provided but no matching check — reject if plans exist
+    if (!latestCheck && session.governancePlans.size > 0) {
+      return {
+        errors: [{
+          code: 'GOVERNANCE_DENIED',
+          message: `governance_context "${govCtx}" does not match any governance check. Call check_governance first.`,
+        }] as TaskError[],
+      };
+    }
+  } else if (session.governancePlans.size > 0) {
+    // No governance_context provided but plans exist — compute budget and check
+    const buyBudget = req.total_budget?.amount
+      ?? (req.packages?.reduce((sum, pkg) => sum + ((pkg as unknown as { budget: number }).budget || 0), 0));
+    if (buyBudget !== undefined) {
+      for (const plan of session.governancePlans.values()) {
+        const remaining = plan.budget.total - plan.committedBudget;
+        if (buyBudget > remaining) {
+          return {
+            errors: [{
+              code: 'GOVERNANCE_DENIED',
+              message: `Buy budget $${buyBudget} exceeds governance plan "${plan.planId}" remaining budget $${remaining}. Call check_governance first.`,
+            }] as TaskError[],
+          };
+        }
+        const typeAllocation = plan.budget.allocations?.media_buy;
+        if (typeAllocation?.amount !== undefined) {
+          const typeCommitted = plan.committedByType?.media_buy ?? 0;
+          const typeRemaining = typeAllocation.amount - typeCommitted;
+          if (buyBudget > typeRemaining) {
+            return {
+              errors: [{
+                code: 'GOVERNANCE_DENIED',
+                message: `Buy budget $${buyBudget} exceeds media_buy allocation $${typeRemaining} remaining in plan "${plan.planId}". Call check_governance first.`,
+              }] as TaskError[],
+            };
+          }
+        }
+      }
+    }
+  }
+
   const catalog = getCatalog();
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
 
@@ -1225,8 +1288,7 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
   const resolvedStart = buyStart === 'asap' ? now : buyStart;
 
   // Persist governance_context if provided (spec: sellers MUST persist and return on get_media_buys)
-  const rawGovCtx = (req as unknown as Record<string, unknown>).governance_context;
-  const governanceContext = typeof rawGovCtx === 'string' && rawGovCtx.length <= 4096 ? rawGovCtx : undefined;
+  const governanceContext = govCtx && govCtx.length <= 4096 ? govCtx : undefined;
 
   const mediaBuy: MediaBuyState = {
     mediaBuyId,

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -5620,6 +5620,176 @@ describe('storyboard governance sample_requests accepted by training agent', () 
     expect(isError).toBeFalsy();
     expect(result.status).toBe('denied');
   });
+
+  it('create_media_buy returns GOVERNANCE_DENIED when buy exceeds plan budget', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'gov-denied.example' }, operator: 'gov-denied.example' };
+
+    // Sync a plan with $10K budget — pass brand at top level to align session key
+    await simulateCallTool(server, 'sync_plans', {
+      brand: { domain: 'gov-denied.example' },
+      plans: [{
+        plan_id: 'gov_deny_buy',
+        brand: { domain: 'gov-denied.example' },
+        objectives: 'strict budget',
+        budget: { total: 10000, currency: 'USD', authority_level: 'agent_limited' },
+        flight: { start: '2026-04-01T00:00:00Z', end: '2026-06-30T23:59:59Z' },
+      }],
+    });
+
+    // Attempt create_media_buy with budget exceeding plan — no governance_context
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'gov-denied.example' },
+      start_time: '2026-04-01T00:00:00Z',
+      end_time: '2026-06-30T23:59:59Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 50000,
+      }],
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('GOVERNANCE_DENIED');
+  });
+
+  it('create_media_buy returns GOVERNANCE_DENIED when governance_context maps to denied check', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'gov-ctx-denied.example' }, operator: 'gov-ctx-denied.example' };
+
+    // Sync plan — brand at top level for session key alignment
+    await simulateCallTool(server, 'sync_plans', {
+      brand: { domain: 'gov-ctx-denied.example' },
+      plans: [{
+        plan_id: 'gov_ctx_deny',
+        brand: { domain: 'gov-ctx-denied.example' },
+        objectives: 'strict budget',
+        budget: { total: 10000, currency: 'USD', authority_level: 'agent_limited' },
+        flight: { start: '2026-04-01T00:00:00Z', end: '2026-06-30T23:59:59Z' },
+      }],
+    });
+
+    // check_governance with a governance_context — gets denied
+    const { result: checkResult } = await simulateCallTool(server, 'check_governance', {
+      brand: { domain: 'gov-ctx-denied.example' },
+      plan_id: 'gov_ctx_deny',
+      caller: 'https://test-buyer.example',
+      governance_context: 'gc-for-deny-test',
+      payload: {
+        total_budget: 50000,
+        packages: [{ product_id: 'test', budget: 50000 }],
+      },
+    });
+    expect(checkResult.status).toBe('denied');
+
+    // Attempt create_media_buy with the denied governance_context
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'gov-ctx-denied.example' },
+      start_time: '2026-04-01T00:00:00Z',
+      end_time: '2026-06-30T23:59:59Z',
+      governance_context: 'gc-for-deny-test',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 5000,
+      }],
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('GOVERNANCE_DENIED');
+  });
+
+  it('create_media_buy succeeds when governance_context maps to approved check', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'gov-ok.example' }, operator: 'gov-ok.example' };
+
+    // Sync plan with large budget
+    await simulateCallTool(server, 'sync_plans', {
+      brand: { domain: 'gov-ok.example' },
+      plans: [{
+        plan_id: 'gov_approve_buy',
+        brand: { domain: 'gov-ok.example' },
+        objectives: 'large budget',
+        budget: { total: 100000, currency: 'USD', authority_level: 'agent_full' },
+        flight: { start: '2026-04-01T00:00:00Z', end: '2026-06-30T23:59:59Z' },
+      }],
+    });
+
+    // check_governance — approved
+    const { result: checkResult } = await simulateCallTool(server, 'check_governance', {
+      brand: { domain: 'gov-ok.example' },
+      plan_id: 'gov_approve_buy',
+      caller: 'https://test-buyer.example',
+      payload: { total_budget: 25000 },
+    });
+    expect(checkResult.status).toBe('approved');
+
+    // create_media_buy with approved governance_context
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'gov-ok.example' },
+      start_time: '2026-04-01T00:00:00Z',
+      end_time: '2026-06-30T23:59:59Z',
+      governance_context: checkResult.governance_context,
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 25000,
+      }],
+    });
+
+    expect(isError).toBeFalsy();
+    expect(result.media_buy_id).toBeDefined();
+  });
+
+  it('create_media_buy returns GOVERNANCE_DENIED for fabricated governance_context', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'gov-fake.example' }, operator: 'gov-fake.example' };
+
+    // Sync plan so governance is active
+    await simulateCallTool(server, 'sync_plans', {
+      brand: { domain: 'gov-fake.example' },
+      plans: [{
+        plan_id: 'gov_fake_ctx',
+        brand: { domain: 'gov-fake.example' },
+        objectives: 'strict budget',
+        budget: { total: 10000, currency: 'USD', authority_level: 'agent_limited' },
+        flight: { start: '2026-04-01T00:00:00Z', end: '2026-06-30T23:59:59Z' },
+      }],
+    });
+
+    // Attempt create_media_buy with a fabricated governance_context
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'gov-fake.example' },
+      start_time: '2026-04-01T00:00:00Z',
+      end_time: '2026-06-30T23:59:59Z',
+      governance_context: 'totally-made-up-context',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 5000,
+      }],
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('GOVERNANCE_DENIED');
+    expect(result.message).toContain('does not match any governance check');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Training agent's `create_media_buy` now enforces governance instead of passively storing `governance_context`
- Returns structured `GOVERNANCE_DENIED` AdCP error when:
  - `governance_context` maps to a denied governance check
  - `governance_context` is unrecognized (no matching check in session)
  - No `governance_context` provided but buy budget exceeds governance plan limits
- Uses latest check for a given `governance_context` (not first match) to handle re-checks correctly

## Test plan
- [x] 4 new unit tests: budget exceeds plan, denied context, approved context, fabricated context
- [x] All 272 training-agent tests pass
- [x] All 76 storyboard tests pass
- [x] Full suite (597 tests) passes
- [x] TypeScript compiles cleanly
- [x] Code review: addressed Must Fix (first-match-wins) and Should Fix (bypass via fabricated context)
- [x] Security review: addressed Should Fix (governance bypass via unrecognized context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)