### PR TITLE
docs: teach Addie about self-service dashboard features

### DIFF
--- a/.changeset/addie-self-service-dashboard-knowledge.md
+++ b/.changeset/addie-self-service-dashboard-knowledge.md
@@ -1,0 +1,4 @@
+---
+---
+
+Teach Addie about self-service dashboard features (email linking, profile settings, notifications) so she directs members there instead of escalating.

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -182,15 +182,26 @@ When someone wants to build an agent or integrate with AdCP, start with the SDKs
 - Both SDKs include CLI tools for quick testing (\`npx @adcp/client\`, \`uvx adcp\`).
 - Full docs: https://docs.adcontextprotocol.org. MCP integration docs for AI coding agents: https://docs.adcontextprotocol.org/mcp
 
-**API Keys:**
-API key management is done through the member dashboard, not through Addie tools.
-- To create, view, or revoke API keys, direct members to: https://agenticadvertising.org/dashboard/api-keys
-- For the public test agent, no personal API key is needed — the public token above works for anyone.
-- Members must be signed in to manage their own API keys
-- You cannot create or manage API keys on behalf of users - always link them to the dashboard
-
 **Account Linking:**
 - get_account_link: Generate a sign-in link
+
+**Account Settings (self-service via dashboard):**
+The account settings page at https://agenticadvertising.org/dashboard/settings lets members manage their own profile. When someone asks about any of the following, direct them there — these are NOT things you can do on their behalf:
+- **Link or change email**: Settings → Linked Emails. Members can link additional email addresses and merge duplicate accounts. If someone wants to change their primary email, they should link the new one first, then it becomes their sign-in.
+- **Profile photo**: Upload or change their avatar
+- **Name and bio**: Edit first name, last name, headline, bio
+- **Community visibility**: Control whether their personal profile appears in the community
+- **Expertise & location**: Set focus areas, job title, location
+- **Social links**: Add LinkedIn, Twitter/X, website
+- **Preferences**: Communication and display preferences
+- **Email notifications**: Settings → Notifications. Choose which emails they receive (also at https://agenticadvertising.org/dashboard/emails)
+
+Other self-service dashboard pages:
+- **API keys**: https://agenticadvertising.org/dashboard/api-keys — create, view, revoke API keys
+- **Organization settings**: https://agenticadvertising.org/dashboard/organization — manage org details, team members, roles
+- **Membership & billing**: https://agenticadvertising.org/dashboard/membership — view subscription, invoices, payment info
+
+When a member asks you to do something that's available on their settings page, don't escalate — link them directly to the right page.
 
 **Slack Workspace:**
 - The Slack workspace has a public join link: ${SLACK_INVITE_URL}


### PR DESCRIPTION
## Summary
- Addie was escalating requests (like email changes) that members can handle themselves via the dashboard settings page
- Added an "Account Settings (self-service via dashboard)" section to `ADDIE_TOOL_REFERENCE` listing all self-service features: email linking, profile photo, name/bio, visibility, expertise, social links, preferences, notifications
- Added links to all dashboard pages (API keys, org settings, membership/billing)
- Consolidated the standalone API Keys section to avoid duplication
- Key instruction: "When a member asks you to do something that's available on their settings page, don't escalate — link them directly to the right page"

Triggered by: Addie escalated a paid member's email change request instead of directing them to Settings → Linked Emails

## Test plan
- [x] All 599 unit tests pass
- [x] TypeScript typecheck passes
- [x] Code review: no must-fix issues
- [x] Security review: no new attack surfaces (static string constant, no user input interpolation)
- [ ] Verify Addie correctly directs email-change requests to dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)