### PR TITLE
fix(test-vectors): correct stale Content-Digest in request-signing positive/002

### DIFF
--- a/.changeset/fix-request-signing-002-stale-digest.md
+++ b/.changeset/fix-request-signing-002-stale-digest.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix stale `Content-Digest` and `Signature` in request-signing test vector `positive/002-post-with-content-digest.json` (issue #2335). The shipped digest was not the SHA-256 of the body bytes, so verifiers that recompute at verifier checklist step 11 rejected the vector. Recomputed digest against the 22-byte body `{"plan_id":"plan_001"}`, updated `expected_signature_base`, and re-signed with `test-ed25519-2026`. Also updated `negative/018-digest-covered-when-forbidden.json`, which reused the stale values — the intended failure mode is at step 6 (coverage policy), but keeping downstream fields valid prevents lenient verifiers from reporting the wrong error.

--- a/static/compliance/source/test-vectors/request-signing/negative/018-digest-covered-when-forbidden.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/018-digest-covered-when-forbidden.json
@@ -7,9 +7,9 @@
     "url": "https://seller.example.com/adcp/create_media_buy",
     "headers": {
       "Content-Type": "application/json",
-      "Content-Digest": "sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+      "Content-Digest": "sha-256=:SNIVma8dgUBx/U1CBaYFQnsJep9S0/tXaNXlQQOdoxQ=:",
       "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
-      "Signature": "sig1=:c70cPF7y-cC7a2QEfdmFzgsP9JJ1B17BgG_bzQgX6t9uMkMjVI19DU5fDMd8BchTblf129X2GA3TztTbYn_zAQ:"
+      "Signature": "sig1=:RiD5mPhxpBWhmaqUL5-vceyPX5jpjzYZhSnteuYCIYhIqdIl0Yxdh5qstCPXwkKL4AZOsPBL7-8ctbPkHunSAw:"
     },
     "body": "{\"plan_id\":\"plan_001\"}"
   },

--- a/static/compliance/source/test-vectors/request-signing/positive/002-post-with-content-digest.json
+++ b/static/compliance/source/test-vectors/request-signing/positive/002-post-with-content-digest.json
@@ -7,9 +7,9 @@
     "url": "https://seller.example.com/adcp/create_media_buy",
     "headers": {
       "Content-Type": "application/json",
-      "Content-Digest": "sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+      "Content-Digest": "sha-256=:SNIVma8dgUBx/U1CBaYFQnsJep9S0/tXaNXlQQOdoxQ=:",
       "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
-      "Signature": "sig1=:c70cPF7y-cC7a2QEfdmFzgsP9JJ1B17BgG_bzQgX6t9uMkMjVI19DU5fDMd8BchTblf129X2GA3TztTbYn_zAQ:"
+      "Signature": "sig1=:RiD5mPhxpBWhmaqUL5-vceyPX5jpjzYZhSnteuYCIYhIqdIl0Yxdh5qstCPXwkKL4AZOsPBL7-8ctbPkHunSAw:"
     },
     "body": "{\"plan_id\":\"plan_001\"}"
   },
@@ -23,7 +23,7 @@
   "jwks_ref": [
     "test-ed25519-2026"
   ],
-  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://seller.example.com/adcp/create_media_buy\n\"@authority\": seller.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://seller.example.com/adcp/create_media_buy\n\"@authority\": seller.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:SNIVma8dgUBx/U1CBaYFQnsJep9S0/tXaNXlQQOdoxQ=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
   "expected_outcome": {
     "success": true
   },


### PR DESCRIPTION
## Summary

Fixes #2335.

`static/compliance/source/test-vectors/request-signing/positive/002-post-with-content-digest.json` shipped a `Content-Digest` header value that was not the SHA-256 of the body bytes. Every implementation that recomputes the digest at step 11 of the verifier checklist rejected this vector.

The existing `Signature` cryptographically verified against `expected_signature_base` (step 10 passed), because the signer signed over a base that inlined the stale digest. The mismatch was only visible once a verifier independently hashed the body.

## Changes

**`positive/002-post-with-content-digest.json`** — recomputed `Content-Digest` against the 22-byte body `{"plan_id":"plan_001"}`:

- `Content-Digest`: `sha-256=:SNIVma8dgUBx/U1CBaYFQnsJep9S0/tXaNXlQQOdoxQ=:`
- `expected_signature_base`: updated digest line to match
- `Signature`: re-signed with `test-ed25519-2026` → `RiD5mPhxpBWhmaqUL5-vceyPX5jpjzYZhSnteuYCIYhIqdIl0Yxdh5qstCPXwkKL4AZOsPBL7-8ctbPkHunSAw`

**`negative/018-digest-covered-when-forbidden.json`** — reused the same stale digest/signature (copied from 002 by construction). Its intended failure is at step 6 (verifier's `covers_content_digest='forbidden'` policy), not step 11, so the stale values were inert — but a lenient verifier that runs digest recompute before policy could surface the wrong error code. Updated to the correct digest and re-signed so the vector isolates its intended failure mode.

## Verification

Reproduced positive/001's committed signature byte-for-byte using the same signer implementation, confirming the signer is correct. For positive/002, end-to-end checks against the shipped vector now pass:

```
digest recomputed == shipped? true
expected_signature_base uses shipped digest? true
signature verifies? true
```

Local precommit (587 unit tests + tsc typecheck) passes.

## Test plan

- [x] Unit tests pass
- [x] Typecheck passes
- [x] End-to-end signer verification against 001 (reproduces shipped sig) and 002 (digest + base + crypto all consistent)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)