### PR TITLE
fix(spec,storyboards)!: model IO approval at task layer, not MediaBuy.pending_approval

### DIFF
--- a/.changeset/fix-storyboard-account-setup-url-path.md
+++ b/.changeset/fix-storyboard-account-setup-url-path.md
@@ -1,0 +1,23 @@
+---
+---
+
+**Fixes the IO-approval modelling across storyboards and the media-buy spec.** Two related bugs:
+
+1. **#2270** — storyboard narratives described the IO-signing setup URL as a top-level `setup.url` field on a media buy response. The correct path is `account.setup.url` (nested on the account), since `setup` only exists on `Account`.
+2. **#2351** — storyboards and the media-buy spec treated `pending_approval` as a MediaBuy status and/or a task-level synonym for `input-required`. `pending_approval` is **only** a valid value on `Account.status`; it is not in `MediaBuy.status` or `Task.status`.
+
+Adopted **Option B** from #2351: IO review is modelled entirely at the A2A **task** layer. During IO signing, the `create_media_buy` task stays `submitted` and no `media_buy_id` is issued yet. On task completion, the final artifact delivers the `media_buy_id` and the buyer calls `get_media_buys` to confirm the buy is `active`. There is no queryable intermediate "pending_approval" MediaBuy state.
+
+Updates:
+
+- **`sales-guaranteed`** — rewrote the submitted/active flow: `create_media_buy` now returns a task envelope (`status: submitted`, `task_id`) with no `media_buy_id`. Removed the `poll_approval` / `get_media_buys_pending` phase entirely (no addressable MediaBuy during IO review). `confirm_active` narrative updated to show media_buy_id arrives via task completion.
+- **`sales-broadcast-tv`** — `create_media_buy` narrative and expected block updated to return a submitted task envelope when traffic-manager review is needed, with an explicit "do NOT use pending_approval media-buy status" note.
+- **`sales-social`** — `list_accounts` bullet points at `accounts[].setup.url`.
+- **`protocols/media-buy`** — `sync_accounts` narrative/expected clarified; `create_media_buy` phase narrative reworked to drop the "pending_approval with URL" framing and replace with task-layer modelling; `get_media_buys` (check_buy_status) narrative reworked similarly.
+- **`docs/media-buy/specification.mdx`** — normative updates: "Asynchronous Operations" bullet, "Orchestrator conformance" list, and the "Human-in-the-Loop" subsection all rewritten to describe approval as task-layer `submitted` / `input-required`, with explicit notes that `pending_approval` exists only on Account.status.
+- **`docs/protocol/required-tasks.mdx`** — orchestrator conformance bullet updated to list task-level async states (`submitted`, `working`, `input-required`) instead of `pending_approval`.
+- **`docs/media-buy/index.mdx`** — governance walkthrough prose updated to describe the escalation path as task-layer `submitted` / `input-required`, not a MediaBuy pausing at `pending_approval`.
+- **`docs/building/implementation/task-lifecycle.mdx`** — "Approval Flow" section: clarified that `pending_approval` is not a task-level status; task-layer approval uses `submitted` (seller waiting on internal human) or `input-required` (buyer must respond).
+- **`docs/building/integration/a2a-response-format.mdx`** — "Media Buy with Approval Required" example no longer puts an invalid `status: "pending_approval"` on package objects (Package has no `status` field); replaced with `total_budget` / `currency`.
+
+Closes #2270, closes #2351.

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -115,7 +115,9 @@ if (response.status === 'input-required') {
 
 ### Approval Flow
 
-Human approval is a special case of `input-required`. The `pending_approval` and `input-required` statuses implement the [Embedded Human Judgment](/docs/governance/embedded-human-judgment) principle that judgment cannot be delegated to software — when an action exceeds autonomous authority, the system halts for human review rather than proceeding.
+Human approval at the task layer is modelled as `input-required` (when the buyer must respond, e.g. confirm a budget) or `submitted` (when the seller is waiting on an internal human, e.g. IO signing). These implement the [Embedded Human Judgment](/docs/governance/embedded-human-judgment) principle that judgment cannot be delegated to software — when an action exceeds autonomous authority, the system halts for human review rather than proceeding.
+
+> `pending_approval` is an Account status, not a task status and not a MediaBuy status. It indicates the seller is reviewing an account (credit, contracts) before it can be used. Don't reuse the name for task-level approval.
 
 ```json
 {

--- a/docs/building/integration/a2a-response-format.mdx
+++ b/docs/building/integration/a2a-response-format.mdx
@@ -643,15 +643,11 @@ A2A's `taskId` enables retry detection. Agents SHOULD:
         "data": {
           "media_buy_id": "mb_pending_456",
           "packages": [
-            {
-              "package_id": "pkg_pending_001",
-              "status": "pending_approval"
-            },
-            {
-              "package_id": "pkg_pending_002",
-              "status": "pending_approval"
-            }
+            { "package_id": "pkg_pending_001" },
+            { "package_id": "pkg_pending_002" }
           ],
+          "total_budget": 150000,
+          "currency": "USD",
           "creative_deadline": "2025-02-01T23:59:59Z"
         }
       }

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -153,7 +153,7 @@ Before any money moves, Sam's governance agent validates the buy:
 - **Compliance**: Targeting parameters meet regulatory requirements for US and Canada
 - **Creative**: All creatives carry required provenance metadata
 
-If the buy exceeds Sam's authority — say, if the total across all sellers hit $75K — the governance agent escalates to his manager. The campaign pauses at `pending_approval` until a human signs off.
+If the buy exceeds Sam's authority — say, if the total across all sellers hit $75K — the governance agent escalates to his manager. The `create_media_buy` task sits in `submitted` (or `input-required`) at the task layer until a human signs off; only once approved does the task complete and the media buy get its `media_buy_id`.
 
 Campaign governance requires the orchestrator to register the campaign plan via [`sync_plans`](/docs/governance/campaign/tasks/sync_plans) before any governance checks. The plan defines authorized parameters — budget limits, channels, flight dates, and compliance policies — against which all subsequent actions are validated. The full governance sequence is `sync_plans` → `check_governance` (proposed) → `create_media_buy` → `check_governance` (committed by seller). See [Campaign Governance](/docs/governance/campaign/index) for the complete specification.
 

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -86,7 +86,7 @@ The Media Buy Protocol is asynchronous by design. Operations MAY return immediat
 
 - **Synchronous responses**: Sales agents MAY return completed results immediately
 - **Asynchronous responses**: Sales agents MAY return `status: "submitted"` or `status: "working"` with a task reference
-- **Human-in-the-loop**: Sales agents MAY require manual approval, indicated by `status: "pending_approval"`
+- **Human-in-the-loop**: Sales agents MAY require internal human review (e.g. IO signing) by keeping the task in `status: "submitted"` until the reviewer acts. Sales agents MAY also use `status: "input-required"` when the buyer must respond (e.g. confirm a budget). Human approval is modelled at the task layer — there is no `pending_approval` MediaBuy status (that value exists only on Account.status for account onboarding review)
 - **Rejection**: Sales agents MAY reject a media buy in `pending_creatives` or `pending_start` status when platform setup reveals the order cannot be fulfilled (e.g., inventory sold out, policy issue discovered during ad server setup). Orchestrators MUST treat `rejected` as a terminal state. If the seller does not want to accept the order at create time, it SHOULD fail `create_media_buy` with an error rather than creating a media buy in `rejected` status.
 
 Orchestrators MUST handle all response types and MUST NOT assume synchronous completion.
@@ -462,7 +462,7 @@ A conformant Media Buy Protocol orchestrator MUST:
 
 1. Authenticate with sales agents
 2. Include required fields as defined in request schemas
-3. Handle asynchronous responses (submitted, working, pending_approval)
+3. Handle asynchronous task-level responses (`submitted`, `working`, `input-required`) including webhook delivery of completion artifacts
 4. Use `media_buy_id` to reference media buys in subsequent operations
 5. Respect `creative_deadline` for creative uploads
 
@@ -490,11 +490,14 @@ For mutation tasks (`update_media_buy`, `sync_creatives`), orchestrators MAY inc
 
 ### Human-in-the-Loop
 
-Sales agents MAY require human approval for any operation. When approval is required:
+Sales agents MAY require human approval for any operation. Approval is modelled at the **task layer**:
 
-- Sales agents MUST return `status: "pending_approval"`
-- Sales agents SHOULD provide an estimated approval timeline
-- Orchestrators SHOULD implement webhook handlers for status updates
+- When the seller is waiting on an **internal** human (e.g. IO signing, traffic-manager review), sales agents MUST keep the task in `status: "submitted"` until the reviewer acts. On completion, the task transitions to `completed` with the final artifact carrying `media_buy_id` and the full success payload.
+- When the seller needs the **buyer** to respond (e.g. confirm a budget that exceeds a pre-approved limit), sales agents MUST return `status: "input-required"` with a message describing what is needed. The buyer responds within the same A2A context.
+- Sales agents SHOULD provide an estimated approval timeline in the task message.
+- Orchestrators SHOULD implement webhook handlers (via `push_notification_config`) for completion notifications rather than polling.
+
+`pending_approval` is not a valid MediaBuy or Task status — that value exists only on `Account.status` (for account onboarding review). Do not repurpose it for media-buy or task-level approval.
 
 ## Schema Reference
 

--- a/docs/protocol/required-tasks.mdx
+++ b/docs/protocol/required-tasks.mdx
@@ -51,7 +51,7 @@ Orchestrators are not MCP/A2A servers — they call sales agent tasks. Conforman
 
 1. Authenticate with sales agents
 2. Include required fields per request schemas
-3. Handle asynchronous responses (`submitted`, `working`, `pending_approval`)
+3. Handle asynchronous task-level responses (`submitted`, `working`, `input-required`) and webhook delivery of completion artifacts
 4. Use `media_buy_id` for all subsequent operations
 5. Respect `creative_deadline` for creative uploads
 

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -115,8 +115,9 @@ phases:
           provisions the account, and returns its status.
 
           If your platform requires manual approval (credit checks, sales team review),
-          return pending_approval with a setup URL. The buyer will complete setup there
-          and poll list_accounts until the status changes to active.
+          return the account with status pending_approval and account.setup.url populated.
+          The buyer directs the human to that URL to complete setup, then polls list_accounts
+          until the account status changes to active.
         task: sync_accounts
         schema_ref: "account/sync-accounts-request.json"
         response_schema_ref: "account/sync-accounts-response.json"
@@ -129,7 +130,7 @@ phases:
           - action: created or updated
           - status: active (instant approval) or pending_approval (requires human review)
           - account_scope: operator, brand, operator_brand, or agent
-          - setup: URL and message if pending_approval (where the human completes onboarding)
+          - setup.url and setup.message: populated on the account when status is pending_approval (where the human completes onboarding)
           - rate_card: pricing tiers if applicable
           - payment_terms: net_30, prepay, etc.
 
@@ -314,9 +315,11 @@ phases:
       equivalent of signing an IO — the buyer commits to specific products, budgets,
       and flight dates.
 
-      This operation may be synchronous (completed immediately), asynchronous (working
-      or submitted while your platform processes), or require human approval
-      (pending_approval with a URL for the human to sign off).
+      This operation may be synchronous (completed immediately), short-async (working
+      while your platform processes), or long-async (task stays submitted while a human
+      signs the IO internally; task completion delivers the final media_buy_id). There
+      is no "pending_approval" media buy status — IO review is modelled at the task
+      layer, not as a MediaBuy.status value.
 
       If the buyer registered governance agents in Phase 2, your platform calls
       check_governance before confirming the buy. The governance agent validates budget
@@ -361,13 +364,15 @@ phases:
           - current_step: what's happening ("Validating inventory", "Checking governance")
 
           Async with human approval (submitted):
-          - estimated_completion: when the buyer should expect a result
-          - The buyer configures push_notification_config to receive a webhook when done
+          - task_id / taskId: handle the buyer polls or receives webhooks on
+          - message (optional): explanation of what the seller is waiting on (e.g., "Awaiting IO signature from sales team; typical turnaround 2–4 hours")
+          - No media_buy_id yet — it is issued on task completion
+          - Seller-side IO signing is modelled here (task stays submitted until signed). Do not emit a "pending_approval" media buy status — that value is not in MediaBuy.status
 
           Needs input (input-required):
           - reason: APPROVAL_REQUIRED, BUDGET_EXCEEDS_LIMIT, CLARIFICATION_NEEDED
           - errors: what needs to be resolved
-          - setup URL for human to complete approval (IO signing, budget authorization)
+          - Used only when the seller needs the buyer to respond (e.g., confirm a budget). If the blocker is account-level (credit application, funding), the resolution path is list_accounts / sync_accounts, where account.setup.url surfaces on the pending_approval account
 
         sample_request:
           account:
@@ -411,14 +416,15 @@ phases:
       - id: check_buy_status
         title: "Check media buy status"
         narrative: |
-          If create_media_buy returned working or submitted, the buyer polls for status
-          updates. Your platform returns the current state of the media buy — whether
-          it's still processing, awaiting approval, or active.
+          Once create_media_buy has completed and a media_buy_id is issued, the buyer
+          calls get_media_buys to read current state — pending_creatives, pending_start,
+          active, paused, completed, rejected, or canceled.
 
-          This is also how the buyer checks for pending_approval status. If your platform
-          requires IO signing or human authorization, the buy sits at pending_approval
-          until the human completes the action. Your platform sends back a URL where the
-          human goes to approve.
+          While the create_media_buy task is still submitted (e.g., waiting on internal
+          IO signing), the media buy does not exist as a queryable MediaBuy yet. IO
+          review is tracked at the task layer, not as a MediaBuy.status value. The buyer
+          polls tasks/get or waits on the webhook until the task completes and a
+          media_buy_id is delivered.
         task: get_media_buys
         schema_ref: "media-buy/get-media-buys-request.json"
         response_schema_ref: "media-buy/get-media-buys-response.json"

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -207,9 +207,9 @@ phases:
           specify C7 as the guarantee window — the seller will reconcile delivery
           and billing against C7 ratings.
 
-          The response may be synchronous (buy confirmed) or require human approval
-          (pending_approval with a URL for the traffic manager to review and confirm
-          the order in their scheduling system).
+          The response may be synchronous (buy confirmed) or — when traffic-manager
+          review is needed — the A2A task returns submitted with a task_id, and the
+          buyer waits on a webhook or tasks/get poll until the order is scheduled.
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -225,9 +225,13 @@ phases:
           - measurement_terms: confirmed guarantee window (c7)
           - valid_actions: sync_creatives as the next step
 
-          If pending_approval:
-          - setup URL for the traffic manager to review and confirm scheduling
-          - estimated_completion for when the buyer should expect confirmation
+          If traffic-manager review is needed, return an A2A task envelope instead:
+          - status: submitted (task-level — not a MediaBuy status)
+          - task_id / taskId: handle the buyer polls or receives webhooks on
+          - message (optional): explanation that the traffic manager is reviewing
+
+          Do NOT use a "pending_approval" media buy status — that value is not in the
+          MediaBuy.status enum. IO / traffic-manager review is modelled at the task layer.
 
         sample_request:
           account:

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -23,16 +23,20 @@ requires_scenarios:
 
 narrative: |
   You run a sell-side platform that requires human approval before guaranteed media buys go
-  live. When a buyer creates a guaranteed buy, your platform returns a submitted status with
-  an estimated completion time. A human reviewer on your side reviews the deal terms and
-  signs the IO through a URL your platform provides.
+  live. When a buyer creates a guaranteed buy, your platform returns an A2A task in the
+  submitted state with a task_id — no media_buy_id is issued yet because IO signing may fail.
+  A human reviewer on your side reviews the deal terms and signs the IO through your own
+  internal workflow.
 
-  The buyer either polls get_media_buys or configures a push_notification_config webhook to
-  receive a callback when the IO is signed. Once approved, the media buy transitions from
-  pending_approval to active and the buyer can sync creatives and monitor delivery.
+  The buyer either polls tasks/get with the task_id or configures a push_notification_config
+  webhook to receive a callback when IO signing completes. Only on task completion does your
+  platform issue a media_buy_id and the final CreateMediaBuy result; the buyer then calls
+  get_media_buys to confirm the buy is active and sync creatives.
 
   This storyboard isolates the guaranteed approval path — the async handshake between agent
-  automation and human decision-making that makes guaranteed buys work in practice.
+  automation and human decision-making that makes guaranteed buys work in practice. IO review
+  is modelled entirely at the A2A task layer; there is no interim "pending_approval" media buy
+  status (that value only exists on Account.status, not MediaBuy.status).
 
 agent:
   interaction_model: media_buy_seller
@@ -222,25 +226,24 @@ phases:
             path: "products[0].format_ids[0].id"
             description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: create_buy_submitted
-    title: "Create guaranteed buy (submitted for approval)"
+    title: "Create guaranteed buy (task submitted for approval)"
     narrative: |
       The buyer creates a guaranteed media buy. Because your platform requires human
-      IO signing for guaranteed deals, the response comes back as submitted — not
-      completed. The buyer gets an estimated_completion timestamp indicating when the
-      IO review should finish. The buyer configures a webhook to be notified when the
-      status changes.
+      IO signing, the A2A task transitions to submitted rather than completed. The
+      buyer gets back a task_id and configures a webhook (or polls tasks/get) to be
+      notified when IO review finishes.
 
     steps:
       - id: create_media_buy
         title: "Create a guaranteed media buy"
         narrative: |
           The buyer commits to guaranteed products with budgets and flight dates. Your
-          platform accepts the request but does not confirm it immediately. Instead,
-          it enters an IO approval workflow and returns submitted status with an
-          estimated_completion timestamp.
+          platform accepts the request but does not create the media buy yet. Instead,
+          the A2A task enters the submitted state — no media_buy_id is issued because
+          IO signing may fail. The buyer receives a task_id to watch.
 
           The buyer includes push_notification_config so your platform can call back
-          when the IO is signed (or rejected).
+          when the IO is signed (completed) or rejected (failed).
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -248,14 +251,15 @@ phases:
         comply_scenario: create_media_buy
         stateful: true
         expected: |
-          Return the media buy in submitted status:
-          - media_buy_id: your platform's identifier
-          - status: submitted (NOT completed — this requires human approval)
-          - estimated_completion: timestamp when the IO review should finish
-          - packages: the proposed line items echoed back
-          - The buyer's push_notification_config is acknowledged
+          Return an A2A task envelope in submitted state:
+          - status: submitted (task-level — the CreateMediaBuy success artifact is not yet produced)
+          - task_id / taskId: the handle the buyer polls or receives webhooks on
+          - message (optional): human-readable explanation (e.g., "Awaiting IO signature from sales team; typical turnaround 2–4 hours")
 
-          Do NOT return completed status for guaranteed buys that require IO signing.
+          Do NOT return media_buy_id or packages yet — those land on the task's final artifact
+          when the task transitions to completed. Do NOT return completed status for guaranteed
+          buys that require IO signing. Do NOT use a "pending_approval" media buy status; that
+          value is not in MediaBuy.status — IO review is modelled at the task layer only.
 
         sample_request:
           account:
@@ -293,78 +297,25 @@ phases:
             path: "context.correlation_id"
             value: "sales_guaranteed--create_media_buy"
             description: "Context correlation_id returned unchanged"
-  - id: poll_approval
-    title: "Poll for IO approval"
-    narrative: |
-      The media buy is sitting in an approval queue. A human on the seller side needs
-      to review the deal terms and sign the IO. The buyer polls get_media_buys to check
-      the current status. Your platform returns pending_approval with a setup URL where
-      the human reviewer signs the IO and a message explaining what is needed.
-
-    steps:
-      - id: get_media_buys_pending
-        title: "Check media buy status (pending approval)"
-        narrative: |
-          The buyer polls for the media buy status. Your platform returns
-          pending_approval with a setup object containing the URL where the human
-          reviewer signs the IO and a message describing what action is needed.
-        task: get_media_buys
-        schema_ref: "media-buy/get-media-buys-request.json"
-        response_schema_ref: "media-buy/get-media-buys-response.json"
-        doc_ref: "/media-buy/task-reference/get_media_buys"
-        comply_scenario: media_buy_lifecycle
-        stateful: true
-        expected: |
-          Return the media buy in pending_approval status:
-          - media_buy_id: matches the buy created earlier
-          - status: pending_approval
-          - setup.url: where the human goes to review and sign the IO
-          - setup.message: explains what the human needs to do (e.g., "Review and sign the IO for Acme Outdoor Q2 campaign")
-          - packages: line items with their current state
-          - valid_actions: what the buyer can do in this state
-
-        sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          media_buy_ids:
-            - "mb_acme_q2_2026_guaranteed"
-
-          context:
-            correlation_id: "sales_guaranteed--get_media_buys_pending"
-        validations:
-          - check: response_schema
-            description: "Response matches get-media-buys-response.json schema"
-          - check: field_present
-            path: "media_buys[0].status"
-            description: "Media buy has a status"
-          - check: field_present
-            path: "media_buys[0].valid_actions"
-            description: "Pending approval buy includes valid actions"
-
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "sales_guaranteed--get_media_buys_pending"
-            description: "Context correlation_id returned unchanged"
   - id: confirm_active
     title: "Confirm active after IO signing"
     narrative: |
-      The human has reviewed the IO and signed it through the setup URL. The buyer
-      polls get_media_buys again (or received a webhook notification) and sees that the
-      media buy has transitioned from pending_approval to active. The buy
-      is now live.
+      The human on your side reviews and signs the IO through your internal workflow.
+      Your platform then transitions the A2A task to completed and emits the final
+      CreateMediaBuy result — including the newly-issued media_buy_id — to the buyer's
+      push_notification webhook (or to the next tasks/get poll). The buyer now calls
+      get_media_buys with that media_buy_id and sees the buy active. There is no
+      intermediate "pending_approval" media buy status in this flow; the buy does not
+      exist as a queryable MediaBuy until the task completes.
 
     steps:
       - id: get_media_buys_active
         title: "Check media buy status (active)"
         narrative: |
-          After the human signs the IO, the buyer checks the media buy status again.
-          Your platform returns active, indicating the buy is approved
-          and inventory is reserved.
+          After the task completes and your platform issues a media_buy_id, the buyer
+          calls get_media_buys to confirm the buy is live. Your platform returns active
+          (or pending_creatives when creatives are still outstanding), indicating the
+          buy is approved and inventory is reserved.
         task: get_media_buys
         schema_ref: "media-buy/get-media-buys-request.json"
         response_schema_ref: "media-buy/get-media-buys-response.json"

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -143,7 +143,7 @@ phases:
           Return accounts matching the query:
           - accounts array with status, account_id, brand, operator
           - Active accounts ready for ad operations
-          - Pending accounts with setup URLs if verification needed
+          - Pending accounts with accounts[].setup.url populated if verification is needed
 
         sample_request:
           brand:


### PR DESCRIPTION
## Summary

Closes #2270 (storyboard `setup.url` path trap) and closes #2351 (broader spec inconsistency: `pending_approval` is not a MediaBuy or Task status).

Adopts **Option B** from #2351: IO review is modelled entirely at the A2A task layer. While IO is being signed, `create_media_buy` stays in `submitted` with a `task_id`; no `media_buy_id` is issued yet. On completion, the task artifact delivers the `media_buy_id` and the buyer calls `get_media_buys` to confirm `active`. There is no addressable intermediate "pending_approval" MediaBuy — that value is only valid on `Account.status`.

## What changed

**Storyboards** (tighten and align with schema):
- `sales-guaranteed` — rewrote `create_buy_submitted` expected (task envelope, no `media_buy_id`), **removed the `poll_approval` / `get_media_buys_pending` phase** (nothing to address during IO review).
- `sales-broadcast-tv` — `create_media_buy` expected now returns a submitted task envelope when traffic-manager review is needed; explicit "do NOT use `pending_approval` media-buy status" note.
- `sales-social` — `list_accounts` bullet points at `accounts[].setup.url`.
- `protocols/media-buy` — `create_media_buy` and `get_media_buys` narratives reworked; `sync_accounts` bullets clarified.

**Normative spec alignment** (prose was out of sync with shipped schemas):
- `docs/media-buy/specification.mdx` — "Asynchronous Operations", "Orchestrator conformance", and "Human-in-the-Loop" all describe approval as task-layer `submitted` / `input-required`.
- `docs/protocol/required-tasks.mdx` — orchestrator conformance bullet uses task-level states.
- `docs/media-buy/index.mdx` — governance escalation described at task layer.
- `docs/building/implementation/task-lifecycle.mdx` — "Approval Flow" clarified.

**Example fixes:**
- `docs/building/integration/a2a-response-format.mdx` — "Media Buy with Approval Required" example no longer puts invalid `status: "pending_approval"` on `package` objects (Package has no `status` field); replaced with `total_budget` / `currency`.

## Breaking change note

This is marked `!` because `docs/media-buy/specification.mdx` previously contained normative MUST language saying `"Sales agents MUST return status: 'pending_approval'"` for human-in-the-loop. Any implementation that followed that prose was already schema-invalid (the value isn't in `MediaBuy.status`), but the spec prose changes.

## Verification

- Protocol expert review confirmed Option B is the correct modelling — adding `pending_approval` to `MediaBuy.status` would have duplicated task-state semantics on the resource.
- Expert also confirmed the removed `poll_approval` step wasn't testing anything existential: no `media_buy_id` exists during IO review, so `get_media_buys` had nothing legitimate to query.
- `submitted` response shape matches canonical `create_media_buy.mdx:1231-1260` example and the async-submitted schema.

## Test plan

- [ ] CI: compliance build, typecheck, unit tests (587 pass locally).
- [ ] Confirm no other storyboards assume a `pending_approval` MediaBuy status after merge.
- [ ] adcp-client#502 (seller SKILL.md trap row) remains complementary — this PR reinforces the setup URL trap guidance with two layers of defense (narrative + storyboard validations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)