### PR TITLE
spec(webhooks): require idempotency_key on all webhook payloads (#2416)

### DIFF
--- a/.changeset/webhook-idempotency-key-required.md
+++ b/.changeset/webhook-idempotency-key-required.md
@@ -4,18 +4,21 @@
 
 Require `idempotency_key` on every webhook payload (#2416).
 
-Webhooks use at-least-once delivery, so receivers must dedupe. Prior to this change, only `mcp-webhook-payload` carried fields usable for dedup — and only as the fragile `(task_id, status, timestamp)` tuple, which collides when two status transitions share a timestamp. The governance and artifact webhooks had no dedup field at all.
+Webhooks use at-least-once delivery, so receivers must dedupe. Prior to this change, only `mcp-webhook-payload` carried fields usable for dedup — and only as the fragile `(task_id, status, timestamp)` tuple, which collides when a single transition is retried with unchanged timestamp or when two transitions share a timestamp. The governance, artifact, and revocation webhook payloads had no standardized dedup field at all; `revocation-notification` used its own `notification_id` with a different name and format.
 
-Every webhook payload now carries a required, sender-generated `idempotency_key` stable across retries of the same event. Receivers MUST dedupe by this key; a repeat key with matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects.
+Every webhook payload now carries a required, sender-generated `idempotency_key` stable across retries of the same event. The field uses the same name and format as the request-side `idempotency_key` (16–255 chars, `^[A-Za-z0-9_.:-]{16,255}$`). UUID v4 is required to be cryptographically random — predictable keys allow pre-seeding a receiver's dedup cache to suppress legitimate events.
 
-**Schemas changed:**
+**Schemas changed (required `idempotency_key` added):**
 - `core/mcp-webhook-payload.json`
 - `collection/collection-list-changed-webhook.json`
 - `property/property-list-changed-webhook.json`
 - `content-standards/artifact-webhook-payload.json`
+- `brand/revocation-notification.json` — also renames the prior `notification_id` field to `idempotency_key` (safe in 3.0-rc, unifies the protocol-wide dedup vocabulary)
 
-The field uses the same name and format as the request-side `idempotency_key` (16–255 chars, `^[A-Za-z0-9_.:-]{16,255}$`). UUID v4 is the recommended value.
+**Docs updated:**
+- `docs/building/implementation/webhooks.mdx` §Reliability — makes `idempotency_key` the canonical dedup field with normative sender/receiver requirements: cryptographic-random keys, sender-scoped dedup (never trust a payload field for sender identity), 24h minimum TTL, cache-growth bounds, and an explicit note that webhooks do not verify payload equivalence (unlike request-side `IDEMPOTENCY_CONFLICT`).
+- `docs/governance/collection/tasks/collection_lists.mdx`, `docs/governance/property/tasks/property_lists.mdx` — example payloads include `idempotency_key`; property example also adds the `signature` field that was missing.
+- `docs/governance/content-standards/implementation-guide.mdx` — artifact webhook example updated.
+- `docs/brand-protocol/tasks/acquire_rights.mdx`, `docs/brand-protocol/walkthrough-rights-licensing.mdx` — revocation notification references use `idempotency_key`.
 
-Docs in `webhooks.mdx`, `collection_lists.mdx`, `property_lists.mdx`, and `content-standards/implementation-guide.mdx` updated to reflect `idempotency_key` as the canonical dedup field.
-
-Note: `core/reporting-webhook.json` is the reporting webhook *configuration* (sent in `create_media_buy`), not a payload, so no change there. A separate reporting-webhook *payload* schema does not currently exist.
+Note: `core/reporting-webhook.json` is the reporting webhook *configuration* (passed in `create_media_buy`), not a payload. No reporting-webhook payload schema exists today, so it is out of scope. If one is added later, it will need the same field.

--- a/.changeset/webhook-idempotency-key-required.md
+++ b/.changeset/webhook-idempotency-key-required.md
@@ -1,0 +1,21 @@
+---
+"adcontextprotocol": minor
+---
+
+Require `idempotency_key` on every webhook payload (#2416).
+
+Webhooks use at-least-once delivery, so receivers must dedupe. Prior to this change, only `mcp-webhook-payload` carried fields usable for dedup — and only as the fragile `(task_id, status, timestamp)` tuple, which collides when two status transitions share a timestamp. The governance and artifact webhooks had no dedup field at all.
+
+Every webhook payload now carries a required, sender-generated `idempotency_key` stable across retries of the same event. Receivers MUST dedupe by this key; a repeat key with matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects.
+
+**Schemas changed:**
+- `core/mcp-webhook-payload.json`
+- `collection/collection-list-changed-webhook.json`
+- `property/property-list-changed-webhook.json`
+- `content-standards/artifact-webhook-payload.json`
+
+The field uses the same name and format as the request-side `idempotency_key` (16–255 chars, `^[A-Za-z0-9_.:-]{16,255}$`). UUID v4 is the recommended value.
+
+Docs in `webhooks.mdx`, `collection_lists.mdx`, `property_lists.mdx`, and `content-standards/implementation-guide.mdx` updated to reflect `idempotency_key` as the canonical dedup field.
+
+Note: `core/reporting-webhook.json` is the reporting webhook *configuration* (sent in `create_media_buy`), not a payload, so no change there. A separate reporting-webhook *payload* schema does not currently exist.

--- a/docs/brand-protocol/tasks/acquire_rights.mdx
+++ b/docs/brand-protocol/tasks/acquire_rights.mdx
@@ -239,10 +239,10 @@ If `acquire_rights` returns `pending_approval` and you provided `push_notificati
 
 ## Revocation
 
-If the rights holder needs to revoke rights (talent controversy, contract violation, etc.), they POST a [`revocation-notification`](https://adcontextprotocol.org/schemas/latest/brand/revocation-notification.json) to the buyer's `revocation_webhook`, authenticating with the credentials provided at acquisition time. The notification contains a `notification_id` (for deduplication), `rights_id`, `brand_id`, `reason`, and `effective_at` timestamp.
+If the rights holder needs to revoke rights (talent controversy, contract violation, etc.), they POST a [`revocation-notification`](https://adcontextprotocol.org/schemas/latest/brand/revocation-notification.json) to the buyer's `revocation_webhook`, authenticating with the credentials provided at acquisition time. The notification contains an `idempotency_key` (required, used for deduplication across retries), `rights_id`, `brand_id`, `reason`, and `effective_at` timestamp.
 
 The buyer is responsible for:
-- Deduplicating by `notification_id` — the same revocation may be delivered multiple times
+- Deduplicating by `idempotency_key` — the same revocation may be delivered multiple times; see [Push Notifications — Reliability](/docs/building/implementation/webhooks#reliability) for the canonical dedup contract
 - Stopping creative delivery by `effective_at`
 - Removing or replacing affected creatives from active campaigns
 - Ceasing use of generation credentials (providers may also invalidate credentials independently)

--- a/docs/brand-protocol/walkthrough-rights-licensing.mdx
+++ b/docs/brand-protocol/walkthrough-rights-licensing.mdx
@@ -500,7 +500,7 @@ If the talent's agency needs to revoke rights — a scandal, a contract violatio
 
 ```json
 {
-  "notification_id": "rev_loti_dj_2026_001",
+  "idempotency_key": "rev_01HW9DHSP8TV1N3R5T7V9X1Z3B5D",
   "rights_id": "loti_dj_talent_2026",
   "brand_id": "daan_janssen",
   "reason": "Rights revoked due to updated talent representation terms",

--- a/docs/building/implementation/webhooks.mdx
+++ b/docs/building/implementation/webhooks.mdx
@@ -341,29 +341,41 @@ The 5-minute timestamp window prevents replay attacks. Publishers must use Unix 
 
 Webhooks use **at-least-once delivery** — you may receive the same event more than once, and events may arrive out of order.
 
-**Primary dedup key: `idempotency_key`.** Every webhook payload (MCP envelope, governance list-change webhooks, artifact push webhooks) carries a required `idempotency_key`. Publishers generate this key once per distinct event and reuse it on every retry. Receivers MUST dedupe by it: a repeat key with a matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects.
+### Dedup by `idempotency_key`
+
+Every webhook payload — MCP task envelope, governance list-change webhooks (`collection_list_changed`, `property_list_changed`), artifact push webhooks, and rights `revocation-notification` — carries a required `idempotency_key`. Publishers generate this key once per distinct event and reuse it on every retry. Receivers MUST dedupe by it.
+
+**Sender requirements:**
+- The key MUST be cryptographically random (UUID v4 recommended). Sequential, timestamp-only, or otherwise predictable values are non-conformant: receivers dedupe on the raw value, so a predictable key lets an attacker pre-seed a receiver's cache to suppress a later legitimate event.
+- The key MUST be stable across retries of the same event and MUST NOT be reused for a distinct event.
+
+**Receiver requirements:**
+- Dedup scope is `(authenticated sender identity, idempotency_key)`. "Authenticated sender identity" means the credential binding from the verified HMAC secret or Bearer token — never a payload field. Keys from different senders MUST be kept in independent keyspaces; a receiver integrated with multiple publishers MUST NOT collapse them.
+- Dedup state SHOULD persist for at least 24h. Publishers SHOULD NOT retry beyond that window; retries arriving after the receiver's TTL will be reprocessed as fresh events.
+- Receivers SHOULD bound dedup cache size per sender and return `429 Too Many Requests` (or drop the connection) rather than grow unbounded — a misbehaving or hostile publisher emitting high-volume fresh keys is otherwise a storage-amplification vector.
+- Webhook receivers do **not** verify payload equivalence across key reuse. If a sender reuses a key with a changed payload (a sender bug), the receiver's cached first copy wins and the second is silently deduped. This differs from the request-side `IDEMPOTENCY_CONFLICT` behavior — senders are solely responsible for generating a fresh key on every distinct event.
 
 ```javascript
-async function processWebhook(payload) {
+async function processWebhook(req, payload) {
   const { idempotency_key, task_id, status, timestamp, result } = payload;
 
-  // Dedup: same idempotency_key within the replay window → already processed
-  if (await db.webhookAlreadyProcessed(idempotency_key)) return;
+  // Scope dedup to the authenticated sender — never trust a payload field for identity.
+  const sender = req.verifiedSenderId; // set by HMAC/Bearer middleware
 
-  // Ordering: don't apply a stale status on top of a newer one
+  // Dedup: same (sender, idempotency_key) within the replay window → already processed
+  if (await db.webhookAlreadyProcessed(sender, idempotency_key)) return;
+  await db.markWebhookProcessed(sender, idempotency_key); // before side effects — fail-closed on crash
+
+  // Ordering: separately, don't apply a stale status on top of a newer one.
+  // Ordering state is keyed on task_id, not idempotency_key — two distinct events
+  // (different keys) can still arrive out of order.
   const task = await db.getTask(task_id);
-  if (task?.updated_at >= timestamp) {
-    await db.markWebhookProcessed(idempotency_key);
-    return;
-  }
+  if (task?.updated_at >= timestamp) return;
 
   await db.updateTask(task_id, { status, updated_at: timestamp, result });
-  await db.markWebhookProcessed(idempotency_key);
   await triggerBusinessLogic(task_id, status);
 }
 ```
-
-Dedup state SHOULD persist for at least the longest expected retry window (24h is a safe default).
 
 **Always implement polling as backup.** Webhooks can fail due to network issues or server downtime. Use a slower poll interval when webhooks are configured (e.g., every 2 minutes instead of 30 seconds), and stop polling once you receive a terminal status via webhook.
 

--- a/docs/building/implementation/webhooks.mdx
+++ b/docs/building/implementation/webhooks.mdx
@@ -24,6 +24,7 @@ create_media_buy request
 
 POST https://you.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443
   {
+    "idempotency_key": "whk_01HW9D3H8FZP2N6R8T0V4X6Z9B",   ← dedup by this
     "task_id": "task_456",
     "operation_id": "cd51e063-2b79-4a6d-afac-ed7789c3a443",   ← echoed from your URL
     "status": "completed",
@@ -144,6 +145,7 @@ If the task completes synchronously (initial response is already `completed` or 
 
 ```json
 {
+  "idempotency_key": "whk_01HW9D3H8FZP2N6R8T0V4X6Z9B",
   "task_id": "task_456",
   "operation_id": "cd51e063-2b79-4a6d-afac-ed7789c3a443",
   "task_type": "create_media_buy",
@@ -159,6 +161,8 @@ If the task completes synchronously (initial response is already `completed` or 
   }
 }
 ```
+
+Every webhook payload carries a required `idempotency_key` — a sender-generated key that is stable across retries of the same event. This is the canonical dedup field; see [Reliability](#reliability) below.
 
 ### A2A
 
@@ -337,28 +341,36 @@ The 5-minute timestamp window prevents replay attacks. Publishers must use Unix 
 
 Webhooks use **at-least-once delivery** — you may receive the same event more than once, and events may arrive out of order.
 
-Use `task_id` + `status` + `timestamp` to handle this:
+**Primary dedup key: `idempotency_key`.** Every webhook payload (MCP envelope, governance list-change webhooks, artifact push webhooks) carries a required `idempotency_key`. Publishers generate this key once per distinct event and reuse it on every retry. Receivers MUST dedupe by it: a repeat key with a matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects.
 
 ```javascript
 async function processWebhook(payload) {
-  const { task_id, status, timestamp, result } = payload;
+  const { idempotency_key, task_id, status, timestamp, result } = payload;
 
+  // Dedup: same idempotency_key within the replay window → already processed
+  if (await db.webhookAlreadyProcessed(idempotency_key)) return;
+
+  // Ordering: don't apply a stale status on top of a newer one
   const task = await db.getTask(task_id);
-
-  // Skip if we've already processed a newer status
-  if (task?.updated_at >= timestamp) return;
+  if (task?.updated_at >= timestamp) {
+    await db.markWebhookProcessed(idempotency_key);
+    return;
+  }
 
   await db.updateTask(task_id, { status, updated_at: timestamp, result });
+  await db.markWebhookProcessed(idempotency_key);
   await triggerBusinessLogic(task_id, status);
 }
 ```
+
+Dedup state SHOULD persist for at least the longest expected retry window (24h is a safe default).
 
 **Always implement polling as backup.** Webhooks can fail due to network issues or server downtime. Use a slower poll interval when webhooks are configured (e.g., every 2 minutes instead of 30 seconds), and stop polling once you receive a terminal status via webhook.
 
 ## Best practices
 
 1. **Always implement polling as backup** — webhooks can fail; poll at a reduced interval (e.g. every 2 minutes) when webhooks are configured, and stop once you receive a terminal status
-2. **Handle duplicates** — use `task_id` + `timestamp` to skip already-processed or out-of-order events
+2. **Dedupe by `idempotency_key`** — every payload carries a required key stable across retries; track processed keys for at least 24h
 3. **Verify signatures** — always validate `X-ADCP-Signature` before processing
 4. **Acknowledge immediately** — return `200` before doing any heavy processing to avoid publisher timeouts and unnecessary retries
 5. **Don't rely on URL structure** — use `operation_id` from the payload for routing, not URL parsing
@@ -402,7 +414,7 @@ function detectFormat(payload) {
 
 - **Content-Type validation**: Publishers MUST send `application/json`. Receivers MUST reject other types before HMAC verification.
 - **Payload size limit**: Receivers SHOULD enforce a 1MB limit. Reject before HMAC computation — computing HMAC over large payloads is a DoS vector. Return `413 Payload Too Large`.
-- **Deduplication**: `task_id` + `timestamp` dedup provides defense-in-depth against replay attacks within the timestamp window.
+- **Deduplication**: `idempotency_key` is the canonical dedup field. HMAC + timestamp replay rejection protects the transport; `idempotency_key` protects against duplicate side effects at the application layer.
 - **Format detection**: Auto-detection is a defensive fallback. Receivers SHOULD use the known format from their transport configuration (`knownFormat` parameter) rather than relying solely on payload inspection. A compromised intermediary could craft an ambiguous payload that routes extraction to the wrong path.
 
 ### Test vectors

--- a/docs/building/implementation/webhooks.mdx
+++ b/docs/building/implementation/webhooks.mdx
@@ -353,28 +353,36 @@ Every webhook payload — MCP task envelope, governance list-change webhooks (`c
 - Dedup scope is `(authenticated sender identity, idempotency_key)`. "Authenticated sender identity" means the credential binding from the verified HMAC secret or Bearer token — never a payload field. Keys from different senders MUST be kept in independent keyspaces; a receiver integrated with multiple publishers MUST NOT collapse them.
 - Dedup state SHOULD persist for at least 24h. Publishers SHOULD NOT retry beyond that window; retries arriving after the receiver's TTL will be reprocessed as fresh events.
 - Receivers SHOULD bound dedup cache size per sender and return `429 Too Many Requests` (or drop the connection) rather than grow unbounded — a misbehaving or hostile publisher emitting high-volume fresh keys is otherwise a storage-amplification vector.
+- **Duplicates MUST be answered with `2xx`** (typically `200 OK`), not `409 Conflict`. At-least-once senders interpret any non-2xx response as "delivery failed" and retry with exponential back-off; returning `4xx` on a successfully-deduped event turns correct receiver behavior into a retry storm. A duplicate is a no-op, not an error.
 - Webhook receivers do **not** verify payload equivalence across key reuse. If a sender reuses a key with a changed payload (a sender bug), the receiver's cached first copy wins and the second is silently deduped. This differs from the request-side `IDEMPOTENCY_CONFLICT` behavior — senders are solely responsible for generating a fresh key on every distinct event.
 
 ```javascript
-async function processWebhook(req, payload) {
+app.post('/webhooks/adcp', async (req, res) => {
+  const payload = req.body;
   const { idempotency_key, task_id, status, timestamp, result } = payload;
 
   // Scope dedup to the authenticated sender — never trust a payload field for identity.
   const sender = req.verifiedSenderId; // set by HMAC/Bearer middleware
 
-  // Dedup: same (sender, idempotency_key) within the replay window → already processed
-  if (await db.webhookAlreadyProcessed(sender, idempotency_key)) return;
+  // Dedup: same (sender, idempotency_key) within the replay window → already processed.
+  // Return 200 (not 409) so the sender stops retrying.
+  if (await db.webhookAlreadyProcessed(sender, idempotency_key)) {
+    return res.status(200).end();
+  }
   await db.markWebhookProcessed(sender, idempotency_key); // before side effects — fail-closed on crash
 
   // Ordering: separately, don't apply a stale status on top of a newer one.
   // Ordering state is keyed on task_id, not idempotency_key — two distinct events
-  // (different keys) can still arrive out of order.
+  // (different keys) can still arrive out of order. Still a 200: we received it cleanly.
   const task = await db.getTask(task_id);
-  if (task?.updated_at >= timestamp) return;
+  if (task?.updated_at >= timestamp) {
+    return res.status(200).end();
+  }
 
   await db.updateTask(task_id, { status, updated_at: timestamp, result });
   await triggerBusinessLogic(task_id, status);
-}
+  res.status(200).end();
+});
 ```
 
 **Always implement polling as backup.** Webhooks can fail due to network issues or server downtime. Use a slower poll interval when webhooks are configured (e.g., every 2 minutes instead of 30 seconds), and stop polling once you receive a terminal status via webhook.
@@ -383,7 +391,8 @@ async function processWebhook(req, payload) {
 
 1. **Always implement polling as backup** — webhooks can fail; poll at a reduced interval (e.g. every 2 minutes) when webhooks are configured, and stop once you receive a terminal status
 2. **Dedupe by `idempotency_key`** — every payload carries a required key stable across retries; track processed keys for at least 24h
-3. **Verify signatures** — always validate `X-ADCP-Signature` before processing
+3. **Return 2xx on duplicates** — a successfully-deduped event is a no-op, not an error; returning non-2xx triggers the sender's retry back-off and creates retry storms
+4. **Verify signatures** — always validate `X-ADCP-Signature` before processing
 4. **Acknowledge immediately** — return `200` before doing any heavy processing to avoid publisher timeouts and unnecessary retries
 5. **Don't rely on URL structure** — use `operation_id` from the payload for routing, not URL parsing
 6. **Use HMAC-SHA256 in production** — Bearer tokens are simpler but don't protect against payload tampering

--- a/docs/governance/collection/tasks/collection_lists.mdx
+++ b/docs/governance/collection/tasks/collection_lists.mdx
@@ -275,6 +275,7 @@ When a collection list's resolved collections change (new programs matched, rati
 
 ```json
 {
+  "idempotency_key": "clch_01HW9DEPJ5MN8Q2R4T6V8X0Z2B",
   "event": "collection_list_changed",
   "list_id": "cl_novamotors_dna_2026",
   "list_name": "Nova Motors CTV Do Not Air — 2026",
@@ -289,7 +290,7 @@ When a collection list's resolved collections change (new programs matched, rati
 }
 ```
 
-Webhooks contain a summary only — recipients must call `get_collection_list` for the updated entries. Recipients MUST verify the `signature` before processing.
+Webhooks contain a summary only — recipients must call `get_collection_list` for the updated entries. Recipients MUST verify the `signature` before processing and MUST dedupe by `idempotency_key` so retried deliveries of the same change event are ignored.
 
 ## Live sports
 

--- a/docs/governance/content-standards/implementation-guide.mdx
+++ b/docs/governance/content-standards/implementation-guide.mdx
@@ -130,6 +130,7 @@ After delivery, push artifacts to the orchestrator so they can validate against 
 ```json
 // Artifact webhook payload (you send this to the orchestrator)
 {
+  "idempotency_key": "artw_01HW9DGRM7NQ0S4U6W8Y0A2C4E",
   "media_buy_id": "mb_nike_reddit_q1",
   "batch_id": "batch_20250115_001",
   "timestamp": "2025-01-15T11:00:00Z",

--- a/docs/governance/property/tasks/property_lists.mdx
+++ b/docs/governance/property/tasks/property_lists.mdx
@@ -138,6 +138,7 @@ Configure webhooks via `update_property_list` to receive notifications when the 
 
 ```json
 {
+  "idempotency_key": "plch_01HW9DFQK6NP9R3T5V7X9Z1B3D",
   "event": "property_list_changed",
   "list_id": "uk_premium_news_q1",
   "list_name": "UK Premium News Sites Q1 2026",
@@ -147,11 +148,14 @@ Configure webhooks via `update_property_list` to receive notifications when the 
     "total_properties": 856
   },
   "resolved_at": "2026-01-03T18:00:00Z",
-  "cache_valid_until": "2026-01-04T18:00:00Z"
+  "cache_valid_until": "2026-01-04T18:00:00Z",
+  "signature": "..."
 }
 ```
 
 The webhook payload includes counts but NOT the actual properties. This keeps payloads small and avoids redundant data transfer when recipients may not need the full list immediately.
+
+Recipients MUST verify the `signature` before processing and MUST dedupe by `idempotency_key` so retried deliveries of the same change event are ignored.
 
 ### Webhook Use Cases
 

--- a/static/schemas/source/brand/revocation-notification.json
+++ b/static/schemas/source/brand/revocation-notification.json
@@ -5,9 +5,12 @@
   "description": "Payload sent by a rights holder to a buyer's revocation_webhook when rights are revoked. The buyer must cease creative delivery by effective_at. Partial revocation is supported — if revoked_uses is present, only those uses are revoked.",
   "type": "object",
   "properties": {
-    "notification_id": {
+    "idempotency_key": {
       "type": "string",
-      "description": "Unique identifier for this notification. Buyers use this for deduplication — the same revocation may be delivered multiple times."
+      "description": "Sender-generated key stable across retries of the same revocation notification. Rights holders MUST generate a cryptographically random value (UUID v4 recommended) per distinct revocation event and reuse the same key when retrying delivery. Buyers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential); keys from different senders are independent.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
     },
     "rights_id": {
       "type": "string",
@@ -41,6 +44,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
-  "required": ["notification_id", "rights_id", "brand_id", "reason", "effective_at"],
+  "required": ["idempotency_key", "rights_id", "brand_id", "reason", "effective_at"],
   "additionalProperties": true
 }

--- a/static/schemas/source/collection/collection-list-changed-webhook.json
+++ b/static/schemas/source/collection/collection-list-changed-webhook.json
@@ -7,7 +7,7 @@
   "properties": {
     "idempotency_key": {
       "type": "string",
-      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a unique key per distinct list-change event (typically a UUID v4) and reuse the same key when retrying delivery. Recipients MUST dedupe by this key.",
+      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.",
       "minLength": 16,
       "maxLength": 255,
       "pattern": "^[A-Za-z0-9_.:-]{16,255}$"

--- a/static/schemas/source/collection/collection-list-changed-webhook.json
+++ b/static/schemas/source/collection/collection-list-changed-webhook.json
@@ -5,6 +5,13 @@
   "description": "Webhook notification sent when a collection list's resolved collections change. Contains a summary only — recipients must call get_collection_list to retrieve the updated collections.",
   "type": "object",
   "properties": {
+    "idempotency_key": {
+      "type": "string",
+      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a unique key per distinct list-change event (typically a UUID v4) and reuse the same key when retrying delivery. Recipients MUST dedupe by this key.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
     "event": {
       "type": "string",
       "const": "collection_list_changed",
@@ -55,6 +62,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
-  "required": ["event", "list_id", "resolved_at", "signature"],
+  "required": ["idempotency_key", "event", "list_id", "resolved_at", "signature"],
   "additionalProperties": false
 }

--- a/static/schemas/source/content-standards/artifact-webhook-payload.json
+++ b/static/schemas/source/content-standards/artifact-webhook-payload.json
@@ -7,7 +7,7 @@
   "properties": {
     "idempotency_key": {
       "type": "string",
-      "description": "Sender-generated key stable across retries of the same webhook event. Sales agents MUST generate a unique key per distinct batch push (typically a UUID v4) and reuse the same key when retrying delivery of that batch. Recipients MUST dedupe by this key. Distinct from `batch_id`, which identifies the logical batch but may be reused if a batch is re-emitted; `idempotency_key` identifies the specific delivery attempt of that batch.",
+      "description": "Sender-generated key stable across retries of the same webhook event. Sales agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct emission of a batch and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different sales agents are independent. Distinct from `batch_id`, which identifies the logical batch: `idempotency_key` identifies this specific emission event, so a re-emission of the same `batch_id` (e.g., after a correction) is a different event and MUST carry a fresh `idempotency_key`.",
       "minLength": 16,
       "maxLength": 255,
       "pattern": "^[A-Za-z0-9_.:-]{16,255}$"

--- a/static/schemas/source/content-standards/artifact-webhook-payload.json
+++ b/static/schemas/source/content-standards/artifact-webhook-payload.json
@@ -5,6 +5,13 @@
   "description": "Payload sent by sales agents to orchestrators when pushing content artifacts for governance validation. Complements get_media_buy_artifacts for push-based artifact delivery.",
   "type": "object",
   "properties": {
+    "idempotency_key": {
+      "type": "string",
+      "description": "Sender-generated key stable across retries of the same webhook event. Sales agents MUST generate a unique key per distinct batch push (typically a UUID v4) and reuse the same key when retrying delivery of that batch. Recipients MUST dedupe by this key. Distinct from `batch_id`, which identifies the logical batch but may be reused if a batch is re-emitted; `idempotency_key` identifies the specific delivery attempt of that batch.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
     "media_buy_id": {
       "type": "string",
       "description": "Media buy identifier these artifacts belong to"
@@ -67,6 +74,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
-  "required": ["media_buy_id", "batch_id", "timestamp", "artifacts"],
+  "required": ["idempotency_key", "media_buy_id", "batch_id", "timestamp", "artifacts"],
   "additionalProperties": true
 }

--- a/static/schemas/source/core/mcp-webhook-payload.json
+++ b/static/schemas/source/core/mcp-webhook-payload.json
@@ -7,7 +7,7 @@
   "properties": {
     "idempotency_key": {
       "type": "string",
-      "description": "Sender-generated key stable across retries of the same webhook event. Publishers MUST generate a unique key per distinct event (typically a UUID v4) and reuse the same key when retrying delivery of that event. Receivers MUST dedupe by this key; a repeat key with matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects. This is the canonical dedup field — the (task_id, status, timestamp) tuple is insufficient when two status transitions share a timestamp.",
+      "description": "Sender-generated key stable across retries of the same webhook event. Publishers MUST generate a cryptographically random value (UUID v4 recommended) per distinct event and reuse the same key on every retry of that event. Receivers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different publishers are independent. This is the canonical dedup field — the (task_id, status, timestamp) tuple is insufficient when a single transition is retried with unchanged timestamp or when two transitions share a timestamp.",
       "minLength": 16,
       "maxLength": 255,
       "pattern": "^[A-Za-z0-9_.:-]{16,255}$"

--- a/static/schemas/source/core/mcp-webhook-payload.json
+++ b/static/schemas/source/core/mcp-webhook-payload.json
@@ -5,6 +5,13 @@
   "description": "Standard envelope for HTTP-based push notifications (MCP). This defines the wire format sent to the URL configured in `pushNotificationConfig`. NOTE: This envelope is NOT used in A2A integration, which uses native Task/TaskStatusUpdateEvent messages with the AdCP payload nested in `status.message.parts[].data`.",
   "type": "object",
   "properties": {
+    "idempotency_key": {
+      "type": "string",
+      "description": "Sender-generated key stable across retries of the same webhook event. Publishers MUST generate a unique key per distinct event (typically a UUID v4) and reuse the same key when retrying delivery of that event. Receivers MUST dedupe by this key; a repeat key with matching payload is a retry of an already-delivered event and MUST NOT re-trigger side effects. This is the canonical dedup field — the (task_id, status, timestamp) tuple is insufficient when two status transitions share a timestamp.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
     "operation_id": {
       "type": "string",
       "description": "Client-generated identifier that was embedded in the webhook URL by the buyer. Publishers echo this back in webhook payloads so clients can correlate notifications without parsing URL paths. Typically generated as a unique ID per task invocation."
@@ -44,6 +51,7 @@
     }
   },
   "required": [
+    "idempotency_key",
     "task_id",
     "task_type",
     "status",
@@ -54,6 +62,7 @@
     {
       "description": "Webhook for input-required status (human approval needed)",
       "data": {
+        "idempotency_key": "whk_01HW9D2T3VXQ5M7K9N1P3R5S7U",
         "operation_id": "op_456",
         "task_id": "task_456",
         "task_type": "create_media_buy",
@@ -77,6 +86,7 @@
     {
       "description": "Webhook for completed create_media_buy",
       "data": {
+        "idempotency_key": "whk_01HW9D3H8FZP2N6R8T0V4X6Z9B",
         "operation_id": "op_456",
         "task_id": "task_456",
         "task_type": "create_media_buy",
@@ -110,6 +120,7 @@
     {
       "description": "Webhook for working status with progress",
       "data": {
+        "idempotency_key": "whk_01HW9D4K5RMS7P8T2V4X6Z8B0D",
         "operation_id": "op_456",
         "task_id": "task_456",
         "task_type": "create_media_buy",
@@ -128,6 +139,7 @@
     {
       "description": "Webhook for failed sync_creatives",
       "data": {
+        "idempotency_key": "whk_01HW9D5N9TQV4M6P8R0T2V4X6Z",
         "operation_id": "op_789",
         "task_id": "task_789",
         "task_type": "sync_creatives",

--- a/static/schemas/source/property/property-list-changed-webhook.json
+++ b/static/schemas/source/property/property-list-changed-webhook.json
@@ -5,6 +5,13 @@
   "description": "Webhook notification sent when a property list's resolved properties change. Contains a summary only - recipients must call get_property_list to retrieve the updated properties. This keeps payloads small and avoids redundant data transfer.",
   "type": "object",
   "properties": {
+    "idempotency_key": {
+      "type": "string",
+      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a unique key per distinct list-change event (typically a UUID v4) and reuse the same key when retrying delivery. Recipients MUST dedupe by this key.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
     "event": {
       "type": "string",
       "const": "property_list_changed",
@@ -55,6 +62,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
-  "required": ["event", "list_id", "resolved_at", "signature"],
+  "required": ["idempotency_key", "event", "list_id", "resolved_at", "signature"],
   "additionalProperties": false
 }

--- a/static/schemas/source/property/property-list-changed-webhook.json
+++ b/static/schemas/source/property/property-list-changed-webhook.json
@@ -7,7 +7,7 @@
   "properties": {
     "idempotency_key": {
       "type": "string",
-      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a unique key per distinct list-change event (typically a UUID v4) and reuse the same key when retrying delivery. Recipients MUST dedupe by this key.",
+      "description": "Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.",
       "minLength": 16,
       "maxLength": 255,
       "pattern": "^[A-Za-z0-9_.:-]{16,255}$"


### PR DESCRIPTION
## Summary

Closes #2416.

- Add a required `idempotency_key` to every webhook payload schema — MCP task webhook, collection-list-changed, property-list-changed, artifact-webhook — so receivers have a single, canonical dedup field across all webhook types.
- Update `webhooks.mdx` Reliability section, MCP example payload, and best practices to make `idempotency_key` the canonical dedup key. Replace the fragile `(task_id, status, timestamp)` tuple guidance.
- Update governance docs (`collection_lists.mdx`, `property_lists.mdx`) and content-standards implementation guide examples to include `idempotency_key`.

## Why now (3.0, not 3.1)

Webhook delivery is at-least-once per spec, so receivers must dedupe — but today only `mcp-webhook-payload` carries dedup-usable fields, and only as the fragile `(task_id, status, timestamp)` tuple. The other four webhook payloads have no dedup field at all.

We're still in 3.0-rc, so adding a required field doesn't break any released integration. Deferring to 3.1 would ship the first GA with a known-gappy dedup story.

## Field format

Same name and format as the request-side `idempotency_key` in `security.mdx` — string, 16–255 chars, `^[A-Za-z0-9_.:-]{16,255}$`. UUID v4 is the recommended value. Reusing the exact field shape avoids inventing a second "id for dedup" concept.

## Scope note — reporting-webhook.json

The issue listed `core/reporting-webhook.json` as a fifth payload needing the field. On review, that schema is the reporting webhook *configuration* (passed in `create_media_buy`/`update_media_buy`), not a payload. There is no published reporting-webhook payload schema today, so it is out of scope here. If we later publish one, it will need the same `idempotency_key` field.

## Changeset

`minor` — published schema change to 4 schemas under `static/schemas/source/`.

## Test plan
- [x] `npm run build:schemas` — bundled schemas regenerate cleanly
- [x] `npm run test:schemas` — all 7 structural checks pass
- [x] `npm run test:examples` — 31 example validations pass (including updated MCP webhook examples)
- [x] `npm run test:composed` — 12 composed-schema validations pass
- [x] `npm run test:json-schema` — 249 doc JSON blocks with `$schema` validate
- [x] `npm run test:migrations`, `npm run test:docs-nav`, `npm run test:extensions`, `npm run test:error-handling` — pass
- [x] `npm run test:unit` + `npm run typecheck` via precommit hook — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)