### PR TITLE
refactor(governance): rename Scope3 Common Sense to CSBS (#2305)

### DIFF
--- a/.changeset/rename-scope3-common-sense-to-csbs.md
+++ b/.changeset/rename-scope3-common-sense-to-csbs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Rename "Scope3 Common Sense" brand-safety framework to **CSBS (Common Sense Brand Standards)** across normative protocol docs, schemas, policy registry, and Addie knowledge. Policy identifier `scope3_brand_safety` → `csbs` (migration 412). Vendor-branded example URLs (`agentic.scope3.com`, `scope3.com/methodology`) and extension namespaces (`ext.scope3`) replaced with neutral `vendor.example.com` / `ext.example`. Drops "industry baseline replacing GARM" framing in favor of neutral "contributed to AAO" language. Follow-up #2314 tracks the formal donation/IP-assignment record from Scope3 to AAO. Closes #2305.

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -309,13 +309,6 @@ See [calibrate_content](./tasks/calibrate_content) for the full task specificati
 | [get_media_buy_artifacts](./tasks/get_media_buy_artifacts) | Retrieve content artifacts from a media buy |
 | [validate_content_delivery](./tasks/validate_content_delivery) | Batch validation of content artifacts |
 
-## Typical Providers
-
-- **IAS** - Integral Ad Science
-- **DoubleVerify** - Brand suitability and verification
-- **Scope3** - Sustainability-focused brand suitability with prompt-based policies
-- **Custom** - Brand-specific implementations
-
 ## Future: Secure Enclaves
 
 The current model trusts the publisher to faithfully implement the calibrated standards. A future evolution uses **secure enclaves** (Trusted Execution Environments / TEEs) to provide cryptographic guarantees:

--- a/docs/governance/policy-registry.mdx
+++ b/docs/governance/policy-registry.mdx
@@ -261,11 +261,11 @@ The registry ships with 14 seeded policies covering common advertising regulatio
 | `pharma_us_fda` | `pharmaceutical_advertising` | FDA-aligned pharmaceutical advertising |
 | `gambling_advertising` | `gambling_advertising` | Responsible gambling advertising |
 | `financial_services` | `fair_lending` | Financial product advertising disclosure |
-| `scope3_brand_safety` | All | Scope3 Common Sense brand safety framework -- content adjacency baseline (enforcement: `must`) donated to AgenticAdvertising.org |
+| `csbs` | All | Common Sense Brand Standards -- content adjacency standard (enforcement: `must`) contributed to AgenticAdvertising.org |
 | `childrens_advertising` | `children_directed` | Global standards for advertising directed at or seen by children (UK CAP/BCAP, EU AVMSD, ICC) |
 
 <Note>
-The Scope3 Common Sense brand safety framework was donated to AgenticAdvertising.org as the industry baseline for brand safety, replacing the defunct GARM framework. It defines common-sense content adjacency standards applicable to all industries and channels.
+Common Sense Brand Standards (CSBS) is a content adjacency standard governed by AgenticAdvertising.org. It defines content categories where advertising placement poses brand-reputation risk, applicable across industries and channels. CSBS was originally contributed to AAO by Scope3.
 </Note>
 
 ## Policy category definitions

--- a/docs/media-buy/advanced-topics/agentic-execution-engine.mdx
+++ b/docs/media-buy/advanced-topics/agentic-execution-engine.mdx
@@ -297,7 +297,7 @@ AXE is a protocol-level concept. **Orchestrators implement AXE** and integrate i
 
 | Integration Path | How It Works | Example |
 |------------------|-------------|---------|
-| **Prebid RTD module** | Orchestrator distributes a Prebid module that calls the AXE endpoint during auction | Scope3's `scope3RtdProvider` |
+| **Prebid RTD module** | Orchestrator distributes a Prebid module that calls the AXE endpoint during auction | `exampleRtdProvider` |
 | **Proprietary ad platform** | AXE runs as a container or secure enclave within the platform's infrastructure | Platform-native integration |
 | **Server-side** | AXE endpoint called server-to-server by the ad platform before decisioning | Custom ad server integration |
 
@@ -318,7 +318,7 @@ The `axe_integrations` URL in a seller's [`get_adcp_capabilities`](/docs/protoco
 {
   "media_buy": {
     "execution": {
-      "axe_integrations": ["https://agentic.scope3.com"]
+      "axe_integrations": ["https://axe.example.com"]
     }
   }
 }
@@ -329,13 +329,13 @@ The `axe_integrations` URL in a seller's [`get_adcp_capabilities`](/docs/protoco
 For web publishers using Prebid, AXE integrates via the orchestrator's RTD module. The module name in Prebid matches the orchestrator, not "AXE":
 
 ```javascript test=false
-// Prebid build includes: rtdModule, scope3RtdProvider, ...other modules
+// Prebid build includes: rtdModule, exampleRtdProvider, ...other modules
 
 pbjs.setConfig({
   realTimeData: {
     auctionDelay: 100,
     dataProviders: [{
-      name: 'scope3',        // Orchestrator's module name
+      name: 'example',       // Orchestrator's module name
       waitForIt: true,
       params: {
         // Orchestrator-specific configuration
@@ -365,14 +365,14 @@ This is particularly relevant for platforms that don't use Prebid or where laten
 
 ### Identifying AXE Support
 
-The definitive check is the seller's `get_adcp_capabilities` response. For Prebid-based integrations, you can also inspect the page directly. Using Scope3 as an example:
+The definitive check is the seller's `get_adcp_capabilities` response. For Prebid-based integrations, you can also inspect the page directly:
 
 | What to look for | Where | Meaning |
 |-------------------|-------|---------|
 | `axe_integrations` in capabilities | `get_adcp_capabilities` response | Seller supports AXE |
 | `axei`/`axex`/`axem` key-values | Ad server request (network tab) | AXE segments flowing to ad server |
-| `scope3RtdProvider` in Prebid build | Page source or `pbjs.installedModules` | Scope3 AXE via Prebid |
-| `name: 'scope3'` in `realTimeData.dataProviders` | `pbjs.getConfig('realTimeData')` | Scope3 AXE is active |
+| Orchestrator RTD module (e.g., `exampleRtdProvider`) in Prebid build | Page source or `pbjs.installedModules` | AXE via Prebid |
+| Orchestrator entry in `realTimeData.dataProviders` | `pbjs.getConfig('realTimeData')` | AXE is active |
 
 Different orchestrators may implement AXE through different integration paths — the segment protocol (axei/axex/axem) is the same regardless of how AXE is deployed.
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -376,7 +376,7 @@ Policy registry integration capabilities. See [Policy Registry](/docs/governance
       { "feature_id": "mfa_score", "type": "quantitative", "range": { "min": 0, "max": 100 }, "description": "Made For Advertising detection (0=quality content, 100=likely MFA)", "methodology_url": "https://vendor.example.com/methodology/mfa" },
       { "feature_id": "coppa_certified", "type": "binary", "description": "COPPA compliance certification" },
       { "feature_id": "registry:uk_hfss", "type": "binary", "description": "UK HFSS advertising restrictions compliance" },
-      { "feature_id": "carbon_score", "type": "quantitative", "range": { "min": 0, "max": 100 }, "description": "Carbon footprint sustainability score", "methodology_url": "https://scope3.com/methodology/carbon-score" }
+      { "feature_id": "carbon_score", "type": "quantitative", "range": { "min": 0, "max": 100 }, "description": "Carbon footprint sustainability score", "methodology_url": "https://vendor.example.com/methodology/carbon-score" }
     ],
     "creative_features": [
       { "feature_id": "registry:eu_ai_act_article_50", "type": "binary", "description": "EU AI Act Article 50 — AI-generated content disclosure" },
@@ -418,21 +418,21 @@ Array of extension namespaces this agent supports. Buyers can expect meaningful 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `extensions_supported` | string[] | Extension namespaces (e.g., `["scope3", "garm"]`) |
+| `extensions_supported` | string[] | Extension namespaces (e.g., `["iab_tcf", "iab_gpp"]`) |
 
 Extension schemas are published in the [AdCP extension registry](/docs/building/integration/context-sessions#extensions). When an agent declares support for an extension, buyers know to look for and process `ext.{namespace}` data in responses.
 
 **Example:**
 ```json
 {
-  "extensions_supported": ["scope3", "garm", "iab_tcf"]
+  "extensions_supported": ["iab_tcf", "iab_gpp", "acmecorp"]
 }
 ```
 
 This tells buyers:
-- Product responses may include `ext.scope3` with Scope3 sustainability data
-- Creative policies may include `ext.garm` with GARM brand suitability categorizations
 - Responses may include `ext.iab_tcf` with IAB TCF consent data
+- Responses may include `ext.iab_gpp` with IAB GPP (Global Privacy Platform) signals
+- Responses may include `ext.acmecorp` with vendor-specific data from Acme Corp
 
 ## The Capability Contract
 
@@ -477,8 +477,8 @@ if (result.supported_protocols.includes('media_buy')) {
   }
 
   // Check AXE integrations (legacy — new integrations use TMP via trusted_match on products)
-  if (mediaBuy.execution?.axe_integrations?.includes('https://agentic.scope3.com')) {
-    console.log('Scope3 AXE integration available');
+  if (mediaBuy.execution?.axe_integrations?.includes('https://axe.example.com')) {
+    console.log('AXE integration available');
   }
 
   // Check geo targeting
@@ -558,7 +558,7 @@ async function findCompatibleSellers(sellers, requirements) {
 const sellers = await findCompatibleSellers(
   ['https://seller1.com/mcp', 'https://seller2.com/mcp'],
   {
-    axeIntegration: 'https://agentic.scope3.com',
+    axeIntegration: 'https://axe.example.com',
     postalCodeTargeting: true,
     contentStandards: true
   }
@@ -591,7 +591,7 @@ const products = await client.getProducts({
       { level: 'postal_area', system: 'us_zip' }
     ],
     // Only include if seller supports this AXE (legacy — new integrations use TMP)
-    required_axe_integrations: ['https://agentic.scope3.com']
+    required_axe_integrations: ['https://axe.example.com']
   }
 });
 
@@ -682,7 +682,7 @@ const buy = await client.createMediaBuy({
       "property_list_filtering": true
     },
     "execution": {
-      "axe_integrations": ["https://agentic.scope3.com"],
+      "axe_integrations": ["https://axe.example.com"],
       "creative_specs": {
         "vast_versions": ["4.0", "4.1", "4.2"],
         "mraid_versions": ["3.0"],
@@ -735,7 +735,7 @@ const buy = await client.createMediaBuy({
       "primary_countries": ["US", "CA"]
     }
   },
-  "extensions_supported": ["scope3"],
+  "extensions_supported": ["acmecorp"],
   "last_updated": "2025-01-23T10:00:00Z"
 }
 ```
@@ -751,7 +751,7 @@ This tells buyers:
 - **Postal targeting**: US ZIP, UK outward codes, Canadian FSA
 - **Audience targeting**: Accepts hashed email, hashed phone, UID2, and RampID; minimum matched audience size of 500; matching latency 1–24 hours
 - **Conversion tracking**: Accepts purchase, lead, add_to_cart, view_content events from website/app; no multi-source dedup
-- **Extensions**: Scope3 sustainability data in `ext.scope3`
+- **Extensions**: Vendor-specific data in `ext.acmecorp`
 
 ### Multi-protocol agent
 

--- a/docs/trusted-match/surfaces/ai-assistants.mdx
+++ b/docs/trusted-match/surfaces/ai-assistants.mdx
@@ -42,7 +42,7 @@ When a user sends a message in a conversation, the AI platform sends a Context M
     "sentiment": "positive",
     "keywords": ["sneakers", "running", "recommendations"],
     "language": "en",
-    "content_policies": ["common_sense_brand_safety"],
+    "content_policies": ["csbs"],
     "summary": "User asking for sneaker recommendations for running and casual wear"
   },
   "geo": { "country": "US" }

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -268,7 +268,7 @@ AXE and TMP can run in parallel during migration. For full details, use search_d
 ## AXE (Deprecated)
 AXE (Agentic eXecution Engine) is the legacy impression-time execution layer. It is deprecated and being replaced by TMP. Existing AXE integrations continue to work.
 
-Scope3 is the reference AXE implementation via their scope3RtdProvider Prebid RTD module. The AXE segment model uses three key-values:
+Orchestrators implement AXE via Prebid RTD modules (e.g., `exampleRtdProvider`). The AXE segment model uses three key-values:
 - `axei` — include segment (audience targeting)
 - `axex` — exclude segment (brand suitability/suppression)
 - `axem` — macro data (creative personalization, base64-encoded)
@@ -314,7 +314,7 @@ pbjs.setConfig({
   realTimeData: {
     auctionDelay: 200,  // Max ms to wait
     dataProviders: [{
-      name: 'scope3',
+      name: 'example',
       waitForIt: true    // This module can delay the auction
     }]
   }
@@ -332,21 +332,21 @@ How it works:
 All hooks receive userConsent with: gdpr (TCF), usp (CCPA), gpp (Global Privacy Platform), coppa (boolean).
 Modules must use getStorageManager() for cookie/localStorage access, not direct browser APIs.
 
-## Scope3 RTD Module Specifics
+## Orchestrator RTD Module Specifics
 
-Scope3's scope3RtdProvider implements AXE for Prebid. Key details:
+An orchestrator's RTD module (e.g., `exampleRtdProvider`) implements AXE for Prebid. Key details:
 
 **Publisher params:**
-- orgId (required) - Scope3 organization identifier
-- endpoint (default: https://prebid.scope3.com/prebid) - AXE API endpoint
+- orgId (required) - Orchestrator organization identifier
+- endpoint - AXE API endpoint (orchestrator-specific)
 - timeout (default: 1000ms) - Request timeout
 - includeKey (default: 'axei') - GAM targeting key for include segments
 - excludeKey (default: 'axex') - GAM targeting key for exclude segments
 - macroKey (default: 'axem') - GAM targeting key for macro data
 
 **How it works:**
-1. getBidRequestData: Extracts OpenRTB data from ortb2Fragments.global, builds imp array from adUnits, POSTs to Scope3 endpoint
-2. Scope3 evaluates segments and returns: include[] (opaque targeting codes), exclude[] (suppression codes), macro (base64 contextual payload), bidders.{name}.segments/deals
+1. getBidRequestData: Extracts OpenRTB data from ortb2Fragments.global, builds imp array from adUnits, POSTs to the orchestrator's endpoint
+2. Orchestrator evaluates segments and returns: include[] (opaque targeting codes), exclude[] (suppression codes), macro (base64 contextual payload), bidders.{name}.segments/deals
 3. Module distributes signals to: ortb2Fragments.global (all bidders), ortb2Fragments.bidder (per-bidder segments/deals), adUnit.ortb2Imp (per-slot)
 4. getTargetingData: Returns cached signals as axei/axex/axem key-values per ad unit for GAM
 
@@ -355,9 +355,9 @@ Scope3's scope3RtdProvider implements AXE for Prebid. Key details:
 ## Common Debugging
 
 **Module not loading:**
-- Check pbjs.installedModules includes 'scope3RtdProvider' (or the module name)
-- Verify rtdModule is also in the build: gulp build --modules=rtdModule,scope3RtdProvider
-- Check browser console for "RTD provider 'scope3': error in 'init'" messages
+- Check pbjs.installedModules includes the orchestrator's RTD module name (e.g., 'exampleRtdProvider')
+- Verify rtdModule is also in the build: gulp build --modules=rtdModule,exampleRtdProvider
+- Check browser console for "RTD provider '{name}': error in 'init'" messages
 
 **Data not reaching bidders:**
 - Verify getBidRequestData callback is being called (auction won't proceed for waitForIt modules otherwise)
@@ -379,10 +379,10 @@ Scope3's scope3RtdProvider implements AXE for Prebid. Key details:
 - pbjs.installedModules — list all loaded modules
 - pbjs.getConfig('realTimeData') — see RTD configuration
 - pbjs.getConfig('ortb2') — see first-party data config
-- Network tab: filter for the orchestrator's endpoint (e.g., prebid.scope3.com)
+- Network tab: filter for the orchestrator's endpoint
 - GAM request: look for axei/axex/axem in key-value params
 
-Note: Prebid and Scope3 are external projects. For their latest API details, use search_repos with repo_ids "prebid-docs", "prebid-js", or "prebid-server". The above is operational knowledge to help users debug — always verify against current Prebid documentation for the definitive API.
+Note: Prebid is an external project. For the latest API details, use search_repos with repo_ids "prebid-docs", "prebid-js", or "prebid-server". The above is operational knowledge to help users debug — always verify against current Prebid documentation for the definitive API.
 
 ## Ads.txt and Sellers.json Accuracy
 When discussing ads.txt and sellers.json, be precise about how they work:

--- a/server/src/db/migrations/412_rename_scope3_brand_safety_to_csbs.sql
+++ b/server/src/db/migrations/412_rename_scope3_brand_safety_to_csbs.sql
@@ -1,0 +1,27 @@
+-- Rename the brand-safety standard from a vendor-branded identifier
+-- ('scope3_brand_safety') to the neutral framework name 'csbs'
+-- (Common Sense Brand Standards). The framework was contributed to
+-- AgenticAdvertising.org; the renamed identifier reflects AAO governance.
+--
+-- policy_revisions.policy_id is an FK to policies.policy_id with no
+-- ON UPDATE CASCADE, so the FK is temporarily dropped, both tables are
+-- updated, and the FK is restored.
+
+ALTER TABLE policy_revisions
+  DROP CONSTRAINT IF EXISTS policy_revisions_policy_id_fkey;
+
+UPDATE policies
+SET policy_id = 'csbs',
+    name = 'Common Sense Brand Standards',
+    description = 'Common Sense Brand Standards (CSBS) — content adjacency standard governed by AgenticAdvertising.org.',
+    source_name = 'AgenticAdvertising.org',
+    updated_at = NOW()
+WHERE policy_id = 'scope3_brand_safety';
+
+UPDATE policy_revisions
+SET policy_id = 'csbs'
+WHERE policy_id = 'scope3_brand_safety';
+
+ALTER TABLE policy_revisions
+  ADD CONSTRAINT policy_revisions_policy_id_fkey
+  FOREIGN KEY (policy_id) REFERENCES policies(policy_id) ON UPDATE CASCADE;

--- a/static/schemas/source/content-standards/validate-content-delivery-response.json
+++ b/static/schemas/source/content-standards/validate-content-delivery-response.json
@@ -49,7 +49,7 @@
                     "message": { "type": "string" },
                     "rule_id": {
                       "type": "string",
-                      "description": "Which rule triggered this result (e.g., GARM category, Scope3 standard)"
+                      "description": "Which rule triggered this result (e.g., CSBS category, vendor-defined standard)"
                     }
                   },
                   "required": ["feature_id", "status"]

--- a/static/schemas/source/core/offering.json
+++ b/static/schemas/source/core/offering.json
@@ -151,7 +151,7 @@
         "tagline": "Start measuring your digital carbon footprint today",
         "valid_from": "2025-01-01T00:00:00Z",
         "valid_to": "2025-03-31T23:59:59Z",
-        "checkout_url": "https://scope3.com/signup",
+        "checkout_url": "https://vendor.example.com/signup",
         "keywords": ["carbon", "sustainability", "measurement", "emissions"],
         "categories": ["measurement", "sustainability"]
       }

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -802,7 +802,7 @@
       "items": {
         "type": "string",
         "pattern": "^[a-z][a-z0-9_]*$",
-        "description": "Extension namespace (lowercase alphanumeric with underscores, e.g., 'scope3', 'garm', 'iab_tcf')"
+        "description": "Extension namespace (lowercase alphanumeric with underscores, e.g., 'iab_tcf', 'iab_gpp')"
       },
       "uniqueItems": true
     },

--- a/static/schemas/source/tmp/context-match-request.json
+++ b/static/schemas/source/tmp/context-match-request.json
@@ -170,7 +170,7 @@
         },
         "content_policies": {
           "type": "array",
-          "description": "Policy IDs from the AdCP policy registry that this content satisfies (e.g., 'common_sense_brand_safety' for Common Sense Brand Standards baseline). Buyers filter on policies they require. An empty array means no policies have been evaluated.",
+          "description": "Policy IDs from the AdCP policy registry that this content satisfies (e.g., 'csbs' for Common Sense Brand Standards). Buyers filter on policies they require. An empty array means no policies have been evaluated.",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
Closes #2305. Follow-up for the formal IP-donation record: #2314.

## Summary
- Renames policy \`scope3_brand_safety\` → \`csbs\` (Common Sense Brand Standards) across the policy registry, normative docs, and TMP / capabilities schemas.
- Neutralizes vendor-branded examples: \`agentic.scope3.com\` → \`axe.example.com\`, \`scope3.com/methodology\` → \`vendor.example.com/methodology\`, \`scope3RtdProvider\` → \`exampleRtdProvider\`, \`ext.scope3\` → \`ext.acmecorp\` (matching the repo's \`acmecorp\` placeholder-brand idiom). Updates \`extensions_supported\` example to \`["iab_tcf", "iab_gpp", "acmecorp"]\`.
- Drops the "industry baseline replacing GARM" framing and the vendor provider list in \`docs/governance/content-standards/index.mdx\`.
- Migration 412 renames the live \`policies\` row + restores the FK with \`ON UPDATE CASCADE\` so the next rename is a one-liner. Migration 286 left alone (applied history — fresh installs seed then 412 renames).
- \`server/src/addie/rules/knowledge.md\` updated (canonical runtime source per migration 380); migrations 219/220 left as historical \`addie_rules\` seeds.

## What's out of scope
- Formal IP donation / license assignment record — tracked in #2314 pending legal text.
- \`dist/schemas/3.0.0-rc.3/\` release snapshot and \`CHANGELOG.md\` (intentionally frozen).
- Real-vendor attribution in gmsf-reference, authentication/aggregator examples, signals/ecosystem, adagents sample data (factual vendor references, not normative protocol examples).

## Test plan
- [x] \`npm run build:schemas\` — \`dist/schemas/latest/\` rebuilt
- [x] \`npm run test:schemas\` — 7/7 schema validation tests pass
- [x] \`npm run test:unit\` — 587/587 pass (via precommit hook)
- [x] \`npm run typecheck\` — clean
- [ ] Reviewer sanity-check the new Note wording in \`docs/governance/policy-registry.mdx\`
- [ ] Reviewer confirm the \`ext.acmecorp\` namespace choice reads as clearly placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)