### PR TITLE
fix(digest): wrong column names in getDigestEmailRecipients

### DIFF
--- a/.changeset/fix-digest-recipients-module-id.md
+++ b/.changeset/fix-digest-recipients-module-id.md
@@ -1,4 +1,6 @@
 ---
 ---
 
-Fix crash in `getDigestEmailRecipients` — `certification_modules` has neither a `module_id` column nor an `is_active` column. Count capstone modules (`format = 'capstone'`) to match the per-capstone semantics of `cert_modules_completed` (which counts completed `certification_attempts`).
+Fix crash in `getDigestEmailRecipients` — `certification_modules` has neither a `module_id` column nor an `is_active` column, so the previous subquery threw `column "module_id" does not exist`.
+
+Also correct the semantics for the newsletter's "You're X modules in — Y to go for your certification" nudge: `cert_modules_completed` and `cert_total_modules` are now scoped to the user's most recently touched track (via `learner_progress` joined to `certification_modules`). Previously the completed count was pulled from `certification_attempts` (track-level capstones, not modules) and the total was across every track globally, which overstated "Y to go" for users pursuing a single track.

--- a/.changeset/fix-digest-recipients-module-id.md
+++ b/.changeset/fix-digest-recipients-module-id.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix crash in `getDigestEmailRecipients` — `certification_modules` has neither a `module_id` column nor an `is_active` column. Count capstone modules (`format = 'capstone'`) to match the per-capstone semantics of `cert_modules_completed` (which counts completed `certification_attempts`).

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -540,8 +540,13 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
        o.journey_stage,
        om.seat_type,
        COALESCE((SELECT COUNT(*) FROM working_group_memberships wgm WHERE wgm.workos_user_id = u.workos_user_id AND wgm.status = 'active'), 0)::int AS wg_count,
-       COALESCE((SELECT COUNT(*) FROM certification_attempts ca WHERE ca.workos_user_id = u.workos_user_id AND ca.status = 'completed'), 0)::int AS cert_modules_completed,
-       COALESCE((SELECT COUNT(*) FROM certification_modules WHERE format = 'capstone'), 0)::int AS cert_total_modules,
+       COALESCE((SELECT COUNT(*) FROM learner_progress lp
+                 JOIN certification_modules cm ON cm.id = lp.module_id
+                 WHERE lp.workos_user_id = u.workos_user_id
+                   AND lp.status IN ('completed', 'tested_out')
+                   AND cm.track_id = active_track.track_id), 0)::int AS cert_modules_completed,
+       COALESCE((SELECT COUNT(*) FROM certification_modules
+                 WHERE track_id = active_track.track_id), 0)::int AS cert_total_modules,
        COALESCE(o.subscription_status = 'active', FALSE) AS is_member,
        (u.first_name IS NOT NULL AND u.last_name IS NOT NULL) AS has_profile
      FROM users u
@@ -549,6 +554,14 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
        ON om.workos_user_id = u.workos_user_id
      LEFT JOIN organizations o
        ON o.workos_organization_id = om.workos_organization_id
+     LEFT JOIN LATERAL (
+       SELECT cm.track_id
+       FROM learner_progress lp
+       JOIN certification_modules cm ON cm.id = lp.module_id
+       WHERE lp.workos_user_id = u.workos_user_id
+       ORDER BY lp.updated_at DESC
+       LIMIT 1
+     ) active_track ON TRUE
      WHERE u.email IS NOT NULL
        AND u.email != ''
        AND NOT EXISTS (

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -554,12 +554,17 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
        ON om.workos_user_id = u.workos_user_id
      LEFT JOIN organizations o
        ON o.workos_organization_id = om.workos_organization_id
+     -- "Active track" = the track the user most recently touched. A learner
+     -- halfway through track A who briefly opens a track-B module will get
+     -- B-scoped counts on the next digest; that's the intended nudge behavior.
+     -- module_id tiebreaker keeps the choice deterministic across identical
+     -- updated_at values (possible on backfills or same-request writes).
      LEFT JOIN LATERAL (
        SELECT cm.track_id
        FROM learner_progress lp
        JOIN certification_modules cm ON cm.id = lp.module_id
        WHERE lp.workos_user_id = u.workos_user_id
-       ORDER BY lp.updated_at DESC
+       ORDER BY lp.updated_at DESC, lp.module_id DESC
        LIMIT 1
      ) active_track ON TRUE
      WHERE u.email IS NOT NULL

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -541,7 +541,7 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
        om.seat_type,
        COALESCE((SELECT COUNT(*) FROM working_group_memberships wgm WHERE wgm.workos_user_id = u.workos_user_id AND wgm.status = 'active'), 0)::int AS wg_count,
        COALESCE((SELECT COUNT(*) FROM certification_attempts ca WHERE ca.workos_user_id = u.workos_user_id AND ca.status = 'completed'), 0)::int AS cert_modules_completed,
-       COALESCE((SELECT COUNT(DISTINCT module_id) FROM certification_modules WHERE is_active = TRUE), 0)::int AS cert_total_modules,
+       COALESCE((SELECT COUNT(*) FROM certification_modules WHERE format = 'capstone'), 0)::int AS cert_total_modules,
        COALESCE(o.subscription_status = 'active', FALSE) AS is_member,
        (u.first_name IS NOT NULL AND u.last_name IS NOT NULL) AS has_profile
      FROM users u

--- a/server/tests/integration/digest-email-recipients.test.ts
+++ b/server/tests/integration/digest-email-recipients.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for getDigestEmailRecipients SQL — specifically the per-track scoping
+ * of cert_modules_completed / cert_total_modules via the "active track" LATERAL.
+ *
+ * Regression guard for two prior bugs:
+ * 1. Crash: query referenced certification_modules.module_id / is_active (neither
+ *    column exists; PK is id, and there is no activity flag).
+ * 2. Semantics: counts were global across all tracks, so the newsletter nudge
+ *    "You're X modules in — Y to go" overstated "Y to go" for single-track users.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { getDigestEmailRecipients } from '../../src/db/digest-db.js';
+
+const TEST_USER = 'test-digest-recip-001';
+const TEST_EMAIL = `${TEST_USER}@test.example.com`;
+
+async function seedUser() {
+  await query('DELETE FROM learner_progress WHERE workos_user_id = $1', [TEST_USER]);
+  await query('DELETE FROM user_email_category_preferences WHERE user_preference_id IN (SELECT id FROM user_email_preferences WHERE workos_user_id = $1)', [TEST_USER]);
+  await query('DELETE FROM user_email_preferences WHERE workos_user_id = $1', [TEST_USER]);
+  await query('DELETE FROM users WHERE workos_user_id = $1', [TEST_USER]);
+
+  await query(
+    `INSERT INTO users (workos_user_id, email, first_name, last_name)
+     VALUES ($1, $2, 'Test', 'User')`,
+    [TEST_USER, TEST_EMAIL]
+  );
+  await query(
+    `INSERT INTO user_email_preferences (workos_user_id, email, unsubscribe_token, marketing_opt_in, marketing_opt_in_at)
+     VALUES ($1, $2, $3, TRUE, NOW())`,
+    [TEST_USER, TEST_EMAIL, `tok-${TEST_USER}`]
+  );
+}
+
+async function recipient() {
+  const rows = await getDigestEmailRecipients();
+  const r = rows.find(x => x.workos_user_id === TEST_USER);
+  if (!r) throw new Error(`test user not returned by getDigestEmailRecipients`);
+  return r;
+}
+
+describe('getDigestEmailRecipients — active track scoping', () => {
+  beforeAll(async () => {
+    initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:51734/adcp_registry',
+    });
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    await query('DELETE FROM learner_progress WHERE workos_user_id = $1', [TEST_USER]);
+    await query('DELETE FROM user_email_category_preferences WHERE user_preference_id IN (SELECT id FROM user_email_preferences WHERE workos_user_id = $1)', [TEST_USER]);
+    await query('DELETE FROM user_email_preferences WHERE workos_user_id = $1', [TEST_USER]);
+    await query('DELETE FROM users WHERE workos_user_id = $1', [TEST_USER]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await seedUser();
+  });
+
+  it('returns 0/0 when the user has no learner_progress rows', async () => {
+    const r = await recipient();
+    expect(r.cert_modules_completed).toBe(0);
+    expect(r.cert_total_modules).toBe(0);
+  });
+
+  it('scopes counts to the track most recently touched', async () => {
+    // Track A: A1 + A2 completed, touched earlier (should NOT be the active track)
+    await query(
+      `INSERT INTO learner_progress (workos_user_id, module_id, status, updated_at)
+       VALUES
+         ($1, 'A1', 'completed', NOW() - INTERVAL '2 days'),
+         ($1, 'A2', 'completed', NOW() - INTERVAL '2 days')`,
+      [TEST_USER]
+    );
+    // Track B: B1 completed + B2 in_progress, touched most recently → active track = B
+    await query(
+      `INSERT INTO learner_progress (workos_user_id, module_id, status, updated_at)
+       VALUES
+         ($1, 'B1', 'completed', NOW() - INTERVAL '1 hour'),
+         ($1, 'B2', 'in_progress', NOW())`,
+      [TEST_USER]
+    );
+
+    const r = await recipient();
+    // Track B has 3 seeded modules (B1, B2, B3); 1 is completed.
+    expect(r.cert_modules_completed).toBe(1);
+    expect(r.cert_total_modules).toBe(3);
+  });
+
+  it('counts tested_out the same as completed', async () => {
+    await query(
+      `INSERT INTO learner_progress (workos_user_id, module_id, status, updated_at)
+       VALUES
+         ($1, 'A1', 'tested_out', NOW() - INTERVAL '1 hour'),
+         ($1, 'A2', 'completed', NOW())`,
+      [TEST_USER]
+    );
+
+    const r = await recipient();
+    expect(r.cert_modules_completed).toBe(2);
+    expect(r.cert_total_modules).toBe(3);
+  });
+
+  it('breaks updated_at ties deterministically via module_id DESC', async () => {
+    // Two rows with identical updated_at on different tracks. The ORDER BY
+    // tiebreak of module_id DESC should pick 'B1' > 'A1', so active track = B.
+    await query(
+      `INSERT INTO learner_progress (workos_user_id, module_id, status, updated_at)
+       VALUES
+         ($1, 'A1', 'in_progress', '2026-04-17 12:00:00+00'),
+         ($1, 'B1', 'in_progress', '2026-04-17 12:00:00+00')`,
+      [TEST_USER]
+    );
+
+    // Run several times to make sure the pick is stable (non-deterministic
+    // behavior would show up as flakes here).
+    for (let i = 0; i < 5; i++) {
+      const r = await recipient();
+      expect(r.cert_total_modules).toBe(3); // track B has 3 modules
+      expect(r.cert_modules_completed).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes to `getDigestEmailRecipients` in `server/src/db/digest-db.ts`:

- **Crash fix**: the recipient-count query threw `column "module_id" does not exist`. `certification_modules` has neither a `module_id` nor an `is_active` column (PK is `id`; no activity flag). The bad subquery was introduced in #1939 and was wrong from the moment it merged.
- **Semantic fix**: `cert_modules_completed` / `cert_total_modules` now reflect the user's actual active track, not global aggregates. Previously:
  - `cert_modules_completed` counted completed `certification_attempts` — track-level capstone attempts, not modules.
  - `cert_total_modules` (after the quick crash fix) counted capstone modules across all tracks.
  - Result: the newsletter nudge text "You're X modules in — Y to go for your certification" overstated "Y to go" for users pursuing a single track.

New behavior uses a `LATERAL` join to find the user's most recently touched track in `learner_progress`, then:
- `cert_modules_completed` = `learner_progress` rows in that track with status `completed` or `tested_out`.
- `cert_total_modules` = `certification_modules` in that track.
- If the user has never started a track, both counts are 0 and the existing `cert_modules_completed > 0` guard skips the nudge.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:unit` — 587 tests pass
- [ ] Trigger newsletter admin "get recipient count" in staging and confirm it no longer errors
- [ ] Verify nudge text on a real recipient pursuing one track shows correct "X in, Y to go" count