### PR TITLE
spec(compliance): declare auth.api_key / auth.probe_task on fictional test kits (#2317)

### DIFF
--- a/.changeset/test-kits-security-auth-block.md
+++ b/.changeset/test-kits-security-auth-block.md
@@ -1,0 +1,20 @@
+---
+---
+
+Add `auth.api_key` and `auth.probe_task` to the five fictional test kits
+(`acme-outdoor`, `bistro-oranje`, `nova-motors`, `osei-natural`,
+`summit-foods`) so the `security_baseline` storyboard exercises the
+api-key phase instead of skipping it, and so its unauth / invalid-key
+probes hit a task the fictional agent actually implements. Without this,
+`api_key_path` was always skipped via `skip_if: "!test_kit.auth.api_key"`
+and the default `list_creatives` probe would fail against the signal-
+scoped nova-motors fictional agent.
+
+The `demo-<kit>-` prefix is the conformance handle — agents SHOULD accept
+any Bearer with that prefix rather than the literal suffix, so the suffix
+can rotate without breaking previously-conformant agents. nova-motors
+probes `get_signals` because its primary consumers are signal specialisms;
+non-signal storyboards that reuse the kit should select a different
+fixture for `security_baseline`.
+
+Closes #2317.

--- a/static/compliance/source/test-kits/acme-outdoor.yaml
+++ b/static/compliance/source/test-kits/acme-outdoor.yaml
@@ -15,6 +15,21 @@ name: "Acme Outdoor"
 description: "Fictional outdoor gear brand for storyboard testing"
 sandbox: true
 
+# Authentication fixture for the universal security_baseline storyboard
+# (universal/security.yaml). Declares:
+#   - api_key: the demo Bearer the runner sends on the positive api-key
+#     probe. The conformance handle is the `demo-<kit>-` prefix — agents
+#     SHOULD accept any Bearer matching that prefix (not this literal
+#     value) so the suffix can rotate across spec versions without
+#     breaking previously-conformant agents.
+#   - probe_task: the protected, auth-required read the runner calls under
+#     `auth: none` and with a random-invalid key. Default is list_creatives;
+#     declare explicitly so the api_key phase runs instead of being skipped
+#     via `skip_if: "!test_kit.auth.api_key"`.
+auth:
+  api_key: "demo-acme-outdoor-v1"
+  probe_task: list_creatives
+
 brand:
   house:
     domain: "acmeoutdoor.example"

--- a/static/compliance/source/test-kits/bistro-oranje.yaml
+++ b/static/compliance/source/test-kits/bistro-oranje.yaml
@@ -14,6 +14,11 @@ name: "Bistro Oranje"
 description: "Dutch restaurant chain for rights licensing storyboard testing"
 sandbox: true
 
+# security_baseline auth fixture — see acme-outdoor.yaml for semantics.
+auth:
+  api_key: "demo-bistro-oranje-v1"
+  probe_task: list_creatives
+
 brand:
   house:
     domain: "bistro-oranje.example"

--- a/static/compliance/source/test-kits/nova-motors.yaml
+++ b/static/compliance/source/test-kits/nova-motors.yaml
@@ -16,6 +16,18 @@ description: |
   configurations for testing signal agent storyboards.
 sandbox: true
 
+# security_baseline auth fixture — see acme-outdoor.yaml for semantics.
+#
+# probe_task is `get_signals` because this kit's primary consumers are
+# signal agents (specialisms/signal-owned, specialisms/signal-marketplace)
+# where list_creatives is not implemented. Non-signal storyboards that
+# reuse this kit (collection-lists, sales-broadcast-tv, sponsored-
+# intelligence) should select acme-outdoor for security_baseline, or
+# override probe_task at the storyboard layer.
+auth:
+  api_key: "demo-nova-motors-v1"
+  probe_task: get_signals
+
 brand:
   house:
     domain: "novamotors.example"

--- a/static/compliance/source/test-kits/osei-natural.yaml
+++ b/static/compliance/source/test-kits/osei-natural.yaml
@@ -15,6 +15,11 @@ name: "Osei Natural"
 description: "Natural skincare brand for small-business advertiser storyboard testing"
 sandbox: true
 
+# security_baseline auth fixture — see acme-outdoor.yaml for semantics.
+auth:
+  api_key: "demo-osei-natural-v1"
+  probe_task: list_creatives
+
 brand:
   house:
     domain: "oseinatural.example"

--- a/static/compliance/source/test-kits/summit-foods.yaml
+++ b/static/compliance/source/test-kits/summit-foods.yaml
@@ -14,6 +14,11 @@ name: "Summit Foods"
 description: "Organic food CPG brand for retail media storyboard testing"
 sandbox: true
 
+# security_baseline auth fixture — see acme-outdoor.yaml for semantics.
+auth:
+  api_key: "demo-summit-foods-v1"
+  probe_task: list_creatives
+
 brand:
   house:
     domain: "summitfoods.example"


### PR DESCRIPTION
## Summary

- Adds an `auth:` block to each of the five fictional test kits (`acme-outdoor`, `bistro-oranje`, `nova-motors`, `osei-natural`, `summit-foods`) with `api_key` and `probe_task`. Unblocks the `security_baseline` storyboard's api-key phase, which was always skipped via `skip_if: "!test_kit.auth.api_key"`.
- `nova-motors` uses `probe_task: get_signals` because its primary consumers are signal specialisms where `list_creatives` isn't implemented; the remaining four use `list_creatives`, matching the runner's default.
- `demo-<kit>-` is documented as the conformance handle — agents SHOULD accept any Bearer matching the prefix rather than the literal value, so the suffix can rotate without breaking previously-conformant agents.

Closes #2317.

## Test plan

- [x] `npm run build:compliance` — compliance bundle rebuilds cleanly (8 universal, 6 protocols, 23 specialisms).
- [x] `npm run test:unit` — 587 tests pass; storyboards module loads all five kits.
- [x] `npm run typecheck` — clean.
- [x] YAML round-trips through `yaml.safe_load`; each kit's `auth` block parses to the expected shape.
- [x] Reviewed by `code-reviewer` and `security-reviewer` — feedback addressed (dropped `${random_hex}` template since it isn't in `storyboard-schema.yaml`; clarified nova-motors signal-primary scope; reduced comment redundancy on the deferred kits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)