### PR TITLE
fix: training agent protocol compliance (#2235–#2239)

### DIFF
--- a/.changeset/training-agent-protocol-fixes.md
+++ b/.changeset/training-agent-protocol-fixes.md
@@ -1,0 +1,10 @@
+---
+---
+
+Training agent protocol compliance fixes:
+
+- **#2235**: `create_media_buy` and `update_media_buy` now persist `package.targeting.property_list`, `targeting.collection_list`, and `targeting.collection_list_exclude`; `get_media_buys` echoes them back. Targeting refs are validated (type, length, http(s) scheme) and malformed input returns `VALIDATION_ERROR` instead of being silently dropped. Added `MAX_PACKAGES_PER_BUY = 50` cap.
+- **#2236**: `get_collection_list`, `update_collection_list`, and `delete_collection_list` now validate `list_id` (type and length) and return clean responses.
+- **#2237**: Structured AdCP errors (handler returns `{ errors: [...] }`) now complete the task instead of marking it failed, so clients see `GOVERNANCE_DENIED`, `INVALID_REQUEST`, etc. in the response body rather than `MCP -32603: Task failed`. Only thrown exceptions mark tasks as failed. Task-created log includes `errorCode` so anomaly monitoring still distinguishes structured-error from successful operations.
+- **#2238**: Central dispatcher validates `adcp_major_version` against `SUPPORTED_MAJOR_VERSIONS` ([3]) and returns `VERSION_UNSUPPORTED` for unsupported versions.
+- **#2239**: `get_signals` returns the full catalog (capped) instead of `INVALID_REQUEST` when called without `signal_spec` or `signal_ids`, supporting browse-style discovery.

--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -123,6 +123,15 @@ interface DeleteInput extends ToolArgs {
   list_id: string;
 }
 
+const MAX_LIST_ID_LEN = 128;
+
+function validateListId(value: unknown): { code: string; message: string; field: string } | undefined {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_LIST_ID_LEN) {
+    return { code: 'VALIDATION_ERROR', message: `list_id must be a non-empty string up to ${MAX_LIST_ID_LEN} chars`, field: 'list_id' };
+  }
+  return undefined;
+}
+
 // ── Handlers ─────────────────────────────────────────────────────
 
 export function handleCreateCollectionList(args: ToolArgs, ctx: TrainingContext) {
@@ -160,21 +169,28 @@ export function handleGetCollectionList(args: ToolArgs, ctx: TrainingContext) {
   const session = getSession(sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId));
   const input = args as GetCollectionListInput;
 
+  const listIdError = validateListId((input as unknown as { list_id: unknown }).list_id);
+  if (listIdError) return { errors: [listIdError] };
+
   const list = session.collectionLists.get(input.list_id);
   if (!list) return { errors: [{ code: 'NOT_FOUND', message: `Collection list ${input.list_id} not found` }] };
 
   const now = new Date().toISOString();
-  return {
-    list,
-    collections: input.resolve ? generateSampleCollections(list.collection_count) : undefined,
-    resolved_at: input.resolve ? now : undefined,
-    cache_valid_until: input.resolve ? new Date(Date.now() + 168 * 60 * 60 * 1000).toISOString() : undefined,
-  };
+  const response: Record<string, unknown> = { list };
+  if (input.resolve) {
+    response.collections = generateSampleCollections(list.collection_count);
+    response.resolved_at = now;
+    response.cache_valid_until = new Date(Date.now() + 168 * 60 * 60 * 1000).toISOString();
+  }
+  return response;
 }
 
 export function handleUpdateCollectionList(args: ToolArgs, ctx: TrainingContext) {
   const session = getSession(sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId));
   const input = args as UpdateCollectionListInput;
+
+  const listIdError = validateListId((input as unknown as { list_id: unknown }).list_id);
+  if (listIdError) return { errors: [listIdError] };
 
   const list = session.collectionLists.get(input.list_id);
   if (!list) return { errors: [{ code: 'NOT_FOUND', message: `Collection list ${input.list_id} not found` }] };
@@ -206,6 +222,10 @@ export function handleListCollectionLists(args: ToolArgs, ctx: TrainingContext) 
 export function handleDeleteCollectionList(args: ToolArgs, ctx: TrainingContext) {
   const session = getSession(sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId));
   const input = args as DeleteInput;
+
+  const listIdError = validateListId((input as unknown as { list_id: unknown }).list_id);
+  if (listIdError) return { errors: [listIdError] };
+
   const deleted = session.collectionLists.delete(input.list_id);
   return { deleted, list_id: input.list_id };
 }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -17,7 +17,7 @@ import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks'
 import { PostgresTaskStore } from '@adcp/client';
 import { isDatabaseInitialized, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
-import type { TrainingContext, CatalogProduct, MediaBuyState, PackageState, SignalActivationState, CreativeState, CreativeManifest, ToolArgs } from './types.js';
+import type { TrainingContext, CatalogProduct, MediaBuyState, PackageState, SignalActivationState, CreativeState, CreativeManifest, ToolArgs, ListReference, PackageTargeting } from './types.js';
 import type {
   Product,
   Proposal,
@@ -60,7 +60,7 @@ function adcpError(code: string, opts: { message: string; details?: unknown; rec
 
 // Derive types from SDK request types that aren't re-exported from main entry
 type PackageUpdate = NonNullable<UpdateMediaBuyRequest['packages']>[number];
-type PackageUpdateExt = PackageUpdate & { canceled?: boolean; cancellation_reason?: string };
+type PackageUpdateExt = PackageUpdate & { canceled?: boolean; cancellation_reason?: string; targeting?: PackageTargeting };
 type Destination = NonNullable<ActivateSignalRequest['destinations']>[number];
 type SignalFilters = NonNullable<GetSignalsRequest['filters']>;
 type PricingOption = Product['pricing_options'][number];
@@ -90,12 +90,66 @@ interface PackageInput {
   start_time?: string;
   end_time?: string;
   format_ids?: FormatID[];
+  targeting?: PackageTargeting;
 }
 
 interface CreativeAssignmentInput {
   creative_id: string;
   package_id: string;
   media_buy_id: string;
+}
+
+const MAX_URL_LEN = 2048;
+const MAX_ID_LEN = 256;
+const MAX_TOKEN_LEN = 4096;
+
+function validateListRef(ref: unknown, pathLabel: string): { ref?: ListReference; error?: TaskError } {
+  if (ref === undefined || ref === null) return {};
+  if (typeof ref !== 'object' || Array.isArray(ref)) {
+    return { error: { code: 'VALIDATION_ERROR', message: `${pathLabel}: must be an object with agent_url and list_id`, field: pathLabel } };
+  }
+  const r = ref as Record<string, unknown>;
+  const agent_url = r.agent_url;
+  const list_id = r.list_id;
+  const auth_token = r.auth_token;
+  if (typeof agent_url !== 'string' || agent_url.length === 0 || agent_url.length > MAX_URL_LEN) {
+    return { error: { code: 'VALIDATION_ERROR', message: `${pathLabel}.agent_url: must be a non-empty string up to ${MAX_URL_LEN} chars`, field: `${pathLabel}.agent_url` } };
+  }
+  if (!/^https?:\/\//i.test(agent_url)) {
+    return { error: { code: 'VALIDATION_ERROR', message: `${pathLabel}.agent_url: must use http:// or https://`, field: `${pathLabel}.agent_url` } };
+  }
+  if (typeof list_id !== 'string' || list_id.length === 0 || list_id.length > MAX_ID_LEN) {
+    return { error: { code: 'VALIDATION_ERROR', message: `${pathLabel}.list_id: must be a non-empty string up to ${MAX_ID_LEN} chars`, field: `${pathLabel}.list_id` } };
+  }
+  if (auth_token !== undefined && (typeof auth_token !== 'string' || auth_token.length > MAX_TOKEN_LEN)) {
+    return { error: { code: 'VALIDATION_ERROR', message: `${pathLabel}.auth_token: must be a string up to ${MAX_TOKEN_LEN} chars`, field: `${pathLabel}.auth_token` } };
+  }
+  return { ref: { agent_url, list_id, ...(typeof auth_token === 'string' && { auth_token }) } };
+}
+
+function validateTargeting(t: unknown, pathLabel: string): { targeting?: PackageTargeting; errors: TaskError[] } {
+  if (t === undefined || t === null) return { errors: [] };
+  if (typeof t !== 'object' || Array.isArray(t)) {
+    return { errors: [{ code: 'VALIDATION_ERROR', message: `${pathLabel}: must be an object`, field: pathLabel }] };
+  }
+  const src = t as Record<string, unknown>;
+  const errors: TaskError[] = [];
+  const pl = validateListRef(src.property_list, `${pathLabel}.property_list`);
+  const cl = validateListRef(src.collection_list, `${pathLabel}.collection_list`);
+  const cle = validateListRef(src.collection_list_exclude, `${pathLabel}.collection_list_exclude`);
+  if (pl.error) errors.push(pl.error);
+  if (cl.error) errors.push(cl.error);
+  if (cle.error) errors.push(cle.error);
+  if (errors.length) return { errors };
+  if (!pl.ref && !cl.ref && !cle.ref) return { errors: [] };
+  return {
+    targeting: {
+      ...(pl.ref && { property_list: pl.ref }),
+      ...(cl.ref && { collection_list: cl.ref }),
+      ...(cle.ref && { collection_list_exclude: cle.ref }),
+    },
+    errors: [],
+  };
 }
 
 // Proposal lifecycle fields not yet in @adcp/client — remove after client update
@@ -173,6 +227,9 @@ import {
 } from './comply-test-controller.js';
 import { PUBLISHERS } from './publishers.js';
 
+const SUPPORTED_MAJOR_VERSIONS = [3] as const;
+const MAX_PACKAGES_PER_BUY = 50;
+
 // ── MCP Tasks store (SDK-managed) ─────────────────────────────────
 
 /**
@@ -215,7 +272,8 @@ interface TaskError {
   code: string;
   message: string;
   field?: string;
-  suggestion?: string;
+  details?: unknown;
+  recovery?: string;
 }
 
 /** Signal deployment entry in get_signals response. */
@@ -1165,6 +1223,12 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
     };
   }
 
+  if (req.packages.length > MAX_PACKAGES_PER_BUY) {
+    return {
+      errors: [{ code: 'LIMIT_EXCEEDED', message: `Too many packages: ${req.packages.length} (max ${MAX_PACKAGES_PER_BUY}).` }] as TaskError[],
+    };
+  }
+
   if (session.mediaBuys.size >= MAX_MEDIA_BUYS_PER_SESSION) {
     return {
       errors: [{ code: 'LIMIT_EXCEEDED', message: `Session limit reached (max ${MAX_MEDIA_BUYS_PER_SESSION} media buys). Start a new session.` }] as TaskError[],
@@ -1260,6 +1324,11 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
     }
 
     // Don't build package state if there are any validation errors (atomic create)
+    const targetingResult = validateTargeting(pkg.targeting, `packages[${i}].targeting`);
+    if (targetingResult.errors.length) {
+      errors.push(...targetingResult.errors);
+    }
+
     if (errors.length > 0) continue;
 
     const resolvedStart = startTime === 'asap' ? new Date().toISOString() : startTime;
@@ -1276,6 +1345,7 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
       endTime,
       formatIds: pkg.format_ids,
       creativeAssignments: [],
+      targeting: targetingResult.targeting,
     });
   }
 
@@ -1327,6 +1397,7 @@ function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
       start_time: pkg.startTime,
       end_time: pkg.endTime,
       ...(pkg.formatIds && { format_ids: pkg.formatIds }),
+      ...(pkg.targeting && { targeting: pkg.targeting }),
       creative_assignments: [],
     })),
   };
@@ -1406,6 +1477,7 @@ function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext) {
               creative_id: cid,
               approval_status: 'approved' as const,
             })),
+            ...(pkg.targeting && { targeting: pkg.targeting }),
             ...(pkg.canceledAt && {
               cancellation: {
                 canceled_at: pkg.canceledAt,
@@ -1891,12 +1963,32 @@ function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
           pkg.endTime = update.end_time;
         }
       }
+
+      if (update.targeting !== undefined) {
+        const targetingResult = validateTargeting(update.targeting, `packages[${pkgId}].targeting`);
+        if (targetingResult.errors.length) {
+          return { errors: targetingResult.errors };
+        }
+        const before = pkg.targeting;
+        pkg.targeting = targetingResult.targeting;
+        const changed = JSON.stringify(before ?? null) !== JSON.stringify(pkg.targeting ?? null);
+        if (changed) {
+          const action = pkg.targeting ? 'targeting_updated' : 'targeting_cleared';
+          const summary = pkg.targeting ? `Package ${pkgId} targeting updated` : `Package ${pkgId} targeting cleared`;
+          mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action, summary, packageId: pkgId });
+        }
+      }
     }
   }
 
   // Add new packages
   const newPackages = req.new_packages;
   if (newPackages?.length) {
+    if (mb.packages.length + newPackages.length > MAX_PACKAGES_PER_BUY) {
+      return {
+        errors: [{ code: 'LIMIT_EXCEEDED', message: `Adding ${newPackages.length} packages would exceed the per-buy limit of ${MAX_PACKAGES_PER_BUY}.` }] as TaskError[],
+      };
+    }
     const catalog = getCatalog();
     const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
 
@@ -1909,6 +2001,10 @@ function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
       }
 
       const pkgId = `pkg-${mb.packages.length + i}`;
+      const targetingResult = validateTargeting(npkg.targeting, `new_packages[${i}].targeting`);
+      if (targetingResult.errors.length) {
+        return { errors: targetingResult.errors };
+      }
       const newPkg: PackageState = {
         packageId: pkgId,
         productId,
@@ -1921,6 +2017,7 @@ function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
         endTime: npkg.end_time || mb.endTime,
         formatIds: npkg.format_ids,
         creativeAssignments: [],
+        targeting: targetingResult.targeting,
       };
       mb.packages.push(newPkg);
       mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'package_added', summary: `New package ${pkgId} added (product: ${productId})`, packageId: pkgId });
@@ -1946,6 +2043,7 @@ function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
       paused: pkg.paused,
       start_time: pkg.startTime,
       end_time: pkg.endTime,
+      ...(pkg.targeting && { targeting: pkg.targeting }),
       ...(pkg.canceledAt && {
         cancellation: { canceled_at: pkg.canceledAt, canceled_by: pkg.canceledBy, reason: pkg.cancellationReason },
       }),
@@ -1962,7 +2060,7 @@ function handleGetAdcpCapabilities(_args: ToolArgs, _ctx: TrainingContext): Reco
   const channels = [...new Set(PUBLISHERS.flatMap(p => p.channels))].sort();
   const publisherDomains = PUBLISHERS.map(p => p.domain);
   return {
-    adcp: { major_versions: [3] },
+    adcp: { major_versions: [...SUPPORTED_MAJOR_VERSIONS] },
     supported_protocols: ['media_buy', 'creative', 'governance', 'signals', 'brand', 'compliance_testing'],
     protocol_version: '3.0',
     tasks,
@@ -2040,12 +2138,6 @@ function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
   const signalSpec = req.signal_spec || req.brief;
   const maxResults = Math.min(Math.max(req.max_results || MAX_SIGNAL_RESULTS, 1), 50);
   const session = getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
-
-  if (!signalSpec && !req.signal_ids?.length) {
-    return {
-      errors: [{ code: 'INVALID_REQUEST', message: 'Either signal_spec or signal_ids is required' }],
-    };
-  }
 
   const allSignals = getAllSignals();
   let results = allSignals;
@@ -2890,6 +2982,18 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       return adcpError('INVALID_REQUEST', { message: `Unknown tool: ${name}` }, callerContext);
     }
 
+    const requestedVersion = (handlerArgs as { adcp_major_version?: unknown }).adcp_major_version;
+    if (
+      requestedVersion !== undefined
+      && !(SUPPORTED_MAJOR_VERSIONS as readonly number[]).includes(requestedVersion as number)
+    ) {
+      return adcpError('VERSION_UNSUPPORTED', {
+        message: `AdCP major version ${String(requestedVersion)} is not supported`,
+        details: { supported_major_versions: SUPPORTED_MAJOR_VERSIONS },
+        field: 'adcp_major_version',
+      }, callerContext);
+    }
+
     // Check for task-augmented request (explicit `task` field in params).
     // Dry-run requests always return synchronously — there's no reason to
     // async a dry-run operation, and clients expect immediate results.
@@ -2900,22 +3004,27 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       throw new Error(`Tool "${name}" does not support task augmentation`);
     }
 
-    // Execute the tool handler
+    // Execute the tool handler. Structured AdCP errors (handler returns
+    // { errors: [...] }) are well-formed responses — the task completes
+    // successfully with an adcp_error envelope. Only thrown exceptions
+    // mark the task as failed.
     let toolResult: CallToolResult;
-    let isError = false;
+    let taskFailed = false;
     try {
       const result = await Promise.resolve(handler((handlerArgs as ToolArgs) || {}, ctx));
-      const resultObj = result as { errors?: Array<{ code: string; message: string; field?: string }> };
+      const resultObj = result as { errors?: Array<{ code: string; message: string; field?: string; details?: unknown; recovery?: string }> };
       const hasErrors = resultObj.errors && resultObj.errors.length > 0;
       if (hasErrors) {
-        isError = true;
         const firstError = resultObj.errors![0];
         toolResult = adcpError(firstError.code, {
           message: firstError.message,
           ...(firstError.field && { field: firstError.field }),
-          details: resultObj.errors!.length > 1
-            ? { all_errors: resultObj.errors }
-            : undefined,
+          ...(firstError.recovery && { recovery: firstError.recovery }),
+          details: firstError.details !== undefined
+            ? firstError.details
+            : resultObj.errors!.length > 1
+              ? { all_errors: resultObj.errors }
+              : undefined,
         }, callerContext);
       } else {
         const response = callerContext !== undefined
@@ -2927,7 +3036,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       }
     } catch (error) {
       logger.error({ error, tool: name }, 'Training agent tool error');
-      isError = true;
+      taskFailed = true;
       toolResult = adcpError('SERVICE_UNAVAILABLE', {
         message: error instanceof Error ? error.message : 'Unknown error',
         recovery: 'transient',
@@ -2951,7 +3060,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     // after storing results, which fails in stateless HTTP mode (each
     // request uses a fresh transport). Using the raw store avoids this
     // while keeping tasks visible to subsequent tasks/get requests.
-    const terminalStatus: 'completed' | 'failed' = isError ? 'failed' : 'completed';
+    const terminalStatus: 'completed' | 'failed' = taskFailed ? 'failed' : 'completed';
     const created = await taskStore.createTask(
       { ttl: clampedTtl },
       0,
@@ -2962,7 +3071,13 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     if (!task) {
       throw new Error(`Task disappeared after creation for tool "${name}"`);
     }
-    logger.info({ taskId: task.taskId, tool: name, status: terminalStatus }, 'Created MCP task');
+    const errorCode = toolResult.isError
+      ? (toolResult.structuredContent as { adcp_error?: { code?: string } } | undefined)?.adcp_error?.code
+      : undefined;
+    logger.info(
+      { taskId: task.taskId, tool: name, status: terminalStatus, isError: !!toolResult.isError, ...(errorCode && { errorCode }) },
+      'Created MCP task',
+    );
 
     return { task } as object;
   });

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -264,6 +264,19 @@ export interface PackageState {
   endTime: string;
   formatIds?: FormatID[];
   creativeAssignments: string[];
+  targeting?: PackageTargeting;
+}
+
+export interface ListReference {
+  agent_url: string;
+  list_id: string;
+  auth_token?: string;
+}
+
+export interface PackageTargeting {
+  property_list?: ListReference;
+  collection_list?: ListReference;
+  collection_list_exclude?: ListReference;
 }
 
 /** A single asset slot inside a creative manifest (e.g., headline, hero_image). */

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -3297,11 +3297,11 @@ describe('get_signals handler', () => {
     stopSessionCleanup();
   });
 
-  it('returns error when neither signal_spec nor signal_ids provided', async () => {
+  it('returns full catalog (capped) when neither signal_spec nor signal_ids provided', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_signals', { account });
-    expect(result.code).toBeDefined();
-    expect(result.message).toContain('signal_spec or signal_ids');
+    expect(Array.isArray(result.signals)).toBe(true);
+    expect((result.signals as unknown[]).length).toBeGreaterThan(0);
   });
 
   it('discovers signals by natural language spec', async () => {
@@ -4440,7 +4440,7 @@ describe('MCP Tasks protocol', () => {
     expect(tasks.length).toBe(2);
   });
 
-  it('sets failed status when tool execution errors', async () => {
+  it('structured errors complete the task (with adcp_error in result)', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const response = await simulateCallToolAsTask(server, 'create_media_buy', {
       buyer_ref: 'test',
@@ -4448,12 +4448,19 @@ describe('MCP Tasks protocol', () => {
       brand: { domain: 'test.com' },
       start_time: '2025-01-01T00:00:00Z',
       end_time: '2025-02-01T00:00:00Z',
-      // Missing packages — will return validation error
+      // Missing packages — structured INVALID_REQUEST response, not a task failure
     });
 
     const task = response.task as Record<string, unknown>;
-    expect(task.taskId).toBeDefined();
-    expect(task.status).toBe('failed');
+    const taskId = task.taskId as string;
+    expect(taskId).toBeDefined();
+    expect(task.status).toBe('completed');
+
+    const result = await simulateGetTaskResult(server, taskId);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(content[0]!.text) as { adcp_error?: { code: string } };
+    expect(body.adcp_error?.code).toBe('INVALID_REQUEST');
   });
 
   it('rejects task augmentation on forbidden tools', async () => {
@@ -5985,5 +5992,289 @@ describe('context echo', () => {
     expect(parsed.success).toBe(false);
     expect(parsed.error).toBe('NOT_FOUND');
     expect(parsed.context).toEqual(TEST_CONTEXT);
+  });
+});
+
+describe('AdCP protocol compliance', () => {
+  beforeEach(() => {
+    clearSessions();
+  });
+  afterEach(() => {
+    clearSessions();
+    stopSessionCleanup();
+  });
+
+  it('rejects unsupported adcp_major_version with VERSION_UNSUPPORTED', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server, 'get_products', {
+      adcp_major_version: 99,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+    expect(isError).toBe(true);
+    expect(result.code).toBe('VERSION_UNSUPPORTED');
+    const details = result.details as { supported_major_versions?: number[] };
+    expect(details?.supported_major_versions).toContain(3);
+  });
+
+  it('accepts supported adcp_major_version', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server, 'get_products', {
+      adcp_major_version: 3,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+    expect(isError).toBeFalsy();
+    expect(Array.isArray(result.products)).toBe(true);
+  });
+
+  it('persists property_list and collection_list in package targeting', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      buying_mode: 'brief',
+      brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    const targeting = {
+      property_list: { agent_url: 'https://gov.example/mcp', list_id: 'pl_allow_v1' },
+      collection_list: { agent_url: 'https://gov.example/mcp', list_id: 'cl_shows_v1' },
+    };
+
+    const created = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 5000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+        targeting,
+      }],
+    });
+    const mediaBuyId = created.result.media_buy_id as string;
+    expect(mediaBuyId).toBeDefined();
+    const createdPackages = created.result.packages as Array<{ targeting?: unknown }>;
+    expect(createdPackages[0]!.targeting).toEqual(targeting);
+
+    const fetched = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const buy = (fetched.result.media_buys as Array<{ packages: Array<{ targeting?: unknown }> }>)[0]!;
+    expect(buy.packages[0]!.targeting).toEqual(targeting);
+  });
+
+  it('persists collection_list_exclude in package targeting', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account, brand: { domain: 'acmeoutdoor.example' }, buying_mode: 'brief', brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    const targeting = {
+      collection_list_exclude: { agent_url: 'https://gov.example/mcp', list_id: 'cl_block_v1', auth_token: 'tok_secret' },
+    };
+
+    const created = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 5000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+        targeting,
+      }],
+    });
+    const createdPackages = created.result.packages as Array<{ targeting?: unknown }>;
+    expect(createdPackages[0]!.targeting).toEqual(targeting);
+  });
+
+  it('update_media_buy round-trips targeting changes', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account, brand: { domain: 'acmeoutdoor.example' }, buying_mode: 'brief', brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    const initialTargeting = {
+      property_list: { agent_url: 'https://gov.example/mcp', list_id: 'pl_v1' },
+    };
+    const created = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 5000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+        targeting: initialTargeting,
+      }],
+    });
+    const mediaBuyId = created.result.media_buy_id as string;
+    const packageId = (created.result.packages as Array<{ package_id: string }>)[0]!.package_id;
+
+    const newTargeting = {
+      property_list: { agent_url: 'https://gov.example/mcp', list_id: 'pl_v2' },
+      collection_list: { agent_url: 'https://gov.example/mcp', list_id: 'cl_v2' },
+    };
+    await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: packageId, targeting: newTargeting }],
+    });
+
+    const fetched = await simulateCallTool(server, 'get_media_buys', {
+      account, media_buy_ids: [mediaBuyId],
+    });
+    const buy = (fetched.result.media_buys as Array<{ packages: Array<{ targeting?: unknown }> }>)[0]!;
+    expect(buy.packages[0]!.targeting).toEqual(newTargeting);
+  });
+
+  it('rejects malformed targeting with VALIDATION_ERROR', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account, brand: { domain: 'acmeoutdoor.example' }, buying_mode: 'brief', brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    // Missing agent_url
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 5000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+        targeting: { property_list: { list_id: 'pl_v1' } },
+      }],
+    });
+    expect(isError).toBe(true);
+    expect(result.code).toBe('VALIDATION_ERROR');
+    expect(result.field).toContain('property_list.agent_url');
+  });
+
+  it('rejects non-http(s) agent_url in targeting', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account, brand: { domain: 'acmeoutdoor.example' }, buying_mode: 'brief', brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 5000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+        targeting: { property_list: { agent_url: 'javascript:alert(1)', list_id: 'pl_v1' } },
+      }],
+    });
+    expect(isError).toBe(true);
+    expect(result.code).toBe('VALIDATION_ERROR');
+    expect(result.message).toContain('http');
+  });
+
+  it('GOVERNANCE_DENIED via task-augmented call completes the task with structured error', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.com' };
+    // Seed a denied governance check via sync_plans + check_governance (shared session key)
+    await simulateCallTool(server, 'sync_plans', {
+      account,
+      plans: [{
+        plan_id: 'gov_test_strict',
+        brand: { domain: 'acmeoutdoor.example' },
+        objectives: 'strict',
+        budget: { total: 10000, currency: 'USD', authority_level: 'agent_limited' },
+        flight: { start: new Date().toISOString(), end: new Date(Date.now() + 90 * 86_400_000).toISOString() },
+      }],
+    });
+    const govContext = 'gov-ctx-test-denied';
+    const checkResponse = await simulateCallTool(server, 'check_governance', {
+      account,
+      plan_id: 'gov_test_strict',
+      governance_context: govContext,
+      caller: 'acmeoutdoor.example',
+      payload: { type: 'media_buy', account, total_budget: 50000 },
+    });
+    expect(checkResponse.result.status).toBe('denied');
+
+    const productsResponse = await simulateCallTool(server, 'get_products', {
+      account, brand: { domain: 'acmeoutdoor.example' }, buying_mode: 'brief', brief: 'display',
+    });
+    const products = productsResponse.result.products as Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string; pricing_model: string; floor_price?: number }> }>;
+    const product = products[0]!;
+    const pricing = product.pricing_options[0]!;
+    const bidPrice = pricing.pricing_model === 'cpm' || pricing.pricing_model === 'vcpm'
+      ? (pricing.floor_price ?? 5) * 1.5
+      : undefined;
+
+    // Task-augmented create_media_buy with denied governance_context
+    const response = await simulateCallToolAsTask(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'acmeoutdoor.example' },
+      governance_context: govContext,
+      start_time: new Date(Date.now() + 86_400_000).toISOString(),
+      end_time: new Date(Date.now() + 8 * 86_400_000).toISOString(),
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricing.pricing_option_id,
+        budget: 50000,
+        ...(bidPrice !== undefined && { bid_price: bidPrice }),
+      }],
+    });
+    const task = response.task as Record<string, unknown>;
+    expect(task.status).toBe('completed');
+
+    const taskResult = await simulateGetTaskResult(server, task.taskId as string);
+    expect(taskResult.isError).toBe(true);
+    const body = JSON.parse((taskResult.content as Array<{ text: string }>)[0]!.text) as { adcp_error?: { code: string } };
+    expect(body.adcp_error?.code).toBe('GOVERNANCE_DENIED');
   });
 });


### PR DESCRIPTION
## Summary

Five bug fixes for the training agent (the public test agent at `test-agent.adcontextprotocol.org`) that buyers hit running storyboards. All independent of the cross-machine session persistence work.

- **#2235** — `create_media_buy` and `update_media_buy` now persist `package.targeting.property_list / collection_list / collection_list_exclude` and echo them on `get_media_buys`. Refs are validated (type, length, http(s) scheme) and malformed input returns `VALIDATION_ERROR` instead of being silently dropped. Adds `MAX_PACKAGES_PER_BUY = 50`.
- **#2236** — `get_collection_list` / `update_collection_list` / `delete_collection_list` validate `list_id` (type + length) so missing or wrong-shape input returns a structured `VALIDATION_ERROR`.
- **#2237** — Structured AdCP errors (handler returning `{ errors: [...] }`) now complete the MCP task instead of marking it failed. Clients see the `GOVERNANCE_DENIED` / `INVALID_REQUEST` / etc. code in the response body rather than `MCP -32603: Task failed`. Only thrown exceptions mark a task as failed. Task-created log carries `errorCode` so anomaly monitoring can still distinguish structured-error from successful runs.
- **#2238** — Central dispatcher validates `adcp_major_version` against `SUPPORTED_MAJOR_VERSIONS` (`[3]`) and returns `VERSION_UNSUPPORTED` with the supported list in `details`.
- **#2239** — `get_signals` returns the full catalog (capped at `MAX_SIGNAL_RESULTS=10`) when called without `signal_spec` or `signal_ids`, supporting browse-style discovery instead of returning `INVALID_REQUEST`.

## Reviews

Ran code-reviewer and security-reviewer; addressed all Should-Fix items:
- Tightened targeting normalization (type/length/http(s) scheme, reject malformed instead of silent-drop)
- Added `list_id` type validation across all collection-list handlers
- Consolidated duplicate `ListReference` / `PackageTargeting` types
- Extended `PackageUpdateExt` to include `targeting`
- Widened `TaskError` to include `details` / `recovery`
- Added `MAX_PACKAGES_PER_BUY` cap (DoS amplification mitigation in shared sandbox)
- Added missing test coverage (update round-trip, exclude, GOVERNANCE_DENIED via task, malformed targeting)
- Added `errorCode` to task-created log for anomaly monitoring

## Test plan

- [x] 599 unit tests pass (286 in `training-agent.test.ts` including 8 new compliance tests)
- [x] `npm run typecheck` clean
- [ ] CI passes
- [ ] Storyboard regression check against `test-agent.adcontextprotocol.org` after deploy:
  - [ ] `governance_denied_recovery` — see `GOVERNANCE_DENIED` instead of `MCP -32603`
  - [ ] `error_compliance` `version_negotiation` — see `VERSION_UNSUPPORTED`
  - [ ] `signal_marketplace` discover step — `get_signals` returns signals
  - [ ] `inventory_list_targeting` — targeting echoes back from `get_media_buys`
  - [ ] `collection_governance` — `get_collection_list` returns the list

## Out of scope

Cross-machine session persistence (`property_list` create on machine A → get on machine B = not found) — deferred to follow-up that uses the new `AdcpStateStore` from `@adcp/client#541`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)