### PR TITLE
fix: correct LinkedIn and YouTube URLs in site footer

### DIFF
--- a/.changeset/fix-social-links.md
+++ b/.changeset/fix-social-links.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix broken LinkedIn and YouTube links in site footer.

--- a/docs.json
+++ b/docs.json
@@ -1209,8 +1209,8 @@
     ]
   },
   "socials": {
-    "linkedin": "https://www.linkedin.com/company/agenticadvertisingorg",
-    "youtube": "https://www.youtube.com/@AgenticAdvertisingOrg",
+    "linkedin": "https://www.linkedin.com/company/ad-context-protocol/",
+    "youtube": "https://www.youtube.com/@AgenticAdvertising",
     "github": "https://github.com/adcontextprotocol/adcp"
   },
   "api": {


### PR DESCRIPTION
## Summary
- LinkedIn URL pointed to `/company/agenticadvertisingorg` (page doesn't exist) — corrected to `/company/ad-context-protocol/`
- YouTube URL pointed to `@AgenticAdvertisingOrg` (wrong handle) — corrected to `@AgenticAdvertising`

Reported by Mary Mason with screenshots of the 404 pages.

## Test plan
- [ ] Verify LinkedIn icon in footer links to https://www.linkedin.com/company/ad-context-protocol/
- [ ] Verify YouTube icon in footer links to https://www.youtube.com/@AgenticAdvertising

🤖 Generated with [Claude Code](https://claude.com/claude-code)