### PR TITLE
docs(building): add Operating an Agent guide (#2202)

### DIFF
--- a/.changeset/docs-operating-an-agent.md
+++ b/.changeset/docs-operating-an-agent.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs: set expectations on what a storyboard-validated agent still needs to go live (issue #2202).
+
+Adds a "Protocol-compliant ≠ production-ready" warning after the storyboard section of `Build an Agent`, and a new `Operating an Agent` page covering the three paths (partner, self-host a prebuilt agent like Prebid Sales Agent, or build your own), the components publishers still need to provision (products, creative review, activation, delivery reporting, order management, hosting, discovery registration), and how operations diverge across sales, signals, creative, and retail-media agents.

--- a/docs.json
+++ b/docs.json
@@ -111,6 +111,7 @@
                   "docs/building/schemas-and-sdks",
                   "docs/building/build-an-agent",
                   "docs/building/validate-your-agent",
+                  "docs/building/operating-an-agent",
                   "docs/building/compliance-catalog",
                   {
                     "group": "Foundations",
@@ -602,6 +603,7 @@
               "docs/building/schemas-and-sdks",
               "docs/building/build-an-agent",
               "docs/building/validate-your-agent",
+              "docs/building/operating-an-agent",
               "docs/building/compliance-catalog",
               {
                 "group": "Foundations",

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -5,7 +5,11 @@ description: "Use AdCP SDK skill files to generate storyboard-compliant agents w
 "og:title": "AdCP — Build an Agent"
 ---
 
-The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from an AdCP SDK. Each skill produces a working, storyboard-validated agent in 2–8 minutes.
+The fastest way to build an AdCP agent is to point a coding agent (Claude Code, Codex, Cursor, Windsurf) at a skill file from an AdCP SDK. Each skill produces a protocol-compliant, storyboard-validated agent in 2–8 minutes.
+
+<Note>
+**Publisher without an engineering team?** Protocol compliance is one piece of going live — product management, activation into your ad server, and hosting are separate lifts. See **[Operating an Agent](/docs/building/operating-an-agent)** for the three paths: partner with a managed platform, self-host a prebuilt agent, or build your own.
+</Note>
 
 ## Install the SDK
 
@@ -122,9 +126,9 @@ In Cursor or Windsurf, download the skill file and include it as context with yo
 
 ## Validate with storyboards
 
-<Warning>
+<Note>
 The storyboard runner requires Node.js, regardless of what language your agent is written in.
-</Warning>
+</Note>
 
 Once the agent is running, validate it against the matching storyboard:
 
@@ -158,6 +162,10 @@ media_buy_seller (9 steps)
   9/9 passed
 ```
 
+<Warning>
+**Protocol-compliant ≠ production-ready.** A passing run means your agent speaks AdCP correctly. Going live requires business infrastructure behind each tool call — products and pricing, activation into your ad server, order management, hosting, and discovery registration via `adagents.json`. See **[Operating an Agent](/docs/building/operating-an-agent)** for the full list and whether to partner, self-host, or build.
+</Warning>
+
 <Tip>
 Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, proposal mode, and more. Run `npx @adcp/client storyboard list` to see all available storyboards.
 </Tip>
@@ -178,6 +186,7 @@ Python and Go equivalents are in each SDK's GitHub repository. See [adcp-python]
 ## What's next
 
 - **[Validate Your Agent](/docs/building/validate-your-agent)** — Storyboards, compliance checks, and the build-validate-fix loop
+- **[Operating an Agent](/docs/building/operating-an-agent)** — What sits behind the protocol layer, and whether to partner, self-host, or build
 - **[Schemas and SDKs](/docs/building/schemas-and-sdks)** — Schema access, CLI tools, and SDK package exports
 - **[MCP integration guide](/docs/building/integration/mcp-guide)** — Transport, sessions, and auth details
 - **[Task lifecycle](/docs/building/implementation/task-lifecycle)** — Status values, transitions, and polling

--- a/docs/building/implementation/seller-integration.mdx
+++ b/docs/building/implementation/seller-integration.mdx
@@ -308,6 +308,9 @@ AdCP sits alongside your existing APIs and dashboards. It doesn't replace your s
   <Card title="Building with AdCP" icon="rocket" href="/docs/building">
     Implementation guides, SDKs, and integration patterns.
   </Card>
+  <Card title="Operating an agent" icon="gears" href="/docs/building/operating-an-agent">
+    What sits behind protocol compliance — activation, storage, hosting, and build-vs-buy.
+  </Card>
   <Card title="Ask Addie" icon="message-bot" href="https://adcontextprotocol.org/chat">
     Ask questions about implementing AdCP for your platform — no code required.
   </Card>

--- a/docs/building/operating-an-agent.mdx
+++ b/docs/building/operating-an-agent.mdx
@@ -1,0 +1,74 @@
+---
+title: Operating an Agent
+sidebarTitle: Operating an Agent
+description: "What sits behind a protocol-compliant agent — products, activation, hosting, and whether to partner, self-host, or build."
+"og:title": "AdCP — Operating an Agent"
+---
+
+The 2–8 minute [Build an Agent](/docs/building/build-an-agent) path gets you a protocol-compliant agent. This page is what comes after — the business infrastructure behind each tool call, and how to decide who runs it.
+
+The worked example here is a **sales agent**, since that's the most infrastructure-heavy case. Short callouts mark where the operational concerns diverge for signals, creative, and retail-media agents.
+
+## What the SDK already handles
+
+Before listing what's missing, it helps to be explicit about what a storyboard-validated agent already gives you:
+
+- AdCP tool schemas and typed registration
+- Request/response shapes that pass compliance
+- Error formats and version negotiation
+- A starting point with example products you can swap for real ones
+
+Everything below is what sits behind those tool handlers.
+
+## Partner, self-host, or build
+
+There are three paths to a live agent. They differ in how much you own, not whether you own anything at all — in every case you still own products, pricing, and the activation into your ad server.
+
+**Partner with a managed sales agent platform.** The platform runs the agent endpoint, holds state, and exposes admin UIs for your ad ops team to manage products, pricing, and approvals. You connect your ad server; the platform handles the protocol and the operations around it. Fastest to live, least control.
+
+**Self-host a prebuilt agent.** Deploy an existing open-source agent — today this usually means the [Prebid Sales Agent](https://github.com/prebid/salesagent), a community full-stack seller agent with GAM integration — on your own infrastructure, and connect it to your systems. You skip writing the protocol layer and admin UI, but you own hosting, upgrades, database, and the ad-server wiring. Middle ground: more control than partnering, less work than building.
+
+**Build your own.** Use the SDK and skill files to write a custom agent. You get full control over business logic, pricing models, and activation paths, at the cost of owning the code alongside everything else. Right answer when no prebuilt agent fits your stack or pricing model.
+
+The SDKs and storyboards cover protocol compliance across all three paths. Everything in the table below is what's outside that line, regardless of which path you take.
+
+## What you'll still need to build or provision
+
+| Component | What it does | Example approaches |
+|---|---|---|
+| **Product & pricing management** | Lets ad ops define products, rate cards, packaging, and availability without code changes. The skill files hardcode example products; a real agent needs these dynamic and editable. | A partner platform's product catalog, a prebuilt agent's admin UI (e.g. Prebid Sales Agent), or a custom admin UI backed by a database. |
+| **Persistent storage** | Stores products, pricing, media buys, creative assignments, and delivery state across requests. | PostgreSQL, MySQL, or any datastore your team is comfortable operating. |
+| **Creative review & policy** | Applies brand-safety, legal, and format checks to creatives before they go live. The protocol carries the creative; your policy decides whether to accept it. | Human review queue, automated policy engine (IAB categories, brand lists), or a hybrid. Often the first thing ad ops teams underestimate. |
+| **Trafficking & fulfillment** | Turns a sold media buy into a live campaign in your ad server. This sits entirely outside AdCP and is usually the hardest piece. | *Manual:* email or Slack alerts that prompt ad ops to set up campaigns in GAM. *Semi-automated:* Google Ad Manager API to create line items and assign creatives. *Full automation:* end-to-end pipeline from buy confirmation to live delivery. |
+| **Delivery reporting & performance** | Powers `get_media_buy_delivery` and `provide_performance_feedback` with real numbers. The protocol tools exist; the log ingest, aggregation, and attribution pipeline behind them is yours to build. | Ad server reporting API pulls, log-level ingest into a warehouse, or a managed analytics tool feeding the agent. |
+| **Order management** | Tracks buy status, approval workflows, creative deadlines, and pacing beyond what the protocol's task lifecycle covers. | Status fields in your database to start; a dashboard as volume grows. |
+| **Hosting** | Keeps your agent live at the URL you declare in `adagents.json`. Downtime or URL drift breaks buyer discovery. | Cloud VM, container service (Cloud Run, ECS, Fly.io), or a managed hosting platform. |
+| **Discovery registration** | Tells buyer agents your agent exists and which protocols it supports. Handled via `adagents.json` on your domain — not through a central registry. | Publish `adagents.json` at your domain root. See [How Agents Communicate](/docs/building/understanding/how-agents-communicate) and [Authorized Properties](/docs/governance/property/authorized-properties). |
+
+## Where the protocol ends and your business begins
+
+AdCP defines the shape of the conversation between agents. It does not define:
+
+- **Pricing strategy** — how you price inventory, how rate cards flex, when discounts apply
+- **Approval policy** — which campaigns you accept or reject, and on what grounds
+- **Billing and invoicing** — no spec-level billing; you reconcile with buyers out-of-band
+- **Identity and consent** — user-level identity, consent capture, and data-subject rights are regulated and implementation-specific
+- **SLA monitoring** — uptime, latency, and error budgets for your agent endpoint
+- **Ad ops workflow** — how your team monitors pacing, makegoods, and escalations
+
+A partner platform makes default choices for most of these; a self-hosted prebuilt agent gives you its defaults to override; a self-built agent makes you make every call.
+
+## Where this differs by agent type
+
+The components table above assumes a sales agent. Other agent types share most of it but have specific additions:
+
+- **Signals agents** — consent and provenance are load-bearing. You need a defensible data lineage (where a segment came from, what consent covers it) and the ability to honor opt-outs. Activation is less about ad-server trafficking and more about delivering segments to platforms that already ingest them.
+- **Creative agents** — asset storage, transcoding, and rendering SLAs replace ad-server trafficking. Creative review becomes policy on what you'll render, not what you'll traffic.
+- **Retail-media agents** — catalog freshness is the operational constraint; your products change as SKUs change. Activation often runs through retail-specific ad platforms rather than GAM.
+
+## What's next
+
+- **[Validate Your Agent](/docs/building/validate-your-agent)** — The compliance side of the same question
+- **[How Agents Communicate](/docs/building/understanding/how-agents-communicate)** — Discovery via `adagents.json` and `brand.json`
+- **[Seller Integration](/docs/building/implementation/seller-integration)** — Patterns for connecting an agent to an ad server
+- **[Authorized Properties](/docs/governance/property/authorized-properties)** — Who can sell what, and how that's declared

--- a/docs/building/understanding/how-agents-communicate.mdx
+++ b/docs/building/understanding/how-agents-communicate.mdx
@@ -174,4 +174,7 @@ The agency's team sets strategy and reviews results. The agent handles the cross
   <Card title="Seller integration" icon="store" href="/docs/building/implementation/seller-integration">
     How platforms expose their inventory to AI buyer agents.
   </Card>
+  <Card title="Operating an agent" icon="gears" href="/docs/building/operating-an-agent">
+    What sits behind a protocol-compliant agent, and whether to build or buy.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Closes #2202. The Build an Agent guide could mislead non-developer publisher readers into thinking a storyboard-validated agent is production ready. The "2–8 minutes" framing and `9/9 passed` output read like a finish line.

- Added a `<Warning>` at the moment the 9/9 output lands: *protocol-compliant ≠ production-ready*, linking to the new page
- Softened the lede on Build an Agent (*"working" → "protocol-compliant"*) and added an early `<Note>` routing engineering-light publishers to the new page *before* they install
- New page `docs/building/operating-an-agent.mdx` covering the three paths (**partner** with a managed platform, **self-host** a prebuilt agent like the [Prebid Sales Agent](https://github.com/prebid/salesagent), or **build** from the SDK), what the SDK already handles, and the components still owned by the publisher (products & pricing, creative review & policy, trafficking & fulfillment, delivery reporting & performance, order management, hosting, discovery registration via `adagents.json`)
- Section on where operational concerns diverge for signals (consent/provenance), creative (rendering SLAs), and retail-media (catalog freshness) agents
- Corrected the original issue's drift (*"Scope3 handles discovery"* → discovery is via `adagents.json` on your domain)
- Cross-linked from `how-agents-communicate.mdx` and `seller-integration.mdx`
- Added to sidebar in both `docs.json` entries

## Test plan

- [ ] Build an Agent guide: Warning lands immediately after the `9/9 passed` block and before the Tip
- [ ] Operating an Agent page renders with correct sidebar title and all three paths
- [ ] Discovery description references `adagents.json` (not a central registry)
- [ ] Backlinks from `how-agents-communicate` and `seller-integration` render
- [ ] Prebid Sales Agent link resolves
- [ ] No stale "Operating a Sales Agent" string remains (title now "Operating an Agent")

🤖 Generated with [Claude Code](https://claude.com/claude-code)