### PR TITLE
fix: force revalidation on /schemas/latest and version aliases

### DIFF
--- a/.changeset/schemas-latest-no-cache.md
+++ b/.changeset/schemas-latest-no-cache.md
@@ -1,0 +1,4 @@
+---
+---
+
+Force revalidation on `/schemas/latest/` and version aliases (`/v2`, `/v2.5`, `/v3`, etc.) by serving `Cache-Control: public, no-cache, must-revalidate` instead of the 10-minute default. Pinned semver paths (`/3.0.0-rc.3/...`) remain `immutable`. Prevents edge caches from serving different versions from different POPs while an alias retargets, which caused CI drift for consumers generating types from the schemas.

--- a/server/src/schemas-middleware.ts
+++ b/server/src/schemas-middleware.ts
@@ -129,16 +129,22 @@ export function mountSchemasRoutes(app: Application, schemasPath: string): void 
       }
     }
 
-    // 2. Redirect bare version directories to their index.json.
-    if (VERSIONED_DIR.test(req.path)) {
-      return res.redirect("/schemas" + req.path + "index.json");
-    }
-
-    // 3. Only direct versioned paths (client pinned a full semver) are immutable.
-    //    Aliases and /latest/ keep the static 10m + ETag default so caches
-    //    revalidate when the alias retargets to a new version.
+    // 2. Set cache-control based on the original request path:
+    //    - Pinned semver (client asked for an immutable version): 1-year immutable.
+    //    - /latest/ and aliases (/v2, /v2.5, ...): no-cache + ETag, so shared
+    //      caches revalidate on every request and pick up retargeting immediately.
+    //      Without this, edge caches can serve different versions from different
+    //      POPs within their TTL window and cause drift for consumers generating
+    //      types from the schemas.
     if (!isAlias && IMMUTABLE_PATH.test(originalPath)) {
       res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    } else {
+      res.setHeader("Cache-Control", "public, no-cache, must-revalidate");
+    }
+
+    // 3. Redirect bare version directories to their index.json.
+    if (VERSIONED_DIR.test(req.path)) {
+      return res.redirect("/schemas" + req.path + "index.json");
     }
 
     schemasStatic(req, res, next);

--- a/server/tests/integration/schema-routing.test.ts
+++ b/server/tests/integration/schema-routing.test.ts
@@ -111,27 +111,44 @@ describe("/schemas HTTP routing", () => {
   });
 
   describe("cache-control policy", () => {
-    // Aliases and /latest/ must not be immutably cached — they retarget over time.
-    // Only direct versioned paths (client pinned a full semver) get immutable.
-    it("does NOT mark alias file responses immutable", async () => {
+    // Aliases and /latest/ must force revalidation — they retarget over time,
+    // and edge caches serving stale copies cause version drift for consumers
+    // that fetch schemas to generate types.
+    it("marks alias file responses no-cache", async () => {
       if (!latestStableMajor2) return;
       const res = await request(app).get("/schemas/v2/adagents.json");
       expect(res.status).toBe(200);
       expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
     });
 
-    it("does NOT mark minor-alias file responses immutable", async () => {
+    it("marks minor-alias file responses no-cache", async () => {
       if (!latestStableMajor2) return;
       const res = await request(app).get("/schemas/v2.5/adagents.json");
       expect(res.status).toBe(200);
       expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
     });
 
-    it("does NOT mark /latest/ file responses immutable", async () => {
+    it("marks /latest/ file responses no-cache", async () => {
       const res = await request(app).get("/schemas/latest/adagents.json");
       // /latest/ may or may not exist depending on build; only assert when present.
       if (res.status !== 200) return;
       expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
+    });
+
+    it("marks alias bare-directory redirects no-cache", async () => {
+      if (!latestStableMajor2) return;
+      const res = await request(app).get("/schemas/v2/");
+      expect(res.status).toBe(302);
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
+    });
+
+    it("marks /latest/ bare-directory redirect no-cache", async () => {
+      const res = await request(app).get("/schemas/latest/");
+      if (res.status !== 302) return;
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
     });
   });
 


### PR DESCRIPTION
## Summary

- `/schemas/latest/*` and version aliases (`/v2`, `/v2.5`, `/v3`, …) now send `Cache-Control: public, no-cache, must-revalidate` so Cloudflare edges revalidate every request via ETag (cheap 304s when unchanged).
- Pinned semver paths (`/3.0.0-rc.3/...`) unchanged — still `public, max-age=31536000, immutable`.
- Moved the Cache-Control assignment above the bare-directory redirect so 302s from `/latest/` → `/latest/index.json` carry the correct header.

## Why

Cloudflare edge POPs were caching mutable schema paths for up to 4 hours (the zone-level Browser Cache TTL was overriding origin). Different POPs could serve different versions during that window — consumers fetching schemas to generate types saw drift between CI and local runs. Zone-level Browser Cache TTL has since been flipped to "Respect Existing Headers," so origin's new `no-cache` directive will pass through cleanly.

## Test plan

- [x] `server/tests/integration/schema-routing.test.ts` — 16/16 passing, added 2 redirect assertions
- [x] Full `npm run test:unit` — 587/587 passing
- [x] Typecheck clean
- [ ] Post-deploy: `curl -I https://adcontextprotocol.org/schemas/latest/adagents.json` shows `cache-control: public, no-cache, must-revalidate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)