### PR TITLE
ci(registry): add publication-completeness linter for policy entries

### DIFF
--- a/.changeset/registry-completeness-linter.md
+++ b/.changeset/registry-completeness-linter.md
@@ -1,0 +1,13 @@
+---
+---
+
+Add CI linter (`npm run check:registry`) that enforces the publication bar for
+`static/registry/policies/**/*.json`. Registry-published policies must carry
+the full metadata set (`source: "registry"`, `version`, `name`, `category`,
+`jurisdictions`, `source_url`, `source_name`, `effective_date`, plus at least
+one pass and one fail exemplar). Schema-level validation stays relaxed so
+inline bespoke `PolicyEntry` authoring in `sync-plans` and `content-standards`
+remains ergonomic. Existing registry entries backfilled to meet the bar, and
+`static/registry/README.md` added documenting the requirement.
+
+Closes #2319.

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -28,3 +28,6 @@ jobs:
 
     - name: Validate schemas
       run: npm run test:schemas && npm run test:json-schema && npm run test:extension-schemas && npm run test:composed
+
+    - name: Check policy registry publication completeness
+      run: npm run check:registry

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "update-schema-versions": "echo 'Schema versioning is now handled by build:schemas script'",
     "release": "npm run version && npm test && npm run build && git add -A && git commit -m 'Version packages' && git push",
     "verify-version-sync": "node scripts/verify-version-sync.cjs",
+    "check:registry": "node scripts/check-registry-completeness.cjs",
     "check:seo": "node scripts/check-seo-metadata.cjs",
     "check:owned-links": "node scripts/check-owned-links.js",
     "check:images": "bash scripts/check-image-quality.sh"

--- a/scripts/check-registry-completeness.cjs
+++ b/scripts/check-registry-completeness.cjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+/**
+ * Registry publication linter.
+ *
+ * The PolicyEntry schema only requires three fields (policy_id, enforcement,
+ * policy) so inline bespoke authoring stays ergonomic. Entries published to the
+ * shared registry at static/registry/policies/ still need the full metadata so
+ * downstream consumers can aggregate across publishers.
+ *
+ * Schema validation can't tell "this is being published to the registry" from
+ * "this is an inline bespoke entry" — both use the same type. CI is the
+ * enforcement point.
+ *
+ * See: https://github.com/adcontextprotocol/adcp/issues/2319
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REGISTRY_DIR = path.join(__dirname, '..', 'static', 'registry', 'policies');
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_ALPHA2 = /^[A-Z]{2}$/;
+const VALID_CATEGORIES = new Set(['regulation', 'standard']);
+
+function checkExemplars(list, kind, errors) {
+  if (!Array.isArray(list) || list.length < 1) {
+    errors.push(`exemplars.${kind} must contain at least one entry (calibration requires ${kind === 'pass' ? 'positive' : 'negative'} examples)`);
+    return;
+  }
+  list.forEach((ex, i) => {
+    if (!ex || typeof ex !== 'object') {
+      errors.push(`exemplars.${kind}[${i}] must be an object with scenario and explanation`);
+      return;
+    }
+    if (typeof ex.scenario !== 'string' || ex.scenario.trim().length === 0) {
+      errors.push(`exemplars.${kind}[${i}].scenario must be a non-empty string`);
+    }
+    if (typeof ex.explanation !== 'string' || ex.explanation.trim().length === 0) {
+      errors.push(`exemplars.${kind}[${i}].explanation must be a non-empty string`);
+    }
+  });
+}
+
+function checkEntry(entry, filename) {
+  const errors = [];
+
+  if (entry.source !== 'registry') {
+    errors.push(`source must be "registry" (got ${JSON.stringify(entry.source ?? null)})`);
+  }
+
+  if (typeof entry.version !== 'string' || !SEMVER.test(entry.version)) {
+    errors.push(`version must be a semver string (got ${JSON.stringify(entry.version ?? null)})`);
+  }
+
+  if (typeof entry.name !== 'string' || entry.name.trim().length === 0) {
+    errors.push('name must be a non-empty string');
+  }
+
+  if (!VALID_CATEGORIES.has(entry.category)) {
+    errors.push(`category must be "regulation" or "standard" (got ${JSON.stringify(entry.category ?? null)})`);
+  }
+
+  if (!Array.isArray(entry.jurisdictions)) {
+    errors.push('jurisdictions must be an array (empty array is valid for non-jurisdiction-specific policies)');
+  } else {
+    const badCodes = entry.jurisdictions.filter((j) => typeof j !== 'string' || !ISO_ALPHA2.test(j));
+    if (badCodes.length > 0) {
+      errors.push(`jurisdictions entries must be ISO 3166-1 alpha-2 country codes (got ${JSON.stringify(badCodes)})`);
+    }
+  }
+
+  if (!Array.isArray(entry.governance_domains) || entry.governance_domains.length === 0) {
+    errors.push('governance_domains must be a non-empty array — registry consumers need it to route policies to the right governance surface');
+  }
+
+  if (typeof entry.source_url !== 'string' || entry.source_url.trim().length === 0) {
+    errors.push('source_url must be a non-empty URI string');
+  } else {
+    try {
+      const parsed = new URL(entry.source_url);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        errors.push(`source_url must use http(s) (got ${JSON.stringify(parsed.protocol)})`);
+      }
+    } catch {
+      errors.push(`source_url must be a valid URI (got ${JSON.stringify(entry.source_url)})`);
+    }
+  }
+
+  if (typeof entry.source_name !== 'string' || entry.source_name.trim().length === 0) {
+    errors.push('source_name must be a non-empty string');
+  }
+
+  if (typeof entry.effective_date !== 'string' || !ISO_DATE.test(entry.effective_date)) {
+    errors.push(`effective_date must be an ISO 8601 date (YYYY-MM-DD), got ${JSON.stringify(entry.effective_date ?? null)}`);
+  }
+
+  const exemplars = entry.exemplars;
+  if (!exemplars || typeof exemplars !== 'object') {
+    errors.push('exemplars must be present with at least one pass and one fail entry');
+  } else {
+    checkExemplars(exemplars.pass, 'pass', errors);
+    checkExemplars(exemplars.fail, 'fail', errors);
+  }
+
+  const expectedId = filename.replace(/\.json$/, '');
+  if (entry.policy_id !== expectedId) {
+    errors.push(`policy_id must match filename (expected "${expectedId}", got ${JSON.stringify(entry.policy_id ?? null)})`);
+  }
+
+  return errors;
+}
+
+function main() {
+  if (!fs.existsSync(REGISTRY_DIR)) {
+    console.error(`Registry directory not found: ${REGISTRY_DIR}`);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(REGISTRY_DIR).filter((f) => f.endsWith('.json')).sort();
+
+  if (files.length === 0) {
+    console.log('No registry entries found — nothing to check.');
+    return;
+  }
+
+  const failures = [];
+
+  for (const file of files) {
+    const fullPath = path.join(REGISTRY_DIR, file);
+    let entry;
+    try {
+      entry = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+    } catch (err) {
+      failures.push({ file, errors: [`invalid JSON: ${err.message}`] });
+      continue;
+    }
+    const errors = checkEntry(entry, file);
+    if (errors.length > 0) {
+      failures.push({ file, errors });
+    }
+  }
+
+  if (failures.length === 0) {
+    console.log(`Registry completeness: ${files.length} entr${files.length === 1 ? 'y' : 'ies'} OK.`);
+    return;
+  }
+
+  console.error(`Registry completeness check failed for ${failures.length} of ${files.length} entr${files.length === 1 ? 'y' : 'ies'}:\n`);
+  for (const { file, errors } of failures) {
+    console.error(`  ${file}`);
+    for (const err of errors) {
+      console.error(`    - ${err}`);
+    }
+    console.error('');
+  }
+  console.error('Registry-published policies must carry the full metadata set (see static/registry/README.md).');
+  console.error('Inline bespoke policies in sync-plans/content-standards are unaffected — only files in static/registry/policies/ are checked.');
+  process.exit(1);
+}
+
+main();

--- a/static/registry/README.md
+++ b/static/registry/README.md
@@ -1,0 +1,82 @@
+# AdCP Shared Registry
+
+This directory holds entries published to the shared AdCP registry:
+
+- `policies/` — governance policies (regulations, standards, platform rules)
+- `policy-categories/` — named categories referenced by policy entries and plans
+- `attributes/` — restricted-attribute definitions used in signal declarations
+
+Registry entries are intended for aggregation across publishers. Downstream
+consumers (governance agents, plan authors, compliance reporting) rely on each
+entry carrying enough metadata to be understood without out-of-band context.
+
+## Publication bar for `policies/`
+
+The `PolicyEntry` schema only requires three fields (`policy_id`,
+`enforcement`, `policy`) so buyers can author bespoke inline policies
+ergonomically. **Registry-published entries must meet a higher bar.**
+
+Every file under `policies/*.json` must set:
+
+| Field | Requirement |
+| --- | --- |
+| `policy_id` | Must match the filename. Registry ids are flat snake_case (e.g. `us_coppa_data_collection`); colonned namespace-style ids seen in the schema examples are not yet supported at the file level. |
+| `source` | Must be `"registry"` |
+| `version` | Semver string (e.g. `"1.0.0"`). Bump on content changes. |
+| `name` | Non-empty human-readable name |
+| `category` | `"regulation"` or `"standard"` |
+| `jurisdictions` | Array of ISO 3166-1 alpha-2 codes. Use `[]` for non-jurisdiction-specific policies (e.g. platform rules). |
+| `governance_domains` | Non-empty array. Routes the policy to the right governance surface (e.g. `["campaign"]`, `["creative", "property"]`). Without this, consumers can't tell which agents should evaluate the policy. |
+| `source_url` | http(s) link to the authoritative source text |
+| `source_name` | Issuing body |
+| `effective_date` | ISO 8601 date (`YYYY-MM-DD`). Future dates are fine — the schema treats pre-effective policies as informational. |
+| `exemplars.pass` | At least one passing scenario. Each entry must have non-empty `scenario` and `explanation`. |
+| `exemplars.fail` | At least one failing scenario. Same shape as `pass`. |
+
+The pass/fail exemplar requirement is what makes registry entries useful for
+governance-agent calibration — an entry without both sides doesn't tell a
+downstream agent where the line actually sits.
+
+## Why this isn't schema-enforced
+
+The same `PolicyEntry` type is used for inline bespoke authoring inside
+`sync-plans`, `content-standards`, etc. Forcing buyers to fill in
+`version: "1.0.0"` plus `name`, `category`, etc. for every ad-hoc rule would
+make inline authoring painful for no downstream benefit. The distinction is a
+publishing concern, not a protocol concern — so CI is the enforcement point.
+
+## CI enforcement
+
+```bash
+npm run check:registry
+```
+
+This runs `scripts/check-registry-completeness.cjs` against every file under
+`policies/*.json` and fails the build if any entry is missing a required
+field. Hooked into the `JSON Schema Validation` workflow and runs on every PR.
+
+The linter only covers `policies/` today. `attributes/` and `policy-categories/`
+have their own shapes and aren't yet gated — add similar checks when those
+directories grow.
+
+## Adding a new policy
+
+1. Create `policies/<stable_snake_case_id>.json`. Pick an id that reflects
+   jurisdiction + scope (e.g. `us_ftc_health_claims`, `eu_dsa_political_targeting`).
+2. Fill in the required fields above plus relevant optional metadata
+   (`policy_categories`, `region_aliases`, `requires_human_review`, `channels`,
+   `guidance`).
+3. Write at least one pass and one fail exemplar. These are the calibration
+   signal for governance agents — they carry more weight than the policy text
+   alone.
+4. Run `npm run check:registry` locally to confirm the entry passes the bar.
+
+## Non-goals
+
+- This bar does **not** apply to inline `PolicyEntry` values used in
+  `sync-plans`, `content-standards`, or `custom_policies`. Those remain
+  lightweight (only `policy_id`, `enforcement`, `policy` required) and are
+  unaffected by the CI linter.
+- Registry-sourced policies are authoritative within a governance evaluation
+  and cannot be relaxed by inline policies — see the `PolicyEntry` schema
+  description for the evaluation-precedence rules.

--- a/static/registry/policies/eu_ai_act_annex_iii.json
+++ b/static/registry/policies/eu_ai_act_annex_iii.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "eu_ai_act_annex_iii",
+  "source": "registry",
   "version": "1.0.0",
   "name": "EU AI Act — Annex III High-Risk Decisions (Ad Targeting)",
   "description": "When AdCP agents make automated decisions affecting access to credit, insurance, housing, or employment opportunities, the deployer falls within EU AI Act Annex III high-risk categories. Those decisions require human oversight and cannot be made solely by an agent.",

--- a/static/registry/policies/eu_dsa_political_targeting.json
+++ b/static/registry/policies/eu_dsa_political_targeting.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "eu_dsa_political_targeting",
+  "source": "registry",
   "version": "1.0.0",
   "name": "EU Digital Services Act — Political Ad Targeting Restrictions",
   "description": "Prohibits targeting political advertisements using special categories of personal data under DSA Article 26 and the EU Political Advertising Regulation.",

--- a/static/registry/policies/eu_gdpr_special_category_targeting.json
+++ b/static/registry/policies/eu_gdpr_special_category_targeting.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "eu_gdpr_special_category_targeting",
+  "source": "registry",
   "version": "1.0.0",
   "name": "EU GDPR — Special Category Data Targeting Restrictions",
   "description": "Restricts processing of special categories of personal data for advertising targeting under GDPR Article 9.",

--- a/static/registry/policies/eu_rx_dtc_ban.json
+++ b/static/registry/policies/eu_rx_dtc_ban.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "eu_rx_dtc_ban",
+  "source": "registry",
   "version": "1.0.0",
   "name": "EU — Prescription Drug DTC Advertising Ban",
   "description": "Prohibits direct-to-consumer advertising of prescription medicines in the EU under Directive 2001/83/EC Article 88.",

--- a/static/registry/policies/platform_firearms_restrictions.json
+++ b/static/registry/policies/platform_firearms_restrictions.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "platform_firearms_restrictions",
+  "source": "registry",
   "version": "1.0.0",
   "name": "Platform Firearms Advertising Restrictions",
   "description": "Platform-level restrictions on firearms and weapons advertising, varying by platform but broadly limiting promotion, targeting, and placement.",
@@ -8,7 +9,9 @@
   "jurisdictions": [],
   "policy_categories": ["firearms_weapons"],
   "governance_domains": ["campaign", "content_standards"],
-  "source_name": "Industry — Major Platform Policies",
+  "effective_date": "2020-01-01",
+  "source_url": "https://support.google.com/adspolicy/answer/6014299",
+  "source_name": "Industry — Major Platform Policies (Google Ads reference)",
   "policy": "Firearms and weapons advertising is subject to platform-specific restrictions that vary in scope but share common patterns.\n\nCommon restrictions:\n1. Most major platforms prohibit ads that promote the sale of firearms, ammunition, or explosives.\n2. Accessories that modify firearms (e.g., silencers, high-capacity magazines) are typically restricted.\n3. Some platforms allow ads from licensed retailers with additional restrictions (age-gating, no automatic weapons).\n4. Firearms safety courses and advocacy organizations may be permitted on some platforms.\n5. Content depicting violence or unsafe firearms handling is prohibited across all platforms.\n\nSpecific platform policies vary significantly:\n- Google: Prohibits ads promoting firearms, parts, and ammunition\n- Meta: Prohibits ads promoting the sale or use of weapons\n- Amazon: No firearms or weapons advertising\n- Some CTV/streaming platforms: May allow licensed retailer ads with restrictions\n\nGovernance agents should check seller-specific policies for the exact restrictions that apply.",
   "guidance": "Firearms restrictions are primarily platform-driven rather than federal regulation (in the US). The enforcement level is 'should' because some sellers/channels do permit restricted firearms advertising from licensed dealers. Governance agents should flag firearms_weapons campaigns for additional seller-specific policy review. The seller's enforced_policies response is authoritative for what is actually permitted on their platform.",
   "exemplars": {

--- a/static/registry/policies/platform_special_ad_categories.json
+++ b/static/registry/policies/platform_special_ad_categories.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "platform_special_ad_categories",
+  "source": "registry",
   "version": "1.0.0",
   "name": "Platform Special Ad Categories (Housing, Employment, Credit)",
   "description": "Platform-enforced restrictions on audience targeting for ads related to housing, employment, and credit, following the Meta/DOJ settlement model.",

--- a/static/registry/policies/us_coppa_data_collection.json
+++ b/static/registry/policies/us_coppa_data_collection.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_coppa_data_collection",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US COPPA — Children's Data Collection Restrictions",
   "description": "Restricts collection and use of personal information from children under 13 for advertising under COPPA (15 U.S.C. 6501-6506).",

--- a/static/registry/policies/us_ecoa_targeting.json
+++ b/static/registry/policies/us_ecoa_targeting.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_ecoa_targeting",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US Equal Credit Opportunity Act — Targeting Restrictions",
   "description": "Prohibits discriminatory targeting in credit and lending advertising under ECOA (15 U.S.C. 1691) and Regulation B.",

--- a/static/registry/policies/us_eeoc_employment_targeting.json
+++ b/static/registry/policies/us_eeoc_employment_targeting.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_eeoc_employment_targeting",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US EEOC — Employment Ad Targeting Restrictions",
   "description": "Prohibits discriminatory targeting in employment advertising under Title VII, ADEA, ADA, and GINA.",

--- a/static/registry/policies/us_fda_dtc_fair_balance.json
+++ b/static/registry/policies/us_fda_dtc_fair_balance.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_fda_dtc_fair_balance",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US FDA — DTC Pharmaceutical Advertising Fair Balance",
   "description": "Requires fair balance of benefit and risk information in direct-to-consumer pharmaceutical advertising (21 CFR 202.1).",

--- a/static/registry/policies/us_fha_targeting.json
+++ b/static/registry/policies/us_fha_targeting.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_fha_targeting",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US Fair Housing Act — Targeting Restrictions",
   "description": "Prohibits targeting or exclusion by protected characteristics in housing advertising under the Fair Housing Act (42 U.S.C. 3604(c)).",

--- a/static/registry/policies/us_ftc_health_claims.json
+++ b/static/registry/policies/us_ftc_health_claims.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_ftc_health_claims",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US FTC — Health and Wellness Claim Substantiation",
   "description": "Requires competent and reliable scientific evidence for health-related advertising claims under FTC Act Section 5.",

--- a/static/registry/policies/us_state_gambling_geofencing.json
+++ b/static/registry/policies/us_state_gambling_geofencing.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_state_gambling_geofencing",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US State Gambling — Geofencing Requirements",
   "description": "Requires gambling advertising to be geofenced to jurisdictions where online gambling is legal, with age restrictions.",
@@ -8,6 +9,7 @@
   "jurisdictions": ["US"],
   "policy_categories": ["gambling_advertising"],
   "governance_domains": ["campaign"],
+  "effective_date": "2019-09-23",
   "source_url": "https://www.americangaming.org/resources/responsible-marketing-code-for-sports-wagering/",
   "source_name": "American Gaming Association",
   "policy": "Online gambling and sports betting advertising must be geofenced to states where the activity is legal and must target only adults of legal gambling age.\n\nRequirements:\n1. Advertising must be geographically restricted to states/territories where the specific gambling activity (sports betting, online casino, daily fantasy) is licensed and legal.\n2. Audience targeting must include age verification — minimum age is 21 in most states, 18 in some.\n3. Self-exclusion lists must be respected where platforms support them.\n4. Ads must not target audiences identified as having gambling problems or addictive behaviors.\n5. Cross-state ad delivery (serving to users in states where the activity is illegal) must be prevented.\n\nState gaming commissions can revoke licenses for advertising violations.",

--- a/static/registry/policies/us_ttb_alcohol_audience.json
+++ b/static/registry/policies/us_ttb_alcohol_audience.json
@@ -1,5 +1,6 @@
 {
   "policy_id": "us_ttb_alcohol_audience",
+  "source": "registry",
   "version": "1.0.0",
   "name": "US TTB — Alcohol Advertising Audience Restrictions",
   "description": "Requires alcohol advertising to target legal drinking age audiences and comply with TTB advertising regulations (27 CFR Parts 4, 5, 7).",


### PR DESCRIPTION
## Summary

- Adds `scripts/check-registry-completeness.cjs` + a CI step in the JSON Schema Validation workflow that enforces the publication bar for every file in `static/registry/policies/*.json`.
- Backfills all 14 existing registry entries with `"source": "registry"`. Two also got missing `effective_date`/`source_url`.
- Adds `static/registry/README.md` documenting the bar, the flat snake_case `policy_id` decision, and which directories the linter currently covers.

## Why

In 3.0 GA we relaxed `PolicyEntry` from 6→3 required fields so buyers can author bespoke inline policies ergonomically (inside `sync-plans`, `content-standards`, `custom_policies`). Registry-published entries still need full metadata so downstream consumers can aggregate across publishers — but schema validation can't tell the two contexts apart (both use the same type). CI is the enforcement point.

## What the linter enforces

For every `static/registry/policies/*.json`:

| Field | Requirement |
| --- | --- |
| `policy_id` | Matches filename (flat snake_case) |
| `source` | `"registry"` |
| `version` | Semver |
| `name` | Non-empty |
| `category` | `"regulation"` or `"standard"` |
| `jurisdictions` | Array of ISO 3166-1 alpha-2 codes (empty array valid) |
| `governance_domains` | Non-empty array — routes policies to the right governance surface |
| `source_url` | http(s) URL |
| `source_name` | Non-empty |
| `effective_date` | ISO 8601 `YYYY-MM-DD` |
| `exemplars.pass` | ≥1 entry, non-empty `scenario` + `explanation` |
| `exemplars.fail` | ≥1 entry, non-empty `scenario` + `explanation` |

Inline bespoke `PolicyEntry` values in `sync-plans`, `content-standards`, and `custom_policies` are unaffected — the schema stays relaxed.

## Reviewed by

`code-reviewer` and `ad-tech-protocol-expert` subagents. Protocol reviewer drove the `governance_domains` requirement (without it, consumers can't route a registry policy to the right governance surface). Code reviewer drove the http(s) restriction on `source_url` and ISO alpha-2 validation on `jurisdictions`.

## Test plan

- [x] `npm run check:registry` — 14 entries OK
- [x] `npm run test:schemas && npm run test:json-schema && npm run test:composed && npm run test:extension-schemas` — all green
- [x] 13 adversarial cases (strip `source`, bad semver, bad ISO date, non-http URL, non-alpha-2 jurisdictions, missing/empty `governance_domains`, empty exemplar `scenario`, whitespace-only `explanation`, wrong category enum, filename/id mismatch, malformed JSON) — all caught with specific errors
- [x] Pre-commit hook: 587 unit tests + typecheck clean

Closes #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)