### PR TITLE
fix: bypass PgBouncer, connect directly to Postgres

### DIFF
--- a/.changeset/fix-db-pool-direct.md
+++ b/.changeset/fix-db-pool-direct.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bypass PgBouncer and connect directly to Postgres with a properly configured connection pool (max=40, min=5, 30s idle timeout). Removes PgBouncer-specific workarounds that caused double-pooling issues.

--- a/.env.local.example
+++ b/.env.local.example
@@ -37,11 +37,11 @@ DATABASE_SSL=false
 # Verify SSL certificates when SSL is enabled (default: true)
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
-# Connection timeout (how long to wait for a connection from the pool)
-DATABASE_CONNECTION_TIMEOUT_MS=10000
-# NOTE: Pool size and idle timeout are hardcoded (max=3, idle=1s) because
-# PgBouncer owns connection pooling. Overriding them creates a second pool
-# that conflicts with PgBouncer's idle timeouts (causing client_idle_timeout).
+# Connection pool settings (direct Postgres connection, no PgBouncer)
+DATABASE_POOL_MAX=40
+DATABASE_POOL_MIN=5
+DATABASE_CONNECTION_TIMEOUT_MS=5000
+DATABASE_IDLE_TIMEOUT_MS=30000
 
 # ============================================================================
 # AUTHENTICATION - WorkOS (Required for Registry Features)
@@ -197,7 +197,7 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # 3. Database:
 #    - Use SSL in production (DATABASE_SSL=true)
 #    - Ensure DATABASE_URL uses strong password
-#    - PgBouncer handles connection pooling (pool size/idle timeout are hardcoded)
+#    - Pool settings tunable via DATABASE_POOL_MAX, DATABASE_POOL_MIN, DATABASE_IDLE_TIMEOUT_MS
 #
 # 4. Stripe keys:
 #    - Use live keys (sk_live_..., pk_live_...) in production
@@ -207,5 +207,5 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # 5. Monitoring:
 #    - Set LOG_LEVEL=info in production
 #    - Configure log aggregation (CloudWatch, Datadog, etc.)
-#    - Monitor PgBouncer stats for connection health
+#    - Monitor connection pool stats in application logs
 #

--- a/.env.local.example
+++ b/.env.local.example
@@ -37,8 +37,10 @@ DATABASE_SSL=false
 # Verify SSL certificates when SSL is enabled (default: true)
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
-# Connection pool settings (direct Postgres connection, no PgBouncer)
-DATABASE_POOL_MAX=40
+# Connection pool settings (direct Postgres connection).
+# Total connections = num_processes * DATABASE_POOL_MAX.
+# Ensure total doesn't exceed Postgres max_connections (check with SHOW max_connections).
+DATABASE_POOL_MAX=20
 DATABASE_POOL_MIN=5
 DATABASE_CONNECTION_TIMEOUT_MS=5000
 DATABASE_IDLE_TIMEOUT_MS=30000

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -10,6 +10,7 @@ export interface DatabaseConfig {
   password?: string;
   ssl?: boolean | { rejectUnauthorized: boolean };
   maxPoolSize?: number;
+  minPoolSize?: number;
   connectionTimeoutMillis?: number;
   idleTimeoutMillis?: number;
 }
@@ -37,10 +38,9 @@ export function getDatabaseConfig(): DatabaseConfig | null {
   return {
     connectionString,
     ssl,
-    // Pool settings are hardcoded in client.ts (PgBouncer owns pooling).
-    // These fields exist only so migrate.ts can pass a partial config.
-    maxPoolSize: 3,
-    connectionTimeoutMillis: 10000,
-    idleTimeoutMillis: 1,
+    maxPoolSize: parseInt(process.env.DATABASE_POOL_MAX || "40", 10),
+    minPoolSize: parseInt(process.env.DATABASE_POOL_MIN || "5", 10),
+    connectionTimeoutMillis: parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS || "5000", 10),
+    idleTimeoutMillis: parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS || "30000", 10),
   };
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -15,6 +15,16 @@ export interface DatabaseConfig {
   idleTimeoutMillis?: number;
 }
 
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${name}: "${raw}" (must be a non-negative integer)`);
+  }
+  return parsed;
+}
+
 /**
  * Get database configuration from environment variables
  */
@@ -38,9 +48,9 @@ export function getDatabaseConfig(): DatabaseConfig | null {
   return {
     connectionString,
     ssl,
-    maxPoolSize: parseInt(process.env.DATABASE_POOL_MAX || "40", 10),
-    minPoolSize: parseInt(process.env.DATABASE_POOL_MIN || "5", 10),
-    connectionTimeoutMillis: parseInt(process.env.DATABASE_CONNECTION_TIMEOUT_MS || "5000", 10),
-    idleTimeoutMillis: parseInt(process.env.DATABASE_IDLE_TIMEOUT_MS || "30000", 10),
+    maxPoolSize: envInt("DATABASE_POOL_MAX", 20),
+    minPoolSize: envInt("DATABASE_POOL_MIN", 5),
+    connectionTimeoutMillis: envInt("DATABASE_CONNECTION_TIMEOUT_MS", 5000),
+    idleTimeoutMillis: envInt("DATABASE_IDLE_TIMEOUT_MS", 30000),
   };
 }

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1517,8 +1517,7 @@ export async function getAdminLearnerDetail(userId: string): Promise<AdminLearne
  * Uses CONCURRENTLY to avoid locking reads during refresh.
  */
 export async function refreshEngagementTime(): Promise<void> {
-  // REFRESH MATERIALIZED VIEW CONCURRENTLY cannot run inside a transaction,
-  // and PgBouncer transaction mode discards non-LOCAL SET between statements.
+  // REFRESH MATERIALIZED VIEW CONCURRENTLY cannot run inside a transaction.
   // Rely on the role-level statement_timeout (set to 120s via ALTER ROLE for
   // this specific need, or accept the 30s default — the view is non-critical).
   try {

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -30,14 +30,10 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
     user: config.user,
     password: config.password,
     ssl: config.ssl,
-    // PgBouncer owns connection pooling — pg.Pool is only a concurrency
-    // limiter and connection manager. idleTimeoutMillis: 1 (not 0 — 0 is
-    // falsy and disables eviction entirely in pg-pool) closes idle
-    // connections after 1 ms, preventing stale connections that conflict
-    // with PgBouncer's client_idle_timeout. max: 3 caps concurrent checkouts.
-    max: 3,
-    idleTimeoutMillis: 1,
-    connectionTimeoutMillis: 10000,
+    max: config.maxPoolSize ?? 40,
+    min: config.minPoolSize ?? 5,
+    idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
+    connectionTimeoutMillis: config.connectionTimeoutMillis ?? 5000,
     allowExitOnIdle: true,
   });
 
@@ -60,10 +56,8 @@ export function getPool(): Pool {
   return pool;
 }
 
-/** Transient connection errors that are safe to retry (PgBouncer / TCP resets). */
+/** Transient connection errors that are safe to retry once. */
 const TRANSIENT_CONNECTION_ERRORS = new Set([
-  "client_idle_timeout",
-  "server_login_retry",
   "connection_reset",
   "ECONNRESET",
   "EPIPE",
@@ -85,8 +79,7 @@ function isTransientConnectionError(err: unknown): boolean {
  * Execute a parameterized query. All callers must use $1, $2, etc. placeholders
  * with the params array -- never concatenate user input into the text argument.
  *
- * Automatically retries once on transient connection errors (e.g. PgBouncer
- * closing an idle connection between pool checkout and query execution).
+ * Automatically retries once on transient connection errors.
  */
 export async function query<T extends QueryResultRow = any>(
   text: string,
@@ -106,45 +99,15 @@ export async function query<T extends QueryResultRow = any>(
 
 /**
  * Get a client from the pool for transactions.
- *
- * Validates the connection with a probe query before returning it.
- * If the connection is stale (PgBouncer killed it), releases it and
- * retries once with a fresh connection.
  */
 export async function getClient(): Promise<PoolClient> {
   const p = getPool();
-  const client = await p.connect();
-  try {
-    await client.query("SELECT 1");
-    return client;
-  } catch (err) {
-    client.release(true);
-    if (isTransientConnectionError(err)) {
-      console.warn("Stale DB connection on checkout, retrying:", (err as Error).message);
-      const retryClient = await p.connect();
-      try {
-        await retryClient.query("SELECT 1");
-        return retryClient;
-      } catch (retryErr) {
-        retryClient.release(true);
-        throw retryErr;
-      }
-    }
-    throw err;
-  }
+  return p.connect();
 }
 
 /**
- * Perform a health check using the pool.
- *
- * Previous versions opened a dedicated pg.Client on every call, bypassing
- * the pool. Under load this added connection churn (TCP + TLS handshake
- * every 15 s per machine) and competed with real traffic for PgBouncer
- * slots — causing the very timeouts it was trying to avoid.
- *
- * Using the pool is the correct signal: if the pool cannot serve a trivial
- * query within the timeout, the machine genuinely cannot handle DB traffic
- * and Fly should stop routing to it.
+ * Perform a health check. If the pool can't serve a trivial query,
+ * the machine can't handle DB traffic and Fly should stop routing to it.
  */
 export async function healthCheck(timeoutMs = 5000): Promise<void> {
   const p = getPool();

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -30,7 +30,7 @@ export function initializeDatabase(config: DatabaseConfig): Pool {
     user: config.user,
     password: config.password,
     ssl: config.ssl,
-    max: config.maxPoolSize ?? 40,
+    max: config.maxPoolSize ?? 20,
     min: config.minPoolSize ?? 5,
     idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
     connectionTimeoutMillis: config.connectionTimeoutMillis ?? 5000,

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -235,6 +235,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     connectionString:
       process.env.DATABASE_URL || process.env.DATABASE_PRIVATE_URL,
     ssl,
+    maxPoolSize: 2,
+    minPoolSize: 0,
   };
 
   runMigrations(config)

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -274,8 +274,7 @@ export function createAccountLinkingRouter(): Router {
 
       // Update WorkOS (source of truth for auth) AFTER the transaction is
       // committed and the connection is released. This avoids holding a DB
-      // connection idle while waiting on an external network call, which
-      // triggers PgBouncer client_idle_timeout errors.
+      // connection idle while waiting on an external network call.
       // If WorkOS rejects the update the outer catch handles the error;
       // the DB change is already committed, and the user.updated webhook
       // will re-sync on the next WorkOS event if needed.

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -1202,8 +1202,7 @@ export function createOrganizationsRouter(): Router {
             }
 
             // Commit the read-lock transaction before making external API calls.
-            // This avoids holding a DB connection idle during network round-trips,
-            // which triggers PgBouncer client_idle_timeout errors.
+            // This avoids holding a DB connection idle during network round-trips.
             await client.query('COMMIT');
 
             // --- WorkOS API calls (outside any DB transaction) ---


### PR DESCRIPTION
## Summary
- Bypass PgBouncer and connect directly to Postgres with a properly configured connection pool
- Pool defaults: max=20, min=5, 30s idle timeout, 5s connection timeout (all configurable via env vars)
- Remove PgBouncer-specific workarounds: SELECT 1 probe on checkout, 1ms idle timeout, pgbouncer error codes
- Migration CLI uses minimal pool (max=2, min=0) since it's single-shot
- Fail-fast validation on pool env vars (rejects NaN/negative values)

## Why
PgBouncer and pg-pool were double-pooling — pg-pool's 1ms idle timeout fought PgBouncer's client_idle_timeout, causing persistent transient connection errors. With 8GB Postgres RAM and only 3 processes, we can manage our own pool directly.

## Deploy steps
```bash
fly secrets set DATABASE_URL="postgresql://fly-user:...@direct.vmkq6098ekpr35ln.flympg.net/fly-db" DATABASE_SSL=true
```

Pool size tunable without redeploy:
```bash
fly secrets set DATABASE_POOL_MAX=30 DATABASE_POOL_MIN=10
```

## Test plan
- [x] Unit tests pass (587/587)
- [x] TypeScript compiles clean
- [ ] Verify production `SHOW max_connections` and size pool accordingly
- [ ] Monitor connection count after deploy (`SELECT count(*) FROM pg_stat_activity`)
- [ ] Watch for pool exhaustion errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)