### PR TITLE
fix(newsletter-admin): make escapeHtml null-safe to prevent admin page crash

### DIFF
--- a/.changeset/fix-newsletter-escapehtml-null-safe.md
+++ b/.changeset/fix-newsletter-escapehtml-null-safe.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix newsletter admin crash when a content item has a missing/undefined field. `escapeHtml` in the shared email layout now tolerates `null` / `undefined` input and coerces values to strings, so a single malformed decision/spotlight/release no longer returns a 500 for `/editions/current`.

--- a/server/src/newsletters/email-layout.ts
+++ b/server/src/newsletters/email-layout.ts
@@ -13,8 +13,9 @@ const BASE_URL = process.env.BASE_URL || 'https://agenticadvertising.org';
 
 // ─── Utilities ─────────────────────────────────────────────────────────
 
-export function escapeHtml(text: string): string {
-  return text
+export function escapeHtml(text: string | null | undefined): string {
+  if (text == null) return '';
+  return String(text)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
## Summary
- Newsletter admin page (`/editions/current` for The Build) was returning 500 with `TypeError: Cannot read properties of undefined (reading 'replace')` when any content item in an edition's `candidatePool` had a missing/undefined string field (e.g. a decision without an `id`).
- Root cause: the shared `escapeHtml` helper in `server/src/newsletters/email-layout.ts` called `.replace()` directly on its argument, which crashed on `undefined` input. One malformed item in any section's `renderHtml` blocked the entire admin UI from loading.
- Fix: `escapeHtml` now accepts `string | null | undefined`, returns `''` for nullish, and coerces other values via `String()`. A single malformed item can no longer take down the whole page.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm run test:unit` (587 tests) passes
- [ ] Verify admin page (`/admin/newsletters/the_build`) loads successfully in preview/staging against the offending edition