### PR TITLE
docs: TMP schema privacy notes for ext/context omission

### DIFF
--- a/.changeset/tmp-ext-privacy-notes.md
+++ b/.changeset/tmp-ext-privacy-notes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document why TMP schemas intentionally omit ext and context fields (privacy boundary).

--- a/static/schemas/source/tmp/context-match-request.json
+++ b/static/schemas/source/tmp/context-match-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/context-match-request.json",
   "title": "Context Match Request",
-  "description": "Sent by publisher to router or provider to evaluate packages against contextual signals. The provider uses its synced package set for the placement. MUST NOT contain user identity. The request_id MUST NOT correlate with any identity match request_id.",
+  "description": "Sent by publisher to router or provider to evaluate packages against contextual signals. The provider uses its synced package set for the placement. MUST NOT contain user identity. The request_id MUST NOT correlate with any identity match request_id. Extension fields (ext, context) are intentionally omitted — extension data in the context path could inadvertently carry or correlate user identity signals.",
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/tmp/context-match-response.json
+++ b/static/schemas/source/tmp/context-match-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/context-match-response.json",
   "title": "Context Match Response",
-  "description": "Response from router or provider with offers for matched packages. An empty offers array means no packages matched. For simple GAM integration, package_id flows as a macro via signals. For rich integrations, the offer includes brand, price, summary, and optionally an inline creative manifest.",
+  "description": "Response from router or provider with offers for matched packages. An empty offers array means no packages matched. For simple GAM integration, package_id flows as a macro via signals. For rich integrations, the offer includes brand, price, summary, and optionally an inline creative manifest. Extension fields (ext, context) are intentionally omitted — extension data in the context path could inadvertently carry or correlate user identity signals.",
   "type": "object",
   "properties": {
     "type": {

--- a/static/schemas/source/tmp/identity-match-request.json
+++ b/static/schemas/source/tmp/identity-match-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/identity-match-request.json",
   "title": "Identity Match Request",
-  "description": "Sent by publisher to evaluate user eligibility for packages using an opaque identity token. MUST NOT contain page context. The request_id MUST NOT correlate with any context match request_id. The package_ids MUST include ALL active packages for the buyer, not just those on the current page, to prevent set-correlation attacks.",
+  "description": "Sent by publisher to evaluate user eligibility for packages using an opaque identity token. MUST NOT contain page context. The request_id MUST NOT correlate with any context match request_id. The package_ids MUST include ALL active packages for the buyer, not just those on the current page, to prevent set-correlation attacks. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/tmp/identity-match-response.json
+++ b/static/schemas/source/tmp/identity-match-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/identity-match-response.json",
   "title": "Identity Match Response",
-  "description": "Response indicating which packages the user is eligible for. The ttl_sec field defines a caching contract: the router caches this response and returns cached eligibility without re-querying the buyer during the TTL window.",
+  "description": "Response indicating which packages the user is eligible for. The ttl_sec field defines a caching contract: the router caches this response and returns cached eligibility without re-querying the buyer during the TTL window. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
   "type": "object",
   "properties": {
     "type": {


### PR DESCRIPTION
## Summary

- Closes #2154 (stale — all non-TMP schemas already have ext and context)
- Adds privacy rationale to TMP schema descriptions explaining why ext/context are intentionally omitted
- Identity match: prevents data leakage across identity privacy boundary
- Context match: prevents extension data from carrying or correlating user identity signals

## Test Plan

- [x] All 587 unit tests pass
- [x] All 20 extension field tests pass
- [x] TypeScript compilation succeeds
- [x] Schema build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)