### PR TITLE
fix: require account on update_media_buy, flatten preview_creative schema

### DIFF
--- a/.changeset/update-media-buy-account-preview-creative-flat.md
+++ b/.changeset/update-media-buy-account-preview-creative-flat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add required account field to update_media_buy for governance parity (#2174). Flatten preview_creative union schema into single object with request_type discriminant (#2175).

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -173,38 +173,23 @@ Since each variant from `get_creative_delivery` includes its full `manifest`, yo
 
 ## Request Parameters
 
-### Variant Mode
+All modes use a single flat object with `request_type` as the discriminant.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `request_type` | string | Yes | `"variant"` |
-| `variant_id` | string | Yes | Platform-assigned variant identifier from `get_creative_delivery` |
-| `creative_id` | string | No | Creative identifier for context |
-| `output_format` | string | No | `"url"` (default) or `"html"` |
+| `request_type` | string | Yes | `"single"`, `"batch"`, or `"variant"` |
+| `creative_manifest` | object | Single | Complete creative manifest with all required assets for the format. |
+| `format_id` | FormatID | No | Format identifier (agent_url + id). Defaults to `creative_manifest.format_id` if omitted. Used in single mode. |
+| `inputs` | array | No | Array of input sets for multiple preview variants. Used in single mode. |
+| `quality` | string | No | `"draft"` (fast, lower-fidelity) or `"production"` (full quality). In batch mode, sets the default for all requests. |
+| `output_format` | string | No | `"url"` (default) or `"html"`. In batch mode, sets the default for all requests. |
+| `item_limit` | integer | No | Maximum catalog items to render per preview variant. Used in single mode. |
+| `template_id` | string | No | Specific template ID for custom format rendering. Used in single mode. |
+| `requests` | array | Batch | Array of 1-50 preview requests. Each item accepts `creative_manifest` (required), `format_id`, `inputs`, `quality`, `output_format`, `item_limit`, and `template_id`. |
+| `variant_id` | string | Variant | Platform-assigned variant identifier from `get_creative_delivery`. |
+| `creative_id` | string | No | Creative identifier for context. Used in variant mode. |
 
-### Single Mode
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `request_type` | string | Yes | `"single"` |
-| `format_id` | FormatID | No | Format identifier (agent_url + id). Defaults to `creative_manifest.format_id` if omitted. |
-| `creative_manifest` | object | Yes | Complete creative manifest with all required assets for the format. |
-| `inputs` | array | No | Array of input sets for multiple preview variants |
-| `quality` | string | No | `"draft"` (fast, lower-fidelity) or `"production"` (full quality). If omitted, the agent uses its own default. |
-| `output_format` | string | No | `"url"` (default) or `"html"` |
-| `item_limit` | integer | No | Maximum catalog items to render per preview variant. Creative agents SHOULD default to a reasonable sample when omitted and the catalog is large. |
-| `template_id` | string | No | Specific template ID for custom format rendering. Used when a format supports multiple visual templates. |
-
-### Batch Mode
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `request_type` | string | Yes | `"batch"` |
-| `requests` | array | Yes | Array of 1-50 preview requests |
-| `quality` | string | No | Default quality for all requests: `"draft"` or `"production"` |
-| `output_format` | string | No | Default output format for all requests |
-
-Each item in `requests` also accepts `quality`, `output_format`, `item_limit`, and `template_id` to override batch-level defaults for that individual preview.
+**Required** column values: *Single* = required when `request_type` is `"single"`, *Batch* = required when `"batch"`, *Variant* = required when `"variant"`.
 
 ### Input Sets
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -63,6 +63,7 @@ console.log(`Created media buy ${created.media_buy_id}`);
 
 // Now update it - pause the campaign
 const updateResult = await testAgent.updateMediaBuy({
+  account: { brand: { domain: 'acmecorp.com' }, operator: 'acmecorp.com' },
   media_buy_id: created.media_buy_id,
   paused: true
 });
@@ -116,6 +117,7 @@ async def create_and_pause_campaign():
 
     # Now update it - pause the campaign
     update_result = await test_agent.simple.update_media_buy(
+        account={'brand': {'domain': 'acmecorp.com'}, 'operator': 'acmecorp.com'},
         media_buy_id=create_result.media_buy_id,
         paused=True
     )
@@ -134,7 +136,8 @@ asyncio.run(create_and_pause_campaign())
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `media_buy_id` | string | Yes* | Seller's media buy identifier to update |
+| `account` | [account-ref](/docs/building/integration/accounts-and-agents#account-references) | Yes | Account that owns this media buy. Pass `{ "account_id": "..." }` or `{ "brand": {...}, "operator": "..." }`. Required for governance checks and account resolution. |
+| `media_buy_id` | string | Yes | Seller's media buy identifier to update |
 | `revision` | integer | No | Expected current revision for optimistic concurrency. Seller rejects with `CONFLICT` on mismatch. Obtain from `get_media_buys` or the most recent response. |
 | `start_time` | string | No | Updated campaign start time |
 | `end_time` | string | No | Updated campaign end time |
@@ -148,7 +151,7 @@ asyncio.run(create_and_pause_campaign())
 | `new_packages` | PackageRequest[] | No | New packages to add to this media buy. Same shape as `create_media_buy` packages. Only supported by sellers that advertise `add_packages` in `valid_actions`. |
 | `push_notification_config` | object | No | Webhook for async operation notifications |
 
-`media_buy_id` is required to identify the media buy to update.
+`account` and `media_buy_id` are always required.
 
 ### Reporting Webhook Object
 
@@ -225,6 +228,7 @@ import { testAgent } from '@adcp/client/testing';
 import { UpdateMediaBuyResponseSchema } from '@adcp/client';
 
 const result = await testAgent.updateMediaBuy({
+  account: { account_id: 'acc_acme_001' },
   media_buy_id: 'mb_12345',
   packages: [{
     package_id: 'pkg_001',
@@ -256,6 +260,7 @@ from adcp.types import UpdateMediaBuyRequest
 async def increase_budget():
     result = await test_agent.update_media_buy(
         UpdateMediaBuyRequest(
+            account={'account_id': 'acc_acme_001'},
             media_buy_id='mb_12345',
             packages=[
                 {'package_id': 'pkg_001', 'budget': 50000}
@@ -286,6 +291,7 @@ import { testAgent } from '@adcp/client/testing';
 import { UpdateMediaBuyResponseSchema } from '@adcp/client';
 
 const result = await testAgent.updateMediaBuy({
+  account: { account_id: 'acc_acme_001' },
   media_buy_id: 'mb_12345',
   end_time: '2025-09-30T23:59:59Z'
 });
@@ -312,6 +318,7 @@ from adcp.types import UpdateMediaBuyRequest
 async def extend_campaign():
     result = await test_agent.update_media_buy(
         UpdateMediaBuyRequest(
+            account={'account_id': 'acc_acme_001'},
             media_buy_id='mb_12345',
             end_time='2025-09-30T23:59:59Z'
         )
@@ -339,6 +346,7 @@ import { testAgent } from '@adcp/client/testing';
 import { UpdateMediaBuyResponseSchema } from '@adcp/client';
 
 const result = await testAgent.updateMediaBuy({
+  account: { account_id: 'acc_acme_001' },
   media_buy_id: 'mb_12345',
   packages: [{
     package_id: 'pkg_001',
@@ -370,6 +378,7 @@ from adcp.types import UpdateMediaBuyRequest
 async def update_targeting():
     result = await test_agent.update_media_buy(
         UpdateMediaBuyRequest(
+            account={'account_id': 'acc_acme_001'},
             media_buy_id='mb_12345',
             packages=[
                 {
@@ -404,6 +413,7 @@ import { testAgent } from '@adcp/client/testing';
 import { UpdateMediaBuyResponseSchema } from '@adcp/client';
 
 const result = await testAgent.updateMediaBuy({
+  account: { account_id: 'acc_acme_001' },
   media_buy_id: 'mb_12345',
   packages: [{
     package_id: 'pkg_001',
@@ -437,6 +447,7 @@ from adcp.types import UpdateMediaBuyRequest
 async def replace_creatives():
     result = await test_agent.update_media_buy(
         UpdateMediaBuyRequest(
+            account={'account_id': 'acc_acme_001'},
             media_buy_id='mb_12345',
             packages=[
                 {
@@ -473,6 +484,7 @@ import { testAgent } from '@adcp/client/testing';
 import { UpdateMediaBuyResponseSchema } from '@adcp/client';
 
 const result = await testAgent.updateMediaBuy({
+  account: { account_id: 'acc_acme_001' },
   media_buy_id: 'mb_12345',
   packages: [
     {
@@ -509,6 +521,7 @@ from adcp.types import UpdateMediaBuyRequest
 async def update_multiple_packages():
     result = await test_agent.update_media_buy(
         UpdateMediaBuyRequest(
+            account={'account_id': 'acc_acme_001'},
             media_buy_id='mb_12345',
             packages=[
                 {
@@ -541,6 +554,7 @@ Cancel an entire media buy:
 
 ```json
 {
+  "account": { "account_id": "acc_acme_001" },
   "media_buy_id": "mb_12345",
   "canceled": true,
   "cancellation_reason": "Campaign strategy changed"
@@ -586,6 +600,7 @@ Cancel a single package while the media buy remains active:
 
 ```json
 {
+  "account": { "account_id": "acc_acme_001" },
   "media_buy_id": "mb_12345",
   "packages": [
     {
@@ -694,6 +709,7 @@ Only specified fields are updated - omitted fields remain unchanged:
 
 ```json
 {
+  "account": { "account_id": "acc_acme_001" },
   "media_buy_id": "mb_12345",
   "packages": [{
     "package_id": "pkg_001",
@@ -706,6 +722,7 @@ Only specified fields are updated - omitted fields remain unchanged:
 
 ```json
 {
+  "account": { "account_id": "acc_acme_001" },
   "media_buy_id": "mb_12345",
   "packages": [{
     "package_id": "pkg_001",

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -78,6 +78,7 @@ export const ADCP_TASK_REGISTRY: Record<string, AdcpTaskMeta> = {
     area: 'media-buy',
     description: 'Modify an existing media buy (dates, pause/resume, cancel, budget, targeting, creatives)',
     validate: (params) => {
+      if (!params.account) return 'account is required (account_id or brand+operator).';
       if (!params.media_buy_id) return 'media_buy_id is required to identify the media buy to update.';
       return null;
     },
@@ -87,7 +88,17 @@ export const ADCP_TASK_REGISTRY: Record<string, AdcpTaskMeta> = {
 
   // Creative
   build_creative: { area: 'creative', description: 'Generate a creative from a brief or transform an existing creative to a different format' },
-  preview_creative: { area: 'creative', description: 'Generate visual previews of creative manifests' },
+  preview_creative: {
+    area: 'creative',
+    description: 'Generate visual previews of creative manifests',
+    validate: (params) => {
+      if (!params.request_type) return 'request_type is required (single, batch, or variant).';
+      if (params.request_type === 'single' && !params.creative_manifest) return 'creative_manifest is required for single mode.';
+      if (params.request_type === 'batch' && !params.requests) return 'requests array is required for batch mode.';
+      if (params.request_type === 'variant' && !params.variant_id) return 'variant_id is required for variant mode.';
+      return null;
+    },
+  },
   get_creative_delivery: { area: 'creative', description: 'Retrieve variant-level creative delivery data from a creative agent' },
 
   // Signals
@@ -397,7 +408,7 @@ const callAdcpTaskTool: AddieTool = {
           'Task-specific parameters. Quick reference for common tasks:',
           '• get_products: { brief, brand: { domain }, buying_mode?: "brief"|"wholesale"|"refine", filters?: { channels, budget_range } }',
           '• create_media_buy: { brand: { domain }, packages: [{ product_id, pricing_option_id, budget }], start_time: { type: "asap"|"scheduled" }, end_time }',
-          '• update_media_buy: { media_buy_id, paused?, canceled?, packages?: [{ package_id, budget? }] }',
+          '• update_media_buy: { account: { account_id | brand+operator }, media_buy_id, paused?, canceled?, packages?: [{ package_id, budget? }] }',
           '• sync_creatives: { creatives: [{ creative_id, format_id: { agent_url, id }, assets }], assignments? }',
           '• build_creative: { message, target_format_id: { agent_url, id }, brand?: { domain } }',
           '• get_signals: { signal_spec, destinations?, countries? }',

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -640,13 +640,17 @@ const TOOLS = [
       type: 'object' as const,
       properties: {
         account: ACCOUNT_REF_SCHEMA,
-        request_type: { type: 'string', enum: ['single', 'batch'], description: 'Single or batch preview' },
-        creative_manifest: { type: 'object', description: 'Creative manifest with assets to preview' },
-        creative_id: { type: 'string', description: 'Reference to a synced creative to preview' },
-        creatives: { type: 'array', description: 'Array of manifests for batch preview' },
+        request_type: { type: 'string', enum: ['single', 'batch', 'variant'], description: 'Preview mode: single, batch, or variant' },
+        creative_manifest: { type: 'object', description: 'Creative manifest with assets to preview (required for single mode)' },
+        creative_id: { type: 'string', description: 'Creative identifier for context (variant mode)' },
+        requests: { type: 'array', description: 'Array of preview requests for batch mode (1-50 items)', minItems: 1, maxItems: 50, items: { type: 'object', properties: { creative_manifest: { type: 'object' } }, required: ['creative_manifest'] } },
+        variant_id: { type: 'string', description: 'Variant ID from get_creative_delivery (required for variant mode)' },
         output_format: { type: 'string', enum: ['url', 'html', 'both'], description: 'Preview output format' },
         quality: { type: 'string', enum: ['draft', 'production'] },
+        template_id: { type: 'string', description: 'Specific template ID for custom format rendering' },
+        item_limit: { type: 'integer', minimum: 1, description: 'Max catalog items to render per preview' },
       },
+      required: ['request_type'] as const,
     },
   },
   {
@@ -668,7 +672,7 @@ const TOOLS = [
         end_time: { type: 'string' },
         action: { type: 'string', description: 'Action to perform (pause, resume, cancel, extend)' },
       },
-      required: ['media_buy_id'] as const,
+      required: ['account', 'media_buy_id'] as const,
     },
   },
   {
@@ -2562,12 +2566,15 @@ function handleBuildCreative(args: ToolArgs, ctx: TrainingContext): BuildCreativ
 
 interface PreviewCreativeArgs {
   account?: unknown;
-  request_type?: 'single' | 'batch';
+  request_type?: 'single' | 'batch' | 'variant';
   creative_manifest?: { format_id?: FormatID; creative_id?: string; assets?: Record<string, unknown> };
   creative_id?: string;
-  creatives?: Array<{ format_id?: FormatID; creative_id?: string; assets?: Record<string, unknown> }>;
+  requests?: Array<{ format_id?: FormatID; creative_id?: string; assets?: Record<string, unknown> }>;
+  variant_id?: string;
   output_format?: 'url' | 'html' | 'both';
   quality?: 'draft' | 'production';
+  template_id?: string;
+  item_limit?: number;
 }
 
 function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext) {
@@ -2623,11 +2630,19 @@ function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext) {
     };
   }
 
+  // Variant mode
+  if (req.request_type === 'variant') {
+    if (!req.variant_id) {
+      return { errors: [{ code: 'INVALID_REQUEST', message: 'variant_id is required for variant mode.' }] };
+    }
+    return { errors: [{ code: 'NOT_SUPPORTED', message: 'Variant replay is not supported by the training agent. Use single or batch mode.' }] };
+  }
+
   // Batch mode
-  if (req.request_type === 'batch' && req.creatives?.length) {
+  if (req.request_type === 'batch' && req.requests?.length) {
     return {
       response_type: 'batch',
-      results: req.creatives.map(c => ({
+      results: req.requests.map(c => ({
         success: true,
         creative_id: c.creative_id || 'unknown',
         response: {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2566,7 +2566,7 @@ function handleBuildCreative(args: ToolArgs, ctx: TrainingContext): BuildCreativ
 
 interface PreviewCreativeArgs {
   account?: unknown;
-  request_type?: 'single' | 'batch' | 'variant';
+  request_type: 'single' | 'batch' | 'variant';
   creative_manifest?: { format_id?: FormatID; creative_id?: string; assets?: Record<string, unknown> };
   creative_id?: string;
   requests?: Array<{ format_id?: FormatID; creative_id?: string; assets?: Record<string, unknown> }>;

--- a/static/schemas/source/creative/preview-creative-request.json
+++ b/static/schemas/source/creative/preview-creative-request.json
@@ -2,238 +2,176 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/creative/preview-creative-request.json",
   "title": "Preview Creative Request",
-  "description": "Request to generate previews of one or more creative manifests. Accepts either a single creative request or an array of requests for batch processing.",
-  "oneOf": [
-    {
-      "type": "object",
-      "description": "Single creative preview request",
-      "properties": {
-        "adcp_major_version": {
-          "type": "integer",
-          "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
-          "minimum": 1,
-          "maximum": 99
-        },
-        "request_type": {
-          "type": "string",
-          "const": "single",
-          "description": "Discriminator indicating this is a single preview request"
-        },
-        "format_id": {
-          "$ref": "/schemas/core/format-id.json",
-          "description": "Format identifier for rendering the preview. Optional — defaults to creative_manifest.format_id if omitted."
-        },
-        "creative_manifest": {
-          "$ref": "/schemas/core/creative-manifest.json",
-          "description": "Complete creative manifest with all required assets for the format."
-        },
-        "inputs": {
-          "type": "array",
-          "description": "Array of input sets for generating multiple preview variants. Each input set defines macros and context values for one preview rendering. If not provided, creative agent will generate default previews.",
-          "items": {
+  "description": "Request to generate previews of creative manifests. Uses request_type to select single, batch, or variant mode.",
+  "type": "object",
+  "properties": {
+    "adcp_major_version": {
+      "type": "integer",
+      "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
+    "request_type": {
+      "type": "string",
+      "enum": ["single", "batch", "variant"],
+      "description": "Preview mode. 'single' previews one creative manifest. 'batch' previews multiple creatives in one call. 'variant' replays a post-flight variant by ID."
+    },
+    "creative_manifest": {
+      "$ref": "/schemas/core/creative-manifest.json",
+      "description": "Complete creative manifest with all required assets for the format. Required when request_type is 'single'. Also accepted per item in batch mode."
+    },
+    "format_id": {
+      "$ref": "/schemas/core/format-id.json",
+      "description": "Format identifier for rendering the preview. Defaults to creative_manifest.format_id if omitted. Used in single mode."
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Array of input sets for generating multiple preview variants. Each input set defines macros and context values for one preview rendering. Used in single mode.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for this input set (e.g., 'Sunny morning on mobile', 'Evening podcast ad', 'Desktop dark mode')"
+          },
+          "macros": {
             "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Human-readable name for this input set (e.g., 'Sunny morning on mobile', 'Evening podcast ad', 'Desktop dark mode')"
-              },
-              "macros": {
-                "type": "object",
-                "description": "Macro values to use for this preview. Supports all universal macros from the format's supported_macros list. See docs/creative/universal-macros.md for available macros.",
-                "additionalProperties": {
-                  "type": "string"
+            "description": "Macro values to use for this preview. Supports all universal macros from the format's supported_macros list.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "context_description": {
+            "type": "string",
+            "description": "Natural language description of the context for AI-generated content (e.g., 'User just searched for running shoes', 'Podcast discussing weather patterns')"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": true
+      },
+      "minItems": 1
+    },
+    "template_id": {
+      "type": "string",
+      "description": "Specific template ID for custom format rendering. Used in single mode."
+    },
+    "quality": {
+      "$ref": "/schemas/enums/creative-quality.json",
+      "description": "Render quality. 'draft' produces fast, lower-fidelity renderings. 'production' produces full-quality renderings. In batch mode, sets the default for all requests (individual items can override)."
+    },
+    "output_format": {
+      "$ref": "/schemas/enums/preview-output-format.json",
+      "default": "url",
+      "description": "Output format. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML). In batch mode, sets the default for all requests (individual items can override). Default: 'url'."
+    },
+    "item_limit": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum number of catalog items to render per preview variant. Used in single mode. Creative agents SHOULD default to a reasonable sample when omitted and the catalog is large."
+    },
+    "requests": {
+      "type": "array",
+      "description": "Array of preview requests (1-50 items). Required when request_type is 'batch'. Each item follows the single request structure.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "format_id": {
+            "$ref": "/schemas/core/format-id.json",
+            "description": "Format identifier for rendering the preview. Defaults to creative_manifest.format_id if omitted."
+          },
+          "creative_manifest": {
+            "$ref": "/schemas/core/creative-manifest.json",
+            "description": "Complete creative manifest with all required assets."
+          },
+          "inputs": {
+            "type": "array",
+            "description": "Array of input sets for generating multiple preview variants",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Human-readable name for this input set"
+                },
+                "macros": {
+                  "type": "object",
+                  "description": "Macro values to use for this preview",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "context_description": {
+                  "type": "string",
+                  "description": "Natural language description of the context for AI-generated content"
                 }
               },
-              "context_description": {
-                "type": "string",
-                "description": "Natural language description of the context for AI-generated content (e.g., 'User just searched for running shoes', 'Podcast discussing weather patterns', 'Article about electric vehicles')"
-              }
+              "required": [
+                "name"
+              ],
+              "additionalProperties": true
             },
-            "required": [
-              "name"
-            ],
-            "additionalProperties": true
+            "minItems": 1
           },
-          "minItems": 1
-        },
-        "template_id": {
-          "type": "string",
-          "description": "Specific template ID for custom format rendering"
-        },
-        "quality": {
-          "$ref": "/schemas/enums/creative-quality.json",
-          "description": "Render quality for the preview. 'draft' produces fast, lower-fidelity renderings for rapid iteration. 'production' produces full-quality renderings for final review. If omitted, the creative agent uses its own default."
-        },
-        "output_format": {
-          "$ref": "/schemas/enums/preview-output-format.json",
-          "default": "url",
-          "description": "Output format for previews. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML for direct embedding). Default: 'url' for backward compatibility."
-        },
-        "item_limit": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of catalog items to render in the preview. For catalog-driven generative formats, caps how many items are rendered per preview variant. When item_limit exceeds the format's max_items, the creative agent SHOULD use the lesser of the two. Ignored when the manifest contains no catalog assets. Creative agents SHOULD default to a reasonable sample when omitted and the catalog is large."
-        },
-        "context": {
-          "$ref": "/schemas/core/context.json"
-        },
-        "ext": {
-          "$ref": "/schemas/core/ext.json"
-        }
-      },
-      "required": [
-        "request_type",
-        "creative_manifest"
-      ],
-      "additionalProperties": true
-    },
-    {
-      "type": "object",
-      "description": "Batch preview request for multiple creatives (5-10x faster than individual calls)",
-      "properties": {
-        "adcp_major_version": {
-          "type": "integer",
-          "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
-          "minimum": 1,
-          "maximum": 99
-        },
-        "request_type": {
-          "type": "string",
-          "const": "batch",
-          "description": "Discriminator indicating this is a batch preview request"
-        },
-        "requests": {
-          "type": "array",
-          "description": "Array of preview requests (1-50 items). Each follows the single request structure.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "format_id": {
-                "$ref": "/schemas/core/format-id.json",
-                "description": "Format identifier for rendering the preview. Optional — defaults to creative_manifest.format_id if omitted."
-              },
-              "creative_manifest": {
-                "$ref": "/schemas/core/creative-manifest.json",
-                "description": "Complete creative manifest with all required assets."
-              },
-              "inputs": {
-                "type": "array",
-                "description": "Array of input sets for generating multiple preview variants",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Human-readable name for this input set"
-                    },
-                    "macros": {
-                      "type": "object",
-                      "description": "Macro values to use for this preview",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    },
-                    "context_description": {
-                      "type": "string",
-                      "description": "Natural language description of the context for AI-generated content"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "additionalProperties": true
-                },
-                "minItems": 1
-              },
-              "template_id": {
-                "type": "string",
-                "description": "Specific template ID for custom format rendering"
-              },
-              "quality": {
-                "$ref": "/schemas/enums/creative-quality.json",
-                "description": "Render quality for this preview. 'draft' produces fast, lower-fidelity renderings. 'production' produces full-quality renderings. Overrides any batch-level default."
-              },
-              "output_format": {
-                "$ref": "/schemas/enums/preview-output-format.json",
-                "default": "url",
-                "description": "Output format for this preview. 'url' returns preview_url, 'html' returns preview_html."
-              },
-              "item_limit": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Maximum number of catalog items to render in this preview."
-              }
-            },
-            "required": [
-              "creative_manifest"
-            ],
-            "additionalProperties": true
+          "template_id": {
+            "type": "string",
+            "description": "Specific template ID for custom format rendering"
           },
-          "minItems": 1,
-          "maxItems": 50
+          "quality": {
+            "$ref": "/schemas/enums/creative-quality.json",
+            "description": "Render quality for this preview. Overrides batch-level default."
+          },
+          "output_format": {
+            "$ref": "/schemas/enums/preview-output-format.json",
+            "default": "url",
+            "description": "Output format for this preview. Overrides batch-level default."
+          },
+          "item_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of catalog items to render in this preview."
+          }
         },
-        "quality": {
-          "$ref": "/schemas/enums/creative-quality.json",
-          "description": "Default render quality for all requests in this batch. Individual requests can override this. 'draft' produces fast, lower-fidelity renderings. 'production' produces full-quality renderings."
-        },
-        "output_format": {
-          "$ref": "/schemas/enums/preview-output-format.json",
-          "default": "url",
-          "description": "Default output format for all requests in this batch. Individual requests can override this. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML for direct embedding)."
-        },
-        "context": {
-          "$ref": "/schemas/core/context.json"
-        },
-        "ext": {
-          "$ref": "/schemas/core/ext.json"
-        }
+        "required": [
+          "creative_manifest"
+        ],
+        "additionalProperties": true
       },
-      "required": [
-        "request_type",
-        "requests"
-      ],
-      "additionalProperties": true
+      "minItems": 1,
+      "maxItems": 50
     },
-    {
-      "type": "object",
-      "description": "Variant preview request - retrieve a post-flight preview of a specific creative variant that was served during delivery",
-      "properties": {
-        "adcp_major_version": {
-          "type": "integer",
-          "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
-          "minimum": 1,
-          "maximum": 99
-        },
-        "request_type": {
-          "type": "string",
-          "const": "variant",
-          "description": "Discriminator indicating this is a variant preview request"
-        },
-        "variant_id": {
-          "type": "string",
-          "description": "Platform-assigned variant identifier from get_creative_delivery response"
-        },
-        "creative_id": {
-          "type": "string",
-          "description": "Creative identifier for context"
-        },
-        "output_format": {
-          "$ref": "/schemas/enums/preview-output-format.json",
-          "default": "url",
-          "description": "Output format for the preview. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML for direct embedding)."
-        },
-        "context": {
-          "$ref": "/schemas/core/context.json"
-        },
-        "ext": {
-          "$ref": "/schemas/core/ext.json"
-        }
-      },
-      "required": [
-        "request_type",
-        "variant_id"
-      ],
-      "additionalProperties": true
+    "variant_id": {
+      "type": "string",
+      "description": "Platform-assigned variant identifier from get_creative_delivery response. Required when request_type is 'variant'."
+    },
+    "creative_id": {
+      "type": "string",
+      "description": "Creative identifier for context. Used in variant mode."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
     }
-  ]
+  },
+  "required": [
+    "request_type"
+  ],
+  "allOf": [
+    {
+      "if": { "properties": { "request_type": { "const": "single" } } },
+      "then": { "required": ["creative_manifest"] }
+    },
+    {
+      "if": { "properties": { "request_type": { "const": "batch" } } },
+      "then": { "required": ["requests"] }
+    },
+    {
+      "if": { "properties": { "request_type": { "const": "variant" } } },
+      "then": { "required": ["variant_id"] }
+    }
+  ],
+  "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -11,6 +11,10 @@
       "minimum": 1,
       "maximum": 99
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns this media buy. Pass a natural key (brand, operator, optional sandbox) or a seller-assigned account_id from list_accounts. Required for governance checks and account resolution."
+    },
     "media_buy_id": {
       "type": "string",
       "description": "Seller's ID of the media buy to update"
@@ -84,6 +88,7 @@
     }
   },
   "required": [
+    "account",
     "media_buy_id"
   ],
   "additionalProperties": true


### PR DESCRIPTION
## Summary

Implements two pre-3.0 schema changes discovered during `createAdcpServer` implementation (#537):

- **#2174**: Add required `account` field to `update_media_buy` — enables automated governance and account resolution on the most financially sensitive mutation tool, matching `create_media_buy`'s shape
- **#2175**: Flatten `preview_creative` from `oneOf` union (3 variants) into a single object with `request_type` discriminant — every tool now works with `server.tool(name, schema.shape, handler)`

### Changes

**Schema** (`static/schemas/source/`):
- `update-media-buy-request.json`: added `account` (required) referencing `account-ref.json`
- `preview-creative-request.json`: replaced `oneOf` with flat object + `allOf` conditional validation (`if/then` for mode-specific required fields)

**Server** (`server/src/`):
- `adcp-tools.ts`: added `account` validation on `update_media_buy`, added `validate` function for `preview_creative` mode-specific requirements, updated quick-reference hint text
- `training-agent/task-handlers.ts`: added `account` to required array, updated `preview_creative` tool definition (added `variant` to enum, renamed `creatives` → `requests`, added missing fields), added variant mode handler

**Docs** (`docs/`):
- `update_media_buy.mdx`: added `account` to parameter table, updated all 15 code examples (JS, Python, JSON)
- `preview_creative.mdx`: replaced 3 per-mode parameter tables with single flat table

Closes #2174, closes #2175.

## Test plan

- [x] All 587 unit tests pass (training-agent, storyboards, creative-agent, etc.)
- [x] TypeScript typecheck passes
- [x] Mintlify docs validation passes (no broken links)
- [x] Pre-push hooks pass (version sync, accessibility)
- [ ] Verify `@adcp/client` storyboard `media_buy_state_machine.yaml` sample_requests are updated to include `account` (separate client PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)