### PR TITLE
fix(training-agent): enforce idempotency replay/conflict/expired semantics (#2346)

### DIFF
--- a/.changeset/training-agent-idempotency-enforcement.md
+++ b/.changeset/training-agent-idempotency-enforcement.md
@@ -1,0 +1,39 @@
+---
+---
+
+Enforce idempotency replay/conflict/expired semantics in the training agent (closes #2346).
+
+The hosted training agent at `https://test-agent.adcontextprotocol.org` declares
+`adcp.idempotency.replay_ttl_seconds = 86400` in `get_adcp_capabilities` but
+previously ignored `idempotency_key` on mutating requests — two `create_media_buy`
+calls with the same key and same payload created two distinct resources, and key
+reuse with a different payload succeeded instead of returning `IDEMPOTENCY_CONFLICT`.
+Buyer SDKs integrating against this reference agent shipped without testing their
+retry/conflict paths.
+
+A new middleware (`server/src/training-agent/idempotency.ts`) now implements the
+behavior documented in `docs/building/implementation/security.mdx` and validated
+by `static/compliance/source/universal/idempotency.yaml`:
+
+- Schema validation of `idempotency_key` presence and format (`^[A-Za-z0-9_.:-]{16,255}$`)
+  runs before the cache lookup on all 26 mutating tools.
+- Canonical-payload hash (RFC 8785 JCS via the `canonicalize` package +
+  SHA-256) excludes `idempotency_key`, `context`, `governance_context`, and
+  `push_notification_config.authentication.credentials`. Hash comparison uses
+  `timingSafeEqual` on the decoded digests.
+- Same key + equivalent canonical payload → cached response returned verbatim
+  with `replayed: true` on the envelope (omitted on fresh executions).
+- Same key + different canonical payload within TTL → `IDEMPOTENCY_CONFLICT`
+  (error body carries code + message only — no cached payload, hash, or field
+  pointer; schema-shape leaks would turn key-reuse into a read oracle).
+- Past TTL (with ±60s skew) → `IDEMPOTENCY_EXPIRED` and evict so the key can
+  be reused on a subsequent fresh request.
+- Only successful responses are cached; errors re-execute on retry. Tools that
+  return `{ errors: [...] }` in-body are also not cached.
+- Cache is scoped by `(auth principal, account scope, idempotency_key)`. The
+  public sandbox token would otherwise pool every caller into one oracle;
+  per-account partitioning closes the cross-caller probe surface
+  (security.mdx §"three-state response").
+- Per-principal cap (10k entries) with opportunistic sweep of expired entries
+  on overflow; when the cap is still hit, responds with `RATE_LIMITED` rather
+  than silently dropping the insert (which would let a retry re-execute).

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@workos-inc/node": "^8.12.1",
         "@workos-inc/widgets": "^1.10.1",
         "axios": "^1.13.6",
+        "canonicalize": "^3.0.0",
         "cookie-parser": "^1.4.7",
         "csv-parse": "^6.2.1",
         "dotenv": "^17.3.1",
@@ -10234,6 +10235,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ccount": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@workos-inc/node": "^8.12.1",
     "@workos-inc/widgets": "^1.10.1",
     "axios": "^1.13.6",
+    "canonicalize": "^3.0.0",
     "cookie-parser": "^1.4.7",
     "csv-parse": "^6.2.1",
     "dotenv": "^17.3.1",

--- a/server/src/training-agent/idempotency.ts
+++ b/server/src/training-agent/idempotency.ts
@@ -1,0 +1,273 @@
+/**
+ * Idempotency middleware for the training agent.
+ *
+ * Enforces AdCP's at-most-once semantics on mutating tool calls per
+ * `docs/building/implementation/security.mdx` and the `idempotency.yaml`
+ * compliance storyboard:
+ *
+ * - Same `(principal, idempotency_key)` + equivalent canonical payload →
+ *   return the cached inner response with `replayed: true` on the envelope.
+ * - Same key + different canonical payload → `IDEMPOTENCY_CONFLICT`.
+ * - Key past TTL → `IDEMPOTENCY_EXPIRED`.
+ * - Missing key on a mutating request → `INVALID_REQUEST`.
+ *
+ * Canonicalization is RFC 8785 JSON Canonicalization Scheme (JCS) via the
+ * `canonicalize` package, hashed with SHA-256. Excluded from the hash:
+ * `idempotency_key`, `context`, `governance_context`, and
+ * `push_notification_config.authentication.credentials`.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import canonicalize from 'canonicalize';
+
+export const REPLAY_TTL_SECONDS = 86400;
+const REPLAY_TTL_MS = REPLAY_TTL_SECONDS * 1000;
+// ±60s clock-skew tolerance per security.mdx rule 6.
+const TTL_SKEW_MS = 60_000;
+
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_.:-]{16,255}$/;
+
+const MAX_ENTRIES_PER_PRINCIPAL = 10_000;
+
+/**
+ * Tasks whose request schemas require `idempotency_key`.
+ * Derived from static/schemas/source/**\/*-request.json — every schema whose
+ * `required` list includes `idempotency_key` maps to the corresponding tool.
+ */
+export const MUTATING_TOOLS: ReadonlySet<string> = new Set([
+  'create_media_buy',
+  'update_media_buy',
+  'sync_creatives',
+  'build_creative',
+  'activate_signal',
+  'sync_accounts',
+  'sync_governance',
+  'sync_catalogs',
+  'sync_event_sources',
+  'log_event',
+  'provide_performance_feedback',
+  'sync_plans',
+  'report_plan_outcome',
+  'acquire_rights',
+  'update_rights',
+  'creative_approval',
+  'create_property_list',
+  'update_property_list',
+  'delete_property_list',
+  'create_collection_list',
+  'update_collection_list',
+  'delete_collection_list',
+  'create_content_standards',
+  'update_content_standards',
+  'calibrate_content',
+  'report_usage',
+]);
+
+export function isMutatingTool(name: string): boolean {
+  return MUTATING_TOOLS.has(name);
+}
+
+const EXCLUDED_FROM_HASH = new Set([
+  'idempotency_key',
+  'context',
+  'governance_context',
+]);
+
+/**
+ * Build a cache-scoping principal from the auth layer's principal string
+ * and the caller-supplied account reference.
+ *
+ * The public test token (`static:public`) is shared across all sandbox
+ * callers, so scoping only by auth principal would pool every buyer into
+ * one key-space — the three-state response (miss / conflict / expired)
+ * would then be an observable oracle across callers (security.mdx
+ * §"three-state response"). Account-level partitioning contains the
+ * oracle to keys a caller could already enumerate for their own account.
+ *
+ * The shape matches `sessionKeyFromArgs` conceptually: account_id wins
+ * over brand.domain; both are already length/charset bounded upstream so
+ * this layer just consumes whatever string it receives.
+ */
+export function scopedPrincipal(
+  authPrincipal: string,
+  accountScope: string | undefined,
+): string {
+  // `\u001F` (unit separator) keeps auth principals that contain `:` (like
+  // `workos:org_…`) unambiguous even when the account scope is empty.
+  return `${authPrincipal}\u001F${accountScope ?? ''}`;
+}
+
+interface CacheEntry {
+  requestHash: string;
+  response: Record<string, unknown>;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const entriesPerPrincipal = new Map<string, number>();
+
+function strippedForHash(payload: Record<string, unknown>): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(payload)) {
+    if (EXCLUDED_FROM_HASH.has(k)) continue;
+    filtered[k] = v;
+  }
+  // Strip push_notification_config.authentication.credentials (may rotate)
+  const pnc = filtered.push_notification_config as
+    | { authentication?: { credentials?: unknown; [k: string]: unknown }; [k: string]: unknown }
+    | undefined;
+  if (pnc && typeof pnc === 'object' && pnc.authentication && typeof pnc.authentication === 'object') {
+    const { credentials: _drop, ...rest } = pnc.authentication;
+    filtered.push_notification_config = { ...pnc, authentication: rest };
+  }
+  return filtered;
+}
+
+export function payloadHash(payload: Record<string, unknown>): string {
+  const filtered = strippedForHash(payload);
+  const canonical = canonicalize(filtered);
+  if (canonical === undefined) {
+    // RFC 8785 inputs must be canonicalizable JSON. Unreachable for valid
+    // schema-checked payloads; throw loudly so two non-canonicalizable
+    // payloads can't silently hash-equal to the empty string.
+    throw new Error('Cannot canonicalize payload for idempotency hash');
+  }
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function cacheKey(principal: string, idempotencyKey: string): string {
+  return `${principal}\u0000${idempotencyKey}`;
+}
+
+export function validateKeyFormat(key: unknown): key is string {
+  return typeof key === 'string' && IDEMPOTENCY_KEY_PATTERN.test(key);
+}
+
+/**
+ * Constant-time comparison of two hex SHA-256 digests. The attacker-control
+ * surface here is low — an attacker who sees a timing leak still needs to
+ * iterate payloads, not hash prefixes — but the secure posture is cheap.
+ */
+function hashesEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+}
+
+export type IdempotencyOutcome =
+  | { kind: 'miss' }
+  | { kind: 'replay'; response: Record<string, unknown> }
+  | { kind: 'conflict' }
+  | { kind: 'expired' }
+  | { kind: 'rate_limited' };
+
+/**
+ * Look up `(principal, key)` and classify the outcome.
+ *
+ * - `miss`: no prior entry — the caller should execute the handler and then
+ *   call `cacheResponse(...)` on success.
+ * - `replay`: exact canonical-payload match — return the stored response
+ *   with `replayed: true` injected on the envelope.
+ * - `conflict`: same key, different canonical payload, still within TTL —
+ *   return `IDEMPOTENCY_CONFLICT`.
+ * - `expired`: same key, past TTL (with ±60s skew) — return `IDEMPOTENCY_EXPIRED`.
+ */
+export function lookupIdempotency(
+  principal: string,
+  idempotencyKey: string,
+  requestPayload: Record<string, unknown>,
+  now: number = Date.now(),
+): IdempotencyOutcome {
+  const entry = cache.get(cacheKey(principal, idempotencyKey));
+  if (!entry) return { kind: 'miss' };
+
+  if (entry.expiresAt + TTL_SKEW_MS < now) {
+    // Past TTL → return EXPIRED and evict so a fresh request with the same
+    // key can eventually succeed once the buyer realises their error.
+    cache.delete(cacheKey(principal, idempotencyKey));
+    decrementPrincipalCount(principal);
+    return { kind: 'expired' };
+  }
+
+  const incomingHash = payloadHash(requestPayload);
+  if (!hashesEqual(incomingHash, entry.requestHash)) return { kind: 'conflict' };
+
+  return { kind: 'replay', response: entry.response };
+}
+
+/**
+ * Store a successful response so subsequent replays with the same key and
+ * canonical payload return the same bytes. Only call this for successful
+ * executions — errors must re-execute on retry (security.mdx rule 2 + 3).
+ *
+ * Returns `true` on insert, `false` when the per-principal cap blocked the
+ * insert. Callers who cannot afford a silent-drop-into-re-execution on
+ * retry SHOULD surface `RATE_LIMITED` when this returns `false`
+ * (security.mdx rule 8).
+ */
+export function cacheResponse(
+  principal: string,
+  idempotencyKey: string,
+  requestPayload: Record<string, unknown>,
+  response: Record<string, unknown>,
+  now: number = Date.now(),
+): boolean {
+  let used = entriesPerPrincipal.get(principal) ?? 0;
+  if (used >= MAX_ENTRIES_PER_PRINCIPAL) {
+    // Opportunistic eviction: sweep this principal's expired entries before
+    // giving up. Avoids wedging a principal for 24h once they briefly burst
+    // past the cap on stale keys.
+    used = evictExpiredForPrincipal(principal, now);
+    if (used >= MAX_ENTRIES_PER_PRINCIPAL) return false;
+  }
+  const requestHash = payloadHash(requestPayload);
+  cache.set(cacheKey(principal, idempotencyKey), {
+    requestHash,
+    response,
+    createdAt: now,
+    expiresAt: now + REPLAY_TTL_MS,
+  });
+  entriesPerPrincipal.set(principal, used + 1);
+  return true;
+}
+
+/** Check whether a fresh insert would succeed without actually inserting. */
+export function isPrincipalAtCap(principal: string, now: number = Date.now()): boolean {
+  const used = entriesPerPrincipal.get(principal) ?? 0;
+  if (used < MAX_ENTRIES_PER_PRINCIPAL) return false;
+  const after = evictExpiredForPrincipal(principal, now);
+  return after >= MAX_ENTRIES_PER_PRINCIPAL;
+}
+
+function evictExpiredForPrincipal(principal: string, now: number): number {
+  const prefix = `${principal}\u0000`;
+  let count = entriesPerPrincipal.get(principal) ?? 0;
+  for (const [key, entry] of cache) {
+    if (!key.startsWith(prefix)) continue;
+    if (entry.expiresAt + TTL_SKEW_MS < now) {
+      cache.delete(key);
+      count--;
+    }
+  }
+  if (count <= 0) entriesPerPrincipal.delete(principal);
+  else entriesPerPrincipal.set(principal, count);
+  return Math.max(count, 0);
+}
+
+function decrementPrincipalCount(principal: string): void {
+  const v = entriesPerPrincipal.get(principal) ?? 0;
+  if (v <= 1) entriesPerPrincipal.delete(principal);
+  else entriesPerPrincipal.set(principal, v - 1);
+}
+
+/** Clear the entire cache. Tests only. */
+export function clearIdempotencyCache(): void {
+  cache.clear();
+  entriesPerPrincipal.clear();
+}
+
+/** Test-only introspection. */
+export function _cacheSize(): number {
+  return cache.size;
+}

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -50,6 +50,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 async function requireToken(req: Request, res: Response, next: NextFunction): Promise<void> {
   if (!TRAINING_AGENT_TOKEN && !PUBLIC_TEST_AGENT_TOKEN && !workos) {
     // No tokens configured and no WorkOS = dev mode, allow all
+    res.locals.trainingPrincipal = 'anonymous';
     return next();
   }
   const auth = req.headers.authorization;
@@ -63,9 +64,15 @@ async function requireToken(req: Request, res: Response, next: NextFunction): Pr
   }
   const token = auth.slice(7);
 
-  // Accept static tokens (primary or public test agent)
-  if ((TRAINING_AGENT_TOKEN && constantTimeEqual(token, TRAINING_AGENT_TOKEN)) ||
-      (PUBLIC_TEST_AGENT_TOKEN && constantTimeEqual(token, PUBLIC_TEST_AGENT_TOKEN))) {
+  // Accept static tokens (primary or public test agent).
+  // Principal for idempotency scoping: distinct per token tier but shared
+  // across all callers using that tier. Prefix-stable, no tenant bleed.
+  if (TRAINING_AGENT_TOKEN && constantTimeEqual(token, TRAINING_AGENT_TOKEN)) {
+    res.locals.trainingPrincipal = 'static:primary';
+    return next();
+  }
+  if (PUBLIC_TEST_AGENT_TOKEN && constantTimeEqual(token, PUBLIC_TEST_AGENT_TOKEN)) {
+    res.locals.trainingPrincipal = 'static:public';
     return next();
   }
 
@@ -74,7 +81,9 @@ async function requireToken(req: Request, res: Response, next: NextFunction): Pr
     try {
       const result = await workos.apiKeys.validateApiKey({ value: token });
       if (result.apiKey) {
-        logger.info({ orgId: result.apiKey.owner.id }, 'Training agent: authenticated via AAO API key');
+        const orgId = result.apiKey.owner.id;
+        logger.info({ orgId }, 'Training agent: authenticated via AAO API key');
+        res.locals.trainingPrincipal = `workos:${orgId}`;
         return next();
       }
       res.status(401).json({
@@ -199,8 +208,11 @@ export function createTrainingAgentRouter(): Router {
 
     let server: ReturnType<typeof createTrainingAgentServer> | null = null;
     try {
-      // Build training context (open mode for now; training mode in Stage 2)
-      const ctx: TrainingContext = { mode: 'open' };
+      // Build training context (open mode for now; training mode in Stage 2).
+      // Principal is set by requireToken; defaults to 'anonymous' in dev mode
+      // when no tokens are configured.
+      const principal = (res.locals.trainingPrincipal as string | undefined) ?? 'anonymous';
+      const ctx: TrainingContext = { mode: 'open', principal };
 
       server = createTrainingAgentServer(ctx);
       const transport = new StreamableHTTPServerTransport({
@@ -284,7 +296,8 @@ export function createTrainingAgentRouter(): Router {
 
     let server: ReturnType<typeof createTrainingAgentServer> | null = null;
     try {
-      const ctx: TrainingContext = { mode: 'open' };
+      const principal = (res.locals.trainingPrincipal as string | undefined) ?? 'anonymous';
+      const ctx: TrainingContext = { mode: 'open', principal };
       server = createTrainingAgentServer(ctx);
 
       // The endpoint path is relative to the router mount point

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -230,6 +230,14 @@ import {
   getAccountStatus,
 } from './comply-test-controller.js';
 import { PUBLISHERS } from './publishers.js';
+import {
+  isMutatingTool,
+  validateKeyFormat,
+  lookupIdempotency,
+  cacheResponse,
+  scopedPrincipal,
+  isPrincipalAtCap,
+} from './idempotency.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
 const MAX_PACKAGES_PER_BUY = 50;
@@ -263,6 +271,28 @@ function toolSupportsTask(toolName: string): boolean {
   const tool = TOOLS.find(t => t.name === toolName);
   const support = tool?.execution?.taskSupport as string | undefined;
   return support === 'optional' || support === 'required';
+}
+
+/**
+ * Extract an account-scoping string for the idempotency cache from the
+ * tool arguments. Mirrors `sessionKeyFromArgs` but returns just the scope
+ * portion (no `open:` prefix) so callers can feed it to `scopedPrincipal`.
+ *
+ * The scope is caller-controlled, so it doesn't authenticate anything —
+ * its only job is to keep two different buyers on the same shared token
+ * from seeing each other's idempotency outcomes.
+ */
+function deriveAccountScope(args: Record<string, unknown>): string | undefined {
+  const account = (args.account as { account_id?: string; brand?: { domain?: string } } | undefined);
+  if (account?.account_id && typeof account.account_id === 'string') {
+    return `a:${account.account_id}`;
+  }
+  const domain = account?.brand?.domain
+    ?? (args.brand as { domain?: string } | undefined)?.domain;
+  if (typeof domain === 'string' && domain.length > 0) {
+    return `b:${domain.toLowerCase()}`;
+  }
+  return undefined;
 }
 
 /** Clear the task store (for tests). Calls cleanup() to cancel TTL timers. */
@@ -3060,18 +3090,110 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       throw new Error(`Tool "${name}" does not support task augmentation`);
     }
 
+    // Idempotency enforcement for mutating tools (#2315, #2346).
+    // Key presence + format are schema-level requirements; we check them
+    // before the handler so a malformed key never touches the cache
+    // (prevents key-format-accepting cache misses from leaking timing).
+    const authPrincipal = ctx.principal ?? 'anonymous';
+    // Partition the idempotency cache by caller-stated account scope so the
+    // shared public sandbox token doesn't pool every buyer into one oracle
+    // (security.mdx §"three-state response"). An attacker on the same auth
+    // principal using a different account ref can still cross-probe, but
+    // callers can already enumerate their own account's keys — so the
+    // scoping adds no useful probing surface while closing the cross-caller
+    // leak.
+    const accountScope = deriveAccountScope(handlerArgs);
+    const idempotencyPrincipal = scopedPrincipal(authPrincipal, accountScope);
+    const idempotencyKey = (handlerArgs as { idempotency_key?: unknown }).idempotency_key;
+    let toolResult: CallToolResult | null = null;
+    let taskFailed = false;
+    let handlerThrew = false;
+    let cachableResponse: Record<string, unknown> | null = null;
+    let skipHandler = false;
+
+    if (isMutatingTool(name)) {
+      if (idempotencyKey === undefined || idempotencyKey === null) {
+        return {
+          result: adcpError('INVALID_REQUEST', {
+            message: `idempotency_key is required for ${name}. Generate a UUID v4 and include it on every mutating request; reuse the same key for network retries.`,
+            field: 'idempotency_key',
+            recovery: 'correctable',
+          }, callerContext),
+          flushable: true,
+        };
+      }
+      if (!validateKeyFormat(idempotencyKey)) {
+        return {
+          result: adcpError('INVALID_REQUEST', {
+            message: 'idempotency_key must match ^[A-Za-z0-9_.:-]{16,255}$ (UUID v4 recommended).',
+            field: 'idempotency_key',
+            recovery: 'correctable',
+          }, callerContext),
+          flushable: true,
+        };
+      }
+      // Fail closed when the cache bucket for this principal is full —
+      // silently dropping the insert would let a retry re-execute and
+      // double-book (security.mdx rule 8).
+      if (isPrincipalAtCap(idempotencyPrincipal)) {
+        return {
+          result: adcpError('RATE_LIMITED', {
+            message: 'Idempotency cache capacity exceeded for this principal. Retry after existing keys expire.',
+            recovery: 'transient',
+          }, callerContext),
+          flushable: true,
+        };
+      }
+      const outcome = lookupIdempotency(idempotencyPrincipal, idempotencyKey, handlerArgs);
+      if (outcome.kind === 'expired') {
+        return {
+          result: adcpError('IDEMPOTENCY_EXPIRED', {
+            message: 'idempotency_key is past the replay window. Generate a fresh UUID v4 and resend.',
+            recovery: 'correctable',
+          }, callerContext),
+          flushable: true,
+        };
+      }
+      if (outcome.kind === 'conflict') {
+        // Error body carries code + message only — no `field` json-pointer,
+        // no cached payload, no hash. Any shape hint turns key-reuse into
+        // a read oracle (security.mdx §IDEMPOTENCY_CONFLICT response shape).
+        return {
+          result: adcpError('IDEMPOTENCY_CONFLICT', {
+            message: 'idempotency_key was used with a different payload within the replay window. Either resend the exact original payload (to return the cached response) or generate a fresh UUID v4 to submit this new payload.',
+            recovery: 'correctable',
+          }, callerContext),
+          flushable: true,
+        };
+      }
+      if (outcome.kind === 'replay') {
+        // Cached inner response; envelope fields (`replayed`, `context`) are
+        // produced fresh on every response per security.mdx. Replayed
+        // responses bypass the handler entirely — no mutations, no flush.
+        const body: Record<string, unknown> = { ...outcome.response, replayed: true };
+        if (callerContext !== undefined) body.context = callerContext;
+        toolResult = {
+          content: [{ type: 'text', text: JSON.stringify(body) }],
+          structuredContent: body,
+        };
+        skipHandler = true;
+      }
+    }
+
     // Execute the tool handler. Structured AdCP errors (handler returns
     // { errors: [...] }) are well-formed responses — the task completes
     // successfully with an adcp_error envelope. Only thrown exceptions
     // mark the task as failed.
-    let toolResult: CallToolResult;
-    let taskFailed = false;
-    let handlerThrew = false;
-    try {
+    if (skipHandler) {
+      // toolResult already set from idempotency replay path above
+    } else try {
       const result = await Promise.resolve(handler((handlerArgs as ToolArgs) || {}, ctx));
       const resultObj = result as { errors?: Array<{ code: string; message: string; field?: string; details?: unknown; recovery?: string }> };
       const hasErrors = resultObj.errors && resultObj.errors.length > 0;
       if (hasErrors) {
+        // Error-in-body responses are errors from the buyer's POV — do NOT
+        // cache (security.mdx rule 3). cachableResponse stays null so the
+        // post-dispatch gate below never inserts this into the replay cache.
         const firstError = resultObj.errors![0];
         if (ERROR_IN_BODY_TOOLS.has(name)) {
           const body: Record<string, unknown> = { errors: resultObj.errors };
@@ -3093,9 +3215,15 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           }, callerContext);
         }
       } else {
+        // Inner response (what gets cached for replay). Per security.mdx:
+        // "replayed: false" MAY be omitted on fresh executions and buyers
+        // MUST treat omission as false. Omitting keeps strict per-task
+        // response schemas (additionalProperties: false) passing.
+        const inner = result as Record<string, unknown>;
+        cachableResponse = inner;
         const response = callerContext !== undefined
-          ? { ...result as object, context: callerContext }
-          : result;
+          ? { ...inner, context: callerContext }
+          : inner;
         toolResult = {
           content: [{ type: 'text', text: JSON.stringify(response) }],
         };
@@ -3108,6 +3236,38 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         message: error instanceof Error ? error.message : 'Unknown error',
         recovery: 'transient',
       }, callerContext);
+    }
+
+    // TypeScript: by this point toolResult is guaranteed set — either the
+    // handler branch wrote it or the replay short-circuit did.
+    if (!toolResult) {
+      throw new Error('Internal error: toolResult missing after dispatch');
+    }
+
+    // Cache ONLY successful inner responses (security.mdx rule 2+3).
+    // Errors re-execute on retry; structured { errors: [...] } responses
+    // are errors from the buyer's perspective and are not cached either.
+    if (
+      isMutatingTool(name)
+      && typeof idempotencyKey === 'string'
+      && cachableResponse !== null
+      && !toolResult.isError
+      && !handlerThrew
+    ) {
+      const inserted = cacheResponse(idempotencyPrincipal, idempotencyKey, handlerArgs, cachableResponse);
+      if (!inserted) {
+        // Cap was hit between the pre-check and post-execution insert.
+        // The handler already ran and (likely) mutated state — we can't
+        // undo that. Return RATE_LIMITED so a retry with the same key
+        // doesn't silently re-execute and double-book.
+        return {
+          result: adcpError('RATE_LIMITED', {
+            message: 'Idempotency cache capacity exceeded after request completed. The request succeeded but was not cached; a retry with the same idempotency_key may re-execute.',
+            recovery: 'transient',
+          }, callerContext),
+          flushable: !handlerThrew,
+        };
+      }
     }
 
     // If not task-augmented, return result directly.

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -20,6 +20,10 @@ export interface TrainingContext {
   moduleId?: string;
   trackId?: string;
   learnerLevel?: 'basics' | 'practitioner' | 'specialist';
+  /** Authenticated principal for idempotency cache scoping.
+   *  Derived from the bearer token in the MCP route; defaults to `anonymous`
+   *  when no auth is configured (dev / test). */
+  principal?: string;
 }
 
 export interface ShowSpecial {

--- a/server/tests/unit/account-handlers.test.ts
+++ b/server/tests/unit/account-handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
 import {
   createTrainingAgentServer,
   invalidateCache,
@@ -6,9 +7,16 @@ import {
 } from '../../src/training-agent/task-handlers.js';
 import { clearSessions } from '../../src/training-agent/state.js';
 import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
+import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
+
+function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (!MUTATING_TOOLS.has(toolName)) return args;
+  if (args.idempotency_key !== undefined) return args;
+  return { ...args, idempotency_key: `test-${randomUUID()}` };
+}
 
 /**
  * Simulate CallTool request on an MCP server.
@@ -24,7 +32,7 @@ async function simulateCallTool(
     throw new Error('CallTool handler not found');
   }
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;
@@ -45,6 +53,7 @@ describe('sync_accounts', () => {
     clearSessions();
     clearAccountStore();
     clearTaskStore();
+    clearIdempotencyCache();
     invalidateCache();
     server = createTrainingAgentServer(DEFAULT_CTX);
   });
@@ -238,6 +247,7 @@ describe('sync_governance', () => {
     clearSessions();
     clearAccountStore();
     clearTaskStore();
+    clearIdempotencyCache();
     invalidateCache();
     server = createTrainingAgentServer(DEFAULT_CTX);
   });

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import YAML from 'yaml';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
@@ -10,7 +11,14 @@ import {
   clearTaskStore,
 } from '../../src/training-agent/task-handlers.js';
 import { clearSessions } from '../../src/training-agent/state.js';
+import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
+
+function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (!MUTATING_TOOLS.has(toolName)) return args;
+  if (args.idempotency_key !== undefined) return args;
+  return { ...args, idempotency_key: `test-${randomUUID()}` };
+}
 
 const REPO_ROOT = join(process.cwd());
 const STORYBOARD_PATH = join(
@@ -49,7 +57,7 @@ async function simulateCallTool(
   const handler = requestHandlers.get('tools/call');
   if (!handler) throw new Error('CallTool handler not found');
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;
@@ -129,6 +137,7 @@ describe('collection-lists specialism storyboard', () => {
     clearSessions();
     invalidateCache();
     clearTaskStore();
+    clearIdempotencyCache();
     server = createTrainingAgentServer(ctx);
   });
 

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -8,11 +8,18 @@ import {
 import {
   clearSessions,
 } from '../../src/training-agent/state.js';
+import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
 const ACCOUNT = { brand: { domain: 'comply-test.example.com' }, operator: 'comply-tester', sandbox: true };
 const BRAND = { domain: 'comply-test.example.com', name: 'Comply Test Brand' };
+
+function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (!MUTATING_TOOLS.has(toolName)) return args;
+  if (args.idempotency_key !== undefined) return args;
+  return { ...args, idempotency_key: `test-${crypto.randomUUID()}` };
+}
 
 async function simulateCallTool(
   server: ReturnType<typeof createTrainingAgentServer>,
@@ -23,7 +30,7 @@ async function simulateCallTool(
   const handler = requestHandlers.get('tools/call');
   if (!handler) throw new Error('CallTool handler not found');
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;
@@ -132,6 +139,7 @@ describe('comply_test_controller', () => {
     clearSessions();
     invalidateCache();
     clearTaskStore();
+    clearIdempotencyCache();
     server = createTrainingAgentServer(DEFAULT_CTX);
   });
 

--- a/server/tests/unit/idempotency.test.ts
+++ b/server/tests/unit/idempotency.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Direct unit tests for the idempotency module. The end-to-end middleware
+ * behavior is covered by training-agent-idempotency.test.ts; this file
+ * exercises paths that are awkward to reach through the full dispatcher
+ * (clock-skew arithmetic, per-principal cache cap, payload-exclusion list).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  MUTATING_TOOLS,
+  isMutatingTool,
+  validateKeyFormat,
+  payloadHash,
+  lookupIdempotency,
+  cacheResponse,
+  clearIdempotencyCache,
+  scopedPrincipal,
+  isPrincipalAtCap,
+  REPLAY_TTL_SECONDS,
+} from '../../src/training-agent/idempotency.js';
+
+describe('idempotency primitives', () => {
+  beforeEach(() => clearIdempotencyCache());
+
+  describe('MUTATING_TOOLS', () => {
+    it('covers every mutating task whose schema requires idempotency_key', () => {
+      // Smoke test: the set must contain the 26 mutating tools the training
+      // agent actually dispatches. If a new mutating tool is added without
+      // being listed here, callers can bypass the middleware.
+      const expected = [
+        'create_media_buy',
+        'update_media_buy',
+        'sync_creatives',
+        'build_creative',
+        'activate_signal',
+        'sync_accounts',
+        'sync_governance',
+        'sync_catalogs',
+        'sync_event_sources',
+        'log_event',
+        'provide_performance_feedback',
+        'sync_plans',
+        'report_plan_outcome',
+        'acquire_rights',
+        'update_rights',
+        'creative_approval',
+        'create_property_list',
+        'update_property_list',
+        'delete_property_list',
+        'create_collection_list',
+        'update_collection_list',
+        'delete_collection_list',
+        'create_content_standards',
+        'update_content_standards',
+        'calibrate_content',
+        'report_usage',
+      ];
+      for (const name of expected) {
+        expect(isMutatingTool(name), `${name} should be mutating`).toBe(true);
+      }
+      expect(MUTATING_TOOLS.size).toBe(expected.length);
+    });
+
+    it('excludes read-only and discovery tools', () => {
+      for (const name of ['get_products', 'get_media_buys', 'get_adcp_capabilities', 'check_governance']) {
+        expect(isMutatingTool(name)).toBe(false);
+      }
+    });
+  });
+
+  describe('validateKeyFormat', () => {
+    it('accepts UUIDs and equivalent entropy shapes', () => {
+      expect(validateKeyFormat('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+      expect(validateKeyFormat('A'.repeat(16))).toBe(true);
+      expect(validateKeyFormat('A'.repeat(255))).toBe(true);
+    });
+
+    it('rejects keys outside the schema-mandated regex', () => {
+      expect(validateKeyFormat('tooshort')).toBe(false);          // < 16
+      expect(validateKeyFormat('A'.repeat(256))).toBe(false);    // > 255
+      expect(validateKeyFormat('has spaces inside')).toBe(false);
+      expect(validateKeyFormat('has/slashes/in/it-xxxx')).toBe(false);
+      expect(validateKeyFormat(undefined)).toBe(false);
+      expect(validateKeyFormat(42 as unknown)).toBe(false);
+    });
+  });
+
+  describe('payloadHash', () => {
+    it('ignores idempotency_key, context, governance_context', () => {
+      const base = { account_id: 'acme', amount: 100 };
+      expect(payloadHash({ ...base, idempotency_key: 'aaaaaaaaaaaaaaaa' }))
+        .toBe(payloadHash({ ...base, idempotency_key: 'bbbbbbbbbbbbbbbb' }));
+      expect(payloadHash({ ...base, context: { correlation_id: '1' } }))
+        .toBe(payloadHash({ ...base, context: { correlation_id: '2' } }));
+      expect(payloadHash({ ...base, governance_context: 'g1' }))
+        .toBe(payloadHash({ ...base, governance_context: 'g2' }));
+    });
+
+    it('ignores rotating push_notification credentials', () => {
+      const a = { x: 1, push_notification_config: { url: 'https://a', authentication: { credentials: 'secret-a' } } };
+      const b = { x: 1, push_notification_config: { url: 'https://a', authentication: { credentials: 'secret-b' } } };
+      expect(payloadHash(a)).toBe(payloadHash(b));
+    });
+
+    it('is key-order independent (JCS guarantee)', () => {
+      expect(payloadHash({ a: 1, b: 2 })).toBe(payloadHash({ b: 2, a: 1 }));
+    });
+
+    it('distinguishes materially different payloads', () => {
+      expect(payloadHash({ budget: 5000 })).not.toBe(payloadHash({ budget: 25000 }));
+    });
+
+    it('distinguishes "missing optional field" from "explicit null"', () => {
+      // security.mdx normative: missing ≠ explicit null
+      expect(payloadHash({ x: 1 })).not.toBe(payloadHash({ x: 1, y: null }));
+    });
+  });
+
+  describe('lookupIdempotency TTL behavior', () => {
+    it('returns replay within TTL', () => {
+      const payload = { foo: 'bar' };
+      cacheResponse('p', 'key-aaaaaaaaaaaa01', payload, { media_buy_id: 'mb_1' });
+      const outcome = lookupIdempotency('p', 'key-aaaaaaaaaaaa01', payload);
+      expect(outcome.kind).toBe('replay');
+      if (outcome.kind === 'replay') {
+        expect(outcome.response.media_buy_id).toBe('mb_1');
+      }
+    });
+
+    it('returns conflict when canonical payload drifts', () => {
+      cacheResponse('p', 'key-aaaaaaaaaaaa02', { foo: 'bar' }, { media_buy_id: 'mb_1' });
+      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa02', { foo: 'baz' }).kind).toBe('conflict');
+    });
+
+    it('returns expired past TTL + 60s skew, and evicts so the key can be reused', () => {
+      const now = 1_000_000_000_000;
+      const payload = { foo: 'bar' };
+      cacheResponse('p', 'key-aaaaaaaaaaaa03', payload, { media_buy_id: 'mb_1' }, now);
+
+      const beforeExpiry = now + REPLAY_TTL_SECONDS * 1000 + 30_000; // +30s < 60s skew
+      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, beforeExpiry).kind).toBe('replay');
+
+      const afterExpiry = now + REPLAY_TTL_SECONDS * 1000 + 61_000; // +61s > 60s skew
+      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, afterExpiry).kind).toBe('expired');
+
+      // Evicted — a fresh insert with the same key should now succeed
+      cacheResponse('p', 'key-aaaaaaaaaaaa03', payload, { media_buy_id: 'mb_2' }, afterExpiry);
+      const second = lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, afterExpiry);
+      expect(second.kind).toBe('replay');
+      if (second.kind === 'replay') {
+        expect(second.response.media_buy_id).toBe('mb_2');
+      }
+    });
+
+    it('returns miss for unknown key', () => {
+      expect(lookupIdempotency('p', 'never-seen-1234567', { foo: 1 }).kind).toBe('miss');
+    });
+  });
+
+  describe('scopedPrincipal', () => {
+    it('partitions shared auth tokens by account scope', () => {
+      const a = scopedPrincipal('static:public', 'b:acme.example');
+      const b = scopedPrincipal('static:public', 'b:beta.example');
+      expect(a).not.toBe(b);
+
+      cacheResponse(a, 'shared-key-uuuuu01', { x: 1 }, { id: 'acme' });
+      // Same key on a different account scope is a miss — closes the
+      // cross-caller oracle on the public sandbox token.
+      expect(lookupIdempotency(b, 'shared-key-uuuuu01', { x: 1 }).kind).toBe('miss');
+      expect(lookupIdempotency(a, 'shared-key-uuuuu01', { x: 1 }).kind).toBe('replay');
+    });
+
+    it('keeps auth principals that contain colons unambiguous', () => {
+      // `workos:org_abc` vs `workos:org_abcdef` both contain `:`
+      const p1 = scopedPrincipal('workos:org_abc', 'b:x.example');
+      const p2 = scopedPrincipal('workos:org_abcdef', '');
+      expect(p1).not.toBe(p2);
+    });
+  });
+
+  describe('cache cap', () => {
+    it('isPrincipalAtCap is false by default', () => {
+      expect(isPrincipalAtCap('fresh')).toBe(false);
+    });
+
+    it('cacheResponse returns true on normal inserts', () => {
+      expect(cacheResponse('p', 'unique-key-aaaaaa01', { a: 1 }, { id: 1 })).toBe(true);
+    });
+  });
+});
+
+describe('MUTATING_TOOLS drift guard', () => {
+  // If a new mutating tool is added to task-handlers.ts but not listed in
+  // MUTATING_TOOLS, buyers bypass the middleware. This test enumerates the
+  // HANDLER_MAP shipped at runtime and asserts the set is complete.
+  it('every HANDLER_MAP entry whose schema requires idempotency_key is in MUTATING_TOOLS', async () => {
+    // HANDLER_MAP is module-private; we detect drift by introspecting the
+    // server's tools/list response instead.
+    const { createTrainingAgentServer } = await import('../../src/training-agent/task-handlers.js');
+    const server = createTrainingAgentServer({ mode: 'open', principal: 'drift-check' });
+    const requestHandlers = (server as unknown as { _requestHandlers: Map<string, Function> })._requestHandlers;
+    const listHandler = requestHandlers.get('tools/list');
+    if (!listHandler) throw new Error('tools/list handler not registered');
+    const { tools } = await listHandler({ method: 'tools/list' }, {}) as { tools: Array<{ name: string; inputSchema?: { required?: string[] } }> };
+
+    // Any tool whose inputSchema lists `idempotency_key` as required is a
+    // mutating tool and must be in MUTATING_TOOLS.
+    const shouldBeMutating = tools
+      .filter(t => Array.isArray(t.inputSchema?.required) && t.inputSchema!.required!.includes('idempotency_key'))
+      .map(t => t.name);
+
+    const missing = shouldBeMutating.filter(name => !MUTATING_TOOLS.has(name));
+    expect(missing, `tools with required idempotency_key not in MUTATING_TOOLS: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Training agent idempotency middleware — validates the behavior documented
+ * in `docs/building/implementation/security.mdx` and the universal
+ * `idempotency.yaml` compliance storyboard.
+ *
+ * Addresses #2346: the training agent previously declared
+ * `adcp.idempotency.replay_ttl_seconds` in get_adcp_capabilities but did
+ * NOT enforce the replay / conflict / expired semantics that declaration
+ * implies — buyers building against the reference agent never observed
+ * IDEMPOTENCY_CONFLICT or IDEMPOTENCY_EXPIRED and could silently double-book
+ * on retry.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import {
+  createTrainingAgentServer,
+  invalidateCache,
+  clearTaskStore,
+} from '../../src/training-agent/task-handlers.js';
+import { clearSessions } from '../../src/training-agent/state.js';
+import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const CTX: TrainingContext = { mode: 'open', principal: 'test-principal' };
+
+const ACCOUNT = { brand: { domain: 'idem-test.example' }, operator: 'idem-op' };
+const BRAND = { domain: 'idem-test.example' };
+
+async function call(
+  server: ReturnType<typeof createTrainingAgentServer>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ parsed: Record<string, unknown>; isError?: boolean }> {
+  const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+  const handler = requestHandlers.get('tools/call');
+  if (!handler) throw new Error('CallTool handler not found');
+  const response = await handler(
+    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    {},
+  );
+  const text = response.content?.[0]?.text;
+  return { parsed: text ? JSON.parse(text) : {}, isError: response.isError };
+}
+
+const basePayload = () => ({
+  account: ACCOUNT,
+  brand: BRAND,
+  start_time: '2026-06-01T00:00:00Z',
+  end_time: '2026-06-30T23:59:59Z',
+  packages: [{ product_id: 'test-product', budget: 5000, pricing_option_id: 'test-pricing' }],
+});
+
+async function getValidProductAndPricing(
+  server: ReturnType<typeof createTrainingAgentServer>,
+): Promise<{ productId: string; pricingOptionId: string }> {
+  const { parsed } = await call(server, 'get_products', {
+    buying_mode: 'wholesale',
+    account: ACCOUNT,
+    brand: BRAND,
+  });
+  const products = (parsed as { products?: Array<{ product_id: string; pricing_options: Array<{ pricing_option_id: string }> }> }).products ?? [];
+  if (!products.length) throw new Error('no products in catalog');
+  return {
+    productId: products[0].product_id,
+    pricingOptionId: products[0].pricing_options[0].pricing_option_id,
+  };
+}
+
+describe('training agent idempotency middleware', () => {
+  let server: ReturnType<typeof createTrainingAgentServer>;
+
+  beforeEach(() => {
+    clearSessions();
+    invalidateCache();
+    clearTaskStore();
+    clearIdempotencyCache();
+    server = createTrainingAgentServer(CTX);
+  });
+
+  describe('missing / malformed key', () => {
+    it('rejects create_media_buy with no idempotency_key → INVALID_REQUEST', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const { parsed, isError } = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+      });
+      expect(isError).toBe(true);
+      expect((parsed as any).adcp_error?.code).toBe('INVALID_REQUEST');
+      expect((parsed as any).adcp_error?.field).toBe('idempotency_key');
+    });
+
+    it('rejects create_media_buy with too-short key → INVALID_REQUEST', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const { parsed, isError } = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: 'short',
+      });
+      expect(isError).toBe(true);
+      expect((parsed as any).adcp_error?.code).toBe('INVALID_REQUEST');
+    });
+
+    it('does not require idempotency_key on read-only tools', async () => {
+      const { isError } = await call(server, 'get_products', {
+        buying_mode: 'wholesale',
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      expect(isError).toBeFalsy();
+    });
+  });
+
+  describe('replay with same key + same payload', () => {
+    it('returns the cached media_buy_id with replayed: true', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      const payload = {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      };
+
+      const first = await call(server, 'create_media_buy', payload);
+      expect(first.isError).toBeFalsy();
+      const originalMediaBuyId = (first.parsed as any).media_buy_id;
+      expect(originalMediaBuyId).toBeTruthy();
+      // Fresh execution: `replayed` should be false or omitted
+      expect((first.parsed as any).replayed ?? false).toBe(false);
+
+      // Replay with the same key and the same payload
+      const second = await call(server, 'create_media_buy', { ...payload });
+      expect(second.isError).toBeFalsy();
+      expect((second.parsed as any).media_buy_id).toBe(originalMediaBuyId);
+      expect((second.parsed as any).replayed).toBe(true);
+    });
+
+    it('echoes a fresh context block on replay (envelope-level, not cached)', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      const payload = {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+        context: { correlation_id: 'first-call' },
+      };
+
+      await call(server, 'create_media_buy', payload);
+
+      const replay = await call(server, 'create_media_buy', {
+        ...payload,
+        context: { correlation_id: 'retry-call' },
+      });
+      // Context is excluded from the canonical hash (see EXCLUDED_FROM_HASH),
+      // so retry with a different correlation_id is still a replay. Envelope
+      // context echoes the NEW correlation_id, not the cached one.
+      expect((replay.parsed as any).replayed).toBe(true);
+      expect((replay.parsed as any).context?.correlation_id).toBe('retry-call');
+    });
+
+    it('treats governance_context as excluded from the hash (retry with new delegation)', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      const payload = {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+        governance_context: 'gov-token-a',
+      };
+
+      await call(server, 'create_media_buy', payload);
+      const replay = await call(server, 'create_media_buy', { ...payload, governance_context: 'gov-token-b' });
+      expect((replay.parsed as any).replayed).toBe(true);
+    });
+  });
+
+  describe('key reuse with different payload', () => {
+    it('returns IDEMPOTENCY_CONFLICT when budget changes', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      });
+
+      const conflict = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 25000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      });
+      expect(conflict.isError).toBe(true);
+      expect((conflict.parsed as any).adcp_error?.code).toBe('IDEMPOTENCY_CONFLICT');
+      // Security: no payload / fingerprint / cached state leak
+      expect((conflict.parsed as any).adcp_error?.details?.hash).toBeUndefined();
+      expect((conflict.parsed as any).adcp_error?.details?.cached_payload).toBeUndefined();
+    });
+
+    it('returns IDEMPOTENCY_CONFLICT when end_time changes', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      });
+
+      const conflict = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        end_time: '2026-09-30T23:59:59Z',
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      });
+      expect((conflict.parsed as any).adcp_error?.code).toBe('IDEMPOTENCY_CONFLICT');
+    });
+  });
+
+  describe('fresh key → new resource', () => {
+    it('a different key with identical payload creates a distinct media buy', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const basePkg = { product_id: productId, budget: 5000, pricing_option_id: pricingOptionId };
+
+      const first = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [basePkg],
+        idempotency_key: `idem-${randomUUID()}`,
+      });
+      const firstId = (first.parsed as any).media_buy_id;
+
+      const second = await call(server, 'create_media_buy', {
+        ...basePayload(),
+        packages: [basePkg],
+        idempotency_key: `idem-${randomUUID()}`,
+      });
+      const secondId = (second.parsed as any).media_buy_id;
+
+      expect(firstId).toBeTruthy();
+      expect(secondId).toBeTruthy();
+      expect(firstId).not.toBe(secondId);
+    });
+  });
+
+  describe('failed executions are not cached', () => {
+    it('re-executes on retry after an error (no replay cache pollution)', async () => {
+      const key = `idem-${randomUUID()}`;
+      const badPayload = {
+        ...basePayload(),
+        packages: [{ product_id: 'DOES_NOT_EXIST', budget: 100, pricing_option_id: 'bad' }],
+        idempotency_key: key,
+      };
+
+      const first = await call(server, 'create_media_buy', badPayload);
+      expect(first.isError).toBe(true);
+
+      // Retry with the same key: the first was an error, so the second
+      // must re-execute (and also error) — not return a cached success.
+      const second = await call(server, 'create_media_buy', badPayload);
+      expect(second.isError).toBe(true);
+      expect((second.parsed as any).replayed).toBeUndefined();
+    });
+  });
+
+  describe('principal isolation', () => {
+    it('the same key used by a different auth principal is a cache miss', async () => {
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `idem-${randomUUID()}`;
+      const payload = {
+        ...basePayload(),
+        packages: [{ product_id: productId, budget: 5000, pricing_option_id: pricingOptionId }],
+        idempotency_key: key,
+      };
+      const first = await call(server, 'create_media_buy', payload);
+      const firstId = (first.parsed as any).media_buy_id;
+
+      const otherServer = createTrainingAgentServer({ mode: 'open', principal: 'other-principal' });
+      const second = await call(otherServer, 'create_media_buy', payload);
+      const secondId = (second.parsed as any).media_buy_id;
+
+      expect(firstId).toBeTruthy();
+      expect(secondId).toBeTruthy();
+      expect(secondId).not.toBe(firstId);
+      expect((second.parsed as any).replayed ?? false).toBe(false);
+    });
+
+    it('partitions by account scope so shared auth tokens do not pool callers', async () => {
+      // Both calls are made against the SAME server (same auth principal),
+      // but the account brand.domain differs. The middleware must treat
+      // these as separate cache scopes — otherwise the public sandbox
+      // token would be a cross-caller oracle.
+      const { productId, pricingOptionId } = await getValidProductAndPricing(server);
+      const key = `shared-${randomUUID()}`;
+      const pkg = { product_id: productId, budget: 5000, pricing_option_id: pricingOptionId };
+
+      const payloadA = {
+        account: { brand: { domain: 'caller-a.example' }, operator: 'op' },
+        brand: { domain: 'caller-a.example' },
+        start_time: '2026-06-01T00:00:00Z',
+        end_time: '2026-06-30T23:59:59Z',
+        packages: [pkg],
+        idempotency_key: key,
+      };
+      const payloadB = {
+        ...payloadA,
+        account: { brand: { domain: 'caller-b.example' }, operator: 'op' },
+        brand: { domain: 'caller-b.example' },
+      };
+
+      const a = await call(server, 'create_media_buy', payloadA);
+      const b = await call(server, 'create_media_buy', payloadB);
+
+      expect((a.parsed as any).media_buy_id).toBeTruthy();
+      expect((b.parsed as any).media_buy_id).toBeTruthy();
+      // Different account scope → cache miss, new media buy, no conflict
+      expect((b.parsed as any).media_buy_id).not.toBe((a.parsed as any).media_buy_id);
+      expect((b.parsed as any).replayed ?? false).toBe(false);
+      expect(b.isError).toBeFalsy();
+    });
+  });
+
+  describe('missing key rejected for every mutating tool', () => {
+    // Parameterized sanity check: the middleware must reject all mutating
+    // tools at the dispatch layer regardless of whether the handler would
+    // have validated the field itself. Catches routing regressions where a
+    // new tool is added to HANDLER_MAP but omitted from MUTATING_TOOLS.
+    for (const toolName of MUTATING_TOOLS) {
+      it(`${toolName}: missing idempotency_key → INVALID_REQUEST`, async () => {
+        const { parsed, isError } = await call(server, toolName, {
+          account: ACCOUNT,
+          brand: BRAND,
+        });
+        expect(isError).toBe(true);
+        expect((parsed as any).adcp_error?.code).toBe('INVALID_REQUEST');
+        expect((parsed as any).adcp_error?.field).toBe('idempotency_key');
+      });
+    }
+  });
+});

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -19,6 +19,11 @@ import {
   invalidateCache,
   clearTaskStore,
 } from '../../src/training-agent/task-handlers.js';
+import {
+  MUTATING_TOOLS,
+  clearIdempotencyCache,
+} from '../../src/training-agent/idempotency.js';
+import { randomUUID } from 'node:crypto';
 import { getAgentUrl } from '../../src/training-agent/config.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 import {
@@ -56,6 +61,21 @@ async function simulateListTools(server: ReturnType<typeof createTrainingAgentSe
 }
 
 /**
+ * Auto-inject a fresh UUID v4 `idempotency_key` on mutating tools when the
+ * test doesn't provide one. The idempotency middleware requires the key per
+ * #2315; most tests in this file predate that requirement and don't care
+ * about replay semantics — they just want the tool to run once.
+ *
+ * Tests that DO care (conflict / replay / expired / missing-key coverage)
+ * pass an explicit `idempotency_key`, which this helper preserves.
+ */
+function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (!MUTATING_TOOLS.has(toolName)) return args;
+  if (args.idempotency_key !== undefined) return args;
+  return { ...args, idempotency_key: `test-${randomUUID()}` };
+}
+
+/**
  * Simulate CallTool request on an MCP server.
  */
 async function simulateCallTool(
@@ -69,7 +89,7 @@ async function simulateCallTool(
     throw new Error('CallTool handler not found');
   }
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;
@@ -100,7 +120,7 @@ async function simulateCallToolAsTask(
     throw new Error('CallTool handler not found');
   }
   return handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args, task: taskParams } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args), task: taskParams } },
     {},
   );
 }
@@ -6175,7 +6195,7 @@ async function simulateCallToolRaw(
   const handler = requestHandlers.get('tools/call');
   if (!handler) throw new Error('CallTool handler not found');
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;
@@ -6247,7 +6267,7 @@ describe('context echo', () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { parsed, isError } = await simulateCallToolRaw(server, 'create_media_buy', {
       context: TEST_CONTEXT,
-      idempotency_key: 'ctx-neg-budget',
+      idempotency_key: 'ctx-neg-budget-01',
       start_time: '2026-05-01T00:00:00Z',
       end_time: '2026-05-31T23:59:59Z',
       packages: [{ product_id: 'test-product', budget: -500, pricing_option_id: 'test-pricing' }],
@@ -6261,7 +6281,7 @@ describe('context echo', () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { parsed, isError } = await simulateCallToolRaw(server, 'create_media_buy', {
       context: TEST_CONTEXT,
-      idempotency_key: 'ctx-nonexistent',
+      idempotency_key: 'ctx-nonexistent-01',
       start_time: '2026-05-01T00:00:00Z',
       end_time: '2026-05-31T23:59:59Z',
       packages: [{ product_id: 'NONEXISTENT_PRODUCT_ID_12345', budget: 1000, pricing_option_id: 'nonexistent-pricing' }],
@@ -6275,7 +6295,7 @@ describe('context echo', () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { parsed, isError } = await simulateCallToolRaw(server, 'create_media_buy', {
       context: TEST_CONTEXT,
-      idempotency_key: 'ctx-reversed',
+      idempotency_key: 'ctx-reversed-key-01',
       start_time: '2026-12-31T00:00:00Z',
       end_time: '2026-01-01T00:00:00Z',
       packages: [{ product_id: 'test-product', budget: 1000, pricing_option_id: 'test-pricing' }],

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -21,7 +21,6 @@ import {
 } from '../../src/training-agent/task-handlers.js';
 import {
   MUTATING_TOOLS,
-  clearIdempotencyCache,
 } from '../../src/training-agent/idempotency.js';
 import { randomUUID } from 'node:crypto';
 import { getAgentUrl } from '../../src/training-agent/config.js';


### PR DESCRIPTION
Closes #2346.

## Summary

The hosted training agent at `test-agent.adcontextprotocol.org` advertised
`adcp.idempotency.replay_ttl_seconds: 86400` in `get_adcp_capabilities` but
did not enforce the contract. Two `create_media_buy` calls with the same key
and same payload created two distinct media buys; key reuse with a different
payload succeeded instead of returning `IDEMPOTENCY_CONFLICT`. Buyer SDKs
integrating against the reference agent shipped without ever exercising
their retry/conflict code paths.

A new middleware at `server/src/training-agent/idempotency.ts` implements the
normative behavior from `docs/building/implementation/security.mdx`
§"Request Safety" and the `static/compliance/source/universal/idempotency.yaml`
storyboard:

- **Key validation** — presence + `^[A-Za-z0-9_.:-]{16,255}$` regex checked
  before the cache lookup on all 26 mutating tools; the `MUTATING_TOOLS` set
  is drift-guarded by a test that introspects `tools/list` and asserts every
  tool whose schema requires `idempotency_key` is listed.
- **Canonicalization** — RFC 8785 JCS via the `canonicalize` npm package +
  SHA-256. Excludes `idempotency_key`, `context`, `governance_context`, and
  `push_notification_config.authentication.credentials`. Hash comparison
  uses `timingSafeEqual` on decoded digests.
- **Replay** — same key + equivalent canonical payload returns the cached
  inner response with `replayed: true` on the envelope (omitted on fresh
  executions so strict `additionalProperties: false` schemas keep passing).
- **Conflict** — same key + different canonical payload → `IDEMPOTENCY_CONFLICT`
  with code + message only; no cached payload, hash, or `field` pointer
  (any shape hint would turn key-reuse into a read oracle).
- **Expiry** — past TTL with ±60s skew → `IDEMPOTENCY_EXPIRED` and evict.
- **Cache-only-success** — errors re-execute on retry; error-in-body
  responses (`{ errors: [...] }`) are not cached.
- **Scope** — `(auth principal, account scope, idempotency_key)`. The
  public sandbox token is shared across all callers, so scoping only by
  auth principal would make the three-state response observable
  cross-caller (security.mdx §"three-state response"); per-account
  partitioning closes that oracle.
- **Cap** — 10k entries per principal, with opportunistic eviction of
  expired entries on overflow. When the cap is still hit, responds with
  `RATE_LIMITED` (rule 8) rather than silently dropping the insert and
  letting a retry re-execute.

## Review cycle

Both `code-reviewer` and `security-reviewer` pointed out real issues that
landed in the final diff:

- added `structuredContent` on replay path (code-review M2)
- fixed error-in-body caching bypass (code-review M3)
- scoped principal by account, closing the shared-token oracle (code M4 /
  security M1 + M2)
- silent-drop-on-cap → `RATE_LIMITED` (code M5 / security S2)
- dropped `field: idempotency_key` from conflict body (code M7)
- `timingSafeEqual` for hash compare (security S1)
- throw on canonicalize failure instead of collapsing to `''` (code N10)
- parameterized missing-key test for every mutating tool (code M8)
- drift-guard test for `MUTATING_TOOLS` vs `tools/list` (code M1)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run server/tests/unit/` — 1569 pass (56 new in
      `idempotency.test.ts` + `training-agent-idempotency.test.ts`)
- [x] `npm run test:unit` — 587 pass
- [x] `npm run test:schemas`, `test:json-schema` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)