### PR TITLE
docs(spec-completeness): time semantics + activate_signal idempotency row

### DIFF
--- a/.changeset/time-semantics-and-activate-signal-idempotency.md
+++ b/.changeset/time-semantics-and-activate-signal-idempotency.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add a Time Semantics section to `docs/building/implementation/security.mdx` normativizing timestamp format (ISO 8601 with explicit offset MUST; naïve timestamps rejected with `INVALID_REQUEST`; UTC recommended on the wire), interval semantics (half-open `[start, end)`), and daypart targeting semantics (three declared modes: buyer-declared IANA zone, publisher-local, viewer-local; ambiguous dayparts rejected). Add the missing `idempotency_key` row to the `activate_signal` task reference — the schema already required the field; the doc had drifted.
+
+Closes #2395, #2396.

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -206,6 +206,37 @@ CREATE POLICY account_isolation_list ON media_buys
   USING (account_id = ANY(current_setting('app.authorized_accounts')::uuid[]));
 ```
 
+## Time Semantics
+
+AdCP operates across jurisdictions, ad servers, and daypart calendars. Implementations MUST be precise about time or buyers and sellers will disagree about what "delivered by 5pm" meant.
+
+### Timestamp format
+
+All timestamp fields in AdCP requests, responses, and webhook payloads MUST be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) with an explicit timezone offset.
+
+```
+✅ 2026-04-19T10:00:00Z            // UTC, recommended
+✅ 2026-04-19T10:00:00-04:00       // explicit offset
+❌ 2026-04-19T10:00:00             // no offset — ambiguous
+❌ 2026-04-19 10:00:00             // not ISO 8601
+```
+
+Implementations MUST reject ambiguous ("naïve") timestamps with `INVALID_REQUEST`. Implementations SHOULD use UTC (`Z` suffix) on the wire and convert to local time at the presentation layer.
+
+### Intervals
+
+Any time window in AdCP — flight dates, reporting windows, daypart targeting, idempotency replay TTLs — uses a **half-open interval**: `[start, end)`. The start timestamp is inclusive; the end timestamp is exclusive. A campaign with `start_time: 2026-04-01T00:00:00Z` and `end_time: 2026-05-01T00:00:00Z` runs for April and stops at the first tick of May.
+
+### Daypart targeting
+
+Daypart definitions MUST declare their **timezone semantics** — which of the three meanings the time values carry:
+
+- **Buyer-declared zone** — an IANA zone name alongside the daypart (e.g., `timezone: "America/New_York"`). The daypart is evaluated against that zone regardless of viewer or publisher location. Use this when the buyer wants "9–11pm New York time" enforced globally.
+- **Publisher-local** — the daypart is evaluated in the publisher's declared local zone. Use this when the buyer wants "prime time on the publisher's schedule" and is willing to let the publisher decide what that means.
+- **Viewer-local** — the daypart is evaluated against each viewer's timezone, resolved at serve time from the viewer's location signal. Use this when the buyer wants "serve at 8pm local" across a global audience.
+
+A daypart with no declared semantics is ambiguous and MUST be rejected with `INVALID_REQUEST`. Sellers MUST honor the declared semantics; if a seller cannot support the requested mode (e.g., a publisher operating in a single zone cannot serve viewer-local dayparting), the seller MUST reject with `INVALID_REQUEST` rather than silently converting. Per-agent defaults are non-normative and MUST NOT be relied on.
+
 ## Request Safety
 
 ### Idempotency

--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -21,6 +21,7 @@ The `activate_signal` task handles the entire activation lifecycle, including:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `idempotency_key` | string | Yes | Client-generated unique key for this request. Prevents duplicate activations on retries. MUST be unique per (seller, request) pair. Min 16 chars. See [Idempotency](/docs/building/implementation/security#idempotency) for normative semantics. |
 | `signal_agent_segment_id` | string | Yes | The universal identifier for the signal to activate |
 | `action` | string | No | `"activate"` (default) or `"deactivate"`. Deactivating removes segments from downstream platforms for data governance compliance (GDPR, CCPA). |
 | `destinations` | Destination[] | Yes | Target destination(s) for activation (see Destination Object below) |


### PR DESCRIPTION
## Summary

Two focused answers from the hostile-reviewer punch list. Rebased on main after #2415 and #2381 landed; scope reduced significantly.

Closes #2395, #2396.

## What's in

**Time Semantics** — new section in `docs/building/implementation/security.mdx` between Agent and Account Isolation and Request Safety:
- ISO 8601 with explicit timezone offset MUST on every timestamp in requests, responses, and webhook payloads; naïve timestamps rejected with `INVALID_REQUEST`; UTC recommended on the wire
- Half-open intervals `[start, end)` as the canonical semantics for every time window (flight dates, reporting, daypart, idempotency replay TTLs)
- Daypart targeting rewritten as three declared modes — buyer-declared IANA zone (global), publisher-local (publisher's declared zone), viewer-local (resolved per-viewer at serve time). Ambiguous dayparts rejected. Per-agent defaults explicitly non-normative.

**`activate_signal` idempotency row** — `docs/signals/tasks/activate_signal.mdx` now lists `idempotency_key` in the request parameters table. The schema already required the field; `security.mdx` already listed the task in the mutating-tasks set; only the task reference had drifted.

## What's cut (and why)

The earlier version of this PR had six additional items; all are now covered elsewhere or dropped as drift risk:

- **Auth normativity** — #2415's "OAuth 2.1 + resource indicators is NOT a requirement" is the correct 3.0 position. My OAuth 2.1 MUST language was overreach.
- **Rate-limiting / throttling** — #2415's `error-handling.mdx` covers this.
- **Content-standards mid-flight pinning** — #2415's "Versioning and mid-flight amendments" section covers this.
- **Account-bound object access** — main's "Agent and Account Isolation" section (post-#2381) covers this with the explicit + natural-key binding model.
- **Webhook reliability tightening** — moved to #2416, where it pairs with the schema-level `idempotency_key` addition.
- **Spec-completeness manifest** — dropped. Cross-referencing open issues in a doc is drift-prone; milestones and issues are the source of truth.

## Related issues

**Filed by this workstream:**
- #2391 — billing reconciliation / dispute flow (3.1)
- #2392 — cross-agent trust model (3.1)
- #2393 — FX and currency handling (3.1)
- #2394 — GDPR Article 22 explicit signaling (3.1)
- #2395 — ISO 8601 timestamps (3.0) ✅ closed by this PR
- #2396 — activate_signal idempotency_key doc drift (3.0) ✅ closed by this PR
- #2399 — rate-limiting normative (closed by #2415)
- #2400 — webhook delivery guarantees (doc-closed; schema piece tracked as #2416)
- #2401 — required_disclosures jurisdictional (closed on inspection — schema was already jurisdiction-keyed)
- #2402 — auth normative (closed by #2415 with OAuth-non-goal position)
- #2403 — `check_governance` threshold (open; revised design with anomaly-ratio model posted: https://github.com/adcontextprotocol/adcp/issues/2403#issuecomment-4276547946)
- #2416 — add required `idempotency_key` to webhook payload schemas (3.0, minor bump)

## Test plan

- [x] `npm run test:unit` — 587 tests pass (pre-commit)
- [x] `npm run typecheck` — clean (pre-commit)
- [x] Mintlify documentation validation passes (pre-push)
- [ ] Reviewer check: three daypart timezone modes are the right shape (buyer-declared, publisher-local, viewer-local)
- [ ] Reviewer check: the half-open interval `[start, end)` claim matches existing schema usage on flight-window fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)