### PR TITLE
fix: redirect editorial WG to perspectives, hide governance posts

### DIFF
--- a/.changeset/fix-editorial-wg-routing.md
+++ b/.changeset/fix-editorial-wg-routing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Redirect /working-groups/editorial to /latest/perspectives, hide Posts & Updates for governance committees, and point Slack content approval links to content admin dashboard.

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1463,7 +1463,10 @@
         }
 
         renderWorkingGroup();
-        loadPosts();
+        // Governance committees (e.g. editorial) use content admin, not WG posts
+        if (currentGroup.committee_type !== 'governance') {
+          loadPosts();
+        }
         loadDocuments();
 
         // Load events for chapters

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -2345,6 +2345,14 @@ export class HTTPServer {
       await this.serveHtmlWithConfig(req, res, 'industry-gatherings.html');
     });
 
+    // Editorial is a content pipeline, not a working group — send visitors to Perspectives
+    this.app.get("/working-groups/editorial", (_req, res) => {
+      res.redirect(301, '/latest/perspectives');
+    });
+    this.app.get("/working-groups/editorial/manage", (_req, res) => {
+      res.redirect(301, '/dashboard/content');
+    });
+
     this.app.get("/working-groups/:slug", async (req, res) => {
       await this.serveHtmlWithConfig(req, res, 'working-groups/detail.html');
     });

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -96,7 +96,7 @@ async function notifyWorkingGroupOfPendingContent(
                 text: 'Review Content',
                 emoji: true,
               },
-              url: `https://agenticadvertising.org/my-content.html`,
+              url: `https://agenticadvertising.org/dashboard/content?status=pending_review`,
               action_id: 'review_content',
             },
           ],


### PR DESCRIPTION
## Summary
- Redirect `/working-groups/editorial` → `/latest/perspectives` (301) since editorial is a content pipeline, not a working group
- Redirect `/working-groups/editorial/manage` → `/dashboard/content` (301)
- Hide "Posts & Updates" section for all governance-type committees on the detail page
- Point Slack content approval notifications to `/dashboard/content?status=pending_review` instead of the defunct `/my-content.html`

## Test plan
- [x] Browser tested: `/working-groups/editorial` redirects to `/latest/perspectives`
- [x] Browser tested: governance committee (board) hides Posts & Updates section
- [x] Browser tested: regular working group still shows Posts & Updates
- [x] Verified Slack approval URL in source points to `/dashboard/content?status=pending_review`
- [x] 599/599 unit tests passing
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)