### PR TITLE
docs(known-limitations): expand measurement, privacy, and system-of-record boundaries

### DIFF
--- a/.changeset/known-limitations-expand.md
+++ b/.changeset/known-limitations-expand.md
@@ -1,0 +1,16 @@
+---
+---
+
+docs(known-limitations): expand disclosure across measurement, privacy, regulated categories, and system-of-record boundaries
+
+**Security and privacy.** Pseudonymous-vs-anonymous clarification on hashed identifiers; jurisdictionally-aware consent signaling (TCF/GPP/Law 25/APPI/LGPD); cross-border transfer mechanics (SCC/IDTA/adequacy); versioned content-provenance chain (CAI/C2PA); retention/deletion SLA.
+
+**Measurement and attribution.** New section stating AdCP is not an attribution protocol (MMM/MTA/incrementality live in the buyer's measurement stack).
+
+**Governance.** Regulated categories beyond FHLE enumerated — political, pharma, gambling, alcohol, tobacco, financial promotions (crypto/digital assets), cannabis/CBD, firearms, supplement health claims, children's advertising — with regional disclosure regime references (FCA s.21, MiCA, COPPA, UK Children's Code, GDPR Art. 8).
+
+**Conformance and testing.** No latency/response-time SLA, contrasted with OpenRTB `tmax`.
+
+**What is outside the protocol.** Billing-grade metric accounting and IVT/viewability framed as system-of-record boundaries (delivery stack is the ledger; AdCP itself is not MRC-accredited and does not seek accreditation). Accessibility conformance (WCAG/ADA/EN 301 549) added.
+
+**Intro.** Pointer to Experimental Status so skimmers see the stability-contract boundary.

--- a/docs/reference/known-limitations.mdx
+++ b/docs/reference/known-limitations.mdx
@@ -9,21 +9,32 @@ Knowing what a protocol doesn't do is part of evaluating it. This page consolida
 
 Each limitation below is either a visible edge of the specification or a tracked follow-up. None is hidden.
 
+Surfaces shipped in 3.x but not yet frozen are listed separately — see [Experimental Status](/docs/reference/experimental-status).
+
 ## Security and privacy
 
 - **No end-user authentication.** AdCP authenticates agents, not the humans they act for. User-level identity, consent capture, and data-subject rights are handled upstream in the buyer's stack and are outside the protocol's scope.
 - **No protocol-level breach-notification SLA.** AdCP does not specify "seller MUST notify buyer within N hours of suspected key compromise." Notification commitments live in DPAs between parties. A future major version may tighten this.
 - **No coordinated vulnerability disclosure baked into the protocol.** Individual agent operators should publish `/.well-known/security.txt`; there is no normative AdCP requirement yet.
 - **No protocol-level PII transport.** The `hashed_email` and `hashed_phone` fields in `sync_audiences` require SHA-256 hashing on the buyer side — the schemas do not accept cleartext for those fields. Other identifier types exist for non-PII spaces. If you need cleartext PII on the wire, AdCP is not the right carrier.
+- **Hashed identifiers are pseudonymous, not anonymous.** SHA-256 hashes of email and phone remain pseudonymous identifiers under GDPR and CPRA and inherit the regulatory treatment of the underlying PII. AdCP does not claim de-identification.
 - **No protocol-level data-residency mechanism.** Residency is a configuration and contract property of individual agents; the protocol does not carry a normative residency tag.
 - **No protocol guarantee about LLM prompt-injection defense.** That is an operator concern on every LLM-powered agent in the loop. See the [Security Model — threats specific to agentic advertising](/docs/building/understanding/security-model#threats-specific-to-agentic-advertising).
 - **Structural privacy applies only to TMP.** The Trusted Match Protocol enforces privacy structurally (separated code paths, schema prohibitions). Every other domain relies on contractual confidentiality or per-session consent. See [Privacy posture across domains](/docs/protocol/architecture#privacy-posture-across-domains).
+- **No jurisdictionally-aware consent signal on the wire.** AdCP does not carry a normative consent tag (e.g., IAB TCF, GPP, or equivalents used to express compliance with regimes like Quebec's Law 25, Japan's APPI, or Brazil's LGPD). Lawful-basis determination, consent capture, and jurisdictional routing remain the responsibility of each party acting as controller or processor in its own stack, governed by the DPAs between them. A structured cross-agent consent signal is a candidate for future work.
+- **No protocol-level cross-border transfer mechanism.** AdCP does not carry SCC, IDTA, or adequacy-decision metadata. International-transfer lawfulness is a contract and configuration property of the parties.
+- **No versioned content-provenance chain.** AdCP carries right-use assertions and the `ai_generated_image` flag — the latter is a boolean marker, not a signed provenance assertion. The protocol does not specify a cryptographically signed provenance graph that accumulates assertions as a creative passes through generation, editing, and adaptation steps. Interoperation with emerging content-authenticity standards (CAI/C2PA) is tracked as future work.
+- **No retention or deletion SLA.** The protocol does not specify how long parties retain `sync_audiences` inputs, `report_usage` records, or task history. Retention windows and data-subject-request fulfillment live in DPAs between the parties.
 
 ## Commerce and settlement
 
 - **No in-protocol payment or settlement.** `report_usage` provides the consumption data that feeds invoicing, but invoicing and settlement happen out-of-band through the buyer/seller commercial relationship.
 - **No cross-currency media buy.** Each media buy uses a single ISO 4217 currency (see `core/price.json`). If the buyer's budget currency differs from the seller's pricing currency, the buy either uses a matching currency or is rejected. FX rate pinning, risk attribution, and cross-currency reporting are deferred to a future version.
 - **No protocol-level delivery-dispute flow.** When buyer and seller delivery numbers disagree, reconciliation happens out-of-band through the commercial relationship (backed by the audit trail on both sides). A structured dispute task is a candidate for future work.
+
+## Measurement and attribution
+
+- **Not an attribution protocol.** AdCP carries exposure records, identifiers where permitted, and the outcome signals that feed attribution, but it does not specify an attribution model. Media-mix modeling, multi-touch attribution, and incrementality testing live in the buyer's measurement stack — fed by AdCP data ([`report_usage`](/docs/accounts/tasks/report_usage) and task-level outputs) rather than computed by the protocol.
 
 ## Authentication and identity
 
@@ -34,11 +45,13 @@ Each limitation below is either a visible edge of the specification or a tracked
 
 - **Regulated-category human review is enforced by governance agents, not by a schema invariant.** 3.0 GA will reject `authority_level: agent_full` on campaigns that declare `fair_housing`, `fair_lending`, or `fair_employment` — before GA, enforcement depends on the governance-agent implementation, not a schema rule. A schema-level invariant is tracked in [#2310](https://github.com/adcontextprotocol/adcp/issues/2310).
 - **No protocol-mandated HITL on `sync_catalogs` or `sync_creatives`.** The universal task-lifecycle mechanism is available; no normative rule requires a human gate. `acquire_rights` is governed via the campaign-governance path ([purchase phase](/docs/governance/campaign/specification#governance-phases)) when the buyer's plan is configured for it. See [How human-in-the-loop enters the protocol](/docs/governance/embedded-human-judgment#how-human-in-the-loop-enters-the-protocol) for the two channels and the EHJ register for the normative rules on `check_governance`, `TERMS_REJECTED`, and lifecycle tasks.
+- **Regulated categories beyond `fair_housing`, `fair_lending`, and `fair_employment` have no first-class treatment.** Political advertising, pharmaceutical, gambling, alcohol, tobacco, financial promotions (including crypto and digital assets), cannabis/CBD, firearms, dietary-supplement health claims, and advertising directed at children rely on the general [campaign-governance](/docs/governance/campaign/specification) mechanism (HITL gates, governance tasks) rather than category-specific schema rules. Regionally specific disclosure requirements (e.g., UK FCA s.21, EU MiCA, political ad registries, COPPA, the UK Children's Code, GDPR Article 8) sit in the seller's delivery stack and the buyer's compliance posture, not the protocol.
 
 ## Conformance and testing
 
 - **No canonical conformance specification yet.** The compliance suite tests behavior; the formal spec naming every MUST that an "AdCP-compliant" implementation must satisfy is tracked in [#2380](https://github.com/adcontextprotocol/adcp/issues/2380). Reference test vectors are tracked in [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
 - **No automated enforcement of platform agnosticism** beyond the `check:platform-agnostic` lint scanning property names. A richer check covering schema semantics is future work.
+- **No latency or response-time SLA.** The protocol has no normative expectations for how quickly an agent must respond (unlike OpenRTB's per-auction `tmax`). Buyers and sellers negotiate timing through the commercial relationship or through task-specific [accountability terms](/docs/media-buy/advanced-topics/accountability). A structured SLA declaration is deferred.
 
 ## What is outside the protocol
 
@@ -49,6 +62,9 @@ AdCP specifies the wire. It does not specify — and cannot substitute for — a
 - **Monitoring and incident response.** The protocol emits the signals worth watching (idempotency conflicts, governance failures, SSRF rejections). Detecting and responding to them is the operator's job.
 - **Human controls.** Approval thresholds, spend caps, pause authority — these are policy configurations inside the operator's agent or governance platform, not the protocol.
 - **Physical and personnel security.** The usual controls over who can touch production, who holds break-glass credentials, and who can push to main.
+- **Billing-grade metric accounting.** AdCP carries delivery and usage data end-to-end from the seller's ad delivery system, and [`report_usage`](/docs/accounts/tasks/report_usage) feeds invoicing. The underlying delivery platform — or a buyer-specified measurement vendor — is the system of record for counting, audit, and MRC accreditation of the measurement methodology. AdCP itself is not MRC-accredited and does not seek accreditation; accreditation attaches to measurement systems, which sit downstream. AdCP is the wire and the contract, not the ledger.
+- **Invalid-traffic filtration and viewability measurement.** Buyers and sellers agree on verification vendors, thresholds, and remediation through [accountability terms](/docs/media-buy/advanced-topics/accountability). GIVT/SIVT filtration (per MRC), viewability measurement (per the MRC Viewable Ad Impression standard), and brand-safety verification execute in the delivery stack or the chosen vendor layer (e.g., DoubleVerify, IAS, HUMAN).
+- **Accessibility conformance of served creatives.** WCAG, ADA, and EN 301 549 conformance of rendered ads sit with the creative supplier, the delivery stack, and the publisher's rendering context. AdCP does not carry accessibility-conformance assertions as normative fields.
 
 Think of AdCP as specifying the locks on the doors. The operator still owns the building.
 


### PR DESCRIPTION
## Summary

Expands the Known Limitations page so a reporter, privacy auditor, or enterprise procurement team finds the visible edges explicit rather than implied. Reviewed by protocol, docs, security, and product experts before submitting.

**Security and privacy**
- Pseudonymous-vs-anonymous clarification on hashed identifiers (closes a misread of the existing PII-transport bullet)
- Jurisdictionally-aware consent signaling (IAB TCF / GPP with Law 25 / APPI / LGPD framed as regimes)
- Cross-border transfer mechanism (SCC / IDTA / adequacy)
- Versioned content-provenance chain (vendor-neutral; CAI / C2PA as examples)
- Retention / deletion SLA

**Measurement and attribution** (new section)
- AdCP is not an attribution protocol; MMM / MTA / incrementality live downstream

**Governance**
- Regulated categories beyond FHLE enumerated: political, pharma, gambling, alcohol, tobacco, financial promotions (crypto / digital assets), cannabis / CBD, firearms, supplement health claims, children's advertising — with regional regime references (FCA s.21, MiCA, COPPA, UK Children's Code, GDPR Art. 8)

**Conformance and testing**
- No latency / response-time SLA, contrasted with OpenRTB's `tmax`

**What is outside the protocol**
- Billing-grade metric accounting and IVT / viewability as system-of-record boundaries (delivery stack is the ledger; AdCP itself is not MRC-accredited and does not seek accreditation). GIVT / SIVT and MRC Viewable Ad Impression vocabulary; DV / IAS / HUMAN as vendor examples.
- Accessibility conformance (WCAG / ADA / EN 301 549)

**Intro**
- Pointer to Experimental Status so skimmers see the stability-contract boundary

## Test plan

- [x] `npm run test:unit` (587 tests) — passed
- [x] `npm run typecheck` — clean
- [x] Mintlify validation — no broken links
- [ ] Spot-check rendered page in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)