### PR TITLE
docs(spec-hardening): close hostile-reviewer punch list

### DIFF
--- a/.changeset/spec-hardening-hostile-review.md
+++ b/.changeset/spec-hardening-hostile-review.md
@@ -1,0 +1,16 @@
+---
+---
+
+docs(spec-hardening): close out hostile-reviewer punch list
+
+Lands normative text and non-goal declarations addressing the hostile-reviewer
+critique on trust, commerce, and governance semantics:
+
+- `docs/building/understanding/security-model.mdx` — adds three bullets to "What AdCP does not do in 3.0": OAuth 2.1 is not required (mTLS / API key / RFC 9421 are the three mechanisms), cross-currency buys are deferred, protocol-level delivery disputes reconcile out-of-band.
+- `docs/building/implementation/error-handling.mdx` — adds RFC 2119 normative section for throttling response behavior (MUST honor retry_after, SHOULD back off with jitter, MUST NOT retry non-throttling errors as if throttled).
+- `docs/governance/campaign/specification.mdx` — adds "Both checks must pass" subsection stating the invariant that buyer-side intent and seller-side planned-delivery checks are complementary and both MUST pass against the same governance authority; contradictory conditions resolve to `denied`.
+- `docs/governance/embedded-human-judgment.mdx` — adds register framing note explaining why the five principles use principles language rather than RFC 2119 (enforceable surface lives in check_governance, TERMS_REJECTED, and lifecycle tasks).
+- `docs/media-buy/task-reference/get_media_buy_delivery.mdx` — adds billing-grade vs best-effort normative paragraph: default is best-effort unless seller declares a finalization window in capabilities.
+- `docs/governance/content-standards/index.mdx` — adds "Versioning and mid-flight amendments" section establishing pinned-at-buy as the default, with per-policy `evaluation_mode: continuous` opt-in for policies that must track regulatory changes.
+
+Closes #2406, #2408, #2410, #2412, #2413, #2414. References #2405 (dispute flow, post-GA) and #2409 (FX cross-border, post-GA) via the Security Model non-goals list.

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -171,6 +171,17 @@ function isRetryable(error) {
 
 ## Retry Logic
 
+### Normative throttling behavior
+
+These rules apply when a caller receives a throttling-category error (`RATE_LIMITED`, or any error whose `recovery` is `transient` and whose `details` conform to the [`rate-limited`](https://adcontextprotocol.org/schemas/latest/error-details/rate-limited.json) detail shape):
+
+- Callers **MUST** honor `retry_after` when present and **MUST NOT** retry the same request sooner than the indicated number of seconds.
+- Callers **SHOULD** use exponential backoff with jitter when `retry_after` is absent. A base of 2 seconds, a cap of 60 seconds, and ±25% jitter is a safe default.
+- Callers **MUST NOT** treat non-throttling errors (e.g., `INVALID_REQUEST`, `CREATIVE_REJECTED`) as if they were throttled. Retrying a rejected-for-other-reasons response at backoff cadence is a bug, not a defensive posture.
+- Callers **SHOULD** surface repeated throttling to their operator rather than retrying indefinitely; a persistent `RATE_LIMITED` response is a capacity or policy signal, not a transient blip.
+- Sellers **SHOULD** return `RATE_LIMITED` with a populated `retry_after` rather than silently queuing or dropping requests, so well-behaved callers can back off intentionally.
+- Sellers **MAY** populate the [`rate-limited`](https://adcontextprotocol.org/schemas/latest/error-details/rate-limited.json) detail shape (`limit`, `remaining`, `window_seconds`, `scope`) to let callers plan ahead rather than react per-429.
+
 ### Exponential Backoff
 
 Implement exponential backoff for retryable errors:

--- a/docs/building/understanding/security-model.mdx
+++ b/docs/building/understanding/security-model.mdx
@@ -215,6 +215,9 @@ Knowing what a protocol doesn't do is part of evaluating it. These are explicit 
 - **No in-protocol payment or settlement.** `report_usage` provides the consumption data that feeds invoicing, but invoicing and settlement happen out-of-band through the buyer/seller commercial relationship.
 - **No protocol guarantee about LLM prompt-injection defense.** That is an operator concern on every LLM-powered agent in the loop. See the threat class above.
 - **No protocol-level data-residency mechanism.** Residency is a configuration and contract property of individual agents.
+- **No OAuth 2.1 + resource-indicators normative requirement.** AdCP authenticates agents using mTLS, pre-provisioned API keys, and RFC 9421 signed HTTP requests (the last normative in 3.1). These are deliberately chosen for mutual authentication between autonomous agents rather than for delegated human-user authorization. OAuth 2.1 with resource indicators is an acceptable transport where an operator's infrastructure already standardizes on it, but is not a protocol requirement and does not substitute for the three mechanisms above.
+- **No cross-currency buy support in 3.0.** Each media buy uses a single ISO 4217 currency (see `static/schemas/source/core/price.json`). If the buyer's budget currency differs from the seller's pricing currency, the buy either uses a matching currency or is rejected. FX rate pinning, risk attribution, and cross-currency reporting are deferred to a future version.
+- **No protocol-level delivery-dispute flow.** When buyer and seller delivery numbers disagree, reconciliation happens out-of-band through the commercial relationship between counterparties (backed by the audit trail on both sides). A structured dispute task is a candidate for future work.
 
 None of these are hidden. Each is a visible edge of the specification and a candidate for future work.
 

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -519,6 +519,17 @@ Campaign Governance's buyer-side validation has a trust limitation: the buyer's 
 
 The seller POSTs to the buyer's `governance_agents` URLs when governed action events occur. The governance agent maintains all state and correlates requests by `plan_id` + `governance_context` -- the seller does not need to track governance history or chain IDs across calls.
 
+### Both checks must pass
+
+Every governed action **MUST** pass both the buyer-side intent check and the seller-side planned-delivery check. Both calls hit the same authority (the buyer's governance agent), so there is no "two agents disagreeing" case — but the invariant that both calls must succeed is load-bearing:
+
+- The buyer-side intent check confirms the *plan permits the spend in principle*.
+- The seller-side planned-delivery check confirms the *seller's actual delivery parameters are consistent with the approved plan*.
+
+These are not redundant. A buyer's intent check can pass (the plan allows $100K on premium video) while the seller's planned-delivery check fails (the seller's planned line-up includes inventory the plan excludes). If either returns `denied`, the action **MUST NOT** proceed. When both return `approved` with non-empty `conditions`, the applied set is the **union** of both responses' conditions. Contradictory conditions (one side requires X, the other requires NOT X) resolve to `denied` with a structured `finding` rather than silent precedence.
+
+A seller that rejects a trade for its own content-standards or commercial reasons is not participating in a governance conflict — that is a separate, commerce-layer rejection (e.g., `TERMS_REJECTED`) and follows the regular rejection path. Governance speaks only for the buyer's plan.
+
 ### Setup
 
 The buyer syncs governance agents via [`sync_governance`](/docs/accounts/tasks/sync_governance), pairing each account with the governance agent endpoints to call. Each agent includes authentication credentials so the governance agent can verify the seller's identity:

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -221,6 +221,16 @@ The policy prompt enables AI-powered verification agents to understand context a
 
 See [Artifacts](./artifacts) for details on artifact structure and secured asset access.
 
+## Versioning and mid-flight amendments
+
+Content standards carry a `version` field and MAY be amended while campaigns are running. `update_content_standards` creates a new version for audit purposes rather than mutating the previous one.
+
+AdCP 3.0 default: **pinned at buy time.** Unless otherwise declared, a media buy references the version of the standards that was in effect when its `create_media_buy` was approved, and subsequent amendments do **not** retroactively apply to in-flight delivery on that buy. This is the conservative default because it prevents a mid-campaign amendment from silently re-characterizing already-approved delivery.
+
+Governance agents MAY mark an individual policy as continuously re-evaluated by declaring `evaluation_mode: continuous` on the policy entry (default is `pinned`). Use `continuous` for policies that must track regulatory changes without re-approval — emerging regulatory disclosures, new legal prohibitions, accessibility requirements. Use the default `pinned` for brand-voice, taxonomy, and commercial preferences where stability across a flight is the desired behavior.
+
+When a policy is `continuous`, a finding generated against a newer version **MUST** carry both the evaluation-time version and the pinned-at-buy version on the finding, so downstream audit can reconstruct which version applied. When a policy is `pinned`, the pinned version applies for the life of the buy; the governance agent MAY still surface advisory findings based on later versions but **MUST NOT** mark them as enforcement failures against the pinned buy.
+
 ## Scoped Standards
 
 Buyers typically maintain multiple standards configurations for different contexts - UK TV campaigns have different regulations than US display, and children's brands need stricter safety than adult beverages.

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -10,6 +10,10 @@ As AI agents gain autonomy in advertising — discovering inventory, building cr
 
 Embedded Human Judgment (EHJ) is AdCP's answer. It is not an after-the-fact review process. It is not a temporary safety phase while AI "matures." It is a permanent design constraint for accountable systems.
 
+<Note>
+**On register.** This page specifies *where* humans belong in the loop — which classes of decisions require human judgment — not *how* operators implement that judgment. AdCP uses a principles register here rather than RFC 2119 MUST/SHOULD because the enforceable surface is elsewhere: [`check_governance`](/docs/governance/campaign/tasks/check_governance) returning `conditions` or `denied` (MUST escalate), `TERMS_REJECTED` (MUST route to human), and lifecycle tasks like [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) (MUST be available to authorized humans). Those are where the normative rules live. The principles below tell you *which* decisions those rules must cover; they do not prescribe UI or workflow.
+</Note>
+
 ## The five principles
 
 ### 1. Humans remain the locus of judgment and accountability

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -61,6 +61,14 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 
 See [schema](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) for complete field list.
 
+### Billing-grade vs best-effort numbers
+
+Unless the seller explicitly declares otherwise, `get_media_buy_delivery` returns **best-effort** numbers: real-time or near-real-time telemetry, subject to revision as counts settle, **not** an invoicing source of truth. Callers that use these numbers for client reporting or pacing decisions are safe; callers that use them for reconciliation, accruals, or finance close are not.
+
+Sellers **MAY** declare a finalization window in their capabilities (e.g., `delivery_reporting.finalization_window_hours`) and, once that window has elapsed for a reporting period, treat the numbers returned for that period as authoritative for billing — stable across subsequent calls, suitable for invoice reconciliation, and liable as the source of truth in a dispute. Callers **MUST NOT** assume finalization in the absence of such a declaration.
+
+When a buyer's independent measurement disagrees with these numbers, reconciliation happens out-of-band through the commercial relationship between counterparties, backed by the audit trail on both sides. AdCP 3.0 does not specify a structured dispute task.
+
 ## Common Scenarios
 
 ### Single Media Buy


### PR DESCRIPTION
## Summary

Closes six fix-before-GA items from the hostile-reviewer spec-hardening punch list. All changes are doc-only — no schema churn, no new task surface.

- **security-model.mdx** — three bullets added to "What AdCP does not do in 3.0": OAuth 2.1 + resource indicators is not a requirement (mTLS / API key / RFC 9421 are the three mechanisms), cross-currency buys are deferred, delivery disputes reconcile out-of-band
- **error-handling.mdx** — RFC 2119 throttling-response section (MUST honor `retry_after`, SHOULD back off with jitter, MUST NOT retry non-throttling errors as throttled, sellers SHOULD return `RATE_LIMITED` rather than silently queue)
- **campaign/specification.mdx** — "Both checks must pass" invariant: buyer-side intent check and seller-side planned-delivery check are complementary and both MUST pass against the same governance authority; contradictory conditions resolve to `denied`
- **embedded-human-judgment.mdx** — register-framing note explaining why the five principles use principles language rather than RFC 2119 (the enforceable surface lives in `check_governance`, `TERMS_REJECTED`, and lifecycle tasks)
- **get_media_buy_delivery.mdx** — billing-grade vs best-effort default: numbers are best-effort unless the seller declares a finalization window in capabilities; callers MUST NOT assume finalization absent declaration
- **content-standards/index.mdx** — "Versioning and mid-flight amendments" section: pinned-at-buy default, with per-policy `evaluation_mode: continuous` opt-in for policies that must track regulatory changes

## Context

Follow-up to the 15-item hostile-reviewer audit. Of the 15, 4 were already covered by security-model.mdx (#2381) and webhook/schema docs; 2 (#2411 disclosures-jurisdictional, original #2406 governance-conflict) turned out to be misreads on review and were closed with explanation; 3 are post-GA (#2405 dispute flow, #2409 FX cross-border) and are referenced in the Security Model non-goals list here; the remaining 6 are addressed by this PR.

## Closes

- #2406 — governance invariant (both checks must pass)
- #2408 — billing-grade vs best-effort reporting default
- #2410 — content standards mid-flight pinning default
- #2412 — rate-limiting RFC 2119 normative text
- #2413 — OAuth non-goal declaration
- #2414 — HITL register framing

## Test plan

- [x] `npm run test:unit` — 587 tests pass
- [x] `npm run typecheck` — clean
- [x] Mintlify broken-links check — passes (fixed one initial broken schema link)
- [ ] Visual review of rendered docs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)