### PR TITLE
feat(schemas)!: add collection-lists specialism + complete account migration

### DIFF
--- a/.changeset/account-migration-property-collection-lists.md
+++ b/.changeset/account-migration-property-collection-lists.md
@@ -1,0 +1,64 @@
+---
+"adcontextprotocol": major
+---
+
+Complete the Account migration for property-list and collection-list task families. Removes the deprecated `principal: string` field everywhere it appeared and replaces it with `account: $ref /schemas/core/account-ref.json`, bringing these two families in line with every other task family in AdCP 3.0 (media-buy, creative, signals, content-standards, account).
+
+## Motivation
+
+Per the glossary (`docs/reference/glossary.mdx:228`), `Principal` is deprecated: AdCP now splits authentication (**Agent**) from billing/platform mapping (**Account**). Every request family that needs account scoping already uses `account: $ref /schemas/core/account-ref.json` — except property-list and collection-list, which still carried the legacy `principal` field. This PR finishes the migration so there is a single, consistent identity primitive across the spec.
+
+A protocol-expert audit in #2333 confirmed that without this change, the training agent is forced to use `brand.domain` as a session-key proxy — a training-only workaround that diverges from how real sellers derive isolation (auth-derived Agent scoped to Account).
+
+## Breaking changes
+
+**Schema rename (4 files):** `principal: string` removed; `account: $ref /schemas/core/account-ref.json` added.
+- `static/schemas/source/property/property-list.json`
+- `static/schemas/source/property/list-property-lists-request.json`
+- `static/schemas/source/collection/collection-list.json`
+- `static/schemas/source/collection/list-collection-lists-request.json`
+
+**New optional `account` field added (9 request schemas):** gives callers a way to disambiguate across accounts when the authenticated agent has access to more than one, matching the `get-media-buys-request.json` pattern.
+- `static/schemas/source/property/create-property-list-request.json`
+- `static/schemas/source/property/get-property-list-request.json`
+- `static/schemas/source/property/update-property-list-request.json`
+- `static/schemas/source/property/delete-property-list-request.json`
+- `static/schemas/source/property/validate-property-delivery-request.json`
+- `static/schemas/source/collection/create-collection-list-request.json`
+- `static/schemas/source/collection/get-collection-list-request.json`
+- `static/schemas/source/collection/update-collection-list-request.json`
+- `static/schemas/source/collection/delete-collection-list-request.json`
+
+`brand` stays on `create_*_list` and `update_*_list` as campaign-identity metadata (same role as in `create-media-buy`). It is no longer overloaded as an identity primitive on read/list/update/delete.
+
+## Reference implementation (training agent)
+
+- `server/src/training-agent/account-handlers.ts` — `ACCOUNT_REF_SCHEMA` is now exported for reuse.
+- `server/src/training-agent/property-handlers.ts` and `inventory-governance-handlers.ts` — all 10 CRUD + validate tools now declare `account: ACCOUNT_REF_SCHEMA` in their inputSchema. The stray `brand`-on-list/get/delete workaround introduced in #2333 is removed.
+- `PropertyListState.principal` is renamed to `PropertyListState.account: AccountRef`. `CollectionListState` gains `account: AccountRef`. Both handlers persist and echo the account on list/get responses.
+
+## Storyboards
+
+- `static/compliance/source/specialisms/property-lists/index.yaml` — every `brand:` block on list/get/update/delete/validate_property_delivery is now `account: { brand: { domain }, operator }`; `principal: "acmeoutdoor.example"` on the list call is gone.
+- `static/compliance/source/specialisms/collection-lists/index.yaml` — same migration.
+
+## Docs
+
+Fixed references to `principal` that describe the protocol (not the deprecated-term glossary entry, which stays as a redirect, and not `docs/building/implementation/security.mdx` legacy vocabulary):
+- `docs/governance/property/tasks/property_lists.mdx`
+- `docs/governance/collection/tasks/collection_lists.mdx`
+- `docs/governance/collection/index.mdx`
+- `docs/governance/property/specification.mdx`
+
+## Migration guide
+
+For agents that were declaring `principal` on list or resource payloads:
+- Replace `principal: "some-id"` with `account: { account_id: "some-id" }` if you had a seller-assigned ID.
+- Replace `principal: "example.com"` with `account: { brand: { domain: "example.com" }, operator: "example.com" }` for the direct-operated brand case.
+- For agency-operated flows, use `account: { brand: { domain: "brand.com" }, operator: "agency.com" }`.
+
+Creators can continue to pass `brand` on `create_*_list` / `update_*_list` — that field is unchanged and carries campaign metadata (industry, audience) per the spec's existing description.
+
+All request schemas for this family declare `additionalProperties: false`, so stray `principal` fields on the wire will now fail validation rather than being silently ignored. Sellers upgrading their clients should search their payloads for `"principal":` and replace per the guide above.
+
+**Follow-up (not in this PR):** `server/src/training-agent/state.ts:310` still falls back to `args.brand?.domain` when `account` is absent. With `additionalProperties: false` now enforced at the gateway, this fallback is unreachable on spec-compliant paths and can be removed in a separate training-agent-only cleanup.

--- a/.changeset/add-collection-lists-specialism.md
+++ b/.changeset/add-collection-lists-specialism.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `collection-lists` specialism covering program-level brand safety via collection-list CRUD. Closes #2330.
+
+Collection lists operate on content programs (shows, series, podcasts) identified by platform-independent IDs (IMDb, Gracenote, EIDR), parallel to the `property-lists` specialism which operates on technical surfaces (domains, apps). The new specialism bundle exercises the full CRUD lifecycle — `create_collection_list`, `list_collection_lists`, `get_collection_list` (with `resolve: true`), `update_collection_list`, `delete_collection_list` — plus capability discovery.
+
+**Scope (CRUD-only, by design).** Unlike `property-lists`, collection lists have no `validate_collection_delivery` counterpart yet. Enforcement is setup-time (the governance agent resolves the list, sellers cache it, delivery matches at serve time) rather than post-hoc. When `validate_collection_delivery` is added, a validation phase can be appended to this specialism.
+
+**Additive enum value.** `collection-lists` is new — no existing agent declares it, so no migration required. Minor rather than major bump.
+
+**Training agent fix.** Several property-list and collection-list tool definitions were missing `brand` (and `resolve` on `get_property_list`) from their inputSchema, even though the handlers already read those fields for session keying. MCP clients that strip undeclared fields were collapsing post-create calls to an empty session — making the CRUD lifecycle fail on the second call. Tool inputSchemas now declare these fields. This also repairs the `property-lists` storyboard smoke path, which was failing end-to-end against the deployed training agent for the same reason. An in-tree storyboard test (`server/tests/unit/collection-lists-storyboard.test.ts`) pins the invariant.

--- a/docs/building/compliance-catalog.mdx
+++ b/docs/building/compliance-catalog.mdx
@@ -102,6 +102,7 @@ Specialisms are grouped below by parent protocol.
 |-----------|--------|---------|
 | `content-standards` | stable | Content standards enforcement (brand safety, policy compliance) |
 | `property-lists` | stable | Property list governance — curated inclusion and exclusion lists for targeting and delivery compliance |
+| `collection-lists` | stable | Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety |
 | `governance-delivery-monitor` | stable | Campaign delivery monitoring with drift detection |
 | `governance-spend-authority` | stable | Conditional spend approval and human-in-the-loop governance |
 | `measurement-verification` | **preview** | Third-party measurement and verification. Parked under `governance` for 3.1; a dedicated `measurement` protocol is planned once the viewability, attribution, brand-safety, and SI-outcome surfaces split out. |
@@ -151,6 +152,7 @@ The kebab↔snake swap between wire specialism IDs and storyboard categories is 
 | `sales-broadcast-tv` | `channels: ['linear_tv']` | `sales_broadcast_tv` | — |
 | `audience-sync` | `sync_audiences` tool | `audience_sync` | — |
 | `property-lists` | `property_list` tools | `property_lists` | — |
+| `collection-lists` | `collection_list` tools | `collection_lists` | — |
 | `governance-spend-authority` | `check_governance`, `sync_plans` | `governance_spend_authority` | `governance_spend_authority/denied` |
 | `creative-generative` | `build_creative` | `creative_generative` | `creative_generative/seller` |
 | `brand-rights` | `get_brand_identity`, `acquire_rights` | `brand_rights` | `brand_rights/governance_denied` |

--- a/docs/governance/collection/index.mdx
+++ b/docs/governance/collection/index.mdx
@@ -162,5 +162,5 @@ Property lists and collection lists are sibling constructs — both are inventor
 - **[create_collection_list](/docs/governance/collection/tasks/collection_lists#create_collection_list)**: Create a new collection list on a governance agent
 - **[get_collection_list](/docs/governance/collection/tasks/collection_lists#get_collection_list)**: Retrieve resolved collections (with caching guidance)
 - **[update_collection_list](/docs/governance/collection/tasks/collection_lists#update_collection_list)**: Modify filters or base collections
-- **[list_collection_lists](/docs/governance/collection/tasks/collection_lists#list_collection_lists)**: List collection lists for a principal
+- **[list_collection_lists](/docs/governance/collection/tasks/collection_lists#list_collection_lists)**: List collection lists for an account
 - **[delete_collection_list](/docs/governance/collection/tasks/collection_lists#delete_collection_list)**: Remove a collection list

--- a/docs/governance/collection/tasks/collection_lists.mdx
+++ b/docs/governance/collection/tasks/collection_lists.mdx
@@ -32,7 +32,7 @@ Collection lists are **setup-time resources**. They are resolved once by the gov
 | `create_collection_list` | Create a new collection list | Seconds |
 | `get_collection_list` | Fetch list with resolved collections | Seconds (cached) |
 | `update_collection_list` | Modify base collections or filters | Seconds |
-| `list_collection_lists` | List collection lists for a principal | Seconds |
+| `list_collection_lists` | List collection lists for an account | Seconds |
 | `delete_collection_list` | Remove a collection list | Seconds |
 
 ## Base collection sources
@@ -247,12 +247,12 @@ Modify an existing collection list. `base_collections` and `filters` are complet
 
 ## list_collection_lists
 
-List collection lists for a principal. Returns metadata only, not resolved collections.
+List collection lists for an account. Returns metadata only, not resolved collections.
 
 ```json
 {
   "$schema": "https://adcontextprotocol.org/schemas/latest/collection/list-collection-lists-request.json",
-  "principal": "ops@pinnacleagency.com",
+  "account": { "brand": { "domain": "novamotors.com" }, "operator": "pinnacleagency.com" },
   "pagination": { "max_results": 50 }
 }
 ```
@@ -335,7 +335,7 @@ Collection lists gate delivery decisions, so the `auth_token` and webhook callba
 
 **Webhook signature algorithm.** The webhook signature MUST follow the [standard webhook signing rules](/docs/building/implementation/security#webhook-security): HMAC-SHA256 over `{unix_timestamp}.{raw_http_body_bytes}` where `{unix_timestamp}` is the exact ASCII integer in the `X-ADCP-Timestamp` header (never derived from body fields), transmitted as `X-ADCP-Signature: sha256=<hex digest>`, verified with timing-safe comparison, and rejected when outside the 5-minute replay window. The body `signature` field is a convenience copy — recipients MUST verify against the headers and MUST NOT trust the body value.
 
-**Distribution-ID inputs.** Governance agents SHOULD validate identifier format before persisting (IMDb: `^tt\d+$`, EIDR: `10.5240/...`, Gracenote: vendor-prefixed) and SHOULD enforce per-principal rate limits on list mutations to prevent list-bloat DoS. Surface unresolved identifiers in `coverage_gaps` rather than silently dropping them.
+**Distribution-ID inputs.** Governance agents SHOULD validate identifier format before persisting (IMDb: `^tt\d+$`, EIDR: `10.5240/...`, Gracenote: vendor-prefixed) and SHOULD enforce per-account rate limits on list mutations to prevent list-bloat DoS. Surface unresolved identifiers in `coverage_gaps` rather than silently dropping them.
 
 ## Sharing collection lists with sellers
 

--- a/docs/governance/property/specification.mdx
+++ b/docs/governance/property/specification.mdx
@@ -55,8 +55,8 @@ The platform or system making the API request to the governance agent. In AdCP d
 - **Responsibilities**: Makes API calls, handles authentication, manages the technical interaction
 - **Account**: Has technical credentials and API access to the governance agent
 
-#### Principal
-The entity on whose behalf the request is being made:
+#### Account
+The billing and policy entity on whose behalf the request is being made, identified via `account` (`account_id` or the `{brand, operator}` natural key):
 - **Examples**: Advertiser (Nike), agency (Omnicom), brand team
 - **Responsibilities**: Owns the campaign objectives and policy requirements
 - **Policies**: May have custom thresholds, blocklists, or compliance requirements
@@ -238,7 +238,7 @@ Retrieve a property list with resolved properties.
 
 #### list_property_lists
 
-List all property lists accessible to the authenticated principal.
+List property lists owned by a given account, or all property lists accessible to the authenticated agent when `account` is omitted.
 
 #### delete_property_list
 

--- a/docs/governance/property/tasks/property_lists.mdx
+++ b/docs/governance/property/tasks/property_lists.mdx
@@ -75,7 +75,7 @@ A property list contains:
   "list_id": "uk_premium_news_q1",
   "name": "UK Premium News Sites Q1 2026",
   "description": "High-quality UK news sites for Q1 campaign",
-  "principal": "did:principal:brand-x",
+  "account": { "account_id": "acc_brand_x_direct_01" },
   "base_properties": [
     {
       "selection_type": "publisher_tags",
@@ -321,7 +321,7 @@ Create a new property list.
     "list_id": "pl_abc123",
     "name": "UK Premium News Q1",
     "description": "High-quality UK news sites for Q1 campaign",
-    "principal": "did:principal:brand-x",
+    "account": { "account_id": "acc_brand_x_direct_01" },
     "base_properties": [
       {
         "selection_type": "publisher_tags",
@@ -535,7 +535,7 @@ The `auth_token` is only returned when the list is created via `create_property_
 
 ## list_property_lists
 
-List all property lists accessible to the authenticated principal.
+List property lists owned by a given account, or all property lists accessible to the authenticated agent when `account` is omitted.
 
 ### Request
 
@@ -658,7 +658,7 @@ Pass property lists to media buy creation:
 | Code | Description |
 |------|-------------|
 | `LIST_NOT_FOUND` | Property list ID doesn't exist |
-| `LIST_ACCESS_DENIED` | Principal doesn't have access to this list |
+| `LIST_ACCESS_DENIED` | The authenticated agent or account doesn't have access to this list |
 | `INVALID_FILTER` | Filter configuration is invalid |
 | `LIST_NAME_EXISTS` | A list with this name already exists |
 

--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -103,7 +103,7 @@ export function clearAccountStore(): void {
 
 // ── Tool definitions ─────────────────────────────────────────────
 
-const ACCOUNT_REF_SCHEMA = {
+export const ACCOUNT_REF_SCHEMA = {
   type: 'object',
   oneOf: [
     { properties: { account_id: { type: 'string' } }, required: ['account_id'] },

--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -42,6 +42,7 @@ export const COLLECTION_LIST_TOOLS = [
       properties: {
         list_id: { type: 'string' },
         resolve: { type: 'boolean' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
       },
       required: ['list_id'],
     },
@@ -60,6 +61,7 @@ export const COLLECTION_LIST_TOOLS = [
         base_collections: { type: 'array' },
         filters: { type: 'object' },
         webhook_url: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the update to this brand' },
       },
       required: ['list_id'],
     },
@@ -73,6 +75,7 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         name_contains: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to this brand' },
       },
     },
   },
@@ -85,6 +88,7 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
       },
       required: ['list_id'],
     },

--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from 'node:crypto';
 import type { TrainingContext, ToolArgs, CollectionListState } from './types.js';
 import { getSession, sessionKeyFromArgs } from './state.js';
+import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 
 const MAX_ARRAY_INPUT = 100;
 
@@ -23,11 +24,12 @@ export const COLLECTION_LIST_TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: ACCOUNT_REF_SCHEMA,
         name: { type: 'string' },
         description: { type: 'string' },
         base_collections: { type: 'array' },
         filters: { type: 'object' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } } },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference for automatic rule application (campaign metadata, not identity)' },
       },
       required: ['name'],
     },
@@ -41,8 +43,8 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string' },
+        account: ACCOUNT_REF_SCHEMA,
         resolve: { type: 'boolean' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
       },
       required: ['list_id'],
     },
@@ -56,26 +58,27 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string' },
+        account: ACCOUNT_REF_SCHEMA,
         name: { type: 'string' },
         description: { type: 'string' },
         base_collections: { type: 'array' },
         filters: { type: 'object' },
         webhook_url: { type: 'string' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the update to this brand' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference (campaign metadata)' },
       },
       required: ['list_id'],
     },
   },
   {
     name: 'list_collection_lists',
-    description: 'List collection lists for the authenticated principal.',
+    description: 'List collection lists owned by the given account (or all accessible accounts when account is omitted).',
     annotations: { readOnlyHint: true, idempotentHint: true },
     execution: { taskSupport: 'optional' as const },
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: ACCOUNT_REF_SCHEMA,
         name_contains: { type: 'string' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to this brand' },
       },
     },
   },
@@ -88,7 +91,7 @@ export const COLLECTION_LIST_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
+        account: ACCOUNT_REF_SCHEMA,
       },
       required: ['list_id'],
     },
@@ -117,6 +120,7 @@ interface UpdateCollectionListInput extends ToolArgs {
   base_collections?: unknown[];
   filters?: Record<string, unknown>;
   webhook_url?: string;
+  brand?: { domain: string };
 }
 
 interface ListInput extends ToolArgs {
@@ -156,6 +160,7 @@ export async function handleCreateCollectionList(args: ToolArgs, ctx: TrainingCo
     base_collections: baseColls,
     filters: input.filters,
     brand: input.brand,
+    account: args.account,
     collection_count: baseColls.length ? countSources(baseColls) : 0,
     created_at: now,
     updated_at: now,
@@ -208,6 +213,7 @@ export async function handleUpdateCollectionList(args: ToolArgs, ctx: TrainingCo
   }
   if (input.filters !== undefined) list.filters = input.filters;
   if (input.webhook_url !== undefined) list.webhook_url = input.webhook_url === '' ? undefined : input.webhook_url;
+  if (input.brand !== undefined) list.brand = input.brand;
   list.updated_at = new Date().toISOString();
 
   return { list };

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -28,7 +28,7 @@ export const PROPERTY_TOOLS = [
         list_type: { type: 'string', enum: ['inclusion', 'exclusion'], description: 'Type of property list' },
         base_properties: { type: 'array', description: 'Property sources to include' },
         filters: { type: 'object', description: 'Dynamic filters for list resolution' },
-        brand: { type: 'object', description: 'Brand reference for automatic rule application' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference for automatic rule application' },
         idempotency_key: { type: 'string' },
       },
       required: ['name'],
@@ -43,6 +43,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         name_contains: { type: 'string', description: 'Filter to lists whose name contains this string' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to lists created under this brand' },
       },
     },
   },
@@ -55,6 +56,8 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
+        resolve: { type: 'boolean', description: 'When true, return the resolved properties alongside list metadata' },
       },
       required: ['list_id'],
     },
@@ -72,7 +75,7 @@ export const PROPERTY_TOOLS = [
         description: { type: 'string', description: 'New description' },
         base_properties: { type: 'array', description: 'Complete replacement for the base properties list' },
         filters: { type: 'object', description: 'Complete replacement for the filters' },
-        brand: { type: 'object', description: 'Update brand reference' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference' },
       },
       required: ['list_id'],
     },
@@ -86,6 +89,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
       },
       required: ['list_id'],
     },
@@ -99,7 +103,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list to validate against' },
-        brand: { type: 'object', description: 'Brand reference' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference' },
         records: {
           type: 'array',
           description: 'Delivery records to validate. Each record has an identifier ({type, value}) and impressions.',

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -7,8 +7,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { TrainingContext, ToolArgs, PropertyListState } from './types.js';
+import type { TrainingContext, ToolArgs, AccountRef, PropertyListState } from './types.js';
 import { getSession, sessionKeyFromArgs, MAX_PROPERTY_LISTS_PER_SESSION } from './state.js';
+import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 
 const MAX_PROPERTIES_PER_LIST = 10_000;
 
@@ -23,12 +24,13 @@ export const PROPERTY_TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: ACCOUNT_REF_SCHEMA,
         name: { type: 'string', description: 'Human-readable name for the list' },
         description: { type: 'string', description: 'Description of the list purpose' },
         list_type: { type: 'string', enum: ['inclusion', 'exclusion'], description: 'Type of property list' },
         base_properties: { type: 'array', description: 'Property sources to include' },
         filters: { type: 'object', description: 'Dynamic filters for list resolution' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference for automatic rule application' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference for automatic rule application (campaign metadata, not identity)' },
         idempotency_key: { type: 'string' },
       },
       required: ['name'],
@@ -36,14 +38,14 @@ export const PROPERTY_TOOLS = [
   },
   {
     name: 'list_property_lists',
-    description: 'List all property lists for the current account. Returns list metadata without resolved properties.',
+    description: 'List property lists owned by the given account (or all accessible accounts when account is omitted).',
     annotations: { readOnlyHint: true, idempotentHint: true },
     execution: { taskSupport: 'forbidden' as const },
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: ACCOUNT_REF_SCHEMA,
         name_contains: { type: 'string', description: 'Filter to lists whose name contains this string' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the listing to lists created under this brand' },
       },
     },
   },
@@ -56,7 +58,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the lookup to this brand' },
+        account: ACCOUNT_REF_SCHEMA,
         resolve: { type: 'boolean', description: 'When true, return the resolved properties alongside list metadata' },
       },
       required: ['list_id'],
@@ -71,11 +73,12 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
+        account: ACCOUNT_REF_SCHEMA,
         name: { type: 'string', description: 'New name for the list' },
         description: { type: 'string', description: 'New description' },
         base_properties: { type: 'array', description: 'Complete replacement for the base properties list' },
         filters: { type: 'object', description: 'Complete replacement for the filters' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference' },
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference (campaign metadata)' },
       },
       required: ['list_id'],
     },
@@ -89,7 +92,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list identifier' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference — scopes the deletion to this brand' },
+        account: ACCOUNT_REF_SCHEMA,
       },
       required: ['list_id'],
     },
@@ -103,7 +106,7 @@ export const PROPERTY_TOOLS = [
       type: 'object' as const,
       properties: {
         list_id: { type: 'string', description: 'Property list to validate against' },
-        brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Brand reference' },
+        account: ACCOUNT_REF_SCHEMA,
         records: {
           type: 'array',
           description: 'Delivery records to validate. Each record has an identifier ({type, value}) and impressions.',
@@ -131,7 +134,7 @@ function toListResponse(state: PropertyListState) {
     name: state.name,
     ...(state.description ? { description: state.description } : {}),
     ...(state.listType ? { list_type: state.listType } : {}),
-    ...(state.principal ? { principal: state.principal } : {}),
+    ...(state.account ? { account: state.account } : {}),
     ...(state.baseProperties.length > 0 ? { base_properties: state.baseProperties } : {}),
     ...(state.filters ? { filters: state.filters } : {}),
     ...(state.brand ? { brand: state.brand } : {}),
@@ -189,6 +192,7 @@ export async function handleCreatePropertyList(
     name: req.name,
     description: req.description,
     listType: req.list_type,
+    account: args.account,
     baseProperties,
     filters: req.filters,
     brand: req.brand,

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -188,6 +188,7 @@ export interface CollectionListState {
   base_collections?: unknown[];
   filters?: Record<string, unknown>;
   brand?: { domain: string };
+  account?: AccountRef;
   webhook_url?: string;
   collection_count: number;
   created_at: string;
@@ -416,7 +417,7 @@ export interface PropertyListState {
   name: string;
   description?: string;
   listType?: string;
-  principal?: string;
+  account?: AccountRef;
   baseProperties: unknown[];
   filters?: unknown;
   brand?: unknown;

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import YAML from 'yaml';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import {
   createTrainingAgentServer,
   invalidateCache,
@@ -10,14 +12,17 @@ import {
 import { clearSessions } from '../../src/training-agent/state.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 
+const REPO_ROOT = join(process.cwd());
 const STORYBOARD_PATH = join(
-  process.cwd(),
+  REPO_ROOT,
   'static/compliance/source/specialisms/collection-lists/index.yaml',
 );
+const SCHEMA_BASE_DIR = join(REPO_ROOT, 'static/schemas/source');
 
 interface Step {
   id: string;
   task: string;
+  response_schema_ref?: string;
   sample_request?: Record<string, unknown>;
   context_outputs?: { path: string; key: string }[];
   validations: Validation[];
@@ -79,14 +84,43 @@ function getByPath(obj: unknown, path: string): unknown {
   return cur;
 }
 
+async function loadExternalSchema(uri: string): Promise<object> {
+  if (!uri.startsWith('/schemas/')) {
+    throw new Error(`Cannot load external schema: ${uri}`);
+  }
+  const schemaPath = join(SCHEMA_BASE_DIR, uri.replace('/schemas/', ''));
+  return JSON.parse(readFileSync(schemaPath, 'utf8'));
+}
+
+async function validateAgainstSchema(
+  data: unknown,
+  schemaRef: string,
+): Promise<{ valid: boolean; errors: string }> {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    loadSchema: loadExternalSchema,
+  });
+  addFormats(ajv);
+  const schema = await loadExternalSchema('/schemas/' + schemaRef);
+  const validate = await ajv.compileAsync(schema);
+  const ok = validate(data);
+  if (ok) return { valid: true, errors: '' };
+  const errs = (validate.errors ?? [])
+    .map(e => `${e.instancePath || '(root)'}: ${e.message}`)
+    .join('; ');
+  return { valid: false, errors: errs };
+}
+
 // Two tests live here:
-//   1. An end-to-end walk of the storyboard's phases against in-process handlers.
-//      This passes `brand` into handlers directly, so it does NOT catch the
-//      "inputSchema missing brand" regression.
-//   2. A tools/list invariant that asserts every CRUD tool declares `brand` in
+//   1. An end-to-end walk of the storyboard's phases against in-process
+//      handlers. Each step's response is validated against its declared
+//      response_schema (via ajv) plus field_present/field_value/correlation_id
+//      echo assertions from the storyboard YAML.
+//   2. A tools/list invariant asserting every CRUD tool declares `account` in
 //      its inputSchema — MCP clients strip undeclared keys, collapsing the
-//      session key and breaking multi-step flows. The smoke test against live
-//      agents catches that, but this unit test catches it faster.
+//      session key. The storyboard walk in (1) passes `account` into handlers
+//      directly so it does NOT catch that regression; this second test does.
 describe('collection-lists specialism storyboard', () => {
   let server: ReturnType<typeof createTrainingAgentServer>;
   const ctx: TrainingContext = { mode: 'open' };
@@ -123,13 +157,15 @@ describe('collection-lists specialism storyboard', () => {
         ).toBeUndefined();
 
         for (const v of step.validations) {
-          if (v.check === 'field_present' && v.path && !v.path.startsWith('context')) {
+          if (v.check === 'response_schema' && step.response_schema_ref) {
+            const { valid, errors } = await validateAgainstSchema(result, step.response_schema_ref);
+            expect(valid, `step ${step.id}: ${step.response_schema_ref} validation failed: ${errors}`).toBe(true);
+          } else if (v.check === 'field_present' && v.path) {
             expect(
               getByPath(result, v.path),
               `step ${step.id}: ${v.description}`,
             ).toBeDefined();
-          }
-          if (v.check === 'field_value' && v.path && !v.path.startsWith('context')) {
+          } else if (v.check === 'field_value' && v.path) {
             expect(getByPath(result, v.path), `step ${step.id}: ${v.description}`).toEqual(
               v.value,
             );
@@ -145,15 +181,16 @@ describe('collection-lists specialism storyboard', () => {
     expect(context.collection_list_id).toBeTruthy();
   });
 
-  it('tool inputSchemas declare brand so MCP clients do not strip it', async () => {
+  it('tool inputSchemas declare account so MCP clients do not strip it', async () => {
     const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
     const handler = requestHandlers.get('tools/list');
     if (!handler) throw new Error('ListTools handler not found');
     const { tools } = await handler({ method: 'tools/list' }, {});
 
-    const collectionTools = (tools as { name: string; inputSchema: { properties?: Record<string, unknown> } }[]).filter(
-      t => /^(create|get|list|update|delete)_collection_list/.test(t.name),
-    );
+    const collectionTools = (tools as {
+      name: string;
+      inputSchema: { properties?: Record<string, any> };
+    }[]).filter(t => /^(create|get|list|update|delete)_collection_list/.test(t.name));
     expect(collectionTools.length).toBe(5);
 
     for (const tool of collectionTools) {
@@ -161,9 +198,14 @@ describe('collection-lists specialism storyboard', () => {
         tool.inputSchema.properties,
         `${tool.name} has no inputSchema.properties`,
       ).toBeDefined();
+      const account = tool.inputSchema.properties?.account;
       expect(
-        tool.inputSchema.properties?.brand,
-        `${tool.name} inputSchema does not declare 'brand' — @adcp/client will strip it, collapsing session key to open:default`,
+        account,
+        `${tool.name} inputSchema does not declare 'account' — @adcp/client will strip it, collapsing session key to open:default`,
+      ).toBeDefined();
+      expect(
+        account?.oneOf,
+        `${tool.name} declares 'account' but not the oneOf shape (account_id | {brand, operator}) — agents need the shape hint`,
       ).toBeDefined();
     }
   });

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import YAML from 'yaml';
+import {
+  createTrainingAgentServer,
+  invalidateCache,
+  clearTaskStore,
+} from '../../src/training-agent/task-handlers.js';
+import { clearSessions } from '../../src/training-agent/state.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const STORYBOARD_PATH = join(
+  process.cwd(),
+  'static/compliance/source/specialisms/collection-lists/index.yaml',
+);
+
+interface Step {
+  id: string;
+  task: string;
+  sample_request?: Record<string, unknown>;
+  context_outputs?: { path: string; key: string }[];
+  validations: Validation[];
+}
+
+interface Validation {
+  check: 'field_present' | 'field_value' | 'response_schema';
+  path?: string;
+  value?: unknown;
+  description: string;
+}
+
+interface Phase {
+  id: string;
+  steps: Step[];
+}
+
+async function simulateCallTool(
+  server: ReturnType<typeof createTrainingAgentServer>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ result: Record<string, unknown>; isError?: boolean }> {
+  const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+  const handler = requestHandlers.get('tools/call');
+  if (!handler) throw new Error('CallTool handler not found');
+  const response = await handler(
+    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    {},
+  );
+  const text = response.content?.[0]?.text;
+  const parsed = text ? JSON.parse(text) : {};
+  const result = parsed.adcp_error ?? parsed;
+  return { result, isError: response.isError };
+}
+
+function resolveContextRefs(
+  value: unknown,
+  context: Record<string, unknown>,
+): unknown {
+  if (typeof value === 'string' && value.startsWith('$context.')) {
+    return context[value.slice('$context.'.length)];
+  }
+  if (Array.isArray(value)) return value.map(v => resolveContextRefs(v, context));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = resolveContextRefs(v, context);
+    return out;
+  }
+  return value;
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+// Two tests live here:
+//   1. An end-to-end walk of the storyboard's phases against in-process handlers.
+//      This passes `brand` into handlers directly, so it does NOT catch the
+//      "inputSchema missing brand" regression.
+//   2. A tools/list invariant that asserts every CRUD tool declares `brand` in
+//      its inputSchema — MCP clients strip undeclared keys, collapsing the
+//      session key and breaking multi-step flows. The smoke test against live
+//      agents catches that, but this unit test catches it faster.
+describe('collection-lists specialism storyboard', () => {
+  let server: ReturnType<typeof createTrainingAgentServer>;
+  const ctx: TrainingContext = { mode: 'open' };
+
+  beforeEach(() => {
+    clearSessions();
+    invalidateCache();
+    clearTaskStore();
+    server = createTrainingAgentServer(ctx);
+  });
+
+  it('runs the full CRUD lifecycle end-to-end', async () => {
+    const storyboard = YAML.parse(readFileSync(STORYBOARD_PATH, 'utf8'));
+    expect(storyboard.id).toBe('collection_lists');
+    expect(storyboard.phases).toBeDefined();
+
+    const context: Record<string, unknown> = {};
+
+    for (const phase of storyboard.phases as Phase[]) {
+      for (const step of phase.steps) {
+        const args = resolveContextRefs(step.sample_request ?? {}, context) as Record<
+          string,
+          unknown
+        >;
+        const { result, isError } = await simulateCallTool(server, step.task, args);
+
+        expect(
+          isError,
+          `step ${step.id} (${step.task}) returned isError: ${JSON.stringify(result)}`,
+        ).toBeFalsy();
+        expect(
+          (result as any).errors,
+          `step ${step.id} (${step.task}) returned errors: ${JSON.stringify((result as any).errors)}`,
+        ).toBeUndefined();
+
+        for (const v of step.validations) {
+          if (v.check === 'field_present' && v.path && !v.path.startsWith('context')) {
+            expect(
+              getByPath(result, v.path),
+              `step ${step.id}: ${v.description}`,
+            ).toBeDefined();
+          }
+          if (v.check === 'field_value' && v.path && !v.path.startsWith('context')) {
+            expect(getByPath(result, v.path), `step ${step.id}: ${v.description}`).toEqual(
+              v.value,
+            );
+          }
+        }
+
+        for (const out of step.context_outputs ?? []) {
+          context[out.key] = getByPath(result, out.path);
+        }
+      }
+    }
+
+    expect(context.collection_list_id).toBeTruthy();
+  });
+
+  it('tool inputSchemas declare brand so MCP clients do not strip it', async () => {
+    const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+    const handler = requestHandlers.get('tools/list');
+    if (!handler) throw new Error('ListTools handler not found');
+    const { tools } = await handler({ method: 'tools/list' }, {});
+
+    const collectionTools = (tools as { name: string; inputSchema: { properties?: Record<string, unknown> } }[]).filter(
+      t => /^(create|get|list|update|delete)_collection_list/.test(t.name),
+    );
+    expect(collectionTools.length).toBe(5);
+
+    for (const tool of collectionTools) {
+      expect(
+        tool.inputSchema.properties,
+        `${tool.name} has no inputSchema.properties`,
+      ).toBeDefined();
+      expect(
+        tool.inputSchema.properties?.brand,
+        `${tool.name} inputSchema does not declare 'brand' — @adcp/client will strip it, collapsing session key to open:default`,
+      ).toBeDefined();
+    }
+  });
+});

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -1,0 +1,336 @@
+id: collection_lists
+version: "1.0.0"
+title: "Collection lists"
+protocol: governance
+category: collection_lists
+summary: "Curated collection lists for program-level brand safety and content targeting — create, query, update, and delete lists of content programs (shows, series, podcasts)."
+track: governance
+required_tools:
+  - create_collection_list
+
+narrative: |
+  You run a governance agent that manages collection lists for brand safety. Unlike
+  property lists which operate on technical surfaces (domains, apps), collection lists
+  operate on content programs (shows, series, podcasts) identified by platform-independent
+  IDs like IMDb, Gracenote, or EIDR.
+
+  Buyers create inclusion and exclusion lists that define which programs their ads can
+  and cannot appear against. Your agent resolves the base collections and filters into a
+  concrete list of program identifiers that sellers can cache and enforce at bid time.
+
+  Collection lists are setup-time resources: the governance agent resolves them once and
+  sellers cache the result. Unlike property lists, there is no post-delivery validation
+  task yet — enforcement happens at serve time via the cached list, not via after-the-fact
+  compliance checks. This storyboard therefore exercises the full CRUD lifecycle (create,
+  query, update, delete) but does not test delivery validation.
+
+agent:
+  interaction_model: governance_agent
+  capabilities:
+    - collection_lists
+    - brand_safety
+  examples:
+    - "IAS"
+    - "DoubleVerify"
+    - "GARM-aligned platforms"
+    - "Brand safety services"
+
+caller:
+  role: buyer_agent
+  example: "Nova Motors (buyer)"
+
+prerequisites:
+  description: |
+    The caller needs a brand identity and content-program knowledge (distribution IDs,
+    publisher identifiers, or genre taxonomies). The test kit provides a sample brand
+    with campaign context.
+  test_kit: "test-kits/nova-motors.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent supports governance
+      before creating or fetching collection lists.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares the expected protocol support before
+          proceeding with domain-specific operations.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring governance in supported_protocols, confirming
+          the agent provides governance services.
+        sample_request:
+          context:
+            correlation_id: "collection_lists--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: create_list
+    title: "Create collection lists"
+    narrative: |
+      The buyer creates an inclusion collection list for the campaign. The list defines
+      which content programs the brand is willing to advertise against, selected by
+      platform-independent distribution identifiers.
+
+    steps:
+      - id: create_inclusion_list
+        title: "Create an inclusion collection list"
+        narrative: |
+          The buyer creates an inclusion list of programs the brand considers safe to
+          advertise against, referenced by distribution IDs (e.g. IMDb) so the selection
+          is portable across publishers.
+        task: create_collection_list
+        schema_ref: "collection/create-collection-list-request.json"
+        response_schema_ref: "collection/create-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the created collection list:
+          - list_id: platform-assigned identifier
+          - collection_count reflecting the resolved programs
+          - auth_token issued for sellers to fetch the list
+          - Timestamps populated
+
+        sample_request:
+          brand:
+            domain: "novamotors.example"
+          name: "Nova Motors approved programs"
+          base_collections:
+            - selection_type: "distribution_ids"
+              identifiers:
+                - type: "imdb_id"
+                  value: "tt9999901"
+                - type: "imdb_id"
+                  value: "tt9999902"
+                - type: "imdb_id"
+                  value: "tt9999903"
+          filters:
+            kinds: ["series"]
+
+          context:
+            correlation_id: "collection_lists--create_inclusion_list"
+        context_outputs:
+          - path: "list.list_id"
+            key: "collection_list_id"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "Governance agent assigns list_id — must be echoed in get/update/delete"
+          - check: field_present
+            path: "auth_token"
+            description: "Agent issues an auth_token at creation time for seller fetches"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--create_inclusion_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: list_and_get
+    title: "Query collection lists"
+    narrative: |
+      The buyer lists all collection lists for the brand and retrieves a specific list
+      with resolved collections.
+
+    steps:
+      - id: list_collection_lists
+        title: "List all collection lists"
+        narrative: |
+          The buyer lists all collection lists for the brand. The response includes
+          list metadata without full resolved collection details.
+        task: list_collection_lists
+        schema_ref: "collection/list-collection-lists-request.json"
+        response_schema_ref: "collection/list-collection-lists-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return collection list summaries:
+          - Array of lists with list_id, name, collection_count
+          - Includes the list created in the prior phase
+
+        sample_request:
+          brand:
+            domain: "novamotors.example"
+          name_contains: "Nova Motors"
+
+          context:
+            correlation_id: "collection_lists--list_collection_lists"
+        validations:
+          - check: response_schema
+            description: "Response matches list-collection-lists-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--list_collection_lists"
+            description: "Context correlation_id returned unchanged"
+
+      - id: get_collection_list
+        title: "Get a specific collection list with resolved collections"
+        narrative: |
+          The buyer retrieves a specific collection list with resolve:true to confirm
+          the agent can materialize the programs the list references.
+        task: get_collection_list
+        schema_ref: "collection/get-collection-list-request.json"
+        response_schema_ref: "collection/get-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the full collection list:
+          - list_id, name, collection_count
+          - Resolved collections with distribution_ids, content_rating, genre
+          - cache_valid_until timestamp for seller caching
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          resolve: true
+          brand:
+            domain: "novamotors.example"
+
+          context:
+            correlation_id: "collection_lists--get_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches get-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "List id returned"
+          - check: field_present
+            path: "collections"
+            description: "Resolved collections returned when resolve:true"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--get_collection_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: update_list
+    title: "Update collection lists"
+    narrative: |
+      The buyer modifies an existing collection list — replacing the base collections
+      as the campaign's content preferences evolve.
+
+    steps:
+      - id: update_collection_list
+        title: "Update a collection list"
+        narrative: |
+          The buyer replaces the base collections on an existing list with a new set
+          of distribution identifiers.
+        task: update_collection_list
+        schema_ref: "collection/update-collection-list-request.json"
+        response_schema_ref: "collection/update-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Return the updated collection list:
+          - Same list_id
+          - Updated collection_count reflecting the replaced base collections
+          - Updated updated_at timestamp
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          brand:
+            domain: "novamotors.example"
+          base_collections:
+            - selection_type: "distribution_ids"
+              identifiers:
+                - type: "imdb_id"
+                  value: "tt9999901"
+                - type: "imdb_id"
+                  value: "tt9999904"
+                - type: "imdb_id"
+                  value: "tt9999905"
+                - type: "imdb_id"
+                  value: "tt9999906"
+
+          context:
+            correlation_id: "collection_lists--update_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches update-collection-list-response.json schema"
+          - check: field_present
+            path: "list.list_id"
+            description: "Updated list retains its list_id"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--update_collection_list"
+            description: "Context correlation_id returned unchanged"
+
+  - id: delete_list
+    title: "Delete a collection list"
+    narrative: |
+      The buyer removes a collection list that is no longer needed. Deleting a list
+      revokes the associated auth_token.
+
+    steps:
+      - id: delete_collection_list
+        title: "Delete a collection list"
+        narrative: |
+          The buyer deletes a collection list. The governance agent removes the list
+          and returns confirmation.
+        task: delete_collection_list
+        schema_ref: "collection/delete-collection-list-request.json"
+        response_schema_ref: "collection/delete-collection-list-response.json"
+        doc_ref: "/governance/collection/tasks/collection_lists"
+        comply_scenario: governance_collection_lists
+        stateful: true
+        expected: |
+          Confirm deletion:
+          - deleted: true
+          - list_id: the deleted list
+
+        sample_request:
+          list_id: "$context.collection_list_id"
+          brand:
+            domain: "novamotors.example"
+
+          context:
+            correlation_id: "collection_lists--delete_collection_list"
+        validations:
+          - check: response_schema
+            description: "Response matches delete-collection-list-response.json schema"
+          - check: field_value
+            path: "deleted"
+            value: true
+            description: "Delete returns deleted: true"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "collection_lists--delete_collection_list"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -113,6 +113,10 @@ phases:
           - Timestamps populated
 
         sample_request:
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "novamotors.example"
           brand:
             domain: "novamotors.example"
           name: "Nova Motors approved programs"
@@ -175,8 +179,10 @@ phases:
           - Includes the list created in the prior phase
 
         sample_request:
-          brand:
-            domain: "novamotors.example"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "novamotors.example"
           name_contains: "Nova Motors"
 
           context:
@@ -212,8 +218,10 @@ phases:
         sample_request:
           list_id: "$context.collection_list_id"
           resolve: true
-          brand:
-            domain: "novamotors.example"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "novamotors.example"
 
           context:
             correlation_id: "collection_lists--get_collection_list"
@@ -260,8 +268,10 @@ phases:
 
         sample_request:
           list_id: "$context.collection_list_id"
-          brand:
-            domain: "novamotors.example"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "novamotors.example"
           base_collections:
             - selection_type: "distribution_ids"
               identifiers:
@@ -315,8 +325,10 @@ phases:
 
         sample_request:
           list_id: "$context.collection_list_id"
-          brand:
-            domain: "novamotors.example"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "novamotors.example"
 
           context:
             correlation_id: "collection_lists--delete_collection_list"

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -105,6 +105,10 @@ phases:
           - Status: active
 
         sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           brand:
             domain: "acmeoutdoor.example"
           name: "Acme Outdoor approved properties"
@@ -162,7 +166,10 @@ phases:
           - Includes both inclusion and exclusion lists
 
         sample_request:
-          principal: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           name_contains: "Acme Outdoor"
 
           context:
@@ -196,8 +203,10 @@ phases:
 
         sample_request:
           list_id: "$context.property_list_id"
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
 
           context:
             correlation_id: "property_lists--get_property_list"
@@ -236,8 +245,10 @@ phases:
 
         sample_request:
           list_id: "$context.property_list_id"
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           base_properties:
             - selection_type: "identifiers"
               identifiers:
@@ -288,8 +299,10 @@ phases:
           - Violations with details (property, list, severity)
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -347,8 +360,10 @@ phases:
           - No failed or warning features
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -389,8 +404,10 @@ phases:
           - feature entry references the inclusion list that was breached (via policy_id or code)
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_random_001"
@@ -432,8 +449,10 @@ phases:
 
         sample_request:
           list_id: "$context.property_list_id"
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "acmeoutdoor.example"
 
           context:
             correlation_id: "property_lists--delete_property_list"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -17,7 +17,7 @@
 #   Sales: sales_guaranteed | sales_non_guaranteed | sales_proposal_mode | sales_catalog_driven | sales_broadcast_tv | sales_streaming_tv | sales_social | sales_exchange | sales_retail_media
 #   Creative: creative_ad_server | creative_generative | creative_template
 #   Signals: signal_marketplace | signal_owned
-#   Governance: content_standards | property_lists | governance_delivery_monitor | governance_spend_authority | measurement_verification
+#   Governance: content_standards | property_lists | collection_lists | governance_delivery_monitor | governance_spend_authority | measurement_verification
 #   Brand: brand_rights
 #   Audiences: audience_sync
 #   Universal / domain-level: capability_discovery | schema_validation | behavioral_analysis | error_compliance | security | media_buy_seller | media_buy_governance_escalation | si_session

--- a/static/schemas/source/collection/collection-list.json
+++ b/static/schemas/source/collection/collection-list.json
@@ -17,9 +17,9 @@
       "type": "string",
       "description": "Description of the list's purpose"
     },
-    "principal": {
-      "type": "string",
-      "description": "Principal identity that owns this list"
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns this list. Returned as account_id form (seller-assigned identifier)."
     },
     "base_collections": {
       "type": "array",

--- a/static/schemas/source/collection/create-collection-list-request.json
+++ b/static/schemas/source/collection/create-collection-list-request.json
@@ -11,6 +11,10 @@
       "minimum": 1,
       "maximum": 99
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that will own the list. Pass a natural key (brand, operator, optional sandbox) or a seller-assigned account_id from list_accounts. When omitted, the seller assigns the list to the agent's default account if exactly one is accessible; otherwise returns an error."
+    },
     "name": {
       "type": "string",
       "description": "Human-readable name for the list"

--- a/static/schemas/source/collection/delete-collection-list-request.json
+++ b/static/schemas/source/collection/delete-collection-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the collection list to delete"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts; optional otherwise."
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/collection/get-collection-list-request.json
+++ b/static/schemas/source/collection/get-collection-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the collection list to retrieve"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts and the list_id is not globally unique within that scope; optional otherwise."
+    },
     "resolve": {
       "type": "boolean",
       "description": "Whether to apply filters and return resolved collections (default: true)",

--- a/static/schemas/source/collection/list-collection-lists-request.json
+++ b/static/schemas/source/collection/list-collection-lists-request.json
@@ -11,9 +11,9 @@
       "minimum": 1,
       "maximum": 99
     },
-    "principal": {
-      "type": "string",
-      "description": "Filter to lists owned by this principal"
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Filter to lists owned by this account. When omitted, returns lists across all accounts accessible to the authenticated agent."
     },
     "name_contains": {
       "type": "string",

--- a/static/schemas/source/collection/update-collection-list-request.json
+++ b/static/schemas/source/collection/update-collection-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the collection list to update"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts; optional otherwise."
+    },
     "name": {
       "type": "string",
       "description": "New name for the list"

--- a/static/schemas/source/enums/specialism.json
+++ b/static/schemas/source/enums/specialism.json
@@ -7,6 +7,7 @@
   "enum": [
     "audience-sync",
     "brand-rights",
+    "collection-lists",
     "content-standards",
     "creative-ad-server",
     "creative-generative",
@@ -30,6 +31,7 @@
   "enumDescriptions": {
     "audience-sync": "Syncs buyer-provided audience segments into a platform for activation",
     "brand-rights": "Brand identity and rights licensing (talent, music, stock media)",
+    "collection-lists": "Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety",
     "content-standards": "Content standards enforcement (brand safety, policy compliance)",
     "creative-ad-server": "Creative ad server with tag-based delivery",
     "creative-generative": "Generative creative agent producing assets on demand",

--- a/static/schemas/source/property/create-property-list-request.json
+++ b/static/schemas/source/property/create-property-list-request.json
@@ -11,6 +11,10 @@
       "minimum": 1,
       "maximum": 99
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that will own the list. Pass a natural key (brand, operator, optional sandbox) or a seller-assigned account_id from list_accounts. When omitted, the seller assigns the list to the agent's default account if exactly one is accessible; otherwise returns an error."
+    },
     "name": {
       "type": "string",
       "description": "Human-readable name for the list"

--- a/static/schemas/source/property/delete-property-list-request.json
+++ b/static/schemas/source/property/delete-property-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the property list to delete"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts; optional otherwise."
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/property/get-property-list-request.json
+++ b/static/schemas/source/property/get-property-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the property list to retrieve"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts and the list_id is not globally unique within that scope; optional otherwise."
+    },
     "resolve": {
       "type": "boolean",
       "description": "Whether to apply filters and return resolved identifiers (default: true)",

--- a/static/schemas/source/property/list-property-lists-request.json
+++ b/static/schemas/source/property/list-property-lists-request.json
@@ -11,9 +11,9 @@
       "minimum": 1,
       "maximum": 99
     },
-    "principal": {
-      "type": "string",
-      "description": "Filter to lists owned by this principal"
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Filter to lists owned by this account. When omitted, returns lists across all accounts accessible to the authenticated agent."
     },
     "name_contains": {
       "type": "string",

--- a/static/schemas/source/property/property-list.json
+++ b/static/schemas/source/property/property-list.json
@@ -17,9 +17,9 @@
       "type": "string",
       "description": "Description of the list's purpose"
     },
-    "principal": {
-      "type": "string",
-      "description": "Principal identity that owns this list"
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns this list. Returned as account_id form (seller-assigned identifier)."
     },
     "base_properties": {
       "type": "array",

--- a/static/schemas/source/property/update-property-list-request.json
+++ b/static/schemas/source/property/update-property-list-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the property list to update"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts; optional otherwise."
+    },
     "name": {
       "type": "string",
       "description": "New name for the list"

--- a/static/schemas/source/property/validate-property-delivery-request.json
+++ b/static/schemas/source/property/validate-property-delivery-request.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "ID of the property list to validate against"
     },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "description": "Account that owns the list. Required when the authenticated agent has access to multiple accounts; optional otherwise."
+    },
     "records": {
       "type": "array",
       "description": "Delivery records to validate. Each record represents impressions delivered to a property identifier.",


### PR DESCRIPTION
## Summary

Two related breaking changes in one PR, since they touch the same files and ship together:

1. **Add `collection-lists` specialism** (closes #2330) — parallel to `property-lists`, covering program-level brand safety via CRUD on content programs (shows, series, podcasts identified by IMDb/Gracenote/EIDR). CRUD-only scope; enforcement is setup-time seller caching, not post-hoc validation.
2. **Complete the Account migration for property-list and collection-list task families** (closes #2334) — removes the deprecated `principal` field and adopts the **Account** primitive (natural key `{brand, operator}` or `account_id`) on every CRUD and validate tool in these families. They were the last two holdouts from AdCP 3.0's Agent + Account split.

This supersedes #2333 (closed), which did (1) with a `brand`-on-inputSchema workaround in the training agent. An expert audit on #2333 flagged that workaround as spec-divergent — the spec's identity primitive is Account, not brand. This PR ships both (1) and (2) together with the spec-correct design from the start.

## Schema changes

**Four schemas drop `principal`** in favor of `account: $ref /schemas/core/account-ref.json`:
- `property/property-list.json`, `property/list-property-lists-request.json`
- `collection/collection-list.json`, `collection/list-collection-lists-request.json`

**Nine request schemas gain optional `account`** matching the canonical `get-media-buys-request.json` pattern:
- property: `create`, `get`, `update`, `delete`, `validate-property-delivery`
- collection: `create`, `get`, `update`, `delete`

**`brand` stays on create/update** as campaign metadata, not identity — same split as `create-media-buy`.

**New enum value:** `collection-lists` in `specialism.json`.

## Reference implementation

- Training agent inputSchemas declare `account` via a shared `ACCOUNT_REF_SCHEMA` (exported from `account-handlers.ts`).
- `PropertyListState.principal` → `PropertyListState.account: AccountRef`. `CollectionListState` gains `account: AccountRef`.
- Storyboards pass `account: { brand: { domain }, operator }` on every non-create call.
- `collection-lists` specialism storyboard at `static/compliance/source/specialisms/collection-lists/index.yaml` — 5 phases (capability_discovery → create → list/get → update → delete).
- Added `Specialism`, `Storyboard`, `Storyboard Category` entries to `docs/reference/glossary.mdx`.

## Before / after

- `list_property_lists({ principal: \"acmeoutdoor.example\" })` — **deprecated, now rejected** (`additionalProperties: false`)
- `list_property_lists({ account: { brand: { domain: \"acmeoutdoor.example\" }, operator: \"acmeoutdoor.example\" } })` — **current**
- `create_property_list({ name, brand: { domain }, account: { account_id } })` — both fields coexist; account = billing, brand = campaign metadata

## Expert review

Three rounds of expert review across the stacked work (code, product, docs, protocol). All ship-it verdicts with their findings applied:
- Code reviewer — changeset count corrected; `brand` wired through `handleUpdateCollectionList` to match `handleUpdatePropertyList`.
- Protocol expert — `Principal` subhead in `governance/property/specification.mdx:58` renamed to `Account`; error-code row in `property_lists.mdx:661` updated; `additionalProperties: false` behavior for stray `principal` documented in the migration guide.
- Docs reviewer — glossary entries tightened; broken `[protocol](#p)` cross-ref removed.

## Test plan

- [x] `npm run build:schemas`
- [x] `npm run build:compliance` — 22 specialisms
- [x] `npm run test:schemas` (7/7)
- [x] `npm run test:examples` (31/31)
- [x] `npm run test:composed` (12/12)
- [x] `npm run test:docs-nav` (15/15)
- [x] `npx vitest run server/tests/unit/collection-lists-storyboard.test.ts` (2/2 — end-to-end storyboard walk with ajv response_schema validation + tools/list invariant pinning `account` shape)
- [x] `npm run test:unit` (587/587) via precommit
- [x] `npm run typecheck`
- [x] `npx changeset status` — major bump registered

## Migration guide

Agents that shipped 3.0-rc.x with `principal` on property-list or collection-list payloads:
- `principal: \"acc_xyz\"` → `account: { account_id: \"acc_xyz\" }`
- `principal: \"example.com\"` → `account: { brand: { domain: \"example.com\" }, operator: \"example.com\" }` (direct)
- Agency: `account: { brand: { domain: \"brand.com\" }, operator: \"agency.com\" }`

All request schemas in this family declare `additionalProperties: false`, so stray `principal` fields now fail validation rather than being silently ignored.

## Follow-up (not in this PR)

- `server/src/training-agent/state.ts:310` — the `args.brand?.domain` fallback in `sessionKeyFromArgs` is unreachable on spec-compliant paths now that `additionalProperties: false` rejects stray `brand`. Remove in a training-agent-only cleanup.
- `docs/building/implementation/security.mdx` — legacy `principal_id` RLS vocabulary. Separate doc cleanup.
- `docs/learning/specialist/governance.mdx` — add a `collection-lists` learning card alongside the existing property_lists one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)