### PR TITLE
feat: semantic governance extensions — alignment attestation, decision traces, capability    discovery     

### DIFF
--- a/.changeset/semantic-governance-extensions.md
+++ b/.changeset/semantic-governance-extensions.md
@@ -1,0 +1,13 @@
+---
+---
+
+feat: Add semantic governance extensions — Semantic Alignment Attestation, Decision Trace Protocol, and Ontology Capability Declaration.
+
+Three new extension schemas for governance transparency:
+- `ext.semantic_alignment`: Documents how buyer terms were resolved to seller concepts with confidence scores and alignment chains
+- `ext.decision_trace`: Captures candidate evaluation, scoring, selection rationale, and rejection reasons at each decision point
+- `ext.semantic_capabilities`: Allows sellers to declare supported taxonomies and alignment methods in get_adcp_capabilities
+
+These extensions use the existing ext.* mechanism and are designed for graduated promotion to core protocol fields. They support regulatory compliance (EU DSA Article 26, EU AI Act Article 50, CA SB 942) and enable governance agents to validate semantic resolution quality.
+
+New documentation: docs/governance/semantic-transparency.mdx

--- a/docs.json
+++ b/docs.json
@@ -293,6 +293,7 @@
                     "pages": [
                       "docs/governance/overview",
                       "docs/governance/embedded-human-judgment",
+                      "docs/governance/semantic-transparency",
                       "docs/governance/policy-registry",
                       {
                         "group": "Property Governance",
@@ -781,6 +782,7 @@
                 "pages": [
                   "docs/governance/overview",
                   "docs/governance/embedded-human-judgment",
+                  "docs/governance/semantic-transparency",
                   "docs/governance/policy-registry",
                   {
                     "group": "Property Governance",

--- a/docs/governance/semantic-transparency.mdx
+++ b/docs/governance/semantic-transparency.mdx
@@ -302,6 +302,24 @@ The `decision_type` enum is extensible — implementations MAY define additional
 
 </Accordion>
 
+<Accordion title="Lightweight traces">
+
+The `candidates` array is optional. Sellers MAY omit it and return only the `candidates_evaluated` count for lightweight traces where full candidate details would be excessive:
+
+```json
+{
+  "decision_id": "dp-product-selection",
+  "decision_type": "product_selection",
+  "description": "Select products matching brief constraints",
+  "candidates_evaluated": 47,
+  "selection_strategy": "inventory_constrained_optimization"
+}
+```
+
+This is useful for high-frequency buys where full candidate enumeration per transaction is impractical. Sellers SHOULD support a `trace_detail` parameter on media buy requests with values `none` (no trace), `summary` (counts and strategies only), and `full` (complete candidate details) to give buyers control over response size.
+
+</Accordion>
+
 ## Governance integration
 
 These extensions integrate with AdCP's governance protocol at four points:
@@ -322,7 +340,7 @@ const supportsTrace = capabilities.extensions_supported
 
 ### 2. Pre-buy check
 
-When `check_governance` is called, the orchestrator MAY include semantic context:
+When `check_governance` is called, the orchestrator MAY include semantic context within the existing `payload` field:
 
 ```json
 {
@@ -339,6 +357,10 @@ When `check_governance` is called, the orchestrator MAY include semantic context
   }
 }
 ```
+
+<Info>
+The `semantic_context` object is passed within the existing `payload` field as buyer-defined metadata. It is not schema-validated by the governance protocol — it is a convention that governance agents supporting these extensions SHOULD recognize. The `check_governance` request schema treats `payload` as pass-through, so no schema changes are required.
+</Info>
 
 The governance agent validates that the seller declared the requested taxonomy in capabilities, and flags if expected confidence exceeds historical performance.
 
@@ -369,7 +391,7 @@ Findings use the standard governance format:
 
 ### 4. Audit trail
 
-Decision traces are stored alongside existing governance audit entries. When `get_plan_audit_logs` is called, entries include trace references:
+Decision traces are stored alongside existing governance audit entries. When `get_plan_audit_logs` is called, entries include trace references via the `ext.*` namespace — consistent with the extension pattern used throughout:
 
 ```json
 {
@@ -377,17 +399,23 @@ Decision traces are stored alongside existing governance audit entries. When `ge
     {
       "event_type": "buy_executed",
       "timestamp": "2026-04-16T16:44:30Z",
-      "decision_trace_id": "dt-acme-2026-04-16-001",
-      "semantic_alignment_summary": {
-        "terms_resolved": 3,
-        "terms_unresolved": 0,
-        "overall_confidence": 0.97,
-        "alignment_methods_used": ["notation", "lexical", "structural"]
+      "ext": {
+        "decision_trace_summary": {
+          "decision_trace_id": "dt-acme-2026-04-16-001",
+          "terms_resolved": 3,
+          "terms_unresolved": 0,
+          "overall_confidence": 0.97,
+          "alignment_methods_used": ["notation", "lexical", "structural"]
+        }
       }
     }
   ]
 }
 ```
+
+<Info>
+The `ext.decision_trace_summary` field uses the existing `ext.*` namespace rather than adding top-level fields to audit entries. The `get-plan-audit-logs-response.json` schema uses `"additionalProperties": false` on entry objects, so new top-level fields would be rejected by validators. The `ext.*` pattern avoids this and is consistent with how the extensions surface on other response types.
+</Info>
 
 Every decision, every resolution, every confidence score — structured, timestamped, attributable.
 

--- a/docs/governance/semantic-transparency.mdx
+++ b/docs/governance/semantic-transparency.mdx
@@ -1,0 +1,477 @@
+---
+title: Semantic Transparency
+sidebarTitle: Semantic transparency
+description: "Semantic alignment attestation, decision traces, and ontology capability discovery for transparent, auditable agentic advertising."
+"og:title": "AdCP — Semantic Transparency"
+---
+
+A buyer agent sends a brief requesting `half_page_300x600` placements across California. The seller's catalog uses `medium_rectangle_300x600` and `US-CA`. The seller resolves the terms, returns three products, and the buyer runs the campaign.
+
+Six months later, an auditor asks: "How did the system decide that `half_page_300x600` means the same thing as `medium_rectangle_300x600`?" Nobody can answer. The resolution happened inside the seller's implementation, and nothing in the AdCP response documented the reasoning. The protocol tracked *what* was bought but not *how* the system understood the brief.
+
+This is the semantic gap. AdCP's governance protocol validates budgets, policies, and brand safety — but until now, it had no way to validate the reasoning that connects a buyer's intent to a seller's inventory.
+
+Three extensions close this gap using AdCP's existing `ext.*` mechanism.
+
+## The three extensions
+
+| Extension | Namespace | Surfaces on | Purpose |
+|---|---|---|---|
+| **Semantic Alignment Attestation** | `ext.semantic_alignment` | `create_media_buy` responses | Documents how each buyer term was resolved to seller concepts |
+| **Decision Trace Protocol** | `ext.decision_trace` | `create_media_buy` and governance responses | Captures candidate evaluation, scoring, and selection rationale |
+| **Ontology Capability Declaration** | `ext.semantic_capabilities` | `get_adcp_capabilities` responses | Declares supported taxonomies and alignment methods |
+
+These extensions are additive — no existing schemas are modified. Sellers that don't support them simply omit the `ext.*` fields. Buyers check `extensions_supported` before relying on them.
+
+## Capability discovery
+
+Before issuing a brief, a buyer agent calls `get_adcp_capabilities` and discovers the seller's semantic capabilities:
+
+```json
+{
+  "extensions_supported": [
+    "semantic_alignment",
+    "decision_trace",
+    "semantic_capabilities"
+  ],
+  "ext": {
+    "semantic_capabilities": {
+      "supported_taxonomies": [
+        {
+          "taxonomy_id": "iab_ad_product_taxonomy",
+          "version": "2.0",
+          "authority": "https://iabtechlab.com/ad-product-taxonomy/2.0/",
+          "coverage": "full"
+        },
+        {
+          "taxonomy_id": "nielsen_dma",
+          "version": "2026",
+          "authority": "https://www.nielsen.com/dma-regions/",
+          "coverage": "full"
+        },
+        {
+          "taxonomy_id": "iso_3166",
+          "version": "2020",
+          "authority": "https://www.iso.org/iso-3166-country-codes.html",
+          "coverage": "full"
+        }
+      ],
+      "alignment_methods": ["exact", "structural", "notation", "lexical"],
+      "resolution_transparency": true
+    }
+  }
+}
+```
+
+The buyer now knows:
+- The seller understands IAB Ad Product Taxonomy 2.0, Nielsen DMAs, and ISO 3166 codes
+- The seller supports four alignment methods, from exact string matching to lexical/NLP resolution
+- The seller will include `semantic_alignment` attestations in media buy responses
+
+This happens *before* the brief is sent. No capability surprise at execution time.
+
+<Accordion title="What each coverage level means">
+
+| Coverage | Meaning |
+|---|---|
+| `full` | Seller's catalog is fully indexed against this taxonomy. All taxonomy entries can be resolved. |
+| `partial` | Subset coverage. Some taxonomy entries may not resolve. |
+| `mapping_only` | Seller can resolve terms using this taxonomy but may not have direct inventory for all entries. |
+
+A seller with `mapping_only` for Nielsen DMAs can translate "San Francisco-Oakland-San Jose" to DMA code 807, but may not have inventory specifically targeted to that DMA.
+
+</Accordion>
+
+## Semantic alignment in action
+
+When Pinnacle Agency's orchestrator sends a brief for Acme Corp's Q2 campaign, the seller returns products with full alignment attestation:
+
+```json
+{
+  "packages": [
+    {
+      "product_id": "42",
+      "product_name": "Premium Display 300x600",
+      "ext": {
+        "semantic_alignment": {
+          "resolutions": [
+            {
+              "buyer_term": "half_page_300x600",
+              "seller_concept": "medium_rectangle_300x600",
+              "taxonomy_id": "iab_ad_product_taxonomy",
+              "taxonomy_version": "2.0",
+              "alignment_method": "notation",
+              "confidence": 0.98,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "exact",
+                  "input": "half_page_300x600",
+                  "result": null,
+                  "note": "No exact match in seller catalog"
+                },
+                {
+                  "step": 2,
+                  "method": "notation",
+                  "input": "half_page_300x600",
+                  "result": "medium_rectangle_300x600",
+                  "note": "IAB Ad Product Taxonomy 2.0 cross-reference: half_page maps to 300x600 fixed format",
+                  "taxonomy_path": "Display > Fixed Size > Half Page (300x600)"
+                }
+              ]
+            },
+            {
+              "buyer_term": "California",
+              "seller_concept": "US-CA",
+              "taxonomy_id": "iso_3166",
+              "taxonomy_version": "2020",
+              "alignment_method": "lexical",
+              "confidence": 1.0,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "lexical",
+                  "input": "California",
+                  "result": "US-CA",
+                  "note": "Colloquial state name resolved to ISO 3166-2 subdivision code"
+                }
+              ]
+            },
+            {
+              "buyer_term": "Bay Area",
+              "seller_concept": ["807", "828"],
+              "taxonomy_id": "nielsen_dma",
+              "taxonomy_version": "2026",
+              "alignment_method": "structural",
+              "confidence": 0.95,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "lexical",
+                  "input": "Bay Area",
+                  "result": "San Francisco Bay Area (colloquial region)",
+                  "note": "Recognized as colloquial US geographic region"
+                },
+                {
+                  "step": 2,
+                  "method": "structural",
+                  "input": "San Francisco Bay Area",
+                  "result": ["807", "828"],
+                  "note": "Decomposed to overlapping Nielsen DMAs: 807 (San Francisco-Oakland-San Jose), 828 (Monterey-Salinas)"
+                }
+              ]
+            }
+          ],
+          "overall_confidence": 0.97,
+          "unresolved_terms": [],
+          "alignment_timestamp": "2026-04-16T16:44:00Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+Every resolution is documented:
+- **What** the buyer asked for (`buyer_term`)
+- **What** the seller matched it to (`seller_concept`)
+- **How** the match was made (`alignment_method`, `alignment_chain`)
+- **How confident** the match is (`confidence`)
+
+The `alignment_chain` shows the full resolution path. For "Bay Area," the system first recognized it as a colloquial region name (lexical), then decomposed it to the two overlapping Nielsen DMAs (structural). An auditor can trace every step.
+
+<Accordion title="Understanding confidence scores">
+
+Confidence scores range from 0.0 to 1.0:
+
+| Range | Meaning | Governance action |
+|---|---|---|
+| 0.95 - 1.0 | High confidence — exact or near-exact match | No action needed |
+| 0.70 - 0.94 | Medium confidence — reasonable match via structural or lexical methods | Governance agent MAY flag for review |
+| Below 0.70 | Low confidence — uncertain match | Governance agent SHOULD escalate |
+
+The `overall_confidence` is the geometric mean of all individual resolution confidences. A single low-confidence resolution pulls the overall score down, ensuring that partial mismatches are visible.
+
+Sellers calibrate confidence scores based on their alignment implementation. Scores are seller-relative — a 0.95 from one seller is not directly comparable to a 0.95 from another.
+
+</Accordion>
+
+## Decision traces
+
+While semantic alignment documents *how terms were understood*, decision traces document *why specific products were chosen*. The decision trace captures the full evaluation path:
+
+```json
+{
+  "ext": {
+    "decision_trace": {
+      "trace_id": "dt-acme-2026-04-16-001",
+      "trace_version": "1.0.0",
+      "decision_points": [
+        {
+          "decision_id": "dp-product-selection",
+          "decision_type": "product_selection",
+          "description": "Select products matching brief constraints",
+          "candidates_evaluated": 47,
+          "candidates": [
+            {
+              "candidate_id": "product-42",
+              "scores": {
+                "composite_score": 0.92,
+                "targeting_overlap": 1.0,
+                "format_match": 1.0,
+                "cpm_efficiency": 0.80
+              },
+              "outcome": "selected",
+              "selection_rationale": "Highest format match for 300x600 requirement with perfect targeting overlap across all specified DMAs"
+            },
+            {
+              "candidate_id": "product-17",
+              "scores": {
+                "composite_score": 0.71,
+                "targeting_overlap": 0.75,
+                "format_match": 1.0,
+                "cpm_efficiency": 0.60
+              },
+              "outcome": "rejected",
+              "rejection_reason": "Targeting overlap below threshold (0.75 < 0.80 minimum) — limited audience segment overlap"
+            }
+          ],
+          "selection_strategy": "inventory_constrained_optimization",
+          "constraints_applied": [
+            {
+              "constraint": "budget_cap",
+              "value": "$5,000",
+              "effect": "Limits total product count to stay within budget"
+            },
+            {
+              "constraint": "targeting_overlap_minimum",
+              "value": 0.8,
+              "effect": "Requires composite targeting overlap >= 0.8 for selection"
+            }
+          ]
+        },
+        {
+          "decision_id": "dp-budget-allocation",
+          "decision_type": "budget_allocation",
+          "description": "Allocate budget across selected products",
+          "candidates_evaluated": 3,
+          "candidates": [
+            {
+              "candidate_id": "product-42",
+              "scores": { "composite_score": 0.92 },
+              "outcome": "selected",
+              "selection_rationale": "Primary driver — allocated 40% of budget for broadest reach"
+            }
+          ],
+          "selection_strategy": "tiered_budget_allocation"
+        }
+      ],
+      "governance_compatibility": {
+        "plan_id": null,
+        "governance_context": null,
+        "exportable_as_governance_findings": true
+      },
+      "metadata": {
+        "protocol_version": "adcp-3.0",
+        "trace_generated_at": "2026-04-16T16:44:30Z",
+        "retention_policy": "90_days"
+      }
+    }
+  }
+}
+```
+
+The trace answers questions that product lists alone cannot:
+- **How many candidates were considered?** 47 products evaluated, not just the 3 returned.
+- **Why was product-17 rejected?** Targeting overlap (0.75) fell below the 0.80 minimum threshold.
+- **What constraints bounded the decision?** Budget cap and targeting overlap minimum.
+- **Can this trace feed into governance?** Yes — `exportable_as_governance_findings: true`.
+
+<Accordion title="Decision types">
+
+| Type | When used |
+|---|---|
+| `product_selection` | Choosing which products to include in the response |
+| `budget_allocation` | Distributing budget across selected products |
+| `forecast_selection` | Choosing impression estimation methodology |
+| `creative_assignment` | Matching creatives to placements |
+| `targeting_resolution` | Resolving targeting parameters to inventory constraints |
+| `policy_evaluation` | Evaluating compliance with governance policies |
+
+The `decision_type` enum is extensible — implementations MAY define additional types as needs emerge.
+
+</Accordion>
+
+## Governance integration
+
+These extensions integrate with AdCP's governance protocol at four points:
+
+### 1. Capability discovery
+
+A governance agent can discover whether a seller supports semantic transparency:
+
+```javascript
+const capabilities = await seller.getAdcpCapabilities();
+
+const supportsAlignment = capabilities.extensions_supported
+  .includes("semantic_alignment");
+
+const supportsTrace = capabilities.extensions_supported
+  .includes("decision_trace");
+```
+
+### 2. Pre-buy check
+
+When `check_governance` is called, the orchestrator MAY include semantic context:
+
+```json
+{
+  "plan_id": "acme-q2-outdoor",
+  "tool": "create_media_buy",
+  "payload": {
+    "seller": "https://seller.example",
+    "amount": 5000,
+    "semantic_context": {
+      "buyer_taxonomy_version": "iab_ad_product_taxonomy_2.0",
+      "expected_resolution_confidence": 0.9,
+      "require_attestation": true
+    }
+  }
+}
+```
+
+The governance agent validates that the seller declared the requested taxonomy in capabilities, and flags if expected confidence exceeds historical performance.
+
+### 3. Post-buy validation
+
+After a media buy completes, the governance agent validates the attestation:
+
+- **Confidence check**: Are all resolution confidences above the governance threshold?
+- **Coverage check**: Were all buyer terms resolved? Are there unresolved terms?
+- **Consistency check**: Do the alignment methods used match the seller's declared capabilities?
+- **Regulatory check**: For campaigns in EU/CA jurisdictions, does the attestation satisfy algorithmic transparency requirements?
+
+Findings use the standard governance format:
+
+```json
+{
+  "findings": [
+    {
+      "category_id": "semantic_alignment",
+      "policy_id": "registry:eu_ai_act_article_50",
+      "severity": "should",
+      "explanation": "Resolution for 'Bay Area' used lexical+structural alignment with 0.95 confidence. Full alignment chain provided. Meets Article 50 algorithmic transparency requirements.",
+      "confidence": 0.95
+    }
+  ]
+}
+```
+
+### 4. Audit trail
+
+Decision traces are stored alongside existing governance audit entries. When `get_plan_audit_logs` is called, entries include trace references:
+
+```json
+{
+  "audit_entries": [
+    {
+      "event_type": "buy_executed",
+      "timestamp": "2026-04-16T16:44:30Z",
+      "decision_trace_id": "dt-acme-2026-04-16-001",
+      "semantic_alignment_summary": {
+        "terms_resolved": 3,
+        "terms_unresolved": 0,
+        "overall_confidence": 0.97,
+        "alignment_methods_used": ["notation", "lexical", "structural"]
+      }
+    }
+  ]
+}
+```
+
+Every decision, every resolution, every confidence score — structured, timestamped, attributable.
+
+## Error handling
+
+When some buyer terms cannot be resolved, the seller SHOULD return a warning with suggestions:
+
+```json
+{
+  "warnings": [
+    {
+      "code": "semantic_resolution_partial",
+      "message": "1 of 4 buyer terms could not be resolved",
+      "details": {
+        "unresolved": ["display_static"],
+        "suggestions": [
+          {
+            "buyer_term": "display_static",
+            "candidates": [
+              { "concept": "medium_rectangle_300x250", "confidence": 0.72 },
+              { "concept": "half_page_300x600", "confidence": 0.65 }
+            ],
+            "hint": "Did you mean a specific IAB fixed-size format? Try: half_page_300x600, medium_rectangle_300x250, leaderboard_728x90"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Semantic failures become actionable — the buyer agent can retry with corrected terms, and the interaction is fully logged for governance.
+
+## Extension graduation path
+
+Following AdCP's extension model, these enhancements follow a three-phase graduation:
+
+| Phase | Version | What happens |
+|---|---|---|
+| **1. Extension namespace** | AdCP 3.0.x | All fields live under `ext.*`. Sellers declare support via `extensions_supported`. |
+| **2. Community validation** | AdCP 3.1.0-beta | Three or more independent implementations validate the schema. Extension schemas published in registry. Conformance tests added. |
+| **3. Core protocol** | AdCP 3.2.0+ | With community consensus, fields promote from `ext.*` to top-level. Governance agents MAY require attestation for regulated jurisdictions. |
+
+Sellers and buyers never change their code between phases — the protocol handles the namespace migration.
+
+## Regulatory alignment
+
+These extensions address requirements from three regulatory frameworks:
+
+- **EU Digital Services Act (Article 26)** — Decision traces satisfy the requirement to explain the main parameters of recommender systems and options to modify them.
+- **EU AI Act (Article 50)** — Semantic alignment attestations demonstrate how AI systems resolved user inputs to outputs, with confidence scoring.
+- **California SB 942** — Decision traces provide the "explanation of how the AI system works" required for generative AI disclosures.
+
+The [Policy Registry](/docs/governance/policy-registry) already includes entries for these regulations. These extensions provide the structured evidence format that satisfies the requirements those policies define.
+
+## Open questions
+
+These extensions are submitted for community discussion. Key questions:
+
+1. **Trace verbosity vs. performance.** Full alignment chains increase response size. Should there be a protocol-level maximum for `alignment_chain` length, or should this be implementation-specific?
+
+2. **Confidence score calibration.** Different sellers calibrate confidence differently. Should AdCP standardize a calibration methodology, or accept that scores are seller-relative?
+
+3. **Rejected candidate limits.** How many rejected candidates should sellers include in decision traces? A recommended range (e.g., "top 3 by composite score") may balance auditability with response size.
+
+4. **Cross-seller trace correlation.** When a buyer orchestrator queries multiple sellers, the buyer-side selection is currently outside AdCP scope. Should the protocol define a buyer-side trace format?
+
+5. **Taxonomy registry governance.** Who maintains the community taxonomy ID registry? AgenticAdvertising.org is the natural home, but taxonomy authorities should validate their entries.
+
+<Info>
+**Extension schemas**
+
+The JSON Schema definitions for these extensions are published at:
+- [`semantic_alignment.json`](/schemas/extensions/semantic_alignment.json)
+- [`decision_trace.json`](/schemas/extensions/decision_trace.json)
+- [`semantic_capabilities.json`](/schemas/extensions/semantic_capabilities.json)
+
+All schemas follow the [extension-meta.json](/schemas/extensions/extension-meta.json) meta-schema and are auto-discovered by the AdCP build system.
+</Info>
+
+## Go deeper
+
+- **Governance overview**: [How governance works](/docs/governance/overview) — three-party model, plan registration, escalation, audit trails
+- **Embedded human judgment**: [The five principles](/docs/governance/embedded-human-judgment) that ensure humans remain accountable in agentic systems
+- **Policy registry**: [Community policies](/docs/governance/policy-registry) — standardized regulations including EU DSA and AI Act entries
+- **Campaign governance**: [Full specification](/docs/governance/campaign/specification) — plans, checks, outcomes, and policy resolution
+- **Content standards**: [Brand suitability](/docs/governance/content-standards/index) — privacy-preserving calibration for content evaluation

--- a/docs/governance/semantic-transparency.mdx
+++ b/docs/governance/semantic-transparency.mdx
@@ -449,6 +449,509 @@ When some buyer terms cannot be resolved, the seller SHOULD return a warning wit
 
 Semantic failures become actionable — the buyer agent can retry with corrected terms, and the interaction is fully logged for governance.
 
+## End-to-end example
+
+This walkthrough follows a complete media buy flow showing how the three extensions surface in actual AdCP request/response pairs. Pinnacle Agency is buying display placements for Acme Outdoor across California.
+
+### Step 1: Capability discovery
+
+The orchestrator calls `get_adcp_capabilities` and discovers the seller's semantic support:
+
+```json
+{
+  "adcp": { "major_versions": [3] },
+  "supported_protocols": ["media_buy", "governance", "creative"],
+  "media_buy": {
+    "supported_pricing_models": ["cpm", "cpc"],
+    "execution": {
+      "targeting": {
+        "geo_countries": true,
+        "geo_regions": true,
+        "geo_metros": { "nielsen_dma": true }
+      }
+    },
+    "portfolio": {
+      "publisher_domains": ["news.example.com", "sports.example.com"],
+      "primary_channels": ["display", "video"],
+      "primary_countries": ["US"],
+      "description": "Premium display and video across news and sports properties"
+    }
+  },
+  "extensions_supported": [
+    "semantic_alignment",
+    "decision_trace",
+    "semantic_capabilities"
+  ],
+  "ext": {
+    "semantic_capabilities": {
+      "supported_taxonomies": [
+        {
+          "taxonomy_id": "iab_ad_product_taxonomy",
+          "version": "2.0",
+          "authority": "https://iabtechlab.com/ad-product-taxonomy/2.0/",
+          "coverage": "full"
+        },
+        {
+          "taxonomy_id": "nielsen_dma",
+          "version": "2026",
+          "authority": "https://www.nielsen.com/dma-regions/",
+          "coverage": "full"
+        },
+        {
+          "taxonomy_id": "iso_3166",
+          "version": "2020",
+          "authority": "https://www.iso.org/iso-3166-country-codes.html",
+          "coverage": "full"
+        }
+      ],
+      "alignment_methods": ["exact", "structural", "notation", "lexical"],
+      "resolution_transparency": true
+    }
+  },
+  "last_updated": "2026-04-16T00:00:00Z"
+}
+```
+
+The buyer now knows: the seller resolves IAB format IDs, Nielsen DMAs, and ISO geo codes. It supports all four alignment methods and will include attestation on responses. The orchestrator can proceed with confidence.
+
+### Step 2: Product discovery (`get_products`)
+
+The orchestrator sends a brief:
+
+```json
+{
+  "buying_mode": "brief",
+  "brief": "Acme Outdoor is launching the Trail Pro 3000 across California. We need display formats (300x600 and 300x250) targeting outdoor enthusiasts aged 25-54. Budget is $5,000 USD for April 2026.",
+  "budget": { "amount": 5000, "currency": "USD" },
+  "geo_targeting": {
+    "countries": ["US"],
+    "regions": ["US-CA"]
+  }
+}
+```
+
+The seller returns products with `ext.semantic_alignment` on each product and `ext.decision_trace` on the response:
+
+```json
+{
+  "products": [
+    {
+      "product_id": "prod-42",
+      "name": "Premium Display 300x600",
+      "description": "Half-page display across news and sports properties",
+      "publisher_properties": [
+        { "domain": "news.example.com", "name": "Example News" },
+        { "domain": "sports.example.com", "name": "Example Sports" }
+      ],
+      "channels": ["display"],
+      "format_ids": [
+        { "id": "medium_rectangle_300x600" }
+      ],
+      "delivery_type": "impression",
+      "pricing_options": [
+        {
+          "pricing_option_id": "cpm-standard",
+          "pricing_model": "cpm",
+          "price": 6.50,
+          "currency": "USD",
+          "minimum_spend": 500
+        }
+      ],
+      "forecast": {
+        "points": [
+          { "budget": 2000, "impressions": 307000 },
+          { "budget": 3000, "impressions": 461000 }
+        ],
+        "method": "historical_30d",
+        "currency": "USD",
+        "generated_at": "2026-04-16T16:44:00Z"
+      },
+      "reporting_capabilities": {
+        "metrics": ["impressions", "clicks", "viewability"],
+        "dimensions": ["date", "geo", "device"]
+      },
+      "ext": {
+        "semantic_alignment": {
+          "resolutions": [
+            {
+              "buyer_term": "300x600",
+              "seller_concept": "medium_rectangle_300x600",
+              "taxonomy_id": "iab_ad_product_taxonomy",
+              "taxonomy_version": "2.0",
+              "alignment_method": "notation",
+              "confidence": 0.98,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "exact",
+                  "input": "300x600",
+                  "result": null,
+                  "note": "No exact match — buyer used size shorthand"
+                },
+                {
+                  "step": 2,
+                  "method": "notation",
+                  "input": "300x600",
+                  "result": "medium_rectangle_300x600",
+                  "note": "IAB Ad Product Taxonomy 2.0: 300x600 maps to medium_rectangle_300x600",
+                  "taxonomy_path": "Display > Fixed Size > Half Page (300x600)"
+                }
+              ]
+            },
+            {
+              "buyer_term": "US-CA",
+              "seller_concept": "US-CA",
+              "taxonomy_id": "iso_3166",
+              "taxonomy_version": "2020",
+              "alignment_method": "exact",
+              "confidence": 1.0,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "exact",
+                  "input": "US-CA",
+                  "result": "US-CA",
+                  "note": "Exact ISO 3166-2 match"
+                }
+              ]
+            }
+          ],
+          "overall_confidence": 0.99,
+          "unresolved_terms": [],
+          "alignment_timestamp": "2026-04-16T16:44:00Z"
+        }
+      }
+    },
+    {
+      "product_id": "prod-78",
+      "name": "Standard Display 300x250",
+      "description": "Medium rectangle across all properties",
+      "publisher_properties": [
+        { "domain": "news.example.com", "name": "Example News" }
+      ],
+      "channels": ["display"],
+      "format_ids": [
+        { "id": "medium_rectangle_300x250" }
+      ],
+      "delivery_type": "impression",
+      "pricing_options": [
+        {
+          "pricing_option_id": "cpm-standard",
+          "pricing_model": "cpm",
+          "price": 4.25,
+          "currency": "USD",
+          "minimum_spend": 250
+        }
+      ],
+      "forecast": {
+        "points": [
+          { "budget": 2000, "impressions": 470000 }
+        ],
+        "method": "historical_30d",
+        "currency": "USD",
+        "generated_at": "2026-04-16T16:44:00Z"
+      },
+      "reporting_capabilities": {
+        "metrics": ["impressions", "clicks", "viewability"],
+        "dimensions": ["date", "geo"]
+      },
+      "ext": {
+        "semantic_alignment": {
+          "resolutions": [
+            {
+              "buyer_term": "300x250",
+              "seller_concept": "medium_rectangle_300x250",
+              "taxonomy_id": "iab_ad_product_taxonomy",
+              "taxonomy_version": "2.0",
+              "alignment_method": "notation",
+              "confidence": 0.99,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "notation",
+                  "input": "300x250",
+                  "result": "medium_rectangle_300x250",
+                  "note": "IAB Ad Product Taxonomy 2.0: 300x250 is the standard medium rectangle"
+                }
+              ]
+            },
+            {
+              "buyer_term": "US-CA",
+              "seller_concept": "US-CA",
+              "taxonomy_id": "iso_3166",
+              "taxonomy_version": "2020",
+              "alignment_method": "exact",
+              "confidence": 1.0,
+              "alignment_chain": [
+                {
+                  "step": 1,
+                  "method": "exact",
+                  "input": "US-CA",
+                  "result": "US-CA",
+                  "note": "Exact ISO 3166-2 match"
+                }
+              ]
+            }
+          ],
+          "overall_confidence": 0.99,
+          "unresolved_terms": [],
+          "alignment_timestamp": "2026-04-16T16:44:00Z"
+        }
+      }
+    }
+  ],
+  "proposals": [
+    {
+      "proposal_id": "prop-acme-q2",
+      "name": "Acme Outdoor Q2 Display Package",
+      "description": "Balanced 300x600 and 300x250 display across CA news and sports",
+      "allocations": [
+        { "product_id": "prod-42", "percentage": 60, "budget": 3000 },
+        { "product_id": "prod-78", "percentage": 40, "budget": 2000 }
+      ],
+      "proposal_status": "draft",
+      "total_budget_guidance": {
+        "min": 2000,
+        "recommended": 5000,
+        "max": 10000,
+        "currency": "USD"
+      },
+      "brief_alignment": "Full coverage of requested formats and geography"
+    }
+  ],
+  "ext": {
+    "decision_trace": {
+      "trace_id": "dt-acme-2026-04-16-001",
+      "trace_version": "1.0.0",
+      "decision_points": [
+        {
+          "decision_id": "dp-product-selection",
+          "decision_type": "product_selection",
+          "description": "Select display products matching 300x600 and 300x250 formats in California",
+          "candidates_evaluated": 23,
+          "candidates": [
+            {
+              "candidate_id": "prod-42",
+              "scores": {
+                "composite_score": 0.94,
+                "format_match": 1.0,
+                "geo_coverage": 1.0,
+                "cpm_efficiency": 0.82
+              },
+              "outcome": "selected",
+              "selection_rationale": "Best 300x600 match — covers all CA inventory with $6.50 CPM"
+            },
+            {
+              "candidate_id": "prod-78",
+              "scores": {
+                "composite_score": 0.91,
+                "format_match": 1.0,
+                "geo_coverage": 1.0,
+                "cpm_efficiency": 0.92
+              },
+              "outcome": "selected",
+              "selection_rationale": "Best 300x250 match — strong CA reach at efficient $4.25 CPM"
+            },
+            {
+              "candidate_id": "prod-15",
+              "scores": {
+                "composite_score": 0.62,
+                "format_match": 1.0,
+                "geo_coverage": 0.40,
+                "cpm_efficiency": 0.75
+              },
+              "outcome": "rejected",
+              "rejection_reason": "Geo coverage 0.40 — only covers Los Angeles DMA, not statewide CA"
+            }
+          ],
+          "selection_strategy": "brief_constrained_optimization",
+          "constraints_applied": [
+            {
+              "constraint": "budget_cap",
+              "value": "$5,000 USD",
+              "effect": "Limits selection to products deliverable within budget"
+            },
+            {
+              "constraint": "geo_coverage_minimum",
+              "value": 0.8,
+              "effect": "Products must cover >= 80% of requested California geography"
+            },
+            {
+              "constraint": "format_match",
+              "value": ["300x600", "300x250"],
+              "effect": "Only products with requested format sizes"
+            }
+          ]
+        },
+        {
+          "decision_id": "dp-budget-allocation",
+          "decision_type": "budget_allocation",
+          "description": "Allocate $5,000 across selected products",
+          "candidates_evaluated": 2,
+          "candidates": [
+            {
+              "candidate_id": "prod-42",
+              "scores": { "composite_score": 0.94 },
+              "outcome": "selected",
+              "selection_rationale": "60% allocation ($3,000) — primary format, broader property coverage"
+            },
+            {
+              "candidate_id": "prod-78",
+              "scores": { "composite_score": 0.91 },
+              "outcome": "selected",
+              "selection_rationale": "40% allocation ($2,000) — complementary format, higher CPM efficiency"
+            }
+          ],
+          "selection_strategy": "proportional_to_composite_score"
+        }
+      ],
+      "governance_compatibility": {
+        "plan_id": null,
+        "governance_context": null,
+        "exportable_as_governance_findings": true
+      },
+      "metadata": {
+        "protocol_version": "adcp-3.0",
+        "trace_generated_at": "2026-04-16T16:44:00Z",
+        "retention_policy": "90_days"
+      }
+    }
+  },
+  "property_list_applied": false,
+  "catalog_applied": false,
+  "sandbox": false
+}
+```
+
+Notice: `ext.semantic_alignment` lives on each **product** (documenting how that product's terms were resolved), while `ext.decision_trace` lives on the **response root** (documenting how products were selected and budget was allocated).
+
+### Step 3: Create media buy (`create_media_buy`)
+
+The orchestrator commits to the proposal. The response includes both extensions on the confirmed packages:
+
+```json
+{
+  "media_buy_id": "mb-acme-001",
+  "status": "pending_creatives",
+  "confirmed_at": "2026-04-16T17:00:00Z",
+  "creative_deadline": "2026-04-20T00:00:00Z",
+  "revision": 1,
+  "valid_actions": ["cancel", "sync_creatives", "update_budget"],
+  "packages": [
+    {
+      "package_id": "pkg-001",
+      "product_id": "prod-42",
+      "budget": 3000,
+      "pricing_option_id": "cpm-standard",
+      "impressions": 461000,
+      "format_ids": [{ "id": "medium_rectangle_300x600" }],
+      "start_time": "2026-04-01T00:00:00Z",
+      "end_time": "2026-04-30T23:59:59Z",
+      "paused": false,
+      "canceled": false,
+      "ext": {
+        "semantic_alignment": {
+          "resolutions": [
+            {
+              "buyer_term": "300x600",
+              "seller_concept": "medium_rectangle_300x600",
+              "taxonomy_id": "iab_ad_product_taxonomy",
+              "taxonomy_version": "2.0",
+              "alignment_method": "notation",
+              "confidence": 0.98
+            }
+          ],
+          "overall_confidence": 0.98,
+          "unresolved_terms": [],
+          "alignment_timestamp": "2026-04-16T17:00:00Z"
+        }
+      }
+    },
+    {
+      "package_id": "pkg-002",
+      "product_id": "prod-78",
+      "budget": 2000,
+      "pricing_option_id": "cpm-standard",
+      "impressions": 470000,
+      "format_ids": [{ "id": "medium_rectangle_300x250" }],
+      "start_time": "2026-04-01T00:00:00Z",
+      "end_time": "2026-04-30T23:59:59Z",
+      "paused": false,
+      "canceled": false,
+      "ext": {
+        "semantic_alignment": {
+          "resolutions": [
+            {
+              "buyer_term": "300x250",
+              "seller_concept": "medium_rectangle_300x250",
+              "taxonomy_id": "iab_ad_product_taxonomy",
+              "taxonomy_version": "2.0",
+              "alignment_method": "notation",
+              "confidence": 0.99
+            }
+          ],
+          "overall_confidence": 0.99,
+          "unresolved_terms": [],
+          "alignment_timestamp": "2026-04-16T17:00:00Z"
+        }
+      }
+    }
+  ],
+  "planned_delivery": {
+    "geo": {
+      "countries": ["US"],
+      "regions": ["US-CA"]
+    },
+    "channels": ["display"],
+    "start_time": "2026-04-01T00:00:00Z",
+    "end_time": "2026-04-30T23:59:59Z",
+    "total_budget": 5000,
+    "currency": "USD"
+  },
+  "ext": {
+    "decision_trace": {
+      "trace_id": "dt-acme-2026-04-16-002",
+      "trace_version": "1.0.0",
+      "decision_points": [
+        {
+          "decision_id": "dp-buy-commitment",
+          "decision_type": "product_selection",
+          "description": "Commit proposal prop-acme-q2 as media buy",
+          "candidates_evaluated": 2,
+          "candidates": [
+            {
+              "candidate_id": "prod-42",
+              "scores": { "composite_score": 0.94 },
+              "outcome": "selected",
+              "selection_rationale": "Committed from proposal — 60% budget allocation"
+            },
+            {
+              "candidate_id": "prod-78",
+              "scores": { "composite_score": 0.91 },
+              "outcome": "selected",
+              "selection_rationale": "Committed from proposal — 40% budget allocation"
+            }
+          ]
+        }
+      ],
+      "governance_compatibility": {
+        "plan_id": "acme-q2-outdoor",
+        "governance_context": "gov-ctx-acme-001",
+        "exportable_as_governance_findings": true
+      },
+      "metadata": {
+        "protocol_version": "adcp-3.0",
+        "trace_generated_at": "2026-04-16T17:00:00Z",
+        "retention_policy": "90_days"
+      }
+    }
+  },
+  "sandbox": false
+}
+```
+
+At this point, the governance agent has everything it needs: the `plan_id` links to the registered plan, the `governance_context` references the `check_governance` approval, and the decision trace documents every step from product discovery through commitment.
+
 ## Extension graduation path
 
 Following AdCP's extension model, these enhancements follow a three-phase graduation:

--- a/static/schemas/source/extensions/decision_trace.json
+++ b/static/schemas/source/extensions/decision_trace.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/extensions/decision_trace.json",
+  "title": "Decision Trace Protocol",
+  "description": "Captures the full decision-making path for a media buy or governance action. Records candidate evaluation, scoring, selection rationale, and rejection reasons at each decision point. Designed for governance agent consumption and regulatory compliance (EU DSA Article 26, EU AI Act Article 50).",
+  "valid_from": "3.0",
+  "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
+  "type": "object",
+  "required": ["trace_id", "trace_version", "decision_points", "metadata"],
+  "properties": {
+    "trace_id": {
+      "type": "string",
+      "description": "Unique identifier for this decision trace."
+    },
+    "trace_version": {
+      "type": "string",
+      "description": "Schema version of this trace (e.g., '1.0.0')."
+    },
+    "decision_points": {
+      "type": "array",
+      "description": "Ordered decision points in the decision-making path.",
+      "items": {
+        "type": "object",
+        "required": ["decision_id", "decision_type", "description"],
+        "properties": {
+          "decision_id": {
+            "type": "string",
+            "description": "Unique identifier for this decision point within the trace."
+          },
+          "decision_type": {
+            "type": "string",
+            "enum": ["product_selection", "budget_allocation", "forecast_selection", "creative_assignment", "targeting_resolution", "policy_evaluation"],
+            "description": "Category of decision. Extensible via future enum additions."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what decision was being made."
+          },
+          "candidates_evaluated": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total number of candidates considered."
+          },
+          "candidates": {
+            "type": "array",
+            "description": "Evaluated candidates with scores and outcomes. Sellers MAY limit to selected + top-N rejected.",
+            "items": {
+              "type": "object",
+              "required": ["candidate_id", "scores", "outcome"],
+              "properties": {
+                "candidate_id": { "type": "string", "description": "Identifier for the candidate (e.g., product ID)." },
+                "scores": {
+                  "type": "object",
+                  "description": "Scoring breakdown. MUST include composite_score (0.0-1.0).",
+                  "required": ["composite_score"],
+                  "properties": {
+                    "composite_score": { "type": "number", "minimum": 0, "maximum": 1, "description": "Overall score for cross-candidate comparison." }
+                  },
+                  "additionalProperties": true
+                },
+                "outcome": {
+                  "type": "string",
+                  "enum": ["selected", "rejected", "deferred"],
+                  "description": "Result of evaluation for this candidate."
+                },
+                "selection_rationale": {
+                  "type": "string",
+                  "description": "Required when outcome is 'selected'."
+                },
+                "rejection_reason": {
+                  "type": "string",
+                  "description": "Required when outcome is 'rejected'."
+                }
+              }
+            }
+          },
+          "selection_strategy": {
+            "type": "string",
+            "description": "Optimization strategy applied (e.g., 'inventory_constrained_optimization')."
+          },
+          "constraints_applied": {
+            "type": "array",
+            "description": "Business constraints that bounded the decision.",
+            "items": {
+              "type": "object",
+              "required": ["constraint", "value", "effect"],
+              "properties": {
+                "constraint": { "type": "string", "description": "Name of the constraint." },
+                "value": { "description": "Constraint value (string, number, or object)." },
+                "effect": { "type": "string", "description": "How this constraint affected the decision." }
+              }
+            }
+          }
+        }
+      }
+    },
+    "governance_compatibility": {
+      "type": "object",
+      "description": "Enables decision traces to feed into AdCP's existing governance protocol.",
+      "properties": {
+        "plan_id": { "type": ["string", "null"], "description": "Associated governance plan ID, if any." },
+        "governance_context": { "type": ["string", "null"], "description": "Governance context token from check_governance." },
+        "exportable_as_governance_findings": { "type": "boolean", "description": "Whether this trace can be submitted as evidence to a governance agent." }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Trace metadata for provenance and lifecycle management.",
+      "required": ["trace_generated_at"],
+      "properties": {
+        "agent_version": { "type": "string", "description": "Version of the agent that generated this trace." },
+        "protocol_version": { "type": "string", "description": "AdCP protocol version used." },
+        "trace_generated_at": { "type": "string", "format": "date-time", "description": "When this trace was generated (ISO 8601)." },
+        "retention_policy": { "type": "string", "description": "How long this trace should be retained." }
+      }
+    }
+  }
+}

--- a/static/schemas/source/extensions/decision_trace.json
+++ b/static/schemas/source/extensions/decision_trace.json
@@ -7,6 +7,7 @@
   "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
   "type": "object",
   "required": ["trace_id", "trace_version", "decision_points", "metadata"],
+  "additionalProperties": true,
   "properties": {
     "trace_id": {
       "type": "string",

--- a/static/schemas/source/extensions/semantic_alignment.json
+++ b/static/schemas/source/extensions/semantic_alignment.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/extensions/semantic_alignment.json",
+  "title": "Semantic Alignment Attestation",
+  "description": "Documents how buyer terms were resolved to seller concepts during a media buy. Provides resolution method, confidence scores, and alignment chains for full traceability. Enables governance agents to validate resolution quality and supports regulatory transparency requirements (EU DSA Article 26, EU AI Act Article 50, CA SB 942).",
+  "valid_from": "3.0",
+  "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
+  "type": "object",
+  "required": ["resolutions", "overall_confidence", "unresolved_terms", "alignment_timestamp"],
+  "properties": {
+    "resolutions": {
+      "type": "array",
+      "description": "One entry per buyer term that required resolution for this product.",
+      "items": {
+        "type": "object",
+        "required": ["buyer_term", "seller_concept", "taxonomy_id", "alignment_method", "confidence"],
+        "properties": {
+          "buyer_term": {
+            "type": "string",
+            "description": "The original term from the buyer's brief."
+          },
+          "seller_concept": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "The seller's internal concept(s) the buyer term resolved to. Array when a single buyer term maps to multiple seller concepts."
+          },
+          "taxonomy_id": {
+            "type": "string",
+            "description": "Which taxonomy was used for resolution. Must match an entry from get_adcp_capabilities extensions_supported."
+          },
+          "taxonomy_version": {
+            "type": "string",
+            "description": "Version of the taxonomy used."
+          },
+          "alignment_method": {
+            "type": "string",
+            "enum": ["exact", "structural", "notation", "lexical"],
+            "description": "The method that produced the final resolution. exact=string-equal, structural=hierarchy traversal, notation=code cross-reference, lexical=synonym/NLP."
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Confidence score (0.0-1.0) for this resolution."
+          },
+          "alignment_chain": {
+            "type": "array",
+            "description": "Ordered steps showing how the resolution was reached.",
+            "items": {
+              "type": "object",
+              "required": ["step", "method", "input"],
+              "properties": {
+                "step": { "type": "integer", "minimum": 1 },
+                "method": { "type": "string" },
+                "input": { "type": "string" },
+                "result": { "description": "Resolution result, or null if no match at this step." },
+                "note": { "type": "string", "description": "Human-readable explanation of this step." },
+                "taxonomy_path": { "type": "string", "description": "Taxonomy hierarchy path traversed." }
+              }
+            }
+          }
+        }
+      }
+    },
+    "overall_confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Geometric mean of individual resolution confidences."
+    },
+    "unresolved_terms": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Buyer terms that could not be resolved. Empty array when all terms resolved."
+    },
+    "alignment_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the alignment was performed (ISO 8601)."
+    }
+  }
+}

--- a/static/schemas/source/extensions/semantic_alignment.json
+++ b/static/schemas/source/extensions/semantic_alignment.json
@@ -7,6 +7,7 @@
   "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
   "type": "object",
   "required": ["resolutions", "overall_confidence", "unresolved_terms", "alignment_timestamp"],
+  "additionalProperties": true,
   "properties": {
     "resolutions": {
       "type": "array",
@@ -55,7 +56,14 @@
                 "step": { "type": "integer", "minimum": 1 },
                 "method": { "type": "string" },
                 "input": { "type": "string" },
-                "result": { "description": "Resolution result, or null if no match at this step." },
+                "result": {
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                  ],
+                  "description": "Resolution result: a string, array of strings (when one term resolves to multiple concepts), or null if no match at this step."
+                },
                 "note": { "type": "string", "description": "Human-readable explanation of this step." },
                 "taxonomy_path": { "type": "string", "description": "Taxonomy hierarchy path traversed." }
               }

--- a/static/schemas/source/extensions/semantic_capabilities.json
+++ b/static/schemas/source/extensions/semantic_capabilities.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/extensions/semantic_capabilities.json",
+  "title": "Ontology Capability Declaration",
+  "description": "Allows sellers to declare which ontologies and taxonomies they support, enabling buyers to discover semantic interoperability before issuing a brief. Designed for use in get_adcp_capabilities responses.",
+  "valid_from": "3.0",
+  "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
+  "type": "object",
+  "required": ["supported_taxonomies"],
+  "properties": {
+    "supported_taxonomies": {
+      "type": "array",
+      "description": "Taxonomies this seller can resolve buyer terms against.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["taxonomy_id", "version", "authority", "coverage"],
+        "properties": {
+          "taxonomy_id": {
+            "type": "string",
+            "description": "Identifier for the taxonomy (e.g., 'iab_ad_product_taxonomy', 'nielsen_dma')."
+          },
+          "version": {
+            "type": "string",
+            "description": "Version of the taxonomy supported."
+          },
+          "authority": {
+            "type": "string",
+            "format": "uri",
+            "description": "Canonical URI of the taxonomy authority."
+          },
+          "coverage": {
+            "type": "string",
+            "enum": ["full", "partial", "mapping_only"],
+            "description": "full=fully indexed, partial=subset, mapping_only=can resolve terms but may not have direct inventory."
+          }
+        }
+      }
+    },
+    "alignment_methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["exact", "structural", "notation", "lexical"]
+      },
+      "description": "Alignment methods the seller supports, ordered by priority."
+    },
+    "resolution_transparency": {
+      "type": "boolean",
+      "description": "When true, seller includes semantic_alignment attestations in media buy responses."
+    },
+    "ontology_uri": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI of the seller's published ontology."
+    },
+    "max_alignment_confidence_precision": {
+      "type": "integer",
+      "description": "Decimal places in confidence scores (default: 2).",
+      "default": 2
+    }
+  }
+}

--- a/static/schemas/source/extensions/semantic_capabilities.json
+++ b/static/schemas/source/extensions/semantic_capabilities.json
@@ -7,6 +7,7 @@
   "docs_url": "https://adcontextprotocol.org/docs/governance/semantic-transparency",
   "type": "object",
   "required": ["supported_taxonomies"],
+  "additionalProperties": true,
   "properties": {
     "supported_taxonomies": {
       "type": "array",


### PR DESCRIPTION
## Summary

Adds three interoperable governance transparency extensions to AdCP using the existing `ext.*` mechanism:

- **Semantic Alignment Attestation** (`ext.semantic_alignment`) — Structured documentation of how buyer terms were resolved to seller concepts, with alignment method, confidence scores, and full resolution chains. Attached to `create_media_buy` responses.

- **Decision Trace Protocol** (`ext.decision_trace`) — Captures candidate evaluation, scoring, selection rationale, and rejection reasons at each decision point. Compatible with `check_governance` and `report_plan_outcome` for end-to-end audit trails.

- **Ontology Capability Declaration** (`ext.semantic_capabilities`) — Sellers declare supported taxonomies, alignment methods, and resolution transparency in `get_adcp_capabilities`, enabling buyers to discover semantic interoperability before issuing a brief.

## Motivation

AdCP 3.0 treats semantic alignment — the process by which buyer terminology is resolved to seller inventory concepts — as an implementation detail invisible to both parties and auditors. This creates three problems:

1. **Silent failure**: Buyer terms that don't match seller catalogs return zero products with no explanation
2. **Audit blindness**: Governance validates transactions but not the reasoning behind product selection
3. **Interoperability friction**: Buyers cannot compare semantic capabilities across sellers pre-buy

These extensions also address regulatory requirements for algorithmic transparency (EU DSA Article 26, EU AI Act Article 50, CA SB 942) that the Policy Registry already references but the protocol has no structured format to satisfy.

## Changes

| File | Type |
|---|---|
| `static/schemas/source/extensions/semantic_alignment.json` | New extension schema |
| `static/schemas/source/extensions/decision_trace.json` | New extension schema |
| `static/schemas/source/extensions/semantic_capabilities.json` | New extension schema |
| `docs/governance/semantic-transparency.mdx` | New documentation page |
| `.changeset/semantic-governance-extensions.md` | Changeset |
| `docs.json` | Navigation update (both 3.0-rc and latest) |

## Design Principles

- **Additive, not breaking** — All new fields use `ext.*` namespaces. No existing schemas modified.
- **Declare before use** — Sellers advertise capabilities; buyers discover before issuing briefs.
- **Attestation, not prescription** — Protocol specifies what to attest, not how to implement alignment.
- **Governance-integrated** — Decision traces feed into existing `check_governance` and audit log workflows.
- **Graduated adoption** — Start in `ext.*`, validate with 3+ implementations, promote to core.

## Extension Schema Compliance

All three extension schemas pass validation against `extension-meta.json`:

| Check | Status |
|---|---|
| `$schema` = `http://json-schema.org/draft-07/schema#` | Pass |
| `$id` matches `^/schemas/extensions/[a-z][a-z0-9_]*\.json$` | Pass |
| `valid_from` = `3.0` matches `^\d+\.\d+$` | Pass |
| `type` = `object` | Pass |
| All required fields present (`$schema`, `$id`, `title`, `description`, `valid_from`, `type`, `properties`) | Pass |

Schemas are placed in `static/schemas/source/extensions/` for auto-discovery by the build system.

## How It Works

### 1. Capability Discovery

Buyers discover semantic interoperability **before** issuing a brief:

```json
{
  "extensions_supported": ["semantic_alignment", "decision_trace", "semantic_capabilities"],
  "ext": {
    "semantic_capabilities": {
      "supported_taxonomies": [
        { "taxonomy_id": "iab_ad_product_taxonomy", "version": "2.0", "coverage": "full" },
        { "taxonomy_id": "nielsen_dma", "version": "2026", "coverage": "full" }
      ],
      "alignment_methods": ["exact", "structural", "notation", "lexical"],
      "resolution_transparency": true
    }
  }
}
```

### 2. Semantic Alignment Attestation

Every term resolution is documented with confidence scores and full alignment chains:

```json
{
  "ext": {
    "semantic_alignment": {
      "resolutions": [
        {
          "buyer_term": "half_page_300x600",
          "seller_concept": "medium_rectangle_300x600",
          "taxonomy_id": "iab_ad_product_taxonomy",
          "alignment_method": "notation",
          "confidence": 0.98,
          "alignment_chain": [
            { "step": 1, "method": "exact", "input": "half_page_300x600", "result": null },
            { "step": 2, "method": "notation", "input": "half_page_300x600", "result": "medium_rectangle_300x600" }
          ]
        }
      ],
      "overall_confidence": 0.97,
      "unresolved_terms": []
    }
  }
}
```

### 3. Decision Trace

Full candidate evaluation, scoring, and rejection rationale:

```json
{
  "ext": {
    "decision_trace": {
      "trace_id": "dt-acme-2026-04-16-001",
      "decision_points": [
        {
          "decision_type": "product_selection",
          "candidates_evaluated": 47,
          "candidates": [
            { "candidate_id": "product-42", "scores": { "composite_score": 0.92 }, "outcome": "selected" },
            { "candidate_id": "product-17", "scores": { "composite_score": 0.71 }, "outcome": "rejected",
              "rejection_reason": "Targeting overlap below threshold (0.75 < 0.80 minimum)" }
          ]
        }
      ],
      "governance_compatibility": { "exportable_as_governance_findings": true }
    }
  }
}
```

## Governance Integration Points

| Integration | How |
|---|---|
| **Capability discovery** | Governance agents check if seller supports `semantic_alignment` before requiring attestation |
| **Pre-buy check** | Orchestrator includes `semantic_context` in `check_governance` payload |
| **Post-buy validation** | Governance validates confidence scores, coverage, and regulatory compliance |
| **Audit trail** | Decision trace IDs are stored alongside `get_plan_audit_logs` entries |

## Extension Graduation Path

| Phase | Version | What happens |
|---|---|---|
| **1. Extension namespace** | AdCP 3.0.x | Fields live under `ext.*`. Sellers declare via `extensions_supported`. |
| **2. Community validation** | AdCP 3.1.0-beta | 3+ independent implementations validate. Schemas published in registry. |
| **3. Core protocol** | AdCP 3.2.0+ | Community consensus promotes fields from `ext.*` to top-level. |

## Regulatory Alignment

| Regulation | How these extensions help |
|---|---|
| **EU DSA Article 26** | Decision traces explain recommender system parameters |
| **EU AI Act Article 50** | Semantic alignment attestations demonstrate input-to-output resolution |
| **CA SB 942** | Decision traces provide required AI system explanations |

## Test Plan

- [x] Extension schemas validate against `extension-meta.json` meta-schema
- [x] Extension `$id` patterns match required regex
- [x] All required fields present per extension-meta.json
- [x] JSON Schema Draft-07 compliant
- [x] No breaking changes to existing schemas
- [x] Changeset properly formatted
- [x] Navigation added to both `3.0-rc` and `latest` version groups
- [ ] Documentation renders correctly in Mintlify

## Open Questions for Community

1. **Trace verbosity** — Should there be a protocol-level max for alignment chain length?
2. **Confidence calibration** — Standardize across sellers or accept seller-relative scores?
3. **Rejected candidate limits** — Recommend top-N rejected candidates?
4. **Cross-seller correlation** — Define buyer-side decision trace linking seller traces?
5. **Taxonomy registry** — Who maintains the community taxonomy ID registry?
