### PR TITLE
docs: security hardening for AdCP 3.0 partner rollout

### DIFF
--- a/.changeset/security-hardening-3-0.md
+++ b/.changeset/security-hardening-3-0.md
@@ -1,0 +1,12 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify 3.0 security requirements before partners run these flows in production.
+
+- **SSRF (canonical rules in `security.mdx`).** Consolidated list of reserved IPv4 and IPv6 ranges (RFC 1918, RFC 6598 CGNAT, loopback, `169.254.0.0/16` with cloud metadata called out, `::ffff:0:0/96` IPv4-mapped IPv6, multicast). DNS-based filtering alone is insufficient — fetchers MUST pin the TCP connection to the validated IP or re-validate the post-handshake peer address. No redirect following on counterparty-controlled URLs.
+- **Webhook signatures.** The signed `{unix_timestamp}` MUST be the exact ASCII integer in `X-ADCP-Timestamp`; signers and verifiers MUST NOT derive it from any body field. Header format and body-field precedence spelled out explicitly.
+- **Offline reporting buckets (`#2223`).** IAM-layer prefix scoping (not obscurity), scoped `ListBucket` (not just `GetObject`) to prevent cross-tenant prefix enumeration, revocation tied to `account.status` transitions, `setup_instructions` marked as operator-facing with MUST NOT auto-fetch and indirect-prompt-injection guidance.
+- **Collection lists (`#2225`).** `auth_token` scope, per-seller issuance (MUST), log hygiene, webhook URL SSRF via canonical rules, normative HMAC-SHA256 signatures, distribution-ID format validation and rate limits. Compromise-driven revocation requires cache invalidation, not just TTL expiry.
+- **Managed network `authoritative_location` (`#2224`).** Validator fetch semantics (HTTPS only, no redirects, size and timeout caps), 24-hour cached fallback on 5xx with a 7-day absolute cap measured from the most recent successful fetch, non-monotonic `last_updated` treated as an invalid response to block rollback attacks, concrete change-detection thresholds, relationship-termination handling.
+- **TMP provider registration (`#2226`).** SSRF via canonical rules with connection pinning, dynamic-registration caller authentication, router-to-provider auth minimum bar, and `/health` info-leakage rules (no subsystem-specific status codes or response bodies).

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -61,9 +61,11 @@ Webhook signature verification and replay prevention are defined in [Push Notifi
 
 - **Algorithm**: HMAC-SHA256 only
 - **Signed message**: `{unix_timestamp}.{raw_http_body_bytes}` — never re-serialize the JSON
+- **Timestamp source**: The `{unix_timestamp}` in the signed message MUST be the exact ASCII integer sent in the `X-ADCP-Timestamp` header. Signers and verifiers MUST NOT derive it from any body field.
 - **Timing-safe comparison**: MUST use constant-time comparison (e.g., `timingSafeEqual`)
 - **Replay window**: Reject requests where `|current_time - timestamp| > 300` seconds
 - **Minimum secret length**: 32 bytes
+- **Header format**: `X-ADCP-Signature: sha256=<hex digest>` and `X-ADCP-Timestamp: <unix seconds>`. Any body-level `signature` field is a convenience copy and MUST NOT be trusted over the headers.
 
 ### Verification order
 
@@ -81,10 +83,24 @@ Verify in this order to minimize computation on invalid requests:
 
 ### Webhook URL validation (SSRF)
 
-Buyer-provided `push_notification_config.url` is an SSRF vector. Publishers MUST:
-- Reject non-HTTPS URLs
-- Reject URLs targeting private/reserved IP ranges (RFC 1918, RFC 6598, link-local)
-- Resolve DNS and validate the resolved IP is not private before connecting
+Any URL that a buyer, seller, or governance agent provides for another party to fetch is an SSRF vector. This includes `push_notification_config.url`, collection-list `webhook_url`, TMP provider `endpoint`, `adagents.json` `authoritative_location`, and `reporting_bucket.setup_instructions`.
+
+Before any outbound fetch to a counterparty-controlled URL, fetchers MUST:
+
+1. **Reject non-HTTPS URLs** in production.
+2. **Resolve the hostname** and reject the fetch if the resolved IP falls in any reserved range:
+   - IPv4: RFC 1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), RFC 6598 CGNAT (`100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16` — explicitly includes `169.254.169.254` used by AWS/GCP/Azure/Alibaba instance metadata), broadcast (`255.255.255.255`), `0.0.0.0/8`, multicast (`224.0.0.0/4`).
+   - IPv6: loopback (`::1`), unique-local (`fc00::/7`), link-local (`fe80::/10`), IPv4-mapped (`::ffff:0:0/96` — the most common bypass, mapping reserved IPv4 into IPv6), multicast (`ff00::/8`), and the AWS IMDSv2 fd00:ec2::254 address.
+3. **Pin the connection to the validated IP.** DNS-based filtering alone is vulnerable to DNS rebinding: an attacker serves a public IP at validation time and a private IP at connect time. Fetchers MUST either (a) pass the validated IP directly to the TCP connect call and set the `Host:` header from the URL, or (b) validate the socket's post-handshake peer address against the reserved-range list before sending any request body. Re-resolving DNS without pinning is not sufficient.
+4. **Refuse to follow redirects** when fetching counterparty-controlled URLs (a 30x response lets the origin redirect to a reserved address that bypassed the initial check).
+5. **Cap response size and timeouts.** Recommended: 5 MB body cap, 10 s connect, 10 s read.
+6. **Do not echo fetch errors to the agent that supplied the URL.** Detailed error messages (connection refused vs. timed out vs. TLS failure) are a side-channel for probing internal network topology.
+
+Feature-specific security sections extend these rules with their own lifecycle and content-handling requirements:
+- [Offline reporting buckets](/docs/media-buy/media-buys/optimization-reporting#security-considerations-for-offline-delivery) — IAM-layer prefix scoping, credential revocation on account status change.
+- [Collection lists](/docs/governance/collection/tasks/collection_lists#security-considerations) — `auth_token` scope and revocation, distribution-ID validation, webhook signature normative rules.
+- [Managed networks `authoritative_location`](/docs/governance/property/managed-networks#security-considerations) — validator fetch semantics, change detection, relationship termination.
+- [TMP provider registration](/docs/trusted-match/specification#provider-registration-security) — dynamic registration authentication, router-to-provider auth, `/health` info-leakage rules.
 
 ## Authentication Best Practices
 

--- a/docs/governance/collection/tasks/collection_lists.mdx
+++ b/docs/governance/collection/tasks/collection_lists.mdx
@@ -316,6 +316,23 @@ Live sports is one of the largest CTV brand safety concerns. Collection lists ha
 
 This excludes specific sports programs by Gracenote ID (SP-prefixed for sports) and structurally excludes all combat sports event series. The `event_series` kind filter ensures the list targets live event programming, not documentary series about sports.
 
+## Security considerations
+
+Collection lists gate delivery decisions, so the `auth_token` and webhook callbacks need explicit lifecycle rules. General controls in [Security](/docs/building/implementation/security) apply; the collection-list-specific rules:
+
+**`auth_token` scope, revocation, and log hygiene.** Each token authorizes exactly one `list_id`; do not reuse a token across lists. Governance agents MUST issue a distinct token per seller that receives the list — shared tokens cannot be revoked per relationship and make list-wide rotation the only response to a single compromise. Tokens MUST NOT be written to logs, cache keys, or metric labels, and error responses from `get_collection_list` MUST NOT echo the presented token.
+
+`delete_collection_list` and per-seller revocation differ:
+
+- **Normal deletion or end-of-relationship**: the token MUST fail subsequent `get_collection_list` calls immediately, but sellers with a cached resolution MAY continue serving from cache until `cache_valid_until`. A natural relationship end is not a compromise.
+- **Compromise-driven revocation**: the governance agent MUST signal cache invalidation. Either return a reduced `cache_valid_until` (at or before `now`) on the next poll that the seller still has access to complete, or emit a `collection_list_changed` webhook whose `change_summary` conveys that the list version has been invalidated so cached copies are discarded. Leaving compromised content in seller caches until the scheduled TTL is not acceptable.
+
+**Webhook URL validation.** The `webhook_url` on `update_collection_list` is SSRF-equivalent to any other buyer-provided callback URL. Apply the canonical [Webhook URL validation (SSRF)](/docs/building/implementation/security#webhook-url-validation-ssrf) rules — HTTPS only, validated IP ranges (IPv4 and IPv6 including `::ffff:0:0/96`), connection pinning (not just DNS re-resolution), no redirect following, size and timeout caps.
+
+**Webhook signature algorithm.** The webhook signature MUST follow the [standard webhook signing rules](/docs/building/implementation/security#webhook-security): HMAC-SHA256 over `{unix_timestamp}.{raw_http_body_bytes}` where `{unix_timestamp}` is the exact ASCII integer in the `X-ADCP-Timestamp` header (never derived from body fields), transmitted as `X-ADCP-Signature: sha256=<hex digest>`, verified with timing-safe comparison, and rejected when outside the 5-minute replay window. The body `signature` field is a convenience copy — recipients MUST verify against the headers and MUST NOT trust the body value.
+
+**Distribution-ID inputs.** Governance agents SHOULD validate identifier format before persisting (IMDb: `^tt\d+$`, EIDR: `10.5240/...`, Gracenote: vendor-prefixed) and SHOULD enforce per-principal rate limits on list mutations to prevent list-bloat DoS. Surface unresolved identifiers in `coverage_gaps` rather than silently dropping them.
+
 ## Sharing collection lists with sellers
 
 The pattern matches [property list sharing](/docs/governance/property/index#sharing-property-lists-with-sellers):

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -274,12 +274,16 @@ When AdCP validators encounter a URL reference:
 5. **Prevent Loops**: Reject if authoritative file is also a reference
 6. **Validate Structure**: Validate the authoritative file as normal inline structure
 
+Validators MUST apply the fetch semantics, change-detection, and rollback protection rules in [Managed network security considerations](/docs/governance/property/managed-networks#security-considerations). That section is the canonical source for blast-radius guidance on the authoritative_location pattern.
+
 ### Caching Recommendations
 
 - Cache reference files for 24 hours minimum
 - Cache authoritative files separately with their own TTL
 - Use `last_updated` timestamp to detect when cache should be invalidated
 - Implement exponential backoff for failed fetches
+
+Absolute cache caps and refresh floors for authoritative files live in [Managed network security considerations](/docs/governance/property/managed-networks#security-considerations) — the requirements there take precedence over any `Cache-Control` on the origin.
 
 ## Authorization Patterns
 

--- a/docs/governance/property/managed-networks.mdx
+++ b/docs/governance/property/managed-networks.mdx
@@ -585,6 +585,28 @@ npx adcp check-network --url <authoritative_url>
 
 The `check-network` command validates all agent endpoints and reports response times, so you can catch slow or failing agents before buyers do.
 
+## Security considerations
+
+One deploy to the authoritative file changes authorization across every publisher in the network. That scale is the point, and it's also the blast radius — a compromised network CDN can authorize a malicious sales agent across thousands of domains simultaneously. Two concrete implications that go beyond schema correctness:
+
+**Validator fetch semantics.** The authoritative URL points at a network-controlled origin. Without explicit fetch rules, a misbehaving origin can poison caches or hang validators. Validators MUST:
+
+- Connect only over HTTPS with valid certificates, and refuse to follow redirects (a redirect changes the declared location — treat as an error).
+- Cap response size (recommended: reject > 5 MB) and enforce short connect/read timeouts (≤ 10s each).
+- On 5xx or timeout, serve the previously cached authoritative file for up to 24 hours rather than failing closed. A transient CDN outage is not a revocation.
+- Attempt a refresh at least every 24 hours. Repeated 5xx responses MUST NOT extend the cache — the 7-day absolute cap is measured from the most recent successful fetch, not from the most recent response of any kind.
+- Cap cached lifetime at 7 days from the most recent successful fetch, regardless of the origin's `Cache-Control`. After that, fail closed — the network has had seven days to fix its origin.
+- Treat a non-monotonic `last_updated` (the refreshed file's timestamp is older than the cached file's) as an invalid response, equivalent to a 5xx: serve the cache, alert, do not adopt the older file. This blocks rollback attacks where an attacker re-serves a stale file to reinstate a previously revoked agent.
+
+**Change detection.** Because one deploy affects every publisher, buyer agents and validators SHOULD store the previous authoritative file and diff on each refresh, alerting on outlier changes. Concrete default thresholds that partners can implement on day one: any newly added `authorized_agents` entry that was not present in the previous fetch, any delegation-type downgrade (for example, an `exclusive` entry becoming non-exclusive), any property-count decrease greater than 10% or 50 absolute properties, and any change to `authoritative_location` itself. Tune from there — the goal is to catch a compromised deploy before it routes spend, not to suppress routine updates.
+
+**Relationship termination.** The pointer-file pattern relies on the network controlling publisher DNS or edge. When the relationship ends, both sides of the delegation must come down together:
+
+- The network MUST remove the publisher from the authoritative file's `properties` at termination, even when it has already lost DNS/edge control. A publisher still pointing at an ex-network's file with no matching property becomes an [orphaned pointer](#orphaned-pointer) — visible to buyers as unauthorized.
+- Validators SHOULD re-fetch and re-validate when a publisher domain transfers ownership, rather than relying on cached delegation.
+
+A signed-attestation layer (signed authoritative files, publisher-signed pointers) would strengthen this further but is a separate protocol change rather than a security-section requirement.
+
 ## Next steps
 
 - [adagents.json Tech Spec](/docs/governance/property/adagents) — full schema reference, authorization patterns, and validation behavior

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -793,6 +793,18 @@ Each file contains one media buy delivery per line (JSONL), row (CSV/Parquet/ORC
 - Validate file integrity using checksums if provided
 - Monitor for missing files and alert on gaps
 
+### Security considerations for offline delivery
+
+Offline files sit at rest for `file_retention_days`, so a misconfigured IAM policy leaks historical reporting across tenants. The [general security controls](/docs/building/implementation/security) apply; the offline-specific requirements:
+
+- **Scope access at the IAM layer, not by obscurity.** Buyer read access MUST be scoped to `{bucket}/{prefix}/*` (S3 bucket policy condition, GCS conditional IAM binding on `resource.name.startsWith(...)`, or Azure SAS scoped to the prefix). A bucket-wide read grant is non-compliant even when the seller only writes under one prefix per account.
+- **Scope listing as well as reads.** Prefix scoping MUST cover both object-level operations (`s3:GetObject`) and listing (`s3:ListBucket` with an `s3:prefix` condition). A policy that scopes `GetObject` to the prefix but leaves `ListBucket` unscoped lets a buyer enumerate other tenants' prefix names — a cross-tenant isolation failure even without read access to their objects. The same applies to GCS `storage.objects.list` and Azure `list` SAS permissions.
+- **Revoke access when the account closes.** When the seller emits an `account.status` transition to `inactive`, `suspended`, or `closed`, the seller MUST stop honoring the associated credentials, and buyers SHOULD treat that status change as the trigger to remove matching IAM trust on their end. A seller IAM role left granted to a decommissioned bucket is a lateral-movement risk.
+
+PII scrubbing requirements (see [above](#pii-scrubbing-for-gdpr-ccpa)) apply to offline files identically — scrub at the collection layer, not at delivery, because the files accumulate at rest.
+
+`setup_instructions` is a seller-provided URL. It is operator-facing documentation, not agent-consumable content. Buyer agents MUST NOT auto-fetch the URL; they SHOULD surface it to a human operator. If an implementation chooses to fetch it (for example, to preview the target before showing it to the operator), apply [webhook URL SSRF validation](/docs/building/implementation/security#webhook-url-validation-ssrf), and the fetched content MUST NOT be passed into an LLM context without indirect-prompt-injection guarding — seller-controlled text in this field can contain instructions to rotate credentials, change billing, or alter downstream agent behavior.
+
 ## Data Reconciliation
 
 **The `get_media_buy_delivery` API is the authoritative source of truth for all campaign metrics.** Polling is always available as a baseline. When the seller also supports push-based delivery (webhooks or offline buckets), those methods provide timely data but `get_media_buy_delivery` remains the reconciliation path.

--- a/docs/trusted-match/router-architecture.mdx
+++ b/docs/trusted-match/router-architecture.mdx
@@ -69,7 +69,7 @@ Provider registration typically comes from the **page configuration** — the pu
 - Router polls a discovery endpoint or watches for configuration changes
 - Changes take effect within one refresh cycle (recommended: 30 seconds)
 - Appropriate for publishers managing many providers or needing runtime updates without redeploys
-- Dynamic registration endpoints MUST validate that provider `endpoint` URLs are external HTTPS addresses. Implementations MUST reject private (RFC 1918), link-local (169.254.x.x), and cloud metadata IP ranges to prevent SSRF through provider registration.
+- Dynamic registration endpoints MUST validate that provider `endpoint` URLs are external HTTPS addresses. Implementations MUST reject private (RFC 1918), link-local (169.254.x.x), and cloud metadata IP ranges to prevent SSRF through provider registration. See [Provider registration security](/docs/trusted-match/specification#provider-registration-security) in the specification for the full normative requirements — endpoint URL validation (with DNS re-resolution), dynamic registration endpoint authentication, router-to-provider auth minimum bar, and `/health` endpoint guidance.
 
 Both models use the same schema. The router does not distinguish between providers loaded from a YAML file and providers loaded from an API — the registration fields are identical.
 

--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -256,6 +256,16 @@ Providers have three lifecycle states:
 
 State transitions are immediate in static configuration (reload the config) and take effect within one refresh cycle in dynamic registration.
 
+### Provider registration security
+
+**Endpoint URL validation (SSRF).** Both static configuration and dynamic registration MUST validate provider `endpoint` URLs against the canonical [Webhook URL validation (SSRF)](/docs/building/implementation/security#webhook-url-validation-ssrf) rules — HTTPS only in production, reserved IPv4 and IPv6 ranges rejected (including `::ffff:0:0/96` IPv4-mapped bypasses and the `169.254.169.254` / `fd00:ec2::254` cloud metadata addresses), no redirects. Because a router calls the provider on every request, DNS rebinding is the primary risk: routers MUST either pin the TCP connection to the IP that passed validation or re-validate the socket's post-handshake peer address before sending the request body. Re-resolving DNS without pinning is not sufficient.
+
+**Dynamic registration authentication.** The dynamic registration API is a privileged surface; unauthenticated registration lets an attacker point publisher traffic at arbitrary HTTPS endpoints. Routers exposing dynamic registration MUST authenticate callers (mTLS or short-lived OAuth 2.0 tokens; static API keys only with IP allow-listing) and SHOULD apply per-principal rate limits on mutations and a cap on total registered providers per publisher to bound registration-storm abuse.
+
+**Router-to-provider auth.** The existing "deployment-specific (mTLS, API key, etc.)" language in [Request Authentication](#request-authentication) sets the mechanism; the minimum bar is that production providers MUST NOT accept anonymous calls. Static bearer tokens MAY be used only with IP allow-listing.
+
+**`/health` endpoint.** The `/health` endpoint providers are encouraged to expose for router liveness MAY be unauthenticated, but the response MUST NOT leak internal state. Providers SHOULD return `200` with body `{"status": "ok"}` when ready and `503` when not ready; other status codes are bugs. Providers MUST NOT differentiate status codes or response bodies by internal subsystem (for example, a distinct code when the database is down versus when the identity cache is down is a side-channel that maps external probing onto internal topology). Version strings, build hashes, internal hostnames, and dependency statuses MUST NOT appear in the body. Rate-limit the endpoint (recommended: 1 req/sec per source IP) so it doesn't become a DoS amplifier.
+
 ## Product Integration
 
 Publishers declare TMP support on their products via the `trusted_match` field. Buyers see this on `get_products` and know what TMP capabilities are available.

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -16,7 +16,7 @@
           "type": "string",
           "format": "uri",
           "pattern": "^https://",
-          "description": "HTTPS URL of the authoritative adagents.json file. When present, this file is a reference and the authoritative location contains the actual agent authorization data."
+          "description": "HTTPS URL of the authoritative adagents.json file. When present, this file is a reference and the authoritative location contains the actual agent authorization data. Because one deploy can change authorization across every publisher in the network, validators MUST cap response size, refuse redirects on the fetch, enforce short timeouts, and serve the previously cached file on transient 5xx. See docs/governance/property/managed-networks#security-considerations."
         },
         "last_updated": {
           "type": "string",

--- a/static/schemas/source/collection/collection-list-changed-webhook.json
+++ b/static/schemas/source/collection/collection-list-changed-webhook.json
@@ -49,7 +49,7 @@
     },
     "signature": {
       "type": "string",
-      "description": "Cryptographic signature of the webhook payload, signed with the agent's private key. Recipients MUST verify this signature."
+      "description": "HMAC-SHA256 webhook signature over {unix_timestamp}.{raw_http_body_bytes} using the secret exchanged out-of-band when the seller registered with the governance agent. Recipients MUST verify against the X-ADCP-Signature and X-ADCP-Timestamp headers using timing-safe comparison and MUST reject requests where |now - timestamp| > 300 seconds. The body copy of this field is a convenience only — the headers are authoritative. See docs/building/implementation/security#webhook-security."
     },
     "ext": {
       "$ref": "/schemas/core/ext.json"

--- a/static/schemas/source/collection/create-collection-list-response.json
+++ b/static/schemas/source/collection/create-collection-list-response.json
@@ -11,7 +11,7 @@
     },
     "auth_token": {
       "type": "string",
-      "description": "Token that can be shared with sellers to authorize fetching this list. Store this - it is only returned at creation time."
+      "description": "Token that authorizes sellers to fetch this list via get_collection_list. Only returned at creation time — buyers MUST store it in a secret manager. Scoped to this one list_id; MUST NOT be reused across lists. Governance agents MUST issue a distinct token per seller so per-relationship revocation is possible. Tokens MUST NOT be logged, appear in cache keys, or echo in error responses. delete_collection_list MUST revoke the token immediately; compromise-driven revocation MUST also signal cache invalidation to sellers (reduced cache_valid_until or a list-changed webhook). See Security considerations in docs/governance/collection/tasks/collection_lists."
     },
     "context": {
       "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/collection/update-collection-list-request.json
+++ b/static/schemas/source/collection/update-collection-list-request.json
@@ -41,7 +41,7 @@
     "webhook_url": {
       "type": "string",
       "format": "uri",
-      "description": "Update the webhook URL for list change notifications (set to empty string to remove)"
+      "description": "Update the webhook URL for list change notifications (set to empty string to remove). Governance agents MUST validate this URL against SSRF per docs/building/implementation/security#webhook-url-validation-ssrf."
     },
     "context": {
       "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/core/account.json
+++ b/static/schemas/source/core/account.json
@@ -120,7 +120,7 @@
     },
     "reporting_bucket": {
       "type": "object",
-      "description": "Cloud storage bucket where the seller delivers offline reporting files for this account. Seller provisions a dedicated bucket or a per-account prefix within a shared bucket, and grants the buyer read access out-of-band. Access MUST be scoped so each account can only read its own prefix. Only present when the seller supports offline delivery (reporting_delivery_methods includes 'offline' in capabilities).",
+      "description": "Cloud storage bucket where the seller delivers offline reporting files for this account. Seller provisions a dedicated bucket or a per-account prefix within a shared bucket, and grants the buyer read access out-of-band. Access MUST be scoped at the IAM layer so each account can only read its own prefix — bucket-wide grants are non-compliant even with per-account prefixes. Seller MUST revoke access when the account's status transitions to inactive, suspended, or closed. See security considerations for offline delivery in docs/media-buy/media-buys/optimization-reporting. Only present when the seller supports offline delivery (reporting_delivery_methods includes 'offline' in capabilities).",
       "properties": {
         "protocol": {
           "$ref": "/schemas/enums/cloud-storage-protocol.json",
@@ -175,7 +175,7 @@
           "type": "string",
           "format": "uri",
           "pattern": "^https://",
-          "description": "URL to documentation for configuring buyer read access to this bucket (IAM role, service account, etc.)"
+          "description": "URL to documentation for configuring buyer read access to this bucket (IAM role, service account, etc.). Operator-facing documentation — buyer agents MUST NOT auto-fetch this URL; surface it to a human operator. If an implementation fetches it (for preview), apply webhook URL SSRF validation and do not pass the fetched content into an LLM context without indirect-prompt-injection guarding. See docs/media-buy/media-buys/optimization-reporting#security-considerations-for-offline-delivery."
         }
       },
       "required": ["protocol", "bucket", "file_retention_days"],

--- a/static/schemas/source/tmp/provider-registration.json
+++ b/static/schemas/source/tmp/provider-registration.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/provider-registration.json",
   "title": "TMP Provider Registration",
-  "description": "Declares a TMP provider's endpoint, capabilities, and operational parameters. Used in router configuration (static YAML or dynamic API) and referenced by product-level provider entries. The publisher controls which providers participate in their ad decisioning.",
+  "description": "Declares a TMP provider's endpoint, capabilities, and operational parameters. Used in router configuration (static YAML or dynamic API) and referenced by product-level provider entries. The publisher controls which providers participate in their ad decisioning. Endpoint URLs MUST be validated against SSRF, and dynamic registration endpoints MUST authenticate callers — see docs/trusted-match/specification#provider-registration-security.",
   "type": "object",
   "properties": {
     "provider_id": {
@@ -12,7 +12,7 @@
     "endpoint": {
       "type": "string",
       "format": "uri",
-      "description": "Base URL the router calls. The router appends /context for Context Match and /identity for Identity Match. Must be HTTPS in production."
+      "description": "Base URL the router calls. The router appends /context for Context Match and /identity for Identity Match. MUST be HTTPS in production, validated against the canonical reserved IPv4 and IPv6 ranges, with the TCP connection pinned to the validated IP (DNS re-resolution alone is insufficient against rebinding). See docs/trusted-match/specification#provider-registration-security and docs/building/implementation/security#webhook-url-validation-ssrf."
     },
     "context_match": {
       "type": "boolean",


### PR DESCRIPTION
## Summary

Tighten normative security guidance for four features that partners will run in production before 3.0 GA so partner security reviewers have concrete requirements to check against. No protocol shape changes — docs and schema descriptions only.

- **Canonical SSRF rules** (`docs/building/implementation/security.mdx`): full reserved IPv4/IPv6 list (RFC 1918, RFC 6598 CGNAT, `169.254.0.0/16` with cloud metadata, `::ffff:0:0/96` IPv4-mapped IPv6, multicast). DNS-based filtering alone is insufficient — fetchers MUST pin the TCP connection to the validated IP or re-validate the post-handshake peer address. Applies to webhooks, collection-list callbacks, TMP provider endpoints, `authoritative_location`, and `setup_instructions`.
- **HMAC webhook signatures**: signed `{unix_timestamp}` MUST be the exact ASCII integer from `X-ADCP-Timestamp` (not derived from body fields). Header format pinned explicitly.
- **Offline reporting buckets** (#2223): IAM-layer prefix scoping including `s3:ListBucket` with `s3:prefix` condition (not just `GetObject`) to prevent cross-tenant prefix enumeration, revocation tied to `account.status` transitions, `setup_instructions` marked operator-facing (MUST NOT auto-fetch, indirect-prompt-injection guidance for any preview ingestion).
- **Collection lists** (#2225): `auth_token` scope, per-seller issuance required, log hygiene, webhook signature spec, distribution-ID format validation with rate limits. Compromise-driven revocation requires cache invalidation signal, not just TTL expiry.
- **Managed network `authoritative_location`** (#2224): validator fetch semantics, 24h cached fallback on 5xx with a 7-day absolute cap measured from the most recent successful fetch, non-monotonic `last_updated` treated as an invalid response to block rollback attacks, concrete change-detection thresholds, relationship-termination handling.
- **TMP provider registration** (#2226): dynamic-registration caller authentication, router-to-provider auth minimum bar, `/health` info-leakage rules (no subsystem-specific status codes or response bodies).

Closes #2223
Closes #2225
Closes #2224
Closes #2226

## Test plan

- [x] Schemas validate (`python3 -c "import json; json.load(...)"`)
- [x] `node scripts/build-schemas.cjs` — 81 schemas bundled, no warnings
- [x] Precommit: 587 unit tests pass, typecheck clean
- [x] Mintlify link check passes, no accessibility regressions
- [ ] CI green on PR
- [ ] CodeQL review on PR comments

## Risks / follow-ups

- **Cryptographic attestation for `authoritative_location`** (signed files, publisher-signed pointers) would further reduce the blast radius of a compromised network CDN. Out of scope here — it is a protocol change requiring its own proposal, not a security-section addition.
- **TMP provider registration `anyOf` schema bug** noted in review (`context_match` required to be both present and `true` breaks identity-only providers) is pre-existing; fixing it is a separate schema shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)