### PR TITLE
docs: generalize measurement_window beyond broadcast TV

### DIFF
--- a/.changeset/generalize-measurement-window.md
+++ b/.changeset/generalize-measurement-window.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Generalize `measurement_window` beyond broadcast TV. The concept — a maturation stage with its own expected data availability — applies equally to DOOH (`tentative` → `final` after IVT/fraud-check), digital with IVT filtering (`post_givt` → `post_sivt`), podcast (`downloads_7d` → `downloads_30d`), and any other channel where billing-grade data arrives in phases. The schema mechanism is unchanged; descriptions and examples on `measurement-window.json`, `reporting-capabilities.measurement_windows`, and `measurement-terms.billing_measurement.measurement_window` have been broadened so sellers in those channels know this is where they declare their maturation/processing cycle. Accountability, optimization-reporting, and get_media_buy_delivery docs updated to match. No field additions or removals.

--- a/docs/media-buy/advanced-topics/accountability.mdx
+++ b/docs/media-buy/advanced-topics/accountability.mdx
@@ -110,9 +110,9 @@ The seller has three responses:
 
 When the buyer omits `performance_standards` or `measurement_terms`, the product's defaults apply.
 
-#### Broadcast measurement terms
+#### Measurement terms for phased-maturation channels
 
-For broadcast TV, the buyer proposes a `measurement_window` alongside the vendor — this specifies which maturation window (Live, C3, or C7) the guarantee is reconciled against:
+Some channels produce billing-grade data in phases rather than delivering final numbers on day one — broadcast TV, DOOH, digital with IVT filtering, podcast downloads, and others. For these, the buyer proposes a `measurement_window` alongside the vendor, specifying which maturation stage the guarantee is reconciled against:
 
 ```json
 {
@@ -130,7 +130,7 @@ For broadcast TV, the buyer proposes a `measurement_window` alongside the vendor
 }
 ```
 
-The `measurement_window` references a `window_id` from the product's `reporting_capabilities.measurement_windows`. This tells both sides: "VideoAmp's C7 numbers are what we reconcile against." The `agency_estimate_number` is the financial reference that links the order to the agency's media plan — it travels with the order through the transaction lifecycle.
+The `measurement_window` references a `window_id` from the product's `reporting_capabilities.measurement_windows`. This tells both sides: "VideoAmp's C7 numbers are what we reconcile against." For a DOOH product it would be `"final"` (post-IVT/fraud-check); for digital it might be `"post_sivt"`. The same mechanism declares both which data is authoritative for billing and when it becomes available — reconciliation and invoicing clocks follow that declared availability. The `agency_estimate_number` is the financial reference that links the order to the agency's media plan — it travels with the order through the transaction lifecycle.
 
 ### 5. Confirmed Package: The Contract
 

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -243,19 +243,20 @@ If reporting data is not available within the product's `expected_delay_minutes`
 
 This prevents buyers from incorrectly assuming a missed notification.
 
-#### Broadcast Measurement Windows
+#### Measurement Maturation Windows
 
-Broadcast TV measurement works differently from digital. Measurement data is not delayed — it **matures over time** as time-shifted (DVR) viewing accumulates. Sellers declare `measurement_windows` on their products to describe this maturation:
+For channels where billing-grade data is produced in **phases** rather than arriving final on day one, sellers declare `measurement_windows` on their products. Each window describes a maturation stage with its own expected availability. This pattern is used across channels:
 
-| Window | Accumulation | Typical availability |
-|--------|-------------|---------------------|
-| `live` | Real-time viewers only | ~1 day after broadcast |
-| `c3` | Live + 3 days DVR playback | ~4 days after broadcast |
-| `c7` | Live + 7 days DVR playback | ~15 days after broadcast |
+| Channel | Typical windows |
+|---------|-----------------|
+| Broadcast / linear TV | `live` (same day) → `c3` (~4 days) → `c7` (~15–22 days, guarantee basis) |
+| DOOH | `tentative` (same day) → `final` post-IVT/fraud-check (~1 day, guarantee basis) |
+| Digital with IVT filtering | raw → `post_givt` → `post_sivt` (~2–3 days, guarantee basis) |
+| Podcast | `downloads_7d` → `downloads_30d` (guarantee basis) |
 
-Each window's numbers supersede the previous one. C7 is typically the guarantee basis — the number both sides reconcile against. Note that the measurement vendor (VideoAmp, Nielsen, Comscore) adds processing time on top of the accumulation period — C7 raw data accumulates over 7 days, but vendor-certified C7 numbers may arrive ~15 days after broadcast.
+Each window's numbers supersede the previous one. One window is typically the `is_guarantee_basis` — the number both sides reconcile against. The measurement vendor's processing time is captured in `expected_availability_days` on each window (it includes both accumulation and processing).
 
-Broadcast sellers set `expected_delay_minutes` on their products to reflect the longest measurement pipeline. The `measurement_windows` array on `reporting_capabilities` provides per-window timelines via `expected_availability_days`.
+Sellers set `expected_delay_minutes` on their products to reflect the first-available data pipeline. The `measurement_windows` array on `reporting_capabilities` provides per-window timelines.
 
 Delivery data for products with measurement windows includes three fields on each package:
 
@@ -320,14 +321,9 @@ When the seller sends updated data for the same period with a wider window, they
 }
 ```
 
-The buyer replaces stored data each time a `window_update` arrives. When `is_final: true`, this is the number to reconcile against the guarantee.
+The buyer replaces stored data each time a `window_update` arrives. When `is_final: true`, this is the number to reconcile against the guarantee. The same lifecycle shape applies to DOOH (`tentative` → `final`), digital with IVT filtering (`post_givt` → `post_sivt`), podcast (`downloads_7d` → `downloads_30d`), and any other channel where data matures in phases — only the window IDs and timing differ.
 
-This pattern also applies beyond broadcast:
-- **Podcast**: 7-day downloads → 30-day downloads
-- **Influencer/YouTube**: 24-hour views → 7-day views → 30-day views
-- **Digital with IVT filtering**: raw impressions → GIVT filtered → SIVT filtered
-
-For broadcast reconciliation timing and the `measurement_window` field on billing measurement terms, see [Accountability](/docs/media-buy/advanced-topics/accountability).
+For how `measurement_window` appears on billing terms and drives reconciliation and invoicing clocks, see [Accountability](/docs/media-buy/advanced-topics/accountability).
 
 #### Webhook Aggregation
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -540,7 +540,7 @@ asyncio.run(main())
 - Real-time impression counts not available
 - Use for periodic reporting and optimization decisions, not live monitoring
 
-**Broadcast TV**: Data freshness differs significantly for linear TV. Measurement data matures through defined windows (Live, C3, C7) as DVR playback accumulates. Final C7 numbers arrive ~15 days after broadcast. Products with `reporting_capabilities.measurement_windows` declare these timelines. Buyers reconcile against the `measurement_window` specified in `billing_measurement` on the agreed terms. See [Accountability](/docs/media-buy/advanced-topics/accountability) for measurement terms and [Optimization and reporting](/docs/media-buy/media-buys/optimization-reporting) for broadcast measurement windows.
+**Phased-maturation channels**: Data freshness differs for channels where billing-grade data is produced in phases rather than arriving final on day one — broadcast TV (Live → C3 → C7 DVR accumulation, final C7 ~15–22 days after broadcast), DOOH (tentative plays → post-IVT/fraud-check final), digital with IVT filtering (raw → post-GIVT → post-SIVT), and podcast (7-day → 30-day downloads). Products with `reporting_capabilities.measurement_windows` declare these timelines. Buyers reconcile against the `measurement_window` specified in `billing_measurement` on the agreed terms. See [Accountability](/docs/media-buy/advanced-topics/accountability) for measurement terms and [Optimization and reporting](/docs/media-buy/media-buys/optimization-reporting) for the full lifecycle.
 
 ## Error Handling
 

--- a/static/schemas/source/core/measurement-terms.json
+++ b/static/schemas/source/core/measurement-terms.json
@@ -21,11 +21,16 @@
         },
         "measurement_window": {
           "type": "string",
-          "description": "Which measurement window the billing metric is reconciled against. References a window_id from the product's reporting_capabilities.measurement_windows. For broadcast TV, this is typically 'c7' (live + 7 days DVR). When absent, billing is based on the seller's standard reporting without windowed maturation.",
+          "description": "Which measurement maturation stage the billing metric is reconciled against. References a window_id from the product's reporting_capabilities.measurement_windows. Examples: 'c7' for broadcast TV guarantees (live + 7 days DVR), 'final' for DOOH after IVT/fraud-check processing, 'post_sivt' for digital after sophisticated invalid-traffic filtering, 'downloads_30d' for podcast. When absent, billing is based on the seller's standard reporting without windowed maturation.",
           "examples": [
             "live",
             "c3",
-            "c7"
+            "c7",
+            "tentative",
+            "final",
+            "post_ivt",
+            "post_sivt",
+            "downloads_30d"
           ]
         }
       },

--- a/static/schemas/source/core/measurement-window.json
+++ b/static/schemas/source/core/measurement-window.json
@@ -2,17 +2,21 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/measurement-window.json",
   "title": "Measurement Window",
-  "description": "A measurement maturation window for broadcast and linear TV. Broadcast measurement is not delayed data — it matures over time as time-shifted (DVR) viewing accumulates. Each window represents a defined accumulation period after the live broadcast.",
+  "description": "A measurement maturation stage for any channel where billing-grade data is produced in phases rather than arriving final on day one. Each window represents an accumulation or processing stage with its own expected availability. Examples: broadcast/linear TV (live → C3 → C7 DVR accumulation), DOOH (tentative plays → post-IVT/fraud-check final), digital (raw impressions → GIVT filtered → SIVT filtered), podcast (7-day downloads → 30-day downloads), audio/radio (tentative → diary/panel-certified). Sellers whose data is final on first delivery omit this.",
   "type": "object",
   "properties": {
     "window_id": {
       "type": "string",
       "maxLength": 50,
-      "description": "Identifier for this measurement window. Standard values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Sellers may define custom windows for other accumulation periods.",
+      "description": "Identifier for this maturation stage. Standard broadcast values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Standard values for other channels include 'tentative' (provisional data available quickly), 'final' (post-processing certified data), 'post_ivt' (digital after invalid-traffic filtering), 'post_sivt' (digital after sophisticated-IVT filtering), 'downloads_7d' / 'downloads_30d' (podcast download maturation). Sellers may define custom IDs.",
       "examples": [
         "live",
         "c3",
-        "c7"
+        "c7",
+        "tentative",
+        "final",
+        "post_ivt",
+        "downloads_30d"
       ]
     },
     "description": {
@@ -21,23 +25,25 @@
       "description": "Human-readable description of what this window measures",
       "examples": [
         "Live broadcast impressions only",
-        "Live plus 3 days of time-shifted viewing",
-        "Live plus 7 days of time-shifted viewing"
+        "Live plus 7 days of time-shifted viewing",
+        "Tentative plays before IVT and fraud-check processing",
+        "Final plays after IVT and fraud-check processing",
+        "Impressions after sophisticated invalid-traffic filtering"
       ]
     },
     "duration_days": {
       "type": "integer",
-      "description": "Number of days after live broadcast included in this window. 0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR.",
+      "description": "Number of days of accumulation included in this window before processing begins. For broadcast, this is DVR accumulation (0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR). For channels without an accumulation period (DOOH tentative→final, digital IVT filtering), this is 0 — maturation is entirely vendor processing time captured in expected_availability_days.",
       "minimum": 0
     },
     "expected_availability_days": {
       "type": "integer",
-      "description": "Expected number of days after broadcast before this window's data is available from the measurement vendor. For example, C7 window data from VideoAmp typically arrives ~22 days after broadcast (7-day accumulation + ~15-day processing).",
+      "description": "Expected number of days after delivery before this window's data is available from the measurement vendor. Captures accumulation time plus vendor processing time. Examples: broadcast C7 from VideoAmp ~22 days (7-day accumulation + ~15-day processing); DOOH tentative plays same-day; DOOH final (post-IVT/fraud-check) ~1 day; digital post-SIVT ~2–3 days.",
       "minimum": 0
     },
     "is_guarantee_basis": {
       "type": "boolean",
-      "description": "Whether this window is the basis for delivery guarantees and reconciliation. A product typically has one guarantee basis window (e.g., C7 for most US broadcast). Buyers reconcile against the guarantee basis window's final numbers."
+      "description": "Whether this window is the basis for delivery guarantees, reconciliation, and invoicing. A product typically has one guarantee basis window (e.g., C7 for most US broadcast, post-IVT final for DOOH). Buyers reconcile against the guarantee basis window's final numbers."
     }
   },
   "required": [

--- a/static/schemas/source/core/reporting-capabilities.json
+++ b/static/schemas/source/core/reporting-capabilities.json
@@ -95,7 +95,7 @@
     },
     "measurement_windows": {
       "type": "array",
-      "description": "Measurement maturation windows available for this product. Used by broadcast and linear TV sellers where measurement accumulates over time (Live, C3, C7). Each window defines an accumulation period and expected data availability. When present, delivery reports reference a specific window_id. Digital-only sellers typically omit this.",
+      "description": "Measurement maturation stages available for this product. Used by any channel where billing-grade data is produced in phases rather than arriving final on day one. Examples: broadcast/linear TV (Live → C3 → C7 DVR accumulation), DOOH (tentative plays → post-IVT/fraud-check final), digital with IVT filtering (raw → GIVT filtered → SIVT filtered), podcast (7-day downloads → 30-day downloads). Each window defines an accumulation period and expected data availability. When present, delivery reports reference a specific window_id. Sellers whose data is final on first delivery typically omit this.",
       "items": {
         "$ref": "/schemas/core/measurement-window.json"
       },


### PR DESCRIPTION
## Summary

- The `measurement_window` mechanism — a maturation stage with its own expected data availability — applies equally to DOOH (`tentative` → post-IVT/fraud-check `final`), digital with IVT filtering (`post_givt` → `post_sivt`), podcast (`downloads_7d` → `downloads_30d`), and any channel where billing-grade data arrives in phases. Schema descriptions and examples now reflect this.
- No field additions or removals — this is a clarification/broadening of existing fields.
- Prompted by ToS v3.0-14 adding _"reporting cycle as specified in the applicable Transaction Order or product listing"_ for reconciliation and invoicing timing, which now has machine-readable backing via `reporting_capabilities.measurement_windows` + `billing_measurement.measurement_window`.

## Why not add `reporting_lag` to `billing_measurement`?

The originally proposed `reporting_lag: { interval, unit }` would have duplicated information already captured by `measurement_window.expected_availability_days`. For broadcast C7 this resolves to ~22 days after airing (7-day DVR accumulation + ~15-day vendor processing) — more expressive than a flat `15 days`. DOOH tentative→final, digital IVT filtering, and podcast download maturation are the same pattern with different IDs and timelines.

## Files changed

- **Schemas (descriptions/examples only):**
  - `static/schemas/source/core/measurement-window.json`
  - `static/schemas/source/core/reporting-capabilities.json`
  - `static/schemas/source/core/measurement-terms.json`
- **Docs:**
  - `docs/media-buy/media-buys/optimization-reporting.mdx` — section renamed "Measurement Maturation Windows" with a cross-channel table
  - `docs/media-buy/advanced-topics/accountability.mdx` — "Broadcast measurement terms" → "Measurement terms for phased-maturation channels"
  - `docs/media-buy/task-reference/get_media_buy_delivery.mdx` — "Broadcast TV" data-freshness callout → "Phased-maturation channels"
- **Changeset:** `.changeset/generalize-measurement-window.md` (patch)

Left `docs/creative/channels/broadcast.mdx` alone — broadcast framing is correct on the channel-specific page.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7 pass
- [x] `npm run test:examples` — 29/29 pass
- [x] `npm run test:composed` — 12/12 pass
- [x] Precommit (`test:unit` + `typecheck`) — 587/587 pass
- [ ] Docs render correctly in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)