### PR TITLE
docs: publish release cadence policy + tighten red-team FAQ titles (#2312, #2313)

### DIFF
--- a/.changeset/publish-release-cadence-policy.md
+++ b/.changeset/publish-release-cadence-policy.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(versioning, roadmap, faq): publish named release cadence policy — minimum 18 months between majors, 4.0 target early 2027, minimum 12-month support window after successor GA, minimum 6-month deprecation notice before removal. Adds 4.0 to the planned-releases table, cross-links versioning.mdx ↔ roadmap.mdx ↔ v2-sunset.mdx ↔ faq.mdx, and retitles two red-team FAQ accordions to match adversarial search phrasing. Addresses #2312 and #2313.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -92,7 +92,7 @@ Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/l
 <Accordion title="How mature is the protocol?">
 AdCP is in the 3.0 release-candidate cycle, with 3.0 GA targeted for April 2026. The protocol design is stable and suitable for pilot implementations; schemas may still receive minor refinements based on implementer feedback before GA.
 
-The next major version (4.0) is targeted for early 2027, with future major cycles running 18 months to two years. See [Versioning & Governance](/docs/reference/versioning) for the full release cadence, stability guarantees within a version, and deprecation policy. For production use prior to 3.0 GA, we recommend implementing against [v2.5](/docs/reference/v2-sunset).
+The next major version (4.0) is targeted for early 2027. Under the [release cadence policy](/docs/reference/versioning#release-cadence), majors are at least 18 months apart, the previous major receives security patches for at least 12 months after successor GA, and deprecation notices are published at least 6 months before removal. See [Versioning & Governance](/docs/reference/versioning) for the full policy and 3.x stability guarantees. For production use prior to 3.0 GA, we recommend implementing against [v2.5](/docs/reference/v2-sunset).
 </Accordion>
 
 <Accordion title="I built against AdCP 2.5 — what changed?">
@@ -146,7 +146,7 @@ AdCP is governed by AgenticAdvertising.Org, a pending 501(c)(6) trade associatio
 The Foundation has four voting member classes with equal representation on the Board — Brands, Agencies, Publishers, and Technology Providers — targeting ten seats per class at the first elected board, replacing the current interim board at the 2026 Annual General Meeting. Day-to-day protocol work happens in [working groups](/docs/community/working-group); change proposals flow through this repository.
 </Accordion>
 
-<Accordion title="What is AAO's relationship with Scope3?">
+<Accordion title="Is Scope3 getting preferential treatment?">
 Scope3 contributed foundational IP and early funding to AgenticAdvertising.Org. Specifically:
 
 - **CSBS (Common Sense Brand Standards)** — formerly "Scope3 Common Sense" — was donated to AAO and is now governed by AAO. The formal donation and rename are tracked in [#2305](https://github.com/adcontextprotocol/adcp/issues/2305).
@@ -158,7 +158,7 @@ The interim board has four directors: Michael Blum (Scope3), Brian O'Kelley (Sco
 See [CHARTER.md](https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md) for the governance framework and [agenticadvertising.org/governance](https://agenticadvertising.org/governance) for the authoritative board list, funding disclosures, and recusal rules.
 </Accordion>
 
-<Accordion title="How is AdCP secured against a compromised buyer agent?">
+<Accordion title="What if my buyer agent is compromised?">
 AdCP today uses bearer-token authentication between agents — see [authentication](/docs/building/integration/authentication) for the shipped model.
 
 AdCP 3.0 GA will add request signing for mutating calls (`create_*`, `update_*`, `sync_*`, `activate_*`, `acquire_*`) via RFC 9421 HTTP Signatures or JWS-signed bodies, with sellers verifying against the buyer's published signing keys. Bearer tokens alone will not be sufficient for mutating calls. Tracked in [#2307](https://github.com/adcontextprotocol/adcp/issues/2307).

--- a/docs/reference/roadmap.mdx
+++ b/docs/reference/roadmap.mdx
@@ -79,9 +79,9 @@ Triage owners rotate quarterly. To volunteer, reach out in the relevant working 
 
 Named milestones group roadmap items that will ship together in a future major version. Each milestone lists accepted RFCs — exploratory items (community input open) remain on the main board until maintainers decide to land them.
 
-### v4.0 (planned)
+### v4.0 — target early 2027
 
-v4.0 is the next **breaking-changes accumulation window**. Breaking changes are gathered here so the ecosystem can plan a single migration window rather than chase per-minor deprecations. Items listed below are committed floor requirements for v4.0; additional items will be added here as RFCs are accepted.
+v4.0 is the next **breaking-changes accumulation window**, targeted for early 2027 under the [release cadence policy](/docs/reference/versioning#release-cadence). Breaking changes are gathered here so the ecosystem can plan a single migration window rather than chase per-minor deprecations. Items listed below are committed floor requirements for v4.0; additional items will be added here as RFCs are accepted.
 
 | Area | Item |
 |---|---|

--- a/docs/reference/v2-sunset.mdx
+++ b/docs/reference/v2-sunset.mdx
@@ -16,7 +16,7 @@ description: "AdCP v2 is unsupported as of 3.0 GA. Security-only patches through
 | **April 2026** (3.0 GA) | v2 no longer supported by AAO. Security-only patches begin. No feature work. |
 | **August 1, 2026** | v2 fully deprecated. No further patches. Reference documentation archived. |
 
-The v2 sunset is not tied to 4.0. v2 reaches end of life on its own schedule because 2.5 was an early, preliminary version — adoption remained small, and the architecture committee identified protections missing from v2 that cannot be backported without a major redesign.
+The v2 sunset is not tied to 4.0. v2 reaches end of life on its own schedule because 2.5 was an early, preliminary version — adoption remained small, and the architecture committee identified protections missing from v2 that cannot be backported without a major redesign. v2's shorter window is the documented exception to the [12-month previous-major support commitment](/docs/reference/versioning#support-window-for-previous-major); future majors will not invoke this exception.
 
 ## What "unsupported" means
 

--- a/docs/reference/versioning.mdx
+++ b/docs/reference/versioning.mdx
@@ -68,7 +68,7 @@ Schema changes are accepted in releases under the following conditions:
 
 ### Deprecation policy
 
-Deprecated features remain functional for at least one full release cycle after deprecation. Deprecated features are never removed within the same version — a feature deprecated in 3.x will not be removed until 4.0 at the earliest.
+Deprecation notices are published at least **6 months** before any feature is removed. Deprecated features remain functional for at least one full release cycle after deprecation, and are never removed within the same major version — a feature deprecated in 3.x will not be removed until 4.0 at the earliest.
 
 Every release with schema changes is called out in the changelog, release notes, and inline documentation. Every release with schema changes ships with a migration guide.
 
@@ -107,11 +107,24 @@ Any change that requires an implementation to adapt — renamed field, required-
 
 ## Release cadence
 
-AdCP releases frequently early in a version cycle (every 6–8 weeks) and stretches toward quarterly as the version stabilizes. This gives builders fast iteration when they need it and predictability when they don't.
+AdCP publishes the following named policy so implementers can plan:
 
-Version cycles lengthen over time. The 3.x cycle is expected to last roughly a year, with 4.0 targeted for early 2027. Future version cycles may run 18 months to two years. Longer cycles mean builders can plan further ahead and invest in implementations with confidence.
+| Commitment | Window |
+|---|---|
+| **Major releases (breaking)** | minimum 18 months apart |
+| **Next major (4.0)** | target early 2027 |
+| **Support for previous major after successor GA** | minimum 12 months |
+| **Deprecation notice before removal** | minimum 6 months |
 
-The number of releases within a version is not predetermined. It depends on what builders need and what the working groups surface.
+Within a version, releases land every 6–8 weeks early in the cycle and stretch toward quarterly as the version stabilizes. Release count within a version is not fixed.
+
+### Support window for previous major
+
+When a new major ships, the prior major receives security patches for at least 12 months after successor GA. Security patches (CVE fixes and security advisories) are backported for the full window; feature work is not. The exact end-of-life date for each version is published on a per-version sunset page and linked from the transition note that accompanies the successor's GA release.
+
+Deprecation windows do not reset when a deprecated feature is modified — the original removal date holds.
+
+The v2 sunset is the documented exception to this commitment: v2 predates this policy and lacks account and governance protections that cannot be backported. Its security-only window runs through August 1, 2026 — see the [v2 sunset page](/docs/reference/v2-sunset). Future majors will not invoke this exception.
 
 ### Planned releases
 
@@ -120,6 +133,7 @@ The number of releases within a version is not predetermined. It depends on what
 | **3.0** | April 2026 | GA release |
 | **3.1** | Late June 2026 | |
 | **3.2** | Late September 2026 | |
+| **4.0** | Early 2027 | Next major — accumulated breaking changes |
 
 Further 3.x releases will be scheduled based on implementation feedback and working group priorities, with at least 8 weeks between releases.
 


### PR DESCRIPTION
## Summary

Closes the red-team "breaking change velocity contradicts stable standard" finding by publishing a named release cadence so implementers can plan (#2312), and tightens two FAQ accordion titles so a skeptical journalist searching the adversarial phrasing lands on the shipped answers (#2313 follow-up — the seven FAQ bodies already shipped in #2329).

### Cadence policy (`docs/reference/versioning.mdx`)

| Commitment | Window |
|---|---|
| Major releases (breaking) | minimum 18 months apart |
| Next major (4.0) | target early 2027 |
| Support for previous major after successor GA | minimum 12 months |
| Deprecation notice before removal | minimum 6 months |

Additions:
- Explicit security-backport commitment (CVE fixes only, no feature backports)
- Deprecation-window-does-not-reset clause
- v2 documented as the explicit exception to the 12-month commitment; "future majors will not invoke this exception"
- 4.0 added to the planned-releases table

### Cross-links

- `roadmap.mdx`: v4.0 milestone heading gains the early-2027 target and links to the policy; dropped an inline restatement of the numbers so versioning.mdx is the single source of truth
- `v2-sunset.mdx`: back-link to the 12-month commitment section, naming v2 as the documented exception
- `faq.mdx:95`: "How mature is the protocol?" updated to reflect the named policy

### Red-team FAQ titles (#2313)

Content was already shipped in #2329. Retitled two accordions so the adversarial search phrase in the issue actually matches:
- "What is AAO's relationship with Scope3?" → **"Is Scope3 getting preferential treatment?"**
- "How is AdCP secured against a compromised buyer agent?" → **"What if my buyer agent is compromised?"**

Body text unchanged.

### Expert review

Changes were reviewed by adtech-product, copywriter, and docs-expert subagents. Key applied feedback: tightened "1–2 years apart" → "minimum 18 months apart" (matches existing faq.mdx wording), trimmed marketing hedges from the cadence prose, rewrote the v2 exception paragraph to drop apologetic framing, dropped duplicated numbers from roadmap.mdx to prevent drift.

Two calls remain for maintainer judgment, not blocking this PR:
- Product expert flagged 12 months of previous-major support as potentially below enterprise norm (18–24 months is typical Salesforce/SAP/AWS/K8s LTS); the issue explicitly asked for 12.
- Naming early 2027 for 4.0 pre-3.0-GA was flagged as a mild credibility risk; the issue explicitly asked to name it.

### Deferred to follow-ups

- Definition-of-breaking rubric
- Canonical deprecations page with SLA
- Cadence footer on `whats-new-in-v3.mdx`

## Test plan

- [x] `npm run test:unit` — 587 pass
- [x] `npm run typecheck` — clean
- [x] Mintlify validation — pass (pre-existing unrelated accessibility warning in security.mdx:552 not touched by this PR)
- [ ] Render the three edited pages in Mintlify preview and confirm anchor links resolve (`#release-cadence`, `#support-window-for-previous-major`)
- [ ] Confirm #2313 can be closed referencing the shipped FAQ content in `docs/faq.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)