### PR TITLE
docs: SDK parity on build page, remove reference implementations

### DIFF
--- a/.changeset/docs-sdk-parity-no-reference-arch.md
+++ b/.changeset/docs-sdk-parity-no-reference-arch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Give all three SDKs (JS/TS, Python, Go) equal treatment on the Build an Agent page. Remove "reference implementations" framing in favor of SDK-first guidance.

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -9,39 +9,83 @@ The fastest way to build an AdCP agent is to point a coding agent (Claude Code, 
 
 ## Install the SDK
 
+Each SDK handles protocol compliance — schema validation, error formats, version negotiation, and response builders — so you write business logic, not protocol plumbing.
+
 <Tabs>
 <Tab title="JavaScript/TypeScript">
 ```bash
 npm install @adcp/client
 ```
+
+The JS/TS SDK provides typed tool registration, response builders, and a built-in storyboard runner. Most agents in production use this SDK.
+
+- [NPM Package](https://www.npmjs.com/package/@adcp/client)
+- [GitHub Repository](https://github.com/adcontextprotocol/adcp-client)
 </Tab>
 <Tab title="Python">
 ```bash
 pip install adcp
 ```
+
+The Python SDK provides the same capabilities — subclass `ADCPHandler`, implement tools, and use response builders for every return value:
+
+```python
+from adcp.server import ADCPHandler, serve
+from adcp.server.responses import capabilities_response
+
+class MySeller(ADCPHandler):
+    async def get_adcp_capabilities(self, params, context=None):
+        return capabilities_response(["media_buy", "compliance_testing"])
+
+    # ... implement tools, use response builders for every return
+
+serve(MySeller(), name="my-seller")
+```
+
+Response builders (`adcp.server.responses`) handle schema compliance so you don't construct raw JSON. Use them for every tool return.
+
+- [PyPI Package](https://pypi.org/project/adcp/)
+- [GitHub Repository](https://github.com/adcontextprotocol/adcp-python)
 </Tab>
 <Tab title="Go">
 ```bash
 go get github.com/adcontextprotocol/adcp-go/adcp
 ```
+
+The Go SDK provides typed tool registration, response builders, and a compliance test controller. Types are generated from canonical AdCP schemas.
+
+| Component | Import |
+|-----------|--------|
+| Tool registration | `adcp.AddTool(server, name, desc, handler)` |
+| HTTP server | `adcp.Serve(createAgent)` |
+| Response builders | `adcp.ProductsResponse(data)`, `adcp.MediaBuyResponse(data)` |
+| Test controller | `adcp.RegisterTestController(server, store)` |
+
+See the [Go SDK README](https://github.com/adcontextprotocol/adcp-go) for complete examples.
+
+Response builders (`adcp.ProductsResponse()`, `adcp.MediaBuyResponse()`, etc.) handle schema compliance so you return typed structs, not raw JSON.
+
+- [GitHub Repository](https://github.com/adcontextprotocol/adcp-go)
 </Tab>
 </Tabs>
 
-This installs the client library used for storyboard validation. Skill files are not included in the package — you'll fetch them from GitHub in the next step.
+<Info>
+**Use the SDK for your language.** All three SDKs — JS/TS, Python, and Go — handle schema validation, error formats, and protocol negotiation. You do not need to use a different language for protocol compliance.
+</Info>
 
 ## Choose a skill
 
 Each skill targets a specific agent type. Pick the one that matches what you're building:
 
-| Skill | You are building... | Storyboard | JS/TS | Go |
-|-------|---------------------|------------|-------|-----|
-| `build-seller-agent` | Publisher, SSP, or media network selling inventory | `media_buy_seller` | [adcp-client](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-seller-agent) | [adcp-go](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-seller-agent) |
-| `build-generative-seller-agent` | AI ad network generating ads from briefs | `media_buy_generative_seller` | [adcp-client](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-generative-seller-agent) | — |
-| `build-retail-media-agent` | Retail media network with catalog-driven creative | `media_buy_catalog_creative` | [adcp-client](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-retail-media-agent) | — |
-| `build-signals-agent` | CDP or data provider serving audience segments | `signal_owned`, `signal_marketplace` | [adcp-client](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-signals-agent) | [adcp-go](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-signals-agent) |
-| `build-creative-agent` | Ad server or CMP rendering creatives | `creative_lifecycle` | [adcp-client](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-creative-agent) | [adcp-go](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-creative-agent) |
+| Skill | You are building... | Storyboard | JS/TS / Python | Go |
+|-------|---------------------|------------|----------------|-----|
+| `build-seller-agent` | Publisher, SSP, or media network selling inventory | `media_buy_seller` | [skill](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-seller-agent) | [skill](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-seller-agent) |
+| `build-generative-seller-agent` | AI ad network generating ads from briefs | `media_buy_generative_seller` | [skill](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-generative-seller-agent) | — |
+| `build-retail-media-agent` | Retail media network with catalog-driven creative | `media_buy_catalog_creative` | [skill](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-retail-media-agent) | — |
+| `build-signals-agent` | CDP or data provider serving audience segments | `signal_owned`, `signal_marketplace` | [skill](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-signals-agent) | [skill](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-signals-agent) |
+| `build-creative-agent` | Ad server or CMP rendering creatives | `creative_lifecycle` | [skill](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-creative-agent) | [skill](https://github.com/adcontextprotocol/adcp-go/tree/main/skills/build-creative-agent) |
 
-Python agents use the same skill files as JS/TS — the skills are language-agnostic.
+Skill files are language-agnostic. JS/TS and Python use the same skill — specify your language in the prompt and the coding agent uses the correct SDK. Go has its own skills in the [adcp-go](https://github.com/adcontextprotocol/adcp-go) repo.
 
 ## Build the agent
 
@@ -58,23 +102,7 @@ Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skill
 Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skills/build-seller-agent/SKILL.md, then build a seller agent in Python for a premium sports news publisher with guaranteed CTV and OLV inventory.
 ```
 
-Every Python agent follows the same structure — subclass `ADCPHandler`, implement tools, use response builders for every return value:
-
-```python
-from adcp.server import ADCPHandler, serve
-from adcp.server.responses import capabilities_response, products_response
-from adcp.server.test_controller import TestControllerStore
-
-class MySeller(ADCPHandler):
-    async def get_adcp_capabilities(self, params, context=None):
-        return capabilities_response(["media_buy", "compliance_testing"])
-
-    # ... implement tools, use response builders for every return
-
-serve(MySeller(), name="my-seller", test_controller=MyStore())
-```
-
-Response builders (`adcp.server.responses`) handle schema compliance so you don't have to construct raw JSON. Use them for every tool return.
+The skill URL points to the JS/TS SDK repo — this is correct. Skills are language-agnostic; specifying "in Python" in your prompt is what tells the coding agent to use the Python SDK.
 </Tab>
 <Tab title="Go">
 ```
@@ -91,6 +119,10 @@ In Cursor or Windsurf, download the skill file and include it as context with yo
 4. Error handling and edge cases
 
 ## Validate with storyboards
+
+<Warning>
+The storyboard runner requires Node.js, regardless of what language your agent is written in.
+</Warning>
 
 Once the agent is running, validate it against the matching storyboard:
 
@@ -132,12 +164,14 @@ See **[Validate Your Agent](/docs/building/validate-your-agent)** for the full t
 
 ## Additional resources
 
-Each SDK includes documentation designed for both humans and coding agents:
+The JS/TS SDK includes documentation designed for both humans and coding agents:
 
-| Resource | Location | Purpose |
-|----------|----------|---------|
+| Resource | JS/TS location | Purpose |
+|----------|----------------|---------|
 | Protocol spec | `node_modules/@adcp/client/docs/llms.txt` | Full protocol in one file — tools, types, error codes, examples |
 | Server guide | `node_modules/@adcp/client/docs/guides/BUILD-AN-AGENT.md` | Server-side implementation patterns |
+
+Python and Go equivalents are in each SDK's GitHub repository. See [adcp-python](https://github.com/adcontextprotocol/adcp-python) and [adcp-go](https://github.com/adcontextprotocol/adcp-go).
 
 ## What's next
 

--- a/docs/building/understanding/industry-landscape.mdx
+++ b/docs/building/understanding/industry-landscape.mdx
@@ -70,7 +70,7 @@ AdCP uses A2A as its other transport layer. In an A2A setup, a buyer agent sends
 
 | Organization | Focus | Key outputs |
 |---|---|---|
-| **[AgenticAdvertising.org](https://agenticadvertising.org)** | AI agent advertising standards | AdCP specification, JSON schemas, reference implementations |
+| **[AgenticAdvertising.org](https://agenticadvertising.org)** | AI agent advertising standards | AdCP specification, JSON schemas, client SDKs |
 | **[IAB Tech Lab](https://iabtechlab.com)** | Digital advertising standards | OpenRTB, VAST, ads.txt, sellers.json, content taxonomy |
 | **[Anthropic](https://anthropic.com)** | AI safety and research | MCP specification |
 | **[Google](https://google.github.io/A2A/)** | AI and cloud | A2A specification |

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -607,7 +607,7 @@ Governance isn't a gate that slows things down. It's the safety net that lets yo
     Ask questions about AdCP, explore the protocol, and test tasks — no code required
   </Card>
   <Card title="Client SDKs" icon="rocket" href="/docs/building/schemas-and-sdks">
-    JavaScript and Python libraries with CLI tools for testing
+    JavaScript, Python, and Go libraries with CLI tools for testing
   </Card>
   <Card title="Brand.json builder" icon="palette" href="https://agenticadvertising.org/brand/builder">
     Create and validate your brand's brand.json file
@@ -678,15 +678,18 @@ npm install @adcp/client
 ```bash Python
 pip install adcp
 ```
+```bash Go
+go get github.com/adcontextprotocol/adcp-go/adcp
+```
 </CodeGroup>
 
 - **NPM**: [@adcp/client](https://www.npmjs.com/package/@adcp/client) | [GitHub](https://github.com/adcontextprotocol/adcp-client)
 - **PyPI**: [adcp](https://pypi.org/project/adcp/) | [GitHub](https://github.com/adcontextprotocol/adcp-python)
+- **Go**: [adcp-go](https://github.com/adcontextprotocol/adcp-go)
 
-## Reference implementations
+## Open-source examples
 
-- [Signals Agent](https://github.com/adcontextprotocol/signals-agent)
-- [Sales Agent](https://github.com/prebid/salesagent)
+The [Prebid Sales Agent](https://github.com/prebid/salesagent) is a full-stack seller agent (Python backend, TypeScript protocol layer) with GAM integration, built by a Prebid working group. It is a community example, not a maintained reference implementation. To build your own agent, start with the [official SDKs](/docs/building/schemas-and-sdks) and [skill files](/docs/building/build-an-agent).
 
 ## Organization
 


### PR DESCRIPTION
## Summary
- Give JS/TS, Python, and Go SDKs equal treatment on the **Build an Agent** page — each tab now has install commands, code examples or API tables, response builder callouts, and repo links
- Replace "Reference implementations" section with "Open-source examples" on the intro page — removes dead signals-agent link, reframes prebid/salesagent as a community example
- Add Go to client libraries and SDK card on intro page
- Add `<Warning>` callout that storyboard runner requires Node.js regardless of agent language
- Change AAO key outputs from "reference implementations" to "client SDKs" on industry landscape page

Prompted by Vox Media's experience building a sales agent — they used the JS/TS SDK for protocol compliance and Python for backend, partly because the docs didn't make the Python SDK story clear enough.

## Test plan
- [ ] Verify Mintlify renders all three SDK tabs correctly (no stray code fences, tables render)
- [ ] Check skills table renders cleanly with 5 columns on desktop and mobile
- [ ] Confirm `<Info>` and `<Warning>` callouts render as expected
- [ ] Verify all external links resolve (GitHub repos, NPM, PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)