### PR TITLE
fix: include CHANGELOG.md in deployed protocol tarball

### DIFF
--- a/.changeset/fix-changelog-in-tarball.md
+++ b/.changeset/fix-changelog-in-tarball.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix: include CHANGELOG.md in deployed protocol tarball
+
+`.dockerignore` was stripping all `*.md` except `README.md`, so the builder stage had no `CHANGELOG.md` on disk when `build:protocol-tarball` ran, and deployed tarballs shipped with `manifest.changelog: false`. Added `!CHANGELOG.md` exception. Takes effect on next deploy.

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@ dist/schemas/registry.*
 .github
 *.md
 !README.md
+!CHANGELOG.md
 .venv
 .conductor
 .context


### PR DESCRIPTION
## Summary
- `.dockerignore` was stripping all `*.md` except `README.md`, so the Docker builder stage had no `CHANGELOG.md` on disk when `build:protocol-tarball` ran — every deployed `/protocol/latest.tgz` shipped with `manifest.changelog: false` and no `CHANGELOG.md` inside.
- One-line fix: add `!CHANGELOG.md` exception to `.dockerignore` so it rides along into the Docker build context. Takes effect on next deploy.

## Verification
Local rebuild with the fix produces a tarball containing `adcp-latest/CHANGELOG.md` and `manifest.changelog: true`.

## Test plan
- [ ] After deploy, `curl -s https://adcontextprotocol.org/protocol/latest.tgz | tar tzO adcp-latest/manifest.json` shows `"changelog": true`
- [ ] `tar tzf` on the deployed tarball lists `adcp-latest/CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)