### PR TITLE
fix: consolidate parent WGs onto existing slugs

### DIFF
--- a/.changeset/consolidate-parent-wgs.md
+++ b/.changeset/consolidate-parent-wgs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Consolidate the five top-level parent working groups onto existing slugs instead of creating a parallel structure. Migration 405 (in PR #2243) seeded four new WGs with fresh slugs (`wg-campaign-lifecycle`, `wg-creative`, `wg-signals-measurement`, `wg-governance`) that duplicated existing WGs (`media-buying-protocol-wg`, `creative-wg`, `signals-data-wg`, `brand-standards-wg`). Migration 406 corrects this by reparenting any subgroups to the existing WGs, deleting the duplicates, and renaming the originals to the new display names. `wg-builders` remains — it's a genuinely new category with no existing equivalent. Preserves URLs, members, documents, and history.

--- a/server/src/db/migrations/406_consolidate_parent_wgs.sql
+++ b/server/src/db/migrations/406_consolidate_parent_wgs.sql
@@ -1,0 +1,71 @@
+-- Correct the consolidation approach in migration 405.
+--
+-- Migration 405 created five new parallel working groups with fresh slugs
+-- (wg-campaign-lifecycle, wg-creative, wg-signals-measurement, wg-governance,
+-- wg-builders). That left two parallel structures: the original WGs seeded
+-- long ago (creative-wg, signals-data-wg, media-buying-protocol-wg,
+-- brand-standards-wg, events-thought-leadership-wg) and the new duplicates.
+--
+-- This migration consolidates onto the existing slugs to preserve URLs,
+-- members, documents, meetings, and history. It:
+--   1. Reparents any subgroups that point at a duplicate parent over to
+--      the corresponding existing WG.
+--   2. Deletes the four duplicate parents (wg-builders is legitimately new
+--      and is kept).
+--   3. Renames existing WGs to the new display names.
+--
+-- Idempotent: safe to re-run. Uses slug lookups throughout.
+
+-- 1. Reparent subgroups from duplicate parents to the existing WG equivalents.
+UPDATE working_groups
+SET parent_id = (SELECT id FROM working_groups WHERE slug = 'media-buying-protocol-wg')
+WHERE parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-campaign-lifecycle');
+
+UPDATE working_groups
+SET parent_id = (SELECT id FROM working_groups WHERE slug = 'creative-wg')
+WHERE parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-creative');
+
+UPDATE working_groups
+SET parent_id = (SELECT id FROM working_groups WHERE slug = 'signals-data-wg')
+WHERE parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-signals-measurement');
+
+UPDATE working_groups
+SET parent_id = (SELECT id FROM working_groups WHERE slug = 'brand-standards-wg')
+WHERE parent_id = (SELECT id FROM working_groups WHERE slug = 'wg-governance');
+
+-- 2. Delete the four duplicate parents created in migration 405.
+-- (wg-builders stays — it's a new concept with no existing equivalent.)
+DELETE FROM working_groups
+WHERE slug IN ('wg-campaign-lifecycle', 'wg-creative', 'wg-signals-measurement', 'wg-governance');
+
+-- 3. Rename existing WGs to the new display names and set display_order.
+UPDATE working_groups SET
+  name = 'Campaign Lifecycle',
+  description = 'Discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation. The full arc from finding inventory through reconciling the buy.',
+  display_order = 10
+WHERE slug = 'media-buying-protocol-wg';
+
+UPDATE working_groups SET
+  name = 'Creative',
+  description = 'Creative lifecycle, generative creative, governance, and audit.',
+  display_order = 20
+WHERE slug = 'creative-wg';
+
+UPDATE working_groups SET
+  name = 'Signals and Measurement',
+  description = 'Audience signals, measurement, verification, attribution.',
+  display_order = 30
+WHERE slug = 'signals-data-wg';
+
+UPDATE working_groups SET
+  name = 'Governance',
+  description = 'brand.json, adagents.json, brand safety, compliance, policy.',
+  committee_type = 'governance',
+  display_order = 40
+WHERE slug = 'brand-standards-wg';
+
+UPDATE working_groups SET
+  name = 'Community & Events',
+  description = 'Community building, events, thought leadership, marketing, and training programs.',
+  display_order = 60
+WHERE slug = 'events-thought-leadership-wg';

--- a/server/src/db/migrations/406_consolidate_parent_wgs.sql
+++ b/server/src/db/migrations/406_consolidate_parent_wgs.sql
@@ -69,3 +69,8 @@ UPDATE working_groups SET
   description = 'Community building, events, thought leadership, marketing, and training programs.',
   display_order = 60
 WHERE slug = 'events-thought-leadership-wg';
+
+-- 4. Attach #salesagent-dev as the Slack channel for Builders. Channel will be
+-- renamed to #builders separately; ID stays stable across a Slack rename.
+UPDATE working_groups SET slack_channel_id = 'C09J28K9K29'
+WHERE slug = 'wg-builders' AND slack_channel_id IS NULL;

--- a/specs/committee-hierarchy.md
+++ b/specs/committee-hierarchy.md
@@ -4,15 +4,18 @@
 
 Let working groups nest under other working groups so we can consolidate a sprawl of dead committees into a coherent tree of five protocol areas. Dead WGs (like `wg-pmp-and-deals`, `wg-sponsored-intelligence`, the nine councils) become subgroups of a living parent without losing their members, documents, meetings, or history. Heavy "topics" that deserve their own members, channel, and docs graduate to first-class subgroups; lightweight tags stay as topics.
 
-The five top-level parents are:
+The top-level parents reuse existing WG slugs wherever possible to preserve URLs, members, documents, and history. Only Builders is genuinely new.
 
-1. `wg-campaign-lifecycle` - discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation
-2. `wg-creative` - creative lifecycle, generative, governance, audit
-3. `wg-signals-measurement` - audience signals, measurement, verification, attribution
-4. `wg-governance` - brand.json, adagents.json, brand safety, compliance, policy
-5. `wg-builders` - SDKs, tooling, integration help (not protocol design)
+1. `media-buying-protocol-wg` → "Campaign Lifecycle" — discovery, proposals, execution, trafficking, pacing, makegoods, reconciliation
+2. `creative-wg` → "Creative" — creative lifecycle, generative, governance, audit
+3. `signals-data-wg` → "Signals and Measurement"
+4. `brand-standards-wg` → "Governance" — brand.json, adagents.json, brand safety, compliance, policy
+5. `events-thought-leadership-wg` → "Community & Events"
+6. `wg-builders` *(new)* — SDKs, tooling, integration help
 
-Everything else is either a subgroup of one of these five, archived, or a chapter/industry gathering (those remain top-level, not nested under the five).
+Migration 405 originally seeded parallel parents with fresh slugs (`wg-campaign-lifecycle`, etc.); migration 406 consolidates onto the existing slugs.
+
+Everything else is either a subgroup of one of these, archived, or a chapter/industry gathering (those remain top-level, not nested).
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Fix a mistake in #2243 — migration 405 created parallel parent WGs with fresh slugs instead of reusing existing WGs.

- **Before:** `creative-wg` (existing) + `wg-creative` (new, duplicate) both exist
- **After:** one `creative-wg` row, renamed to "Creative", preserving URLs/members/history

## What changed

Migration 406 runs three steps in order, all idempotent:

1. **Reparent** any subgroups that point at a duplicate parent to the corresponding existing WG
2. **Delete** the four duplicate parents (`wg-campaign-lifecycle`, `wg-creative`, `wg-signals-measurement`, `wg-governance`)
3. **Rename** existing WGs to the new display names and set display_order:
   - `media-buying-protocol-wg` → "Campaign Lifecycle"
   - `creative-wg` → "Creative"
   - `signals-data-wg` → "Signals and Measurement"
   - `brand-standards-wg` → "Governance" (committee_type also updated)
   - `events-thought-leadership-wg` → "Community & Events"

`wg-builders` remains — it's the one genuinely new category with no existing equivalent.

## Test plan

- [x] 587 unit tests pass; typecheck clean
- [x] Verified against local postgres simulating post-405 prod state:
    - Seeded duplicate parents + subgroups parented to fakes
    - Ran migration 406
    - Confirmed subgroups reparented to `media-buying-protocol-wg`, duplicates deleted, renames applied
- [x] Re-ran migration on the new state — no changes (idempotent)

## Why this matters

Existing WGs carry real data: members, documents, meeting history, Slack channels, community URLs that are linked from outside. Creating parallel structures would have meant deciding whether to migrate data across or abandon it. Reusing slugs avoids that entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)