### PR TITLE
feat(schemas): add collection-lists specialism + training agent fix

### DIFF
--- a/.changeset/add-collection-lists-specialism.md
+++ b/.changeset/add-collection-lists-specialism.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `collection-lists` specialism covering program-level brand safety via collection-list CRUD. Closes #2330.
+
+Collection lists operate on content programs (shows, series, podcasts) identified by platform-independent IDs (IMDb, Gracenote, EIDR), parallel to the `property-lists` specialism which operates on technical surfaces (domains, apps). The new specialism bundle exercises the full CRUD lifecycle — `create_collection_list`, `list_collection_lists`, `get_collection_list` (with `resolve: true`), `update_collection_list`, `delete_collection_list` — plus capability discovery.
+
+**Scope (CRUD-only, by design).** Unlike `property-lists`, collection lists have no `validate_collection_delivery` counterpart yet. Enforcement is setup-time (the governance agent resolves the list, sellers cache it, delivery matches at serve time) rather than post-hoc. When `validate_collection_delivery` is added, a validation phase can be appended to this specialism.
+
+**Additive enum value.** `collection-lists` is new — no existing agent declares it, so no migration required. Minor rather than major bump.
+
+**Training agent fix.** Several property-list and collection-list tool definitions were missing `brand` (and `resolve` on `get_property_list`) from their inputSchema, even though the handlers already read those fields for session keying. MCP clients that strip undeclared fields were collapsing post-create calls to an empty session — making the CRUD lifecycle fail on the second call. Tool inputSchemas now declare these fields. This also repairs the `property-lists` storyboard smoke path, which was failing end-to-end against the deployed training agent for the same reason. An in-tree storyboard test (`server/tests/unit/collection-lists-storyboard.test.ts`) pins the invariant.

--- a/docs/building/compliance-catalog.mdx
+++ b/docs/building/compliance-catalog.mdx
@@ -102,6 +102,7 @@ Specialisms are grouped below by parent protocol.
 |-----------|--------|---------|
 | `content-standards` | stable | Content standards enforcement (brand safety, policy compliance) |
 | `property-lists` | stable | Property list governance — curated inclusion and exclusion lists for targeting and delivery compliance |
+| `collection-lists` | stable | Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety |
 | `governance-delivery-monitor` | stable | Campaign delivery monitoring with drift detection |
 | `governance-spend-authority` | stable | Conditional spend approval and human-in-the-loop governance |
 | `measurement-verification` | **preview** | Third-party measurement and verification. Parked under `governance` for 3.1; a dedicated `measurement` protocol is planned once the viewability, attribution, brand-safety, and SI-outcome surfaces split out. |
@@ -151,6 +152,7 @@ The kebab↔snake swap between wire specialism IDs and storyboard categories is 
 | `sales-broadcast-tv` | `channels: ['linear_tv']` | `sales_broadcast_tv` | — |
 | `audience-sync` | `sync_audiences` tool | `audience_sync` | — |
 | `property-lists` | `property_list` tools | `property_lists` | — |
+| `collection-lists` | `collection_list` tools | `collection_lists` | — |
 | `governance-spend-authority` | `check_governance`, `sync_plans` | `governance_spend_authority` | `governance_spend_authority/denied` |
 | `creative-generative` | `build_creative` | `creative_generative` | `creative_generative/seller` |
 | `brand-rights` | `get_brand_identity`, `acquire_rights` | `brand_rights` | `brand_rights/governance_denied` |

--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -42,6 +42,7 @@ export const COLLECTION_LIST_TOOLS = [
       properties: {
         list_id: { type: 'string' },
         resolve: { type: 'boolean' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
       },
       required: ['list_id'],
     },
@@ -60,6 +61,7 @@ export const COLLECTION_LIST_TOOLS = [
         base_collections: { type: 'array' },
         filters: { type: 'object' },
         webhook_url: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the update to this brand' },
       },
       required: ['list_id'],
     },
@@ -73,6 +75,7 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         name_contains: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to this brand' },
       },
     },
   },
@@ -85,6 +88,7 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
       },
       required: ['list_id'],
     },

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -28,7 +28,7 @@ export const PROPERTY_TOOLS = [
         list_type: { type: 'string', enum: ['inclusion', 'exclusion'], description: 'Type of property list' },
         base_properties: { type: 'array', description: 'Property sources to include' },
         filters: { type: 'object', description: 'Dynamic filters for list resolution' },
-        brand: { type: 'object', description: 'Brand reference for automatic rule application' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference for automatic rule application' },
         idempotency_key: { type: 'string' },
       },
       required: ['name'],
@@ -43,6 +43,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         name_contains: { type: 'string', description: 'Filter to lists whose name contains this string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to lists created under this brand' },
       },
     },
   },
@@ -55,6 +56,8 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
+        resolve: { type: 'boolean', description: 'When true, return the resolved properties alongside list metadata' },
       },
       required: ['list_id'],
     },
@@ -72,7 +75,7 @@ export const PROPERTY_TOOLS = [
         description: { type: 'string', description: 'New description' },
         base_properties: { type: 'array', description: 'Complete replacement for the base properties list' },
         filters: { type: 'object', description: 'Complete replacement for the filters' },
-        brand: { type: 'object', description: 'Update brand reference' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference' },
       },
       required: ['list_id'],
     },
@@ -86,6 +89,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
       },
       required: ['list_id'],
     },
@@ -99,7 +103,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list to validate against' },
-        brand: { type: 'object', description: 'Brand reference' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference' },
         records: {
           type: 'array',
           description: 'Delivery records to validate. Each record has an identifier ({type, value}) and impressions.',

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import YAML from 'yaml';
+import {
+  createTrainingAgentServer,
+  invalidateCache,
+  clearTaskStore,
+} from '../../src/training-agent/task-handlers.js';
+import { clearSessions } from '../../src/training-agent/state.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const STORYBOARD_PATH = join(
+  process.cwd(),
+  'static/compliance/source/specialisms/collection-lists/index.yaml',
+);
+
+interface Step {
+  id: string;
+  task: string;
+  sample_request?: Record<string, unknown>;
+  context_outputs?: { path: string; key: string }[];
+  validations: Validation[];
+}
+
+interface Validation {
+  check: 'field_present' | 'field_value' | 'response_schema';
+  path?: string;
+  value?: unknown;
+  description: string;
+}
+
+interface Phase {
+  id: string;
+  steps: Step[];
+}
+
+async function simulateCallTool(
+  server: ReturnType<typeof createTrainingAgentServer>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ result: Record<string, unknown>; isError?: boolean }> {
+  const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+  const handler = requestHandlers.get('tools/call');
+  if (!handler) throw new Error('CallTool handler not found');
+  const response = await handler(
+    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    {},
+  );
+  const text = response.content?.[0]?.text;
+  const parsed = text ? JSON.parse(text) : {};
+  const result = parsed.adcp_error ?? parsed;
+  return { result, isError: response.isError };
+}
+
+function resolveContextRefs(
+  value: unknown,
+  context: Record<string, unknown>,
+): unknown {
+  if (typeof value === 'string' && value.startsWith('$context.')) {
+    return context[value.slice('$context.'.length)];
+  }
+  if (Array.isArray(value)) return value.map(v => resolveContextRefs(v, context));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = resolveContextRefs(v, context);
+    return out;
+  }
+  return value;
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+// Two tests live here:
+//   1. An end-to-end walk of the storyboard's phases against in-process handlers.
+//      This passes `brand` into handlers directly, so it does NOT catch the
+//      "inputSchema missing brand" regression.
+//   2. A tools/list invariant that asserts every CRUD tool declares `brand` in
+//      its inputSchema — MCP clients strip undeclared keys, collapsing the
+//      session key and breaking multi-step flows. The smoke test against live
+//      agents catches that, but this unit test catches it faster.
+describe('collection-lists specialism storyboard', () => {
+  let server: ReturnType<typeof createTrainingAgentServer>;
+  const ctx: TrainingContext = { mode: 'open' };
+
+  beforeEach(() => {
+    clearSessions();
+    invalidateCache();
+    clearTaskStore();
+    server = createTrainingAgentServer(ctx);
+  });
+
+  it('runs the full CRUD lifecycle end-to-end', async () => {
+    const storyboard = YAML.parse(readFileSync(STORYBOARD_PATH, 'utf8'));
+    expect(storyboard.id).toBe('collection_lists');
+    expect(storyboard.phases).toBeDefined();
+
+    const context: Record<string, unknown> = {};
+
+    for (const phase of storyboard.phases as Phase[]) {
+      for (const step of phase.steps) {
+        const args = resolveContextRefs(step.sample_request ?? {}, context) as Record<
+          string,
+          unknown
+        >;
+        const { result, isError } = await simulateCallTool(server, step.task, args);
+
+        expect(
+          isError,
+          `step ${step.id} (${step.task}) returned isError: ${JSON.stringify(result)}`,
+        ).toBeFalsy();
+        expect(
+          (result as any).errors,
+          `step ${step.id} (${step.task}) returned errors: ${JSON.stringify((result as any).errors)}`,
+        ).toBeUndefined();
+
+        for (const v of step.validations) {
+          if (v.check === 'field_present' && v.path && !v.path.startsWith('context')) {
+            expect(
+              getByPath(result, v.path),
+              `step ${step.id}: ${v.description}`,
+            ).toBeDefined();
+          }
+          if (v.check === 'field_value' && v.path && !v.path.startsWith('context')) {
+            expect(getByPath(result, v.path), `step ${step.id}: ${v.description}`).toEqual(
+              v.value,
+            );
+          }
+        }
+
+        for (const out of step.context_outputs ?? []) {
+          context[out.key] = getByPath(result, out.path);
+        }
+      }
+    }
+
+    expect(context.collection_list_id).toBeTruthy();
+  });
+
+  it('tool inputSchemas declare brand so MCP clients do not strip it', async () => {
+    const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+    const handler = requestHandlers.get('tools/list');
+    if (!handler) throw new Error('ListTools handler not found');
+    const { tools } = await handler({ method: 'tools/list' }, {});
+
+    const collectionTools = (tools as { name: string; inputSchema: { properties?: Record<string, unknown> } }[]).filter(
+      t => /^(create|get|list|update|delete)_collection_list/.test(t.name),
+    );
+    expect(collectionTools.length).toBe(5);
+
+    for (const tool of collectionTools) {
+      expect(
+        tool.inputSchema.properties,
+        `${tool.name} has no inputSchema.properties`,
+      ).toBeDefined();
+      expect(
+        tool.inputSchema.properties?.brand,
+        `${tool.name} inputSchema does not declare 'brand' — @adcp/client will strip it, collapsing session key to open:default`,
+      ).toBeDefined();
+    }
+  });
+});

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -1,0 +1,336 @@
+id: collection_lists
+version: "1.0.0"
+title: "Collection lists"
+protocol: governance
+category: collection_lists
+summary: "Curated collection lists for program-level brand safety and content targeting — create, query, update, and delete lists of content programs (shows, series, podcasts)."
+track: governance
+required_tools:
+  - create_collection_list
+
+narrative: |
+  You run a governance agent that manages collection lists for brand safety. Unlike
+  property lists which operate on technical surfaces (domains, apps), collection lists
+  operate on content programs (shows, series, podcasts) identified by platform-independent
+  IDs like IMDb, Gracenote, or EIDR.
+
+  Buyers create inclusion and exclusion lists that define which programs their ads can
+  and cannot appear against. Your agent resolves the base collections and filters into a
+  concrete list of program identifiers that sellers can cache and enforce at bid time.
+
+  Collection lists are setup-time resources: the governance agent resolves them once and
+  sellers cache the result. Unlike property lists, there is no post-delivery validation
+  task yet — enforcement happens at serve time via the cached list, not via after-the-fact
+  compliance checks. This storyboard therefore exercises the full CRUD lifecycle (create,
+  query, update, delete) but does not test delivery validation.
+
+agent:
+  interaction_model: governance_agent
+  capabilities:
+    - collection_lists
+    - brand_safety
+  examples:
+    - "IAS"
+    - "DoubleVerify"
+    - "GARM-aligned platforms"
+    - "Brand safety services"
+
+caller:
+  role: buyer_agent
+  example: "Nova Motors (buyer)"
+
+prerequisites:
+  description: |
+    The caller needs a brand identity and content-program knowledge (distribution IDs,
+    publisher identifiers, or genre taxonomies). The test kit provides a sample brand
+    with campaign context.
+  test_kit: "test-kits/nova-motors.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent supports governance
+      before creating or fetching collection lists.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares the expected protocol support before
+          proceeding with domain-specific operations.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring governance in supported_protocols, confirming
+          the agent provides governance services.
+        sample_request:
+          context:
+            correlation_id: "collection_lists--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: create_list
+    title: "Create collection lists"
+    narrative: |
+      The buyer creates an inclusion collection list for the campaign. The list defines
+      which content programs the brand is willing to advertise against, selected by
+      platform-independent distribution identifiers.
+
+    steps:
+      - id: create_inclusion_list
+        title: "Create an inclusion collection list"
+        narrative: |
+          The buyer creates an inclusion list of programs the brand considers safe to
+          advertise against, referenced by distribution IDs (e.g. IMDb) so the selection
+          is portable across publishers.
+        task: create_collection_list
+        schema_ref: "collection/create-collection-list-request.json"
+        response_schema_ref: "collection/create-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the created collection list:
+          - list_id: platform-assigned identifier
+          - collection_count reflecting the resolved programs
+          - auth_token issued for sellers to fetch the list
+          - Timestamps populated
+
+        sample_request:
+          brand:
+            domain: "novamotors.example"
+          name: "Nova Motors approved programs"
+          base_collections:
+            - selection_type: "distribution_ids"
+              identifiers:
+                - type: "imdb_id"
+                  value: "tt9999901"
+                - type: "imdb_id"
+                  value: "tt9999902"
+                - type: "imdb_id"
+                  value: "tt9999903"
+          filters:
+            kinds: ["series"]
+
+          context:
+            correlation_id: "collection_lists--create_inclusion_list"
+        context_outputs:
+          - path: "list.list_id"
+            key: "collection_list_id"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "Governance agent assigns list_id — must be echoed in get/update/delete"
+          - check: field_present
+            path: "auth_token"
+            description: "Agent issues an auth_token at creation time for seller fetches"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--create_inclusion_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: list_and_get
+    title: "Query collection lists"
+    narrative: |
+      The buyer lists all collection lists for the brand and retrieves a specific list
+      with resolved collections.
+
+    steps:
+      - id: list_collection_lists
+        title: "List all collection lists"
+        narrative: |
+          The buyer lists all collection lists for the brand. The response includes
+          list metadata without full resolved collection details.
+        task: list_collection_lists
+        schema_ref: "collection/list-collection-lists-request.json"
+        response_schema_ref: "collection/list-collection-lists-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return collection list summaries:
+          - Array of lists with list_id, name, collection_count
+          - Includes the list created in the prior phase
+
+        sample_request:
+          brand:
+            domain: "novamotors.example"
+          name_contains: "Nova Motors"
+
+          context:
+            correlation_id: "collection_lists--list_collection_lists"
+        validations:
+          - check: response_schema
+            description: "Response matches list-collection-lists-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--list_collection_lists"
+            description: "Context correlation_id returned unchanged"
+
+      - id: get_collection_list
+        title: "Get a specific collection list with resolved collections"
+        narrative: |
+          The buyer retrieves a specific collection list with resolve:true to confirm
+          the agent can materialize the programs the list references.
+        task: get_collection_list
+        schema_ref: "collection/get-collection-list-request.json"
+        response_schema_ref: "collection/get-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the full collection list:
+          - list_id, name, collection_count
+          - Resolved collections with distribution_ids, content_rating, genre
+          - cache_valid_until timestamp for seller caching
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          resolve: true
+          brand:
+            domain: "novamotors.example"
+
+          context:
+            correlation_id: "collection_lists--get_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches get-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "List id returned"
+          - check: field_present
+            path: "collections"
+            description: "Resolved collections returned when resolve:true"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--get_collection_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: update_list
+    title: "Update collection lists"
+    narrative: |
+      The buyer modifies an existing collection list — replacing the base collections
+      as the campaign's content preferences evolve.
+
+    steps:
+      - id: update_collection_list
+        title: "Update a collection list"
+        narrative: |
+          The buyer replaces the base collections on an existing list with a new set
+          of distribution identifiers.
+        task: update_collection_list
+        schema_ref: "collection/update-collection-list-request.json"
+        response_schema_ref: "collection/update-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the updated collection list:
+          - Same list_id
+          - Updated collection_count reflecting the replaced base collections
+          - Updated updated_at timestamp
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          brand:
+            domain: "novamotors.example"
+          base_collections:
+            - selection_type: "distribution_ids"
+              identifiers:
+                - type: "imdb_id"
+                  value: "tt9999901"
+                - type: "imdb_id"
+                  value: "tt9999904"
+                - type: "imdb_id"
+                  value: "tt9999905"
+                - type: "imdb_id"
+                  value: "tt9999906"
+
+          context:
+            correlation_id: "collection_lists--update_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches update-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "Updated list retains its list_id"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--update_collection_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: delete_list
+    title: "Delete a collection list"
+    narrative: |
+      The buyer removes a collection list that is no longer needed. Deleting a list
+      revokes the associated auth_token.
+
+    steps:
+      - id: delete_collection_list
+        title: "Delete a collection list"
+        narrative: |
+          The buyer deletes a collection list. The governance agent removes the list
+          and returns confirmation.
+        task: delete_collection_list
+        schema_ref: "collection/delete-collection-list-request.json"
+        response_schema_ref: "collection/delete-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Confirm deletion:
+          - deleted: true
+          - list_id: the deleted list
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          brand:
+            domain: "novamotors.example"
+
+          context:
+            correlation_id: "collection_lists--delete_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches delete-collection-list-response.json schema"
+          - check: field_value
+            path: "deleted"
+            value: true
+            description: "Delete returns deleted: true"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--delete_collection_list"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -17,7 +17,7 @@
 #   Sales: sales_guaranteed | sales_non_guaranteed | sales_proposal_mode | sales_catalog_driven | sales_broadcast_tv | sales_streaming_tv | sales_social | sales_exchange | sales_retail_media
 #   Creative: creative_ad_server | creative_generative | creative_template
 #   Signals: signal_marketplace | signal_owned
-#   Governance: content_standards | property_lists | governance_delivery_monitor | governance_spend_authority | measurement_verification
+#   Governance: content_standards | property_lists | collection_lists | governance_delivery_monitor | governance_spend_authority | measurement_verification
 #   Brand: brand_rights
 #   Audiences: audience_sync
 #   Universal / domain-level: capability_discovery | schema_validation | behavioral_analysis | error_compliance | security | media_buy_seller | media_buy_governance_escalation | si_session

--- a/static/schemas/source/enums/specialism.json
+++ b/static/schemas/source/enums/specialism.json
@@ -7,6 +7,7 @@
   "enum": [
     "audience-sync",
     "brand-rights",
+    "collection-lists",
     "content-standards",
     "creative-ad-server",
     "creative-generative",
@@ -30,6 +31,7 @@
   "enumDescriptions": {
     "audience-sync": "Syncs buyer-provided audience segments into a platform for activation",
     "brand-rights": "Brand identity and rights licensing (talent, music, stock media)",
+    "collection-lists": "Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety",
     "content-standards": "Content standards enforcement (brand safety, policy compliance)",
     "creative-ad-server": "Creative ad server with tag-based delivery",
     "creative-generative": "Generative creative agent producing assets on demand",


### PR DESCRIPTION
## Summary

- Adds a `collection-lists` specialism for program-level brand safety (shows, series, podcasts via IMDb/Gracenote/EIDR IDs), parallel to the just-renamed `property-lists` specialism (domains, apps).
- CRUD-only scope — capability discovery + create + list/get + update + delete. No validation phase: `validate_collection_delivery` doesn't exist in the spec, so enforcement is setup-time seller caching, not post-hoc validation.
- Fixes a pre-existing bug in the training agent where property_list and collection_list tool inputSchemas omitted `brand` (and `resolve` on `get_property_list`), even though the handlers read those fields for session keying. MCP clients strip undeclared fields, collapsing post-create calls to an empty session. Both `property-lists` and `collection-lists` storyboards now work end-to-end.

Closes #2330. Follow-up to #2287 / PR #2332.

## Scope

- `static/compliance/source/specialisms/collection-lists/index.yaml` — new storyboard bundle (5 phases)
- `static/schemas/source/enums/specialism.json` — additive `collection-lists` enum value
- `static/compliance/source/universal/storyboard-schema.yaml` — governance categories comment
- `docs/building/compliance-catalog.mdx` — governance table + mapping table rows
- `server/src/training-agent/property-handlers.ts` + `inventory-governance-handlers.ts` — add `brand` (and `resolve` on get_property_list) to tool inputSchemas
- `server/tests/unit/collection-lists-storyboard.test.ts` — in-process storyboard walk + pins the schema invariant

## Expert review applied

Both reviews returned ship-it. Nits applied:
- **code-reviewer** — symmetry fix on property-handlers.ts `brand` schema (now declares `properties: { domain }`); added header comment to the test explaining why two tests live there (in-process walk + inputSchema invariant).
- **adtech-product-expert** — changeset now explicitly notes the fix repairs the `property-lists` smoke path too.

Pre-existing test failures in `test:server-unit` (comply-test-controller account/session/delivery tests, mcp-response-unwrap) — confirmed via `git stash` that they exist without this PR's changes. Not caused by this work.

## Follow-ups (flagged by product expert, not blockers)

- `docs/learning/specialist/governance.mdx:46` — property_lists has a learning card; add a collection_lists one.
- AAO badge rendering + Addie capability wiring for the new specialism.

## Test plan

- [x] `npm run build:schemas`
- [x] `npm run build:compliance` — 22 specialisms (was 21), `collection-lists` present
- [x] `npm run test:schemas` (7/7)
- [x] `npm run test:docs-nav` (15/15)
- [x] `npm run test:examples` (31/31)
- [x] `npm run test:composed` (12/12)
- [x] `npx vitest run server/tests/unit/collection-lists-storyboard.test.ts` (2/2)
- [x] `npm run test:unit` (587/587) via precommit
- [x] `npm run typecheck`
- [x] `npx changeset status` — minor bump registered
- [ ] Post-deploy smoke: `ADCP_COMPLIANCE_DIR=./dist/compliance/latest npx tsx server/tests/manual/storyboard-smoke.ts --storyboard collection_lists` against the deployed training agent (will work once this PR's server fix ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)