### PR TITLE
fix: comply session persistence + storyboard sync_plans drift (#2266, #2274)

### DIFF
--- a/.changeset/fix-storyboard-drift-comply-session-persistence.md
+++ b/.changeset/fix-storyboard-drift-comply-session-persistence.md
@@ -1,0 +1,12 @@
+---
+---
+
+Fix pre-3.0 `sync_plans` sample_requests in governance storyboards (#2266). Updates `campaign_governance` / `governance_spend_authority` / `governance_delivery_monitor` bundles plus the `governance_approved` / `governance_conditions` / `governance_denied` / `governance_denied_recovery` scenarios to use the current `plan_id` / `objectives` / `budget` / `flight` shape with a top-level `idempotency_key`. Reshapes `custom_policies` entries to the `policy-entry` schema.
+
+Fix training-agent `comply_test_controller` state loss across requests (#2274). Moved account / SI-session / delivery / budget simulation state into `SessionState.complyExtensions` so it survives the per-request serialize/deserialize round trip — previously held in a `WeakMap<SessionState, ...>` that became empty on every rehydration.
+
+Fix the `structuredContent`-only branch of the MCP response unwrap test to read `adcp_error.code` (what `unwrapProtocolResponse` actually returns) instead of a non-existent `errors[0].code`.
+
+Fix two `storyboards.test.ts` iteration tests that timed out at 5s by switching the inner lookups from O(N²) `getStoryboard(id)` scans to a single `getAllStoryboards()` pass.
+
+Add `npm run test:server-unit` to `build-check.yml` so server unit regressions fail at PR time.

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Server unit tests
+        run: npm run test:server-unit

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -9,7 +9,14 @@
 
 import { TestControllerError } from '@adcp/client';
 import type { TestControllerStore } from '@adcp/client';
-import type { TrainingContext, ToolArgs, SessionState, MediaBuyState } from './types.js';
+import type {
+  TrainingContext,
+  ToolArgs,
+  SessionState,
+  MediaBuyState,
+  ComplyDeliveryAccumulator,
+  ComplyBudgetSimulation,
+} from './types.js';
 import { getSession, sessionKeyFromArgs } from './state.js';
 import { deriveStatus } from './task-handlers.js';
 
@@ -55,57 +62,40 @@ const SI_SESSION_TRANSITIONS: Record<string, string[]> = {
 
 const SI_SESSION_TERMINAL = new Set(['complete', 'terminated']);
 
+/**
+ * Per-Map cap on `complyExtensions`. These Maps are keyed by caller-supplied
+ * IDs (account_id, session_id, media_buy_id) and, since they are persisted
+ * with the session, a sandbox caller could otherwise loop with fresh IDs
+ * until the SDK's 5 MB session cap throws `PAYLOAD_TOO_LARGE` at flush —
+ * which aborts the request after the response was sent. Cap here so the
+ * rejection happens at the mutation site with a clear error code.
+ */
+const MAX_COMPLY_ENTRIES_PER_MAP = 1000;
+
+function enforceComplyCap<V>(map: Map<string, V>, key: string, kind: string): void {
+  if (!map.has(key) && map.size >= MAX_COMPLY_ENTRIES_PER_MAP) {
+    throw new TestControllerError(
+      'INVALID_STATE',
+      `Too many ${kind} entries in this sandbox session (limit ${MAX_COMPLY_ENTRIES_PER_MAP}). Clear the session or reuse an existing id.`,
+    );
+  }
+}
+
 // ── Session extensions ────────────────────────────────────────────
 
-interface ComplyExtensions {
-  accountStatuses: Map<string, string>;
-  siSessions: Map<string, { status: string; terminationReason?: string }>;
-  deliverySimulations: Map<string, DeliveryAccumulator>;
-  budgetSimulations: Map<string, BudgetSimulation>;
-}
-
-interface DeliveryAccumulator {
-  impressions: number;
-  clicks: number;
-  reportedSpend: { amount: number; currency: string };
-  conversions: number;
-}
-
-interface BudgetSimulation {
-  spendPercentage: number;
-  computedSpend: { amount: number; currency: string };
-  budget: { amount: number; currency: string };
-}
-
-const complyExtensions = new WeakMap<SessionState, ComplyExtensions>();
-
-function getExtensions(session: SessionState): ComplyExtensions {
-  let ext = complyExtensions.get(session);
-  if (!ext) {
-    ext = {
-      accountStatuses: new Map(),
-      siSessions: new Map(),
-      deliverySimulations: new Map(),
-      budgetSimulations: new Map(),
-    };
-    complyExtensions.set(session, ext);
-  }
-  return ext;
-}
-
 /** Get delivery simulation data for a media buy (used by get_media_buy_delivery). */
-export function getDeliverySimulation(session: SessionState, mediaBuyId: string): DeliveryAccumulator | undefined {
-  return complyExtensions.get(session)?.deliverySimulations.get(mediaBuyId);
+export function getDeliverySimulation(session: SessionState, mediaBuyId: string): ComplyDeliveryAccumulator | undefined {
+  return session.complyExtensions.deliverySimulations.get(mediaBuyId);
 }
 
 /** Get budget simulation data for an entity (used by get_account_financials). */
-export function getBudgetSimulation(session: SessionState, entityId: string): BudgetSimulation | undefined {
-  return complyExtensions.get(session)?.budgetSimulations.get(entityId);
+export function getBudgetSimulation(session: SessionState, entityId: string): ComplyBudgetSimulation | undefined {
+  return session.complyExtensions.budgetSimulations.get(entityId);
 }
 
 /** Get account status set by comply test controller. */
 export function getAccountStatus(session: SessionState, accountId: string): string | undefined {
-  return complyExtensions.get(session)?.accountStatuses.get(accountId);
+  return session.complyExtensions.accountStatuses.get(accountId);
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
@@ -156,7 +146,7 @@ function createStore(session: SessionState): TestControllerStore {
     },
 
     async forceAccountStatus(accountId, status) {
-      const ext = getExtensions(session);
+      const ext = session.complyExtensions;
       const prev = ext.accountStatuses.get(accountId) ?? 'active';
 
       if (prev === status) {
@@ -164,6 +154,7 @@ function createStore(session: SessionState): TestControllerStore {
       }
 
       validateTransition(ACCOUNT_TRANSITIONS, ACCOUNT_TERMINAL, prev, status, 'account');
+      enforceComplyCap(ext.accountStatuses, accountId, 'account status');
       ext.accountStatuses.set(accountId, status);
       return { success: true, previous_state: prev, current_state: status, message: `Account ${accountId} transitioned from ${prev} to ${status}` };
     },
@@ -207,7 +198,7 @@ function createStore(session: SessionState): TestControllerStore {
     },
 
     async forceSessionStatus(sessionId, status, terminationReason) {
-      const ext = getExtensions(session);
+      const ext = session.complyExtensions;
       const siSession = ext.siSessions.get(sessionId);
 
       if (!siSession) {
@@ -215,6 +206,7 @@ function createStore(session: SessionState): TestControllerStore {
         if (status === 'terminated' && !terminationReason) {
           throw new TestControllerError('INVALID_PARAMS', 'termination_reason is required when status = terminated');
         }
+        enforceComplyCap(ext.siSessions, sessionId, 'si session');
         ext.siSessions.set(sessionId, { status, terminationReason });
         return { success: true, previous_state: 'active', current_state: status, message: `Session ${sessionId} transitioned from active to ${status}` };
       }
@@ -250,9 +242,10 @@ function createStore(session: SessionState): TestControllerStore {
       const conversions = params.conversions || 0;
       const reportedSpend = params.reported_spend;
 
-      const ext = getExtensions(session);
+      const ext = session.complyExtensions;
       let cumulative = ext.deliverySimulations.get(mediaBuyId);
       if (!cumulative) {
+        enforceComplyCap(ext.deliverySimulations, mediaBuyId, 'delivery simulation');
         cumulative = {
           impressions: 0,
           clicks: 0,
@@ -322,7 +315,8 @@ function createStore(session: SessionState): TestControllerStore {
 
       const computedSpend = Math.round(budgetAmount * (spendPercentage / 100) * 100) / 100;
 
-      const ext = getExtensions(session);
+      const ext = session.complyExtensions;
+      enforceComplyCap(ext.budgetSimulations, entityId, 'budget simulation');
       ext.budgetSimulations.set(entityId, {
         spendPercentage,
         computedSpend: { amount: computedSpend, currency },

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -168,6 +168,12 @@ function createSession(): SessionState {
     creatives: new Map(),
     signalActivations: new Map(),
     usageRecords: [],
+    complyExtensions: {
+      accountStatuses: new Map(),
+      siSessions: new Map(),
+      deliverySimulations: new Map(),
+      budgetSimulations: new Map(),
+    },
     createdAt: now,
     lastAccessedAt: now,
   };
@@ -212,6 +218,7 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
   const fresh = createSession();
   const asMap = <V>(v: unknown, fallback: Map<string, V>): Map<string, V> =>
     v instanceof Map ? (v as Map<string, V>) : fallback;
+  const hydratedComply = (hydrated.complyExtensions ?? {}) as Partial<SessionState['complyExtensions']>;
   return {
     ...fresh,
     ...hydrated,
@@ -226,6 +233,12 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
     contentStandards: asMap(hydrated.contentStandards, fresh.contentStandards),
     rightsGrants: asMap(hydrated.rightsGrants, fresh.rightsGrants),
     usageRecords: Array.isArray(hydrated.usageRecords) ? hydrated.usageRecords : [],
+    complyExtensions: {
+      accountStatuses: asMap(hydratedComply.accountStatuses, fresh.complyExtensions.accountStatuses),
+      siSessions: asMap(hydratedComply.siSessions, fresh.complyExtensions.siSessions),
+      deliverySimulations: asMap(hydratedComply.deliverySimulations, fresh.complyExtensions.deliverySimulations),
+      budgetSimulations: asMap(hydratedComply.budgetSimulations, fresh.complyExtensions.budgetSimulations),
+    },
     lastGetProductsContext: (hydrated.lastGetProductsContext as SessionState['lastGetProductsContext']) ?? undefined,
     createdAt: hydrated.createdAt instanceof Date ? hydrated.createdAt : fresh.createdAt,
     lastAccessedAt: hydrated.lastAccessedAt instanceof Date ? hydrated.lastAccessedAt : fresh.lastAccessedAt,

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -159,6 +159,26 @@ export interface RightsGrantState {
   createdAt: string;
 }
 
+export interface ComplyDeliveryAccumulator {
+  impressions: number;
+  clicks: number;
+  reportedSpend: { amount: number; currency: string };
+  conversions: number;
+}
+
+export interface ComplyBudgetSimulation {
+  spendPercentage: number;
+  computedSpend: { amount: number; currency: string };
+  budget: { amount: number; currency: string };
+}
+
+export interface ComplyExtensions {
+  accountStatuses: Map<string, string>;
+  siSessions: Map<string, { status: string; terminationReason?: string }>;
+  deliverySimulations: Map<string, ComplyDeliveryAccumulator>;
+  budgetSimulations: Map<string, ComplyBudgetSimulation>;
+}
+
 export interface SessionState {
   mediaBuys: Map<string, MediaBuyState>;
   creatives: Map<string, CreativeState>;
@@ -171,6 +191,10 @@ export interface SessionState {
   contentStandards: Map<string, ContentStandardsState>;
   rightsGrants: Map<string, RightsGrantState>;
   usageRecords: UsageRecord[];
+  /** Data set by comply_test_controller. Persisted so scenarios survive the
+   * serialize/deserialize round trip that every request does, even in the
+   * single-request case with the InMemoryStateStore. */
+  complyExtensions: ComplyExtensions;
   lastGetProductsContext?: {
     /** Products are deterministic from the catalog — not persisted across requests.
      * After a cross-machine rehydration, this is undefined and callers must re-derive. */

--- a/server/tests/unit/mcp-response-unwrap.test.ts
+++ b/server/tests/unit/mcp-response-unwrap.test.ts
@@ -185,12 +185,10 @@ describe('MCP response unwrapping for evaluator', () => {
         },
       };
 
-      const unwrapped = unwrapProtocolResponse(mcpResponse);
+      const unwrapped = unwrapProtocolResponse(mcpResponse) as { adcp_error?: { code: string; message: string } };
       expect(isAdcpError(unwrapped)).toBe(true);
-      if (isAdcpError(unwrapped)) {
-        expect(unwrapped.errors[0].code).toBe('RATE_LIMITED');
-        expect(unwrapped.errors[0].message).toBe('Too many requests');
-      }
+      expect(unwrapped.adcp_error?.code).toBe('RATE_LIMITED');
+      expect(unwrapped.adcp_error?.message).toBe('Too many requests');
     });
   });
 });

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   listStoryboards,
   getStoryboard,
+  getAllStoryboards,
   getTestKit,
   getTestKitForStoryboard,
   type Storyboard,
@@ -53,8 +54,10 @@ describe('listStoryboards', () => {
   });
 
   it('step counts match actual phase steps', () => {
-    for (const summary of listStoryboards()) {
-      const full = getStoryboard(summary.id);
+    const summaries = listStoryboards();
+    const byId = new Map(getAllStoryboards().map((sb) => [sb.id, sb] as const));
+    for (const summary of summaries) {
+      const full = byId.get(summary.id);
       expect(full).toBeDefined();
       const actualSteps = full!.phases.reduce((sum, p) => sum + p.steps.length, 0);
       expect(summary.step_count).toBe(actualSteps);
@@ -77,8 +80,7 @@ describe('getStoryboard', () => {
   });
 
   it('every step has required fields', () => {
-    for (const summary of listStoryboards()) {
-      const sb = getStoryboard(summary.id)!;
+    for (const sb of getAllStoryboards()) {
       for (const phase of sb.phases) {
         expect(phase.id).toBeTruthy();
         expect(phase.title).toBeTruthy();

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -196,20 +196,31 @@ phases:
         expected: |
           Acknowledge the governance plan:
           - plan_id: identifier for this governance plan
-          - per_transaction_threshold: the spending limit before escalation
-          - escalation_path: how over-limit transactions are handled
+          - budget.reallocation_threshold: spending limit before re-evaluation
+          - human_review_required: set when the plan mandates escalation
 
         sample_request:
+          idempotency_key: "media-buy-governance-escalation-sync-plans-v1"
           plans:
-            - plan_name: "Acme Outdoor Q2 Governance"
+            - plan_id: "gov_acme_q2_2027"
               brand:
                 domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
-              per_transaction_threshold: 20000
-              escalation_path: "human_review"
-              conditions:
-                - "Weekly reporting required for buys over $10K"
-                - "No single-seller concentration above 60% of total budget"
+              objectives: "Q2 outdoor lifestyle campaign — display and video, Adults 25-54, US"
+              budget:
+                total: 50000
+                currency: "USD"
+                reallocation_threshold: 20000
+              flight:
+                start: "2027-04-01T00:00:00Z"
+                end: "2027-06-30T23:59:59Z"
+              countries: ["US"]
+              custom_policies:
+                - policy_id: "weekly_reporting_over_10k"
+                  enforcement: "must"
+                  policy: "Weekly reporting required for buys over $10K."
+                - policy_id: "seller_concentration_cap"
+                  enforcement: "must"
+                  policy: "No single-seller concentration above 60% of total budget."
 
           context:
             correlation_id: "media_buy_governance_escalation--sync_plans"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -55,6 +55,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
+          idempotency_key: "comply-gov-approved-sync-plans-v1"
           plans:
             - plan_id: "comply-gov-approved-plan"
               brand:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -57,6 +57,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
+          idempotency_key: "comply-gov-conditions-sync-plans-v1"
           plans:
             - plan_id: "comply-gov-conditions-plan"
               brand:
@@ -71,8 +72,12 @@ phases:
                 end: "2026-06-30T23:59:59Z"
               countries: ["US", "CA"]
               custom_policies:
-                - "CTV buys require weekly delivery reporting"
-                - "UGC placements require brand safety review before activation"
+                - policy_id: "ctv_weekly_reporting"
+                  enforcement: "must"
+                  policy: "CTV buys require weekly delivery reporting."
+                - policy_id: "ugc_brand_safety"
+                  enforcement: "must"
+                  policy: "UGC placements require brand safety review before activation."
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -57,6 +57,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
+          idempotency_key: "comply-gov-denied-sync-plans-v1"
           plans:
             - plan_id: "comply-gov-denied-plan"
               brand:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -57,6 +57,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan.
         sample_request:
+          idempotency_key: "comply-gov-recovery-sync-plans-v1"
           plans:
             - plan_id: "comply-gov-recovery-plan"
               brand:

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -98,17 +98,27 @@ phases:
         expected: |
           Acknowledge the governance plan:
           - plan_id: identifier for this governance plan
-          - reallocation_threshold: 0.20 (20% drift triggers re-evaluation)
+          - budget.reallocation_threshold: amount above which reallocation requires re-evaluation
 
         sample_request:
+          idempotency_key: "governance-delivery-monitor-sync-plans-v1"
           plans:
-            - plan_name: "Acme Outdoor delivery governance"
+            - plan_id: "gov_acme_delivery_monitor"
               brand:
                 domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
-              reallocation_threshold: 0.20
-              conditions:
-                - "Re-evaluate governance if any line item drifts >20% from plan"
+              objectives: "Delivery-phase governance with drift detection and rebalancing"
+              budget:
+                total: 40000
+                currency: "USD"
+                reallocation_threshold: 8000
+              flight:
+                start: "2027-01-01T00:00:00Z"
+                end: "2027-12-31T23:59:59Z"
+              countries: ["US"]
+              custom_policies:
+                - policy_id: "drift_reevaluation"
+                  enforcement: "must"
+                  policy: "Re-evaluate governance if any line item drifts more than 20% from plan."
 
           context:
             correlation_id: "governance_delivery_monitor--sync_plans"

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -95,16 +95,23 @@ phases:
         expected: |
           Acknowledge the governance plan:
           - plan_id: identifier for this governance plan
-          - per_transaction_threshold: $10K spending limit
+          - budget.total: $10K cap that any single buy above will exceed
 
         sample_request:
+          idempotency_key: "governance-spend-authority-denied-sync-plans-v1"
           plans:
-            - plan_name: "Acme Outdoor strict governance"
+            - plan_id: "gov_acme_strict"
               brand:
                 domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
-              per_transaction_threshold: 10000
-              escalation_path: "none"
+              objectives: "Acme Outdoor low-budget validation flight"
+              budget:
+                total: 10000
+                currency: "USD"
+                reallocation_threshold: 0
+              flight:
+                start: "2027-01-01T00:00:00Z"
+                end: "2027-12-31T23:59:59Z"
+              countries: ["US"]
 
           context:
             correlation_id: "governance_spend_authority--denied--sync_plans"

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -103,14 +103,27 @@ phases:
           - custom_policies: policy conditions registered
 
         sample_request:
+          idempotency_key: "governance-spend-authority-sync-plans-v1"
           plans:
-            - plan_name: "Acme Outdoor conditional governance"
+            - plan_id: "gov_acme_conditional"
               brand:
                 domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+              objectives: "Full spending authority with conditional policies on CTV reporting and UGC brand safety"
+              budget:
+                total: 100000
+                currency: "USD"
+                reallocation_unlimited: true
+              flight:
+                start: "2027-01-01T00:00:00Z"
+                end: "2027-12-31T23:59:59Z"
+              countries: ["US"]
               custom_policies:
-                - "CTV buys require weekly delivery reporting"
-                - "UGC placements require brand safety review before go-live"
+                - policy_id: "ctv_weekly_reporting"
+                  enforcement: "must"
+                  policy: "CTV buys require weekly delivery reporting."
+                - policy_id: "ugc_brand_safety"
+                  enforcement: "must"
+                  policy: "UGC placements require brand safety review before go-live."
 
           context:
             correlation_id: "governance_spend_authority--sync_plans"


### PR DESCRIPTION
## Summary
- **#2266**: Seven governance storyboards still had pre-3.0 `sync_plans` sample_requests (`plan_name`, `per_transaction_threshold`, `operator`, `escalation_path`, string-array `custom_policies`, missing `idempotency_key` / `objectives` / `budget` / `flight`). Updated to match the current `sync-plans-request.json` and `policy-entry.json` schemas.
- **#2274**: Fixed 7 failing server unit tests by:
  - Moving `comply_test_controller` state (account statuses, SI sessions, delivery sims, budget sims) from a `WeakMap<SessionState,...>` — which was empty on every request because sessions serialize/deserialize through a JSONB round trip — into `SessionState.complyExtensions` so it survives rehydration.
  - Capping each `complyExtensions` Map at 1,000 entries so a sandbox caller can't grow a session past the SDK's 5 MB flush limit with fresh IDs (would otherwise throw `PAYLOAD_TOO_LARGE` after the response was sent).
  - Correcting the structuredContent-only assertion in `mcp-response-unwrap.test` to read `adcp_error.code` (what `unwrapProtocolResponse` actually returns), not a non-existent `errors[0].code`.
  - Replacing O(N²) `getStoryboard(id)` scans in `storyboards.test` with a single `getAllStoryboards()` pass so iteration tests don't time out.
- Added `npm run test:server-unit` to `build-check.yml` so future server-unit regressions fail at PR time instead of being discovered ad-hoc.

Reviewed by `code-reviewer` and `security-reviewer`; no Must-Fix findings. Should-Fix items addressed:
- Added quota caps on the new `complyExtensions` Maps (security-reviewer).
- Dropped a misplaced `human_review_required: true` from the budget-escalation storyboard (that flag is scoped to GDPR Art 22 / AI Act Annex III, not budget thresholds).
- Tightened `objectives` strings in the spend-authority / escalation storyboards so they describe the campaign rather than restating budget fields.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:schemas` clean (483 schemas)
- [x] `npm run test:server-unit` — 1513 passed / 34 skipped / 0 failures (was 7 failing on `main`)
- [x] `npm run test:unit` — 587 passed (precommit hook)
- [x] `npm run build:compliance` succeeds with updated YAMLs
- [ ] Watch `build-check.yml` on this PR to confirm `test:server-unit` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)