### PR TITLE
fix(schemas): register brand-protocol tools under tasks.* (#2245)

### DIFF
--- a/.changeset/brand-protocol-tasks-registry.md
+++ b/.changeset/brand-protocol-tasks-registry.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix brand-protocol registration in the schema registry index so SDKs auto-generate the tools. The domain now exposes `get_brand_identity`, `get_rights`, `acquire_rights`, and `update_rights` under `tasks.*` (matching every other AdCP domain), with `rights-pricing-option`, `rights-terms`, `creative-approval-request/response`, and `revocation-notification` moved to `supporting-schemas`. Fixes #2245.

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1550,35 +1550,69 @@
       }
     },
     "brand-protocol": {
-      "description": "Brand protocol schemas for identity retrieval, rights discovery, and rights acquisition",
-      "schemas": {
-        "get-brand-identity-request": {
-          "$ref": "/schemas/brand/get-brand-identity-request.json",
-          "description": "Request brand identity data from a brand agent"
-        },
-        "get-brand-identity-response": {
-          "$ref": "/schemas/brand/get-brand-identity-response.json",
-          "description": "Brand identity data response"
-        },
-        "get-rights-request": {
-          "$ref": "/schemas/brand/get-rights-request.json",
-          "description": "Search for licensable rights with pricing"
-        },
-        "get-rights-response": {
-          "$ref": "/schemas/brand/get-rights-response.json",
-          "description": "Matching rights with pricing options"
-        },
-        "acquire-rights-request": {
-          "$ref": "/schemas/brand/acquire-rights-request.json",
-          "description": "Acquire rights with contractual clearance"
-        },
-        "acquire-rights-response": {
-          "$ref": "/schemas/brand/acquire-rights-response.json",
-          "description": "Rights acquisition result with terms and generation credentials"
-        },
+      "description": "Brand protocol for identity retrieval, rights discovery, acquisition, and lifecycle management",
+      "supporting-schemas": {
         "rights-pricing-option": {
           "$ref": "/schemas/brand/rights-pricing-option.json",
           "description": "Pricing option for licensable rights"
+        },
+        "rights-terms": {
+          "$ref": "/schemas/brand/rights-terms.json",
+          "description": "Terms returned with a rights grant — coverage, restrictions, revocation, and credentials"
+        },
+        "creative-approval-request": {
+          "$ref": "/schemas/brand/creative-approval-request.json",
+          "description": "Payload the buyer submits to the approval_webhook from acquire_rights for rights-holder creative review"
+        },
+        "creative-approval-response": {
+          "$ref": "/schemas/brand/creative-approval-response.json",
+          "description": "Response from the approval_webhook — approved, rejected, or pending_review"
+        },
+        "revocation-notification": {
+          "$ref": "/schemas/brand/revocation-notification.json",
+          "description": "Notification sent to the buyer's revocation_webhook when an acquired rights grant is revoked"
+        }
+      },
+      "tasks": {
+        "get-brand-identity": {
+          "request": {
+            "$ref": "/schemas/brand/get-brand-identity-request.json",
+            "description": "Request parameters for retrieving brand identity data from a brand agent"
+          },
+          "response": {
+            "$ref": "/schemas/brand/get-brand-identity-response.json",
+            "description": "Response payload for get_brand_identity task"
+          }
+        },
+        "get-rights": {
+          "request": {
+            "$ref": "/schemas/brand/get-rights-request.json",
+            "description": "Request parameters for searching licensable rights with pricing"
+          },
+          "response": {
+            "$ref": "/schemas/brand/get-rights-response.json",
+            "description": "Response payload for get_rights task"
+          }
+        },
+        "acquire-rights": {
+          "request": {
+            "$ref": "/schemas/brand/acquire-rights-request.json",
+            "description": "Request parameters for acquiring rights with contractual clearance"
+          },
+          "response": {
+            "$ref": "/schemas/brand/acquire-rights-response.json",
+            "description": "Response payload for acquire_rights task — terms and generation credentials"
+          }
+        },
+        "update-rights": {
+          "request": {
+            "$ref": "/schemas/brand/update-rights-request.json",
+            "description": "Request parameters for modifying an active rights grant — dates, caps, pricing, or pause/resume"
+          },
+          "response": {
+            "$ref": "/schemas/brand/update-rights-response.json",
+            "description": "Response payload for update_rights task"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- Fixes #2245 — brand-protocol was the only AdCP domain registering tools under `schemas.*` instead of `tasks.{name}.{request,response}`, so SDKs that codegen off the schema registry (`@adcp/client`) silently skipped the entire domain
- Restructured `brand-protocol` in `static/schemas/source/index.json` to match every other domain: four tools under `tasks` (`get-brand-identity`, `get-rights`, `acquire-rights`, `update-rights`), shared types + webhook payloads under `supporting-schemas` (`rights-pricing-option`, `rights-terms`, `creative-approval-{request,response}`, `revocation-notification`)
- Two extras beyond the literal ask in the issue: (1) registered `update_rights` as a task since it has full schemas + docs at `docs/brand-protocol/tasks/update_rights.mdx` and leaving it orphaned would perpetuate the same bug; (2) classified `creative-approval-*` and `revocation-notification` as `supporting-schemas` because they're webhook payloads, not tools the brand agent exposes

## Test plan

- [x] `npm run build:schemas` — regenerates `dist/` cleanly
- [x] `npm run test:schemas` — 7/7 pass (registry consistency, $ref resolution, etc.)
- [x] `npm run test:examples` — 31/31 pass
- [x] `npm run test:composed` — 12/12 pass
- [x] Full `npm test` — 1513 passed, 34 skipped, 0 failed; OpenAPI regen clean; typecheck clean
- [x] Reviewed by `ad-tech-protocol-expert` and `code-reviewer` subagents — LGTM from both
- [ ] `@adcp/client` regen picks up `agent.getBrandIdentity()`, `agent.getRights()`, `agent.acquireRights()`, `agent.updateRights()` as typed methods (verify downstream after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)