### PR TITLE
fix: make API key revoke idempotent on WorkOS 404

### DIFF
--- a/.changeset/api-key-revoke-idempotent.md
+++ b/.changeset/api-key-revoke-idempotent.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make API key revoke idempotent: treat WorkOS 404 as success so double-clicks or already-deleted keys no longer surface as "Failed to revoke API key" errors to the user.

--- a/server/src/routes/api-keys.ts
+++ b/server/src/routes/api-keys.ts
@@ -224,12 +224,23 @@ export function createApiKeysRouter(): Router {
       if (!(await verifyOrgMembership(req, res, organizationId))) return;
 
       const apiKeyId = req.params.id;
-      await workosRequest("DELETE", `/organizations/${organizationId}/api_keys/${apiKeyId}`);
-
-      logger.info(
-        { userId: req.user!.id, organizationId, apiKeyId },
-        "API key revoked",
-      );
+      try {
+        await workosRequest("DELETE", `/organizations/${organizationId}/api_keys/${apiKeyId}`);
+        logger.info(
+          { userId: req.user!.id, organizationId, apiKeyId },
+          "API key revoked",
+        );
+      } catch (error) {
+        const status =
+          error instanceof Error && "status" in error && typeof (error as { status: unknown }).status === "number"
+            ? (error as { status: number }).status
+            : null;
+        if (status !== 404) throw error;
+        logger.info(
+          { userId: req.user!.id, organizationId, apiKeyId },
+          "API key revoke: already absent in WorkOS",
+        );
+      }
 
       res.status(204).end();
     } catch (error) {


### PR DESCRIPTION
## Summary
- Revoking an API key that WorkOS no longer has (double-click, already revoked, or upstream-deleted) surfaced as a 404 → "Failed to revoke API key" error to the user, and logged as an error server-side.
- The DELETE handler now catches 404 from WorkOS, logs at info level ("already absent"), and returns 204. All other errors continue to propagate through `sendWorkOSError`.
- DELETE is idempotent per HTTP semantics (RFC 7231); the desired end state — key doesn't exist — is already achieved when WorkOS 404s.

## Test plan
- [ ] Revoke a valid key → 204, "API key revoked" log line.
- [ ] Revoke the same key twice (second call should 204 with "already absent" log line rather than 404).
- [ ] Revoke with a bogus org id you're not a member of → still 403 (unchanged).
- [ ] WorkOS returning 500/other non-404 still surfaces as error to client (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)