### PR TITLE
admin: show member join date, seat type, paid status on account page

### DIFF
--- a/.changeset/admin-account-members-product-paid-status.md
+++ b/.changeset/admin-account-members-product-paid-status.md
@@ -1,0 +1,4 @@
+---
+---
+
+Admin: surface member join date, seat type (product), and a paid-status summary on the account detail page so staff can review who has what access at a glance.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -865,6 +865,7 @@
               <button id="migrateMembersBtn" class="btn btn-sm btn-secondary" onclick="openMigrateMembersModal()" style="display: none;">Migrate Members</button>
             </div>
             <div class="collapsible-content" id="membersContent" style="margin-top: var(--space-4);">
+              <div id="paidStatusSummary" style="display: none; padding: var(--space-2) var(--space-3); background: var(--color-gray-50); border-radius: var(--radius-sm); margin-bottom: var(--space-3); font-size: var(--text-xs); color: var(--color-text-secondary);"></div>
               <!-- Website Members -->
               <div id="membersSectionWrapper">
                 <h3 style="font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-2); font-weight: 600;">Website Members</h3>
@@ -1645,6 +1646,34 @@
       // Set total user count in header
       document.getElementById('memberCount').textContent = totalUserCount > 0 ? `(${totalUserCount})` : '';
 
+      // Paid status summary: subscription + seat breakdown
+      const paidSummaryEl = document.getElementById('paidStatusSummary');
+      if (memberCount > 0 || a.subscription) {
+        const contributorCount = (a.members || []).filter(m => (m.seat_type || 'contributor') === 'contributor').length;
+        const communityCount = (a.members || []).filter(m => m.seat_type === 'community_only').length;
+        const parts = [];
+        if (a.subscription) {
+          const statusClass = a.subscription.status === 'active' ? 'status-active' : 'status-prospect';
+          const label = a.subscription.product_name || a.subscription.status || 'subscription';
+          parts.push(`<span class="status-badge ${statusClass}" style="font-size: var(--text-xs);">${escapeHtml(label)}</span>`);
+          if (a.subscription.current_period_end) {
+            parts.push(`renews ${formatDate(a.subscription.current_period_end)}`);
+          }
+          if (a.subscription.canceled_at) {
+            parts.push(`canceled ${formatDate(a.subscription.canceled_at)}`);
+          }
+        } else {
+          parts.push(`<span class="status-badge status-prospect" style="font-size: var(--text-xs);">no subscription</span>`);
+        }
+        if (memberCount > 0) {
+          parts.push(`${contributorCount} contributor${contributorCount === 1 ? '' : 's'}, ${communityCount} community`);
+        }
+        paidSummaryEl.innerHTML = parts.join(' &middot; ');
+        paidSummaryEl.style.display = '';
+      } else {
+        paidSummaryEl.style.display = 'none';
+      }
+
       // Website members
       if (a.members && a.members.length > 0) {
         // Show migrate button if there are members
@@ -1670,17 +1699,27 @@
           </li>`;
         }
 
+        const SEAT_LABELS = {
+          contributor: 'Contributor',
+          community_only: 'Community',
+        };
         for (const m of a.members) {
           const name = [m.firstName, m.lastName].filter(Boolean).join(' ') || m.email;
           const role = m.role || 'member';
+          const seat = m.seat_type || 'contributor';
+          const seatLabel = SEAT_LABELS[seat] || seat;
+          const joinedLabel = m.joined_at ? `Joined ${formatDate(m.joined_at)}` : '';
           membersHtml += `<li data-member-id="${escapeHtml(m.id)}" data-current-role="${escapeHtml(role)}">
             <span class="member-name-link" onclick="viewMemberContext(this.parentElement.dataset.memberId)">${escapeHtml(name)}</span>
+            <span class="status-badge status-prospect" style="margin-left: var(--space-2); font-size: var(--text-xs);">${escapeHtml(seatLabel)}</span>
             <select class="role-select" onchange="updateUserRole(this.parentElement.dataset.memberId, this.value, this.parentElement.dataset.currentRole)">
               <option value="member" ${role === 'member' ? 'selected' : ''}>Member</option>
               <option value="admin" ${role === 'admin' ? 'selected' : ''}>Admin</option>
               <option value="owner" ${role === 'owner' ? 'selected' : ''}>Owner</option>
             </select>
-            <div style="color: var(--color-text-muted); font-size: var(--text-xs);">${escapeHtml(m.email)}</div>
+            <div style="color: var(--color-text-muted); font-size: var(--text-xs);">
+              ${escapeHtml(m.email)}${joinedLabel ? ` &middot; ${escapeHtml(joinedLabel)}` : ''}
+            </div>
           </li>`;
         }
         document.getElementById('membersList').innerHTML = membersHtml;

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -499,7 +499,9 @@ export function setupAccountRoutes(
               email,
               first_name,
               last_name,
-              role
+              role,
+              seat_type,
+              created_at
             FROM organization_memberships
             WHERE workos_organization_id = $1
             ORDER BY created_at ASC
@@ -848,6 +850,8 @@ export function setupAccountRoutes(
             firstName: m.first_name,
             lastName: m.last_name,
             role: m.role || "member",
+            seat_type: m.seat_type || "contributor",
+            joined_at: m.created_at,
           })),
           member_count: membersResult.rows.length,
           working_groups: workingGroupResult.rows,


### PR DESCRIPTION
## Summary
- Returns `seat_type` and `joined_at` for each member in `GET /api/admin/accounts/:orgId`
- Admin account detail page now shows a per-member seat badge (Contributor / Community) and join date
- Adds a paid-status summary row to the Users card: subscription product + status, renewal / cancel date, contributor vs community seat counts

Closes #2275

## Test plan
- [ ] Visit an admin account page for an org with an active subscription and multiple members — confirm subscription badge, renewal date, and seat counts render
- [ ] Visit an account with no subscription — confirm "no subscription" badge shows
- [ ] Visit an account with members of mixed `seat_type` — confirm per-member badges and join dates display correctly
- [ ] Visit an account with no members — confirm summary hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)