### PR TITLE
feat: TMP provider registration schema, health endpoint, lifecycle

### DIFF
--- a/.changeset/tmp-provider-registration-schema.md
+++ b/.changeset/tmp-provider-registration-schema.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+feat: add TMP provider registration schema, health endpoint, provider lifecycle, and timeout clarification
+
+Adds `provider-registration.json` schema formalizing provider endpoint, capabilities, countries/uid_types (conditionally required for identity_match), timeout, priority, and lifecycle status (active/inactive/draining). Updates specification.mdx, router-architecture.mdx, and buyer-guide.mdx with health endpoint (GET /health), dual discovery models (static config and dynamic API with SSRF guidance), and clarified per-provider vs overall latency budget semantics.

--- a/docs/trusted-match/buyer-guide.mdx
+++ b/docs/trusted-match/buyer-guide.mdx
@@ -163,14 +163,22 @@ Provider registration is an out-of-band process. After establishing a media buy 
 
 ```json
 {
-  "provider_id": "acme-outdoor-buyer",
-  "endpoint": "https://tmp.acmeoutdoor.example/v1",
+  "provider_id": "acme-outdoor-us",
+  "endpoint": "https://us.tmp.acmeoutdoor.example/v1",
   "context_match": true,
-  "identity_match": true
+  "identity_match": true,
+  "countries": ["US"],
+  "uid_types": ["uid2", "rampid", "id5"]
 }
 ```
 
+When you support `identity_match`, you MUST declare `countries` (which country codes you serve) and `uid_types` (which identity types you resolve). The router uses these to filter Identity Match fan-out — without them, the router cannot route requests to your provider.
+
 You can support either or both endpoints. Context Match only means contextual targeting without frequency capping. Identity Match only means the publisher evaluates context locally from your media buy's targeting rules and calls you only for frequency checks. Both means full TMP integration.
+
+### Health endpoint
+
+You SHOULD expose `GET /health` at your base URL. Return HTTP `200` with `{"status": "ok"}` when ready. The publisher's router uses this for pre-flight checks and monitoring. It is not called during request fan-out — only on a background interval.
 
 ## Error Handling
 

--- a/docs/trusted-match/router-architecture.mdx
+++ b/docs/trusted-match/router-architecture.mdx
@@ -52,21 +52,60 @@ TEE attestation is an upgrade path. Without TEE, you trust that the operator dep
 
 ## Provider Registration
 
-Publishers configure which providers the router calls. This is an operational relationship — the publisher trusts the provider to participate in their ad decisioning.
+Publishers configure which providers the router calls. This is an operational relationship — the publisher trusts the provider to participate in their ad decisioning. Provider registrations follow the `provider-registration` schema (`/schemas/tmp/provider-registration.json`).
 
-| Setting | Type | Description |
-|---|---|---|
-| `endpoint` | URL | Provider's base URL. The router appends `/context` or `/identity` when dispatching. |
-| `context_match` | bool | Provider handles Context Match requests |
-| `identity_match` | bool | Provider handles Identity Match requests |
-| `countries` | List\<string\> | ISO 3166-1 alpha-2 country codes this provider serves. Required when `identity_match` is true. |
-| `uid_types` | List\<string\> | Identity types this provider can resolve (from `uid-type` enum). Required when `identity_match` is true. |
+### Discovery models
 
-Additional configuration per provider:
+Provider registration typically comes from the **page configuration** — the publisher declares providers in their Prebid module config or surface-specific setup. This is the standard path and works well for publishers with a stable set of providers.
 
-- **Property scoping**: Which properties or property groups this provider serves
-- **Latency budget**: Per-provider timeout threshold
-- **Priority**: Provider ordering for tie-breaking in merge conflicts
+**Static configuration** (Prebid config, YAML file, infrastructure-as-code):
+- Publisher declares providers at deploy time
+- Router reads config at startup and on config reload
+- Changes require a config update and reload/redeploy
+- Appropriate for most deployments — provider lists change infrequently
+
+**Dynamic registration** (API-driven, database-backed):
+- Publisher manages providers through an admin interface
+- Router polls a discovery endpoint or watches for configuration changes
+- Changes take effect within one refresh cycle (recommended: 30 seconds)
+- Appropriate for publishers managing many providers or needing runtime updates without redeploys
+- Dynamic registration endpoints MUST validate that provider `endpoint` URLs are external HTTPS addresses. Implementations MUST reject private (RFC 1918), link-local (169.254.x.x), and cloud metadata IP ranges to prevent SSRF through provider registration.
+
+Both models use the same schema. The router does not distinguish between providers loaded from a YAML file and providers loaded from an API — the registration fields are identical.
+
+### Registration fields
+
+| Setting | Type | Required | Description |
+|---|---|---|---|
+| `provider_id` | string | Yes | Stable identifier for this provider. Used in logs, metrics, and cache keys. |
+| `endpoint` | URL | Yes | Provider's base URL. The router appends `/context` or `/identity` when dispatching. |
+| `context_match` | bool | No | Provider handles Context Match requests. At least one of `context_match` or `identity_match` must be true. |
+| `identity_match` | bool | No | Provider handles Identity Match requests. At least one of `context_match` or `identity_match` must be true. |
+| `countries` | List\<string\> | Conditional | ISO 3166-1 alpha-2 country codes. MUST be present when `identity_match` is true. |
+| `uid_types` | List\<string\> | Conditional | Identity types this provider resolves. MUST be present when `identity_match` is true. |
+| `timeout_ms` | integer | No | Per-provider timeout. Must be ≤ the router's `latency_budget_ms`. Default: 50. |
+| `priority` | integer | No | Merge conflict resolution order (lower = higher priority). Default: 0. |
+| `status` | enum | No | `active`, `inactive`, or `draining`. Default: `active`. |
+| `properties` | List\<UUID\> | No | Property RIDs this provider serves. When absent, the provider serves all properties. |
+
+At least one of `context_match` or `identity_match` must be true — a provider that handles neither operation is invalid. When `identity_match` is true, `countries` and `uid_types` are **required** — the router cannot route Identity Match requests without them. The router MUST reject invalid provider registrations and SHOULD log a warning identifying the misconfigured provider.
+
+### Provider lifecycle
+
+Providers have three lifecycle states:
+
+- **Active**: Provider receives requests normally.
+- **Draining**: Provider stops receiving new requests. In-flight requests complete normally. Use when taking a provider offline for maintenance.
+- **Inactive**: Provider is skipped entirely. Use to disable a provider without removing its configuration.
+
+### Provider health
+
+Providers SHOULD expose `GET /health` at their base URL. The router uses this for:
+
+- **Pre-flight checks**: On startup or config reload, verify each provider is reachable before including it in fan-out.
+- **Periodic monitoring**: Check provider health on a configurable interval (recommended: 30 seconds). Providers that fail consecutive health checks MAY be temporarily excluded from fan-out and automatically re-included when health recovers.
+
+Health checks are not in the request hot path — they run on a background interval. The router's `/healthz` endpoint reflects overall router health, not individual provider status.
 
 Providers MAY support any combination of `context_match` and `identity_match`. A context-only provider handles enrichment or contextual targeting. An identity-only provider handles frequency capping — the publisher evaluates context locally from the media buy's targeting rules and calls the buyer only for identity checks.
 
@@ -118,11 +157,16 @@ Duplicate `package_id` across providers is a configuration error — packages co
 
 ### Timeout handling
 
-The default latency budget is 50ms per operation. The router allocates this proportionally across providers based on provider count and historical performance.
+The router manages two distinct timeout values:
+
+- **Overall latency budget** (`latency_budget_ms`): The total time the router has to fan out, collect responses, and merge. Default: 50ms. This is the end-to-end budget the publisher allocates to TMP within their ad serving pipeline.
+- **Per-provider timeout** (`timeout_ms` on the provider registration): The maximum time the router waits for a single provider. Must be ≤ the overall latency budget. Default: 50ms (equal to the budget for single-provider setups).
+
+When multiple providers are configured, the per-provider timeout is the effective cap for each individual provider, and the overall budget is the cap for the entire fan-out. The router enforces the tighter of the two for each provider. For example: with a 50ms overall budget and two providers each set to 40ms, both providers are called in parallel and the router waits at most 50ms total — if provider A responds in 45ms, provider B has already timed out at 40ms.
 
 - **Single provider timeout**: Skip that provider, log its latency percentile, proceed with responses from remaining providers. The skipped provider's packages are treated as "not activated" for this request.
 - **All providers timeout**: Return an empty response — no offers for Context Match, no eligibility for Identity Match. The publisher falls back to existing demand sources (Prebid open auction, direct-sold, etc.).
-- **Adaptive timeout**: The router tracks per-provider latency percentiles (p50, p95, p99) and adjusts allocation over time. Consistently slow providers receive smaller timeout allocations or are preemptively skipped. This is an operational decision, not a protocol requirement.
+- **Adaptive timeout**: The router tracks per-provider latency percentiles (p50, p95, p99) and adjusts allocation over time. Consistently slow providers receive smaller timeout allocations or are preemptively skipped. Higher-priority providers (lower `priority` value) receive a larger share of the budget when adaptive allocation is active. This is an operational decision, not a protocol requirement.
 
 ## Latency Budget
 
@@ -179,36 +223,40 @@ tls:
   cert: /etc/tmp/tls.crt
   key: /etc/tmp/tls.key
 
+latency_budget_ms: 50
+adaptive_timeout: true
+health_check_interval_sec: 30
+
 providers:
   # US cluster — UID2, RampID, ID5
-  - id: acme-outdoor-us
+  - provider_id: acme-outdoor-us
     endpoint: https://us.tmp.acmeoutdoor.example/v1
     context_match: true
     identity_match: true
     countries: [US]
     uid_types: [uid2, rampid, id5]
     timeout_ms: 40
+    priority: 0
     properties: ["01916f3a-9c4e-7000-8000-000000000010"]
 
   # EU cluster — EUID, ID5
-  - id: acme-outdoor-eu
+  - provider_id: acme-outdoor-eu
     endpoint: https://eu.tmp.acmeoutdoor.example/v1
     context_match: true
     identity_match: true
     countries: [DE, FR, IT, ES, NL, BE, AT, PL, SE, DK, FI, IE, PT, GR, CZ, RO, HU, BG, HR, SK, SI, LT, LV, EE, CY, MT, LU, GB]
     uid_types: [euid, id5]
     timeout_ms: 40
+    priority: 0
     properties: ["01916f3a-9c4e-7000-8000-000000000010"]
 
   # Context-only enrichment provider (no identity match, no country scoping needed)
-  - id: enrichment-co
+  - provider_id: enrichment-co
     endpoint: https://enrichment.example/v1
     context_match: true
     identity_match: false
     timeout_ms: 30
-
-latency_budget_ms: 50
-adaptive_timeout: true
+    priority: 10
 ```
 
 ### Container deployment

--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -227,12 +227,34 @@ The router SHOULD exclude providers that return errors from the merged response 
 
 TMP providers are registered with the router via publisher configuration. The publisher specifies which providers the router should call, along with each provider's endpoint and supported capabilities. This is an operational relationship — the publisher trusts the provider to run code in their ad decisioning path.
 
+The standard registration path is **static configuration** — the publisher declares providers in their Prebid module config, router YAML, or equivalent surface-specific configuration. Dynamic registration (API-driven, database-backed) is an equally valid variant for publishers who manage many providers or need runtime updates. Both approaches use the same provider registration schema (`/schemas/tmp/provider-registration.json`).
+
 | Setting | Type | Required | Description |
 |---|---|---|---|
-| `context_match` | bool | Yes | Provider supports Context Match requests. |
-| `identity_match` | bool | No | Provider supports Identity Match requests. Default: false. |
+| `provider_id` | string | Yes | Stable identifier for this provider registration. Used in logs, metrics, and cache keys. |
+| `endpoint` | URL | Yes | Provider's base URL. The router appends `/context` or `/identity` when dispatching. |
+| `context_match` | bool | No | Provider handles Context Match requests. At least one of `context_match` or `identity_match` must be true. |
+| `identity_match` | bool | No | Provider handles Identity Match requests. At least one of `context_match` or `identity_match` must be true. |
+| `countries` | List\<string\> | Conditional | ISO 3166-1 alpha-2 country codes this provider serves. MUST be present and non-empty when `identity_match` is true. |
+| `uid_types` | List\<string\> | Conditional | Identity types this provider can resolve (from `uid-type` enum). MUST be present and non-empty when `identity_match` is true. |
+| `properties` | List\<UUID\> | No | Property RIDs this provider serves. When absent, the provider serves all properties. |
+| `timeout_ms` | integer | No | Per-provider timeout in milliseconds. Must be ≤ the router's overall `latency_budget_ms`. Default: 50. |
+| `priority` | integer | No | Provider ordering for merge conflict resolution. Lower values = higher priority. Default: 0. |
+| `status` | enum | No | Provider lifecycle status: `active`, `inactive`, or `draining`. Default: `active`. |
+
+At least one of `context_match` or `identity_match` must be true — a provider that handles neither operation is invalid. When `identity_match` is true, `countries` and `uid_types` are **required** — the router cannot perform country-partitioned identity routing without them. The schema enforces both constraints.
 
 Providers MAY support any combination of `context_match` and `identity_match`. A provider that supports only `context_match` is a pure enrichment or contextual targeting provider. A provider that supports only `identity_match` is a frequency capping provider — the publisher evaluates context locally from the media buy's targeting rules and calls the buyer only for identity checks.
+
+### Provider lifecycle
+
+Providers have three lifecycle states:
+
+- **Active**: Provider receives requests normally.
+- **Draining**: Provider stops receiving new requests. In-flight requests complete normally. Use this when taking a provider offline for maintenance — the router finishes current work without starting new fan-outs to this provider.
+- **Inactive**: Provider is skipped entirely. Use this to disable a provider without removing its configuration.
+
+State transitions are immediate in static configuration (reload the config) and take effect within one refresh cycle in dynamic registration.
 
 ## Product Integration
 
@@ -476,6 +498,7 @@ Publishers MUST NOT parse, decrypt, or make decisions based on TMPX values. The 
 
 - JSON over HTTP/2 POST. All implementations MUST use this transport.
 - Each provider exposes two path-based endpoints under its base URL: `POST /context` for Context Match and `POST /identity` for Identity Match. The router dispatches requests by path, not by inspecting the message body.
+- Each provider SHOULD expose `GET /health` at its base URL. The endpoint returns HTTP `200` with a JSON body `{"status": "ok"}` when the provider is ready to accept requests. Any non-`200` response or connection failure means the provider is not ready. Routers and operators use this for pre-flight checks and monitoring — it is not called in the request hot path.
 - The `type` field in each message identifies the message for deserialization — routers and agents use it to select the correct schema, not for routing. Agents MUST validate that the `type` field matches the endpoint: `context_match_request` on `/context`, `identity_match_request` on `/identity`. A mismatch MUST be rejected with HTTP `400`.
 - Connections SHOULD be reused via HTTP/2 multiplexing.
 - The router SHOULD maintain a connection pool to each buyer agent.

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1520,6 +1520,10 @@
         "error": {
           "$ref": "/schemas/tmp/error.json",
           "description": "Error response from a TMP provider or router when a request cannot be processed"
+        },
+        "provider-registration": {
+          "$ref": "/schemas/tmp/provider-registration.json",
+          "description": "TMP provider registration — endpoint, capabilities, and operational parameters for router configuration"
         }
       },
       "operations": {

--- a/static/schemas/source/tmp/provider-registration.json
+++ b/static/schemas/source/tmp/provider-registration.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/tmp/provider-registration.json",
+  "title": "TMP Provider Registration",
+  "description": "Declares a TMP provider's endpoint, capabilities, and operational parameters. Used in router configuration (static YAML or dynamic API) and referenced by product-level provider entries. The publisher controls which providers participate in their ad decisioning.",
+  "type": "object",
+  "properties": {
+    "provider_id": {
+      "type": "string",
+      "description": "Stable identifier for this provider registration. Used in logs, metrics, and cache keys. Publishers assign this — it is not the provider's agent_url."
+    },
+    "endpoint": {
+      "type": "string",
+      "format": "uri",
+      "description": "Base URL the router calls. The router appends /context for Context Match and /identity for Identity Match. Must be HTTPS in production."
+    },
+    "context_match": {
+      "type": "boolean",
+      "description": "Provider handles Context Match requests (POST /context)."
+    },
+    "identity_match": {
+      "type": "boolean",
+      "description": "Provider handles Identity Match requests (POST /identity)."
+    },
+    "countries": {
+      "type": "array",
+      "description": "ISO 3166-1 alpha-2 country codes this provider serves. The router filters Identity Match providers by the request's country field. MUST be present and non-empty when identity_match is true.",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "minItems": 1
+    },
+    "uid_types": {
+      "type": "array",
+      "description": "Identity types this provider can resolve. The router filters Identity Match providers whose uid_types includes the request's uid_type. MUST be present and non-empty when identity_match is true.",
+      "items": {
+        "$ref": "/schemas/enums/uid-type.json"
+      },
+      "minItems": 1
+    },
+    "properties": {
+      "type": "array",
+      "description": "Property RIDs (UUID v7) this provider serves. When present, the router only sends requests from these properties to this provider. When absent, the provider serves all properties.",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "minItems": 1
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "description": "Per-provider timeout in milliseconds. The router skips this provider if it does not respond within this budget. Must be less than or equal to the router's overall latency_budget_ms. The router may further reduce this based on adaptive timeout allocation.",
+      "minimum": 5,
+      "maximum": 5000,
+      "default": 50
+    },
+    "priority": {
+      "type": "integer",
+      "description": "Provider ordering for merge conflict resolution. Lower values have higher priority. When two providers return offers for the same package_id (a configuration error), the router keeps the offer from the higher-priority provider. Also used for adaptive timeout allocation — higher-priority providers receive a larger share of the latency budget.",
+      "minimum": 0,
+      "default": 0
+    },
+    "status": {
+      "type": "string",
+      "description": "Provider lifecycle status. Active providers receive requests. Inactive providers are skipped entirely. Draining providers stop receiving new requests but in-flight requests complete normally.",
+      "enum": ["active", "inactive", "draining"],
+      "default": "active"
+    }
+  },
+  "required": [
+    "provider_id",
+    "endpoint"
+  ],
+  "if": {
+    "properties": { "identity_match": { "const": true } },
+    "required": ["identity_match"]
+  },
+  "then": {
+    "required": ["countries", "uid_types"]
+  },
+  "anyOf": [
+    { "properties": { "context_match": { "const": true } }, "required": ["context_match"] },
+    { "properties": { "identity_match": { "const": true } }, "required": ["identity_match"] }
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds `provider-registration.json` schema formalizing the provider registration data model that was previously only documented as prose tables
- Adds `GET /health` endpoint to the TMP provider contract for readiness checks and monitoring
- Documents provider lifecycle states (active/inactive/draining) for graceful provider management
- Clarifies per-provider `timeout_ms` vs overall `latency_budget_ms` relationship
- Documents both static (Prebid config, YAML) and dynamic (API-polled) provider discovery models with SSRF guidance
- Makes `countries` and `uid_types` conditionally required when `identity_match` is true (schema-enforced)

## Motivation

Reviewing [prebid/salesagent#1197](https://github.com/prebid/salesagent/pull/1197) (TMP provider admin UI) revealed that implementers had to invent their own data model and missed required fields like `countries` and `uid_types`. This PR closes the spec gaps so future implementations can use the schema directly.

Related Go implementation work tracked in [adcontextprotocol/adcp-go#34](https://github.com/adcontextprotocol/adcp-go/issues/34).

## Changes

| File | Change |
|---|---|
| `static/schemas/source/tmp/provider-registration.json` | New schema with conditional validation |
| `static/schemas/source/index.json` | Add schema to registry |
| `docs/trusted-match/specification.mdx` | Provider registration rewrite, health endpoint in transport |
| `docs/trusted-match/router-architecture.mdx` | Discovery models, lifecycle, health, timeout clarification, SSRF guidance |
| `docs/trusted-match/buyer-guide.mdx` | Registration example with countries/uid_types, health section |
| `.changeset/tmp-provider-registration-schema.md` | Minor changeset |

## Test plan

- [x] All 587 unit tests pass
- [x] TypeScript typecheck passes
- [x] Mintlify link validation passes (no broken links)
- [x] JSON schema validates as valid JSON
- [x] Schema `anyOf` correctly requires at least one of `context_match`/`identity_match` to be explicitly `true`
- [x] Schema `if/then` correctly requires `countries`/`uid_types` when `identity_match: true`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)