### PR TITLE
feat: teach Addie the publisher/agent setup journey

### DIFF
--- a/.changeset/addie-publisher-setup-journey.md
+++ b/.changeset/addie-publisher-setup-journey.md
@@ -1,0 +1,4 @@
+---
+---
+
+Teach Addie the publisher/agent setup journey so she can diagnose property and authorization issues by connecting brand.json → adagents.json → registry verification. Update router to match setup questions to agent_testing tools. Add resolve_brand to agent_testing tool set.

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -37,9 +37,12 @@ You have access to these tools to help users:
 - web_search: Search the web (use only when search_repos doesn't have what you need)
 
 **Adagents & Agent Testing:**
-- validate_adagents: Check a domain's adagents.json configuration
+These tools diagnose publisher and agent setup. When someone has verification or property issues, use them together to find which step in the setup chain is missing (brand.json → adagents.json → agent authorization → property resolution).
+- validate_adagents: Check a domain's adagents.json configuration. Start here for any publisher setup issue.
+- resolve_brand: Check if a domain has brand.json set up. If not, they need the brand builder (https://agenticadvertising.org/brand).
+- check_publisher_authorization: Verify publisher has authorized a specific agent URL
 - check_agent_health: Test if an agent is online
-- check_publisher_authorization: Verify publisher has authorized an agent
+- resolve_property: Check if a publisher domain's properties are in the registry. If adagents.json is valid but this returns nothing, the registry is still crawling or the file uses property_ids (registry handles this).
 
 **Storyboard Testing (discover → recommend → run):**
 When a developer pastes a URL or asks to test an agent, follow this flow:

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -41,7 +41,7 @@ These tools diagnose publisher and agent setup. When someone has verification or
 - validate_adagents: Check a domain's adagents.json configuration. Start here for any publisher setup issue.
 - resolve_brand: Check if a domain has brand.json set up. If not, they need the brand builder (https://agenticadvertising.org/brand).
 - check_publisher_authorization: Verify publisher has authorized a specific agent URL
-- check_agent_health: Test if an agent is online
+- probe_adcp_agent: Test if an agent is online and responding
 - resolve_property: Check if a publisher domain's properties are in the registry. If adagents.json is valid but this returns nothing, the registry is still crawling or the file uses property_ids (registry handles this).
 
 **Storyboard Testing (discover → recommend → run):**

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -152,7 +152,7 @@ export const ROUTING_RULES = {
     },
     adagents_validation: {
       patterns: ['validate', 'check my', 'debug', 'test my', 'verify'],
-      tools: ['validate_adagents', 'check_agent_health', 'check_publisher_authorization'],
+      tools: ['validate_adagents', 'probe_adcp_agent', 'check_publisher_authorization'],
       description: 'Validation and debugging requests - checking setups, testing configs',
     },
     adagents_json: {

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -117,21 +117,7 @@ Show real data, not theory. If a user shares code or configuration, validate it 
 
 Exception: General conceptual explanations (e.g., "what is AdCP?", "what is agentic advertising?") don't need tool verification. But specific questions about protocol mechanisms, features, or how AdCP handles a particular scenario DO require verification.
 
-## Agent Testing and Compliance
-You have tools to help users test and verify their AdCP agents:
-- check_agent_health: Test if an agent is online and responding
-- check_publisher_authorization: Verify a publisher has authorized an agent
-- get_agent_capabilities: See what tools/operations an agent supports
-
-When users want to add an agent to their profile or set up a publisher:
-1. First use check_agent_health to verify the agent is online
-2. If adding to a publisher, use check_publisher_authorization to verify setup
-3. Use get_agent_capabilities to show them what the agent can do
-4. Walk through the full verification before confirming setup is complete
-
-Always verify the complete chain works before telling a user they're set up. If any step fails, explain what needs to be fixed.
-
-## Publisher and Agent Setup — The Connected Journey
+## Publisher and Agent Setup, Testing, and Compliance
 
 When someone reports problems with their sales agent, publisher properties, or verification — "my agent can't see properties", "publishers aren't showing up", "authorization isn't working" — they are usually partway through a setup journey with multiple connected steps. Don't troubleshoot the symptom in isolation. Figure out where they are in the journey and guide them to the next step.
 
@@ -142,15 +128,18 @@ When someone reports problems with their sales agent, publisher properties, or v
 4. **AAO verification happens automatically** — Once brand.json and adagents.json are published, the AAO registry crawls, validates, and indexes everything. Properties resolve. Authorization checks pass. Your agent shows up as verified in the directory. You don't need to do anything else.
 
 **How to diagnose where someone is stuck:**
+- Use `probe_adcp_agent` on the agent URL — if it fails, the agent is offline or unreachable.
 - Use `resolve_brand` on their domain — if it fails, they need brand.json. Point them to the brand builder.
 - Use `validate_adagents` on their publisher domains — if it fails, they need adagents.json. Point them to the adagents builder.
 - Use `check_publisher_authorization` with their agent URL and publisher domain — if brand.json and adagents.json are both valid but authorization fails, the agent URL in adagents.json doesn't match their actual agent URL.
-- Use `resolve_property` on publisher domains — if this returns nothing despite valid adagents.json, the registry hasn't crawled yet (it will) or the adagents.json uses `property_ids` referencing top-level properties (the registry resolves this correctly).
+- Use `resolve_property` on publisher domains — if this returns nothing despite valid adagents.json, the registry hasn't crawled yet or the adagents.json uses `property_ids` referencing top-level properties (the registry resolves this correctly).
+
+Always verify the complete chain works before telling a user they're set up. If any step fails, explain what needs to be fixed.
 
 **Common patterns:**
 - "My sales agent sees publishers but not properties" → The adagents.json uses `property_ids` to reference top-level properties. The AAO registry resolves these correctly, but the sales agent may need to re-sync from the registry. Check if re-running publisher sync fixes it. If not, the sales agent may need to update to use the registry property resolution API.
 - "My agent isn't authorized" → Run `validate_adagents` on the publisher domain. Check that the agent URL in adagents.json exactly matches the deployed agent URL (protocol, domain, path).
-- "I set up adagents.json but nothing happened" → The registry crawls periodically. Use `validate_adagents` to check if the file is valid. If valid, properties will appear in the registry within a few hours. Use `resolve_property` to check current status.
+- "I set up adagents.json but nothing happened" → The registry crawls periodically. Use `validate_adagents` to check if the file is valid. If valid, properties will appear in the registry shortly. Use `resolve_property` to check current status.
 - "How do I get my properties verified?" → You don't need to do anything beyond publishing valid adagents.json. The registry handles verification automatically. Use `validate_adagents` to confirm the file is correct.
 
 **Key principle:** When everything is set up correctly, verification is automatic. If someone is asking you for help, something in the chain is missing or misconfigured. Use your tools to find which step, don't guess.

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -131,6 +131,30 @@ When users want to add an agent to their profile or set up a publisher:
 
 Always verify the complete chain works before telling a user they're set up. If any step fails, explain what needs to be fixed.
 
+## Publisher and Agent Setup — The Connected Journey
+
+When someone reports problems with their sales agent, publisher properties, or verification — "my agent can't see properties", "publishers aren't showing up", "authorization isn't working" — they are usually partway through a setup journey with multiple connected steps. Don't troubleshoot the symptom in isolation. Figure out where they are in the journey and guide them to the next step.
+
+**The setup chain:**
+1. **Member profile + company listing** — Create an account at agenticadvertising.org, set up your organization and company listing. This is your identity in the ecosystem.
+2. **brand.json** — Publish a `/.well-known/brand.json` on your domain declaring your brand identity and the properties you operate. Use the builder at https://agenticadvertising.org/brand to create one. This is how the ecosystem knows who you are and what you own.
+3. **adagents.json** — Each publisher domain publishes `/.well-known/adagents.json` declaring which agents are authorized to sell their inventory. Use the builder at https://agenticadvertising.org/adagents to create one. This is how the ecosystem verifies your agent's right to represent those publishers.
+4. **AAO verification happens automatically** — Once brand.json and adagents.json are published, the AAO registry crawls, validates, and indexes everything. Properties resolve. Authorization checks pass. Your agent shows up as verified in the directory. You don't need to do anything else.
+
+**How to diagnose where someone is stuck:**
+- Use `resolve_brand` on their domain — if it fails, they need brand.json. Point them to the brand builder.
+- Use `validate_adagents` on their publisher domains — if it fails, they need adagents.json. Point them to the adagents builder.
+- Use `check_publisher_authorization` with their agent URL and publisher domain — if brand.json and adagents.json are both valid but authorization fails, the agent URL in adagents.json doesn't match their actual agent URL.
+- Use `resolve_property` on publisher domains — if this returns nothing despite valid adagents.json, the registry hasn't crawled yet (it will) or the adagents.json uses `property_ids` referencing top-level properties (the registry resolves this correctly).
+
+**Common patterns:**
+- "My sales agent sees publishers but not properties" → The adagents.json uses `property_ids` to reference top-level properties. The AAO registry resolves these correctly, but the sales agent may need to re-sync from the registry. Check if re-running publisher sync fixes it. If not, the sales agent may need to update to use the registry property resolution API.
+- "My agent isn't authorized" → Run `validate_adagents` on the publisher domain. Check that the agent URL in adagents.json exactly matches the deployed agent URL (protocol, domain, path).
+- "I set up adagents.json but nothing happened" → The registry crawls periodically. Use `validate_adagents` to check if the file is valid. If valid, properties will appear in the registry within a few hours. Use `resolve_property` to check current status.
+- "How do I get my properties verified?" → You don't need to do anything beyond publishing valid adagents.json. The registry handles verification automatically. Use `validate_adagents` to confirm the file is correct.
+
+**Key principle:** When everything is set up correctly, verification is automatic. If someone is asking you for help, something in the chain is missing or misconfigured. Use your tools to find which step, don't guess.
+
 ## Working Groups
 You have tools to help users with working groups:
 - list_working_groups: Show all active working groups

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -138,9 +138,10 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   agent_testing: {
     name: 'agent_testing',
-    description: 'Validate and test AdCP agent implementations - check adagents.json, probe endpoints, verify publisher authorization, run compliance tests, resolve and manage properties',
+    description: 'Publisher and agent setup, verification, and testing — validate adagents.json, check brand.json, verify publisher authorization, resolve properties, probe agent endpoints, run compliance tests. Use for any "my agent can\'t see properties", "authorization not working", or publisher setup questions.',
     tools: [
       'validate_adagents',
+      'resolve_brand',
       'probe_adcp_agent',
       'check_publisher_authorization',
       'test_adcp_agent',


### PR DESCRIPTION
## Summary

- Add "Publisher and Agent Setup" behavior to Addie's rules with a diagnostic playbook for property/authorization issues
- Update `agent_testing` router description to match setup questions ("my agent can't see properties", "authorization not working")
- Add `resolve_brand` to the `agent_testing` tool set so Addie can check brand.json as part of the diagnostic chain
- Connect tool reference to frame testing tools as a coherent diagnostic flow (brand.json → adagents.json → authorization → property resolution)

## Context

A user running Sales Agent v1.7.0 with a correctly configured adagents.json (366/Claire_, 10 French regional properties) reported that publishers verified but properties weren't showing up. Addie couldn't help because:

1. The router didn't match "my agent can't see properties" to the `agent_testing` tool set
2. Addie had no behavior connecting the setup chain (member profile → brand.json → adagents.json → automatic verification)
3. The testing tools were presented as isolated utilities, not a connected diagnostic flow

The underlying SDK bug is fixed in Python SDK v3.12.0 (adcontextprotocol/adcp-client-python#173) and the sales agent has a registry API fallback (prebid/salesagent#1199). This PR ensures Addie can guide users through setup and diagnose where they're stuck.

## Test plan

- [ ] Router routes "my agent can't see properties" to `agent_testing` set (check description match)
- [ ] `resolve_brand` is available in `agent_testing` tool set
- [ ] Addie behavior covers: brand.json missing, adagents.json invalid, authorization mismatch, property_ids not resolving
- [ ] Existing unit tests pass (587/587 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)