### PR TITLE
compliance: wire 3.0 scenarios into sales-* specialisms (#2228)

### DIFF
--- a/.changeset/wire-3.0-scenarios-into-sales-specialisms.md
+++ b/.changeset/wire-3.0-scenarios-into-sales-specialisms.md
@@ -1,0 +1,16 @@
+---
+---
+
+Wire 3.0 primitive scenarios into sales-* specialism `requires_scenarios`.
+
+The `media_buy_seller/{measurement_terms_rejected, governance_denied_recovery,
+pending_creatives_to_start, inventory_list_targeting, inventory_list_no_match,
+invalid_transitions}` scenarios existed but were not referenced by the
+specialism files a storyboard runner inspects to grade a claim. This surfaces
+them on `sales-guaranteed`, `sales-non-guaranteed`, `sales-broadcast-tv`,
+`sales-catalog-driven`, and `sales-proposal-mode` with the subset appropriate
+for each specialism (e.g., `measurement_terms_rejected` only where measurement
+terms are negotiable; `inventory_list_*` only where property/collection list
+targeting applies).
+
+Addresses adcontextprotocol/adcp#2228.

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -11,9 +11,15 @@ required_tools:
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_denied
+  - media_buy_seller/governance_denied_recovery
   - media_buy_seller/governance_conditions
   - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
+  - media_buy_seller/measurement_terms_rejected
+  - media_buy_seller/pending_creatives_to_start
+  - media_buy_seller/inventory_list_targeting
+  - media_buy_seller/inventory_list_no_match
+  - media_buy_seller/invalid_transitions
 
 narrative: |
   You run a broadcast television platform — a local TV station group, network affiliate,

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -11,9 +11,12 @@ required_tools:
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_denied
+  - media_buy_seller/governance_denied_recovery
   - media_buy_seller/governance_conditions
   - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
+  - media_buy_seller/pending_creatives_to_start
+  - media_buy_seller/invalid_transitions
 
 narrative: |
   You run a platform that supports catalog-driven advertising — think Snap Dynamic Ads,

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -11,9 +11,15 @@ required_tools:
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_denied
+  - media_buy_seller/governance_denied_recovery
   - media_buy_seller/governance_conditions
   - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
+  - media_buy_seller/measurement_terms_rejected
+  - media_buy_seller/pending_creatives_to_start
+  - media_buy_seller/inventory_list_targeting
+  - media_buy_seller/inventory_list_no_match
+  - media_buy_seller/invalid_transitions
 
 narrative: |
   You run a sell-side platform that requires human approval before guaranteed media buys go

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -11,8 +11,13 @@ required_tools:
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_denied
+  - media_buy_seller/governance_denied_recovery
   - media_buy_seller/governance_conditions
   - media_buy_seller/delivery_reporting
+  - media_buy_seller/pending_creatives_to_start
+  - media_buy_seller/inventory_list_targeting
+  - media_buy_seller/inventory_list_no_match
+  - media_buy_seller/invalid_transitions
 
 narrative: |
   You run a sell-side platform with auction-based inventory. Non-guaranteed buys don't

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -11,9 +11,15 @@ required_tools:
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_denied
+  - media_buy_seller/governance_denied_recovery
   - media_buy_seller/governance_conditions
   - media_buy_seller/proposal_finalize
   - media_buy_seller/delivery_reporting
+  - media_buy_seller/measurement_terms_rejected
+  - media_buy_seller/pending_creatives_to_start
+  - media_buy_seller/inventory_list_targeting
+  - media_buy_seller/inventory_list_no_match
+  - media_buy_seller/invalid_transitions
 
 narrative: |
   Your seller generates curated media plan proposals. The buyer sends a brief, your platform


### PR DESCRIPTION
Closes #2228.

## Summary

- Audit of #2228's checklist found all 7 primitive tracks (collection lists, `measurement_terms` round-trip, `GOVERNANCE_DENIED` recovery, `pending_creatives` → `pending_start`, `VERSION_UNSUPPORTED`, broadcast `agency_estimate_number`, governance across purchase types) already have scenarios or specialisms in `static/compliance/source/`.
- The actual gap: five sales-* specialisms' `requires_scenarios` lists didn't reference the newer scenarios, so a runner grading a specialism claim wouldn't exercise them.
- Added scenario references to `sales-broadcast-tv`, `sales-catalog-driven`, `sales-guaranteed`, `sales-non-guaranteed`, and `sales-proposal-mode` with the subset appropriate for each purchase model.

## Applicability matrix

| Specialism | Added |
|---|---|
| `sales-guaranteed` | `governance_denied_recovery`, `measurement_terms_rejected`, `pending_creatives_to_start`, `inventory_list_targeting`, `inventory_list_no_match`, `invalid_transitions` |
| `sales-proposal-mode` | same as `sales-guaranteed` |
| `sales-broadcast-tv` | same as `sales-guaranteed` (`inventory_list_*` included because `collection_list` is the program-level targeting primitive for broadcast) |
| `sales-non-guaranteed` | everything above **except** `measurement_terms_rejected` (auction buys don't negotiate measurement terms) |
| `sales-catalog-driven` | `governance_denied_recovery`, `pending_creatives_to_start`, `invalid_transitions` (catalog-driven uses product feeds, not property/collection list targeting; not a measurement-terms negotiation path) |

Preview specialisms (`sales-streaming-tv`, `sales-exchange`, `sales-retail-media`) left alone — they're 3.1 placeholders without full phases. `sales-social` left alone — walled-garden audience-based, none of these scenarios apply.

#2331 (signed-requests storyboard runner) moved to adcontextprotocol/adcp-client#585 — that's runner-side work, not spec-side.

## Test plan
- [x] `npm run build:compliance` — 8 universal / 6 protocols / 23 specialisms rebuild clean
- [x] `npm run test:unit` — 587 tests pass, including storyboard catalog tests
- [x] `npm run typecheck` — clean
- [x] Reviewed by ad-tech-protocol-expert for applicability of each scenario per specialism

🤖 Generated with [Claude Code](https://claude.com/claude-code)