### PR TITLE
spec(security): clarify request-signing checklist step 9a (per-keyid cap before crypto)

### DIFF
--- a/.changeset/request-signing-checklist-step-9a.md
+++ b/.changeset/request-signing-checklist-step-9a.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify request-signing verifier checklist step ordering: the per-keyid replay-cache cap check is now formalized as **step 9a**, run after revocation (step 9) and **before** cryptographic verify (step 10). This makes conformance test vector `negative/020-rate-abuse.json` reproducible — previously the vector's expected outcome (`request_signature_rate_abuse`) was only producible when the cap check ran before crypto verify, but the checklist numbered the replay-related checks as step 12, *after* crypto verify at step 10. The cap-check ordering parallels revocation: both are cheap O(1) rejections that MUST run before crypto verify so an abusive or revoked signer cannot force amplified Ed25519/ECDSA work on the verifier. Step 12 (nonce dedup) still runs after crypto verify so the replay cache is not consumed by invalid signatures.
+
+Updated files:
+
+- `docs/building/implementation/security.mdx`: added step 9a to the verifier checklist, motivated its placement between step 7 (JWKS resolve) and step 10 (crypto verify) — after 7 so the cap-state oracle only responds for keys already published in JWKS, before 10 to prevent amplified crypto work. Split the rationale section into three paragraphs: the cheap-rejections argument, the load-bearing cap-write invariant (external traffic can't grow the cap because inserts happen at step 13 after crypto verify), and the step-12-runs-post-crypto note. Added a "Single-process vs. distributed enforcement" paragraph to the Transport replay dedup section noting that step 9a is a cheap amplification guard while step 13's insert should be atomic with a cap check to avoid drift on Redis-backed verifiers. Added `isKeyidAtCapacity` to the reference TypeScript verifier. Aligned the shadow-mode conformance bullet at line 701 with the error-code-only grading contract.
+- `static/compliance/source/test-vectors/request-signing/negative/020-rate-abuse.json`: `failed_step` changed from `12` to `"9a"`, `spec_reference` now points at checklist step 9a, `$comment` explains the placeholder `Signature` bytes and why verifiers that defer the cap check until after crypto verify will fail this vector.
+- `static/compliance/source/test-vectors/request-signing/README.md`: updated 020 description, extended the `failed_step` field definition to allow string sub-step labels, documented the `replay_cache_per_keyid_cap_hit` test-harness state key alongside `replay_cache_entries` and `revocation_list`, and added a "Stateful pre-crypto negatives" group to the recommended run order so `017` (revocation) and `020` (cap) are validated together, before crypto-dependent negatives.
+- `static/compliance/source/specialisms/signed-requests/index.yaml`: replaced "13-step verifier checklist" with a reference to the 13 numbered steps plus sub-step 9a.
+
+No wire-format change. This is a verifier-side implementation-order clarification. Signers are unaffected.
+
+Reported as adcontextprotocol/adcp#2339. Surfaced by the Python SDK implementation at adcontextprotocol/adcp-client-python#183, where moving the cap check ahead of crypto verify produced the expected vector outcome without any vector edits.

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -696,11 +696,11 @@ For implementers who want to pilot signing in 3.0 before the 4.0 flip:
 **As a verifier (seller):**
 
 1. Advertise `request_signing.supported: true` in `get_adcp_capabilities`. Leave `required_for: []` during the pilot; add operations incrementally per counterparty.
-2. Enable signature verification middleware on mutating routes. Implement the [verifier checklist](#verifier-checklist-requests) — all 13 steps, short-circuit on first failure.
+2. Enable signature verification middleware on mutating routes. Implement the [verifier checklist](#verifier-checklist-requests) — all 14 checks (13 numbered steps plus sub-step 9a), short-circuit on first failure.
 3. Start in shadow mode (verify and log; do not reject on failure) for a pilot counterparty before populating `required_for`. Surface verification failures in monitoring rather than operations for the first few weeks.
-4. Run the conformance negative vectors against your verifier — each rejection should produce the vector's stated `error_code` at or before its `failed_step`.
+4. Run the conformance negative vectors against your verifier — each rejection MUST produce the vector's stated `error_code`. The vector's `failed_step` is informational; an implementation that rejects with the correct error code is conformant even if its internal step numbering differs.
 
-**Minimum viable verifier (3.0 shadow mode):** steps 1–10 of the checklist, in-memory replay cache, one-minute revocation polling with a lightweight `kid`-membership check (full grace semantics deferred). This is acceptable for log-and-observe shadow mode because no request is being rejected on replay or digest failure. **Before adding any operation to `required_for`, implement steps 11–13** — digest recompute (step 11), replay insert after success (step 13), and the full revocation-stale grace window (part of step 9). Flipping to enforce with an incomplete verifier surfaces replay and body-integrity gaps on live production traffic rather than in shadow logs. Do not skip ahead of step 1 — malformed signatures always reject, never fall back.
+**Minimum viable verifier (3.0 shadow mode):** steps 1–9, 9a, and 10 of the checklist, in-memory replay cache, one-minute revocation polling with a lightweight `kid`-membership check (full grace semantics deferred). This is acceptable for log-and-observe shadow mode because no request is being rejected on replay or digest failure. **Before adding any operation to `required_for`, implement steps 11–13** — digest recompute (step 11), replay insert after success (step 13), and the full revocation-stale grace window (part of step 9). Flipping to enforce with an incomplete verifier surfaces replay and body-integrity gaps on live production traffic rather than in shadow logs. Do not skip ahead of step 1 — malformed signatures always reject, never fall back.
 
 #### AdCP RFC 9421 profile
 
@@ -812,14 +812,21 @@ Otherwise, verifiers MUST perform these checks in order, short-circuiting on the
 7. Resolve `keyid` to a JWK via [Agent key publication](#agent-key-publication). On `kid` miss, refetch once (subject to the 30-second cooldown between refetches) before rejecting with `request_signature_key_unknown`. Reject if `keyid` cannot be resolved to a specific `agents[]` entry.
 8. Verify the JWK's `use` is `"sig"`, `key_ops` includes `"verify"`, and `adcp_use` equals `"request-signing"`. Reject (`request_signature_key_purpose_invalid`) on any mismatch — including absent `adcp_use`, which MUST be treated as non-conforming.
 9. Check the [Transport revocation](#transport-revocation) list. Reject if `keyid` ∈ `revoked_kids` (`request_signature_key_revoked`). Reject with `request_signature_revocation_stale` if the verifier has not refreshed the revocation list within grace.
+
+    **9a. Per-keyid cap check.** Check the [per-keyid replay-cache cap](#transport-replay-dedup). Reject with `request_signature_rate_abuse` if the cap has been reached for this `keyid`. Runs before cryptographic verify (step 10) — same rationale as step 9: a compromised or misconfigured signer exhausting its cap MUST NOT force amplified Ed25519/ECDSA work on the verifier. Runs *after* `keyid` resolution (step 7) so the cap-state oracle only responds for keys the verifier has already committed to recognizing — running 9a earlier would let an attacker probe verifier-internal rate-limit state across the full keyid space, including keyids not published in JWKS.
+
 10. Compute the canonical signature base per RFC 9421 §2.5 using the covered components (after applying `@target-uri` canonicalization). Verify the signature against the JWK (`request_signature_invalid` on failure).
 11. If `content-digest` is covered, recompute the digest from the received body bytes and compare (`request_signature_digest_mismatch` on mismatch).
 12. Check the nonce against the replay cache (see [Transport replay dedup](#transport-replay-dedup)). Reject if `(keyid, nonce)` has been seen within the replay-cache TTL (`request_signature_replayed`).
-13. **Only after steps 1–12 have all passed**, insert `(keyid, nonce)` into the replay cache with TTL = `(expires − now) + 60 s` (the +60 s matches the skew tolerance applied at step 5).
+13. **Only after steps 1–9, 9a, and 10–12 have all passed**, insert `(keyid, nonce)` into the replay cache with TTL = `(expires − now) + 60 s` (the +60 s matches the skew tolerance applied at step 5).
 
-Only after all 13 checks pass does the verifier treat the request as cryptographically authenticated. Verifiers SHOULD record `verified_signer: { keyid, agent_url, verified_at }` on the request context so downstream code — including the subsequent brand-operator authorization check — can log and audit by signed agent identity.
+Only after all 14 checks pass does the verifier treat the request as cryptographically authenticated. Verifiers SHOULD record `verified_signer: { keyid, agent_url, verified_at }` on the request context so downstream code — including the subsequent brand-operator authorization check — can log and audit by signed agent identity.
 
-**Revocation before crypto verify (step 9 before step 10) is deliberate.** If a verifier checks crypto first, an attacker replaying a revoked-key signature forces an Ed25519 or ECDSA verification on every rejection — cheap amplification. Moving revocation ahead closes that O(verify) → O(1) gap. It does not leak additional information: step 7's `keyid` resolution already reveals whether the key exists, and step 9's revocation check reveals whether the known key is revoked — both are strictly less than the information already available to any party that fetches the signer's JWKS and revocation list directly.
+**Cheap rejections before crypto verify (steps 9 and 9a before step 10) are deliberate.** If a verifier checks crypto first, an attacker replaying a revoked-key signature — or a signer hammering a verifier whose per-keyid cap is full — forces an Ed25519 or ECDSA verification on every rejection, cheap amplification. Moving revocation and the per-keyid cap ahead closes that O(verify) → O(1) gap. Step 9's revocation state is already published externally on the signer's origin; step 9a's cap state is verifier-internal but is observable via traffic-pattern analysis by any sustained attacker. The spec intentionally pairs the distinct `request_signature_rate_abuse` error code with the `SHOULD alert operators` requirement (see [Transport replay dedup](#transport-replay-dedup)) so cap observations surface as incident signal rather than silent oracles — a compromised-key event should be loud for the operator even if it is also legible to the attacker who caused it.
+
+**A load-bearing invariant for the cap.** External traffic without the private key cannot grow the cap: the replay-cache insert happens at step 13, *after* crypto verify (step 10), so any request that fails at step 10 never consumes a cap entry. This is why 9a is a *reader* of cap state, not a writer — only the legitimate key holder (or anyone who has compromised the key, the case the cap exists to detect) can grow the set. Future edits to the checklist MUST preserve this ordering: moving the insert earlier would let any external party flood the cap using forged structurally-valid signatures.
+
+Step 12's `(keyid, nonce)` dedup, by contrast, runs *after* crypto verify so the replay cache is not consumed by invalid signatures.
 
 #### Content-digest and proxy compatibility
 
@@ -851,7 +858,9 @@ Step 12 of the [verifier checklist](#verifier-checklist-requests) requires per-`
 
 Verifiers MUST NOT use the request bearer token, IP, or any non-`(keyid, nonce)` value as the replay key — those produce false positives that reject legitimate agent traffic.
 
-**Per-keyid cap.** To prevent an abusive or compromised signer from exhausting verifier memory with unique nonces, verifiers MUST enforce a per-keyid entry cap on the replay cache. Recommended ceiling: 1,000,000 entries per `keyid`. On cap exceeded, verifiers MUST reject new signatures from that `keyid` with `request_signature_rate_abuse` — NOT silently evict — and SHOULD alert operators, because hitting the cap indicates either a compromised key or a grossly misconfigured signer. Silent eviction is the dangerous mode: it creates replay windows exactly when the verifier is under attack. The per-keyid cap is distinct from the total cache ceiling; a verifier may legitimately hit its total ceiling via many well-behaved signers, but per-keyid exhaustion is unambiguously an attack signal.
+**Per-keyid cap.** To prevent an abusive or compromised signer from exhausting verifier memory with unique nonces, verifiers MUST enforce a per-keyid entry cap on the replay cache. Recommended ceiling: 1,000,000 entries per `keyid`. On cap exceeded, verifiers MUST reject new signatures from that `keyid` with `request_signature_rate_abuse` — NOT silently evict — and SHOULD alert operators, because hitting the cap indicates either a compromised key or a grossly misconfigured signer. Silent eviction is the dangerous mode: it creates replay windows exactly when the verifier is under attack. The per-keyid cap is distinct from the total cache ceiling; a verifier may legitimately hit its total ceiling via many well-behaved signers, but per-keyid exhaustion is unambiguously an attack signal. The cap check is step 9a of the [verifier checklist](#verifier-checklist-requests) — evaluated **before** crypto verify so an abusive signer cannot force amplified Ed25519/ECDSA work on the verifier.
+
+**Single-process vs. distributed enforcement.** In a single-process verifier, step 9a (read) and step 13 (insert) are sequential in one execution and the cap is exact. In a distributed verifier sharing a Redis-backed replay cache, step 9a is a cheap fast-path amplification guard but is not authoritative: two verifiers can both observe `size == cap − 1`, both pass 9a, both pass steps 10–12, and both insert at step 13. To avoid cap drift, the step 13 insert SHOULD be atomic with a cap check (e.g., a Lua script or `SETNX` pattern that returns an over-cap sentinel) — step 9a remains the cheap amplification guard, step 13 is the authoritative enforcement point. A verifier whose atomic insert returns over-cap MUST reject the request with `request_signature_rate_abuse` rather than let it succeed; a cap that is advisory at step 13 is not a cap.
 
 #### Transport revocation
 
@@ -968,6 +977,7 @@ export async function verifyAdcpRequestSignature(req: Request, ctx: {
   resolveJwk: (keyid: string) => Promise<{ jwk: unknown; agentUrl: string }>; // throws _key_unknown after refetch
   isKeyRevoked: (keyid: string) => Promise<boolean>;
   isRevocationStale: () => Promise<boolean>;
+  isKeyidAtCapacity: (keyid: string) => Promise<boolean>;
   isReplayed: (keyid: string, nonce: string) => Promise<boolean>;
   recordNonce: (keyid: string, nonce: string, ttlSeconds: number) => Promise<void>;
   verify9421: (req: Request, jwk: unknown, covered: string[]) => Promise<void>; // throws on signature or digest failure
@@ -1025,6 +1035,10 @@ export async function verifyAdcpRequestSignature(req: Request, ctx: {
   // 9: revocation (BEFORE crypto verify)
   if (await ctx.isRevocationStale()) throw new RequestSignatureError("request_signature_revocation_stale");
   if (await ctx.isKeyRevoked(parsed.keyid!)) throw new RequestSignatureError("request_signature_key_revoked");
+  // 9a: per-keyid cap (BEFORE crypto verify) — prevents amplified crypto work by abusive/misconfigured signer.
+  if (await ctx.isKeyidAtCapacity(parsed.keyid!)) {
+    throw new RequestSignatureError("request_signature_rate_abuse");
+  }
   // 10 + 11: crypto verify, content-digest recompute — both inside verify9421.
   try { await ctx.verify9421(req, jwk, parsed.components); }
   catch (e: any) {

--- a/static/compliance/source/specialisms/signed-requests/index.yaml
+++ b/static/compliance/source/specialisms/signed-requests/index.yaml
@@ -134,7 +134,8 @@ phases:
     narrative: |
       The runner sends each negative vector and expects the agent to reject with the
       stable error code in `expected_outcome.error_code`. Negative vectors cover every
-      failure mode in the 13-step verifier checklist plus the pre-check:
+      failure mode in the verifier checklist (13 numbered steps plus sub-step 9a for
+      the per-keyid cap) plus the pre-check:
 
         001 unsigned + required_for           → request_signature_required
         002 wrong tag                         → request_signature_tag_invalid

--- a/static/compliance/source/test-vectors/request-signing/README.md
+++ b/static/compliance/source/test-vectors/request-signing/README.md
@@ -36,7 +36,7 @@ test-vectors/request-signing/
 │   ├── 017-key-revoked.json              → request_signature_key_revoked (step 9; requires test_harness_state preload)
 │   ├── 018-digest-covered-when-forbidden.json → request_signature_components_unexpected (step 6; policy 'forbidden')
 │   ├── 019-signature-without-signature-input.json → request_signature_header_malformed (pre-check; downgrade loophole)
-│   └── 020-rate-abuse.json               → request_signature_rate_abuse (step 12 cap; abuse signal)
+│   └── 020-rate-abuse.json               → request_signature_rate_abuse (step 9a cap; abuse signal)
 └── positive/                             vectors that MUST verify successfully
     ├── 001-basic-post.json                   Ed25519, no content-digest
     ├── 002-post-with-content-digest.json     Ed25519, content-digest covered
@@ -98,13 +98,14 @@ Every vector is a single JSON file with this shape:
 - **`verifier_capability`** — the `request_signing` block the verifier advertises. Drives expected behavior on content-digest coverage (`"required"` | `"forbidden"` | `"either"`) and whether unsigned requests to the operation are rejected pre-check.
 - **`jwks_ref`** — array of `kid` strings from `keys.json`. The test harness builds the verifier's view of the signing agent's JWKS by selecting those entries. Present on most vectors.
 - **`jwks_override`** — full JWKS object (`{ keys: [...] }`) that replaces the default `jwks_ref` lookup for this vector. Used when a vector needs a JWK that is NOT in the canonical `keys.json` (e.g., a malformed `key_ops` to test step 8 rejection). Mutually exclusive with `jwks_ref`.
-- **`test_harness_state`** — optional. Preloads verifier state BEFORE invoking verification. Supported sub-keys:
-  - `replay_cache_entries` — list of `{ keyid, nonce, ttl_seconds }` to preload into the replay cache (used by `016-replayed-nonce.json`).
-  - `revocation_list` — full signed-revocation-list object to preload as the current freshness snapshot (used by `017-key-revoked.json`).
+- **`test_harness_state`** — optional. Preloads verifier state BEFORE invoking verification. Harness implementations translate each sub-key into the appropriate concrete preload for their verifier under test. Supported sub-keys:
+  - `replay_cache_entries` — list of `{ keyid, nonce, ttl_seconds }` to preload into the per-`(keyid, nonce)` replay cache. Used by `016-replayed-nonce.json` to assert the nonce-dedup check at step 12.
+  - `replay_cache_per_keyid_cap_hit` — object `{ keyid }` signalling the per-keyid entry cap is hit for the named key. Used by `020-rate-abuse.json` to assert the cap check at step 9a. The harness MAY simulate by populating the cache with N placeholder entries (where N equals the verifier's configured cap) or by setting an implementation-private flag — what the vector asserts is the rejection behavior when the cap is hit, not the mechanism of reaching it.
+  - `revocation_list` — full signed-revocation-list object to preload as the current freshness snapshot. Used by `017-key-revoked.json` to assert the revocation check at step 9.
 - **`expected_signature_base`** — present on positive vectors and on `015-signature-invalid.json`. The canonical signature base string per RFC 9421 §2.5. Shape specifics that implementers get wrong: **lines are joined with a single `\n`** (LF, not CRLF); **there is no trailing newline** after the final `@signature-params` line; **components appear in the exact order listed in `Signature-Input`**, followed by `@signature-params` as the last line. The JSON string uses `\n` escapes which parse to real newline bytes at load time. Implementers can diff their computed base against this field BEFORE worrying about signatures — canonicalization disagreements are the #1 source of 9421 interop bugs, and checking the base is how you catch them.
 - **`expected_outcome.success`** — `true` for positive vectors, `false` for negative.
 - **`expected_outcome.error_code`** — stable code from the [transport error taxonomy](https://adcontextprotocol.org/docs/building/implementation/security#transport-error-taxonomy). Conformance requires **byte-for-byte match** on this code. Negative vectors only.
-- **`expected_outcome.failed_step`** — which step of the verifier checklist the rejection occurs at. Informational only — an implementation that rejects at an earlier step with the same error code is non-conformant (see [Conformance expectations](#conformance-expectations)). Negative vectors only.
+- **`expected_outcome.failed_step`** — which step of the verifier checklist the rejection occurs at. Integer for numbered steps (`1`–`13`), or a string for lettered sub-steps (e.g. `"9a"` for the per-keyid cap check). Informational only — an implementation that rejects with the correct error code is conformant even if its internal step numbering differs. An implementation that rejects with a DIFFERENT error code is non-conformant (see [Conformance expectations](#conformance-expectations)). Negative vectors only.
 - **`$comment`** — free-form clarifying notes. Some vectors use `$comment` to describe test-harness setup or conformance edge cases.
 
 ## Test keypairs
@@ -156,7 +157,8 @@ Run vectors in this order when validating a new implementation — it isolates f
 2. **Parse-level negatives next** (`001`, `002`, `011`, `012`, `014`, `019`). These fail at the pre-check or early checklist steps without invoking crypto. Passing these means your header parsing and presence checks are correct.
 3. **Semantic negatives** (`003`, `004`, `005`, `006`, `007`, `013`, `018`). These exercise specific rules (window, alg allowlist, covered components, content-digest policy) without requiring valid signatures.
 4. **Key-path negatives** (`008`, `009`). JWKS resolution + `adcp_use` enforcement.
-5. **Crypto / stateful negatives last** (`015`, `010`, `016`, `017`). These require the verifier to have run most of the checklist before reaching the failure point. `015` specifically catches canonicalization bugs where your implementation computes a different signature base than the spec — if you pass `positive/001` but fail `015`, your canonicalization is still off somewhere and `015` is picking it up.
+5. **Stateful pre-crypto negatives** (`017`, `020`). These require preloaded harness state and reject before crypto verify — `017` on revocation (step 9), `020` on the per-keyid cap (step 9a). The committed `Signature` on these vectors is a placeholder and is NOT expected to verify cryptographically; the rejection MUST land on the pre-crypto cheap check.
+6. **Crypto / stateful-post negatives last** (`015`, `010`, `016`). These require the verifier to have run most of the checklist before reaching the failure point. `015` specifically catches canonicalization bugs where your implementation computes a different signature base than the spec — if you pass `positive/001` but fail `015`, your canonicalization is still off somewhere and `015` is picking it up.
 
 ## Adding vectors
 

--- a/static/compliance/source/test-vectors/request-signing/negative/020-rate-abuse.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/020-rate-abuse.json
@@ -1,6 +1,6 @@
 {
   "name": "Per-keyid replay cache entry cap exceeded (abuse or misconfigured signer)",
-  "spec_reference": "#transport-replay-dedup (per-keyid cap) and #transport-error-taxonomy",
+  "spec_reference": "#verifier-checklist-requests step 9a (per-keyid cap; before crypto verify) and #transport-replay-dedup",
   "reference_now": 1776520800,
   "request": {
     "method": "POST",
@@ -27,7 +27,7 @@
   "expected_outcome": {
     "success": false,
     "error_code": "request_signature_rate_abuse",
-    "failed_step": 12
+    "failed_step": "9a"
   },
-  "$comment": "When the per-keyid replay cache has reached its configured cap (recommended: 1M entries), new signatures from that keyid MUST be rejected with request_signature_rate_abuse — not silently evict, not accept. Silent eviction creates replay windows exactly when under attack. The nonce in this vector is fresh (never seen); the rejection is due to the cap, not replay. Verifiers SHOULD alert operators on this condition as a compromised-key or misconfigured-signer signal."
+  "$comment": "When the per-keyid replay cache has reached its configured cap (recommended: 1M entries), new signatures from that keyid MUST be rejected with request_signature_rate_abuse — not silently evict, not accept. Silent eviction creates replay windows exactly when under attack. The nonce in this vector is fresh (never seen); the rejection is due to the cap, not replay. Verifiers SHOULD alert operators on this condition as a compromised-key or misconfigured-signer signal. The cap check is step 9a of the verifier checklist and runs BEFORE crypto verify (step 10) to prevent amplified Ed25519/ECDSA work on an abusive signer — same rationale as revocation (step 9). Implementations that defer the cap check until after crypto verify will fail this vector because the committed Signature bytes are a placeholder copied from positive/001 and do not verify cryptographically against this vector's own signature base (different nonce in @signature-params, different body)."
 }


### PR DESCRIPTION
Closes #2339.

## Summary

Conformance vector `negative/020-rate-abuse.json` expects `request_signature_rate_abuse` but its committed `Signature` is a placeholder copied from `positive/001` — it does not verify cryptographically against its own base (different nonce in `@signature-params`, different body). The only way to produce the mandated outcome is for the per-keyid cap check to run before crypto verify. The checklist numbered the replay-related checks as step 12, *after* crypto verify at step 10, so the vector was specified-but-unreachable by the letter of the checklist.

This PR formalizes the cap check as **step 9a** of the verifier checklist, placed between step 7 (JWKS resolve) and step 10 (crypto verify):

- **After step 7** so the cap-state oracle only responds for keys already published in JWKS — running 9a earlier would let an attacker probe verifier-internal rate-limit state across the full keyid space.
- **Before step 10** so an abusive or misconfigured signer cannot force amplified Ed25519/ECDSA work on the verifier — same rationale as step 9 (revocation) before step 10.

Step 12 (nonce dedup) still runs after crypto verify so the replay cache is not consumed by invalid signatures.

Also documents two invariants the review surfaced:

1. **Cap writes only happen post-crypto.** External traffic without the private key cannot grow the cap: inserts happen at step 13, after step 10's crypto verify. Step 9a is a *reader* of cap state, not a writer. Future checklist edits MUST preserve this ordering.
2. **Distributed enforcement.** On Redis-backed verifiers, step 9a is a cheap amplification guard but not authoritative — step 13's insert SHOULD be atomic with a cap check (Lua/`SETNX`) to avoid drift across concurrent verifiers. An advisory cap at step 13 is not a cap.

## Changes

- `docs/building/implementation/security.mdx` — added step 9a to the verifier checklist (indented continuation under step 9 to keep the outer list numbering valid in CommonMark), split the rationale into three paragraphs (cheap-rejections argument, load-bearing cap-write invariant, step-12-runs-post-crypto note), added a "Single-process vs. distributed enforcement" paragraph to Transport replay dedup, added `isKeyidAtCapacity` to the reference TypeScript verifier, and aligned the shadow-mode conformance bullet with the error-code-only grading contract.
- `static/compliance/source/test-vectors/request-signing/negative/020-rate-abuse.json` — `failed_step: 12 → "9a"`, updated `spec_reference`, extended `$comment` to explain the placeholder `Signature` bytes and why verifiers that defer the cap check until after crypto verify will fail this vector.
- `static/compliance/source/test-vectors/request-signing/README.md` — updated 020 description, extended `failed_step` field definition to allow string sub-step labels, documented the `replay_cache_per_keyid_cap_hit` test-harness state key alongside `replay_cache_entries` and `revocation_list`, and added a "Stateful pre-crypto negatives" run-order group pairing `017` (revocation) and `020` (cap).
- `static/compliance/source/specialisms/signed-requests/index.yaml` — "13-step verifier checklist" → "13 numbered steps plus sub-step 9a".
- `.changeset/request-signing-checklist-step-9a.md` — new patch-level changeset on `adcontextprotocol`.

## Backward compatibility

No wire-format or signer-observable change. Verifiers already implementing the per-keyid cap from the existing Transport replay dedup MUST-enforce paragraph need no code change if their cap check already ran before crypto verify. Only implementations that deferred the cap check need to move it. The reference TypeScript verifier in security.mdx now shows the correct placement.

## Review

- **Code review** — LGTM with nits (addressed: aligned the "at or before" conformance phrasing with the error-code-only grading; nested-list rendering verified against CommonMark).
- **Security review** — no must-fix. Four should-fix, all addressed in this PR:
  - SF-1: rewrote the "strictly less than JWKS" rhetorical overreach in the rationale.
  - SF-2: documented why 9a runs after step 7 (JWKS resolve), not earlier.
  - SF-3: added distributed-enforcement guidance noting step 13 should be atomic with a cap check on Redis-backed verifiers.
  - SF-4: documented the `replay_cache_per_keyid_cap_hit` test-harness state key in the vectors README alongside the other keys.

## Test plan

- [x] `npm run typecheck` passes.
- [x] Precommit (`test:unit` + `typecheck`, 587 tests) passes.
- [x] `jq empty` on vector 020 parses.
- [ ] CI green (waiting).
- [ ] Mintlify preview renders the nested step-9a correctly under step 9 with the outer list numbering 1-13 intact.

Cross-SDK: adcontextprotocol/adcp-client-python#183 surfaced this — moving cap check ahead of crypto verify produced the expected vector outcome without any vector edits. Worth confirming the TypeScript and Go SDKs land the same ordering so all three reference implementations agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)