### PR TITLE
docs: AI disclosure, transparency footer, red-team FAQ entries

### DIFF
--- a/.changeset/redteam-transparency-faq.md
+++ b/.changeset/redteam-transparency-faq.md
@@ -1,0 +1,4 @@
+---
+---
+
+Publish AI disclosure page (authorship, data handling, human-review SLA, institutional conflicts, regulatory posture), add site-wide footer disclosure with a Transparency column linking AI Disclosure and the Governance Charter, and extend the FAQ with red-team-surfaced questions covering governance (pointing at CHARTER.md), auction-vs-agentic scope (with `buy_terms` as the SPO surface), adagents↔ads.txt crosswalk, forward-looking regulated-vertical autonomy limits (referencing #2310), AAO's Scope3 relationship with interim board composition and named recusal areas (referencing #2305 and CHARTER.md), and buyer-agent security posture as 3.0 GA commitments (referencing #2306/#2307). Update FAQ maturity answer to reflect 3.0 GA target and post-3.0 release cadence.

--- a/docs.json
+++ b/docs.json
@@ -473,6 +473,7 @@
                 ]
               },
               "docs/faq",
+              "docs/ai-disclosure",
               {
                 "group": "Reference",
                 "expanded": false,
@@ -931,7 +932,8 @@
           {
             "group": "FAQ",
             "pages": [
-              "docs/faq"
+              "docs/faq",
+              "docs/ai-disclosure"
             ]
           },
           {
@@ -1210,8 +1212,26 @@
             "href": "https://agenticadvertising.org/api/agreement?type=terms_of_service"
           }
         ]
+      },
+      {
+        "header": "Transparency",
+        "items": [
+          {
+            "label": "AI Disclosure",
+            "href": "/docs/ai-disclosure"
+          },
+          {
+            "label": "Governance Charter",
+            "href": "https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md"
+          },
+          {
+            "label": "Working Group",
+            "href": "/docs/community/working-group"
+          }
+        ]
       }
-    ]
+    ],
+    "message": "AI-authored and AI-assisted. AgenticAdvertising.org's public content and code involve Addie, Sage, and other AI agents — see the AI Disclosure for what's written by AI, what's assisted, and how to request human review."
   },
   "socials": {
     "linkedin": "https://www.linkedin.com/company/ad-context-protocol/",

--- a/docs/ai-disclosure.mdx
+++ b/docs/ai-disclosure.mdx
@@ -1,0 +1,73 @@
+---
+title: AI Disclosure
+description: "How AdCP and AgenticAdvertising.org use AI — what's AI-authored, what's AI-assisted, model and provider disclosure, and how to request human review."
+"og:title": "AdCP — AI Disclosure"
+---
+
+AgenticAdvertising.org uses AI extensively to write content, generate imagery, ship code, and run operations. This page names every surface where that happens, the models behind it, and how to request human review.
+
+---
+
+## What's AI-authored
+
+These surfaces are written primarily by an AI agent operated by AAO, with human editorial oversight:
+
+- **Addie** — AAO's teaching assistant and chat agent. All Addie chat responses are AI-generated.
+- **Sage** — the AdCP protocol explainer agent. Protocol Q&A in the docs chat is answered by Sage.
+- **The Prompt** — our biweekly newsletter, authored in first person as Addie. The Prompt is editorial and is also a marketing surface for AAO; read it as both.
+- **The Build** — our triweekly technical newsletter, authored by Sage.
+- **Member portraits** — graphic-novel-style illustrations for members are AI-generated.
+- **Certification grading** — Addie grades the free Basics track against a fixed rubric of 3–5 required demonstrations per module, and also grades the paid Practitioner and Specialist tracks. AAO is both the issuer and the grader of these credentials; we disclose this conflict rather than deny it, and human review of any grading decision is available on request (see below).
+
+## What's AI-assisted
+
+Most of the rest of AAO's public surface is built with AI coding assistants, reviewed by humans before publishing. This includes:
+
+- The protocol schemas and documentation (this site)
+- The open-source reference implementations
+- The admin tools operated by AAO staff
+- Most public-facing code in the [adcontextprotocol](https://github.com/adcontextprotocol) organization
+
+We don't mark individual paragraphs or pull requests as AI-assisted — the default is that AI tools were involved.
+
+## Model and provider disclosure
+
+- **Addie and Sage** run on Anthropic Claude models.
+- **Image generation** (member portraits, illustrations) uses Google Gemini image models.
+- **Protocol development** uses Claude Code and other agentic development tools.
+
+## Data handling
+
+- **Addie and Sage chat** — conversations are logged to improve teaching quality and to allow appeals on grading decisions. Logs are retained by AAO and not used by model providers for training. EU/UK residents: chat inputs are processed on our behalf by Anthropic; see our [privacy policy](https://agenticadvertising.org/api/agreement?type=privacy_policy) for the current data-processor chain and transfer mechanism.
+- **Grading decisions** — the required-demonstrations, the Addie interaction that produced the credit, and the resulting assessment are retained so that a learner (or a regulator) can reconstruct the decision.
+- **Member portraits** — AI-generated images are produced from member-provided inputs; the prompt and generated image are retained on the member's profile.
+
+## Human review
+
+You can request human review on any AI-generated surface. Target turnaround is **five business days**; complex cert appeals may take longer.
+
+- **Certification grading** — if you believe Addie's assessment of your work was wrong, email [help@agenticadvertising.org](mailto:help@agenticadvertising.org) for human review by AAO staff.
+- **Content corrections** — factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via [GitHub issues](https://github.com/adcontextprotocol/adcp/issues) or [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg).
+- **Protocol guidance** — Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.
+
+## Regulatory posture
+
+This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel. Specific obligations that go beyond what this page provides:
+
+- **EU AI Act Art 50(2)** and **CA SB 942** require machine-readable provenance (e.g., C2PA manifests) on AI-generated images and video. We do not currently apply C2PA manifests to member portraits; adding provenance metadata is on the roadmap.
+- **FTC Endorsement Guides** apply to endorsements and testimonials for compensation. They are not activated by general AI authorship; we call them out here for completeness, not because we claim they are satisfied by this page alone.
+
+If you believe a specific AI surface falls short of an applicable standard, let us know.
+
+## Institutional conflicts
+
+AI authorship and evaluation by AAO intersect with AAO's broader governance in ways readers should know:
+
+- AAO is both the issuer and the grader of its certifications (Addie evaluates coursework and grants credentials AAO sells).
+- AAO's founder's other company (Scope3) contributed funding and foundational IP — see the [FAQ entry](/docs/faq#what-is-aao-s-relationship-with-scope3) for the full relationship.
+
+The governance framework, board composition, and recusal rules are set out in [CHARTER.md](https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md), with the authoritative board list and funding disclosures at [agenticadvertising.org/governance](https://agenticadvertising.org/governance).
+
+---
+
+Material changes to how AI is used at AAO will be reflected on this page.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -90,13 +90,9 @@ Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/l
 </Accordion>
 
 <Accordion title="How mature is the protocol?">
-AdCP is currently at version 3.0 release candidate 2 (v3.0-rc.2). This means:
+AdCP is in the 3.0 release-candidate cycle, with 3.0 GA targeted for April 2026. The protocol design is stable and suitable for pilot implementations; schemas may still receive minor refinements based on implementer feedback before GA.
 
-- The protocol design is stable and suitable for pilot implementations
-- Schemas and task definitions may still receive minor refinements based on implementer feedback
-- Breaking changes are possible before the final 3.0 release, but are tracked through semantic versioning
-
-See the [release notes](/docs/reference/release-notes) for version history.
+The next major version (4.0) is targeted for early 2027, with future major cycles running 18 months to two years. See [Versioning & Governance](/docs/reference/versioning) for the full release cadence, stability guarantees within a version, and deprecation policy. For production use prior to 3.0 GA, we recommend implementing against [v2.5](/docs/reference/v2-sunset).
 </Accordion>
 
 <Accordion title="I built against AdCP 2.5 — what changed?">
@@ -124,6 +120,50 @@ A platform can implement both. For example, a publisher's AdCP agent might accep
 
 <Accordion title="What is AdCP's relationship to IAB Tech Lab?">
 AdCP is a separate specification from IAB Tech Lab standards. AgenticAdvertising.org is an independent organization. However, AdCP is designed to be compatible with IAB standards — for example, AdCP's content taxonomy fields align with IAB content categories, and AdCP's audience segments can reference IAB audience taxonomy IDs.
+</Accordion>
+
+<Accordion title="Why isn't AdCP an auction protocol?">
+AdCP is built for agentic workflows — direct-sold inventory, guaranteed deals, and commerce media — not the impression-level auction where OpenRTB already works. Buyers and sellers transact directly through their agents, with pricing surfaced via `pricing_options`, `price_guidance`, and (when the transaction warrants it) `price_breakdown`.
+
+The supply-path-optimization concerns that drove SPO disclosure in programmatic auctions look different in direct-sold transactions, where buyer and seller are authenticated counterparties rather than anonymous bidders. Buyers that want SPO-grade fee disclosure can require it through `buy_terms` as a condition of the purchase — the protocol supports it; it's not imposed as a protocol-wide mandate.
+</Accordion>
+
+<Accordion title="How does adagents.json relate to ads.txt and sellers.json?">
+`adagents.json` extends the authorization model for agentic buying while preserving the ads.txt/sellers.json relationship semantics. A publisher's `adagents.json` with `delegation_type` carries the same signal as an ads.txt `DIRECT` or `RESELLER` row, and `brand.json` properties with a `relationship` field carry the same signal as a sellers.json entry.
+
+The full crosswalk is in [Why adagents.json instead of ads.txt](/docs/governance/property/adagents#why-adagents-json-instead-of-ads-txt).
+</Accordion>
+
+<Accordion title="Can an AI agent autonomously buy credit, insurance, housing, or employment ads?">
+These verticals fall under GDPR Art 22, EU AI Act Annex III, and US FHA / ECOA / EEOC. The policy-category mechanism already ships with `fair_housing`, `fair_lending`, and `fair_employment` entries in the registry.
+
+AdCP 3.0 GA will require campaigns declaring a regulated policy category to run with human review — `authority_level: agent_full` will not be accepted — with an Annex III category taxonomy and a data-subject contestation path added at the same time. Tracked in [#2310](https://github.com/adcontextprotocol/adcp/issues/2310). Until that ships, enforcement depends on the governance agent implementation, not a schema invariant. See the [governance overview](/docs/governance/overview) for the full model.
+</Accordion>
+
+<Accordion title="Who governs AdCP?">
+AdCP is governed by AgenticAdvertising.Org, a pending 501(c)(6) trade association incorporated in Delaware. Governance is summarized in [CHARTER.md](https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md) in the repository, with the authoritative materials (Bylaws, Membership Agreement, IPR Policy, Antitrust Policy) at [agenticadvertising.org/governance](https://agenticadvertising.org/governance).
+
+The Foundation has four voting member classes with equal representation on the Board — Brands, Agencies, Publishers, and Technology Providers — targeting ten seats per class at the first elected board, replacing the current interim board at the 2026 Annual General Meeting. Day-to-day protocol work happens in [working groups](/docs/community/working-group); change proposals flow through this repository.
+</Accordion>
+
+<Accordion title="What is AAO's relationship with Scope3?">
+Scope3 contributed foundational IP and early funding to AgenticAdvertising.Org. Specifically:
+
+- **CSBS (Common Sense Brand Standards)** — formerly "Scope3 Common Sense" — was donated to AAO and is now governed by AAO. The formal donation and rename are tracked in [#2305](https://github.com/adcontextprotocol/adcp/issues/2305).
+- **Property registry seed data** — the initial property universe and ad-infrastructure knowledge graph seeding the AAO property catalog was donated by Scope3.
+- **Seed funding loan** — Scope3 provided a seed funding loan to AAO, which is in the process of being repaid.
+
+The interim board has four directors: Michael Blum (Scope3), Brian O'Kelley (Scope3), Pia Malovrh (Celtra), and Benjamin Masse (Triton Digital). Two of four interim directors are Scope3-affiliated; this composition transitions to an elected board at the 2026 Annual General Meeting, targeting equal representation across four voting classes. Brian co-founded both Scope3 and AAO and serves as AdCP lead architect; he does not hold executive authority at AAO, and Scope3 holds no voting rights, veto, or protocol-control privileges beyond those of any other member. Because of the dual role, he recuses from AAO decisions where Scope3 has a direct commercial interest — including any change to the default brand-safety framework, property-catalog data governance, and the terms of the seed-loan repayment.
+
+See [CHARTER.md](https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md) for the governance framework and [agenticadvertising.org/governance](https://agenticadvertising.org/governance) for the authoritative board list, funding disclosures, and recusal rules.
+</Accordion>
+
+<Accordion title="How is AdCP secured against a compromised buyer agent?">
+AdCP today uses bearer-token authentication between agents — see [authentication](/docs/building/integration/authentication) for the shipped model.
+
+AdCP 3.0 GA will add request signing for mutating calls (`create_*`, `update_*`, `sync_*`, `activate_*`, `acquire_*`) via RFC 9421 HTTP Signatures or JWS-signed bodies, with sellers verifying against the buyer's published signing keys. Bearer tokens alone will not be sufficient for mutating calls. Tracked in [#2307](https://github.com/adcontextprotocol/adcp/issues/2307).
+
+Governance decisions will also be signed so that a seller or regulator can verify a `governance_context` token genuinely came from the issuing governance agent. Tracked in [#2306](https://github.com/adcontextprotocol/adcp/issues/2306). Until those land, implementers should treat bearer auth as an interim floor, not the long-term contract.
 </Accordion>
 
 <Accordion title="Does AdCP support AI platforms and AI ad networks?">


### PR DESCRIPTION
## Summary

- Publishes `docs/ai-disclosure.mdx` — what's AI-authored (Addie, Sage, The Prompt, The Build, member portraits, cert grading), what's AI-assisted, model/provider disclosure, data handling, 5-business-day human-review SLA, institutional conflicts, and regulatory posture (honest on what disclosure alone does and doesn't satisfy under FTC / EU AI Act Art 50 / CA SB 942).
- Adds a site-wide footer *Transparency* column (AI Disclosure, Governance Charter, Working Group) plus an AI-authored/AI-assisted message on every page.
- Extends the FAQ with red-team-surfaced questions: governance (pointing at CHARTER.md), Scope3 relationship with interim board composition and named recusal areas, auction-vs-agentic scope with `buy_terms` as the SPO surface, adagents↔ads.txt crosswalk, forward-looking regulated-vertical autonomy limits (#2310), and buyer-agent security posture as 3.0 GA commitments (#2306/#2307). Maturity answer updated for 3.0 GA + 4.0 early-2027 cadence.

## Test plan

- [ ] `docs.json` still validates (verified locally via `python -m json.tool`)
- [ ] Mintlify preview renders the new AI Disclosure page, footer column, and footer message
- [ ] New FAQ entries render inside the correct accordion groups
- [ ] Cross-links resolve: `/docs/ai-disclosure`, `/docs/reference/versioning`, `/docs/reference/v2-sunset`, `/docs/governance/property/adagents#why-adagents-json-instead-of-ads-txt`, `CHARTER.md`, issues #2305/#2306/#2307/#2310

🤖 Generated with [Claude Code](https://claude.com/claude-code)