### PR TITLE
feat: nested committee hierarchy with subgroups

### DIFF
--- a/.changeset/committee-hierarchy.md
+++ b/.changeset/committee-hierarchy.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add committee hierarchy: working groups can nest under other working groups as subgroups. Enables consolidating dead WGs into a coherent tree of five protocol areas (Campaign Lifecycle, Creative, Signals & Measurement, Governance, Builders) without losing members, documents, meetings, or history. Heavy topics can graduate to first-class subgroups via a new admin tool. Public parent pages show subgroup cards and aggregate posts/events from subgroups with source labels; subgroup pages show a parent breadcrumb and their own content only. Private subgroup visibility is gated to direct members (with an admin escape hatch).

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -450,6 +450,16 @@
             </div>
           </div>
 
+          <div class="form-row">
+            <div class="form-group">
+              <label>Parent Committee</label>
+              <select id="parentId">
+                <option value="">— None (top-level) —</option>
+              </select>
+              <small>Nest this committee as a subgroup under a parent.</small>
+            </div>
+          </div>
+
           <!-- Industry Gathering-specific fields -->
           <div id="gatheringFieldsGroup" style="display: none;">
             <div class="form-row">
@@ -798,8 +808,20 @@
         return;
       }
 
-      let html = '';
-      filtered.forEach(group => {
+      // Build a parent → children map so we can render subgroups nested under
+      // their parent when the parent is also in the filtered list. Filtered
+      // groups whose parent was filtered out render at the top level.
+      const filteredIds = new Set(filtered.map(g => g.id));
+      const roots = filtered.filter(g => !g.parent_id || !filteredIds.has(g.parent_id));
+      const childrenByParent = new Map();
+      for (const g of filtered) {
+        if (g.parent_id && filteredIds.has(g.parent_id)) {
+          if (!childrenByParent.has(g.parent_id)) childrenByParent.set(g.parent_id, []);
+          childrenByParent.get(g.parent_id).push(g);
+        }
+      }
+
+      const renderGroup = (group, depth) => {
         const committeeType = group.committee_type || 'working_group';
         const typeBadge = `<span class="badge badge-${committeeType}">${COMMITTEE_TYPE_LABELS[committeeType] || committeeType}</span>`;
         const statusBadge = `<span class="badge badge-${group.status}">${group.status}</span>`;
@@ -812,11 +834,13 @@
         const gatheringDateDisplay = committeeType === 'industry_gathering' && group.event_start_date
           ? `<span>📅 ${new Date(group.event_start_date).toLocaleDateString()}</span>`
           : '';
+        const indentStyle = depth > 0 ? ` style="margin-left: ${depth * 24}px;"` : '';
+        const subgroupLabel = depth > 0 ? '<span style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-right: var(--space-1);">↳</span>' : '';
 
-        html += `
-          <div class="group-item">
+        let html = `
+          <div class="group-item"${indentStyle}>
             <div class="group-info">
-              <h3>${escapeHtml(group.name)}</h3>
+              <h3>${subgroupLabel}${escapeHtml(group.name)}</h3>
               <div class="group-meta">
                 ${typeBadge}
                 ${statusBadge}
@@ -839,7 +863,16 @@
             </div>
           </div>
         `;
-      });
+
+        const children = childrenByParent.get(group.id) || [];
+        for (const child of children) {
+          html += renderGroup(child, depth + 1);
+        }
+        return html;
+      };
+
+      let html = '';
+      roots.forEach(group => { html += renderGroup(group, 0); });
 
       listDiv.innerHTML = html;
       listDiv.querySelectorAll('.group-actions').forEach(actions => {
@@ -1003,6 +1036,11 @@
         return;
       }
 
+      // Only offer "Graduate" if this is a saved WG that can act as a parent.
+      const canGraduate = !!editingGroup
+        && (editingGroup.committee_type === 'working_group' || editingGroup.committee_type === 'governance')
+        && !editingGroup.parent_id;
+
       listDiv.innerHTML = currentTopics.map((t, i) => `
         <div style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-2); background: var(--color-gray-50); border-radius: var(--radius-sm); margin-bottom: var(--space-2);">
           <div>
@@ -1013,10 +1051,42 @@
           </div>
           <div style="display: flex; gap: var(--space-1);">
             <button type="button" class="btn btn-secondary btn-small" onclick="editTopic(${i})">Edit</button>
+            ${canGraduate ? `<button type="button" class="btn btn-primary btn-small" onclick="graduateTopic('${escapeHtml(t.slug)}','${escapeHtml(t.name)}')">Graduate to subgroup</button>` : ''}
             <button type="button" class="btn btn-danger btn-small" onclick="removeTopic(${i})">Remove</button>
           </div>
         </div>
       `).join('');
+    }
+
+    async function graduateTopic(topicSlug, topicName) {
+      if (!editingGroup) return;
+      const confirmMsg = `Graduate the topic "${topicName}" into a subgroup of "${editingGroup.name}"?\n\n` +
+        `This will create a new working group, migrate topic subscribers to members, and move any tagged meetings/perspectives. ` +
+        `The topic will be removed from the parent.\n\nThis is transactional but cannot be undone.`;
+      if (!confirm(confirmMsg)) return;
+
+      try {
+        const res = await fetch(
+          `/api/admin/working-groups/${encodeURIComponent(editingGroup.slug)}/topics/${encodeURIComponent(topicSlug)}/graduate`,
+          { method: 'POST' }
+        );
+        const data = await res.json();
+        if (!res.ok) {
+          alert(`Failed: ${data.message || data.error || 'Unknown error'}`);
+          return;
+        }
+        const m = data.moved;
+        alert(`Subgroup created: ${data.subgroup.slug}\n\n` +
+          `Members added: ${m.subscriptions}\n` +
+          `Meeting series moved: ${m.meeting_series}\n` +
+          `Meetings moved: ${m.meetings}\n` +
+          `Perspectives moved: ${m.perspectives}`);
+        closeModal();
+        await loadGroups();
+      } catch (err) {
+        console.error('Graduate topic failed', err);
+        alert('Failed to graduate topic');
+      }
     }
 
     function clearTopics() {
@@ -1405,7 +1475,45 @@
       updateRegionVisibility(); // Hide region for non-chapters, hide gathering fields for non-gatherings
       updateMembersSectionVisibility(); // Hide members section for new groups
       document.getElementById('interestSection').style.display = 'none'; // Hide interest section for new groups
+      populateParentSelect(null);
       document.getElementById('groupModal').style.display = 'flex';
+    }
+
+    // Populate parent-committee selector from current groups list.
+    // Excludes the group being edited (and its descendants) to prevent cycles.
+    function populateParentSelect(excludeGroupId) {
+      const select = document.getElementById('parentId');
+      const currentValue = select.value;
+
+      const descendants = new Set();
+      if (excludeGroupId) {
+        descendants.add(excludeGroupId);
+        // Iteratively add any group whose parent is already in the set
+        let added = true;
+        while (added) {
+          added = false;
+          for (const g of groups) {
+            if (g.parent_id && descendants.has(g.parent_id) && !descendants.has(g.id)) {
+              descendants.add(g.id);
+              added = true;
+            }
+          }
+        }
+      }
+
+      // A group can only be a parent if it's a working_group or governance
+      // committee type AND is itself top-level (no parent_id) — matching
+      // the server-side rules in assertValidParent. Filtering client-side
+      // prevents users from picking an ineligible option and hitting 400.
+      const eligible = groups
+        .filter(g => !descendants.has(g.id))
+        .filter(g => ['working_group', 'governance'].includes(g.committee_type))
+        .filter(g => !g.parent_id)
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      select.innerHTML = '<option value="">— None (top-level) —</option>' +
+        eligible.map(g => `<option value="${g.id}">${escapeHtml(g.name)}</option>`).join('');
+      select.value = currentValue;
     }
 
     // Edit group
@@ -1426,6 +1534,8 @@
         document.getElementById('status').value = editingGroup.status || 'active';
         document.getElementById('committeeType').value = editingGroup.committee_type || 'working_group';
         document.getElementById('region').value = editingGroup.region || '';
+        populateParentSelect(editingGroup.id);
+        document.getElementById('parentId').value = editingGroup.parent_id || '';
         // Industry gathering fields
         document.getElementById('gatheringStartDate').value = editingGroup.event_start_date ? editingGroup.event_start_date.split('T')[0] : '';
         document.getElementById('gatheringEndDate').value = editingGroup.event_end_date ? editingGroup.event_end_date.split('T')[0] : '';
@@ -1510,6 +1620,7 @@
         status: document.getElementById('status').value,
         committee_type: committeeType,
         region: committeeType === 'chapter' ? (document.getElementById('region').value.trim() || null) : null,
+        parent_id: document.getElementById('parentId').value || null,
         is_private: document.getElementById('isPrivate').checked,
         display_order: parseInt(document.getElementById('displayOrder').value) || 0,
         leader_user_ids: currentLeaders.map(l => l.user_id),

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1134,6 +1134,11 @@
       <span id="backLinkText">Back to Working Groups</span>
     </a>
 
+    <!-- Parent breadcrumb (shown on subgroup pages) -->
+    <div id="parentBreadcrumb" style="display: none; margin-bottom: var(--space-3); font-size: var(--text-sm); color: var(--color-text-secondary);">
+      Subgroup of <a id="parentLink" href="#" style="color: var(--color-brand); text-decoration: none;"></a>
+    </div>
+
     <!-- Group Header -->
     <div class="group-header">
       <div class="group-header-top">
@@ -1199,6 +1204,14 @@
       <div id="descriptionContent" class="description-content"></div>
     </div>
 
+    <!-- Subgroups Section (parent pages only) -->
+    <div id="subgroupsSection" class="content-section" style="display: none;">
+      <div class="section-header">
+        <h2 class="section-title">Subgroups</h2>
+      </div>
+      <div id="subgroupsList" style="display: grid; gap: var(--space-3); grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));"></div>
+    </div>
+
     <!-- Documents Section -->
     <div id="documentsSection" class="content-section" style="display: none;">
       <div class="section-header">
@@ -1253,13 +1266,21 @@
     <div id="postsSection" class="content-section" style="display: none;">
       <div class="section-header">
         <h2 class="section-title">Posts & Updates</h2>
-        <button id="newPostBtn" class="btn btn-primary" style="display: none;" onclick="createPost()">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <line x1="12" y1="5" x2="12" y2="19"/>
-            <line x1="5" y1="12" x2="19" y2="12"/>
-          </svg>
-          New Post
-        </button>
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <div id="postsFilter" style="display: none; font-size: var(--text-sm);">
+            <label style="display: inline-flex; align-items: center; gap: var(--space-1); cursor: pointer;">
+              <input type="checkbox" id="postsIncludeSubgroups" checked onchange="loadPosts()">
+              Include subgroups
+            </label>
+          </div>
+          <button id="newPostBtn" class="btn btn-primary" style="display: none;" onclick="createPost()">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+            New Post
+          </button>
+        </div>
       </div>
       <div id="postsList" class="posts-list"></div>
     </div>
@@ -1487,6 +1508,31 @@
       // Update meta tags
       updateMetaTags();
 
+      // Parent breadcrumb (subgroup pages only)
+      if (currentGroup.parent) {
+        const breadcrumb = document.getElementById('parentBreadcrumb');
+        const link = document.getElementById('parentLink');
+        link.href = `/working-groups/${currentGroup.parent.slug}`;
+        link.textContent = currentGroup.parent.name;
+        breadcrumb.style.display = 'block';
+      }
+
+      // Subgroups section (parent pages only)
+      if (currentGroup.subgroups && currentGroup.subgroups.length > 0) {
+        const section = document.getElementById('subgroupsSection');
+        const list = document.getElementById('subgroupsList');
+        list.innerHTML = currentGroup.subgroups.map(sg => `
+          <a href="/working-groups/${escapeHtml(sg.slug)}" style="display: block; padding: var(--space-4); border: 1px solid var(--color-gray-200); border-radius: var(--radius-md); text-decoration: none; color: inherit; background: var(--color-bg-card);">
+            <div style="font-weight: var(--font-semibold); margin-bottom: var(--space-1); color: var(--color-text-heading);">${escapeHtml(sg.name)}${sg.is_private ? ' <span style="font-size: var(--text-xs); color: var(--color-error-700); font-weight: var(--font-normal);">· Private</span>' : ''}</div>
+            ${sg.description ? `<div style="font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-2);">${escapeHtml(sg.description.slice(0, 140))}${sg.description.length > 140 ? '…' : ''}</div>` : ''}
+            <div style="font-size: var(--text-xs); color: var(--color-text-secondary);">${sg.member_count} ${sg.member_count === 1 ? 'member' : 'members'}</div>
+          </a>
+        `).join('');
+        section.style.display = 'block';
+        // When there are subgroups, show the posts filter toggle so parent pages can narrow down
+        document.getElementById('postsFilter').style.display = 'block';
+      }
+
       // Header
       document.getElementById('groupName').textContent = currentGroup.name;
 
@@ -1599,7 +1645,9 @@
 
     async function loadPosts() {
       try {
-        const response = await fetch(`/api/working-groups/${currentSlug}/posts`);
+        const includeSubs = document.getElementById('postsIncludeSubgroups')?.checked;
+        const qs = includeSubs === false ? '?include_subgroups=false' : '';
+        const response = await fetch(`/api/working-groups/${currentSlug}/posts${qs}`);
         if (!response.ok) return;
 
         const data = await response.json();
@@ -1627,6 +1675,10 @@
         }
 
         postsList.innerHTML = postsData.map(post => {
+          const fromSubgroup = post.source_group && post.source_group.id !== currentGroup.id
+            ? `<span style="display: inline-flex; align-items: center; padding: 1px 6px; font-size: var(--text-xs); background: var(--color-info-100); color: var(--color-info-700); border-radius: var(--radius-sm); text-decoration: none;">from ${escapeHtml(post.source_group.name)}</span>`
+            : '';
+
           // For link posts, link directly to external URL
           // For article posts, use onclick to open the article view
           if (post.content_type === 'link' && post.external_url) {
@@ -1645,19 +1697,22 @@
                   ${post.external_site_name ? `<span>${escapeHtml(post.external_site_name)}</span>` : ''}
                   ${post.category ? `<span>${escapeHtml(post.category)}</span>` : ''}
                   ${post.is_members_only ? `<span class="badge-members-only">members only</span>` : ''}
+                  ${fromSubgroup}
                 </div>
                 ${post.excerpt ? `<div class="post-excerpt">${escapeHtml(post.excerpt)}</div>` : ''}
               </a>
             `;
           } else {
+            const articleSlug = post.source_group ? post.source_group.slug : currentSlug;
             return `
-              <a href="/working-groups/${currentSlug}#post-${escapeHtml(post.slug)}" id="post-${escapeHtml(post.slug)}" class="post-card article-link" data-post-slug="${escapeHtml(post.slug)}">
+              <a href="/working-groups/${escapeHtml(articleSlug)}#post-${escapeHtml(post.slug)}" id="post-${escapeHtml(post.slug)}" class="post-card article-link" data-post-slug="${escapeHtml(post.slug)}">
                 <div class="post-title">${escapeHtml(post.title)}</div>
                 <div class="post-meta">
                   <span>${formatDate(post.published_at)}</span>
                   ${post.author_name ? `<span>by ${escapeHtml(post.author_name)}</span>` : ''}
                   ${post.category ? `<span>${escapeHtml(post.category)}</span>` : ''}
                   ${post.is_members_only ? `<span class="badge-members-only">members only</span>` : ''}
+                  ${fromSubgroup}
                 </div>
                 ${post.excerpt ? `<div class="post-excerpt">${escapeHtml(post.excerpt)}</div>` : ''}
               </a>

--- a/server/src/db/events-db.ts
+++ b/server/src/db/events-db.ts
@@ -1069,9 +1069,10 @@ export class EventsDatabase {
    * Get events linked to a committee
    */
   async getEventsByCommittee(
-    committeeId: string,
+    committeeId: string | string[],
     options: { includeUnpublished?: boolean } = {}
   ): Promise<{ upcoming: Event[]; past: Event[] }> {
+    const committeeIds = Array.isArray(committeeId) ? committeeId : [committeeId];
     const statusCondition = options.includeUnpublished
       ? ''
       : "AND e.status = 'published' AND e.visibility != 'invite_unlisted'";
@@ -1079,23 +1080,23 @@ export class EventsDatabase {
     const upcomingResult = await query<Event>(
       `SELECT e.* FROM events e
        INNER JOIN event_committee_links ecl ON e.id = ecl.event_id
-       WHERE ecl.committee_id = $1
+       WHERE ecl.committee_id = ANY($1::uuid[])
          ${statusCondition}
          AND e.start_time > NOW()
        ORDER BY e.start_time ASC
        LIMIT 20`,
-      [committeeId]
+      [committeeIds]
     );
 
     const pastResult = await query<Event>(
       `SELECT e.* FROM events e
        INNER JOIN event_committee_links ecl ON e.id = ecl.event_id
-       WHERE ecl.committee_id = $1
+       WHERE ecl.committee_id = ANY($1::uuid[])
          ${statusCondition}
          AND e.start_time <= NOW()
        ORDER BY e.start_time DESC
        LIMIT 10`,
-      [committeeId]
+      [committeeIds]
     );
 
     return {

--- a/server/src/db/migrations/404_working_group_parent_id.sql
+++ b/server/src/db/migrations/404_working_group_parent_id.sql
@@ -1,0 +1,13 @@
+-- Add parent_id to working_groups to support nested committee hierarchy.
+-- Subgroups are first-class working groups that live under a parent, useful
+-- for consolidating dead groups as topics of a living parent without losing
+-- members, documents, or history.
+
+ALTER TABLE working_groups
+ADD COLUMN IF NOT EXISTS parent_id UUID REFERENCES working_groups(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_working_groups_parent_id
+  ON working_groups(parent_id)
+  WHERE parent_id IS NOT NULL;
+
+COMMENT ON COLUMN working_groups.parent_id IS 'Optional parent working group for nested hierarchy. NULL for top-level groups.';

--- a/server/src/db/migrations/405_seed_five_parents.sql
+++ b/server/src/db/migrations/405_seed_five_parents.sql
@@ -1,0 +1,21 @@
+-- Seed the five top-level parent working groups for the consolidation described
+-- in specs/committee-hierarchy.md. Idempotent on slug conflict so re-running is safe.
+
+INSERT INTO working_groups (name, slug, description, committee_type, status, display_order, is_private, topics)
+VALUES
+  ('Campaign Lifecycle', 'wg-campaign-lifecycle',
+   'Discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation. The full arc from finding inventory through reconciling the buy.',
+   'working_group', 'active', 10, false, '[]'::jsonb),
+  ('Creative', 'wg-creative',
+   'Creative lifecycle, generative creative, governance, and audit.',
+   'working_group', 'active', 20, false, '[]'::jsonb),
+  ('Signals and Measurement', 'wg-signals-measurement',
+   'Audience signals, measurement, verification, attribution.',
+   'working_group', 'active', 30, false, '[]'::jsonb),
+  ('Governance', 'wg-governance',
+   'brand.json, adagents.json, brand safety, compliance, policy.',
+   'governance', 'active', 40, false, '[]'::jsonb),
+  ('Builders', 'wg-builders',
+   'SDKs, tooling, integration help. Where people implementing agents get support. Not protocol design.',
+   'working_group', 'active', 50, false, '[]'::jsonb)
+ON CONFLICT (slug) DO NOTHING;

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -1,4 +1,4 @@
-import { query } from './client.js';
+import { query, getPool } from './client.js';
 import { computeJourneyStage } from '../addie/services/journey-computation.js';
 import { CommunityDatabase } from './community-db.js';
 import { createLogger } from '../logger.js';
@@ -97,13 +97,17 @@ export class WorkingGroupDatabase {
     // Auto-extract channel ID from URL if not explicitly provided
     const channelId = input.slack_channel_id || extractSlackChannelId(input.slack_channel_url);
 
+    if (input.parent_id) {
+      await this.assertValidParent(null, input.parent_id);
+    }
+
     const result = await query<WorkingGroup>(
       `INSERT INTO working_groups (
         name, slug, description, slack_channel_url, slack_channel_id,
         is_private, status, display_order, committee_type, region,
         linked_event_id, event_start_date, event_end_date, event_location, auto_archive_after_event,
-        logo_url, website_url, topics
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+        logo_url, website_url, topics, parent_id
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
       RETURNING *`,
       [
         input.name,
@@ -124,6 +128,7 @@ export class WorkingGroupDatabase {
         input.logo_url || null,
         input.website_url || null,
         input.topics ? JSON.stringify(input.topics) : '[]',
+        input.parent_id || null,
       ]
     );
 
@@ -198,7 +203,23 @@ export class WorkingGroupDatabase {
       auto_archive_after_event: 'auto_archive_after_event',
       logo_url: 'logo_url',
       website_url: 'website_url',
+      parent_id: 'parent_id',
     };
+
+    if (updates.parent_id !== undefined) {
+      await this.assertValidParent(id, updates.parent_id);
+    }
+
+    // Block committee_type change to a non-parent type if this group has subgroups.
+    if (updates.committee_type && !['working_group', 'governance'].includes(updates.committee_type)) {
+      const children = await query<{ count: string }>(
+        'SELECT COUNT(*)::text as count FROM working_groups WHERE parent_id = $1',
+        [id]
+      );
+      if (parseInt(children.rows[0]?.count || '0', 10) > 0) {
+        throw new Error(`Cannot change committee type to '${updates.committee_type}' while subgroups exist. Reparent or archive subgroups first.`);
+      }
+    }
 
     const setClauses: string[] = [];
     const params: unknown[] = [];
@@ -448,6 +469,379 @@ export class WorkingGroupDatabase {
        ORDER BY display_order, name`
     );
     return result.rows;
+  }
+
+  /**
+   * List direct subgroups of a working group.
+   */
+  async listSubgroups(parentId: string): Promise<WorkingGroup[]> {
+    const result = await query<WorkingGroup>(
+      `SELECT * FROM working_groups
+       WHERE parent_id = $1
+       ORDER BY display_order, name`,
+      [parentId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Get a group's ID plus all of its descendant IDs. Hierarchy is capped at
+   * two levels, so we only look one level deep.
+   */
+  async getDescendantIds(groupId: string): Promise<string[]> {
+    const result = await query<{ id: string }>(
+      `SELECT id FROM working_groups WHERE id = $1 OR parent_id = $1`,
+      [groupId]
+    );
+    return result.rows.map(r => r.id);
+  }
+
+  /**
+   * Like `getDescendantIds` but excludes private subgroups the caller is not
+   * a member of. Use this when building aggregated feeds so private subgroup
+   * posts/events don't leak to non-members viewing the public parent.
+   *
+   * The target group itself is always included — visibility of the target is
+   * the caller's responsibility (the route guards against viewing private
+   * groups you aren't in).
+   *
+   * Pass `isAdmin: true` to skip the privacy filter entirely (for admin views).
+   */
+  async getVisibleDescendantIds(
+    groupId: string,
+    userId: string | null,
+    options: { isAdmin?: boolean } = {},
+  ): Promise<string[]> {
+    const result = await query<{ id: string; is_private: boolean; parent_id: string | null }>(
+      `SELECT id, is_private, parent_id FROM working_groups
+       WHERE id = $1 OR parent_id = $1`,
+      [groupId]
+    );
+
+    const allowed: string[] = [];
+    for (const row of result.rows) {
+      // Target group: always include.
+      if (row.id === groupId) {
+        allowed.push(row.id);
+        continue;
+      }
+      // Admins see everything.
+      if (options.isAdmin) {
+        allowed.push(row.id);
+        continue;
+      }
+      // Public subgroup: include.
+      if (!row.is_private) {
+        allowed.push(row.id);
+        continue;
+      }
+      // Private subgroup: only if caller is a direct member.
+      if (userId && await this.isMember(row.id, userId)) {
+        allowed.push(row.id);
+      }
+    }
+    return allowed;
+  }
+
+  /**
+   * True if the user is an active member of the group or any of its descendants.
+   */
+  async isFamilyMember(groupId: string, userId: string): Promise<boolean> {
+    const result = await query<{ exists: boolean }>(
+      `SELECT EXISTS(
+         SELECT 1 FROM working_group_memberships m
+         JOIN working_groups g ON g.id = m.working_group_id
+         WHERE (g.id = $1 OR g.parent_id = $1)
+           AND m.workos_user_id = $2
+           AND m.status = 'active'
+       ) as exists`,
+      [groupId, userId]
+    );
+    return !!result.rows[0]?.exists;
+  }
+
+  /**
+   * Count of distinct active members across the group and all descendants.
+   */
+  async countFamilyMembers(groupId: string): Promise<number> {
+    const result = await query<{ count: string }>(
+      `SELECT COUNT(DISTINCT m.workos_user_id)::text as count
+         FROM working_group_memberships m
+         JOIN working_groups g ON g.id = m.working_group_id
+         WHERE (g.id = $1 OR g.parent_id = $1)
+           AND m.status = 'active'`,
+      [groupId]
+    );
+    return parseInt(result.rows[0]?.count || '0', 10);
+  }
+
+  /**
+   * Resolve the Slack channel to post to for a given group. Walks up the
+   * parent chain until a channel is found. Returns the resolving group so
+   * callers can label cross-group posts with the originating subgroup.
+   */
+  async resolveNotificationChannel(groupId: string): Promise<{
+    channelId: string | null;
+    viaParent: boolean;
+    group: WorkingGroup | null;
+  }> {
+    const origin = await this.getWorkingGroupById(groupId);
+    if (!origin) return { channelId: null, viaParent: false, group: null };
+
+    if (origin.slack_channel_id) {
+      return { channelId: origin.slack_channel_id, viaParent: false, group: origin };
+    }
+
+    // Walk up. Cap at two levels; after that we give up.
+    let cursor: string | null = origin.parent_id ?? null;
+    while (cursor) {
+      const parent = await this.getWorkingGroupById(cursor);
+      if (!parent) break;
+      if (parent.slack_channel_id) {
+        return { channelId: parent.slack_channel_id, viaParent: true, group: origin };
+      }
+      cursor = parent.parent_id ?? null;
+    }
+
+    return { channelId: null, viaParent: false, group: origin };
+  }
+
+  /**
+   * Graduate a topic on a parent WG to a full subgroup.
+   *
+   * Runs in a single transaction:
+   *   1. Creates a new WG with `parent_id = parent.id`, inheriting the topic's
+   *      name/description/slack_channel_id.
+   *   2. Converts topic subscribers (users with `topic.slug` in their
+   *      `topic_slugs`) into active members of the new subgroup.
+   *   3. Removes the topic slug from every affected subscription row.
+   *   4. Reassigns meeting_series, meetings, and perspectives tagged with the
+   *      topic to the new subgroup.
+   *   5. Removes the topic from the parent's topics JSONB.
+   *
+   * Returns the new subgroup plus counts of what moved.
+   */
+  async graduateTopicToSubgroup(
+    parentSlug: string,
+    topicSlug: string
+  ): Promise<{
+    subgroup: WorkingGroup;
+    moved: {
+      subscriptions: number;
+      meeting_series: number;
+      meetings: number;
+      perspectives: number;
+    };
+  }> {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // 1. Load parent + find the topic
+      const parentResult = await client.query<WorkingGroup>(
+        'SELECT * FROM working_groups WHERE slug = $1 FOR UPDATE',
+        [parentSlug]
+      );
+      const parent = parentResult.rows[0];
+      if (!parent) throw new Error(`Parent working group not found: ${parentSlug}`);
+
+      const topics = (parent.topics || []) as Array<{ slug: string; name: string; description?: string; slack_channel_id?: string }>;
+      const topic = topics.find(t => t.slug === topicSlug);
+      if (!topic) throw new Error(`Topic '${topicSlug}' not found on '${parentSlug}'`);
+
+      // Ensure parent is a valid parent type (working_group or governance)
+      if (!['working_group', 'governance'].includes(parent.committee_type)) {
+        throw new Error(`Cannot graduate topics from '${parent.committee_type}' committees`);
+      }
+      // Ensure parent isn't already a subgroup (depth cap)
+      if (parent.parent_id) {
+        throw new Error('Cannot graduate a topic on a subgroup (hierarchy is two levels)');
+      }
+
+      // 2. Pick a slug for the new subgroup. If bare slug collides, prefix with parent slug.
+      let newSlug = topic.slug;
+      const collision = await client.query<{ id: string }>(
+        'SELECT id FROM working_groups WHERE slug = $1',
+        [newSlug]
+      );
+      if (collision.rows[0]) {
+        newSlug = `${parent.slug}-${topic.slug}`;
+      }
+
+      // 3. Insert the new subgroup
+      const subgroupResult = await client.query<WorkingGroup>(
+        `INSERT INTO working_groups (
+          name, slug, description, committee_type, status, is_private,
+          display_order, slack_channel_id, parent_id, topics
+        ) VALUES ($1, $2, $3, $4, 'active', $5, 0, $6, $7, '[]'::jsonb)
+        RETURNING *`,
+        [
+          topic.name,
+          newSlug,
+          topic.description || null,
+          parent.committee_type,
+          parent.is_private,
+          topic.slack_channel_id || null,
+          parent.id,
+        ]
+      );
+      const subgroup = subgroupResult.rows[0];
+
+      // 4. Promote subscribers to members
+      const subResult = await client.query<{ workos_user_id: string }>(
+        `SELECT DISTINCT workos_user_id FROM working_group_topic_subscriptions
+         WHERE working_group_id = $1 AND $2 = ANY(topic_slugs)`,
+        [parent.id, topicSlug]
+      );
+      let addedMembers = 0;
+      for (const row of subResult.rows) {
+        const existing = await client.query<{ id: string }>(
+          `SELECT id FROM working_group_memberships
+           WHERE working_group_id = $1 AND workos_user_id = $2`,
+          [subgroup.id, row.workos_user_id]
+        );
+        if (existing.rows[0]) continue;
+        await client.query(
+          `INSERT INTO working_group_memberships (
+            working_group_id, workos_user_id, status, joined_at, updated_at
+          ) VALUES ($1, $2, 'active', NOW(), NOW())`,
+          [subgroup.id, row.workos_user_id]
+        );
+        addedMembers++;
+      }
+
+      // 5. Strip the topic slug from parent subscription rows; delete empty ones
+      await client.query(
+        `UPDATE working_group_topic_subscriptions
+         SET topic_slugs = array_remove(topic_slugs, $2), updated_at = NOW()
+         WHERE working_group_id = $1 AND $2 = ANY(topic_slugs)`,
+        [parent.id, topicSlug]
+      );
+      await client.query(
+        `DELETE FROM working_group_topic_subscriptions
+         WHERE working_group_id = $1 AND (topic_slugs IS NULL OR cardinality(topic_slugs) = 0)`,
+        [parent.id]
+      );
+
+      // 6. Reassign content. meeting_series, meetings, and perspectives all
+      // carry a topic_slugs array. Move rows that include this topic to the
+      // subgroup and strip the topic slug.
+      const movedSeries = await client.query<{ id: string }>(
+        `UPDATE meeting_series
+         SET working_group_id = $1,
+             topic_slugs = array_remove(topic_slugs, $3),
+             updated_at = NOW()
+         WHERE working_group_id = $2 AND $3 = ANY(topic_slugs)
+         RETURNING id`,
+        [subgroup.id, parent.id, topicSlug]
+      );
+      const movedMeetings = await client.query<{ id: string }>(
+        `UPDATE meetings
+         SET working_group_id = $1,
+             topic_slugs = array_remove(topic_slugs, $3),
+             updated_at = NOW()
+         WHERE working_group_id = $2 AND $3 = ANY(topic_slugs)
+         RETURNING id`,
+        [subgroup.id, parent.id, topicSlug]
+      );
+      const movedPerspectives = await client.query<{ id: string }>(
+        `UPDATE perspectives
+         SET working_group_id = $1,
+             tags = array_remove(tags, $3),
+             updated_at = NOW()
+         WHERE working_group_id = $2 AND $3 = ANY(tags)
+         RETURNING id`,
+        [subgroup.id, parent.id, topicSlug]
+      );
+
+      // 7. Remove the topic from the parent's topics JSONB
+      const newTopics = topics.filter(t => t.slug !== topicSlug);
+      await client.query(
+        'UPDATE working_groups SET topics = $1, updated_at = NOW() WHERE id = $2',
+        [JSON.stringify(newTopics), parent.id]
+      );
+
+      await client.query('COMMIT');
+      return {
+        subgroup,
+        moved: {
+          subscriptions: addedMembers,
+          meeting_series: movedSeries.rowCount || 0,
+          meetings: movedMeetings.rowCount || 0,
+          perspectives: movedPerspectives.rowCount || 0,
+        },
+      };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Validate that assigning a parent to a working group would not create a cycle
+   * or a self-reference. Throws on invalid parent. Pass childId=null for creates.
+   */
+  private async assertValidParent(childId: string | null, parentId: string | null | undefined): Promise<void> {
+    if (!parentId) return;
+    if (childId && parentId === childId) {
+      throw new Error('Working group cannot be its own parent');
+    }
+
+    // Fetch proposed parent's metadata (existence + committee_type + its own parent_id).
+    const parentMeta = await query<WorkingGroup>(
+      'SELECT id, committee_type, parent_id FROM working_groups WHERE id = $1',
+      [parentId]
+    );
+    if (!parentMeta.rows[0]) {
+      throw new Error(`Parent working group not found: ${parentId}`);
+    }
+
+    // Depth cap: we only allow two levels. If the proposed parent itself has a
+    // parent, creating a grandchild is not allowed.
+    if (parentMeta.rows[0].parent_id) {
+      throw new Error('Working group hierarchy is limited to two levels');
+    }
+
+    // Committee type constraint: only working_group and governance can be parents.
+    const parentType = parentMeta.rows[0].committee_type;
+    if (parentType && !['working_group', 'governance'].includes(parentType)) {
+      throw new Error(`Committee type '${parentType}' cannot have subgroups`);
+    }
+
+    // Walk up the parent chain to ensure the proposed parent isn't a descendant
+    // of the child (which would create a cycle). Redundant with the two-level cap
+    // but cheap insurance.
+    if (childId) {
+      const visited = new Set<string>();
+      let cursor: string | null = parentId;
+      while (cursor !== null) {
+        const current: string = cursor;
+        if (current === childId) {
+          throw new Error('Cannot create a cycle in working group hierarchy');
+        }
+        if (visited.has(current)) {
+          throw new Error('Cycle detected in working group hierarchy');
+        }
+        visited.add(current);
+        const parentResult = await query<WorkingGroup>(
+          'SELECT parent_id FROM working_groups WHERE id = $1',
+          [current]
+        );
+        cursor = parentResult.rows[0]?.parent_id ?? null;
+      }
+    } else {
+      // For creates, we already verified the parent exists above.
+      const result = await query<{ id: string }>(
+        'SELECT id FROM working_groups WHERE id = $1',
+        [parentId]
+      );
+      if (!result.rows[0]) {
+        throw new Error(`Parent working group not found: ${parentId}`);
+      }
+    }
   }
 
   // ============== Memberships ==============

--- a/server/src/notifications/wg-slack.ts
+++ b/server/src/notifications/wg-slack.ts
@@ -1,0 +1,64 @@
+/**
+ * Working-group-aware Slack posting.
+ *
+ * Automation that posts on behalf of a working group should use these helpers
+ * instead of reading `slack_channel_id` directly. They walk up the parent
+ * chain when a subgroup has no channel of its own, and prefix messages with
+ * `[Subgroup Name]` so members know which group originated the post.
+ *
+ * Human-facing surfaces (the "Join Slack Channel" button on the public page,
+ * admin UI channel display) should keep reading `slack_channel_id` directly —
+ * we don't implicitly tell users to join the parent's channel.
+ */
+
+import { WorkingGroupDatabase } from '../db/working-group-db.js';
+import { sendChannelMessage } from '../slack/client.js';
+import type { SlackBlockMessage } from '../slack/types.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('wg-slack');
+
+const workingGroupDb = new WorkingGroupDatabase();
+
+export interface PostToGroupChannelResult {
+  ok: boolean;
+  ts?: string;
+  error?: string;
+  via_parent?: boolean;
+  resolved_channel_id?: string;
+}
+
+/**
+ * Post a message to a working group's Slack channel. If the group has no
+ * channel, walk up the parent chain. When posting via a parent, prefix the
+ * message text with `[Subgroup Name]`.
+ *
+ * Returns `{ ok: false, error: 'no-channel' }` if no channel exists in the chain.
+ */
+export async function postToGroupChannel(
+  groupId: string,
+  options: SlackBlockMessage,
+): Promise<PostToGroupChannelResult> {
+  const { channelId, viaParent, group } = await workingGroupDb.resolveNotificationChannel(groupId);
+
+  if (!channelId || !group) {
+    logger.warn({ groupId }, 'No Slack channel resolvable for working group');
+    return { ok: false, error: 'no-channel' };
+  }
+
+  // If a private subgroup is falling back to a public parent's channel, flag it —
+  // posting private content to a public channel is almost certainly a leak.
+  if (viaParent && group.is_private) {
+    logger.warn(
+      { groupId, groupSlug: group.slug, parentChannelId: channelId },
+      'Private subgroup posting via parent channel — configure its own channel to keep content private',
+    );
+  }
+
+  const text = viaParent && options.text
+    ? `[${group.name}] ${options.text}`
+    : options.text;
+
+  const result = await sendChannelMessage(channelId, { ...options, text });
+  return { ...result, via_parent: viaParent, resolved_channel_id: channelId };
+}

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -13,7 +13,7 @@ import { requireAuth, requireAdmin, optionalAuth, createRequireWorkingGroupLeade
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { eventsDb } from "../db/events-db.js";
 import { invalidateMemberContextCache } from "../addie/index.js";
-import { invalidateWebAdminStatusCache } from "../addie/mcp/admin-tools.js";
+import { invalidateWebAdminStatusCache, isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
 import { syncWorkingGroupMembersFromSlack, syncAllWorkingGroupMembersFromSlack } from "../slack/sync.js";
 import { notifyPublishedPost } from "../notifications/slack.js";
 import { notifyUser } from "../notifications/notification-service.js";
@@ -357,7 +357,7 @@ export function createCommitteeRouters(): {
   adminApiRouter.post('/', requireAuth, requireAdmin, async (req: Request, res: Response) => {
     try {
       const { name, slug, description, slack_channel_url, is_private, status, display_order,
-              leader_user_ids, committee_type, region } = req.body;
+              leader_user_ids, committee_type, region, parent_id } = req.body;
 
       if (!name || !slug) {
         return res.status(400).json({
@@ -428,7 +428,7 @@ export function createCommitteeRouters(): {
 
       const group = await workingGroupDb.createWorkingGroup({
         name, slug, description, slack_channel_url: finalSlackChannelUrl, is_private, status, display_order,
-        leader_user_ids, committee_type, region: finalRegion
+        leader_user_ids, committee_type, region: finalRegion, parent_id: parent_id || null
       });
 
       // Auto-sync members from Slack channel if a channel was linked to a chapter or event
@@ -453,6 +453,17 @@ export function createCommitteeRouters(): {
           : null,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      if (
+        message.includes('cycle') ||
+        message.includes('own parent') ||
+        message.includes('Parent working group not found') ||
+        message.includes('limited to two levels') ||
+        message.includes('cannot have subgroups') ||
+        message.includes('while subgroups exist')
+      ) {
+        return res.status(400).json({ error: 'Invalid hierarchy', message });
+      }
       logger.error({ err: error }, 'Create working group error:');
       res.status(500).json({
         error: 'Failed to create working group',
@@ -552,6 +563,17 @@ export function createCommitteeRouters(): {
         sync_result: syncResult,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      if (
+        message.includes('cycle') ||
+        message.includes('own parent') ||
+        message.includes('Parent working group not found') ||
+        message.includes('limited to two levels') ||
+        message.includes('cannot have subgroups') ||
+        message.includes('while subgroups exist')
+      ) {
+        return res.status(400).json({ error: 'Invalid hierarchy', message });
+      }
       logger.error({ err: error }, 'Update working group error:');
       res.status(500).json({
         error: 'Failed to update working group',
@@ -699,7 +721,34 @@ export function createCommitteeRouters(): {
     }
   });
 
+  // POST /api/admin/working-groups/:slug/topics/:topicSlug/graduate
+  // Promote a topic on the given working group into a full subgroup.
+  const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,99}$/;
+  adminApiRouter.post('/:slug/topics/:topicSlug/graduate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+    try {
+      const { slug, topicSlug } = req.params;
+      if (!SLUG_PATTERN.test(slug) || !SLUG_PATTERN.test(topicSlug)) {
+        return res.status(400).json({ error: 'Invalid slug format' });
+      }
+      const result = await workingGroupDb.graduateTopicToSubgroup(slug, topicSlug);
+      invalidateMemberContextCache();
+      res.status(201).json(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      if (
+        message.includes('not found') ||
+        message.includes('Cannot graduate') ||
+        message.includes('hierarchy is two levels')
+      ) {
+        return res.status(400).json({ error: 'Graduate failed', message });
+      }
+      logger.error({ err: error }, 'Graduate topic error');
+      res.status(500).json({ error: 'Failed to graduate topic', message });
+    }
+  });
+
   // GET /api/admin/working-groups/:id/interest - Get users who expressed interest in a committee
+
   adminApiRouter.get('/:id/interest', requireAuth, requireAdmin, async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
@@ -928,17 +977,64 @@ export function createCommitteeRouters(): {
       const memberships = await workingGroupDb.getMembershipsByWorkingGroup(group.id);
 
       let isMember = false;
+      let isFamilyMember = false;
       if (user?.id) {
         isMember = await workingGroupDb.isMember(group.id, user.id);
+        isFamilyMember = isMember || await workingGroupDb.isFamilyMember(group.id, user.id);
       }
+
+      // Hierarchy context: parent summary (if any) and list of direct subgroups
+      // filtered by visibility (private subgroups only visible to family members).
+      const parent = group.parent_id
+        ? await workingGroupDb.getWorkingGroupById(group.parent_id)
+        : null;
+
+      // Private subgroups show up only for people who are direct members of
+      // that subgroup, or for AAO admins. Parent membership alone does not
+      // unlock private subgroup visibility.
+      const isAAOAdmin = user?.id ? await isWebUserAAOAdmin(user.id) : false;
+      const allSubgroups = await workingGroupDb.listSubgroups(group.id);
+      const visibleSubgroups: typeof allSubgroups = [];
+      for (const sg of allSubgroups) {
+        if (sg.status !== 'active') continue;
+        if (!sg.is_private || isAAOAdmin) {
+          visibleSubgroups.push(sg);
+          continue;
+        }
+        if (user?.id && await workingGroupDb.isMember(sg.id, user.id)) {
+          visibleSubgroups.push(sg);
+        }
+      }
+
+      const subgroupSummaries = await Promise.all(
+        visibleSubgroups.map(async sg => {
+          const sgMembers = await workingGroupDb.getMembershipsByWorkingGroup(sg.id);
+          return {
+            id: sg.id,
+            slug: sg.slug,
+            name: sg.name,
+            description: sg.description,
+            committee_type: sg.committee_type,
+            is_private: sg.is_private,
+            slack_channel_url: sg.slack_channel_url,
+            member_count: sgMembers.length,
+          };
+        })
+      );
+
+      const familyMemberCount = await workingGroupDb.countFamilyMembers(group.id);
 
       res.json({
         working_group: {
           ...group,
           member_count: memberships.length,
           memberships,
+          parent: parent ? { id: parent.id, slug: parent.slug, name: parent.name } : null,
+          subgroups: subgroupSummaries,
+          family_member_count: familyMemberCount,
         },
         is_member: isMember,
+        is_family_member: isFamilyMember,
       });
     } catch (error) {
       logger.error({ err: error }, 'Get working group error');
@@ -978,18 +1074,53 @@ export function createCommitteeRouters(): {
         }
       }
 
+      // Aggregate from the group plus its subgroups the caller may see.
+      // Private subgroups the caller isn't a member of are filtered out.
+      const includeSubgroups = req.query.include_subgroups !== 'false';
+      const isAAOAdmin = user?.id ? await isWebUserAAOAdmin(user.id) : false;
+      const targetIds = includeSubgroups
+        ? await workingGroupDb.getVisibleDescendantIds(group.id, user?.id ?? null, { isAdmin: isAAOAdmin })
+        : [group.id];
+
       const result = await pool.query(
-        `SELECT id, slug, content_type, title, subtitle, category, excerpt, content,
-          external_url, external_site_name, author_name, author_title,
-          featured_image_url, published_at, tags, is_members_only
-        FROM perspectives
-        WHERE working_group_id = $1 AND status = 'published'
-          AND (is_members_only = false OR $2 = true)
-        ORDER BY published_at DESC NULLS LAST`,
-        [group.id, isMember]
+        `SELECT p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt, p.content,
+          p.external_url, p.external_site_name, p.author_name, p.author_title,
+          p.featured_image_url, p.published_at, p.tags, p.is_members_only,
+          p.working_group_id,
+          wg.id as source_group_id, wg.slug as source_group_slug, wg.name as source_group_name
+        FROM perspectives p
+        JOIN working_groups wg ON wg.id = p.working_group_id
+        WHERE p.working_group_id = ANY($1::uuid[]) AND p.status = 'published'
+          AND (p.is_members_only = false OR $2 = true)
+        ORDER BY p.published_at DESC NULLS LAST`,
+        [targetIds, isMember]
       );
 
-      res.json({ posts: result.rows });
+      const posts = result.rows.map(row => ({
+        id: row.id,
+        slug: row.slug,
+        content_type: row.content_type,
+        title: row.title,
+        subtitle: row.subtitle,
+        category: row.category,
+        excerpt: row.excerpt,
+        content: row.content,
+        external_url: row.external_url,
+        external_site_name: row.external_site_name,
+        author_name: row.author_name,
+        author_title: row.author_title,
+        featured_image_url: row.featured_image_url,
+        published_at: row.published_at,
+        tags: row.tags,
+        is_members_only: row.is_members_only,
+        source_group: {
+          id: row.source_group_id,
+          slug: row.source_group_slug,
+          name: row.source_group_name,
+        },
+      }));
+
+      res.json({ posts });
     } catch (error) {
       logger.error({ err: error }, 'Get working group posts error');
       res.status(500).json({
@@ -1002,6 +1133,7 @@ export function createCommitteeRouters(): {
   publicApiRouter.get('/:slug/events', optionalAuth, async (req: Request, res: Response) => {
     try {
       const { slug } = req.params;
+      const user = req.user;
 
       const group = await workingGroupDb.getWorkingGroupBySlug(slug);
 
@@ -1012,8 +1144,12 @@ export function createCommitteeRouters(): {
         });
       }
 
-      // Get events linked to this committee (published only for public view)
-      const events = await eventsDb.getEventsByCommittee(group.id, { includeUnpublished: false });
+      const includeSubgroups = req.query.include_subgroups !== 'false';
+      const targetIds = includeSubgroups
+        ? await workingGroupDb.getVisibleDescendantIds(group.id, user?.id ?? null)
+        : [group.id];
+
+      const events = await eventsDb.getEventsByCommittee(targetIds, { includeUnpublished: false });
 
       res.json(events);
     } catch (error) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -781,6 +781,7 @@ export interface WorkingGroup {
   display_order: number;
   committee_type: CommitteeType;
   region?: string;
+  parent_id?: string;
   // Topics for filtering meetings/docs
   topics?: WorkingGroupTopic[];
   // Industry gathering fields
@@ -829,6 +830,7 @@ export interface CreateWorkingGroupInput {
   display_order?: number;
   committee_type?: CommitteeType;
   region?: string;
+  parent_id?: string | null;
   topics?: WorkingGroupTopic[];
   // Industry gathering fields
   linked_event_id?: string;
@@ -852,6 +854,7 @@ export interface UpdateWorkingGroupInput {
   display_order?: number;
   committee_type?: CommitteeType;
   region?: string;
+  parent_id?: string | null;
   topics?: WorkingGroupTopic[];
   // Industry gathering fields
   linked_event_id?: string;

--- a/specs/committee-hierarchy.md
+++ b/specs/committee-hierarchy.md
@@ -1,0 +1,435 @@
+# Committee Hierarchy
+
+## What We're Building
+
+Let working groups nest under other working groups so we can consolidate a sprawl of dead committees into a coherent tree of five protocol areas. Dead WGs (like `wg-pmp-and-deals`, `wg-sponsored-intelligence`, the nine councils) become subgroups of a living parent without losing their members, documents, meetings, or history. Heavy "topics" that deserve their own members, channel, and docs graduate to first-class subgroups; lightweight tags stay as topics.
+
+The five top-level parents are:
+
+1. `wg-campaign-lifecycle` - discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation
+2. `wg-creative` - creative lifecycle, generative, governance, audit
+3. `wg-signals-measurement` - audience signals, measurement, verification, attribution
+4. `wg-governance` - brand.json, adagents.json, brand safety, compliance, policy
+5. `wg-builders` - SDKs, tooling, integration help (not protocol design)
+
+Everything else is either a subgroup of one of these five, archived, or a chapter/industry gathering (those remain top-level, not nested under the five).
+
+## Scope
+
+### Already built on this branch
+
+- Migration `404_working_group_parent_id.sql` (self-FK with `ON DELETE SET NULL`).
+- `WorkingGroup.parent_id` on `CreateWorkingGroupInput` / `UpdateWorkingGroupInput`.
+- `WorkingGroupDatabase.listSubgroups(parentId)` and cycle validation in `assertValidParent`.
+- Admin API `POST/PUT /api/admin/working-groups` accepts `parent_id`, returns 400 on cycles.
+- Admin UI `admin-working-groups.html` parent selector and nested list rendering.
+
+### This spec covers
+
+Topic/subgroup decisions, public API and page changes, membership and Slack inheritance, permission model, Slack automation behavior, data migration for the five-parent consolidation, and rollout order.
+
+---
+
+## 1. Data Model Decisions
+
+### 1.1 Topics stay. Some graduate to subgroups.
+
+**Decision**: Keep the lightweight `working_groups.topics` JSONB. Add a tool to "graduate a topic to a subgroup" as an admin action. Do not auto-migrate all topics.
+
+**Why**: Topics are filter tags on meetings, perspectives, and meeting series. They are cheap, they are subscribed-to via `working_group_topic_subscriptions.topic_slugs`, and `meeting_series.invite_mode = 'topic_subscribers'` depends on them. A subgroup is a heavier concept: it has its own membership list, its own documents, optionally its own Slack channel, its own leaders, and its own page. Most topics never need that.
+
+**The graduate action** is defined in section 3 (Migration Strategy). It creates a new subgroup, reparents content, migrates subscribers to members, and removes the topic from the parent's `topics` array.
+
+### 1.2 Membership is per-group, not inherited.
+
+**Decision**: A subgroup member is not automatically a parent member. A parent member is not automatically a subgroup member. Each membership row stands alone.
+
+**Why**: Councils have ~200 members each. If every council member became a member of `wg-governance`, governance would balloon to 1500+ members that never opted in. Notifications, digests, and quorum logic all break. Explicit opt-in keeps the data honest.
+
+**Derived "family membership" for access control and counts**:
+
+- Add `WorkingGroupDatabase.isFamilyMember(groupId, userId)` that returns true if the user is an active member of `groupId` or any of its descendants.
+- Add `WorkingGroupDatabase.countFamilyMembers(groupId)` that returns distinct active members across a group and all descendants.
+- Parent committee pages show `"234 members (412 across subgroups)"` using these.
+
+**Private-group access control**: If the parent is private, subgroup access also requires parent membership OR subgroup membership. Public parent with private subgroup: subgroup access still requires subgroup membership. This matches how people expect nesting to work.
+
+### 1.3 Slack channels are per-group, with a parent fallback for automation.
+
+**Decision**: Each group has its own `slack_channel_id` or it does not. Channels are not structurally inherited in the DB. But for automated posting, we introduce `WorkingGroupDatabase.resolveNotificationChannel(groupId)` that:
+
+1. Returns the group's own `slack_channel_id` if set.
+2. Otherwise walks up `parent_id` until it finds one.
+3. Returns null if nothing in the chain has a channel.
+
+Any automation that "posts to a WG's channel" (spec-insight-post, wg-digest, meeting reminders, new-post notifications) uses `resolveNotificationChannel`. Human-facing UI (the group page's "Join our Slack channel" link) uses only the direct `slack_channel_id` - we don't want to tell users to join the parent's channel implicitly.
+
+**Why**: Creating 20 new Slack channels for newly-graduated subgroups is a mess. We want to be able to create the subgroup first, post updates in the parent channel with a `#subgroup-name` prefix, and only spin up a dedicated channel when activity justifies it.
+
+---
+
+## 2. Public Page and API Changes
+
+### 2.1 `GET /api/working-groups/:slug` response additions
+
+Add three fields to the response body:
+
+```json
+{
+  "working_group": {
+    "...existing fields...",
+    "parent": { "id": "...", "slug": "wg-campaign-lifecycle", "name": "Campaign Lifecycle" } | null,
+    "subgroups": [
+      {
+        "id": "...",
+        "slug": "wg-pmp-and-deals",
+        "name": "PMPs and Deals",
+        "description": "...",
+        "member_count": 12,
+        "slack_channel_url": "...",
+        "last_activity_at": "2026-03-01T00:00:00Z"
+      }
+    ],
+    "family_member_count": 412
+  },
+  "is_member": true,
+  "is_family_member": true
+}
+```
+
+`last_activity_at` is `GREATEST(last perspective.published_at, last meeting.start_time)` for the subgroup - computed in SQL, no new column. If no activity, return `null` and the UI renders "Quiet".
+
+### 2.2 Posts and meetings aggregate up by default, filter down on demand
+
+**Decision**: When viewing a parent WG's page, posts and meetings include content from all descendants, labeled with source. Subgroup pages show only that subgroup's content.
+
+API changes to `GET /api/working-groups/:slug/posts` and `GET /api/working-groups/:slug/events`:
+
+- New optional query param `include_subgroups` (default `true` for parent groups, ignored for leaf groups).
+- Response items get an added `source_group` field: `{ id, slug, name }` identifying which group the post/event belongs to. For direct content, `source_group.id === group.id`.
+- Backend query changes from `WHERE working_group_id = $1` to `WHERE working_group_id IN (SELECT id FROM working_groups WHERE id = $1 OR parent_id = $1 OR parent_id IN (SELECT id FROM working_groups WHERE parent_id = $1))`. Hardcode two-level descent - we do not plan to support arbitrary depth. (See section 1.4 below.)
+
+### 2.3 Depth is capped at two.
+
+**Decision**: Maximum hierarchy depth is 2. Top-level parent, and one level of subgroups. No grandchildren.
+
+**Why**: This is an operational decision, not a schema one. We have five parents and a few dozen potential subgroups. Three-deep nesting creates UI headaches (breadcrumb rendering, post aggregation, membership derivation) without solving any real problem.
+
+Enforce this in `assertValidParent`:
+
+```ts
+// In addition to cycle check
+if (parentId) {
+  const parent = await query<{ parent_id: string | null }>(
+    'SELECT parent_id FROM working_groups WHERE id = $1',
+    [parentId]
+  );
+  if (parent.rows[0]?.parent_id) {
+    throw new Error('Working group hierarchy is limited to two levels');
+  }
+}
+```
+
+### 2.4 Detail page UI changes
+
+On `working-groups/detail.html`:
+
+**If the group has a parent** (subgroup page):
+
+- Above the group title, render: `Subgroup of <a href="/working-groups/{parent.slug}">{parent.name}</a>`
+- Do not render the subgroups list (a subgroup can't have its own subgroups).
+
+**If the group has subgroups** (parent page):
+
+- New section between the description and the posts feed, titled "Subgroups".
+- Each subgroup renders as a card: name (linked to subgroup slug), description, member count, last activity.
+- Posts and events are clearly labeled with `source_group` when they come from a subgroup: a small pill/chip reading "from Creative Audit" that links to the subgroup.
+- Add a view toggle above the posts/events feed: "All (parent + subgroups)" (default) | "Just this group".
+
+**Member counts display**: Parent pages show `"234 direct members - 412 across subgroups"`. Subgroup pages show their own count only.
+
+**Subscribe / join**: The join button on a parent page only joins the parent. Joining a subgroup is a separate action on the subgroup page. We do not auto-join children.
+
+---
+
+## 3. Migration Strategy
+
+Three migrations run in order. They are all in the `server/src/db/migrations/` pipeline.
+
+### 3.1 Migration `405_seed_five_parents.sql`
+
+Creates (if missing) the five top-level parent WGs. Idempotent:
+
+```sql
+INSERT INTO working_groups (name, slug, description, committee_type, status, display_order, is_private, topics)
+VALUES
+  ('Campaign Lifecycle', 'wg-campaign-lifecycle',
+   'Discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation.',
+   'working_group', 'active', 10, false, '[]'),
+  ('Creative', 'wg-creative',
+   'Creative lifecycle, generative creative, governance, and audit.',
+   'working_group', 'active', 20, false, '[]'),
+  ('Signals and Measurement', 'wg-signals-measurement',
+   'Audience signals, measurement, verification, attribution.',
+   'working_group', 'active', 30, false, '[]'),
+  ('Governance', 'wg-governance',
+   'brand.json, adagents.json, brand safety, compliance, policy.',
+   'governance', 'active', 40, false, '[]'),
+  ('Builders', 'wg-builders',
+   'SDKs, tooling, integration help. Not protocol design.',
+   'working_group', 'active', 50, false, '[]')
+ON CONFLICT (slug) DO NOTHING;
+```
+
+### 3.2 Migration `406_reparent_dead_committees.sql`
+
+Data-only migration - no schema change. Reparents the dead committees. Uses slug lookups so it's safe to re-run:
+
+```sql
+-- Campaign Lifecycle subgroups
+UPDATE working_groups SET parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-campaign-lifecycle')
+WHERE slug IN ('wg-pmp-and-deals', 'wg-sponsored-intelligence', 'council-media-buyers', 'council-sellers')
+  AND parent_id IS NULL;
+
+-- Creative subgroups
+UPDATE working_groups SET parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-creative')
+WHERE slug IN ('wg-creative-agents', 'council-creative', 'council-agencies')
+  AND parent_id IS NULL;
+
+-- Signals and Measurement subgroups
+UPDATE working_groups SET parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-signals-measurement')
+WHERE slug IN ('wg-measurement-verification-validation', 'wg-audience-signals',
+               'council-measurement', 'council-data-providers')
+  AND parent_id IS NULL;
+
+-- Governance subgroups
+UPDATE working_groups SET parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-governance')
+WHERE slug IN ('wg-arch-and-technical-standards', 'wg-brand-safety',
+               'council-brands', 'council-publishers', 'council-policy')
+  AND parent_id IS NULL;
+
+-- Builders subgroups (when they exist)
+UPDATE working_groups SET parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-builders')
+WHERE slug IN ('wg-sdk-ts', 'wg-sdk-python', 'wg-sdk-go', 'council-developers')
+  AND parent_id IS NULL;
+
+-- Archive subgroups that were already marked dead (keep them visible under parent history)
+UPDATE working_groups SET status = 'archived'
+WHERE slug IN ('wg-pmp-and-deals', 'wg-sponsored-intelligence',
+               'wg-measurement-verification-validation', 'wg-arch-and-technical-standards')
+  AND status = 'inactive';
+```
+
+**Rule**: Only write exact slugs we've verified exist in production. Any slug in the UPDATE list that doesn't exist is a no-op. Before merging this migration, the engineer implementing it must run against production DB to confirm the slug list - do not ship unverified slugs. Track the authoritative list in a comment at the top of the file.
+
+### 3.3 Migration `407_drop_dead_topics.sql`
+
+Not required at migration time. Topic cleanup happens via the `graduate_topic_to_subgroup` admin tool (section 5.2). We leave the topics as-is in the DB and do the work when someone manually triggers graduation per topic. Skip this migration.
+
+### 3.4 Runtime tool: `graduate_topic_to_subgroup`
+
+New admin endpoint `POST /api/admin/working-groups/:slug/topics/:topicSlug/graduate` that runs in a transaction:
+
+1. Load the parent working group and confirm the topic exists in `topics` JSONB.
+2. Create a new subgroup with `parent_id = parent.id`, `slug = <topicSlug>` (or `<parent-slug>-<topic-slug>` if collision), `name = topic.name`, `description = topic.description`, `slack_channel_id = topic.slack_channel_id`.
+3. Copy all `working_group_topic_subscriptions` rows where `working_group_id = parent.id AND topicSlug = ANY(topic_slugs)` into `working_group_memberships` for the new subgroup (deduped).
+4. Remove `topicSlug` from every user's `topic_slugs` array in the parent's subscriptions (and delete empty-array rows).
+5. For `meeting_series` on the parent with `topicSlug = ANY(topic_slugs)`: move them to the new subgroup (`working_group_id = newSubgroupId`). If a series has multiple topic slugs, split: create one series per group (duplicate recurrence settings, Zoom/Calendar IDs stay with the primary series).
+6. For `meetings` and `perspectives` on the parent with `topicSlug = ANY(topic_slugs)`: update `working_group_id = newSubgroupId` and strip `topicSlug` from their `topic_slugs` arrays.
+7. Remove the topic from the parent's `topics` JSONB.
+8. Return `{ subgroup_id, moved: { subscriptions, meetings, perspectives, series } }` for confirmation in the admin UI.
+
+The UI adds a "Graduate to subgroup" button next to each topic in the edit modal. Clicking it opens a confirmation dialog showing the move counts before running.
+
+**Notification to subscribers**: Send one Slack DM (or email if not on Slack) to everyone whose subscription was converted: "Your topic subscription to 'Brand Safety' is now a subgroup membership in AAO. Same notifications, different name. Manage at `/working-groups/<subgroup-slug>`." Rate-limit to 1 per user per hour to avoid spam if the admin does several in succession.
+
+---
+
+## 4. Permission Model
+
+### 4.1 Who can reparent, who can create subgroups
+
+**Admins only** can set or change `parent_id`. Not group leaders. Reparenting a group is a governance decision - who the group reports to - and can have large downstream effects (access control on private groups, notification routing). Keep it gated.
+
+**Admins only** can create subgroups. Leaders of the parent can request subgroup creation through an existing admin tool but do not have direct API access. We could loosen this later; start tight.
+
+### 4.2 Leader scope is per-group
+
+**Decision**: A parent's leader does not automatically gain leader rights on subgroups. A subgroup's leader does not have any rights on the parent. Leadership is per-group, like membership.
+
+**Why**: Same reason as membership. A leader of `wg-campaign-lifecycle` does not necessarily want to run `wg-pmp-and-deals`. Auto-leader rights create accountability gaps ("the parent leader will handle it").
+
+Admin tooling that manages leader lists shows parent leaders in the subgroup page as a read-only "See also" section for discoverability.
+
+### 4.3 Committee-type constraints
+
+**Decision**: Any committee type can be a child of `working_group` or `governance`. `council`, `chapter`, and `industry_gathering` cannot have subgroups. Enforce in `assertValidParent`:
+
+```ts
+if (parentId) {
+  const { rows } = await query<{ committee_type: string }>(
+    'SELECT committee_type FROM working_groups WHERE id = $1',
+    [parentId]
+  );
+  const parentType = rows[0]?.committee_type;
+  if (parentType && !['working_group', 'governance'].includes(parentType)) {
+    throw new Error(`Committee type '${parentType}' cannot have subgroups`);
+  }
+}
+```
+
+**Why**: Councils are representative bodies with their own membership logic; they should be children of a working group (they report up), not parents. Chapters are geographic and industry gatherings are time-bound events - neither is a protocol area.
+
+---
+
+## 5. Slack Integration
+
+### 5.1 `resolveNotificationChannel` is the only entrypoint
+
+Audit and migrate all existing channel lookups:
+
+- `server/src/addie/jobs/spec-insight-post.ts` - currently uses `getWorkingGroupBySlug(TARGET_CHANNEL_SLUG).slack_channel_id`. Change to `resolveNotificationChannel(targetWg.id)`.
+- `server/src/addie/templates/wg-digest.ts` and `wg-digest-prep.ts` - same substitution.
+- `server/src/addie/services/wg-welcome.ts` - same.
+- Any other code matching `\.slack_channel_id` in automation paths: grep the `server/src/addie` and `server/src/notifications` trees and convert.
+
+Leave human-facing reads (the committee detail page's "Join Slack" link, admin UI channel display) on direct `slack_channel_id`.
+
+### 5.2 Posting prefix convention
+
+When a subgroup has no channel of its own and we post via the parent's channel, prefix the message with `[{subgroup.name}]`:
+
+```
+[PMPs and Deals] Something I've been thinking about...
+```
+
+This applies to spec-insight-post, digest posts, meeting reminders. Implement as a wrapper:
+
+```ts
+export async function postToGroupChannel(groupId: string, text: string, opts?: SlackSendOpts) {
+  const { channelId, viaParent, group } = await resolveNotificationChannel(groupId);
+  if (!channelId) return { ok: false, error: 'No channel in hierarchy' };
+  const prefixedText = viaParent ? `[${group.name}] ${text}` : text;
+  return sendChannelMessage(channelId, { ...opts, text: prefixedText });
+}
+```
+
+### 5.3 Cross-group digest behavior
+
+`wg-digest` currently runs per-group. When it runs on a parent, include a "From subgroups" section that lists the top N posts/meetings from subgroups with links. Don't duplicate: if a user is a member of both parent and a subgroup, deduplicate by group. Add a `seen_in_group_ids` parameter to the digest builder or track at the recipient level.
+
+---
+
+## 6. API Surface Changes
+
+### Admin
+
+| Route | Change |
+|---|---|
+| `POST /api/admin/working-groups` | Already accepts `parent_id`. Add two-level depth validation. |
+| `PUT /api/admin/working-groups/:id` | Already accepts `parent_id`. Add two-level depth validation. |
+| `POST /api/admin/working-groups/:slug/topics/:topicSlug/graduate` | **New**. See section 3.4. |
+| `GET /api/admin/working-groups/:id/subgroups` | **New**. Admin view returning all subgroups including archived. |
+
+### Public
+
+| Route | Change |
+|---|---|
+| `GET /api/working-groups/:slug` | Add `parent`, `subgroups`, `family_member_count`, `is_family_member`. |
+| `GET /api/working-groups/:slug/posts` | Add `include_subgroups` param (default true for parents). Each post gets `source_group`. |
+| `GET /api/working-groups/:slug/events` | Same as posts. |
+| `GET /api/working-groups` | List: each item gets `parent_id` (already in model) and a `subgroup_count` integer. UI can render hierarchy without second request. |
+
+### Database
+
+| Method | Change |
+|---|---|
+| `WorkingGroupDatabase.listSubgroups(parentId)` | Already exists. |
+| `WorkingGroupDatabase.getDescendantIds(groupId)` | **New**. Returns `[groupId, ...childIds]` for content aggregation. Hardcoded two-level SQL. |
+| `WorkingGroupDatabase.resolveNotificationChannel(groupId)` | **New**. Returns `{ channelId, viaParent, group }`. |
+| `WorkingGroupDatabase.isFamilyMember(groupId, userId)` | **New**. Uses `getDescendantIds`. |
+| `WorkingGroupDatabase.countFamilyMembers(groupId)` | **New**. `COUNT(DISTINCT workos_user_id)` across descendant memberships. |
+| `WorkingGroupDatabase.graduateTopicToSubgroup(parentSlug, topicSlug)` | **New**. Transactional. See section 3.4. |
+
+---
+
+## 7. Edge Cases
+
+- **Deleting a parent**: Existing FK is `ON DELETE SET NULL`. Children detach and become top-level groups. Admin UI must warn: "This will orphan 4 subgroups, which will become top-level committees. Consider archiving them first or reparenting." Do not cascade delete.
+- **Events linked to a WG that becomes a subgroup**: Events remain linked via `linked_event_id`. No change needed. The committee filter on the event page shows the subgroup name.
+- **`meeting_series.invite_mode = 'topic_subscribers'` for a topic that graduates**: Migration step 5 converts series to the subgroup and changes `invite_mode` to `'all_members'` of the new subgroup. All former subscribers are already added as members in step 3.
+- **`display_order`**: Applies within a level. Subgroups of the same parent sort by `display_order, name`. Top-level groups sort by `display_order, name`. No global interleaving.
+- **`is_private` inheritance**: A subgroup can be private under a public parent and vice versa. Access check on the subgroup uses the subgroup's own `is_private`. The parent page lists private subgroups only if the viewing user is a family member of that subgroup. Non-members see only public subgroups.
+- **Archived subgroups under an active parent**: The parent page hides archived subgroups from the "Subgroups" section by default. An admin UI toggle shows them. Posts from archived subgroups still aggregate up by default (they're history).
+- **Cycle on self-parent with `ON DELETE SET NULL`**: A group cannot be its own parent. Already enforced. After deletion of the root, the `SET NULL` cannot reintroduce a cycle because `parent_id` goes to `NULL`.
+- **Committee type change after reparenting**: If an admin changes a parent's `committee_type` to `chapter` (which can't have children), block the change if subgroups exist. Add to the PUT validator.
+
+---
+
+## 8. Implementation Order
+
+Work proceeds in discrete PRs. Each PR ships independently.
+
+**PR 1 - Depth cap and committee-type constraint** (backend only, small)
+
+- Extend `assertValidParent` with the two-level check and the committee-type check from section 4.3.
+- Unit tests for: self-parent, cycle, grandchild rejected, chapter-as-parent rejected.
+
+**PR 2 - Family membership and descendant helpers** (backend only)
+
+- Implement `getDescendantIds`, `isFamilyMember`, `countFamilyMembers`, `resolveNotificationChannel`.
+- Unit tests against a tree fixture.
+
+**PR 3 - Public API hierarchy fields** (backend)
+
+- Update `GET /api/working-groups/:slug` to include `parent`, `subgroups`, `family_member_count`, `is_family_member`.
+- Update posts/events endpoints to include descendants with `source_group` and `include_subgroups` param.
+- Update list endpoint to include `subgroup_count`.
+- Integration tests hitting the HTTP endpoints.
+
+**PR 4 - Public page rendering** (frontend only)
+
+- `working-groups/detail.html`: parent breadcrumb on subgroup pages, subgroups section on parent pages, source labels on posts/events, view toggle, family member count.
+
+**PR 5 - Slack automation** (backend)
+
+- Grep audit of all `.slack_channel_id` reads in automation paths.
+- Replace with `resolveNotificationChannel` and `postToGroupChannel` wrapper.
+- Add `[SubgroupName]` prefixing when posting via parent channel.
+- Unit tests for the wrapper. Manual verification against a test channel.
+
+**PR 6 - Five-parent seeding** (migration only)
+
+- Migration `405_seed_five_parents.sql`. Idempotent `ON CONFLICT DO NOTHING`.
+
+**PR 7 - Reparenting migration** (migration + verification)
+
+- Verify the slug list against production before merging.
+- Migration `406_reparent_dead_committees.sql`.
+- Archive flags applied in the same migration.
+- Post-merge: smoke test the five parent pages in production.
+
+**PR 8 - Topic graduation tool** (backend + admin UI)
+
+- `POST /api/admin/working-groups/:slug/topics/:topicSlug/graduate` endpoint.
+- Admin UI button in the edit modal with confirmation dialog showing move counts.
+- Slack DM notification to affected subscribers.
+- Unit tests for the transactional flow. Run once on a staging topic before enabling in production.
+
+**PR 9 - Parent digest cross-surfacing** (backend)
+
+- Update `wg-digest` builder to include "From subgroups" section on parent groups. Dedup by group per recipient.
+
+Production rollout happens after PR 7. PR 8 and 9 are follow-ups that do not block the consolidation launch.
+
+---
+
+## Success Criteria
+
+- [ ] A dead WG like `wg-pmp-and-deals` appears as a subgroup under `wg-campaign-lifecycle` on the public page, with its members and posts intact.
+- [ ] Visiting `/working-groups/wg-campaign-lifecycle` shows the five subgroups, their member counts, and a feed that includes labeled posts from each.
+- [ ] Visiting `/working-groups/wg-pmp-and-deals` shows "Subgroup of Campaign Lifecycle" and only that subgroup's content.
+- [ ] `spec-insight-post` posting to a subgroup without its own channel correctly posts to the parent's channel with a `[Subgroup Name]` prefix.
+- [ ] An admin can graduate a topic to a subgroup in one click, subscribers become members, and nothing sends duplicate notifications.
+- [ ] `assertValidParent` rejects: cycles, self-parent, grandchildren, councils/chapters as parents.
+- [ ] A user who is a member of only `wg-pmp-and-deals` shows as a family member of `wg-campaign-lifecycle` but does not appear in the parent's direct member count.


### PR DESCRIPTION
## Summary

- Working groups can nest under other working groups as subgroups — 2-level cap, cycles prevented, only `working_group` / `governance` types can be parents
- Topics can **graduate** to first-class subgroups via a new admin tool (transactional: moves subscribers to members, reassigns meetings/perspectives, removes the topic from the parent)
- Public parent pages show subgroup cards and aggregate posts/events from subgroups with source labels; subgroup pages show a parent breadcrumb and their own content only
- Private subgroup visibility is gated to direct members, with an admin escape hatch

## Why

Current WG structure is too fragmented — many WGs are dead, and protocol conversations don't map cleanly. The plan is to consolidate around five protocol areas (Campaign Lifecycle, Creative, Signals & Measurement, Governance, Builders) by reparenting dead WGs as subgroups. This PR delivers the schema, APIs, and UIs; the actual reparenting happens in a follow-up after production slug verification.

See [`specs/committee-hierarchy.md`](https://github.com/adcontextprotocol/adcp/blob/bokelley/wg-hierarchy/specs/committee-hierarchy.md) for the full design.

## What changed

**Schema (migrations 404, 405)**
- `parent_id` UUID column on `working_groups` (self-FK, `ON DELETE SET NULL`)
- Seeds the five top-level parent WGs

**Backend**
- New DB methods: `listSubgroups`, `getDescendantIds`, `getVisibleDescendantIds`, `isFamilyMember`, `countFamilyMembers`, `resolveNotificationChannel`, `graduateTopicToSubgroup`
- `assertValidParent` enforces cycles, self-parent, 2-level depth cap, parent-type constraint
- Update blocks committee-type change when subgroups exist
- `server/src/notifications/wg-slack.ts` — `postToGroupChannel` wrapper that walks up the parent chain and prefixes `[Subgroup Name]` on fallback posts; warns on private-via-parent

**Public API**
- `GET /api/working-groups/:slug` returns `parent`, `subgroups`, `family_member_count`, `is_family_member`
- `GET /:slug/posts` and `/:slug/events` aggregate descendants with `source_group` labels; `include_subgroups=false` narrows to direct content
- Private subgroups filtered out of the aggregation for non-members / anonymous

**Admin API**
- `POST`/`PUT` committee endpoints accept `parent_id`, return 400 with a specific message on invalid hierarchy
- New `POST /:slug/topics/:topicSlug/graduate`

**UI**
- `admin-working-groups.html` — parent selector that excludes self, descendants, and types that can't be parents; nested list rendering with `↳` indent; "Graduate to subgroup" button per topic
- `working-groups/detail.html` — parent breadcrumb on subgroup pages, Subgroups cards section on parent pages, source labels on aggregated posts, include-subgroups toggle

## Test plan

- [x] Type check + 587 unit tests pass
- [x] E2E against local docker stack: 22/22 playwright checks pass (admin list nesting, parent selector, public parent page, public subgroup page, aggregated posts with source labels)
- [x] Targeted privacy tests: private subgroup hidden from anonymous users, visible to direct members and to AAO admins
- [x] Validation rejections verified: grandchild (400), cycle (400), self-parent (400), council as parent (400), committee-type change while subgroups exist (400)
- [x] Topic graduation transactional flow: creates subgroup, removes topic, moves subscribers/meetings/perspectives
- [x] Code review (code-reviewer agent) and security review (security-reviewer agent) feedback addressed — notably private subgroup visibility tightened to direct-member-only

## Follow-ups (not in this PR)

- Migration `406_reparent_dead_committees.sql` — after verifying slug list against production
- Remaining Slack automation callers (`content-curator`, `committee-summary-generator`, etc.) migrated to `postToGroupChannel`
- `wg-digest` cross-surfacing "From subgroups" section on parent digests
- `graduateTopicToSubgroup` perf: collapse N+1 membership-check to single `ON CONFLICT DO NOTHING` insert
- Advisory-lock the slug collision check to close a low-probability TOCTOU race

🤖 Generated with [Claude Code](https://claude.com/claude-code)