### PR TITLE
feat: performance observability and CDN caching

### DIFF
--- a/.changeset/perf-observability-and-caching.md
+++ b/.changeset/perf-observability-and-caching.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add server-side performance observability and improve static asset caching for Cloudflare.

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -93,33 +93,18 @@ export async function query<T extends QueryResultRow = any>(
   const p = getPool();
   const start = process.hrtime.bigint();
   try {
-    // CodeQL: text is a parameterized query template (e.g. "SELECT * FROM t WHERE id = $1"),
-    // never raw user input. User values are in params. This is safe by design.
-    const result = await p.query<T>(text, params); // lgtm[js/sql-injection]
-    logSlowQuery(start, text);
-    return result;
+    return await p.query<T>(text, params);
   } catch (err) {
     if (isTransientConnectionError(err)) {
       console.warn("Transient DB connection error, retrying query:", (err as Error).message);
-      const result = await p.query<T>(text, params); // lgtm[js/sql-injection]
-      logSlowQuery(start, text);
-      return result;
+      return p.query<T>(text, params);
     }
     throw err;
-  }
-}
-
-function logSlowQuery(start: bigint, text: string): void {
-  const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
-  if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
-    // Truncate query text for logging safety; first 200 chars is enough to identify it
-    logger.warn(
-      {
-        duration_ms: Math.round(durationMs),
-        query: text.slice(0, 200),
-      },
-      "Slow database query"
-    );
+  } finally {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+      logger.warn({ duration_ms: Math.round(durationMs) }, "Slow database query");
+    }
   }
 }
 

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -93,13 +93,15 @@ export async function query<T extends QueryResultRow = any>(
   const p = getPool();
   const start = process.hrtime.bigint();
   try {
-    const result = await p.query<T>(text, params);
+    // CodeQL: text is a parameterized query template (e.g. "SELECT * FROM t WHERE id = $1"),
+    // never raw user input. User values are in params. This is safe by design.
+    const result = await p.query<T>(text, params); // lgtm[js/sql-injection]
     logSlowQuery(start, text);
     return result;
   } catch (err) {
     if (isTransientConnectionError(err)) {
       console.warn("Transient DB connection error, retrying query:", (err as Error).message);
-      const result = await p.query<T>(text, params);
+      const result = await p.query<T>(text, params); // lgtm[js/sql-injection]
       logSlowQuery(start, text);
       return result;
     }

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -1,5 +1,10 @@
 import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { DatabaseConfig } from "../config.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("db");
+
+const SLOW_QUERY_THRESHOLD_MS = 500;
 
 let pool: Pool | null = null;
 
@@ -86,14 +91,33 @@ export async function query<T extends QueryResultRow = any>(
   params?: any[]
 ): Promise<QueryResult<T>> {
   const p = getPool();
+  const start = process.hrtime.bigint();
   try {
-    return await p.query<T>(text, params);
+    const result = await p.query<T>(text, params);
+    logSlowQuery(start, text);
+    return result;
   } catch (err) {
     if (isTransientConnectionError(err)) {
       console.warn("Transient DB connection error, retrying query:", (err as Error).message);
-      return p.query<T>(text, params);
+      const result = await p.query<T>(text, params);
+      logSlowQuery(start, text);
+      return result;
     }
     throw err;
+  }
+}
+
+function logSlowQuery(start: bigint, text: string): void {
+  const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+  if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+    // Truncate query text for logging safety; first 200 chars is enough to identify it
+    logger.warn(
+      {
+        duration_ms: Math.round(durationMs),
+        query: text.slice(0, 200),
+      },
+      "Slow database query"
+    );
   }
 }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -478,19 +478,27 @@ export class HTTPServer {
       ? __dirname
       : path.join(__dirname, "../../dist");
     const schemasPath = path.join(distPath, 'schemas');
-    this.app.use('/schemas', express.static(schemasPath, {
+    // Use a middleware wrapper so setHeaders can see the *request* path.
+    // express.static resolves symlinks, so checking the file path would
+    // incorrectly mark aliases (latest, v2.5) as immutable when they
+    // resolve to a versioned directory on disk.
+    const schemasStatic = express.static(schemasPath, {
       maxAge: '10m',
-      setHeaders: (res, filePath) => {
+      etag: true,
+      lastModified: true,
+      setHeaders: (res) => {
         res.setHeader('Access-Control-Allow-Origin', '*');
-        // Versioned schemas (e.g. /schemas/2.6.0/task.json) are immutable —
-        // once published, their content never changes. Cache for a year.
-        // "latest" and unversioned paths use the default 10m TTL since
-        // latest changes on every schema release.
-        if (/\/\d+\.\d+\.\d+\//.test(filePath)) {
-          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-        }
       }
-    }));
+    });
+    this.app.use('/schemas', (req, res, next) => {
+      // Only direct versioned paths (/schemas/2.5.3/...) are immutable.
+      // Aliases (/latest/, /v2.5/, /v1/) use the 10m default + ETag so
+      // caches revalidate after the alias target changes.
+      if (/^\/\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?\//.test(req.path)) {
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      }
+      schemasStatic(req, res, next);
+    });
 
     // Track slow API responses and alert ops
     this.app.use(slowResponseTracker);

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import { csrfProtection } from "./middleware/csrf.js";
 import { slowResponseTracker } from "./middleware/slow-response.js";
+import { requestMetrics } from "./middleware/request-metrics.js";
 import escapeHtml from "escape-html";
 import * as fs from "fs/promises";
 import path from "path";
@@ -478,15 +479,24 @@ export class HTTPServer {
       : path.join(__dirname, "../../dist");
     const schemasPath = path.join(distPath, 'schemas');
     this.app.use('/schemas', express.static(schemasPath, {
-      maxAge: '1h',
-      immutable: false,
-      setHeaders: (res) => {
+      maxAge: '10m',
+      setHeaders: (res, filePath) => {
         res.setHeader('Access-Control-Allow-Origin', '*');
+        // Versioned schemas (e.g. /schemas/2.6.0/task.json) are immutable —
+        // once published, their content never changes. Cache for a year.
+        // "latest" and unversioned paths use the default 10m TTL since
+        // latest changes on every schema release.
+        if (/\/\d+\.\d+\.\d+\//.test(filePath)) {
+          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        }
       }
     }));
 
     // Track slow API responses and alert ops
     this.app.use(slowResponseTracker);
+
+    // Capture request duration metrics for all API calls
+    this.app.use(requestMetrics);
 
     // Use JSON parser for all routes EXCEPT those that need raw body for signature verification
     // Limit increased to 10MB to support base64-encoded logo uploads in member profiles
@@ -701,7 +711,15 @@ export class HTTPServer {
     const staticPath = process.env.NODE_ENV === 'production'
       ? path.join(__dirname, "../static")
       : path.join(__dirname, "../../static");
-    this.app.use(express.static(staticPath));
+    this.app.use(express.static(staticPath, {
+      maxAge: '1d',
+      setHeaders: (res, filePath) => {
+        // Images and fonts change rarely — cache aggressively
+        if (/\.(png|jpg|jpeg|svg|gif|ico|woff2?|ttf|eot)$/i.test(filePath)) {
+          res.setHeader('Cache-Control', 'public, max-age=604800'); // 7 days
+        }
+      }
+    }));
 
     // Redirect .html URLs to clean URLs for pages that need template variable injection
     // Must be BEFORE static middleware to intercept these requests
@@ -819,7 +837,20 @@ export class HTTPServer {
       next();
     });
 
-    this.app.use(express.static(publicPath, { index: false, redirect: false }));
+    this.app.use(express.static(publicPath, {
+      index: false,
+      redirect: false,
+      maxAge: '1h',
+      setHeaders: (res, filePath) => {
+        // CSS/JS may change on deploy — 1 day is a good balance.
+        // Images/fonts change rarely — cache for a week.
+        if (/\.(css|js)$/i.test(filePath)) {
+          res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day
+        } else if (/\.(png|jpg|jpeg|svg|gif|ico|woff2?|ttf|eot)$/i.test(filePath)) {
+          res.setHeader('Cache-Control', 'public, max-age=604800'); // 7 days
+        }
+      }
+    }));
   }
 
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,21 @@ async function main() {
   const port = parseInt(process.env.PORT || process.env.CONDUCTOR_PORT || "3000", 10);
   await httpServer.start(port);
 
+  // Log memory usage every 60s so PostHog/OTEL can chart heap trends.
+  // On 1GB Fly machines this is critical for spotting leaks early.
+  setInterval(() => {
+    const mem = process.memoryUsage();
+    logger.info(
+      {
+        heap_used_mb: Math.round(mem.heapUsed / 1024 / 1024),
+        heap_total_mb: Math.round(mem.heapTotal / 1024 / 1024),
+        rss_mb: Math.round(mem.rss / 1024 / 1024),
+        external_mb: Math.round(mem.external / 1024 / 1024),
+      },
+      "Memory usage"
+    );
+  }, 60_000).unref();
+
   // Addie (AAO Community Agent) with Bolt SDK — initialized after server is running.
   // The router is stored in the Bolt app and retrieved via getAddieBoltRouter().
   initializeAddieBolt().then((result) => {

--- a/server/src/middleware/request-metrics.ts
+++ b/server/src/middleware/request-metrics.ts
@@ -1,0 +1,54 @@
+/**
+ * Request metrics middleware.
+ *
+ * Captures timing and status for every /api/* request and sends a PostHog
+ * event so we can build dashboards for latency percentiles, throughput,
+ * and error rates per endpoint.
+ *
+ * Lightweight: one PostHog capture per request (batched by the SDK).
+ */
+
+import { Request, Response, NextFunction } from "express";
+import { captureEvent } from "../utils/posthog.js";
+
+/** Collapse UUIDs and numeric path segments so metrics aggregate cleanly. */
+function normalizeRoute(method: string, path: string): string {
+  return `${method} ${path
+    .replace(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+      ":id"
+    )
+    .replace(/\/\d+\b/g, "/:n")}`;
+}
+
+/**
+ * Express middleware — mount before routes.
+ * Only tracks /api/* paths to keep event volume manageable.
+ */
+export function requestMetrics(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!req.path.startsWith("/api/")) {
+    return next();
+  }
+
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    const route = normalizeRoute(req.method, req.path.slice(0, 200));
+
+    captureEvent("server-metrics", "api_request", {
+      route,
+      method: req.method,
+      path: req.path.slice(0, 200),
+      status: res.statusCode,
+      duration_ms: Math.round(durationMs),
+      ok: res.statusCode < 400,
+    });
+  });
+
+  next();
+}


### PR DESCRIPTION
## Summary
- **Request metrics middleware**: captures `api_request` events in PostHog for every `/api/*` call with route, duration, status, and error flag — enables latency/throughput/error-rate dashboards
- **Slow query logging**: warns on DB queries exceeding 500ms, flows to PostHog via existing OTEL pipeline
- **Memory usage reporting**: logs heap/rss every 60s for leak detection on 1GB Fly machines
- **Cache-Control headers**: versioned schemas are immutable (1yr cache), latest schemas 10min, static CSS/JS 1 day, images/fonts 7 days — pairs with Cloudflare cache rules now active on both domains

## Test plan
- [x] All 587 unit tests pass
- [x] TypeScript compiles clean
- [x] Verified Cloudflare caching active on both `adcontextprotocol.org` and `agenticadvertising.org` (MISS → HIT on schema requests)
- [ ] After deploy: confirm versioned schema responses show `immutable` header
- [ ] After deploy: check PostHog for `api_request` events and "Slow database query" log entries
- [ ] After deploy: check PostHog for "Memory usage" log entries every 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)