### PR TITLE
fix(auth): preserve session on transient JWKS/upstream timeouts

### DIFF
--- a/.changeset/fix-auth-jwks-timeout-no-logout.md
+++ b/.changeset/fix-auth-jwks-timeout-no-logout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Auth middleware no longer logs users out when WorkOS JWKS fetch times out or other transient network errors hit during session validation. These transient failures now return 503 (retryable) instead of 401, preserving the session cookie so users stay logged in across infra blips.

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -148,6 +148,25 @@ function hashSessionCookie(cookie: string): string {
   return createHash('sha256').update(cookie).digest('hex');
 }
 
+// Errors like JWKSTimeout (WorkOS key-fetch stall) or fetch/DNS failures are transient —
+// the session cookie is still valid, the upstream is just slow. Returning 401 here would
+// log the user out for an infra blip, so callers should return 503 instead.
+function isTransientAuthError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const name = err.name;
+  const code = (err as { code?: unknown }).code;
+  if (name === 'JWKSTimeout' || name === 'TimeoutError' || name === 'AbortError') return true;
+  if (typeof code === 'string') {
+    if (code === 'ERR_JWKS_TIMEOUT') return true;
+    if (code === 'ETIMEDOUT' || code === 'ECONNRESET' || code === 'ECONNREFUSED') return true;
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return true;
+    if (code.startsWith('UND_ERR_')) return true; // undici fetch errors
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && cause !== err) return isTransientAuthError(cause);
+  return false;
+}
+
 /**
  * Invalidate session cache for a specific cookie (e.g., on logout)
  */
@@ -834,6 +853,16 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
     next();
   } catch (error) {
+    if (isTransientAuthError(error)) {
+      logger.warn({ err: error, path: req.path }, 'Transient auth upstream failure — returning 503 without clearing session');
+      if (isHtmlRequest) {
+        return res.status(503).send('Authentication service temporarily unavailable. Please refresh in a moment.');
+      }
+      return res.status(503).json({
+        error: 'Service temporarily unavailable',
+        message: 'Unable to verify your session right now. Please try again shortly.',
+      });
+    }
     logger.error({ err: error, path: req.path }, 'Authentication middleware threw unexpectedly — user will be logged out');
     if (isHtmlRequest) {
       return res.redirect(`/auth/login?return_to=${encodeURIComponent(req.originalUrl)}`);


### PR DESCRIPTION
## Summary

- When `session.authenticate()` in `requireAuth` throws `JWKSTimeout` (jose library fails to fetch WorkOS JWKS in time) or any other transient upstream error, the outer catch at `server/src/middleware/auth.ts:836` treated it as an invalid session and returned **401**, forcing the client to redirect users to `/auth/login`. Infra blips → spurious logouts.
- Added `isTransientAuthError(err)` helper that recognizes `JWKSTimeout`, `TimeoutError`, `AbortError`, `ERR_JWKS_TIMEOUT`, common socket error codes (`ETIMEDOUT`, `ECONNRESET`, `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`), and undici fetch errors (`UND_ERR_*`). Also walks `err.cause`.
- Transient errors now return **503** with a retryable message and the session cookie is preserved — so the client can retry without logging the user out. Permanent auth failures keep the existing 401 behavior.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm run test:unit` — 587/587 pass
- [ ] Manual: simulate a slow/failing WorkOS JWKS endpoint (e.g. network interception) and confirm the user sees a 503 and stays logged in rather than being redirected to `/auth/login`
- [ ] Monitor production logs for `Transient auth upstream failure` vs. `Authentication middleware threw unexpectedly` to validate the split

## Observability

The transient path logs at `warn` level with message `Transient auth upstream failure — returning 503 without clearing session`. The existing error path (`Authentication middleware threw unexpectedly — user will be logged out`) is preserved for genuine unknown failures.