### PR TITLE
spec(compliance): runner output contract + security hardening (#2352)

### DIFF
--- a/.changeset/runner-output-contract.md
+++ b/.changeset/runner-output-contract.md
@@ -1,0 +1,33 @@
+---
+---
+
+spec(compliance): define runner output contract for actionable failure detail (#2352)
+
+Storyboard runners (evaluate_agent_quality, `@adcp/client storyboard run`, any
+other compliance harness) MUST emit enough detail on validation failures for an
+implementor to self-diagnose without guesswork. Today a bare "Check agent
+capabilities" failure is indistinguishable from a transport bug, a schema drift
+bug, or a genuine agent bug.
+
+- New `static/compliance/source/universal/runner-output-contract.yaml` defining
+  the minimum shape of a validation failure result: exact request sent, exact
+  response received, RFC 6901 JSON Pointer to the failing field, machine-readable
+  expected vs. actual values, and — for `response_schema` checks — the `$id`
+  and fetchable URL of the schema that was applied. Implementors can re-validate
+  locally against the same artifact the runner used, eliminating the "my local
+  AJV run passed" class of dead-end debugging.
+- Adds a `skip_result` block that requires runners to distinguish
+  `not_applicable` (agent did not claim the protocol) from `no_phases`
+  (storyboard is a placeholder), `prerequisite_failed`, `missing_tool`,
+  `missing_test_controller`, and `unsatisfied_contract` so an agent that
+  declares `supported_protocols: ["signals"]` but sees "Signals track — SKIP"
+  gets a reason that tells them which of those six cases applies.
+- Adds an `extraction` block requiring runners to record which MCP response
+  path (`structured_content` vs `text_fallback`) produced the parsed AdCP
+  response, so runner extraction bugs are separable from agent bugs.
+- Cross-referenced from `storyboard-schema.yaml` — storyboard authors assume
+  failures will be rendered with this detail and write descriptions accordingly.
+
+Non-goals: output formatting, scoring thresholds, UI rendering. The contract
+specifies minimum actionability; runners remain free to add fields and render
+them however the surface requires.

--- a/.changeset/runner-output-contract.md
+++ b/.changeset/runner-output-contract.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-spec(compliance): define runner output contract for actionable failure detail (#2352)
+spec(compliance): runner output contract + security hardening for actionable failure detail (#2352)
 
 Storyboard runners (evaluate_agent_quality, `@adcp/client storyboard run`, any
 other compliance harness) MUST emit enough detail on validation failures for an
@@ -16,18 +16,43 @@ bug, or a genuine agent bug.
   and fetchable URL of the schema that was applied. Implementors can re-validate
   locally against the same artifact the runner used, eliminating the "my local
   AJV run passed" class of dead-end debugging.
-- Adds a `skip_result` block that requires runners to distinguish
-  `not_applicable` (agent did not claim the protocol) from `no_phases`
-  (storyboard is a placeholder), `prerequisite_failed`, `missing_tool`,
-  `missing_test_controller`, and `unsatisfied_contract` so an agent that
-  declares `supported_protocols: ["signals"]` but sees "Signals track — SKIP"
-  gets a reason that tells them which of those six cases applies.
-- Adds an `extraction` block requiring runners to record which MCP response
-  path (`structured_content` vs `text_fallback`) produced the parsed AdCP
-  response, so runner extraction bugs are separable from agent bugs.
-- Cross-referenced from `storyboard-schema.yaml` — storyboard authors assume
-  failures will be rendered with this detail and write descriptions accordingly.
+- `skip_result` block requires runners to distinguish `not_applicable` (agent
+  did not claim the protocol) from `no_phases` (storyboard is a placeholder),
+  `prerequisite_failed`, `missing_tool`, `missing_test_controller`, and
+  `unsatisfied_contract`. Acknowledges that runners MAY track narrower internal
+  reasons and map them onto the canonical six for stable machine-readable output.
+- `extraction` block requires runners to record which MCP response path
+  (`structured_content` vs `text_fallback`) produced the parsed AdCP response,
+  so runner extraction bugs are separable from agent bugs.
+- A2A response payload shape is now specified precisely:
+  `task.artifacts[0].parts[]` DataPart for final states, `task.status.message.parts[]`
+  for interim states, `status.state` alongside payload.
+
+**Security hardening (v1.1.0).** A runner that emits exact request/response
+payloads into a shared report could leak credentials or agent-planted
+breadcrumbs. Four normative rules close this gap, derived from the conforming
+implementation at adcp-client#611:
+
+- **Payload redaction.** Values at keys matching a minimum case-insensitive
+  regex (authorization, token, api_key, password, secret, bearer, cookie,
+  set-cookie, and variants) are replaced with `"[redacted]"` before emission.
+  The pattern is a floor; runners MAY extend but MUST NOT narrow.
+- **Response-header allowlist.** Only `content-type`, `content-length`,
+  `content-encoding`, `www-authenticate`, `location`, `retry-after`,
+  `x-request-id`, `x-correlation-id` pass through. Everything else is dropped
+  (not redacted) to avoid publishing the set of header names a hostile agent
+  added.
+- **Request headers.** Runners SHOULD NOT populate request.headers by default
+  — echoing an in-flight `Authorization: Bearer <token>` into a shared report
+  is a credential leak. When populated (auth-override probes), keys matching
+  the redaction pattern MUST be redacted and all others MUST pass the
+  allowlist.
+- **LLM fencing.** Agent-controlled `error` / `actual` strings rendered into
+  shared surfaces MUST be fenced so a hostile error message cannot inject
+  instructions into a downstream summarizer.
 
 Non-goals: output formatting, scoring thresholds, UI rendering. The contract
 specifies minimum actionability; runners remain free to add fields and render
 them however the surface requires.
+
+Conforming implementation: adcp-client#611.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -1,0 +1,226 @@
+# Runner Output Contract
+#
+# Defines the failure-result shape that any AdCP compliance runner MUST emit
+# when it reports storyboard results to a user or coding agent. Applies to
+# evaluate_agent_quality, `@adcp/client storyboard run`, and any other harness
+# that executes the storyboards published under /compliance/{version}/.
+#
+# Rationale
+# ---------
+# A failing validation is only actionable if the implementor can see:
+#   1. The exact request the runner sent.
+#   2. The exact response the agent returned.
+#   3. Which field failed (as an RFC 6901 JSON Pointer).
+#   4. What the runner expected vs. what it observed.
+#   5. The identity of the schema applied (so the implementor can re-validate
+#      locally against the same artifact).
+#
+# Without these, a buyer building an agent cannot diagnose failures even when
+# their own local validation passes — a mismatch between the schema they tested
+# against and the schema the runner used is indistinguishable from a genuine
+# agent bug.
+#
+# Storyboard AUTHORING is covered in storyboard-schema.yaml. This contract
+# covers runner OUTPUT.
+#
+# --- Schema definition ---
+
+id: runner_output_contract
+version: "1.0.0"
+title: "Runner output contract"
+summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
+
+# A storyboard step result is produced per step the runner executes. Each
+# step result carries zero or more validation results — one per `check` in
+# the storyboard's step.validations array, plus any transport-level check
+# the runner performs (e.g., extraction path).
+
+step_result:
+  description: |
+    Runners MUST emit one step result per executed step. Skipped steps MUST
+    include a skip result block. Failed steps MUST include at least one
+    validation result with passed: false.
+  required_fields:
+    - storyboard_id           # e.g. "capability_discovery"
+    - phase_id                # e.g. "protocol_discovery"
+    - step_id                 # e.g. "get_capabilities"
+    - task                    # AdCP task name invoked, e.g. "get_adcp_capabilities"
+    - passed                  # boolean — all required validations passed
+    - duration_ms             # wall-clock time for this step
+    - validations             # array of validation_result objects (see below)
+    - extraction              # transport extraction record (see below)
+  optional_fields:
+    - skip                    # skip_result block when the step was not run
+    - error                   # transport-level error (no validations attempted)
+    - request                 # exact request the runner sent (see request block)
+    - response                # exact response observed (see response block)
+
+validation_result:
+  description: |
+    Every validation result — whether passed or failed — MUST carry the fields
+    below. Failed validations MUST include request, response, json_pointer,
+    expected, and actual unless the failure is transport-level (in which case
+    json_pointer, expected, and actual MAY be null and the step-level error
+    field carries the transport failure).
+  required_fields:
+    - check                   # Validation kind from storyboard-schema.yaml:
+                              # response_schema | field_present | field_value |
+                              # status_code | http_status | http_status_in |
+                              # error_code | on_401_require_header |
+                              # resource_equals_agent_url | any_of
+    - passed                  # boolean
+    - description             # human-readable description copied from the
+                              # storyboard validation entry (so the implementor
+                              # sees the same text the author wrote)
+  required_on_failure:
+    - request                 # exact request the runner sent (see request block)
+    - response                # exact response observed (see response block)
+    - json_pointer            # RFC 6901 pointer to the failing field in the
+                              # response, or the request for input-level
+                              # failures. Null only when the failure is
+                              # transport-level and no payload was returned.
+    - expected                # machine-readable expected value:
+                              #   response_schema → schema $id that was applied
+                              #   field_value     → expected value (any JSON type)
+                              #   field_present   → the path that should resolve
+                              #   status_code     → expected status
+                              #   error_code      → expected error code
+                              #   any_of          → array of acceptable forms
+    - actual                  # machine-readable actual value observed:
+                              #   response_schema → array of schema errors
+                              #                     (each { instance_path,
+                              #                     schema_path, keyword,
+                              #                     message })
+                              #   field_value     → actual value (any JSON type)
+                              #   field_present   → null (the field was missing)
+                              #                     or the observed non-object
+                              #                     value
+    - schema_id               # $id of the response schema applied. Required
+                              # when check == response_schema, null otherwise.
+    - schema_url              # Resolvable URL the implementor can fetch to
+                              # validate locally. Required when
+                              # check == response_schema, null otherwise.
+  optional_fields:
+    - remediation             # runner-suggested fix when the failure maps to
+                              # a well-known cause (e.g., "agent did not echo
+                              # context.correlation_id — see
+                              # docs/building/implementation/task-lifecycle")
+
+request:
+  description: |
+    Exact request the runner sent, per transport.
+  required_fields:
+    - transport               # "mcp" | "a2a" | "http"
+    - operation               # task/tool/skill name actually invoked (matches
+                              # step.task after any test-kit interpolation)
+    - payload                 # fully-resolved JSON payload after test-kit
+                              # substitution and context injection — the bytes
+                              # that went on the wire (modulo transport
+                              # framing). Secrets SHOULD be redacted with the
+                              # literal string "[redacted]".
+  optional_fields:
+    - headers                 # observed request headers, secrets redacted
+    - url                     # full URL for http/a2a; omit for stdio MCP
+
+response:
+  description: |
+    Exact response observed from the agent, per transport.
+  required_fields:
+    - transport               # "mcp" | "a2a" | "http"
+    - payload                 # MCP: { isError, structuredContent, content }
+                              # A2A: the artifact envelope
+                              # http: parsed body
+  optional_fields:
+    - status                  # HTTP status where applicable
+    - headers                 # observed response headers
+    - duration_ms             # wall-clock time for this request
+
+extraction:
+  description: |
+    Runners MUST follow the MCP response-extraction algorithm at
+    docs/building/implementation/mcp-response-extraction.mdx and the A2A
+    equivalent. When both structuredContent and content[].text are present,
+    structuredContent wins. Recording the path that was actually used lets
+    the implementor distinguish a runner extraction bug from an agent bug.
+  required_fields:
+    - path                    # "structured_content" | "text_fallback" |
+                              # "error" | "none"
+  optional_fields:
+    - note                    # e.g. "structuredContent contained only
+                              # adcp_error — treated as error"
+
+skip_result:
+  description: |
+    When a track, storyboard, phase, or step is skipped, runners MUST
+    distinguish between the reasons below so an implementor knows whether
+    the skip is informative (the agent did not claim the protocol) or
+    masking (the runner could not apply the storyboard even though the
+    agent claimed the protocol).
+  required_fields:
+    - reason                  # not_applicable | no_phases |
+                              # prerequisite_failed | missing_tool |
+                              # missing_test_controller |
+                              # unsatisfied_contract
+    - detail                  # human-readable explanation citing the
+                              # declared supported_protocols / specialisms
+                              # and, if relevant, the missing tool,
+                              # prerequisite step id, or contract key.
+  reasons:
+    not_applicable: |
+      The agent did not declare the protocol or specialism this storyboard
+      targets. detail MUST cite the agent's declared supported_protocols
+      and specialisms.
+    no_phases: |
+      The storyboard is a placeholder with no phases to run (e.g., a
+      protocol baseline that has not been populated yet). detail MUST cite
+      the storyboard id and version.
+    prerequisite_failed: |
+      A prior step this one depends on did not pass. detail MUST cite the
+      prerequisite step id.
+    missing_tool: |
+      The agent declared the protocol or specialism but does not expose a
+      required tool. detail MUST cite the tool name declared in the
+      storyboard's required_tools and the agent's advertised tool list.
+    missing_test_controller: |
+      The storyboard requires comply_test_controller and the agent did not
+      advertise it. Applies only to deterministic_testing phases.
+    unsatisfied_contract: |
+      A test-kit harness contract (e.g., signed-requests-runner) is not in
+      scope for this grading run. detail MUST cite the contract key. Per
+      the signed-requests-runner contract, unsatisfied contracts grade as
+      FAIL, not SKIP, for the specialisms that declare them — this reason
+      applies only where the contract explicitly permits SKIP.
+
+summary:
+  description: |
+    Runners MUST expose a top-level summary for every run. UI surfaces
+    (Addie, CLI, web) may present a condensed form, but the full summary
+    MUST be available in the machine-readable (--json / structuredContent)
+    output.
+  required_fields:
+    - total_steps
+    - steps_passed
+    - steps_failed
+    - steps_skipped
+    - tracks                  # per-track status with the skip distinctions above
+    - schemas_used            # array of { schema_id, schema_url } so an
+                              # implementor can re-validate locally against
+                              # the exact artifacts the runner applied
+
+# --- Non-goals ---
+#
+# This contract does NOT specify:
+#   - Output formatting (markdown, JSON shape in the outer envelope, colors).
+#   - Storage or retention of run artifacts.
+#   - Scoring weights or pass/fail thresholds for a "compliant" verdict.
+#   - How to render results in conversational interfaces.
+# Runners remain free to add fields, nest them under implementation-specific
+# keys, and render them however best fits the surface. The contract is about
+# minimum actionability.
+
+references:
+  storyboard_schema: static/compliance/source/universal/storyboard-schema.yaml
+  mcp_extraction: docs/building/implementation/mcp-response-extraction.mdx
+  a2a_extraction: docs/building/implementation/a2a-response-extraction.mdx
+  transport_errors: docs/building/implementation/transport-errors.mdx
+  signed_requests_runner: static/compliance/source/test-kits/signed-requests-runner.yaml

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,9 +26,15 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "1.0.0"
+version: "1.1.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
+
+# Conforming implementation: adcp-client PR #611
+# (src/lib/testing/storyboard/types.ts — RunnerRequestRecord,
+# RunnerResponseRecord, ValidationResult, RunnerSkipResult, etc.).
+# The concrete shapes, redaction pattern, and header allowlist below are
+# taken from that implementation.
 
 # A storyboard step result is produced per step the runner executes. Each
 # step result carries zero or more validation results — one per `check` in
@@ -108,18 +114,21 @@ validation_result:
 
 request:
   description: |
-    Exact request the runner sent, per transport.
+    Exact request the runner sent, per transport. Runners MUST redact secrets
+    before emission — see the `security` block below.
   required_fields:
     - transport               # "mcp" | "a2a" | "http"
     - operation               # task/tool/skill name actually invoked (matches
                               # step.task after any test-kit interpolation)
     - payload                 # fully-resolved JSON payload after test-kit
-                              # substitution and context injection — the bytes
-                              # that went on the wire (modulo transport
-                              # framing). Secrets SHOULD be redacted with the
-                              # literal string "[redacted]".
+                              # substitution and context injection, with
+                              # secret-bearing fields replaced per the
+                              # redaction policy in the security block.
   optional_fields:
-    - headers                 # observed request headers, secrets redacted
+    - headers                 # Runners SHOULD NOT populate this field by
+                              # default — see security.request_headers. The
+                              # field exists for future auth-override captures
+                              # that carry a fully-redacted form.
     - url                     # full URL for http/a2a; omit for stdio MCP
 
 response:
@@ -128,11 +137,17 @@ response:
   required_fields:
     - transport               # "mcp" | "a2a" | "http"
     - payload                 # MCP: { isError, structuredContent, content }
-                              # A2A: the artifact envelope
+                              # A2A: the Task object — record task.status.state
+                              #   alongside payload. Extract from
+                              #   task.artifacts[0].parts[] DataPart for final
+                              #   states and task.status.message.parts[] for
+                              #   interim states (per
+                              #   docs/building/implementation/a2a-response-extraction.mdx).
                               # http: parsed body
   optional_fields:
     - status                  # HTTP status where applicable
-    - headers                 # observed response headers
+    - headers                 # observed response headers, filtered through
+                              # the allowlist in security.response_headers
     - duration_ms             # wall-clock time for this request
 
 extraction:
@@ -148,6 +163,72 @@ extraction:
   optional_fields:
     - note                    # e.g. "structuredContent contained only
                               # adcp_error — treated as error"
+
+security:
+  description: |
+    Runner output is consumed in compliance reports, chat transcripts, and
+    shared dashboards where credentials or breadcrumbs a hostile agent plants
+    in a response must not surface. A runner claiming contract conformance
+    without the rules below could leak tokens through a compliant-looking
+    report — defeating the contract's purpose. These rules are normative.
+
+  payload_redaction:
+    description: |
+      Runners MUST recursively redact key-value pairs from request.payload
+      and response.payload before emitting the step result. Values at keys
+      matching the pattern below are replaced with the literal string
+      "[redacted]". Matching is case-insensitive and applies at any depth.
+    pattern: |
+      ^(authorization|credentials?|token|api[_-]?key|password|secret|
+      client[_-]secret|refresh[_-]token|access[_-]token|bearer|
+      session[_-]token|offering[_-]token|cookie|set[_-]cookie)$
+    notes: |
+      The pattern above is the MINIMUM floor taken from the adcp-client#611
+      conforming implementation. Runners MAY extend it for operator-
+      specific key names (e.g., internal vendor headers) but MUST NOT
+      narrow it. Redaction happens after the payload is serialized for
+      the report, not at transport time — the wire request carries real
+      credentials; the emitted record does not.
+
+  response_headers:
+    description: |
+      Response headers MUST pass through an allowlist before emission. Any
+      header not in the allowlist MUST be dropped (not redacted — absent).
+      Dropping rather than redacting avoids publishing the set of header
+      names a hostile agent added, which itself can be a breadcrumb.
+    allowlist:
+      - content-type
+      - content-length
+      - content-encoding
+      - www-authenticate
+      - location
+      - retry-after
+      - x-request-id
+      - x-correlation-id
+    notes: |
+      www-authenticate is retained because it's load-bearing for auth-probe
+      validations (on_401_require_header). Matching is case-insensitive.
+
+  request_headers:
+    description: |
+      Runners SHOULD NOT populate request.headers. A runner that builds
+      `Authorization: Bearer <token>` headers in-flight would leak the token
+      by echoing the observed request into a shared report. When a runner
+      does populate request.headers (e.g., for auth-override probes that
+      intentionally send bogus credentials), values at keys matching the
+      payload_redaction pattern MUST be replaced with "[redacted]" and all
+      other headers MUST pass through the response_headers allowlist.
+
+  rendered_output_fencing:
+    description: |
+      Validation `error` and `actual` fields can carry strings the agent
+      under test controlled. When a runner renders these into a shared
+      surface (chat transcript, markdown report, summary fed to another
+      LLM), those strings MUST be fenced with a nonce or otherwise isolated
+      so a hostile error message cannot inject instructions into a
+      downstream summarizer. This applies to rendered output, not to the
+      machine-readable step_result — the raw string stays in the JSON for
+      programmatic consumers.
 
 skip_result:
   description: |
@@ -191,6 +272,17 @@ skip_result:
       FAIL, not SKIP, for the specialisms that declare them — this reason
       applies only where the contract explicitly permits SKIP.
 
+  detailed_reason_mapping:
+    description: |
+      Runners MAY internally track narrower skip reasons (e.g., a grader
+      distinguishing `rate_abuse_opt_out` from `live_side_effect_opt_in_required`).
+      Such runners MUST still populate `reason` with one of the six canonical
+      values above and encode the narrower cause in `detail`. Machine-
+      readable consumers can then switch on a stable enum; human-readable
+      consumers still see the specific cause. See
+      DETAILED_SKIP_TO_CANONICAL in the conforming implementation for a
+      concrete mapping.
+
 summary:
   description: |
     Runners MUST expose a top-level summary for every run. UI surfaces
@@ -224,3 +316,4 @@ references:
   a2a_extraction: docs/building/implementation/a2a-response-extraction.mdx
   transport_errors: docs/building/implementation/transport-errors.mdx
   signed_requests_runner: static/compliance/source/test-kits/signed-requests-runner.yaml
+  conforming_implementation: https://github.com/adcontextprotocol/adcp-client/pull/611

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -119,3 +119,12 @@
 # value: any (expected value — string, number, or boolean; required when check is "field_value")
 # allowed_values: array (acceptable values for "field_value", "http_status_in", "error_code", "any_of")
 # description: string (human-readable description of validation)
+#
+# --- Runner output ---
+#
+# How a runner MUST report validation results — including which fields a
+# failing validation carries (exact request, response, JSON Pointer, expected
+# vs. actual, schema $id, schema URL) and how skipped storyboards MUST
+# distinguish not_applicable vs. no_phases vs. missing_tool — is defined in
+# runner-output-contract.yaml. Storyboard authors SHOULD assume failures will
+# be rendered with that detail and write descriptions accordingly.


### PR DESCRIPTION
## Summary

Adds a universal runner-output contract defining the minimum failure-result shape every AdCP compliance runner (`evaluate_agent_quality`, `@adcp/client storyboard run`, any future harness) MUST emit. Closes the actionability gap raised in #2352.

### What changes
- **New** `static/compliance/source/universal/runner-output-contract.yaml` — contract definition covering:
  - `validation_result` required on failure: exact `request` sent, exact `response` observed, RFC 6901 `json_pointer` to the failing field, machine-readable `expected` / `actual`, and for `response_schema` checks the `schema_id` + fetchable `schema_url`.
  - `skip_result` reasons that distinguish `not_applicable` / `no_phases` / `prerequisite_failed` / `missing_tool` / `missing_test_controller` / `unsatisfied_contract`.
  - `extraction` block requiring runners to record which MCP path (`structured_content` vs `text_fallback`) produced the parsed response.
  - `security` block (v1.1.0 addition, backported from the conforming implementation): payload redaction pattern, response-header allowlist, request-header policy, and LLM fencing for agent-controlled strings in rendered output.
  - A2A response payload shape specified precisely: `task.artifacts[0].parts[]` DataPart for final states, `task.status.message.parts[]` for interim, `status.state` alongside payload.
  - `DETAILED_SKIP_TO_CANONICAL` pattern acknowledgment — runners may track narrower internal reasons and map to the canonical six.
- **Updated** `static/compliance/source/universal/storyboard-schema.yaml` — cross-reference to the contract.

### Why the security hardening matters
A runner that emits exact request/response payloads into a shared compliance report could leak credentials or agent-planted breadcrumbs while still claiming contract conformance. The four security rules close that gap:
- **Payload redaction** — case-insensitive regex covering `authorization`, `token`, `api_key`, `password`, `secret`, `bearer`, `cookie`, `set-cookie`, and variants. Minimum floor; runners MAY extend but MUST NOT narrow.
- **Response-header allowlist** — 8 headers (content-type, content-length, content-encoding, www-authenticate, location, retry-after, x-request-id, x-correlation-id). Others dropped (not redacted).
- **Request headers** — SHOULD NOT be populated by default. When populated (auth-override probes), MUST apply both redaction and allowlist.
- **LLM fencing** — agent-controlled `error` / `actual` strings rendered into shared surfaces MUST be fenced so hostile error messages cannot inject into downstream summarizers.

### Conforming implementation
[adcp-client#611](https://github.com/adcontextprotocol/adcp-client/pull/611) — closes adcp-client#599. The security hardening section is taken directly from that PR's redaction regex and header allowlist.

### Non-goals
Output formatting, scoring thresholds, UI rendering. The contract specifies minimum actionability; runners remain free to add fields and render them however the surface requires.

### Follow-ups (separate PRs/issues)
- #2365 — signals baseline phases + specialism idempotency_key fixes
- #2366 — release-hygiene: re-publish schemas carrying #2315 + tag-at-merge policy

## Test plan

- [x] `node scripts/build-compliance.cjs` — 9 universal, 6 protocols, 23 specialisms. Clean build.
- [x] Precommit: `npm run test:unit && npm run typecheck` — 587 tests pass.
- [x] Mintlify docs validation passes.
- [x] Reviewed by `ad-tech-protocol-expert`, `adtech-product-expert`, and `dx-expert` subagents; blocking items from those reviews addressed. Security hardening added after conforming implementation landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)