### PR TITLE
fix: user merge FK, signalSpec type, upgrade CPUs

### DIFF
--- a/.changeset/fix-merge-signal-cpu.md
+++ b/.changeset/fix-merge-signal-cpu.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix user merge FK violation (ON DELETE CASCADE), fix signalSpec TypeError in training agent, upgrade to 2x performance CPUs.

--- a/fly.toml
+++ b/fly.toml
@@ -62,13 +62,13 @@ primary_region = 'iad'
 
 [[vm]]
   processes = ["web"]
-  memory = "1gb"
-  cpu_kind = "shared"
-  cpus = 1
+  memory = "2gb"
+  cpu_kind = "performance"
+  cpus = 2
 
 [[vm]]
   processes = ["worker"]
   memory = "2gb"
-  cpu_kind = "shared"
-  cpus = 1
+  cpu_kind = "performance"
+  cpus = 2
 

--- a/server/src/db/migrations/397_person_events_cascade_delete.sql
+++ b/server/src/db/migrations/397_person_events_cascade_delete.sql
@@ -1,0 +1,8 @@
+-- When a person_relationships row is merged (deleted), cascade the delete to
+-- orphaned person_events rows. The merge code re-parents events first, so this
+-- only fires if a concurrent insert sneaks in between the re-parent UPDATE and
+-- the DELETE — preventing the FK violation that was crashing user merges.
+ALTER TABLE person_events
+  DROP CONSTRAINT person_events_person_id_fkey,
+  ADD CONSTRAINT person_events_person_id_fkey
+    FOREIGN KEY (person_id) REFERENCES person_relationships(id) ON DELETE CASCADE;

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2037,7 +2037,8 @@ const MAX_SIGNAL_RESULTS = 10;
 function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
   const req = args as unknown as GetSignalsRequest & ToolArgs & { brief?: string };
   // Accept both signal_spec (protocol) and brief (SDK test tool)
-  const signalSpec = req.signal_spec || req.brief;
+  const rawSpec = req.signal_spec || req.brief;
+  const signalSpec = typeof rawSpec === 'string' ? rawSpec : undefined;
   const maxResults = Math.min(Math.max(req.max_results || MAX_SIGNAL_RESULTS, 1), 50);
   const session = getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
 


### PR DESCRIPTION
## Summary
- **User merge FK violation**: Add `ON DELETE CASCADE` to `person_events.person_id` FK. A race condition allowed concurrent `person_events` inserts between the re-parent UPDATE and the loser DELETE, violating the FK constraint and rolling back the merge.
- **Training agent TypeError**: `signalSpec.toLowerCase is not a function` — LLM tool calls can pass non-string values for `signal_spec`. Coerce to string before use.
- **CPU upgrade**: Web and worker machines bumped from 1 shared CPU / 1-2GB to 2 performance CPUs / 2GB. Slow response logs (4-7s for `/count`, `/status`) indicate CPU contention during concurrent LLM streaming.

## Test plan
- [x] 587 unit tests pass
- [x] TypeScript compiles clean
- [ ] After deploy, verify user merges succeed (check Slack for `user-merge-db` errors)
- [ ] After deploy, verify no `signalSpec.toLowerCase` errors in training agent
- [ ] Compare slow response frequency before/after CPU upgrade via Fly metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)