### PR TITLE
spec(compliance): populate signals protocol baseline phases (#2356)

### DIFF
--- a/.changeset/signals-baseline-phases.md
+++ b/.changeset/signals-baseline-phases.md
@@ -2,29 +2,42 @@
 "adcontextprotocol": patch
 ---
 
-spec(compliance): populate signals protocol baseline with real phases (#2356)
+spec(compliance): populate signals protocol baseline + fix signal storyboard gaps (#2356)
 
 The `protocols/signals/index.yaml` baseline was a 3.1 placeholder with
 `phases: []`, which meant every agent declaring
 `supported_protocols: ["signals"]` saw "Signals track — SKIP (not applicable)"
 regardless of how compliant its get_signals and activate_signal implementations
 were. Compliance coverage for signals agents could only come from claiming a
-specialism (signal-owned or signal-marketplace), which is not how
-protocol-level baselines are supposed to work.
+specialism, which is not how protocol-level baselines are supposed to work.
+
+**Signals baseline**
 
 - Populates the baseline with three phases — capability_discovery, discovery
   (get_signals), and activation (activate_signal) — covering the subset of
   behavior that BOTH signal-owned and signal-marketplace specialisms depend
-  on. Specialism storyboards continue to exercise their richer flows (pricing
-  option selection, source discriminators, agent-vs-platform destinations,
-  deactivation).
+  on. The activation phase has two steps (agent destination + platform
+  destination) because the signals spec requires every signals agent to
+  accept both destination types; testing only one lets a non-conformant
+  agent pass.
 - Adds `required_tools: [get_signals, activate_signal]` so an agent declaring
   signals without exposing those tools produces a `missing_tool` skip reason
-  (per the runner-output contract introduced in #2352) rather than the
-  misleading `not_applicable`.
-- Carries `context_outputs` from the discovery step through to activation so
-  the activation step reuses the captured `signal_agent_segment_id` and
-  `pricing_option_id` instead of hard-coded fixtures.
+  (per the runner-output contract in #2352) rather than the misleading
+  `not_applicable`.
+- Carries `context_outputs` from the discovery step through to activation
+  so both activation steps reuse the captured `signal_agent_segment_id`
+  and `pricing_option_id` instead of hard-coded fixtures.
 
-Bumps baseline version to 1.1.0 to mark the transition from placeholder to
-runnable storyboard.
+**Signal specialism storyboard fix (bundled)**
+
+- Every `activate_signal` sample_request in `specialisms/signal-owned` and
+  `specialisms/signal-marketplace` was missing `idempotency_key`, which the
+  request schema marks as required. The `@adcp/client` runner (post
+  adcp-client#602) forwards `idempotency_key` from sample_request through
+  the request builder instead of silently auto-injecting, so a missing key
+  in the storyboard now produces a schema-invalid request. Added
+  `idempotency_key: "$generate:uuid_v4#<alias>"` to all four activation
+  steps so the runner resolves a deterministic UUID per step.
+
+Baseline version bumped to 1.1.0 to mark the transition from placeholder
+to runnable storyboard.

--- a/.changeset/signals-baseline-phases.md
+++ b/.changeset/signals-baseline-phases.md
@@ -1,0 +1,30 @@
+---
+"adcontextprotocol": patch
+---
+
+spec(compliance): populate signals protocol baseline with real phases (#2356)
+
+The `protocols/signals/index.yaml` baseline was a 3.1 placeholder with
+`phases: []`, which meant every agent declaring
+`supported_protocols: ["signals"]` saw "Signals track — SKIP (not applicable)"
+regardless of how compliant its get_signals and activate_signal implementations
+were. Compliance coverage for signals agents could only come from claiming a
+specialism (signal-owned or signal-marketplace), which is not how
+protocol-level baselines are supposed to work.
+
+- Populates the baseline with three phases — capability_discovery, discovery
+  (get_signals), and activation (activate_signal) — covering the subset of
+  behavior that BOTH signal-owned and signal-marketplace specialisms depend
+  on. Specialism storyboards continue to exercise their richer flows (pricing
+  option selection, source discriminators, agent-vs-platform destinations,
+  deactivation).
+- Adds `required_tools: [get_signals, activate_signal]` so an agent declaring
+  signals without exposing those tools produces a `missing_tool` skip reason
+  (per the runner-output contract introduced in #2352) rather than the
+  misleading `not_applicable`.
+- Carries `context_outputs` from the discovery step through to activation so
+  the activation step reuses the captured `signal_agent_segment_id` and
+  `pricing_option_id` instead of hard-coded fixtures.
+
+Bumps baseline version to 1.1.0 to mark the transition from placeholder to
+runnable storyboard.

--- a/static/compliance/source/protocols/signals/index.yaml
+++ b/static/compliance/source/protocols/signals/index.yaml
@@ -156,13 +156,14 @@ phases:
       exercise owned vs. marketplace activation patterns in depth.
 
     steps:
-      - id: activate_discovered_signal
-        title: "Activate a discovered signal"
+      - id: activate_on_agent
+        title: "Activate on a sales agent destination"
         narrative: |
           Using the signal_agent_segment_id and pricing_option_id captured
           from the previous step, the buyer activates the signal on a sales
-          agent destination. The agent returns a deployments array with at
-          least one entry describing how the activation was handled.
+          agent destination. Every signals agent MUST accept `type: agent`
+          per the signals specification — the SA records the activation
+          internally and applies targeting in subsequent media-buy calls.
         task: activate_signal
         schema_ref: "signals/activate-signal-request.json"
         response_schema_ref: "signals/activate-signal-response.json"
@@ -171,10 +172,9 @@ phases:
         stateful: true
         expected: |
           Return a deployments array with at least one entry carrying a
-          `type` discriminator (platform | agent | cleanroom) and, for
-          live deployments, an `activation_key`. Agents MAY return an
-          async deployment with `is_live: false` and
-          `estimated_activation_duration_minutes`.
+          `type` discriminator and, for live deployments, an
+          `activation_key`. Agents MAY return an async deployment with
+          `is_live: false` and `estimated_activation_duration_minutes`.
 
         sample_request:
           signal_agent_segment_id: "$context.signal_agent_segment_id"
@@ -182,8 +182,9 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
+          idempotency_key: "$generate:uuid_v4#signals_baseline_activate_agent"
           context:
-            correlation_id: "signals_baseline--activate_discovered_signal"
+            correlation_id: "signals_baseline--activate_on_agent"
           ext:
             test_platform:
               test_run: true
@@ -199,5 +200,53 @@ phases:
             description: "Response echoes back the context object"
           - check: field_value
             path: "context.correlation_id"
-            value: "signals_baseline--activate_discovered_signal"
+            value: "signals_baseline--activate_on_agent"
+            description: "Context correlation_id returned unchanged"
+
+      - id: activate_on_platform
+        title: "Activate on a platform destination"
+        narrative: |
+          The buyer re-activates the same signal against a platform
+          destination (a DSP). Signal agents MUST accept `type: platform`
+          per the signals specification — the agent pushes the segment to
+          the platform and returns a deployment record.
+        task: activate_signal
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: signals_flow
+        stateful: true
+        expected: |
+          Return a deployments array with at least one entry whose
+          `type: "platform"` and, for live deployments, an
+          `activation_key` with `type: "segment_id"`. Async deployments
+          MAY report `is_live: false` with
+          `estimated_activation_duration_minutes`.
+
+        sample_request:
+          signal_agent_segment_id: "$context.signal_agent_segment_id"
+          pricing_option_id: "$context.pricing_option_id"
+          destinations:
+            - type: "platform"
+              platform: "the-trade-desk"
+              account: "agency-123-ttd"
+          idempotency_key: "$generate:uuid_v4#signals_baseline_activate_platform"
+          context:
+            correlation_id: "signals_baseline--activate_on_platform"
+          ext:
+            test_platform:
+              test_run: true
+        validations:
+          - check: response_schema
+            description: "Response matches activate-signal-response.json schema"
+          - check: field_present
+            path: "deployments[0].type"
+            description: "Deployment carries a type discriminator"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signals_baseline--activate_on_platform"
             description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/signals/index.yaml
+++ b/static/compliance/source/protocols/signals/index.yaml
@@ -1,23 +1,203 @@
 id: signals_baseline
-version: "1.0.0"
+version: "1.1.0"
 title: "Signals baseline"
 protocol: signals
-summary: "Baseline domain storyboard — every signal agent must discover signals, return typed signal responses, and support activation handoff to media-buy agents."
+category: signals_baseline
+summary: "Baseline domain storyboard — every signals agent must discover signals and return an activation, regardless of whether they are owned or marketplace."
 track: signals
+required_tools:
+  - get_signals
+  - activate_signal
 
 narrative: |
-  Signals domain agents expose audience signals, contextual signals, and
-  activation endpoints. The baseline requires capability discovery,
-  get_signals, and activate_signal.
+  Signals domain agents expose audience and contextual signals to buyers and
+  activate them on downstream destinations (DSPs, sales agents, clean rooms).
+  Every signals agent — whether a first-party owned platform or a third-party
+  marketplace — must support the same three-call flow at the protocol level:
 
-  3.1 placeholder: full signals baseline phases will be populated as the
-  signals protocol stabilizes further. Until then, agents claiming this
-  domain must pass universal storyboards.
+    1. Declare the signals protocol in get_adcp_capabilities.
+    2. Respond to get_signals with a schema-valid signals array.
+    3. Respond to activate_signal with a schema-valid deployments array.
+
+  This baseline tests those three calls and nothing beyond them. Specialism
+  storyboards (signal-owned, signal-marketplace) exercise the richer flows
+  specific to each model — pricing option selection, source/provenance
+  discriminators, agent-destination vs. platform-destination activation,
+  and deactivation for compliance.
+
+  Agents declaring supported_protocols: ["signals"] MUST pass this baseline
+  even before claiming a specialism. Declaring signals without exposing
+  get_signals or activate_signal fails the baseline with missing_tool.
 
 agent:
-  interaction_model: signals_agent
+  interaction_model: owned_signals
+  capabilities: []
+  examples:
+    - "Any signals agent (owned or marketplace)"
+    - "Retailer CDPs"
+    - "Publisher contextual platforms"
+    - "Data provider marketplaces"
 
 caller:
   role: buyer_agent
+  example: "Scope3 (DSP)"
 
-phases: []
+prerequisites:
+  description: |
+    The buyer has a campaign brief with broad targeting objectives. The test
+    kit provides a sample brand (Nova Motors) with a signal description that
+    any signals agent should be able to interpret.
+  test_kit: "test-kits/nova-motors.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent serves signals
+      before issuing discovery or activation calls.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares `signals` in supported_protocols.
+          Without this claim the buyer will not send get_signals or
+          activate_signal.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring `signals` in supported_protocols.
+
+        sample_request:
+          context:
+            correlation_id: "signals_baseline--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signals_baseline--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: discovery
+    title: "Signal discovery"
+    narrative: |
+      The buyer calls get_signals with a natural language signal_spec. Every
+      signals agent — owned or marketplace — must return a schema-valid
+      response. The buyer uses the returned signal_agent_segment_id values
+      to drive activation in the next phase.
+
+    steps:
+      - id: search_signals
+        title: "Discover signals matching a spec"
+        narrative: |
+          The buyer describes a target audience in natural language. The agent
+          returns a list of signals from its catalog that match. Each signal
+          must include the fields the buyer needs to proceed to activation.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: signals_flow
+        stateful: false
+        expected: |
+          Return a signals array with at least one entry. Each signal must
+          carry a signal_agent_segment_id that the buyer can pass to
+          activate_signal, along with pricing_options and a signal_id that
+          includes a source discriminator.
+
+        sample_request:
+          signal_spec: "Adults interested in electric vehicles"
+          context:
+            correlation_id: "signals_baseline--search_signals"
+        context_outputs:
+          - name: signal_agent_segment_id
+            path: "signals[0].signal_agent_segment_id"
+          - name: pricing_option_id
+            path: "signals[0].pricing_options[0].pricing_option_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-signals-response.json schema"
+          - check: field_present
+            path: "signals[0].signal_agent_segment_id"
+            description: "First signal carries a signal_agent_segment_id"
+          - check: field_present
+            path: "signals[0].signal_id.source"
+            description: "Signal ID carries a source discriminator (agent_native or data_provider)"
+          - check: field_present
+            path: "signals[0].pricing_options"
+            description: "Signal carries pricing options the buyer can select"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signals_baseline--search_signals"
+            description: "Context correlation_id returned unchanged"
+
+  - id: activation
+    title: "Signal activation"
+    narrative: |
+      The buyer activates one of the signals returned from discovery against
+      a destination. The protocol baseline tests only that the agent accepts
+      the call and returns a schema-valid deployments array — specialisms
+      exercise owned vs. marketplace activation patterns in depth.
+
+    steps:
+      - id: activate_discovered_signal
+        title: "Activate a discovered signal"
+        narrative: |
+          Using the signal_agent_segment_id and pricing_option_id captured
+          from the previous step, the buyer activates the signal on a sales
+          agent destination. The agent returns a deployments array with at
+          least one entry describing how the activation was handled.
+        task: activate_signal
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: signals_flow
+        stateful: true
+        expected: |
+          Return a deployments array with at least one entry carrying a
+          `type` discriminator (platform | agent | cleanroom) and, for
+          live deployments, an `activation_key`. Agents MAY return an
+          async deployment with `is_live: false` and
+          `estimated_activation_duration_minutes`.
+
+        sample_request:
+          signal_agent_segment_id: "$context.signal_agent_segment_id"
+          pricing_option_id: "$context.pricing_option_id"
+          destinations:
+            - type: "agent"
+              agent_url: "https://wonderstruck.salesagents.example"
+          context:
+            correlation_id: "signals_baseline--activate_discovered_signal"
+          ext:
+            test_platform:
+              test_run: true
+        validations:
+          - check: response_schema
+            description: "Response matches activate-signal-response.json schema"
+          - check: field_present
+            path: "deployments[0].type"
+            description: "Deployment carries a type discriminator"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signals_baseline--activate_discovered_signal"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/signals/index.yaml
+++ b/static/compliance/source/protocols/signals/index.yaml
@@ -183,6 +183,7 @@ phases:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
           idempotency_key: "$generate:uuid_v4#signals_baseline_activate_agent"
+
           context:
             correlation_id: "signals_baseline--activate_on_agent"
           ext:
@@ -231,6 +232,7 @@ phases:
               platform: "the-trade-desk"
               account: "agency-123-ttd"
           idempotency_key: "$generate:uuid_v4#signals_baseline_activate_platform"
+
           context:
             correlation_id: "signals_baseline--activate_on_platform"
           ext:

--- a/static/compliance/source/specialisms/signal-marketplace/index.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/index.yaml
@@ -294,6 +294,7 @@ phases:
             - type: "platform"
               platform: "the-trade-desk"
               account: "agency-123-ttd"
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_platform"
 
           context:
             correlation_id: "signal_marketplace--activate_on_platform"
@@ -363,6 +364,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_agent"
 
           context:
             correlation_id: "signal_marketplace--activate_on_agent"

--- a/static/compliance/source/specialisms/signal-owned/index.yaml
+++ b/static/compliance/source/specialisms/signal-owned/index.yaml
@@ -213,6 +213,7 @@ phases:
             - type: "platform"
               platform: "the-trade-desk"
               account: "agency-123-ttd"
+          idempotency_key: "$generate:uuid_v4#signal_owned_activate_platform"
 
           context:
             correlation_id: "signal_owned--activate_on_platform"
@@ -269,6 +270,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
+          idempotency_key: "$generate:uuid_v4#signal_owned_activate_agent"
 
           context:
             correlation_id: "signal_owned--activate_on_agent"


### PR DESCRIPTION
## Summary

Fixes the "Signals track — SKIP (not applicable)" confusion in #2356. The signals protocol baseline shipped as a 3.1 placeholder with `phases: []`, so every agent declaring `supported_protocols: ["signals"]` was told the signals track was not applicable — regardless of how compliant its `get_signals` and `activate_signal` implementations were.

Also bundles two spec-consistency fixes expert review surfaced in adjacent signal storyboards.

### Signals baseline
- Populates `static/compliance/source/protocols/signals/index.yaml` with the minimum every signals agent must do:
  1. `capability_discovery` → `get_adcp_capabilities` with `signals` in `supported_protocols`.
  2. `discovery` → `get_signals` (captures `signal_agent_segment_id` + `pricing_options[0].pricing_option_id` via `context_outputs`).
  3. `activation` → `activate_signal`, **two steps**: agent destination and platform destination. `docs/signals/specification.mdx:186` says signal agents MUST accept both. Testing only `agent` lets a non-conformant agent pass.
- Adds `required_tools: [get_signals, activate_signal]` so an agent declaring signals without those tools produces a `missing_tool` skip reason (per the runner-output contract in #2364) instead of the misleading `not_applicable`.
- Bumps baseline version to 1.1.0.

### Specialism storyboard fix (bundled)
- Every `activate_signal` `sample_request` in `specialisms/signal-owned/index.yaml` and `specialisms/signal-marketplace/index.yaml` was missing `idempotency_key`, which the request schema marks as required. The adcp-client#602 runner changes just landed the forward-through of storyboard-declared idempotency_keys (replacing the silent client-side auto-inject), so the missing declarations are now observable — schema-invalid requests reach the agent.
- Added `idempotency_key: "$generate:uuid_v4#<alias>"` to all four specialism activation steps and both new baseline activation steps, matching the `$generate:` convention in `universal/idempotency.yaml`.

### Specialism storyboards untouched otherwise
Owned-vs-marketplace richer flows (pricing-option selection, source discriminators, deactivation) remain specialism-only. The baseline is the common subset.

### Depends on
- #2364 — runner-output contract: the `missing_tool` skip reason this PR relies on is defined there.
- adcontextprotocol/adcp-client#602 — runner's idempotency_key forward-through makes the specialism storyboard fixes here actually testable.

## Test plan

- [x] `node scripts/build-compliance.cjs` — 6 protocols, 23 specialisms, 8 universal. Clean build.
- [x] Precommit: `npm run test:unit && npm run typecheck` — 587 tests pass.
- [x] Storyboard YAML matches patterns used by signal-owned (context_outputs, stateful activation, response_schema + field_present validations, `$generate:uuid_v4#<alias>` for idempotency_key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)