### PR TITLE
feat: soft-delete for councils

### DIFF
--- a/.changeset/council-soft-delete.md
+++ b/.changeset/council-soft-delete.md
@@ -1,0 +1,4 @@
+---
+---
+
+Replace hard-delete with soft-delete for councils/committees. Deactivated committees are hidden from the public site but preserved for reactivation.

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -97,6 +97,8 @@
     .btn-secondary:hover { background: var(--color-gray-300); }
     .btn-danger { background: var(--color-error-500); color: white; }
     .btn-danger:hover { background: var(--color-error-600); }
+    .btn-success { background: var(--color-success-500, #22c55e); color: white; }
+    .btn-success:hover { background: var(--color-success-600, #16a34a); }
     .modal-overlay {
       display: none;
       position: fixed;
@@ -605,16 +607,16 @@
     </div>
   </div>
 
-  <!-- Delete Confirmation Modal -->
-  <div id="deleteModal" class="modal-overlay">
+  <!-- Deactivate Confirmation Modal -->
+  <div id="deactivateModal" class="modal-overlay">
     <div class="modal" style="max-width: 450px;">
-      <h2>Delete Committee</h2>
+      <h2>Deactivate Committee</h2>
       <p style="margin: var(--space-5) 0; color: var(--color-text-secondary);">
-        Are you sure you want to delete "<span id="deleteTitle"></span>"? This will also remove all memberships.
+        Are you sure you want to deactivate "<span id="deactivateTitle"></span>"? It will be hidden from the public site but can be reactivated later.
       </p>
       <div class="modal-buttons">
-        <button type="button" class="btn btn-secondary" onclick="closeDeleteModal()">Cancel</button>
-        <button type="button" class="btn btn-danger" onclick="confirmDelete()">Delete</button>
+        <button type="button" class="btn btn-secondary" onclick="closeDeactivateModal()">Cancel</button>
+        <button type="button" class="btn btn-danger" onclick="confirmDeactivate()">Deactivate</button>
       </div>
     </div>
   </div>
@@ -623,7 +625,7 @@
     let groups = [];
     let allMemberships = [];
     let editingGroup = null;
-    let deletingGroupId = null;
+    let deactivatingGroupId = null;
     let searchTimeout = null;
     let memberSearchTimeout = null;
 
@@ -830,7 +832,10 @@
               <button class="btn btn-secondary btn-small meetings-btn">Meetings</button>
               <button class="btn btn-secondary btn-small schedule-btn">Schedule</button>
               <button class="btn btn-primary btn-small manage-btn">Manage</button>
-              <button class="btn btn-danger btn-small delete-group-btn">Delete</button>
+              ${group.status === 'active'
+                ? '<button class="btn btn-danger btn-small deactivate-group-btn">Deactivate</button>'
+                : '<button class="btn btn-success btn-small reactivate-group-btn">Reactivate</button>'
+              }
             </div>
           </div>
         `;
@@ -851,9 +856,18 @@
         actions.querySelector('.manage-btn').addEventListener('click', () => {
           editGroup(groupId);
         });
-        actions.querySelector('.delete-group-btn').addEventListener('click', () => {
-          showDeleteModal(groupId, groupName);
-        });
+        const deactivateBtn = actions.querySelector('.deactivate-group-btn');
+        if (deactivateBtn) {
+          deactivateBtn.addEventListener('click', () => {
+            showDeactivateModal(groupId, groupName);
+          });
+        }
+        const reactivateBtn = actions.querySelector('.reactivate-group-btn');
+        if (reactivateBtn) {
+          reactivateBtn.addEventListener('click', () => {
+            reactivateGroup(groupId);
+          });
+        }
       });
     }
 
@@ -1544,38 +1558,57 @@
       saveBtn.textContent = 'Save';
     }
 
-    // Show delete modal
-    function showDeleteModal(id, name) {
-      deletingGroupId = id;
-      document.getElementById('deleteTitle').textContent = name;
-      document.getElementById('deleteModal').style.display = 'flex';
+    // Show deactivate modal
+    function showDeactivateModal(id, name) {
+      deactivatingGroupId = id;
+      document.getElementById('deactivateTitle').textContent = name;
+      document.getElementById('deactivateModal').style.display = 'flex';
     }
 
-    // Close delete modal
-    function closeDeleteModal() {
-      document.getElementById('deleteModal').style.display = 'none';
-      deletingGroupId = null;
+    // Close deactivate modal
+    function closeDeactivateModal() {
+      document.getElementById('deactivateModal').style.display = 'none';
+      deactivatingGroupId = null;
     }
 
-    // Confirm delete
-    async function confirmDelete() {
-      if (!deletingGroupId) return;
+    // Confirm deactivate
+    async function confirmDeactivate() {
+      if (!deactivatingGroupId) return;
 
       try {
-        const response = await fetch(`/api/admin/working-groups/${deletingGroupId}`, {
-          method: 'DELETE',
+        const response = await fetch(`/api/admin/working-groups/${deactivatingGroupId}/deactivate`, {
+          method: 'POST',
           credentials: 'same-origin'
         });
 
         if (!response.ok) {
-          throw new Error('Failed to delete');
+          throw new Error('Failed to deactivate');
         }
 
-        closeDeleteModal();
+        closeDeactivateModal();
         loadGroups();
       } catch (error) {
-        console.error('Error deleting:', error);
-        alert('Failed to delete: ' + error.message);
+        console.error('Error deactivating:', error);
+        alert('Failed to deactivate: ' + error.message);
+      }
+    }
+
+    // Reactivate group
+    async function reactivateGroup(id) {
+      try {
+        const response = await fetch(`/api/admin/working-groups/${id}/reactivate`, {
+          method: 'POST',
+          credentials: 'same-origin'
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to reactivate');
+        }
+
+        loadGroups();
+      } catch (error) {
+        console.error('Error reactivating:', error);
+        alert('Failed to reactivate: ' + error.message);
       }
     }
 

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -245,11 +245,22 @@ export class WorkingGroupDatabase {
   }
 
   /**
-   * Delete working group
+   * Deactivate a working group by setting status to 'inactive'
    */
-  async deleteWorkingGroup(id: string): Promise<boolean> {
+  async deactivateWorkingGroup(id: string): Promise<boolean> {
     const result = await query(
-      'DELETE FROM working_groups WHERE id = $1',
+      `UPDATE working_groups SET status = 'inactive', updated_at = NOW() WHERE id = $1`,
+      [id]
+    );
+    return (result.rowCount || 0) > 0;
+  }
+
+  /**
+   * Reactivate a working group by setting status to 'active'
+   */
+  async reactivateWorkingGroup(id: string): Promise<boolean> {
+    const result = await query(
+      `UPDATE working_groups SET status = 'active', updated_at = NOW() WHERE id = $1`,
       [id]
     );
     return (result.rowCount || 0) > 0;

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -559,24 +559,54 @@ export function createCommitteeRouters(): {
     }
   });
 
-  // DELETE /api/admin/working-groups/:id - Delete working group
-  adminApiRouter.delete('/:id', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  // POST /api/admin/working-groups/:id/deactivate - Deactivate working group
+  adminApiRouter.post('/:id/deactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const deleted = await workingGroupDb.deleteWorkingGroup(id);
+      if (!UUID_REGEX.test(id)) {
+        return res.status(400).json({ error: 'Invalid working group ID' });
+      }
+      const deactivated = await workingGroupDb.deactivateWorkingGroup(id);
 
-      if (!deleted) {
+      if (!deactivated) {
         return res.status(404).json({
           error: 'Working group not found',
           message: `No working group found with id ${id}`
         });
       }
 
-      res.json({ success: true, deleted: id });
+      invalidateMemberContextCache();
+      res.json({ success: true, deactivated: id });
     } catch (error) {
-      logger.error({ err: error }, 'Delete working group error:');
+      logger.error({ err: error }, 'Deactivate working group error:');
       res.status(500).json({
-        error: 'Failed to delete working group',
+        error: 'Failed to deactivate working group',
+      });
+    }
+  });
+
+  // POST /api/admin/working-groups/:id/reactivate - Reactivate working group
+  adminApiRouter.post('/:id/reactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!UUID_REGEX.test(id)) {
+        return res.status(400).json({ error: 'Invalid working group ID' });
+      }
+      const reactivated = await workingGroupDb.reactivateWorkingGroup(id);
+
+      if (!reactivated) {
+        return res.status(404).json({
+          error: 'Working group not found',
+          message: `No working group found with id ${id}`
+        });
+      }
+
+      invalidateMemberContextCache();
+      res.json({ success: true, reactivated: id });
+    } catch (error) {
+      logger.error({ err: error }, 'Reactivate working group error:');
+      res.status(500).json({
+        error: 'Failed to reactivate working group',
       });
     }
   });


### PR DESCRIPTION
## Summary
- Replaces hard-delete with soft-delete for councils/committees in the admin UI
- Admins now see **Deactivate** (for active) / **Reactivate** (for inactive) instead of Delete
- Deactivated councils are hidden from the public site but preserved with all memberships intact
- Prompted by Mary flagging that the admin UI only offered "Delete" with no way to bring councils back

## Changes
- `server/src/db/working-group-db.ts` — `deleteWorkingGroup()` → `deactivateWorkingGroup()` + `reactivateWorkingGroup()`
- `server/src/routes/committees.ts` — `DELETE /:id` → `POST /:id/deactivate` + `POST /:id/reactivate` (with UUID validation and cache invalidation)
- `server/public/admin-working-groups.html` — Delete button/modal replaced with Deactivate/Reactivate toggle

## Test plan
- [x] All 587 unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Manually verify admin UI shows Deactivate for active councils
- [ ] Manually verify deactivated council disappears from public site
- [ ] Manually verify Reactivate button appears for inactive councils and restores them

🤖 Generated with [Claude Code](https://claude.com/claude-code)