### PR TITLE
fix: bump VM memory to 4GB (performance CPU minimum)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -62,13 +62,13 @@ primary_region = 'iad'
 
 [[vm]]
   processes = ["web"]
-  memory = "2gb"
+  memory = "4gb"
   cpu_kind = "performance"
   cpus = 2
 
 [[vm]]
   processes = ["worker"]
-  memory = "2gb"
+  memory = "4gb"
   cpu_kind = "performance"
   cpus = 2
 


### PR DESCRIPTION
## Summary
- Fly.io performance CPUs require minimum 4096 MiB RAM
- The previous 2GB setting caused every deploy to fail at machine update, leaving machines stuck on shared 1vCPU / 1GB
- This is why #2208 fixed migrations but the deploy still failed

## Context
The deploy from #2208 succeeded at running migrations but failed with:
```
invalid config.guest.memory_mb, minimum required 4096 MiB
```

## Test plan
- [ ] Deploy succeeds and machines upgrade to performance 2vCPU / 4GB
- [ ] Health checks pass
- [ ] Site is back up

🤖 Generated with [Claude Code](https://claude.com/claude-code)