### PR TITLE
fix: resolve 404s on /schemas/v{N}/ alias paths

### DIFF
--- a/.changeset/fix-schemas-alias-404.md
+++ b/.changeset/fix-schemas-alias-404.md
@@ -1,0 +1,12 @@
+---
+---
+
+Fix 404s on `/schemas/v{N}/<file>` alias paths (e.g. `/schemas/v3/adagents.json`).
+
+The alias-rewrite middleware was registered after the `/schemas` static handler,
+so alias paths fell through to a 404 even when the version existed. Consolidate
+alias resolution, bare-directory redirects, and static serving into a single
+ordered middleware (`mountSchemasRoutes`), fix the directory-redirect to include
+the `/schemas` prefix, and teach the redirect regex to match prerelease versions
+(e.g. `3.0.0-rc.3/`). Adds HTTP-level integration tests that exercise the real
+middleware against `dist/schemas/`.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -19,6 +19,7 @@ import { CapabilityDiscovery } from "./capabilities.js";
 import { PublisherTracker } from "./publishers.js";
 import { PropertiesService } from "./properties.js";
 import { AdAgentsManager } from "./adagents-manager.js";
+import { mountSchemasRoutes } from "./schemas-middleware.js";
 import { closeDatabase, getPool, healthCheck } from "./db/client.js";
 import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
 import type { Agent, AgentType, AgentWithStats, Company } from "./types.js";
@@ -471,34 +472,12 @@ export class HTTPServer {
     // Required for express-rate-limit and other middleware that use req.ip
     this.app.set('trust proxy', 1);
 
-    // Serve JSON schemas as static files before any other middleware.
-    // These are high-traffic, read-only JSON files that don't need body parsing,
-    // cookies, CSRF, or session handling.
+    // Serve JSON schemas (aliases + static files + discovery) before body-parsing,
+    // cookie, and CSRF middleware so these high-traffic reads stay cheap.
     const distPath = process.env.NODE_ENV === 'production'
       ? __dirname
       : path.join(__dirname, "../../dist");
-    const schemasPath = path.join(distPath, 'schemas');
-    // Use a middleware wrapper so setHeaders can see the *request* path.
-    // express.static resolves symlinks, so checking the file path would
-    // incorrectly mark aliases (latest, v2.5) as immutable when they
-    // resolve to a versioned directory on disk.
-    const schemasStatic = express.static(schemasPath, {
-      maxAge: '10m',
-      etag: true,
-      lastModified: true,
-      setHeaders: (res) => {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-      }
-    });
-    this.app.use('/schemas', (req, res, next) => {
-      // Only direct versioned paths (/schemas/2.5.3/...) are immutable.
-      // Aliases (/latest/, /v2.5/, /v1/) use the 10m default + ETag so
-      // caches revalidate after the alias target changes.
-      if (/^\/\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?\//.test(req.path)) {
-        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-      }
-      schemasStatic(req, res, next);
-    });
+    mountSchemasRoutes(this.app, path.join(distPath, 'schemas'));
 
     // Track slow API responses and alert ops
     this.app.use(slowResponseTracker);
@@ -529,168 +508,6 @@ export class HTTPServer {
     });
     this.app.use(cookieParser());
     this.app.use(csrfProtection);
-
-    // Schema version aliasing and discovery (static serving handled above, before middleware)
-
-    // Cache for schema version directories (refreshed every 60 seconds)
-    let versionCache: { versions: string[], timestamp: number } | null = null;
-    const CACHE_TTL_MS = 60 * 1000;
-
-    async function getSchemaVersions(): Promise<string[]> {
-      const now = Date.now();
-      if (versionCache && (now - versionCache.timestamp) < CACHE_TTL_MS) {
-        return versionCache.versions;
-      }
-
-      const entries = await fs.readdir(schemasPath, { withFileTypes: true });
-      const versions = entries
-        .filter(e => e.isDirectory() && /^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?$/.test(e.name))
-        .map(e => e.name)
-        .sort((a, b) => {
-          // Sort by semver (descending), prereleases come after stable
-          const parseVersion = (v: string) => {
-            const [base, prerelease] = v.split('-');
-            const [major, minor, patch] = base.split('.').map(Number);
-            return { major, minor, patch, prerelease };
-          };
-          const av = parseVersion(a);
-          const bv = parseVersion(b);
-          if (av.major !== bv.major) return bv.major - av.major;
-          if (av.minor !== bv.minor) return bv.minor - av.minor;
-          if (av.patch !== bv.patch) return bv.patch - av.patch;
-          // Stable versions come before prereleases (no prerelease = higher precedence)
-          if (!av.prerelease && bv.prerelease) return -1;
-          if (av.prerelease && !bv.prerelease) return 1;
-          // Both have prereleases, sort descending (beta.3 before beta.1)
-          if (av.prerelease && bv.prerelease) return bv.prerelease.localeCompare(av.prerelease);
-          return 0;
-        });
-
-      versionCache = { versions, timestamp: now };
-      return versions;
-    }
-
-    function parseSemver(version: string): { major: number, minor: number, patch: number, prerelease?: string } {
-      const [base, prerelease] = version.split('-');
-      const [major, minor, patch] = base.split('.').map(Number);
-      return { major, minor, patch, prerelease };
-    }
-
-    function findMatchingVersion(versions: string[], requestedMajor: number, requestedMinor?: number): string | undefined {
-      // Find the latest version that matches the requested major (and optionally minor)
-      return versions.find(v => {
-        const { major, minor } = parseSemver(v);
-        if (major !== requestedMajor) return false;
-        if (requestedMinor !== undefined && minor !== requestedMinor) return false;
-        return true;
-      });
-    }
-
-    // Middleware to resolve version aliases (e.g., v2.5 → 2.5.1)
-    // This handles cases where symlinks don't exist (e.g., in Docker)
-    this.app.use('/schemas', async (req, res, next) => {
-      // Match version alias patterns: /v2/, /v2.5/, /v2.6/, /v1/
-      const versionMatch = req.path.match(/^\/v(\d+)(?:\.(\d+))?(\/.*)?$/);
-      if (!versionMatch) {
-        return next();
-      }
-
-      const requestedMajor = parseInt(versionMatch[1], 10);
-      const requestedMinor = versionMatch[2] ? parseInt(versionMatch[2], 10) : undefined;
-      const restOfPath = versionMatch[3] || '/';
-
-      // Special case: v1 always points to latest
-      if (requestedMajor === 1 && requestedMinor === undefined) {
-        req.url = '/latest' + restOfPath;
-        return next();
-      }
-
-      try {
-        const versions = await getSchemaVersions();
-        const targetVersion = findMatchingVersion(versions, requestedMajor, requestedMinor);
-
-        if (targetVersion) {
-          req.url = '/' + targetVersion + restOfPath;
-        }
-      } catch {
-        // If we can't read the directory, let static middleware handle it
-      }
-      next();
-    });
-
-    // Redirect version directory requests to index.json
-    // e.g., /schemas/2.6.0/ → /schemas/2.6.0/index.json
-    this.app.use('/schemas', (req, res, next) => {
-      // Match paths like /2.6.0/ or /latest/ (directory requests)
-      if (req.path.match(/^\/(\d+\.\d+\.\d+|latest)\/$/)) {
-        return res.redirect(req.path + 'index.json');
-      }
-      next();
-    });
-
-    // Schema discovery endpoint - returns available versions and aliases
-    this.app.get('/schemas/', async (req, res) => {
-      try {
-        const versions = await getSchemaVersions();
-        const latestPerMinor: Record<string, string> = {};
-        let latestMajorVersion: string | undefined;
-
-        for (const version of versions) {
-          const { major, minor } = parseSemver(version);
-          const minorKey = `${major}.${minor}`;
-
-          // First version in sorted list is the overall latest
-          if (!latestMajorVersion) {
-            latestMajorVersion = version;
-          }
-
-          // Track latest patch for each minor
-          if (!latestPerMinor[minorKey]) {
-            latestPerMinor[minorKey] = version;
-          }
-        }
-
-        // Build aliases list
-        const aliases: Array<{ alias: string, resolves_to: string, path: string }> = [];
-
-        // Major version aliases (e.g., v2 -> 2.6.0)
-        if (latestMajorVersion) {
-          const { major } = parseSemver(latestMajorVersion);
-          aliases.push({
-            alias: `v${major}`,
-            resolves_to: latestMajorVersion,
-            path: `/schemas/v${major}/`
-          });
-        }
-
-        // Minor version aliases (e.g., v2.5 -> 2.5.1)
-        for (const [minorKey, version] of Object.entries(latestPerMinor)) {
-          aliases.push({
-            alias: `v${minorKey}`,
-            resolves_to: version,
-            path: `/schemas/v${minorKey}/`
-          });
-        }
-
-        // Sort aliases for consistent output
-        aliases.sort((a, b) => a.alias.localeCompare(b.alias, undefined, { numeric: true }));
-
-        res.json({
-          versions: versions.map(v => ({
-            version: v,
-            path: `/schemas/${v}/`
-          })),
-          aliases,
-          latest: {
-            path: "/schemas/latest/",
-            note: "Development version, may differ from released versions"
-          }
-        });
-      } catch (error) {
-        logger.error({ err: error }, 'Failed to list schema versions');
-        res.status(500).json({ error: "Failed to list schema versions" });
-      }
-    });
 
     // Serve brand.json for both AAO domains.
     // AdCP domain redirects to the AAO house. AAO domain redirects to the DB-managed hosted brand.

--- a/server/src/schemas-middleware.ts
+++ b/server/src/schemas-middleware.ts
@@ -1,0 +1,200 @@
+import type { Application } from "express";
+import express from "express";
+import * as fs from "fs/promises";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger("schemas-middleware");
+
+// Bare version directory requests (/2.5.3/, /3.0.0-rc.3/, /latest/).
+const VERSIONED_DIR = /^\/(\d+\.\d+\.\d+(?:-[a-zA-Z]+\.\d+)?|latest)\/$/;
+// Alias paths like "/v2/...", "/v2.5/...", "/v12/..." (v1 is a special case → latest).
+const ALIAS_PATH = /^\/v(\d+)(?:\.(\d+))?(\/.*)?$/;
+// Direct versioned paths (/2.5.3/..., /3.0.0-rc.3/...) — immutable.
+const IMMUTABLE_PATH = /^\/\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?\//;
+
+/**
+ * Cache of versioned schema directories, refreshed every 60 seconds.
+ * Scoped per-call so each mount has its own cache.
+ */
+function makeVersionCache(schemasPath: string) {
+  let cache: { versions: string[]; timestamp: number } | null = null;
+  const CACHE_TTL_MS = 60 * 1000;
+
+  return async function getSchemaVersions(): Promise<string[]> {
+    const now = Date.now();
+    if (cache && now - cache.timestamp < CACHE_TTL_MS) return cache.versions;
+
+    const entries = await fs.readdir(schemasPath, { withFileTypes: true });
+    const versions = entries
+      .filter(
+        (e) =>
+          e.isDirectory() && /^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?$/.test(e.name),
+      )
+      .map((e) => e.name)
+      .sort((a, b) => {
+        const pa = parseSemver(a);
+        const pb = parseSemver(b);
+        if (pa.major !== pb.major) return pb.major - pa.major;
+        if (pa.minor !== pb.minor) return pb.minor - pa.minor;
+        if (pa.patch !== pb.patch) return pb.patch - pa.patch;
+        // Stable beats prerelease for the same base version.
+        if (!pa.prerelease && pb.prerelease) return -1;
+        if (pa.prerelease && !pb.prerelease) return 1;
+        if (pa.prerelease && pb.prerelease)
+          return pb.prerelease.localeCompare(pa.prerelease);
+        return 0;
+      });
+
+    cache = { versions, timestamp: now };
+    return versions;
+  };
+}
+
+export function parseSemver(version: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+} {
+  const [base, prerelease] = version.split("-");
+  const [major, minor, patch] = base.split(".").map(Number);
+  return { major, minor, patch, prerelease };
+}
+
+export function findMatchingVersion(
+  versions: string[],
+  requestedMajor: number,
+  requestedMinor?: number,
+): string | undefined {
+  return versions.find((v) => {
+    const { major, minor } = parseSemver(v);
+    if (major !== requestedMajor) return false;
+    if (requestedMinor !== undefined && minor !== requestedMinor) return false;
+    return true;
+  });
+}
+
+/**
+ * Mount /schemas routes on the given Express app:
+ *  - rewrites version-alias paths (/v2, /v2.5, /v3, /v12, ...) to a concrete version directory
+ *  - redirects bare version directories (/2.5.3/, /3.0.0-rc.3/, /latest/) to index.json
+ *  - serves JSON schemas from `schemasPath` with per-path cache-control
+ *  - exposes a /schemas/ discovery endpoint listing versions and aliases
+ *
+ * Mounted before body-parsing / cookie / CSRF middleware so schema reads stay cheap.
+ */
+export function mountSchemasRoutes(app: Application, schemasPath: string): void {
+  const getSchemaVersions = makeVersionCache(schemasPath);
+
+  const schemasStatic = express.static(schemasPath, {
+    maxAge: "10m",
+    etag: true,
+    lastModified: true,
+    setHeaders: (res) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+    },
+  });
+
+  app.use("/schemas", async (req, res, next) => {
+    // Capture before any rewrite — caches key on the original URL, so the
+    // immutable-cache decision must be based on what the client requested.
+    const originalPath = req.path;
+    const isAlias = ALIAS_PATH.test(originalPath);
+
+    // 1. Rewrite alias paths to a concrete version directory.
+    if (isAlias) {
+      const aliasMatch = originalPath.match(ALIAS_PATH)!;
+      const requestedMajor = parseInt(aliasMatch[1], 10);
+      const requestedMinor = aliasMatch[2]
+        ? parseInt(aliasMatch[2], 10)
+        : undefined;
+      const restOfPath = aliasMatch[3] || "/";
+
+      if (requestedMajor === 1 && requestedMinor === undefined) {
+        req.url = "/latest" + restOfPath;
+      } else {
+        try {
+          const versions = await getSchemaVersions();
+          const targetVersion = findMatchingVersion(
+            versions,
+            requestedMajor,
+            requestedMinor,
+          );
+          if (targetVersion) {
+            req.url = "/" + targetVersion + restOfPath;
+          }
+        } catch {
+          // Fall through; static handler below will produce the 404.
+        }
+      }
+    }
+
+    // 2. Redirect bare version directories to their index.json.
+    if (VERSIONED_DIR.test(req.path)) {
+      return res.redirect("/schemas" + req.path + "index.json");
+    }
+
+    // 3. Only direct versioned paths (client pinned a full semver) are immutable.
+    //    Aliases and /latest/ keep the static 10m + ETag default so caches
+    //    revalidate when the alias retargets to a new version.
+    if (!isAlias && IMMUTABLE_PATH.test(originalPath)) {
+      res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    }
+
+    schemasStatic(req, res, next);
+  });
+
+  app.get("/schemas/", async (_req, res) => {
+    try {
+      const versions = await getSchemaVersions();
+      const latestPerMinor: Record<string, string> = {};
+      let latestMajorVersion: string | undefined;
+
+      for (const version of versions) {
+        const { major, minor } = parseSemver(version);
+        const minorKey = `${major}.${minor}`;
+        if (!latestMajorVersion) latestMajorVersion = version;
+        if (!latestPerMinor[minorKey]) latestPerMinor[minorKey] = version;
+      }
+
+      const aliases: Array<{
+        alias: string;
+        resolves_to: string;
+        path: string;
+      }> = [];
+
+      if (latestMajorVersion) {
+        const { major } = parseSemver(latestMajorVersion);
+        aliases.push({
+          alias: `v${major}`,
+          resolves_to: latestMajorVersion,
+          path: `/schemas/v${major}/`,
+        });
+      }
+
+      for (const [minorKey, version] of Object.entries(latestPerMinor)) {
+        aliases.push({
+          alias: `v${minorKey}`,
+          resolves_to: version,
+          path: `/schemas/v${minorKey}/`,
+        });
+      }
+
+      aliases.sort((a, b) =>
+        a.alias.localeCompare(b.alias, undefined, { numeric: true }),
+      );
+
+      res.json({
+        versions: versions.map((v) => ({ version: v, path: `/schemas/${v}/` })),
+        aliases,
+        latest: {
+          path: "/schemas/latest/",
+          note: "Development version, may differ from released versions",
+        },
+      });
+    } catch (error) {
+      logger.error({ err: error }, "Failed to list schema versions");
+      res.status(500).json({ error: "Failed to list schema versions" });
+    }
+  });
+}

--- a/server/tests/integration/schema-routing.test.ts
+++ b/server/tests/integration/schema-routing.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import request from "supertest";
+import fs from "fs";
+import path from "path";
+import { mountSchemasRoutes } from "../../src/schemas-middleware.js";
+
+/**
+ * End-to-end tests for /schemas routing: version alias rewriting, bare-directory
+ * redirects, and static file serving. These exercise the real middleware against
+ * the built dist/schemas/ tree to catch ordering/wiring bugs that pure-function
+ * tests miss.
+ */
+describe("/schemas HTTP routing", () => {
+  const schemasPath = path.join(__dirname, "../../../dist/schemas");
+  let app: express.Express;
+  let versions: string[] = [];
+  let latestStableMajor2: string | undefined;
+  let latestPrereleaseMajor3: string | undefined;
+
+  beforeAll(() => {
+    versions = fs
+      .readdirSync(schemasPath, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && /^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?$/.test(e.name))
+      .map((e) => e.name);
+
+    if (versions.length === 0) {
+      throw new Error(`No schema versions found under ${schemasPath}. Run \`npm run build:schemas\` first.`);
+    }
+
+    latestStableMajor2 = versions
+      .filter((v) => v.startsWith("2.") && !v.includes("-"))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0];
+    latestPrereleaseMajor3 = versions
+      .filter((v) => v.startsWith("3."))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0];
+
+    app = express();
+    mountSchemasRoutes(app, schemasPath);
+  });
+
+  describe("direct versioned paths", () => {
+    it("serves files from a concrete stable version", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get(`/schemas/${latestStableMajor2}/adagents.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(res.headers["cache-control"]).toContain("immutable");
+    });
+
+    it("serves files from a concrete prerelease version", async () => {
+      if (!latestPrereleaseMajor3) return;
+      const res = await request(app).get(`/schemas/${latestPrereleaseMajor3}/adagents.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers["cache-control"]).toContain("immutable");
+    });
+
+    it("redirects a bare stable directory to index.json under /schemas", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get(`/schemas/${latestStableMajor2}/`);
+      expect(res.status).toBe(302);
+      expect(res.headers["location"]).toBe(`/schemas/${latestStableMajor2}/index.json`);
+    });
+
+    it("redirects a bare prerelease directory to index.json under /schemas", async () => {
+      if (!latestPrereleaseMajor3) return;
+      const res = await request(app).get(`/schemas/${latestPrereleaseMajor3}/`);
+      expect(res.status).toBe(302);
+      expect(res.headers["location"]).toBe(`/schemas/${latestPrereleaseMajor3}/index.json`);
+    });
+  });
+
+  describe("version aliases (the bug we just fixed)", () => {
+    it("serves /schemas/v2/adagents.json via alias rewrite", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2/adagents.json");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+
+    it("serves /schemas/v2.5/adagents.json via minor-alias rewrite", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2.5/adagents.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("serves /schemas/v3/adagents.json via alias rewrite (prerelease-only)", async () => {
+      if (!latestPrereleaseMajor3) return;
+      const res = await request(app).get("/schemas/v3/adagents.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("redirects /schemas/v2/ to the resolved stable index.json", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2/");
+      expect(res.status).toBe(302);
+      expect(res.headers["location"]).toBe(`/schemas/${latestStableMajor2}/index.json`);
+    });
+
+    it("redirects /schemas/v3/ to the resolved prerelease index.json", async () => {
+      if (!latestPrereleaseMajor3) return;
+      const res = await request(app).get("/schemas/v3/");
+      expect(res.status).toBe(302);
+      expect(res.headers["location"]).toBe(`/schemas/${latestPrereleaseMajor3}/index.json`);
+    });
+
+    it("returns 404 for an alias with no matching major version", async () => {
+      const res = await request(app).get("/schemas/v99/adagents.json");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("cache-control policy", () => {
+    // Aliases and /latest/ must not be immutably cached — they retarget over time.
+    // Only direct versioned paths (client pinned a full semver) get immutable.
+    it("does NOT mark alias file responses immutable", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2/adagents.json");
+      expect(res.status).toBe(200);
+      expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+    });
+
+    it("does NOT mark minor-alias file responses immutable", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2.5/adagents.json");
+      expect(res.status).toBe(200);
+      expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+    });
+
+    it("does NOT mark /latest/ file responses immutable", async () => {
+      const res = await request(app).get("/schemas/latest/adagents.json");
+      // /latest/ may or may not exist depending on build; only assert when present.
+      if (res.status !== 200) return;
+      expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+    });
+  });
+
+  describe("discovery endpoint", () => {
+    it("lists versions and aliases at /schemas/", async () => {
+      const res = await request(app).get("/schemas/");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.versions)).toBe(true);
+      expect(Array.isArray(res.body.aliases)).toBe(true);
+      expect(res.body.latest).toMatchObject({ path: "/schemas/latest/" });
+    });
+  });
+});

--- a/server/tests/integration/schema-versioning.test.ts
+++ b/server/tests/integration/schema-versioning.test.ts
@@ -149,12 +149,17 @@ describe("Schema Versioning Middleware", () => {
   });
 
   describe("directory redirect regex", () => {
-    const regex = /^\/(\d+\.\d+\.\d+|latest)\/$/;
+    const regex = /^\/(\d+\.\d+\.\d+(?:-[a-zA-Z]+\.\d+)?|latest)\/$/;
 
     it("should match semver directory paths", () => {
       expect("/2.6.0/".match(regex)).not.toBeNull();
       expect("/2.5.1/".match(regex)).not.toBeNull();
       expect("/12.0.0/".match(regex)).not.toBeNull();
+    });
+
+    it("should match prerelease directory paths", () => {
+      expect("/3.0.0-rc.3/".match(regex)).not.toBeNull();
+      expect("/3.0.0-beta.1/".match(regex)).not.toBeNull();
     });
 
     it("should match latest directory path", () => {
@@ -170,11 +175,13 @@ describe("Schema Versioning Middleware", () => {
     it("should NOT match file paths", () => {
       expect("/2.6.0/index.json".match(regex)).toBeNull();
       expect("/2.6.0/core/product.json".match(regex)).toBeNull();
+      expect("/3.0.0-rc.3/adagents.json".match(regex)).toBeNull();
       expect("/latest/index.json".match(regex)).toBeNull();
     });
 
     it("should NOT match paths without trailing slash", () => {
       expect("/2.6.0".match(regex)).toBeNull();
+      expect("/3.0.0-rc.3".match(regex)).toBeNull();
       expect("/latest".match(regex)).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

- `/schemas/v3/adagents.json` (and every other alias path) returns 404 in production because the alias-rewrite middleware was registered **after** the `/schemas` static handler — the rewrite had nothing downstream to serve it.
- Consolidate alias resolution, bare-directory redirects, and static serving into one ordered middleware (`mountSchemasRoutes`), fix the directory-redirect `Location` to include the `/schemas` prefix, and teach the redirect regex to match prerelease versions (e.g. `3.0.0-rc.3/`).
- Only direct versioned paths (client pinned a full semver) get the 1-year `immutable` cache header. Aliases and `/latest/` keep the 10-minute `max-age` + ETag default so caches revalidate when the alias retargets.

## Test plan

- [x] New HTTP-level integration tests (`server/tests/integration/schema-routing.test.ts`) exercise the real middleware against `dist/schemas/`:
  - direct stable + prerelease versioned paths serve with `immutable`
  - bare stable + prerelease directory redirects land at `/schemas/<ver>/index.json`
  - `/schemas/v2/`, `/schemas/v2.5/`, `/schemas/v3/` alias rewrites all serve 200
  - `/schemas/v99/` returns 404
  - cache-control negative assertions: `/schemas/v2/`, `/schemas/v2.5/`, `/schemas/latest/` do **not** get `immutable`
- [x] `npm run typecheck` clean
- [x] Full `vitest` suite passes locally (587 tests)
- [ ] After merge: verify `curl -I https://adcontextprotocol.org/schemas/v3/adagents.json` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)