### PR TITLE
feat(addie): capability-driven storyboard selection

### DIFF
--- a/.changeset/addie-specialism-alignment.md
+++ b/.changeset/addie-specialism-alignment.md
@@ -1,0 +1,10 @@
+---
+---
+
+Align Addie and the registry API with the 5.1.0 capability-driven compliance model.
+
+`recommend_storyboards` (MCP) and `GET /api/registry/agents/{encodedUrl}/applicable-storyboards` (REST) now probe `get_adcp_capabilities` and call `resolveStoryboardsForCapabilities` instead of tool-matching against `required_tools`. The agent's declared `supported_protocols` and `specialisms` are the source of truth; the runner returns universal + domain baselines + declared specialism bundles, grouped by bundle kind.
+
+When an agent doesn't declare capabilities, Addie coaches the developer on what to add to their `get_adcp_capabilities` response — no per-org "expected specialisms" state, no extra selection tool. If a declared specialism isn't in the local compliance cache, the REST endpoint returns 422 with `unknown_specialism: true` so the UI can prompt a cache re-sync.
+
+Addie's system prompt updated to frame the new flow: probe → recommend → run, and "don't invent a parallel concept — the agent declares what it supports."

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3296,17 +3296,20 @@ export function createMemberToolHandlers(
       return output;
     }
 
-    const totalStoryboards = resolvedBundles.reduce((n, b) => n + b.storyboards.length, 0);
+    // Skip empty bundles — upstream catalog sometimes ships stubs with 0
+    // storyboards (e.g. fictional-entities). They're not useful to the member.
+    const nonEmpty = resolvedBundles.filter(b => b.storyboards.length > 0);
+    const totalStoryboards = nonEmpty.reduce((n, b) => n + b.storyboards.length, 0);
 
     output += `**Declared:** `;
     output += supportedProtocols.length > 0 ? supportedProtocols.join(', ') : '(no supported_protocols)';
     if (specialisms.length > 0) output += ` | specialisms: ${specialisms.join(', ')}`;
     output += `\n`;
-    output += `**Will run:** ${totalStoryboards} storyboards across ${resolvedBundles.length} bundles\n\n`;
+    output += `**Will run:** ${totalStoryboards} storyboards across ${nonEmpty.length} bundles\n\n`;
 
     // Group by bundle kind for a clean read.
-    const byKind: Record<string, typeof resolvedBundles> = { universal: [], domain: [], specialism: [] };
-    for (const b of resolvedBundles) {
+    const byKind: Record<string, typeof nonEmpty> = { universal: [], domain: [], specialism: [] };
+    for (const b of nonEmpty) {
       (byKind[b.ref.kind] ??= []).push(b);
     }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -29,9 +29,12 @@ import {
 import {
   listAllComplianceStoryboards,
   getComplianceStoryboardById,
+  resolveStoryboardsForCapabilities,
   runStoryboard,
   runStoryboardStep,
   createTestClient,
+  testCapabilityDiscovery,
+  type AgentProfile,
   type Storyboard,
   type StoryboardContext,
   type StoryboardStepResult,
@@ -989,7 +992,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'recommend_storyboards',
     description:
-      'Connect to an agent, discover its tools, and return which storyboards apply. This is the first step when a developer pastes a URL. No configuration needed — storyboards self-select based on agent tools.',
+      'Probe an agent\'s `get_adcp_capabilities` and return the compliance bundles that will run. The agent\'s declared `supported_protocols` and `specialisms` drive the selection — no member configuration needed. If the agent declares nothing, explain what it needs to declare to get coverage.',
     usage_hints: 'use for "test this URL", "what can I test?", "which storyboards apply?", pasted agent URL, or any first-time agent testing. This should be the FIRST tool called when someone wants to test an agent.',
     input_schema: {
       type: 'object',
@@ -3235,72 +3238,98 @@ export function createMemberToolHandlers(
     const organizationId = memberContext?.organization?.workos_organization_id;
     const resolved = await resolveAgentAuth(agentUrl, organizationId);
 
-    // Connect and discover tools
+    // Probe get_adcp_capabilities. The agent is the source of truth for which
+    // domain baselines and specialism bundles apply — we don't guess from tool
+    // lists or ask the member what they're building.
     const authOption = buildAuthOption(resolved);
-    let agentTools: string[];
+    let profile: AgentProfile | undefined;
     try {
-      const client = createTestClient(resolved.resolvedUrl, 'mcp', {
+      const caps = await testCapabilityDiscovery(resolved.resolvedUrl, {
         ...(authOption && { auth: authOption }),
       });
-      const agentInfo = await client.getAgentInfo();
-      agentTools = agentInfo.tools?.map((t: { name: string }) => t.name) || [];
+      profile = caps.profile;
     } catch (error) {
       if (isAuthError(error)) {
         return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
       const msg = error instanceof Error ? error.message : 'Unknown error';
-      throw new ToolError(`Could not connect to agent at ${resolved.resolvedUrl}: ${msg}`);
+      throw new ToolError(`Could not reach agent at ${resolved.resolvedUrl}: ${msg}`);
     }
 
-    // Match storyboards to agent tools
-    const allStoryboards = listAllComplianceStoryboards();
-    const applicable = allStoryboards.filter(sb => {
-      if (!sb.required_tools?.length) return true;
-      return sb.required_tools.some(tool => agentTools.includes(tool));
-    });
+    const supportedProtocols = profile?.supported_protocols ?? [];
+    const specialisms = profile?.specialisms ?? [];
+    const probeError = profile?.capabilities_probe_error;
 
-    // Group by track
-    const byTrack = new Map<string, typeof applicable>();
-    for (const sb of applicable) {
-      const track = sb.track || 'general';
-      if (!byTrack.has(track)) byTrack.set(track, []);
-      byTrack.get(track)!.push(sb);
-    }
+    let output = '';
+    if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
+    output += `## Agent: ${profile?.name || resolved.resolvedUrl}\n\n`;
 
-    let output = `## Agent: ${resolved.resolvedUrl}\n\n`;
-    output += `**Tools discovered:** ${agentTools.length} (${agentTools.join(', ')})\n`;
-    output += `**Applicable storyboards:** ${applicable.length} of ${allStoryboards.length}\n\n`;
-
-    if (applicable.length === 0) {
-      output += `No storyboards match this agent's tools. This agent may not implement any AdCP tasks yet.\n`;
+    // No capabilities declared → coach the developer on how to fix it.
+    if (supportedProtocols.length === 0 && specialisms.length === 0) {
+      output += `**This agent doesn't declare any capabilities.**\n\n`;
+      if (probeError) {
+        output += `\`get_adcp_capabilities\` responded with an error: _${probeError}_\n\n`;
+      } else {
+        output += `Its \`get_adcp_capabilities\` response is missing \`supported_protocols\` and \`specialisms\`.\n\n`;
+      }
+      output += `Without these, the compliance runner can only execute the universal baseline bundles (schema, error handling, capability discovery). To get domain and specialism coverage, the agent needs to declare what it implements:\n\n`;
+      output += `- \`supported_protocols\`: which AdCP domains the agent serves (e.g. \`media_buy\`, \`creative\`, \`signals\`, \`governance\`, \`brand\`, \`sponsored_intelligence\`).\n`;
+      output += `- \`specialisms\`: specialized claims beyond the domain baselines (e.g. \`sales-guaranteed\`, \`sales-exchange\`, \`creative-template\`). See the full list at /compliance/{version}/index.json or the AdCP docs.\n\n`;
+      output += `Once the agent declares these, \`recommend_storyboards\` will resolve them to bundles automatically.\n`;
       return output;
     }
 
-    // Recommend a starting storyboard (prefer core, then media_buy, then first available)
-    const startOrder = ['core', 'media_buy', 'products', 'creative', 'governance', 'signals', 'si', 'audiences'];
-    let recommended: Storyboard | undefined;
-    for (const track of startOrder) {
-      const trackSbs = byTrack.get(track);
-      if (trackSbs?.length) { recommended = trackSbs[0]; break; }
+    // Resolve capabilities → bundles. `resolveStoryboardsForCapabilities` fails
+    // closed if a declared specialism has no local bundle — surface that to the
+    // developer as a cache/version mismatch rather than letting it crash.
+    let resolvedBundles: Array<{ ref: { id: string; kind: string }; storyboards: Storyboard[] }>;
+    try {
+      const res = resolveStoryboardsForCapabilities({
+        supported_protocols: supportedProtocols,
+        specialisms,
+      });
+      resolvedBundles = res.bundles;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      output += `**Couldn't resolve bundles:** ${msg}\n\n`;
+      output += `This usually means the agent declares a specialism that the local compliance cache doesn't know about. Re-sync schemas or check the specialism id against the current registry.\n`;
+      return output;
     }
-    if (!recommended) recommended = applicable[0];
 
-    output += `### Recommended starting point\n\n`;
-    output += `**${recommended.title}** (\`${recommended.id}\`)\n`;
-    output += `${recommended.summary}\n\n`;
+    const totalStoryboards = resolvedBundles.reduce((n, b) => n + b.storyboards.length, 0);
 
-    output += `### All applicable storyboards\n\n`;
-    for (const [track, storyboards] of byTrack) {
-      output += `**${track}**\n`;
-      for (const sb of storyboards) {
-        const stepCount = sb.phases.reduce((sum, p) => sum + p.steps.length, 0);
-        output += `- \`${sb.id}\` — ${sb.title} (${stepCount} steps)\n`;
+    output += `**Declared:** `;
+    output += supportedProtocols.length > 0 ? supportedProtocols.join(', ') : '(no supported_protocols)';
+    if (specialisms.length > 0) output += ` | specialisms: ${specialisms.join(', ')}`;
+    output += `\n`;
+    output += `**Will run:** ${totalStoryboards} storyboards across ${resolvedBundles.length} bundles\n\n`;
+
+    // Group by bundle kind for a clean read.
+    const byKind: Record<string, typeof resolvedBundles> = { universal: [], domain: [], specialism: [] };
+    for (const b of resolvedBundles) {
+      (byKind[b.ref.kind] ??= []).push(b);
+    }
+
+    const sections: Array<[string, string, typeof resolvedBundles]> = [
+      ['Universal', 'Mandatory for every agent (schema, errors, capability discovery).', byKind.universal],
+      ['Domain baselines', 'From `supported_protocols` — one baseline per declared domain.', byKind.domain],
+      ['Specialisms', 'From `specialisms` — specialized claims the agent made.', byKind.specialism],
+    ];
+
+    for (const [title, blurb, bundles] of sections) {
+      if (!bundles || bundles.length === 0) continue;
+      output += `### ${title}\n\n${blurb}\n\n`;
+      for (const bundle of bundles) {
+        output += `**\`${bundle.ref.id}\`** (${bundle.storyboards.length} storyboard${bundle.storyboards.length === 1 ? '' : 's'})\n`;
+        for (const sb of bundle.storyboards) {
+          const stepCount = sb.phases.reduce((sum, p) => sum + p.steps.length, 0);
+          output += `- \`${sb.id}\` — ${sb.title} (${stepCount} steps)\n`;
+        }
+        output += '\n';
       }
-      output += '\n';
     }
 
-    output += `Use \`get_storyboard_detail\` to see what a storyboard tests, or \`run_storyboard\` to execute one.`;
-    if (resolved.source === 'saved') output = '_Using saved credentials._\n\n' + output;
+    output += `Use \`get_storyboard_detail\` to inspect any storyboard, \`run_storyboard\` to execute one, or \`evaluate_agent_quality\` to run the full suite.`;
 
     return output;
   });

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -12,6 +12,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { logger } from '../../logger.js';
+import { classifyProbeError, probeReasonLabel } from '../../utils/probe-error.js';
 import { PUBLIC_TEST_AGENT, INTERNAL_PATH_AGENT_URL } from '../../config/test-agent.js';
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
@@ -290,6 +291,33 @@ function isAuthError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const msg = error.message;
   return msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication');
+}
+
+/**
+ * Sanitize a string that came from an untrusted remote agent before it flows
+ * into markdown that reaches the LLM. The agent is adversarial by assumption —
+ * its response fields (name, capabilities_probe_error, specialism ids) can
+ * contain prompt-injection payloads that would otherwise reach tools with
+ * side effects. Strip newlines + backticks (which break markdown structure
+ * and prompt fences), truncate hard, and collapse whitespace.
+ */
+function sanitizeAgentField(value: unknown, maxLen = 200): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/[\r\n`\u0000-\u001f\u007f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLen);
+}
+
+/**
+ * Wrap an untrusted agent-reported value in quotes, explicitly marking it as
+ * agent-provided so the LLM is less likely to treat it as authoritative.
+ * Returns the empty string if the value is empty after sanitization.
+ */
+function fenceAgentValue(value: unknown, maxLen = 200): string {
+  const cleaned = sanitizeAgentField(value, maxLen);
+  return cleaned ? `"${cleaned}"` : '';
 }
 
 // Channel alias map — normalize buyer language to AdCP channel identifiers
@@ -3171,9 +3199,11 @@ export function createMemberToolHandlers(
       else if (resolved.source === 'oauth') output += '_Using saved OAuth credentials._\n\n';
       else if (resolved.source === 'public') output += '_Using public test agent credentials._\n\n';
 
-      output += `## Quality Evaluation: ${result.agent_profile.name || resolved.resolvedUrl}\n\n`;
+      const safeName = sanitizeAgentField(result.agent_profile.name, 120);
+      output += `## Quality Evaluation: ${safeName || resolved.resolvedUrl}\n\n`;
       output += `**Agent:** ${resolved.resolvedUrl}\n`;
-      output += `**Tools:** ${result.agent_profile.tools.length} (${result.agent_profile.tools.join(', ')})\n`;
+      const safeTools = (result.agent_profile.tools || []).map(t => sanitizeAgentField(t, 80)).filter(Boolean);
+      output += `**Tools:** ${safeTools.length} (${safeTools.join(', ')})\n`;
       output += `**Duration:** ${(result.total_duration_ms / 1000).toFixed(1)}s\n\n`;
 
       output += `### Capability Tracks\n\n`;
@@ -3253,8 +3283,9 @@ export function createMemberToolHandlers(
       if (isAuthError(error)) {
         return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-      throw new ToolError(`Could not reach agent at ${resolved.resolvedUrl}: ${msg}`);
+      logger.warn({ err: error, agentUrl: resolved.resolvedUrl }, 'recommend_storyboards: capability probe failed');
+      const reason = classifyProbeError(error);
+      throw new ToolError(`Could not reach agent at ${resolved.resolvedUrl} (${probeReasonLabel(reason)}).`);
     }
 
     const supportedProtocols = profile?.supported_protocols ?? [];
@@ -3272,15 +3303,25 @@ export function createMemberToolHandlers(
     const docsVersion = index?.adcp_version || 'latest';
     const indexUrl = `https://adcontextprotocol.org/compliance/${docsVersion}/index.json`;
 
+    // Build a dynamic domain example list from the local compliance cache so
+    // coaching output doesn't drift as the protocol adds domains.
+    const knownDomainIds = index?.domains.map(d => d.id.replace(/-/g, '_')) ?? [
+      'media_buy', 'creative', 'signals', 'governance', 'brand', 'sponsored_intelligence',
+    ];
+    const domainExamples = knownDomainIds.map(id => `\`${id}\``).join(', ');
+
+    const safeAgentName = sanitizeAgentField(profile?.name, 120);
+
     let output = '';
     if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
-    output += `## Agent: ${profile?.name || resolved.resolvedUrl}\n\n`;
+    output += `## Agent: ${safeAgentName || resolved.resolvedUrl}\n\n`;
 
     // No capabilities declared → coach the developer on how to fix it.
     if (supportedProtocols.length === 0 && specialisms.length === 0) {
       output += `Your agent didn't tell us what it does yet.\n\n`;
       if (probeError) {
-        output += `\`get_adcp_capabilities\` returned an error, so the runner can only fall back to universal baselines (schema, error handling, capability discovery). Agent-side log: the compliance cache doesn't know what to run for this agent until it declares its domains and specialisms.\n\n`;
+        const safeProbeErr = fenceAgentValue(probeError, 300);
+        output += `\`get_adcp_capabilities\` returned an agent-reported error${safeProbeErr ? ` (${safeProbeErr})` : ''}. The runner can only fall back to universal baselines (schema, error handling, capability discovery) until the agent declares its domains and specialisms.\n\n`;
       } else {
         output += `Its \`get_adcp_capabilities\` response is missing \`supported_protocols\` and \`specialisms\`. Without those, only the universal baselines (schema, errors, capability discovery) can run.\n\n`;
       }
@@ -3291,8 +3332,8 @@ export function createMemberToolHandlers(
       output += '  "specialisms": ["sales-guaranteed"]\n';
       output += '}\n';
       output += '```\n\n';
-      output += `- \`supported_protocols\`: AdCP domains the agent serves (\`media_buy\`, \`creative\`, \`signals\`, \`governance\`, \`brand\`, \`sponsored_intelligence\`).\n`;
-      output += `- \`specialisms\`: specialized claims beyond the domain baselines (e.g. \`sales-guaranteed\`, \`sales-exchange\`, \`creative-template\`). Full registry: ${indexUrl}\n\n`;
+      output += `- \`supported_protocols\`: AdCP domains the agent serves (${domainExamples}).\n`;
+      output += `- \`specialisms\`: optional; specialized claims beyond the domain baselines (e.g. \`sales-guaranteed\`, \`sales-exchange\`, \`creative-template\`). Full registry: ${indexUrl}\n\n`;
       output += `Redeploy, then re-run \`recommend_storyboards\` and we'll map them to bundles.\n`;
       return output;
     }
@@ -3310,7 +3351,10 @@ export function createMemberToolHandlers(
     } catch (error) {
       logger.warn({ err: error, agentUrl: resolved.resolvedUrl, supportedProtocols, specialisms }, 'recommend_storyboards: unknown specialism');
       const knownIds = index?.specialisms.map(s => s.id).sort() || [];
-      output += `**Can't resolve bundles.** The agent declared one of ${specialisms.map(s => `\`${s}\``).join(', ')} as a specialism, but the local compliance cache doesn't have a matching bundle.\n\n`;
+      // specialism ids came from the untrusted agent — fence them so a hostile
+      // id string can't break out of the markdown fence.
+      const safeDeclared = specialisms.map(s => fenceAgentValue(s, 80)).filter(Boolean).join(', ');
+      output += `**Can't resolve bundles.** The agent declared a specialism (${safeDeclared || '(empty)'}) that the local compliance cache doesn't have a matching bundle for.\n\n`;
       if (knownIds.length > 0) {
         output += `Known specialisms in this cache: ${knownIds.map(id => `\`${id}\``).join(', ')}.\n\n`;
       }
@@ -3335,7 +3379,8 @@ export function createMemberToolHandlers(
     // Probe error surfaces even when some caps came back — partial failures
     // shouldn't silently degrade the result.
     if (probeError) {
-      output += `_Note: \`get_adcp_capabilities\` partially failed (${probeError}). Bundle selection below reflects what did come through._\n\n`;
+      const safeProbeErr = fenceAgentValue(probeError, 300);
+      output += `_Note: \`get_adcp_capabilities\` partially failed — agent-reported error${safeProbeErr ? ` ${safeProbeErr}` : ''}. Bundle selection below reflects what did come through._\n\n`;
     }
 
     // Group by bundle kind.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -30,6 +30,7 @@ import {
   listAllComplianceStoryboards,
   getComplianceStoryboardById,
   resolveStoryboardsForCapabilities,
+  loadComplianceIndex,
   runStoryboard,
   runStoryboardStep,
   createTestClient,
@@ -3260,28 +3261,45 @@ export function createMemberToolHandlers(
     const specialisms = profile?.specialisms ?? [];
     const probeError = profile?.capabilities_probe_error;
 
+    // Load the compliance index once so coaching paths can interpolate the
+    // real cache version instead of emitting a literal `{version}` placeholder.
+    let index;
+    try {
+      index = loadComplianceIndex();
+    } catch (err) {
+      logger.warn({ err }, 'recommend_storyboards: failed to load compliance index');
+    }
+    const docsVersion = index?.adcp_version || 'latest';
+    const indexUrl = `https://adcontextprotocol.org/compliance/${docsVersion}/index.json`;
+
     let output = '';
     if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
     output += `## Agent: ${profile?.name || resolved.resolvedUrl}\n\n`;
 
     // No capabilities declared → coach the developer on how to fix it.
     if (supportedProtocols.length === 0 && specialisms.length === 0) {
-      output += `**This agent doesn't declare any capabilities.**\n\n`;
+      output += `Your agent didn't tell us what it does yet.\n\n`;
       if (probeError) {
-        output += `\`get_adcp_capabilities\` responded with an error: _${probeError}_\n\n`;
+        output += `\`get_adcp_capabilities\` returned an error, so the runner can only fall back to universal baselines (schema, error handling, capability discovery). Agent-side log: the compliance cache doesn't know what to run for this agent until it declares its domains and specialisms.\n\n`;
       } else {
-        output += `Its \`get_adcp_capabilities\` response is missing \`supported_protocols\` and \`specialisms\`.\n\n`;
+        output += `Its \`get_adcp_capabilities\` response is missing \`supported_protocols\` and \`specialisms\`. Without those, only the universal baselines (schema, errors, capability discovery) can run.\n\n`;
       }
-      output += `Without these, the compliance runner can only execute the universal baseline bundles (schema, error handling, capability discovery). To get domain and specialism coverage, the agent needs to declare what it implements:\n\n`;
-      output += `- \`supported_protocols\`: which AdCP domains the agent serves (e.g. \`media_buy\`, \`creative\`, \`signals\`, \`governance\`, \`brand\`, \`sponsored_intelligence\`).\n`;
-      output += `- \`specialisms\`: specialized claims beyond the domain baselines (e.g. \`sales-guaranteed\`, \`sales-exchange\`, \`creative-template\`). See the full list at /compliance/{version}/index.json or the AdCP docs.\n\n`;
-      output += `Once the agent declares these, \`recommend_storyboards\` will resolve them to bundles automatically.\n`;
+      output += `Add those two fields to the response. Here's the minimum shape:\n\n`;
+      output += '```json\n';
+      output += '{\n';
+      output += '  "supported_protocols": ["media_buy"],\n';
+      output += '  "specialisms": ["sales-guaranteed"]\n';
+      output += '}\n';
+      output += '```\n\n';
+      output += `- \`supported_protocols\`: AdCP domains the agent serves (\`media_buy\`, \`creative\`, \`signals\`, \`governance\`, \`brand\`, \`sponsored_intelligence\`).\n`;
+      output += `- \`specialisms\`: specialized claims beyond the domain baselines (e.g. \`sales-guaranteed\`, \`sales-exchange\`, \`creative-template\`). Full registry: ${indexUrl}\n\n`;
+      output += `Redeploy, then re-run \`recommend_storyboards\` and we'll map them to bundles.\n`;
       return output;
     }
 
     // Resolve capabilities → bundles. `resolveStoryboardsForCapabilities` fails
-    // closed if a declared specialism has no local bundle — surface that to the
-    // developer as a cache/version mismatch rather than letting it crash.
+    // closed if a declared specialism has no local bundle — log the raw error
+    // server-side (it includes cache paths) but show the member a clean message.
     let resolvedBundles: Array<{ ref: { id: string; kind: string }; storyboards: Storyboard[] }>;
     try {
       const res = resolveStoryboardsForCapabilities({
@@ -3290,9 +3308,13 @@ export function createMemberToolHandlers(
       });
       resolvedBundles = res.bundles;
     } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-      output += `**Couldn't resolve bundles:** ${msg}\n\n`;
-      output += `This usually means the agent declares a specialism that the local compliance cache doesn't know about. Re-sync schemas or check the specialism id against the current registry.\n`;
+      logger.warn({ err: error, agentUrl: resolved.resolvedUrl, supportedProtocols, specialisms }, 'recommend_storyboards: unknown specialism');
+      const knownIds = index?.specialisms.map(s => s.id).sort() || [];
+      output += `**Can't resolve bundles.** The agent declared one of ${specialisms.map(s => `\`${s}\``).join(', ')} as a specialism, but the local compliance cache doesn't have a matching bundle.\n\n`;
+      if (knownIds.length > 0) {
+        output += `Known specialisms in this cache: ${knownIds.map(id => `\`${id}\``).join(', ')}.\n\n`;
+      }
+      output += `Either the cache is stale (re-sync the \`@adcp/client\` compliance tarball) or the agent's specialism id is a typo — cross-check it against ${indexUrl}.\n`;
       return output;
     }
 
@@ -3301,22 +3323,37 @@ export function createMemberToolHandlers(
     const nonEmpty = resolvedBundles.filter(b => b.storyboards.length > 0);
     const totalStoryboards = nonEmpty.reduce((n, b) => n + b.storyboards.length, 0);
 
-    output += `**Declared:** `;
-    output += supportedProtocols.length > 0 ? supportedProtocols.join(', ') : '(no supported_protocols)';
-    if (specialisms.length > 0) output += ` | specialisms: ${specialisms.join(', ')}`;
-    output += `\n`;
-    output += `**Will run:** ${totalStoryboards} storyboards across ${nonEmpty.length} bundles\n\n`;
+    // Verdict first. "6 domains declared, 23 checks ready. Nothing's failing
+    // because nothing's run yet" tells the member where they stand.
+    const protocolCount = supportedProtocols.length;
+    const specialismCount = specialisms.length;
+    const declaredPieces: string[] = [];
+    if (protocolCount > 0) declaredPieces.push(`${protocolCount} domain${protocolCount === 1 ? '' : 's'}`);
+    if (specialismCount > 0) declaredPieces.push(`${specialismCount} specialism${specialismCount === 1 ? '' : 's'}`);
+    output += `**${declaredPieces.join(' + ')} declared. ${totalStoryboards} compliance check${totalStoryboards === 1 ? '' : 's'} ready to run** — nothing is failing yet because nothing has been run.\n\n`;
 
-    // Group by bundle kind for a clean read.
-    const byKind: Record<string, typeof nonEmpty> = { universal: [], domain: [], specialism: [] };
-    for (const b of nonEmpty) {
-      (byKind[b.ref.kind] ??= []).push(b);
+    // Probe error surfaces even when some caps came back — partial failures
+    // shouldn't silently degrade the result.
+    if (probeError) {
+      output += `_Note: \`get_adcp_capabilities\` partially failed (${probeError}). Bundle selection below reflects what did come through._\n\n`;
     }
 
-    const sections: Array<[string, string, typeof resolvedBundles]> = [
-      ['Universal', 'Mandatory for every agent (schema, errors, capability discovery).', byKind.universal],
-      ['Domain baselines', 'From `supported_protocols` — one baseline per declared domain.', byKind.domain],
-      ['Specialisms', 'From `specialisms` — specialized claims the agent made.', byKind.specialism],
+    // Group by bundle kind.
+    const byKind: Record<string, typeof nonEmpty> = { universal: [], domain: [], specialism: [] };
+    for (const b of nonEmpty) {
+      byKind[b.ref.kind]!.push(b);
+    }
+
+    // Universal is the same for every agent. Collapse to one line so domain +
+    // specialism results are above the fold.
+    if (byKind.universal.length > 0) {
+      const universalStoryboards = byKind.universal.reduce((n, b) => n + b.storyboards.length, 0);
+      output += `**Universal baseline**: ${byKind.universal.length} bundle${byKind.universal.length === 1 ? '' : 's'}, ${universalStoryboards} storyboard${universalStoryboards === 1 ? '' : 's'}. Always runs — schema, errors, capability discovery.\n\n`;
+    }
+
+    const sections: Array<[string, string, typeof nonEmpty]> = [
+      ['Domain baselines', 'One baseline per declared `supported_protocols` entry.', byKind.domain],
+      ['Specialisms', 'One bundle per declared specialism.', byKind.specialism],
     ];
 
     for (const [title, blurb, bundles] of sections) {
@@ -3332,7 +3369,27 @@ export function createMemberToolHandlers(
       }
     }
 
-    output += `Use \`get_storyboard_detail\` to inspect any storyboard, \`run_storyboard\` to execute one, or \`evaluate_agent_quality\` to run the full suite.`;
+    // Action-first CTAs. Name the action, keep the tool name in parens so the
+    // LLM still knows what to call.
+    output += `**What next?**\n`;
+    output += `1. Run the full suite — \`evaluate_agent_quality\`\n`;
+    output += `2. Walk one storyboard step-by-step for debugging — \`run_storyboard_step\`\n`;
+    output += `3. Inspect a storyboard before running it — \`get_storyboard_detail\`\n`;
+
+    // Activation hinge: if this is a member with an org and the agent isn't
+    // saved yet, offer to save. Converts drive-by testing into an ongoing
+    // compliance-monitored relationship.
+    const orgId = memberContext?.organization?.workos_organization_id;
+    if (orgId && resolved.source !== 'saved') {
+      try {
+        const existing = await agentContextDb.getByOrgAndUrl(orgId, resolved.resolvedUrl);
+        if (!existing) {
+          output += `\nWant me to save this agent so compliance is tracked over time? Use \`save_agent\`.`;
+        }
+      } catch {
+        // Save-prompt is advisory — never fail the whole tool over it.
+      }
+    }
 
     return output;
   });

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -44,13 +44,15 @@ These tools diagnose publisher and agent setup. When someone has verification or
 - probe_adcp_agent: Test if an agent is online and responding
 - resolve_property: Check if a publisher domain's properties are in the registry. If adagents.json is valid but this returns nothing, the registry is still crawling or the file uses property_ids (registry handles this).
 
-**Storyboard Testing (discover → recommend → run):**
+**Storyboard Testing (probe → recommend → run):**
 When a developer pastes a URL or asks to test an agent, follow this flow:
-1. recommend_storyboards: Connect to agent, discover tools, show applicable storyboards. This is ALWAYS the first step.
+1. recommend_storyboards: Probe get_adcp_capabilities and show the bundles that will run. The agent's declared \`supported_protocols\` and \`specialisms\` drive selection — don't ask the member what kind of agent they're building. If the agent declares nothing, coach them on what to add to their \`get_adcp_capabilities\` response. This is ALWAYS the first step.
 2. get_storyboard_detail: Show what a storyboard tests before running it (phases, steps, validations).
 3. run_storyboard: Run a complete storyboard and return step-by-step results with coaching.
 4. run_storyboard_step: Run one step at a time for debugging. Pass context from previous step to maintain state.
-- evaluate_agent_quality: [Legacy] Runs all applicable storyboards at once via comply(). Prefer the storyboard tools above for interactive testing.
+- evaluate_agent_quality: Runs the full capability-driven suite via comply() — universal + domain baselines + declared specialisms. Prefer the storyboard tools above for interactive, one-at-a-time testing.
+
+**When an agent hasn't declared capabilities yet:** Don't invent a parallel concept. Tell the developer what \`supported_protocols\` and \`specialisms\` they should add to their \`get_adcp_capabilities\` response, then re-run \`recommend_storyboards\`. If they ask "what specialisms should my agent declare?", answer conversationally from the docs — there's no tool for this; it's advice.
 - test_rfp_response: Test how a publisher's agent responds to a real RFP. Takes the RFP brief, calls get_products with buying_mode 'brief', and runs deterministic gap analysis (channels, formats, budget feasibility, KPIs). If the publisher provides their actual sales response (publisher_response), includes it for comparison. Ask for publisher_response before calling — it's the highest-value input.
 - test_io_execution: Test whether a buyer agent can execute deals through a publisher's agent. Takes real IO line items, maps each to the agent's product catalog using normalized channel/format/pricing matching, and constructs the exact create_media_buy JSON a buyer agent would send. Set execute=true to submit the request to the agent. The JSON output is the artifact — publishers can hand it to their eng team.
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -71,6 +71,7 @@ import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js"
 import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
+import { classifyProbeError } from "../utils/probe-error.js";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -92,22 +93,6 @@ const VALID_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-
 
 function isValidDomain(domain: string): boolean {
   return domain.length <= 253 && VALID_DOMAIN_RE.test(domain);
-}
-
-/**
- * Coarse classification of probe failures so the UI can differentiate a
- * mistyped URL from a TLS failure. Keep the mapping conservative — when in
- * doubt, return "unknown" rather than guess.
- */
-function classifyProbeError(err: unknown): "network" | "tls" | "timeout" | "protocol" | "unknown" {
-  if (!(err instanceof Error)) return "unknown";
-  const message = err.message.toLowerCase();
-  const code = (err as NodeJS.ErrnoException).code;
-  if (code === "ETIMEDOUT" || /timed?\s*out|timeout/.test(message)) return "timeout";
-  if (code === "ENOTFOUND" || code === "ECONNREFUSED" || code === "ECONNRESET" || code === "EAI_AGAIN") return "network";
-  if (code?.startsWith("ERR_TLS") || code === "CERT_HAS_EXPIRED" || code === "DEPTH_ZERO_SELF_SIGNED_CERT" || /tls|ssl|certificate/.test(message)) return "tls";
-  if (/jsonrpc|mcp|protocol|invalid response|parse error/.test(message)) return "protocol";
-  return "unknown";
 }
 
 // ── Config ──────────────────────────────────────────────────────
@@ -1690,7 +1675,7 @@ registry.registerPath({
             agent_name: z.string(),
             supported_protocols: z.array(z.string()),
             specialisms: z.array(z.string()),
-            capabilities_probe_error: z.string().optional().openapi({ description: "Present when get_adcp_capabilities was advertised but failed — empty bundle list usually indicates this, not a v2 agent" }),
+            capabilities_probe_error: z.string().optional().openapi({ description: "Agent-reported probe error. Untrusted — sanitized and truncated to 500 chars. Present when get_adcp_capabilities was advertised but failed; empty bundle list usually indicates this, not a v2 agent." }),
             bundles: z.array(z.object({
               kind: z.enum(["universal", "domain", "specialism"]),
               id: z.string(),
@@ -3999,7 +3984,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         total_storyboards: bundles.reduce((n, b) => n + b.storyboards.length, 0),
       };
       if (profile?.capabilities_probe_error) {
-        responseBody.capabilities_probe_error = profile.capabilities_probe_error;
+        // Cap length + strip control chars. The string is agent-reported and
+        // therefore untrusted — consumers should treat it as informational
+        // only (documented on the OpenAPI description).
+        responseBody.capabilities_probe_error = String(profile.capabilities_probe_error)
+          .replace(/[\r\n\u0000-\u001f\u007f]/g, ' ')
+          .slice(0, 500);
       }
 
       res.json(responseBody);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3925,16 +3925,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         });
       }
 
-      const bundles = resolved.bundles.map(b => ({
-        kind: b.ref.kind,
-        id: b.ref.id,
-        storyboards: b.storyboards.map(sb => ({
-          id: sb.id,
-          title: sb.title,
-          summary: sb.summary,
-          step_count: sb.phases.reduce((sum, p) => sum + p.steps.length, 0),
-        })),
-      }));
+      // Drop empty bundles — upstream catalog occasionally ships stubs.
+      const bundles = resolved.bundles
+        .filter(b => b.storyboards.length > 0)
+        .map(b => ({
+          kind: b.ref.kind,
+          id: b.ref.id,
+          storyboards: b.storyboards.map(sb => ({
+            id: sb.id,
+            title: sb.title,
+            summary: sb.summary,
+            step_count: sb.phases.reduce((sum, p) => sum + p.steps.length, 0),
+          })),
+        }));
 
       const responseBody: Record<string, unknown> = {
         agent_url: agentUrl,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -9,7 +9,7 @@ import { Router } from "express";
 import type { RequestHandler } from "express";
 import { z } from "zod";
 import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
-import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities } from "@adcp/client/testing";
+import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities, loadComplianceIndex } from "@adcp/client/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
@@ -92,6 +92,22 @@ const VALID_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-
 
 function isValidDomain(domain: string): boolean {
   return domain.length <= 253 && VALID_DOMAIN_RE.test(domain);
+}
+
+/**
+ * Coarse classification of probe failures so the UI can differentiate a
+ * mistyped URL from a TLS failure. Keep the mapping conservative — when in
+ * doubt, return "unknown" rather than guess.
+ */
+function classifyProbeError(err: unknown): "network" | "tls" | "timeout" | "protocol" | "unknown" {
+  if (!(err instanceof Error)) return "unknown";
+  const message = err.message.toLowerCase();
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === "ETIMEDOUT" || /timed?\s*out|timeout/.test(message)) return "timeout";
+  if (code === "ENOTFOUND" || code === "ECONNREFUSED" || code === "ECONNRESET" || code === "EAI_AGAIN") return "network";
+  if (code?.startsWith("ERR_TLS") || code === "CERT_HAS_EXPIRED" || code === "DEPTH_ZERO_SELF_SIGNED_CERT" || /tls|ssl|certificate/.test(message)) return "tls";
+  if (/jsonrpc|mcp|protocol|invalid response|parse error/.test(message)) return "protocol";
+  return "unknown";
 }
 
 // ── Config ──────────────────────────────────────────────────────
@@ -1693,8 +1709,31 @@ registry.registerPath({
     400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
-    422: { description: "Agent requires authentication, or declares a specialism not in the local compliance cache", content: { "application/json": { schema: z.object({ error: z.string(), needs_auth: z.boolean().optional(), unknown_specialism: z.boolean().optional() }) } } },
-    500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+    422: {
+      description: "Agent requires authentication, or declares a specialism not in the local compliance cache",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            needs_auth: z.boolean().optional(),
+            unknown_specialism: z.boolean().optional(),
+            declared_specialisms: z.array(z.string()).optional().openapi({ description: "Specialisms the agent declared, for unknown-specialism errors" }),
+            known_specialisms: z.array(z.string()).optional().openapi({ description: "Specialism ids present in this server's local compliance cache" }),
+          }),
+        },
+      },
+    },
+    500: {
+      description: "Server error",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            reason: z.enum(["network", "tls", "timeout", "protocol", "unknown"]).optional().openapi({ description: "Coarse error classification for UI differentiation" }),
+          }),
+        },
+      },
+    },
     504: { description: "Connection timeout", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -3918,13 +3957,22 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         });
       } catch (resolveErr) {
         // Fail-closed: agent declared a specialism whose bundle isn't in the
-        // local compliance cache. 422 so the UI can prompt a cache re-sync.
-        // The resolver's message includes server-side paths — log it but
-        // don't leak it to the client.
+        // local compliance cache. The resolver's message includes server-side
+        // paths — log it but don't leak it to the client. Return the
+        // declared vs known lists so a UI can name the offender without
+        // asking the developer to re-read their own config.
         logger.warn({ err: resolveErr, agentUrl, supportedProtocols, specialisms }, "Agent declared an unknown specialism");
+        let knownSpecialisms: string[] = [];
+        try {
+          knownSpecialisms = loadComplianceIndex().specialisms.map(s => s.id).sort();
+        } catch (indexErr) {
+          logger.warn({ err: indexErr }, "Failed to load compliance index for 422 response");
+        }
         return res.status(422).json({
           error: "Agent declared a specialism that isn't in the compliance cache. The cache may be stale, or the specialism id is unrecognized.",
           unknown_specialism: true,
+          declared_specialisms: specialisms,
+          known_specialisms: knownSpecialisms,
         });
       }
 
@@ -3962,7 +4010,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return res.status(504).json({ error: "Connection timeout" });
       }
 
-      return res.status(500).json({ error: "Failed to probe agent capabilities" });
+      return res.status(500).json({
+        error: "Failed to probe agent capabilities",
+        reason: classifyProbeError(error),
+      });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -9,7 +9,7 @@ import { Router } from "express";
 import type { RequestHandler } from "express";
 import { z } from "zod";
 import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
-import { createTestClient, listAllComplianceStoryboards, runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview } from "@adcp/client/testing";
+import { createTestClient, runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities } from "@adcp/client/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
@@ -1656,7 +1656,7 @@ registry.registerPath({
   operationId: "getApplicableStoryboards",
   summary: "Get applicable storyboards for agent",
   description:
-    "Discovers an agent's tools and returns storyboards that are applicable based on its capabilities. Requires authentication and ownership.",
+    "Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }],
   request: {
@@ -1666,21 +1666,26 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Applicable storyboards grouped by track",
+      description: "Bundles the agent will be tested against, driven by its declared capabilities",
       content: {
         "application/json": {
           schema: z.object({
             agent_url: z.string(),
             agent_name: z.string(),
-            tools: z.array(z.string()),
-            storyboards: z.record(z.string(), z.array(z.object({
+            supported_protocols: z.array(z.string()),
+            specialisms: z.array(z.string()),
+            capabilities_probe_error: z.string().optional().openapi({ description: "Present when get_adcp_capabilities was advertised but failed — empty bundle list usually indicates this, not a v2 agent" }),
+            bundles: z.array(z.object({
+              kind: z.enum(["universal", "domain", "specialism"]),
               id: z.string(),
-              title: z.string(),
-              summary: z.string(),
-              step_count: z.number().int(),
-            }))),
-            total_applicable: z.number().int(),
-            total_available: z.number().int(),
+              storyboards: z.array(z.object({
+                id: z.string(),
+                title: z.string(),
+                summary: z.string(),
+                step_count: z.number().int(),
+              })),
+            })),
+            total_storyboards: z.number().int(),
           }),
         },
       },
@@ -1688,7 +1693,7 @@ registry.registerPath({
     400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
-    422: { description: "Agent requires authentication", content: { "application/json": { schema: z.object({ error: z.string(), needs_auth: z.literal(true) }) } } },
+    422: { description: "Agent requires authentication, or declares a specialism not in the local compliance cache", content: { "application/json": { schema: z.object({ error: z.string(), needs_auth: z.boolean().optional(), unknown_specialism: z.boolean().optional() }) } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
     504: { description: "Connection timeout", content: { "application/json": { schema: ErrorSchema } } },
   },
@@ -3888,12 +3893,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         logger.debug({ err: authErr, agentUrl }, "Auth resolution failed — trying without auth");
       }
 
-      let agentInfo;
+      let profile;
       try {
-        const client = createTestClient(agentUrl, "mcp", { ...(auth && { auth }) });
-        agentInfo = await client.getAgentInfo();
+        const caps = await testCapabilityDiscovery(agentUrl, { ...(auth && { auth }) });
+        profile = caps.profile;
       } catch (connectErr) {
-        // If auth failed and connection failed, give a specific error
         if (!auth) {
           return res.status(422).json({
             error: "Agent requires authentication. Save an auth token first using the connect form.",
@@ -3902,35 +3906,49 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
         throw connectErr;
       }
-      const agentTools = agentInfo.tools?.map((t: { name: string }) => t.name) || [];
 
-      const allStoryboards = listAllComplianceStoryboards();
-      const applicable = allStoryboards.filter(sb => {
-        if (!sb.required_tools?.length) return true;
-        return sb.required_tools.some(tool => agentTools.includes(tool));
-      });
+      const supportedProtocols = profile?.supported_protocols ?? [];
+      const specialisms = profile?.specialisms ?? [];
 
-      // Group by track
-      const byTrack: Record<string, Array<{ id: string; title: string; summary: string; step_count: number }>> = {};
-      for (const sb of applicable) {
-        const track = sb.track || "general";
-        if (!byTrack[track]) byTrack[track] = [];
-        byTrack[track].push({
+      let resolved;
+      try {
+        resolved = resolveStoryboardsForCapabilities({
+          supported_protocols: supportedProtocols,
+          specialisms,
+        });
+      } catch (resolveErr) {
+        // Fail-closed: agent declared a specialism whose bundle isn't in the
+        // local compliance cache. 422 so the UI can prompt a cache re-sync.
+        return res.status(422).json({
+          error: resolveErr instanceof Error ? resolveErr.message : "Unknown specialism",
+          unknown_specialism: true,
+        });
+      }
+
+      const bundles = resolved.bundles.map(b => ({
+        kind: b.ref.kind,
+        id: b.ref.id,
+        storyboards: b.storyboards.map(sb => ({
           id: sb.id,
           title: sb.title,
           summary: sb.summary,
           step_count: sb.phases.reduce((sum, p) => sum + p.steps.length, 0),
-        });
+        })),
+      }));
+
+      const responseBody: Record<string, unknown> = {
+        agent_url: agentUrl,
+        agent_name: profile?.name || "Unknown",
+        supported_protocols: supportedProtocols,
+        specialisms,
+        bundles,
+        total_storyboards: bundles.reduce((n, b) => n + b.storyboards.length, 0),
+      };
+      if (profile?.capabilities_probe_error) {
+        responseBody.capabilities_probe_error = profile.capabilities_probe_error;
       }
 
-      res.json({
-        agent_url: agentUrl,
-        agent_name: agentInfo.name || "Unknown",
-        tools: agentTools,
-        storyboards: byTrack,
-        total_applicable: applicable.length,
-        total_available: allStoryboards.length,
-      });
+      res.json(responseBody);
     } catch (error) {
       logger.warn({ err: error, agentUrl }, "Failed to resolve applicable storyboards");
 
@@ -3938,7 +3956,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return res.status(504).json({ error: "Connection timeout" });
       }
 
-      return res.status(500).json({ error: "Failed to discover agent tools" });
+      return res.status(500).json({ error: "Failed to probe agent capabilities" });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -9,7 +9,7 @@ import { Router } from "express";
 import type { RequestHandler } from "express";
 import { z } from "zod";
 import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
-import { createTestClient, runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities } from "@adcp/client/testing";
+import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities } from "@adcp/client/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3919,8 +3919,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       } catch (resolveErr) {
         // Fail-closed: agent declared a specialism whose bundle isn't in the
         // local compliance cache. 422 so the UI can prompt a cache re-sync.
+        // The resolver's message includes server-side paths — log it but
+        // don't leak it to the client.
+        logger.warn({ err: resolveErr, agentUrl, supportedProtocols, specialisms }, "Agent declared an unknown specialism");
         return res.status(422).json({
-          error: resolveErr instanceof Error ? resolveErr.message : "Unknown specialism",
+          error: "Agent declared a specialism that isn't in the compliance cache. The cache may be stale, or the specialism id is unrecognized.",
           unknown_specialism: true,
         });
       }

--- a/server/src/utils/probe-error.ts
+++ b/server/src/utils/probe-error.ts
@@ -1,0 +1,63 @@
+/**
+ * Coarse classification of agent probe failures so the UI (or an LLM) can
+ * differentiate a mistyped URL from a TLS failure without leaking the raw
+ * error message — which can contain cache paths, stack frames, or attacker-
+ * controlled content from a hostile agent response.
+ *
+ * When in doubt, return "unknown" rather than guess. The classification is a
+ * stable, closed enum — no string interpolation of caller data.
+ */
+export type ProbeErrorReason = 'network' | 'tls' | 'timeout' | 'protocol' | 'unknown';
+
+/**
+ * Inspect an error (and, one level deep, its `cause`) and classify. undici /
+ * fetch / node:https all wrap low-level errors in `err.cause.code`, so a
+ * naïve `err.code` check misses the common cases.
+ */
+export function classifyProbeError(err: unknown): ProbeErrorReason {
+  if (!(err instanceof Error)) return 'unknown';
+  const message = err.message.toLowerCase();
+  const code = (err as NodeJS.ErrnoException).code;
+  const causeCode = (err as { cause?: NodeJS.ErrnoException }).cause?.code;
+  const firstCode = code ?? causeCode;
+
+  if (firstCode === 'ETIMEDOUT' || firstCode === 'UND_ERR_CONNECT_TIMEOUT' || /timed?\s*out|timeout/.test(message)) {
+    return 'timeout';
+  }
+  if (
+    firstCode === 'ENOTFOUND' ||
+    firstCode === 'ECONNREFUSED' ||
+    firstCode === 'ECONNRESET' ||
+    firstCode === 'EAI_AGAIN' ||
+    firstCode === 'UND_ERR_SOCKET'
+  ) {
+    return 'network';
+  }
+  if (
+    firstCode?.startsWith('ERR_TLS') ||
+    firstCode === 'CERT_HAS_EXPIRED' ||
+    firstCode === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
+    firstCode === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+    /tls|ssl|certificate/.test(message)
+  ) {
+    return 'tls';
+  }
+  if (/jsonrpc|mcp|protocol|invalid response|parse error|unexpected token/.test(message)) {
+    return 'protocol';
+  }
+  return 'unknown';
+}
+
+/**
+ * Human-facing label for a classified reason. Safe for LLM or UI output.
+ */
+export function probeReasonLabel(reason: ProbeErrorReason): string {
+  switch (reason) {
+    case 'timeout': return 'timed out';
+    case 'network': return 'network / DNS failure';
+    case 'tls': return 'TLS / certificate error';
+    case 'protocol': return 'MCP / protocol error';
+    case 'unknown':
+    default: return 'unreachable';
+  }
+}

--- a/server/tests/manual/capabilities-smoke.ts
+++ b/server/tests/manual/capabilities-smoke.ts
@@ -1,0 +1,108 @@
+/**
+ * Smoke test: capability-driven storyboard resolution
+ *
+ * Hits a live agent, probes get_adcp_capabilities via testCapabilityDiscovery,
+ * and resolves bundles via resolveStoryboardsForCapabilities. Verifies both:
+ *   1. v3 agent that declares capabilities → bundles resolve cleanly
+ *   2. v3 agent with no specialisms / v2 agent → coaching path
+ *
+ * Usage: npx tsx server/tests/manual/capabilities-smoke.ts [agent_url]
+ */
+
+import {
+  testCapabilityDiscovery,
+  resolveStoryboardsForCapabilities,
+} from '@adcp/client/testing';
+import { PUBLIC_TEST_AGENT } from '../../src/config/test-agent.js';
+
+const agentUrl = process.argv[2] || PUBLIC_TEST_AGENT.url;
+const token = process.env.AGENT_TOKEN || PUBLIC_TEST_AGENT.token;
+
+function line() {
+  console.log('='.repeat(70));
+}
+
+async function main() {
+  console.log(`\nAgent: ${agentUrl}\n`);
+
+  line();
+  console.log('Step 1: testCapabilityDiscovery');
+  line();
+
+  const caps = await testCapabilityDiscovery(agentUrl, {
+    auth: { type: 'bearer', token },
+  });
+
+  const profile = caps.profile;
+  if (!profile) {
+    console.log('No profile returned. Agent unreachable or probe crashed.');
+    process.exit(1);
+  }
+
+  console.log('Name:                     ', profile.name ?? '(unknown)');
+  console.log('adcp_version:             ', profile.adcp_version ?? '(unknown)');
+  console.log('supported_protocols:      ', profile.supported_protocols ?? '(none)');
+  console.log('specialisms:              ', profile.specialisms ?? '(none)');
+  console.log('capabilities_probe_error: ', profile.capabilities_probe_error ?? '(none)');
+  console.log('tools:                    ', profile.tools?.length ?? 0, 'tools');
+
+  const supportedProtocols = profile.supported_protocols ?? [];
+  const specialisms = profile.specialisms ?? [];
+
+  line();
+  console.log('Step 2: resolveStoryboardsForCapabilities');
+  line();
+
+  if (supportedProtocols.length === 0 && specialisms.length === 0) {
+    console.log('\nAgent declares no capabilities. Coaching path would kick in here:');
+    console.log('  → "Add supported_protocols and specialisms to your');
+    console.log('     get_adcp_capabilities response so the runner can pick bundles."');
+    console.log('\nResolving with empty capabilities to see what falls through...');
+  }
+
+  let resolved;
+  try {
+    resolved = resolveStoryboardsForCapabilities({
+      supported_protocols: supportedProtocols,
+      specialisms,
+    });
+  } catch (err) {
+    console.log('\nResolution FAILED:', err instanceof Error ? err.message : err);
+    console.log('→ /applicable-storyboards would return 422 unknown_specialism');
+    process.exit(1);
+  }
+
+  const byKind: Record<string, typeof resolved.bundles> = {
+    universal: [],
+    domain: [],
+    specialism: [],
+  };
+  for (const b of resolved.bundles) {
+    (byKind[b.ref.kind] ??= []).push(b);
+  }
+
+  console.log(
+    `\nTotal: ${resolved.bundles.length} bundles, ${resolved.storyboards.length} storyboards\n`,
+  );
+
+  for (const kind of ['universal', 'domain', 'specialism'] as const) {
+    const bundles = byKind[kind];
+    if (!bundles?.length) continue;
+    console.log(`${kind.toUpperCase()} (${bundles.length}):`);
+    for (const b of bundles) {
+      console.log(
+        `  ${b.ref.id}: ${b.storyboards.length} storyboards (${b.storyboards.map(s => s.id).join(', ')})`,
+      );
+    }
+    console.log();
+  }
+
+  line();
+  console.log('Smoke test complete');
+  line();
+}
+
+main().catch(err => {
+  console.error('\nSmoke test failed:', err);
+  process.exit(1);
+});

--- a/server/tests/manual/recommend-storyboards-smoke.ts
+++ b/server/tests/manual/recommend-storyboards-smoke.ts
@@ -1,0 +1,43 @@
+/**
+ * Smoke test: Addie's recommend_storyboards handler end-to-end.
+ *
+ * Calls the tool handler directly against a live agent and prints the
+ * markdown output the member would see. Use this to eyeball formatting
+ * before shipping UI changes.
+ *
+ * Usage: npx tsx server/tests/manual/recommend-storyboards-smoke.ts [agent_url]
+ */
+
+import { createMemberToolHandlers } from '../../src/addie/mcp/member-tools.js';
+import type { MemberContext } from '../../src/addie/member-context.js';
+import { PUBLIC_TEST_AGENT } from '../../src/config/test-agent.js';
+
+const agentUrl = process.argv[2] || PUBLIC_TEST_AGENT.url;
+
+const mockCtx: MemberContext = {
+  workos_user: {
+    workos_user_id: 'smoke',
+    email: 'smoke@test.local',
+    first_name: 'Smoke',
+    last_name: 'Test',
+  },
+  organization: null,
+  member_profile: null,
+  conversation_id: 'smoke',
+  thread_id: null,
+  relationship: null,
+};
+
+async function main() {
+  const handlers = createMemberToolHandlers(mockCtx);
+  const handler = handlers.get('recommend_storyboards');
+  if (!handler) throw new Error('recommend_storyboards handler not registered');
+
+  const output = await handler({ agent_url: agentUrl });
+  console.log(output);
+}
+
+main().catch(err => {
+  console.error('Smoke test failed:', err);
+  process.exit(1);
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4827,7 +4827,7 @@ paths:
     get:
       operationId: getApplicableStoryboards
       summary: Get applicable storyboards for agent
-      description: Discovers an agent's tools and returns storyboards that are applicable based on its capabilities. Requires authentication and ownership.
+      description: Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.
       tags:
         - Agent Compliance
       security:
@@ -4842,7 +4842,7 @@ paths:
           in: path
       responses:
         "200":
-          description: Applicable storyboards grouped by track
+          description: Bundles the agent will be tested against, driven by its declared capabilities
           content:
             application/json:
               schema:
@@ -4852,41 +4852,61 @@ paths:
                     type: string
                   agent_name:
                     type: string
-                  tools:
+                  supported_protocols:
                     type: array
                     items:
                       type: string
-                  storyboards:
-                    type: object
-                    additionalProperties:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          title:
-                            type: string
-                          summary:
-                            type: string
-                          step_count:
-                            type: integer
-                        required:
-                          - id
-                          - title
-                          - summary
-                          - step_count
-                  total_applicable:
-                    type: integer
-                  total_available:
+                  specialisms:
+                    type: array
+                    items:
+                      type: string
+                  capabilities_probe_error:
+                    type: string
+                    description: Present when get_adcp_capabilities was advertised but failed — empty bundle list usually indicates this, not a v2 agent
+                  bundles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - universal
+                            - domain
+                            - specialism
+                        id:
+                          type: string
+                        storyboards:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              title:
+                                type: string
+                              summary:
+                                type: string
+                              step_count:
+                                type: integer
+                            required:
+                              - id
+                              - title
+                              - summary
+                              - step_count
+                      required:
+                        - kind
+                        - id
+                        - storyboards
+                  total_storyboards:
                     type: integer
                 required:
                   - agent_url
                   - agent_name
-                  - tools
-                  - storyboards
-                  - total_applicable
-                  - total_available
+                  - supported_protocols
+                  - specialisms
+                  - bundles
+                  - total_storyboards
         "400":
           description: Invalid agent URL
           content:
@@ -4906,7 +4926,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "422":
-          description: Agent requires authentication
+          description: Agent requires authentication, or declares a specialism not in the local compliance cache
           content:
             application/json:
               schema:
@@ -4916,11 +4936,10 @@ paths:
                     type: string
                   needs_auth:
                     type: boolean
-                    enum:
-                      - true
+                  unknown_specialism:
+                    type: boolean
                 required:
                   - error
-                  - needs_auth
         "500":
           description: Server error
           content:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4862,7 +4862,7 @@ paths:
                       type: string
                   capabilities_probe_error:
                     type: string
-                    description: Present when get_adcp_capabilities was advertised but failed — empty bundle list usually indicates this, not a v2 agent
+                    description: Agent-reported probe error. Untrusted — sanitized and truncated to 500 chars. Present when get_adcp_capabilities was advertised but failed; empty bundle list usually indicates this, not a v2 agent.
                   bundles:
                     type: array
                     items:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4938,6 +4938,16 @@ paths:
                     type: boolean
                   unknown_specialism:
                     type: boolean
+                  declared_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialisms the agent declared, for unknown-specialism errors
+                  known_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialism ids present in this server's local compliance cache
                 required:
                   - error
         "500":
@@ -4945,7 +4955,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+                    enum:
+                      - network
+                      - tls
+                      - timeout
+                      - protocol
+                      - unknown
+                    description: Coarse error classification for UI differentiation
+                required:
+                  - error
         "504":
           description: Connection timeout
           content:


### PR DESCRIPTION
## Summary

Aligns Addie and the registry API with the 5.1.0 capability-driven compliance model shipped in #2277. Stacks on top of that PR.

**The principle:** the agent is the source of truth. It declares `supported_protocols` + `specialisms` in `get_adcp_capabilities`; we probe and resolve. No per-org "expected specialisms" state, no extra tool for members to declare what they're building. If they want advice, Addie answers conversationally from the docs.

## What changed

- **`recommend_storyboards` (MCP)** — was matching storyboards by `required_tools` against `getAgentInfo().tools`. Now calls `testCapabilityDiscovery` and `resolveStoryboardsForCapabilities`, returns bundles grouped by kind (universal / domain / specialism). When an agent declares nothing, the tool coaches the developer on what to add instead of running a silent no-op.
- **`GET /api/registry/agents/{encodedUrl}/applicable-storyboards` (REST)** — same rewrite. Response shape changed from `{ tools, storyboards: {[track]: [...]}, total_applicable }` to `{ supported_protocols, specialisms, bundles: [{kind, id, storyboards}], total_storyboards, capabilities_probe_error? }`. If a declared specialism isn't in the local compliance cache, returns 422 `{ unknown_specialism: true }` so the UI can prompt a re-sync.
- **Addie's system prompt** — new framing: \"probe → recommend → run. Don't ask the member what kind of agent they're building; trust the agent's declarations. If missing, teach them what to add.\"

## Explicitly rejected

- Per-org \"expected specialisms\" DB column. Considered; rejected. The agent declares; we trust. Parallel state would drift.
- \"Select your specialisms\" UI. Same reason. If we need to recommend specialisms during development, Addie can advise from the docs — no tool needed.

## Test plan

- [x] \`npx tsc --noEmit\` clean on changes (two pre-existing \`ParsedRepo\` errors unrelated)
- [x] 1446 / 1446 server unit tests pass (excluding 2 pre-existing failing files)
- [x] OpenAPI spec regenerated
- [ ] Manual: point \`recommend_storyboards\` at test-agent.adcontextprotocol.org, verify bundles group correctly
- [ ] Manual: point it at a v2 agent that doesn't implement \`get_adcp_capabilities\`, verify coaching output reads well

🤖 Generated with [Claude Code](https://claude.com/claude-code)