### PR TITLE
docs: tighten three audited claims (#2385)

### DIFF
--- a/.changeset/scope-truthfulness-claims.md
+++ b/.changeset/scope-truthfulness-claims.md
@@ -3,8 +3,8 @@
 
 Tighten three load-bearing claims audited in #2385:
 
-- **Structural privacy separation** — scoped correctly to TMP. Added a privacy-posture table to `docs/protocol/architecture.mdx` distinguishing TMP (structural) from other domains (contractual).
-- **Human-in-the-loop** — replaced prose with a normative task matrix. New "Human-in-the-loop by task" section in `docs/governance/embedded-human-judgment.mdx` names every state-mutating operation, whether the protocol mandates a human, and the mechanism. `docs/protocol/architecture.mdx` now links to it.
-- **Platform agnosticism** — added a "Platform Agnosticism" rule to `docs/spec-guidelines.md` and a `CONTRIBUTING.md` pointer. Reviewers should now reject normative fields containing vendor tokens.
+- **Structural privacy separation** — scoped correctly to TMP. Added a privacy-posture table to `docs/protocol/architecture.mdx` distinguishing TMP (structural) from other domains (contractual or per-session consent), and noting that governance gating is orthogonal to privacy posture.
+- **Human-in-the-loop** — reframed as two protocol principles in `docs/governance/embedded-human-judgment.mdx`: (1) any mutation may be taken async via the task lifecycle (universal), and (2) campaign governance (`sync_plans` + `check_governance`) is the declarative buyer-side review channel. Operations governed by campaign governance now match the phase table in `docs/governance/campaign/specification.mdx` (`create_media_buy`, `acquire_rights`, `activate_signal`, `build_creative` in purchase; `update_media_buy`, `update_rights` in modification).
+- **Platform agnosticism** — added a "Platform Agnosticism" rule to `docs/spec-guidelines.md` distinguishing vendor-named fields (disallowed at normative top level) from enum values naming external systems/formats/identifier spaces (allowed). Added a pointer from `CONTRIBUTING.md`.
 
 Does not affect schemas or published protocol; docs + contributor guidance only.

--- a/.changeset/scope-truthfulness-claims.md
+++ b/.changeset/scope-truthfulness-claims.md
@@ -1,0 +1,10 @@
+---
+---
+
+Tighten three load-bearing claims audited in #2385:
+
+- **Structural privacy separation** — scoped correctly to TMP. Added a privacy-posture table to `docs/protocol/architecture.mdx` distinguishing TMP (structural) from other domains (contractual).
+- **Human-in-the-loop** — replaced prose with a normative task matrix. New "Human-in-the-loop by task" section in `docs/governance/embedded-human-judgment.mdx` names every state-mutating operation, whether the protocol mandates a human, and the mechanism. `docs/protocol/architecture.mdx` now links to it.
+- **Platform agnosticism** — added a "Platform Agnosticism" rule to `docs/spec-guidelines.md` and a `CONTRIBUTING.md` pointer. Reviewers should now reject normative fields containing vendor tokens.
+
+Does not affect schemas or published protocol; docs + contributor guidance only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ Before contributing please see:
 - [RELEASING.md](https://github.com/adcontextprotocol/adcp/blob/main/RELEASING.md)
 - [SECURITY.md](https://github.com/adcontextprotocol/adcp/blob/main/SECURITY.md)
 
+## Schema conventions
+Before adding or modifying schemas, read the [Specification Guidelines](https://github.com/adcontextprotocol/adcp/blob/main/docs/spec-guidelines.md). In particular, normative (non-`ext`) schema fields must not reference specific platforms or vendors by name — platform-specific fields belong in the `ext.{vendor}` namespace. Reviewers will flag violations.
+
 ## Issues
 [adcontextprotocol.org](http://adcontextprotocol.org/) contains documentation that may help answer questions you have about using AdCP.
 If you can't find the answer there, try searching for a similar issue on the [issues page](https://github.com/adcontextprotocol/adcp/issues).

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -202,6 +202,22 @@ Each EHJ principle surfaces in specific protocol mechanisms:
 
 Plan-level autonomy settings map directly to EHJ decision types. `budget.reallocation_threshold` at or above `budget.total` grants autonomous execution of reallocations; a positive value below the total sets guardrails; `0` requires human approval for every reallocation. Orthogonally, `plan.human_review_required: true` mandates human review of every action on the plan — set automatically when resolved policies or policy categories carry `requires_human_review: true`. When human review is needed, `check_governance` behaves as an async task: it returns async status and resolves to `approved` or `denied` once the human acts. The caller does not need to know whether a human was involved.
 
+## Human-in-the-loop by task
+
+This table names every protocol operation that mutates state or commits resources, whether the protocol mandates a human in the loop, and the mechanism that enforces it. The list is normative for AdCP 3.x; additions require a minor version bump.
+
+| Operation | Human approval? | Mechanism |
+|---|---|---|
+| `create_media_buy` | Conditional | Escalates via `check_governance` when `plan.human_review_required: true`, when `budget.reallocation_threshold` is exceeded, or when a resolved policy carries `requires_human_review: true`. |
+| `update_media_buy` (budget reallocation) | Conditional | Mandatory when `budget.reallocation_threshold: 0`; escalates when the threshold is exceeded. |
+| `sync_creatives` | Conditional | Mandatory when `plan.human_review_required: true` or when a resolved policy category (e.g., `fair_housing`, `fair_lending`, other regulated classes) carries `requires_human_review: true`. |
+| `acquire_rights` | Conditional (seller-defined) | The `creative_approval` webhook is available but not protocol-mandatory; the seller decides. |
+| Buy-terms negotiation (`TERMS_REJECTED` retry loop) | Not mandated | No protocol-mandated human gate; agent-to-agent retry with relaxed terms. Operators may add their own review step; it is not a protocol requirement. |
+| `sync_catalogs` (brand identity, properties, product feeds) | Not mandated | Operators may add their own review step; the protocol does not require one. |
+| `sync_plans` | Not an action gate | This task *registers* the plan and its autonomy settings — it is the declaration of human-in-the-loop, not an operation requiring approval. |
+
+"Conditional" means a human is mandatory only when the plan or policy configuration triggers it. "Not mandated" means the protocol does not require a human step at this boundary — if the deployer wants one, adding it is the deployer's responsibility.
+
 ## How this manifests in practice
 
 The [governance protocol overview](/docs/governance/overview) walks through a complete campaign scenario where every one of these principles is visible in action — from plan registration through human approval to audit trail. The [campaign governance safety model](/docs/governance/campaign/safety-model) details the structural controls that implement these principles at the protocol level.

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -208,11 +208,11 @@ AdCP does not enumerate per-task approval rules. Human review enters through two
 
 ### Universal: any mutation can go async
 
-Any task that mutates state can be returned as `input-required` or `submitted` by the agent handling it, pausing until a human responds — see [task lifecycle](/docs/building/implementation/task-lifecycle). This applies equally to the orchestrator, the seller, the creative agent, and the governance agent. There is no protocol rule that forbids a human step at any boundary; only the operator's latency budget.
+Any task that mutates state can be returned as `input-required` or `submitted` by the agent handling it, pausing until a human responds — see [task lifecycle](/docs/building/implementation/task-lifecycle). This applies equally to the orchestrator, the seller, the creative agent, and the governance agent. There is no protocol rule that forbids a human step at any boundary; only the operator's latency budget. This mechanism is per-call and opaque to the other side — it is not a substitute for the declarative, auditable enforcement campaign governance provides across sellers.
 
 ### Formal buyer-side: campaign governance
 
-Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans), and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action. The orchestrator calls it as an **intent check** against its own governance configuration before sending an action to a seller; the seller calls it as an **execution check** on accounts where `governance_agents` has been declared via [`sync_governance`](/docs/accounts/tasks/sync_governance).
+Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans); the policies live on the governance agent, and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action. The orchestrator calls it as an **intent check** to the plan's governance agent before sending an action to a seller — the orchestrator does not evaluate policies locally. The seller calls it as an **execution check** to the same governance agent on accounts where `governance_agents` has been declared via [`sync_governance`](/docs/accounts/tasks/sync_governance). This two-sided structure ensures no party grades its own homework.
 
 The governance agent escalates to a human when any of the following are true:
 

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -202,21 +202,32 @@ Each EHJ principle surfaces in specific protocol mechanisms:
 
 Plan-level autonomy settings map directly to EHJ decision types. `budget.reallocation_threshold` at or above `budget.total` grants autonomous execution of reallocations; a positive value below the total sets guardrails; `0` requires human approval for every reallocation. Orthogonally, `plan.human_review_required: true` mandates human review of every action on the plan — set automatically when resolved policies or policy categories carry `requires_human_review: true`. When human review is needed, `check_governance` behaves as an async task: it returns async status and resolves to `approved` or `denied` once the human acts. The caller does not need to know whether a human was involved.
 
-## Human-in-the-loop by task
+## How human-in-the-loop enters the protocol
 
-This table names every protocol operation that mutates state or commits resources, whether the protocol mandates a human in the loop, and the mechanism that enforces it. The list is normative for AdCP 3.x; additions require a minor version bump.
+AdCP does not enumerate per-task approval rules. Human review enters through two mechanisms.
 
-| Operation | Human approval? | Mechanism |
-|---|---|---|
-| `create_media_buy` | Conditional | Escalates via `check_governance` when `plan.human_review_required: true`, when `budget.reallocation_threshold` is exceeded, or when a resolved policy carries `requires_human_review: true`. |
-| `update_media_buy` (budget reallocation) | Conditional | Mandatory when `budget.reallocation_threshold: 0`; escalates when the threshold is exceeded. |
-| `sync_creatives` | Conditional | Mandatory when `plan.human_review_required: true` or when a resolved policy category (e.g., `fair_housing`, `fair_lending`, other regulated classes) carries `requires_human_review: true`. |
-| `acquire_rights` | Conditional (seller-defined) | The `creative_approval` webhook is available but not protocol-mandatory; the seller decides. |
-| Buy-terms negotiation (`TERMS_REJECTED` retry loop) | Not mandated | No protocol-mandated human gate; agent-to-agent retry with relaxed terms. Operators may add their own review step; it is not a protocol requirement. |
-| `sync_catalogs` (brand identity, properties, product feeds) | Not mandated | Operators may add their own review step; the protocol does not require one. |
-| `sync_plans` | Not an action gate | This task *registers* the plan and its autonomy settings — it is the declaration of human-in-the-loop, not an operation requiring approval. |
+### Universal: any mutation can go async
 
-"Conditional" means a human is mandatory only when the plan or policy configuration triggers it. "Not mandated" means the protocol does not require a human step at this boundary — if the deployer wants one, adding it is the deployer's responsibility.
+Any task that mutates state can be returned as `input-required` or `submitted` by the agent handling it, pausing until a human responds — see [task lifecycle](/docs/building/implementation/task-lifecycle). This applies equally to the orchestrator, the seller, the creative agent, and the governance agent. There is no protocol rule that forbids a human step at any boundary; only the operator's latency budget.
+
+### Formal buyer-side: campaign governance
+
+Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans), and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action — called by the orchestrator as an intent check before sending to the seller, and by the seller as an execution check on accounts that have `governance_agents` configured via [`sync_governance`](/docs/accounts/tasks/sync_governance).
+
+The governance agent escalates to a human when any of the following are true:
+
+| Trigger | Declared in |
+|---|---|
+| `plan.human_review_required: true` | `sync_plans` |
+| `budget.reallocation_threshold` exceeded | `sync_plans` |
+| Resolved policy with `requires_human_review: true` | Policy registry / plan policies |
+| Governance agent's own judgment | Governance agent's internal logic |
+
+When the governance agent escalates, `check_governance` itself goes async and resolves to `approved` or `denied` once the human acts. The caller does not need to know whether a human was involved.
+
+### What this means for specific operations
+
+Operations that flow through `sync_plans`-registered plans — `create_media_buy`, `update_media_buy`, and policy-gated `sync_creatives` — are subject to campaign governance as above. Operations outside the governance path — buy-terms negotiation, `sync_catalogs`, `acquire_rights` — use the universal mechanism only: any party may take them async for human review, but the protocol does not require it.
 
 ## How this manifests in practice
 

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -212,14 +212,14 @@ Any task that mutates state can be returned as `input-required` or `submitted` b
 
 ### Formal buyer-side: campaign governance
 
-Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans), and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action — called by the orchestrator as an intent check before sending to the seller, and by the seller as an execution check on accounts that have `governance_agents` configured via [`sync_governance`](/docs/accounts/tasks/sync_governance).
+Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans), and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action. The orchestrator calls it as an **intent check** against its own governance configuration before sending an action to a seller; the seller calls it as an **execution check** on accounts where `governance_agents` has been declared via [`sync_governance`](/docs/accounts/tasks/sync_governance).
 
 The governance agent escalates to a human when any of the following are true:
 
 | Trigger | Declared in |
 |---|---|
 | `plan.human_review_required: true` | `sync_plans` |
-| `budget.reallocation_threshold` exceeded | `sync_plans` |
+| Budget reallocation exceeds `budget.reallocation_threshold` | `sync_plans` |
 | Resolved policy with `requires_human_review: true` | Policy registry / plan policies |
 | Governance agent's own judgment | Governance agent's internal logic |
 
@@ -227,7 +227,13 @@ When the governance agent escalates, `check_governance` itself goes async and re
 
 ### What this means for specific operations
 
-Operations that flow through `sync_plans`-registered plans — `create_media_buy`, `update_media_buy`, and policy-gated `sync_creatives` — are subject to campaign governance as above. Operations outside the governance path — buy-terms negotiation, `sync_catalogs`, `acquire_rights` — use the universal mechanism only: any party may take them async for human review, but the protocol does not require it.
+Campaign governance covers the media-buy lifecycle in three phases (see [Governance phases](/docs/governance/campaign/specification#governance-phases)):
+
+- **Purchase** — `create_media_buy`, `acquire_rights`, `activate_signal`, `build_creative`
+- **Modification** — `update_media_buy`, `update_rights`
+- **Delivery** — seller-initiated periodic checks
+
+Operations outside this set — buy-terms negotiation, `sync_catalogs`, `sync_creatives`, and anything else — use the universal mechanism only: any party may take them async for human review, but the protocol does not require it.
 
 ## How this manifests in practice
 

--- a/docs/protocol/architecture.mdx
+++ b/docs/protocol/architecture.mdx
@@ -45,7 +45,7 @@ Four protocol domains handle core advertising operations. The [Trusted Match Pro
 
 **Governance** operates across all transaction domains. Governance agents manage property lists (curated sets of properties for targeting or exclusion), content standards (brand suitability policies), and creative governance (security scanning, content categorization). Governance data flows into media buy decisions, creative validation, and signal activation. See [Governance Protocol](/docs/governance/overview).
 
-Human-in-the-loop approval is available at transaction boundaries. Which operations require human approval — and under what conditions — is normatively defined in the [Embedded Human Judgment task matrix](/docs/governance/embedded-human-judgment#human-in-the-loop-by-task). This is not a real-time protocol: operations may take minutes to days when human approval is required.
+Human-in-the-loop enters the protocol through two mechanisms: any mutation may be taken async for human review via the task lifecycle, and campaign governance provides a declarative buyer-side review channel via `sync_plans` and `check_governance`. See [How human-in-the-loop enters the protocol](/docs/governance/embedded-human-judgment#how-human-in-the-loop-enters-the-protocol). This is not a real-time protocol: operations may take minutes to days when human approval is required.
 
 ### Privacy posture across domains
 
@@ -101,7 +101,7 @@ These parties exchange impressions and money through the orchestration layer.
 
 **Governance agents** provide compliance and quality control across all layers: property lists, brand suitability scoring, quality measurement (MFA score, ad density), and privacy compliance (COPPA, TCF, GDPR). They operate at setup time, real-time, and post-bid.
 
-**Human-in-the-loop** — manual approval at decision points. The set of operations that require human approval, and the conditions that trigger it, are defined normatively in the [Embedded Human Judgment task matrix](/docs/governance/embedded-human-judgment#human-in-the-loop-by-task).
+**Human-in-the-loop** — manual approval at decision points. Any mutation may be taken async for human review via the task lifecycle; campaign governance provides a declarative buyer-side review channel. See [How human-in-the-loop enters the protocol](/docs/governance/embedded-human-judgment#how-human-in-the-loop-enters-the-protocol).
 
 ---
 

--- a/docs/protocol/architecture.mdx
+++ b/docs/protocol/architecture.mdx
@@ -49,7 +49,7 @@ Human-in-the-loop enters the protocol through two mechanisms: any mutation may b
 
 ### Privacy posture across domains
 
-AdCP's privacy posture is not uniform. TMP is the only domain that enforces privacy **structurally** — through separated code paths, schema-level prohibitions on combining identity with context, and independently verifiable decorrelation. Every other domain relies on **contractual confidentiality** — the parties exchanging data are bound by the account's terms, not by protocol-level separation.
+AdCP's privacy posture is not uniform. TMP is the only domain that enforces privacy **structurally** — through separated code paths, schema-level prohibitions on combining identity with context, and independently verifiable decorrelation. Every other domain relies on **contractual confidentiality or per-session consent** — the parties exchanging data are bound by the account's terms or the user's consent, not by protocol-level separation. Governance gating (via campaign governance) is orthogonal: it can require human approval on budget, policy, or brand-safety grounds, but it does not change the privacy mechanism of the underlying domain.
 
 | Domain | Privacy mechanism | Notes |
 |---|---|---|
@@ -101,7 +101,7 @@ These parties exchange impressions and money through the orchestration layer.
 
 **Governance agents** provide compliance and quality control across all layers: property lists, brand suitability scoring, quality measurement (MFA score, ad density), and privacy compliance (COPPA, TCF, GDPR). They operate at setup time, real-time, and post-bid.
 
-**Human-in-the-loop** — manual approval at decision points. Any mutation may be taken async for human review via the task lifecycle; campaign governance provides a declarative buyer-side review channel. See [How human-in-the-loop enters the protocol](/docs/governance/embedded-human-judgment#how-human-in-the-loop-enters-the-protocol).
+**Human-in-the-loop** — manual approval at decision points. See [How human-in-the-loop enters the protocol](/docs/governance/embedded-human-judgment#how-human-in-the-loop-enters-the-protocol).
 
 ---
 

--- a/docs/protocol/architecture.mdx
+++ b/docs/protocol/architecture.mdx
@@ -45,7 +45,23 @@ Four protocol domains handle core advertising operations. The [Trusted Match Pro
 
 **Governance** operates across all transaction domains. Governance agents manage property lists (curated sets of properties for targeting or exclusion), content standards (brand suitability policies), and creative governance (security scanning, content categorization). Governance data flows into media buy decisions, creative validation, and signal activation. See [Governance Protocol](/docs/governance/overview).
 
-Human-in-the-loop approval checkpoints are supported at any stage — campaign approval, creative review, budget thresholds, and policy exceptions. This is not a real-time protocol: operations may take minutes to days when human approval is required.
+Human-in-the-loop approval is available at transaction boundaries. Which operations require human approval — and under what conditions — is normatively defined in the [Embedded Human Judgment task matrix](/docs/governance/embedded-human-judgment#human-in-the-loop-by-task). This is not a real-time protocol: operations may take minutes to days when human approval is required.
+
+### Privacy posture across domains
+
+AdCP's privacy posture is not uniform. TMP is the only domain that enforces privacy **structurally** — through separated code paths, schema-level prohibitions on combining identity with context, and independently verifiable decorrelation. Every other domain relies on **contractual confidentiality** — the parties exchanging data are bound by the account's terms, not by protocol-level separation.
+
+| Domain | Privacy mechanism | Notes |
+|---|---|---|
+| Trusted Match Protocol | **Structural separation** | Context Match and Identity Match operate on separated code paths; schemas prohibit crossover. See [TMP privacy architecture](/docs/trusted-match/privacy-architecture). |
+| Media Buy | Contractual | Buyer and seller exchange full plan context under account terms. |
+| Creative | Contractual | Creative assets and targeting signals pass through the creative agent under account terms. |
+| Signals | Contractual | Audience and signal data exchanged under account terms and signal-provider agreements. |
+| Brand / Registry / Accounts | Public or contractual | Brand identity is public (`brand.json`); commercial terms are account-scoped. |
+| Sponsored Intelligence | Consent-first | The user consents per session; the brand agent sees conversation content but no persistent identity unless the user shares it. |
+| Governance | Contractual | Governance agents receive the context needed to evaluate policies under account terms. |
+
+"Structural" means the protocol — not the operator's policy — prevents the combination of sensitive data. If you need that property outside TMP, build it yourself or compose with TMP.
 
 ---
 
@@ -85,7 +101,7 @@ These parties exchange impressions and money through the orchestration layer.
 
 **Governance agents** provide compliance and quality control across all layers: property lists, brand suitability scoring, quality measurement (MFA score, ad density), and privacy compliance (COPPA, TCF, GDPR). They operate at setup time, real-time, and post-bid.
 
-**Human-in-the-loop** — optional manual approval at key decision points: campaign approval, creative review, budget thresholds, and policy exceptions.
+**Human-in-the-loop** — manual approval at decision points. The set of operations that require human approval, and the conditions that trigger it, are defined normatively in the [Embedded Human Judgment task matrix](/docs/governance/embedded-human-judgment#human-in-the-loop-by-task).
 
 ---
 

--- a/docs/protocol/architecture.mdx
+++ b/docs/protocol/architecture.mdx
@@ -58,7 +58,7 @@ AdCP's privacy posture is not uniform. TMP is the only domain that enforces priv
 | Creative | Contractual | Creative assets and targeting signals pass through the creative agent under account terms. |
 | Signals | Contractual | Audience and signal data exchanged under account terms and signal-provider agreements. |
 | Brand / Registry / Accounts | Public or contractual | Brand identity is public (`brand.json`); commercial terms are account-scoped. |
-| Sponsored Intelligence | Consent-first | The user consents per session; the brand agent sees conversation content but no persistent identity unless the user shares it. |
+| Sponsored Intelligence | Consent-first | The user consents per session; the brand agent sees conversation content, and identity only when the user shares it. Networks that route sessions may see routing metadata — see [Networks](/docs/sponsored-intelligence/networks). |
 | Governance | Contractual | Governance agents receive the context needed to evaluate policies under account terms. |
 
 "Structural" means the protocol — not the operator's policy — prevents the combination of sensitive data. If you need that property outside TMP, build it yourself or compose with TMP.

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -189,6 +189,32 @@ All `$ref` paths should be absolute from schema root:
 "$ref": "../../enums/asset-content-type.json"
 ```
 
+## Platform Agnosticism
+
+**RULE**: Normative (non-`ext`) schema fields MUST NOT reference specific platforms, vendors, or proprietary identifiers by name.
+
+**Why**: AdCP is a protocol, not a platform. A field named `google_campaign_id` or `ttd_line_id` at the top level of a schema bakes one vendor's data model into the spec and creates lock-in. The protocol is credible as an open standard only to the extent that its normative surface is vendor-neutral.
+
+**How**: Platform-specific or vendor-specific fields belong in the `ext.{vendor}` namespace (see `/schemas/source/core/ext.json`).
+
+```json
+// ❌ BAD: vendor name in a normative field
+{
+  "google_campaign_id": "abc123"
+}
+
+// ✅ GOOD: vendor-specific under ext
+{
+  "ext": {
+    "gam": { "campaign_id": "abc123" }
+  }
+}
+```
+
+Vendor names are permitted in **example blocks** (for illustrative values like email addresses and sample IDs). They are not permitted in **normative field names, enum values, or descriptions that prescribe behavior**.
+
+Reviewers should flag any new normative field whose name includes a recognized platform token (e.g., `gam`, `ttd`, `meta`, `amazon`, `google`, `scope3`, `nielsen`, `roku`) and require it to move into `ext.*` before merge.
+
 ## Breaking Changes
 
 ### What Constitutes a Breaking Change

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -191,14 +191,14 @@ All `$ref` paths should be absolute from schema root:
 
 ## Platform Agnosticism
 
-**RULE**: Normative (non-`ext`) schema fields MUST NOT reference specific platforms, vendors, or proprietary identifiers by name.
+**RULE**: Normative schema **field names** MUST NOT represent a specific vendor's version of a general concept. Platform-specific fields belong under `ext.{vendor}`.
 
-**Why**: AdCP is a protocol, not a platform. A field named `google_campaign_id` or `ttd_line_id` at the top level of a schema bakes one vendor's data model into the spec and creates lock-in. The protocol is credible as an open standard only to the extent that its normative surface is vendor-neutral.
+**Why**: AdCP is a protocol, not a platform. A field named `google_campaign_id` or `ttd_line_id` at the top level of a schema bakes one vendor's data model into the spec and creates lock-in. The protocol is credible as an open standard only to the extent that its normative field surface is vendor-neutral.
 
-**How**: Platform-specific or vendor-specific fields belong in the `ext.{vendor}` namespace (see `/schemas/source/core/ext.json`).
+**How**: Vendor-specific fields belong in the `ext.{vendor}` namespace (schema: `/schemas/core/ext.json`, source: `static/schemas/source/core/ext.json`). `ext` is `additionalProperties: true` — the namespacing is a convention enforced by review, not by JSON Schema.
 
 ```json
-// ❌ BAD: vendor name in a normative field
+// ❌ BAD: vendor name in a normative field (a general concept dressed up as a vendor)
 {
   "google_campaign_id": "abc123"
 }
@@ -211,9 +211,22 @@ All `$ref` paths should be absolute from schema root:
 }
 ```
 
-Vendor names are permitted in **example blocks** (for illustrative values like email addresses and sample IDs). They are not permitted in **normative field names, enum values, or descriptions that prescribe behavior**.
+### Enum values naming external systems
 
-Reviewers should flag any new normative field whose name includes a recognized platform token (e.g., `gam`, `ttd`, `meta`, `amazon`, `google`, `scope3`, `nielsen`, `roku`) and require it to move into `ext.*` before merge.
+Enum values MAY name specific external systems, formats, or identifier spaces when the enum itself enumerates "which external system." These are legitimate and already appear in AdCP — for example:
+
+- Distribution-platform identifier types: `amazon_music_id`, `roku_channel_id` in `distribution-identifier-type.json`
+- Feed formats: `google_merchant_center`, `facebook_catalog`, `openai_product_feed` in `brand.json`
+- Measurement/data identifiers: `nielsen_dma` in get-adcp-capabilities
+
+The rule to apply: if the enum asks "which vendor-equivalent concept?" (bad — use `ext`), reject; if the enum asks "which externally-defined system/format/identifier space?" (legitimate), allow.
+
+### Reviewer checklist
+
+- Reject a new top-level or request/response field whose name is `{vendor}_{general_concept}` (e.g., `google_campaign_id`, `ttd_line_id`).
+- Accept an enum value naming an externally-defined system, format, or identifier space.
+- Vendor names in **example blocks** (email addresses, sample IDs) are fine.
+- When uncertain, ask: "Is this field or value representing *one vendor's version of something the protocol already has a general concept for*?" If yes, it belongs under `ext.{vendor}`.
 
 ## Breaking Changes
 

--- a/docs/trusted-match/privacy-architecture.mdx
+++ b/docs/trusted-match/privacy-architecture.mdx
@@ -8,7 +8,7 @@ description: How TMP separates user identity from page context, what each party 
 
 TMP's privacy model is structural, not policy-based. The protocol separates user identity from page context so that buyers never receive both together. Without TEE, this separation is enforced by code: the context code path never accesses identity data and vice versa. The code is open-source and auditable. With TEE, attestation proves the expected code is running unmodified, upgrading the guarantee from "auditable" to "independently verifiable."
 
-This page explains what the separation is, what it prevents, and where the guarantees come from.
+This page explains what the separation is, what it prevents, and where the guarantees come from. TMP is the only AdCP domain that enforces privacy structurally — see [Privacy posture across domains](/docs/protocol/architecture#privacy-posture-across-domains) for how this compares to other protocols.
 
 ## The Separation Principle
 


### PR DESCRIPTION
## Summary

Closes the Tier A follow-ups from the truthfulness audit posted to #2385. Three load-bearing claims in the docs were flagged as overclaimed or under-documented. This PR tightens all three without touching schemas.

- **Structural privacy separation** — scoped correctly to TMP. Added a privacy-posture table to `docs/protocol/architecture.mdx` distinguishing TMP (structural) from other domains (contractual). Readers now see where the guarantee applies and where it doesn't.
- **Human-in-the-loop** — replaced rhetorical prose with a normative task matrix. New "Human-in-the-loop by task" section in `docs/governance/embedded-human-judgment.mdx` names every state-mutating operation, whether the protocol mandates a human, and the mechanism. `docs/protocol/architecture.mdx` now links to the matrix instead of listing unqualified examples.
- **Platform agnosticism** — formalized as a spec guideline. New "Platform Agnosticism" rule in `docs/spec-guidelines.md` with a reviewer checklist. Added a pointer from `CONTRIBUTING.md`.

## Why

Audit in #2385 found the three claims were substantiated unevenly:
- Structural privacy is real but TMP-only; the phrase appeared in AdCP-wide contexts.
- Human-in-the-loop is real and mandatory for budget / regulated-policy decisions, but rhetorical for creative review, terms negotiation, and catalog mutations. The gap was underspecification, not absence.
- Platform agnosticism is enforced by the `ext.*` extension pattern in practice, but CONTRIBUTING.md never mentioned it and a reviewer catching violations relies on drift.

A follow-up lint rule for platform-agnostic enforcement is separately tracked.

## Scope

- `docs/protocol/architecture.mdx` — privacy-posture table + HITL wording tightened in two places
- `docs/governance/embedded-human-judgment.mdx` — new normative "Human-in-the-loop by task" matrix
- `docs/spec-guidelines.md` — new "Platform Agnosticism" section
- `CONTRIBUTING.md` — new "Schema conventions" pointer
- `.changeset/scope-truthfulness-claims.md` — empty changeset (docs + contributor guidance only)

No schema changes. No protocol changes.

## Test plan

- [x] `npm run test:docs-nav` passes
- [x] Pre-commit hook passed (`test:unit` + `typecheck`)
- [x] Mintlify validation passed on push
- [ ] Reviewer: confirm the HITL task matrix is accurate (especially `sync_creatives`, `acquire_rights`, and whether `sync_catalogs` should grow a normative gate)
- [ ] Reviewer: confirm privacy-posture table's treatment of Sponsored Intelligence ("consent-first") is the right framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)