### PR TITLE
fix(admin): use display_name in activity feed query

### DIFF
--- a/.changeset/fix-admin-activity-feed-ec-name.md
+++ b/.changeset/fix-admin-activity-feed-ec-name.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix admin activity feed 500 error: reference `email_contacts.display_name` instead of the non-existent `email_contacts.name` column in the `/api/admin/activity-feed` query.

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -1709,7 +1709,7 @@ export function setupAccountRoutes(
               'email' as source,
               eca.email_date as timestamp,
               'email_received' as action,
-              COALESCE(ec.name, ec.email) as actor_name,
+              COALESCE(ec.display_name, ec.email) as actor_name,
               o.name as org_name,
               o.workos_organization_id as org_id,
               eca.subject as description,
@@ -1730,7 +1730,7 @@ export function setupAccountRoutes(
                 WHEN er.attended THEN 'attended'
                 ELSE er.registration_status
               END as action,
-              COALESCE(ec.name, u.first_name || ' ' || u.last_name, ec.email, 'Unknown') as actor_name,
+              COALESCE(ec.display_name, u.first_name || ' ' || u.last_name, ec.email, 'Unknown') as actor_name,
               e.title as org_name,
               NULL as org_id,
               e.title as description,


### PR DESCRIPTION
## Summary
- `/api/admin/activity-feed` was crashing with `column ec.name does not exist` because the query referenced `ec.name`, but the `email_contacts` table has no `name` column (the actual column is `display_name`, see migration `052_email_contacts.sql`).
- Updated both `COALESCE(...)` actor-name expressions in the activity feed query (email source and event-registration source) to use `ec.display_name`.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run build` succeeds
- [ ] Hit `GET /api/admin/activity-feed` as an admin and confirm it returns 200 instead of 500
- [ ] Spot-check `actor_name` values populated from `email_contacts.display_name`