### PR TITLE
fix: notification poll timeout, cache TTL, and OAuth cleanup indexes

### DIFF
--- a/.changeset/perf-notification-oauth-fixes.md
+++ b/.changeset/perf-notification-oauth-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix notification poll zombie timers, extend count cache, add OAuth cleanup indexes.

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -1148,7 +1148,10 @@
       var notifPollTimer = null;
       async function updateNotifCount() {
         try {
-          const res = await fetch('/api/notifications/count', { credentials: 'include' });
+          const res = await fetch('/api/notifications/count', {
+            credentials: 'include',
+            signal: AbortSignal.timeout(5000),
+          });
           if (res.status === 401) {
             // Session expired — stop polling, hide badge
             if (notifPollTimer) { clearInterval(notifPollTimer); notifPollTimer = null; }

--- a/server/src/db/migrations/402_oauth_cleanup_indexes.sql
+++ b/server/src/db/migrations/402_oauth_cleanup_indexes.sql
@@ -1,0 +1,13 @@
+-- Add indexes on expires_at for OAuth cleanup jobs.
+-- These tables are cleaned every 5 minutes with DELETE WHERE expires_at <= NOW().
+-- Without an index, each cleanup does a full table scan and holds locks longer
+-- than necessary, contributing to pool contention under load.
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_pending_auths_expires
+  ON mcp_oauth_pending_auths(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_auth_codes_expires
+  ON mcp_oauth_auth_codes(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_oauth_pending_flows_expires
+  ON agent_oauth_pending_flows(expires_at);

--- a/server/src/db/notification-db.ts
+++ b/server/src/db/notification-db.ts
@@ -8,7 +8,7 @@ const logger = createLogger('notification-db');
  * Reduces DB pressure from the 30-second polling interval across many tabs/users.
  */
 const countCache = new Map<string, { count: number; expiresAt: number }>();
-const COUNT_CACHE_TTL_MS = 10_000; // 10 seconds
+const COUNT_CACHE_TTL_MS = 30_000; // Match the 30s client poll interval
 
 export interface Notification {
   id: string;


### PR DESCRIPTION
## Summary
Three performance fixes driven by PostHog analysis showing 29K+ slow notification polls and 8K OAuth cleanup exceptions over 3 days:

- **nav.js**: Add 5s `AbortSignal.timeout` to `/api/notifications/count` fetch — prevents zombie timers that report 50+ minute durations (10,710 calls >60s in last 3 days)
- **notification-db**: Extend count cache TTL from 10s to 30s to match client poll interval — cuts DB hits by ~67% (cache was missing 2/3 of polls)
- **Migration 402**: Add `expires_at` indexes on `mcp_oauth_pending_auths`, `mcp_oauth_auth_codes`, and `agent_oauth_pending_flows` — cleanup jobs were doing full table scans every 5 minutes

## Test plan
- [x] All 587 unit tests pass
- [x] TypeScript compiles clean
- [ ] After deploy: verify `slow_api_call` events for `/api/notifications/count` drop significantly (no more >60s zombie timers)
- [ ] After deploy: verify OAuth cleanup exceptions (`Failed to clean up expired MCP OAuth state`) stop appearing
- [ ] After deploy: monitor DB pool utilization for reduced contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)