### PR TITLE
spec(compliance): lint storyboards for idempotency_key on mutating steps (#2372)

### DIFF
--- a/.changeset/build-compliance-idempotency-lint.md
+++ b/.changeset/build-compliance-idempotency-lint.md
@@ -1,0 +1,46 @@
+---
+---
+
+spec(compliance): lint storyboards for idempotency_key on mutating steps (#2372)
+
+`scripts/build-compliance.cjs` now fails the build if any storyboard step
+invokes a mutating task without declaring `idempotency_key` in
+`sample_request`. A mutating task is any task whose request schema lists
+`idempotency_key` in its top-level `required` array — so the lint derives
+its task set from the schemas themselves (source of truth) rather than a
+hardcoded list. New mutating tasks are covered on arrival; no registry to
+forget to update.
+
+Skip rules:
+- `expect_error: true` steps (they exercise invalid-request paths,
+  including the "missing idempotency_key returns INVALID_REQUEST" test in
+  `universal/idempotency.yaml`).
+- `test-kits/` fixtures and `storyboard-schema.yaml` (not storyboards).
+- Tasks whose request schema does not require `idempotency_key` (discovery,
+  read-only, terminate-by-session-id, etc.).
+
+Cleanup included: 101 pre-existing omissions across 38 storyboard files
+(media-buy baseline, sales-* specialisms, creative-* specialisms, signals
+specialisms, governance, content-standards, collection-lists, etc.) are
+fixed in the same commit. Each step gets
+`idempotency_key: "$generate:uuid_v4#<storyboard>_<phase>_<step>"` —
+unique per step per run, descriptive enough to grep. The
+`@adcp/client@5.x` runner (adcp-client#602) forwards storyboard-declared
+idempotency_keys through to the wire, so these examples now match what
+gets sent.
+
+Error message shape — one line per offending step:
+
+    Storyboard idempotency_key lint: N step(s) invoke a mutating task
+    without declaring idempotency_key in sample_request.
+
+      specialisms/X/index.yaml phase=P step=S: task "T" is mutating
+      (schema X/Y-request.json requires idempotency_key) but
+      sample_request omits it.
+
+    Add `idempotency_key: "$generate:uuid_v4#<alias>"` to each
+    sample_request. ...
+
+Closes the loop from adcp-client#611 review: the runner-output contract
+helps *diagnose* missing idempotency at runtime; this lint *prevents*
+storyboards from shipping without it.

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -163,11 +163,18 @@ function discoverProtocols(sourceDir, specialisms) {
 //
 // Every mutating request in AdCP (any task whose request schema lists
 // `idempotency_key` in its top-level `required` array) MUST carry an
-// idempotency_key, per adcontextprotocol/adcp#2315. Storyboard
-// sample_requests are spec artifacts — when they omit it, the published
-// example is non-conforming even if the runner auto-injects at runtime.
-// This lint reads the request schemas (source of truth) rather than
-// hardcoding a task list, so new mutating tasks are covered on arrival.
+// idempotency_key. Normative anchors:
+//   - docs/reference/migration/v3-readiness.mdx §"idempotency_key required
+//     on all mutating requests"
+//   - docs/reference/release-notes.mdx 3.0 entry, idempotency rollout
+//   - adcontextprotocol/adcp#2315 (the PR that made it required)
+// Storyboard sample_requests are spec artifacts — when they omit it, the
+// published example is non-conforming even if the runner auto-injects at
+// runtime. This lint reads the request schemas (source of truth) rather
+// than hardcoding a task list, so new mutating tasks are covered on
+// arrival. The one documented exception (si-terminate-session: naturally
+// idempotent by session_id) carries a `$comment` on its request schema
+// and is correctly absent from the required-key set.
 
 function loadMutatingSchemaRefs(schemasDir) {
   const refs = new Set();
@@ -211,6 +218,11 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
         // expect_error steps intentionally exercise invalid-request paths,
         // including the "missing idempotency_key" test in universal/idempotency.yaml.
         if (step.expect_error === true) continue;
+        // Steps without schema_ref are HTTP probes, controller calls, or
+        // synthetic invocations (e.g., comply_test_controller's
+        // simulate_budget scenarios, universal/security.yaml's probe steps)
+        // that don't send a task request schema. They're out of scope for
+        // this lint.
         const schemaRef = step.schema_ref;
         if (!schemaRef || !mutatingRefs.has(schemaRef)) continue;
         const hasKey =
@@ -245,8 +257,12 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
     throw new Error(
       `Storyboard idempotency_key lint: ${violations.length} step(s) invoke a mutating task without declaring idempotency_key in sample_request.\n\n` +
       lines.join('\n') +
-      `\n\nAdd \`idempotency_key: "$generate:uuid_v4#<alias>"\` to each sample_request. ` +
-      `The alias is resolved to a stable UUID per run by the storyboard runner; see static/compliance/source/universal/idempotency.yaml.`
+      `\n\nAdd \`idempotency_key: "$generate:uuid_v4#<storyboard>_<phase>_<step>"\` ` +
+      `to each sample_request (lowercase, hyphens → underscores; the alias is ` +
+      `resolved to a stable UUID per run by the storyboard runner). See ` +
+      `static/compliance/source/universal/idempotency.yaml for the convention, ` +
+      `and note the deliberate alias-reuse pattern there when two steps must ` +
+      `share a key (replay tests).`
     );
   }
 }

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -39,6 +39,7 @@ const DIST_DIR = path.join(__dirname, '../dist/compliance');
 const PACKAGE_JSON = path.join(__dirname, '../package.json');
 const SPECIALISM_ENUM = path.join(__dirname, '../static/schemas/source/enums/specialism.json');
 const PROTOCOL_ENUM = path.join(__dirname, '../static/schemas/source/enums/adcp-protocol.json');
+const SCHEMAS_DIR = path.join(__dirname, '../static/schemas/source');
 
 const args = process.argv.slice(2);
 const isRelease = args.includes('--release');
@@ -158,6 +159,98 @@ function discoverProtocols(sourceDir, specialisms) {
   return items.sort((a, b) => a.id.localeCompare(b.id));
 }
 
+// ── Idempotency lint ────────────────────────────────────────────────
+//
+// Every mutating request in AdCP (any task whose request schema lists
+// `idempotency_key` in its top-level `required` array) MUST carry an
+// idempotency_key, per adcontextprotocol/adcp#2315. Storyboard
+// sample_requests are spec artifacts — when they omit it, the published
+// example is non-conforming even if the runner auto-injects at runtime.
+// This lint reads the request schemas (source of truth) rather than
+// hardcoding a task list, so new mutating tasks are covered on arrival.
+
+function loadMutatingSchemaRefs(schemasDir) {
+  const refs = new Set();
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) { walk(p); continue; }
+      if (!entry.name.endsWith('-request.json')) continue;
+      let schema;
+      try { schema = JSON.parse(fs.readFileSync(p, 'utf8')); }
+      catch { continue; }
+      const required = Array.isArray(schema.required) ? schema.required : [];
+      if (required.includes('idempotency_key')) {
+        refs.add(path.relative(schemasDir, p));
+      }
+    }
+  }
+  walk(schemasDir);
+  return refs;
+}
+
+function lintStoryboardIdempotency(sourceDir, schemasDir) {
+  const mutatingRefs = loadMutatingSchemaRefs(schemasDir);
+  const violations = [];
+
+  function lintFile(p) {
+    const rel = path.relative(sourceDir, p);
+    // Not storyboards: test-kit fixtures and the schema doc itself.
+    if (rel.startsWith('test-kits/')) return;
+    if (rel.endsWith('storyboard-schema.yaml')) return;
+
+    let doc;
+    try { doc = yaml.load(fs.readFileSync(p, 'utf8')); }
+    catch { return; }
+    if (!doc || typeof doc !== 'object' || !Array.isArray(doc.phases)) return;
+
+    for (const phase of doc.phases) {
+      if (!phase || !Array.isArray(phase.steps)) continue;
+      for (const step of phase.steps) {
+        if (!step || typeof step !== 'object' || !step.task) continue;
+        // expect_error steps intentionally exercise invalid-request paths,
+        // including the "missing idempotency_key" test in universal/idempotency.yaml.
+        if (step.expect_error === true) continue;
+        const schemaRef = step.schema_ref;
+        if (!schemaRef || !mutatingRefs.has(schemaRef)) continue;
+        const hasKey =
+          step.sample_request &&
+          typeof step.sample_request === 'object' &&
+          step.sample_request.idempotency_key !== undefined;
+        if (hasKey) continue;
+        violations.push({
+          file: rel,
+          phase: phase.id,
+          step: step.id,
+          task: step.task,
+          schema: schemaRef,
+        });
+      }
+    }
+  }
+
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) { walk(p); continue; }
+      if (entry.name.endsWith('.yaml')) lintFile(p);
+    }
+  }
+  walk(sourceDir);
+
+  if (violations.length > 0) {
+    const lines = violations.map(v =>
+      `  ${v.file} phase=${v.phase} step=${v.step}: task "${v.task}" is mutating (schema ${v.schema} requires idempotency_key) but sample_request omits it.`
+    );
+    throw new Error(
+      `Storyboard idempotency_key lint: ${violations.length} step(s) invoke a mutating task without declaring idempotency_key in sample_request.\n\n` +
+      lines.join('\n') +
+      `\n\nAdd \`idempotency_key: "$generate:uuid_v4#<alias>"\` to each sample_request. ` +
+      `The alias is resolved to a stable UUID per run by the storyboard runner; see static/compliance/source/universal/idempotency.yaml.`
+    );
+  }
+}
+
 function verifyEnumParity(specialisms, protocols) {
   const fsSpecialisms = new Set(specialisms.map(s => s.id));
   const fsProtocols = new Set(protocols.map(d => d.id));
@@ -200,6 +293,7 @@ function generateIndex(version, sourceDir) {
   const specialisms = discoverSpecialisms(sourceDir);
   const protocols = discoverProtocols(sourceDir, specialisms);
   verifyEnumParity(specialisms, protocols);
+  lintStoryboardIdempotency(sourceDir, SCHEMAS_DIR);
   const universalDir = path.join(sourceDir, 'universal');
   const universal = fs.existsSync(universalDir)
     ? fs.readdirSync(universalDir)

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -14,10 +14,26 @@ import { clearSessions } from '../../src/training-agent/state.js';
 import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 
+// Storyboard sample_requests declare `idempotency_key: "$generate:uuid_v4#<alias>"`
+// per the convention in static/compliance/source/universal/idempotency.yaml.
+// The runtime runner substitutes a stable UUID per alias per run; this test
+// walks the YAML directly, so it performs the same substitution here — a
+// fresh UUID per alias per test invocation. Aliases are test-local; we don't
+// need the cached cross-step reuse the runner implements.
+function resolveIdempotencyPlaceholder(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  if (!value.startsWith('$generate:uuid_v4#')) return value;
+  return `test-${randomUUID()}`;
+}
+
 function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
   if (!MUTATING_TOOLS.has(toolName)) return args;
-  if (args.idempotency_key !== undefined) return args;
-  return { ...args, idempotency_key: `test-${randomUUID()}` };
+  if (args.idempotency_key === undefined) {
+    return { ...args, idempotency_key: `test-${randomUUID()}` };
+  }
+  const resolved = resolveIdempotencyPlaceholder(args.idempotency_key);
+  if (resolved === args.idempotency_key) return args;
+  return { ...args, idempotency_key: resolved };
 }
 
 const REPO_ROOT = join(process.cwd());

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -196,6 +196,7 @@ phases:
                   asset_type: "text"
                   content: "Trail Pro 3000 — Built for the Summit"
 
+          idempotency_key: "$generate:uuid_v4#creative_lifecycle_sync_multiple_sync_creatives"
           context:
             correlation_id: "creative_lifecycle--sync_creatives"
         validations:

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -110,6 +110,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_account_setup_sync_accounts"
           context:
             correlation_id: "media_buy_governance_escalation--sync_accounts"
         validations:
@@ -156,6 +157,7 @@ phases:
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                   categories: ["budget_authority", "brand_policy"]
 
+          idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_account_setup_sync_governance"
           context:
             correlation_id: "media_buy_governance_escalation--sync_governance"
           ext:
@@ -501,6 +503,7 @@ phases:
               creative_assignments:
                 - creative_id: "video_15s_trail_pro"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_create_buy_with_governance_create_media_buy"
           context:
             correlation_id: "media_buy_governance_escalation--create_media_buy"
         validations:
@@ -555,6 +558,7 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
 
+          idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_report_outcome_report_plan_outcome"
           context:
             correlation_id: "media_buy_governance_escalation--report_plan_outcome"
         validations:

--- a/static/compliance/source/protocols/media-buy/creative-reception.yaml
+++ b/static/compliance/source/protocols/media-buy/creative-reception.yaml
@@ -150,6 +150,7 @@ phases:
                   asset_type: "url"
                   url: "https://acme-outdoor.example.com/summer-sale"
 
+          idempotency_key: "$generate:uuid_v4#creative_sales_agent_push_creatives_sync_creatives"
           context:
             correlation_id: "creative_sales_agent--sync_creatives"
         validations:

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -141,6 +141,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_account_setup_sync_accounts"
           context:
             correlation_id: "media_buy_seller--sync_accounts"
 
@@ -196,6 +197,7 @@ phases:
                     schemes: ["Bearer"]
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                   categories: ["budget_authority", "brand_policy"]
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_setup_sync_governance"
           context:
             correlation_id: "media_buy_seller--sync_governance"
           ext:
@@ -396,6 +398,7 @@ phases:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
               scheme: "HMAC-SHA256"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_create_buy_create_media_buy"
           context:
             correlation_id: "media_buy_seller--create_media_buy"
 
@@ -576,6 +579,7 @@ phases:
                   asset_type: "image"
                   url: "https://cdn.pinnacle-agency.example/trail-pro-300x250.png"
                   mime_type: "image/png"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_creative_sync_sync_creatives"
           context:
             correlation_id: "media_buy_seller--sync_creatives"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -58,6 +58,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_delivery_reporting_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -117,6 +118,7 @@ phases:
             - product_id: "outdoor_video_q2"
               budget: 10000
               pricing_option_id: "cpm_standard"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_delivery_reporting_setup_create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -92,6 +92,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_approved_seller_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -117,6 +118,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_approved_seller_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"
@@ -177,6 +179,7 @@ phases:
             - product_id: "outdoor_video_q2"
               budget: 10000
               pricing_option_id: "cpm_standard"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_approved_buy_approved_create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -101,6 +101,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_conditions_seller_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -126,6 +127,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_conditions_seller_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"
@@ -186,6 +188,7 @@ phases:
             - product_id: "outdoor_ctv_q2"
               budget: 25000
               pricing_option_id: "cpm_standard"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_conditions_buy_with_conditions_create_media_buy_conditions"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -94,6 +94,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_seller_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -119,6 +120,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_seller_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -94,6 +94,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_recovery_seller_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -119,6 +120,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_recovery_seller_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -219,6 +219,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Testing NOT_CANCELLABLE on re-cancel"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_invalid_transitions_double_cancel_first_cancel"
           context:
             correlation_id: "invalid_transitions--first_cancel"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -209,6 +209,7 @@ phases:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_no_match_collections_v1"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_inventory_list_targeting_update_swap_lists_update_buy_swap_lists"
           context:
             correlation_id: "inventory_list_targeting--update_buy_swap_lists"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -156,6 +156,7 @@ phases:
               content:
                 media_url: "https://creative.acmeoutdoor.example/q3/display-300x250.jpg"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_pending_creatives_to_start_supply_creatives_sync_creative"
           context:
             correlation_id: "pending_creatives_to_start--sync_creative"
         validations:
@@ -181,6 +182,7 @@ phases:
               creative_assignments:
                 - creative_id: "acme-outdoor-display-q3"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_pending_creatives_to_start_supply_creatives_assign_creative_to_package"
           context:
             correlation_id: "pending_creatives_to_start--assign_creative_to_package"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -62,6 +62,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -239,6 +240,7 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_accept_proposal_create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
@@ -59,6 +59,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_refine_products_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -160,6 +160,7 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_setup_create_buy"
           context:
             correlation_id: "media_buy_state_machine--create_buy"
         context_outputs:
@@ -208,6 +209,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           paused: true
 
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_state_transitions_pause_buy"
           context:
             correlation_id: "media_buy_state_machine--pause_buy"
         validations:
@@ -239,6 +241,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           paused: false
 
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_state_transitions_resume_buy"
           context:
             correlation_id: "media_buy_state_machine--resume_buy"
         validations:
@@ -271,6 +274,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           canceled: true
 
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_state_transitions_cancel_buy"
           context:
             correlation_id: "media_buy_state_machine--cancel_buy"
         validations:
@@ -379,5 +383,6 @@ phases:
           media_buy_id: "$context.media_buy_id"
           canceled: true
 
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_terminal_enforcement_recancel_buy"
           context:
             correlation_id: "media_buy_state_machine--recancel_buy"

--- a/static/compliance/source/protocols/sponsored-intelligence/index.yaml
+++ b/static/compliance/source/protocols/sponsored-intelligence/index.yaml
@@ -158,6 +158,7 @@ phases:
             domain: "novamotors.example"
           campaign_context: "Nova EV launch — targeting environmentally conscious drivers interested in electric vehicles"
 
+          idempotency_key: "$generate:uuid_v4#si_baseline_session_lifecycle_si_initiate_session"
           context:
             correlation_id: "si_session--si_initiate_session"
         context_outputs:
@@ -199,6 +200,7 @@ phases:
           session_id: "$context.session_id"
           message: "What are the best electric vehicles for long road trips?"
 
+          idempotency_key: "$generate:uuid_v4#si_baseline_session_lifecycle_si_send_message"
           context:
             correlation_id: "si_session--si_send_message"
         validations:

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -155,6 +155,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+          idempotency_key: "$generate:uuid_v4#audience_sync_audience_sync_discover_audiences"
           context:
             correlation_id: "audience_sync--discover_audiences"
         validations:
@@ -201,6 +202,7 @@ phases:
                 - hashed_email: "a000000000000000000000000000000000000000000000000000000000000000"
                 - hashed_phone: "b000000000000000000000000000000000000000000000000000000000000000"
 
+          idempotency_key: "$generate:uuid_v4#audience_sync_audience_sync_create_audience"
           context:
             correlation_id: "audience_sync--create_audience"
         validations:
@@ -245,6 +247,7 @@ phases:
             - audience_id: "adcp-test-audience-001"
               delete: true
 
+          idempotency_key: "$generate:uuid_v4#audience_sync_audience_sync_delete_audience"
           context:
             correlation_id: "audience_sync--delete_audience"
         validations:

--- a/static/compliance/source/specialisms/brand-rights/index.yaml
+++ b/static/compliance/source/specialisms/brand-rights/index.yaml
@@ -257,6 +257,7 @@ phases:
                 - "Bearer"
               credentials: "pinnacle-revocation-webhook-secret-token"
 
+          idempotency_key: "$generate:uuid_v4#brand_rights_rights_acquisition_acquire_rights"
           context:
             correlation_id: "brand_rights--acquire_rights"
         context_outputs:

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -69,6 +69,7 @@ phases:
                 start: "2026-04-01T00:00:00Z"
                 end: "2026-06-30T23:59:59Z"
               countries: ["US"]
+          idempotency_key: "$generate:uuid_v4#brand_rights_governance_denied_governance_plan_setup_sync_plans"
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
@@ -92,6 +93,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#brand_rights_governance_denied_brand_agent_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -117,6 +119,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]
+          idempotency_key: "$generate:uuid_v4#brand_rights_governance_denied_brand_agent_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -132,6 +132,7 @@ phases:
           filters:
             kinds: ["series"]
 
+          idempotency_key: "$generate:uuid_v4#collection_lists_create_list_create_inclusion_list"
           context:
             correlation_id: "collection_lists--create_inclusion_list"
         context_outputs:
@@ -284,6 +285,7 @@ phases:
                 - type: "imdb_id"
                   value: "tt9999906"
 
+          idempotency_key: "$generate:uuid_v4#collection_lists_update_list_update_collection_list"
           context:
             correlation_id: "collection_lists--update_collection_list"
         validations:
@@ -330,6 +332,7 @@ phases:
               domain: "novamotors.example"
             operator: "novamotors.example"
 
+          idempotency_key: "$generate:uuid_v4#collection_lists_delete_list_delete_collection_list"
           context:
             correlation_id: "collection_lists--delete_collection_list"
         validations:

--- a/static/compliance/source/specialisms/content-standards/index.yaml
+++ b/static/compliance/source/specialisms/content-standards/index.yaml
@@ -123,6 +123,7 @@ phases:
               enforcement: must
               policy: "Brand colors must match palette within 5% tolerance"
 
+          idempotency_key: "$generate:uuid_v4#content_standards_create_standards_create_content_standards"
           context:
             correlation_id: "content_standards--create_content_standards"
         validations:
@@ -251,6 +252,7 @@ phases:
               enforcement: should
               policy: "All images must have alt text"
 
+          idempotency_key: "$generate:uuid_v4#content_standards_update_standards_update_content_standards"
           context:
             correlation_id: "content_standards--update_content_standards"
         validations:
@@ -301,6 +303,7 @@ phases:
                 width: 300
                 height: 250
 
+          idempotency_key: "$generate:uuid_v4#content_standards_calibration_calibrate_content"
           context:
             correlation_id: "content_standards--calibrate_content"
         validations:
@@ -348,6 +351,7 @@ phases:
                 width: 300
                 height: 250
 
+          idempotency_key: "$generate:uuid_v4#content_standards_must_rule_violation_calibrate_must_violation"
         validations:
           - check: response_schema
             description: "Response matches calibrate-content-response.json schema"
@@ -406,6 +410,7 @@ phases:
               enforcement: must
               policy: "No stock photography"
 
+          idempotency_key: "$generate:uuid_v4#content_standards_standards_version_change_update_stricter_standards"
         validations:
           - check: response_schema
             description: "Response matches update-content-standards-response.json schema"
@@ -439,6 +444,7 @@ phases:
                 width: 300
                 height: 250
 
+          idempotency_key: "$generate:uuid_v4#content_standards_standards_version_change_calibrate_after_policy_change"
         validations:
           - check: response_schema
             description: "Response matches calibrate-content-response.json schema"

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -212,6 +212,7 @@ phases:
           media_buy_id: "mb_summer_campaign_001"
           package_id: "pkg_ctv_premium"
 
+          idempotency_key: "$generate:uuid_v4#creative_ad_server_generate_tags_build_tag"
           context:
             correlation_id: "creative_ad_server--build_tag"
         validations:

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -135,6 +135,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_account_setup_sync_accounts"
           context:
             correlation_id: "creative_generative--seller--sync_accounts"
         validations:
@@ -343,6 +344,7 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_create_buy_create_media_buy"
           context:
             correlation_id: "creative_generative--seller--create_media_buy"
         validations:
@@ -455,6 +457,7 @@ phases:
             - creative_id: "gen_video_summer_sale"
               package_id: "outdoor_video_q2"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_creative_brief_sync_sync_creatives_brief"
           context:
             correlation_id: "creative_generative--seller--sync_creatives_brief"
         validations:
@@ -509,6 +512,7 @@ phases:
                   width: 300
                   height: 250
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_creative_brief_sync_sync_creatives_standard"
           context:
             correlation_id: "creative_generative--seller--sync_creatives_standard"
         validations:
@@ -563,6 +567,7 @@ phases:
                     headline: "Test"
                     cta: "Click"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_creative_brief_sync_sync_creatives_invalid_brand"
           context:
             correlation_id: "creative_generative--seller--sync_creatives_invalid_brand"
         validations:
@@ -645,6 +650,7 @@ phases:
                     headline: "Your Next Adventure Starts Here"
                     cta: "Shop the Sale"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_seller_creative_generation_lifecycle_check_creative_status"
           context:
             correlation_id: "creative_generative--seller--check_creative_status"
         validations:

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -174,6 +174,7 @@ phases:
           quality: "draft"
           include_preview: true
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_generate_from_brief_build_draft"
           context:
             correlation_id: "creative_generative--build_draft"
         validations:
@@ -241,6 +242,7 @@ phases:
           quality: "draft"
           include_preview: true
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_refine_refine_creative"
           context:
             correlation_id: "creative_generative--refine_creative"
         validations:
@@ -315,6 +317,7 @@ phases:
             domain: "acme-outdoor.example.com"
           quality: "production"
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_multi_format_build_multi_format"
           context:
             correlation_id: "creative_generative--build_multi_format"
         validations:
@@ -381,6 +384,7 @@ phases:
           quality: "production"
           include_preview: true
 
+          idempotency_key: "$generate:uuid_v4#creative_generative_production_build_build_production"
           context:
             correlation_id: "creative_generative--build_production"
         validations:

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -312,6 +312,7 @@ phases:
           brand:
             domain: "acme-outdoor.example.com"
 
+          idempotency_key: "$generate:uuid_v4#creative_template_build_build_creative"
           context:
             correlation_id: "creative_template--build_creative"
         validations:
@@ -373,6 +374,7 @@ phases:
           brand:
             domain: "acme-outdoor.example.com"
 
+          idempotency_key: "$generate:uuid_v4#creative_template_build_build_multi_format"
           context:
             correlation_id: "creative_template--build_multi_format"
         validations:

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -257,6 +257,7 @@ phases:
               budget: 15000
               pricing_option_id: "cpm_standard"
 
+          idempotency_key: "$generate:uuid_v4#governance_spend_authority_create_buy_with_conditions_create_media_buy"
           context:
             correlation_id: "governance_spend_authority--create_media_buy"
         validations:

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -122,6 +122,7 @@ phases:
                 - type: "domain"
                   value: "campinggear.example"
 
+          idempotency_key: "$generate:uuid_v4#property_lists_create_list_create_inclusion_list"
           context:
             correlation_id: "property_lists--create_inclusion_list"
         context_outputs:
@@ -259,6 +260,7 @@ phases:
                 - type: "domain"
                   value: "mountaineering.example"
 
+          idempotency_key: "$generate:uuid_v4#property_lists_update_list_update_property_list"
           context:
             correlation_id: "property_lists--update_property_list"
         validations:
@@ -454,6 +456,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "acmeoutdoor.example"
 
+          idempotency_key: "$generate:uuid_v4#property_lists_delete_list_delete_property_list"
           context:
             correlation_id: "property_lists--delete_property_list"
         validations:

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -271,6 +271,7 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          idempotency_key: "$generate:uuid_v4#sales_broadcast_tv_create_buy_create_media_buy"
           context:
             correlation_id: "sales_broadcast_tv--create_media_buy"
         validations:
@@ -449,6 +450,7 @@ phases:
                   container_format: "mp4"
                   video_codec: "h264"
 
+          idempotency_key: "$generate:uuid_v4#sales_broadcast_tv_creative_sync_sync_creatives"
           context:
             correlation_id: "sales_broadcast_tv--sync_creatives"
         validations:

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -123,6 +123,7 @@ phases:
               billing: "operator"
               sandbox: true
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_account_setup_sync_accounts"
           context:
             correlation_id: "sales_catalog_driven--sync_accounts"
         validations:
@@ -254,6 +255,7 @@ phases:
                     amount: 195.00
                     currency: "USD"
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_catalog_sync_sync_catalogs"
           context:
             correlation_id: "sales_catalog_driven--sync_catalogs"
         validations:
@@ -377,6 +379,7 @@ phases:
                 - catalog_id: "menu_spring_2026"
                   catalog_type: "product"
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_create_buy_create_media_buy"
           context:
             correlation_id: "sales_catalog_driven--create_media_buy"
         validations:
@@ -430,6 +433,7 @@ phases:
               event_types: ["purchase", "add_to_cart", "page_view", "lead"]
               allowed_domains: ["amsterdam-steakhouse.com", "book.amsterdam-steakhouse.com"]
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_event_setup_sync_event_sources"
           context:
             correlation_id: "sales_catalog_driven--sync_event_sources"
           ext:
@@ -497,6 +501,7 @@ phases:
               timestamp: "2026-04-15T20:45:00Z"
               content_ids: ["seafood_tower"]
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_conversion_tracking_log_events"
           context:
             correlation_id: "sales_catalog_driven--log_events"
         validations:
@@ -550,6 +555,7 @@ phases:
           metric_type: "conversion_rate"
           feedback_source: "buyer_attribution"
 
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_optimization_loop_provide_feedback"
           context:
             correlation_id: "sales_catalog_driven--provide_feedback"
           ext:

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -134,6 +134,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#sales_guaranteed_account_setup_sync_accounts"
           context:
             correlation_id: "sales_guaranteed--sync_accounts"
         validations:
@@ -284,6 +285,7 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          idempotency_key: "$generate:uuid_v4#sales_guaranteed_create_buy_submitted_create_media_buy"
           context:
             correlation_id: "sales_guaranteed--create_media_buy"
         validations:
@@ -399,6 +401,7 @@ phases:
                   url: "https://cdn.pinnacle-agency.example/trail-pro-30s.mp4"
                   mime_type: "video/mp4"
 
+          idempotency_key: "$generate:uuid_v4#sales_guaranteed_creative_sync_sync_creatives"
           context:
             correlation_id: "sales_guaranteed--sync_creatives"
         validations:

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -219,6 +219,7 @@ phases:
               creative_assignments:
                 - creative_id: "video_30s_trail_pro"
 
+          idempotency_key: "$generate:uuid_v4#sales_non_guaranteed_create_buy_create_media_buy"
           context:
             correlation_id: "sales_non_guaranteed--create_media_buy"
         validations:
@@ -327,6 +328,7 @@ phases:
               bid_price: 20.00
               budget: 13000
 
+          idempotency_key: "$generate:uuid_v4#sales_non_guaranteed_adjust_bids_update_media_buy"
           context:
             correlation_id: "sales_non_guaranteed--update_media_buy"
         validations:

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -125,6 +125,7 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          idempotency_key: "$generate:uuid_v4#sales_proposal_mode_account_setup_sync_accounts"
           context:
             correlation_id: "sales_proposal_mode--sync_accounts"
         validations:
@@ -331,6 +332,7 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
 
+          idempotency_key: "$generate:uuid_v4#sales_proposal_mode_accept_proposal_create_media_buy"
           context:
             correlation_id: "sales_proposal_mode--create_media_buy"
         validations:
@@ -438,6 +440,7 @@ phases:
                   url: "https://cdn.pinnacle-agency.example/trail-pro-15s.mp4"
                   mime_type: "video/mp4"
 
+          idempotency_key: "$generate:uuid_v4#sales_proposal_mode_creative_sync_sync_creatives"
           context:
             correlation_id: "sales_proposal_mode--sync_creatives"
         validations:

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -113,6 +113,7 @@ phases:
               operator: "pinnacle-agency.example"
               billing: "operator"
 
+          idempotency_key: "$generate:uuid_v4#sales_social_account_setup_sync_accounts"
           context:
             correlation_id: "sales_social--sync_accounts"
         validations:
@@ -201,6 +202,7 @@ phases:
               name: "Outdoor enthusiasts 25-54"
               description: "Adults 25-54 interested in hiking, camping, and outdoor gear"
 
+          idempotency_key: "$generate:uuid_v4#sales_social_audience_sync_sync_audiences"
           context:
             correlation_id: "sales_social--sync_audiences"
         validations:
@@ -259,6 +261,7 @@ phases:
                   asset_type: "text"
                   content: "Trail Pro 3000 — Built for the Summit"
 
+          idempotency_key: "$generate:uuid_v4#sales_social_creative_push_sync_creatives"
           context:
             correlation_id: "sales_social--sync_creatives"
         validations:
@@ -308,6 +311,7 @@ phases:
               value: 149.99
               currency: "USD"
 
+          idempotency_key: "$generate:uuid_v4#sales_social_event_logging_log_event"
           context:
             correlation_id: "sales_social--log_event"
         validations:

--- a/static/compliance/source/specialisms/signal-marketplace/index.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/index.yaml
@@ -295,8 +295,6 @@ phases:
               platform: "the-trade-desk"
               account: "agency-123-ttd"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_platform"
-
-          idempotency_key: "$generate:uuid_v4#signal_marketplace_platform_activation_activate_on_platform"
           context:
             correlation_id: "signal_marketplace--activate_on_platform"
           ext:
@@ -366,8 +364,6 @@ phases:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_agent"
-
-          idempotency_key: "$generate:uuid_v4#signal_marketplace_agent_activation_activate_on_agent"
           context:
             correlation_id: "signal_marketplace--activate_on_agent"
           ext:

--- a/static/compliance/source/specialisms/signal-marketplace/index.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/index.yaml
@@ -296,6 +296,7 @@ phases:
               account: "agency-123-ttd"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_platform"
 
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_platform_activation_activate_on_platform"
           context:
             correlation_id: "signal_marketplace--activate_on_platform"
           ext:
@@ -366,6 +367,7 @@ phases:
               agent_url: "https://wonderstruck.salesagents.example"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_agent"
 
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_agent_activation_activate_on_agent"
           context:
             correlation_id: "signal_marketplace--activate_on_agent"
           ext:

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -72,6 +72,7 @@ phases:
                 start: "2026-04-01T00:00:00Z"
                 end: "2026-06-30T23:59:59Z"
               countries: ["US"]
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_governance_plan_setup_sync_plans"
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
@@ -95,6 +96,7 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_signal_agent_setup_sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -120,6 +122,7 @@ phases:
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]
+          idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_signal_agent_setup_sync_governance"
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"

--- a/static/compliance/source/specialisms/signal-owned/index.yaml
+++ b/static/compliance/source/specialisms/signal-owned/index.yaml
@@ -215,6 +215,7 @@ phases:
               account: "agency-123-ttd"
           idempotency_key: "$generate:uuid_v4#signal_owned_activate_platform"
 
+          idempotency_key: "$generate:uuid_v4#signal_owned_platform_activation_activate_on_platform"
           context:
             correlation_id: "signal_owned--activate_on_platform"
           ext:
@@ -272,6 +273,7 @@ phases:
               agent_url: "https://wonderstruck.salesagents.example"
           idempotency_key: "$generate:uuid_v4#signal_owned_activate_agent"
 
+          idempotency_key: "$generate:uuid_v4#signal_owned_agent_activation_activate_on_agent"
           context:
             correlation_id: "signal_owned--activate_on_agent"
           ext:

--- a/static/compliance/source/specialisms/signal-owned/index.yaml
+++ b/static/compliance/source/specialisms/signal-owned/index.yaml
@@ -214,8 +214,6 @@ phases:
               platform: "the-trade-desk"
               account: "agency-123-ttd"
           idempotency_key: "$generate:uuid_v4#signal_owned_activate_platform"
-
-          idempotency_key: "$generate:uuid_v4#signal_owned_platform_activation_activate_on_platform"
           context:
             correlation_id: "signal_owned--activate_on_platform"
           ext:
@@ -272,8 +270,6 @@ phases:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
           idempotency_key: "$generate:uuid_v4#signal_owned_activate_agent"
-
-          idempotency_key: "$generate:uuid_v4#signal_owned_agent_activation_activate_on_agent"
           context:
             correlation_id: "signal_owned--activate_on_agent"
           ext:

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -514,6 +514,7 @@ phases:
               budget: 5000
               pricing_option_id: 'test-pricing'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_media_buy_create_media_buy"
           context:
             correlation_id: "deterministic_testing--create_media_buy"
         validations:
@@ -728,6 +729,7 @@ phases:
                   url: 'https://via.placeholder.com/300x250'
                   mime_type: 'image/png'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_creative_sync_creative_for_state"
           context:
             correlation_id: "deterministic_testing--sync_creative_for_state"
         validations:
@@ -1036,6 +1038,7 @@ phases:
               budget: 5000
               pricing_option_id: 'test-pricing'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_delivery_create_media_buy_for_delivery"
           context:
             correlation_id: "deterministic_testing--create_media_buy_for_delivery"
         validations:
@@ -1166,6 +1169,7 @@ phases:
               budget: 10000
               pricing_option_id: 'test-pricing'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_budget_create_media_buy_for_budget"
           context:
             correlation_id: "deterministic_testing--create_media_buy_for_budget"
         validations:

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -354,6 +354,7 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          idempotency_key: "$generate:uuid_v4#schema_validation_temporal_validation_past_start_date"
           context:
             correlation_id: "schema_validation--past_start_date"
         validations:


### PR DESCRIPTION
## Summary

Closes #2372. Extends `scripts/build-compliance.cjs` with a lint pass that fails the build when any storyboard step invokes a mutating task without declaring `idempotency_key` in `sample_request`. A mutating task is one whose request schema lists `idempotency_key` in its top-level `required` array — the lint reads the schemas themselves (source of truth), so new mutating tasks are covered automatically. The one documented exception (`si-terminate-session`: naturally idempotent by session_id) carries a `$comment` on its request schema and is correctly absent from the required-key set.

Normative anchors for the mutating-request rule: `docs/reference/migration/v3-readiness.mdx`, `docs/reference/release-notes.mdx` 3.0 entry, and adcontextprotocol/adcp#2315.

Also fixes **101 pre-existing omissions across 38 storyboard files** so the build passes at HEAD with the lint enabled.

## What changes

### Lint (`scripts/build-compliance.cjs`)
- `loadMutatingSchemaRefs()` scans `static/schemas/source/**/*-request.json` and builds the set of request schemas that require `idempotency_key` via their top-level `required` array.
- `lintStoryboardIdempotency()` walks every storyboard step, cross-references `step.schema_ref` against that set, and fails with a line-per-violation message:
  ```
  Storyboard idempotency_key lint: N step(s) invoke a mutating task without declaring idempotency_key in sample_request.
    specialisms/sales-guaranteed/index.yaml phase=account_setup step=sync_accounts: task "sync_accounts" is mutating (schema account/sync-accounts-request.json requires idempotency_key) but sample_request omits it.
  ```
- Hooked into `generateIndex()` so every `build:compliance` invocation (dev or release) enforces it.
- Skip rules:
  - `expect_error: true` steps (the universal `idempotency.yaml` missing-key test belongs here).
  - `test-kits/` fixtures and `storyboard-schema.yaml` (not storyboards).
  - Steps without `schema_ref` — HTTP probes, controller-simulate scenarios, synthetic invocations (e.g., `universal/security.yaml` probe steps, `comply_test_controller` simulate_budget scenarios).
  - Tasks whose request schema doesn't require `idempotency_key`.

### Cleanup (38 storyboards, 101 steps)
Every violating step gets `idempotency_key: "$generate:uuid_v4#<storyboard>_<phase>_<step>"` — unique per step per run, descriptive enough to grep, matches the `$generate:` convention the runner already resolves (`universal/idempotency.yaml`). Examples now match what gets sent on the wire post adcp-client#602's storyboard-declared-key forward-through.

`universal/idempotency.yaml` is untouched — its deliberate `#replay_key` alias reuse (for cached-replay and conflict tests) is preserved.

Affected areas:
- `protocols/media-buy/` baseline, state-machine, creative-reception, 9 scenarios
- `protocols/creative/`, `protocols/governance/`, `protocols/sponsored-intelligence/`
- All `specialisms/sales-*/` (guaranteed, non-guaranteed, proposal-mode, catalog-driven, broadcast-tv, social)
- All `specialisms/creative-*/` (template, generative, generative-seller, ad-server)
- `specialisms/signal-owned/`, `specialisms/signal-marketplace/` + scenarios
- `specialisms/brand-rights/`, `specialisms/collection-lists/`, `specialisms/property-lists/`, `specialisms/content-standards/`, `specialisms/governance-spend-authority/`, `specialisms/audience-sync/`
- `universal/deterministic-testing.yaml`, `universal/schema-validation.yaml`

## Why now
Follow-up to adcp-client#611 review (runner-output contract conformance). The code-reviewer agent flagged that the contract improvements help *diagnose* missing idempotency at runtime but don't *prevent* storyboards from shipping without it. This lint closes that loop at author time, before the bundle is ever distributed — and surfaces the 101 pre-existing gaps that slipped through.

## Non-goals
- Doesn't validate the *value* of `idempotency_key` (pattern conformance belongs in request-shape validation, which already runs).
- Doesn't require the same key across stateful replay steps (runtime concern; context injection + deliberate alias reuse in the storyboard already handles that — see `universal/idempotency.yaml`).

## Expert review
Reviewed by `code-reviewer` and `ad-tech-protocol-expert` subagents. No blockers. Polish commit `64e235f3c` applied: normative-anchor comment citing v3-readiness.mdx and release-notes.mdx, and a sharpened error message suggesting the `<storyboard>_<phase>_<step>` alias convention explicitly.

## Test plan
- [x] `node scripts/build-compliance.cjs` — passes with lint enabled (8 universal, 6 protocols, 23 specialisms).
- [x] Negative test: deleted the `idempotency_key` line from one step, re-ran — lint fires with a clean actionable message naming the file, phase, step, task, and schema. Restored.
- [x] Precommit: `npm run test:unit && npm run typecheck` — 587 tests, clean typecheck.
- [x] `expect_error: true` steps (`universal/idempotency.yaml` missing-key test) remain untouched.
- [x] 101 auto-fixes spot-checked across media-buy, sales-*, creative-*, signals specialisms for correct indentation + placement before `context:` / `ext:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)