### PR TITLE
docs: conformance specification (#2380)

### DIFF
--- a/.changeset/conformance-specification.md
+++ b/.changeset/conformance-specification.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: Conformance Specification (`docs/building/conformance.mdx`) — names conformance as "passes the storyboards" and positions the storyboards as the single source of truth, with this doc as a navigational index. Separates *conformant* (wire behavior) from *verified* (third-party attestation) and retires "compliant" as a self-claim. Includes an outside-the-wire section for operator controls (secret storage, rotation, incident response, subprocessors) and a SOC 2 / ISO 27001 / NIST CSF overlap-and-gap table. Retires the "no canonical conformance spec" entry in known-limitations. Closes #2380.

--- a/docs.json
+++ b/docs.json
@@ -114,6 +114,7 @@
                   "docs/building/validate-your-agent",
                   "docs/building/operating-an-agent",
                   "docs/building/compliance-catalog",
+                  "docs/building/conformance",
                   {
                     "group": "Foundations",
                     "pages": [
@@ -610,6 +611,7 @@
               "docs/building/validate-your-agent",
               "docs/building/operating-an-agent",
               "docs/building/compliance-catalog",
+              "docs/building/conformance",
               {
                 "group": "Foundations",
                 "pages": [

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -1,0 +1,139 @@
+---
+title: Conformance Specification
+sidebarTitle: Conformance Specification
+description: "What 'AdCP-conformant' means, defined by the storyboards that verify it. Conformance is what the spec requires; verified is what the suite attests."
+"og:title": "AdCP — Conformance Specification"
+---
+
+**Status**: Request for Comments
+**Last Updated**: April 19, 2026
+
+## Two words, not three
+
+AdCP conformance has two load-bearing terms. A third (one you'll hear in the wild) is a trap.
+
+- **Conformant** — the agent meets the normative rules. Defined by the storyboards this document indexes.
+- **Verified** — AAO has tested the agent recently against those storyboards and issued a signed attestation ([AAO Verified badge](/docs/building/compliance-catalog)). Gated on active membership and a live heartbeat.
+- **"Compliant"** — self-attested, unverified, no external check. Don't claim it; don't design for it. This document uses *conformant* and *verified* exclusively.
+
+Put differently:
+
+- Conformance is a property of the agent's wire behavior.
+- Verification is a time-bounded third-party attestation that an agent is conformant.
+- Verified ⊆ Conformant. You can be conformant without being verified; you cannot be verified without being conformant.
+
+## Storyboards are the truth
+
+Rather than restate every MUST in prose — which would inevitably drift from the executable suite — **the storyboards ARE the conformance specification.** This document is a navigational index to them, grouped by the declaration that obligates the storyboard to run.
+
+Every normative rule in the suite has exactly one home: the storyboard YAML at [`/compliance/latest/`](https://adcontextprotocol.org/compliance/latest/). Changes to what "conformant" means happen there, in a versioned release, tested against real agents. If a rule isn't in a storyboard, it's not part of conformance.
+
+This is deliberate. A separate prose spec that restates storyboard rules creates two sources of truth. Two sources of truth drift. We pick one: the suite.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the referenced storyboards and prose sections below are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Conformance is layered
+
+Every agent satisfies the universal layer. Each `supported_protocols` claim adds a protocol baseline. Each `specialisms` claim adds a specialism baseline.
+
+| Layer | Obligation | Path |
+|-------|------------|------|
+| **Universal** | Every AdCP agent | [`/compliance/latest/universal/`](https://adcontextprotocol.org/compliance/latest/universal/) |
+| **Protocol** | Agent claiming a `supported_protocols` value | [`/compliance/latest/protocols/{protocol}/`](https://adcontextprotocol.org/compliance/latest/protocols/) |
+| **Specialism** | Agent claiming a `specialisms` value | [`/compliance/latest/specialisms/{id}/`](https://adcontextprotocol.org/compliance/latest/specialisms/) |
+
+Agents MUST NOT declare a capability whose storyboards they do not pass. See the [Compliance Catalog](/docs/building/compliance-catalog) for the full taxonomy and [Validate Your Agent](/docs/building/validate-your-agent) for how to run the suite locally.
+
+## Universal conformance
+
+Every agent MUST pass every storyboard below.
+
+| Storyboard | What it verifies |
+|------------|------------------|
+| [`capability_discovery`](https://adcontextprotocol.org/compliance/latest/universal/capability-discovery) | `get_adcp_capabilities` shape, protocol/specialism declarations, version advertising |
+| [`schema_validation`](https://adcontextprotocol.org/compliance/latest/universal/schema-validation) | Request and response schema conformance, ISO 8601 timestamps, temporal invariants |
+| [`error_compliance`](https://adcontextprotocol.org/compliance/latest/universal/error-compliance) | Structured error shape, published error codes, transport binding, no existence leaks across tenants |
+| [`idempotency`](https://adcontextprotocol.org/compliance/latest/universal/idempotency) | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
+| [`security_baseline`](https://adcontextprotocol.org/compliance/latest/universal/security) | Unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |
+| [`deterministic_testing`](https://adcontextprotocol.org/compliance/latest/universal/deterministic-testing) | `comply_test_controller` state machine — skipped if `capabilities.compliance_testing.supported: false` |
+
+Agents that declare `capabilities.compliance_testing.supported: true` MUST implement the full [test controller](/docs/building/implementation/comply-test-controller); a partial controller is non-conformant, so declare `false` rather than ship one.
+
+## Protocol conformance
+
+A `supported_protocols` claim obligates the protocol's baseline storyboard.
+
+| `supported_protocols` | Storyboard |
+|-----------------------|------------|
+| `media_buy` | [`media_buy_seller`](https://adcontextprotocol.org/compliance/latest/protocols/media-buy/) + [`media_buy_state_machine`](https://adcontextprotocol.org/compliance/latest/protocols/media-buy/state-machine) |
+| `creative` | [`creative_lifecycle`](https://adcontextprotocol.org/compliance/latest/protocols/creative/) |
+| `signals` | [`signals_baseline`](https://adcontextprotocol.org/compliance/latest/protocols/signals/) |
+| `governance` | [`media_buy_governance_escalation`](https://adcontextprotocol.org/compliance/latest/protocols/governance/) |
+| `brand` | [`brand_baseline`](https://adcontextprotocol.org/compliance/latest/protocols/brand/) |
+| `sponsored_intelligence` | [`si_baseline`](https://adcontextprotocol.org/compliance/latest/protocols/sponsored-intelligence/) |
+
+## Specialism conformance
+
+A `specialisms` claim obligates the specialism's storyboard in addition to its parent protocol baseline. The catalog lives at [`/compliance/latest/index.json`](https://adcontextprotocol.org/compliance/latest/index.json); the human-readable index is the [Compliance Catalog](/docs/building/compliance-catalog).
+
+Specialisms carry a `status` — `stable` (verified pass/fail), `preview` (storyboard not yet defined; runner emits `passed: null`), `deprecated` (scheduled for removal). Agents MAY claim preview specialisms, but preview claims do not yield a pass/fail verdict.
+
+## Outside the wire
+
+Some requirements can't be verified by a storyboard because they're operator-level, not wire-level. They remain part of running a conformant agent, but the suite can't attest to them. Operators MUST self-assess against these; third-party frameworks (SOC 2, ISO 27001) are the usual attestation path.
+
+- **Secret storage** — credentials SHOULD live in a KMS or equivalent. The wire shows only whether auth succeeds, not where the key was stored.
+- **Credential rotation and revocation** — the operator MUST have a documented path to revoke a compromised credential in under an hour. The wire can't observe the runbook.
+- **Personnel and physical security** — who can touch production, break-glass custody, employee offboarding. Entirely outside the protocol.
+- **Governance agent due diligence** — when the operator relies on a third-party governance agent, the buyer SHOULD treat it as a processor with multi-customer blast radius and assess its posture. The storyboards verify correct JWS handling by the seller but cannot vouch for the governance agent itself.
+- **LLM subprocessor posture** — if the agent uses an LLM provider, the DPA with that provider governs whether prompts, brand assets, or creative metadata may be retained. The protocol can't see upstream DPA terms.
+- **Incident response** — AdCP emits the signals worth watching (`IDEMPOTENCY_CONFLICT` spikes, failed governance verifications, SSRF rejections); detection, alert routing, and response are operator concerns.
+- **Data residency configuration** — whether and how EU / UK data is kept in-region is typically declared in the agent's capabilities or contract; the wire records the declaration, not the underlying infrastructure.
+
+Full operator checklist: [Security Model § What to verify before going live](/docs/building/understanding/security-model#what-to-verify-before-going-live).
+
+## Conformance vs external assurance
+
+Conformance is wire-level correctness. SOC 2, ISO 27001, and NIST CSF are operational assurance. They answer different questions and neither substitutes for the other.
+
+| External control area | Storyboard evidence | Gap to external assurance |
+|------------------------|---------------------|----------------------------|
+| Access control (SOC 2 CC6, ISO 27001 A.5.15) | `security_baseline` (identity) + isolation checks in protocol storyboards | Personnel access reviews, least-privilege admin, offboarding |
+| Change management (SOC 2 CC8) | `idempotency` proves duplicate state changes are prevented on the wire | Deployment approvals, release gates, rollback procedures |
+| System monitoring (SOC 2 CC7, ISO 27001 A.8.16) | Error taxonomy produces a monitorable surface | Detection engineering, alert routing, on-call runbooks |
+| Cryptography (ISO 27001 A.8.24) | TLS, RFC 9421 signing, JWS governance tokens | KMS selection, rotation cadence, cert lifecycle |
+| Audit logging (SOC 2 CC7) | Governance storyboards verify signed-record issuance | Log retention, legal hold, integrity monitoring |
+| Data handling (SOC 2 Privacy, GDPR, ISO 27701) | TMP two-call separation, audience hashing, signal access control | Data subject rights, DPA management, cross-border transfer |
+| Vendor and subprocessor risk (SOC 2 CC9) | `adagents.json` / brand.json discovery, JWKS publication | Third-party risk assessment, LLM provider review |
+| Incident response (SOC 2 CC7, NIST CSF RS) | Signals observable; response not mandated | Runbooks, tabletop exercises, breach notification |
+| Business continuity (ISO 27001 A.5.30) | Cross-instance state storyboard checks | RPO/RTO targets, DR testing |
+
+Two practical consequences:
+
+1. Storyboard pass evidence MAY support specific external control objectives. It is not a substitute for an audit.
+2. External certification does not imply AdCP conformance. SOC 2 Type II says nothing about whether `create_media_buy` responses validate.
+
+## How to claim conformance
+
+1. Declare `supported_protocols` and `specialisms` in `get_adcp_capabilities`.
+2. Pass every storyboard the declaration obligates — universal + protocol baselines + specialism baselines — at a specific AdCP major version.
+3. Keep declaration and behavior in sync. An undeclared capability the suite happens to test is separate from a declared capability that fails. Both are non-conformant.
+
+Conformance is per-version; the suite is per-version. A 3.0-conformant agent is not thereby 3.1-conformant.
+
+**For third-party attestation**, run the heartbeat against AAO and earn an [AAO Verified badge](/docs/building/compliance-catalog). The badge is a signed claim that AAO tested the agent recently and the pass still holds. Buyers filtering on *verified* get a smaller set than *conformant* — fewer agents, fresher attestation, a named party on the hook.
+
+## What this document does not do
+
+- **Define individual MUSTs.** The storyboards do. If a rule isn't in a storyboard, it isn't part of conformance.
+- **Grant or revoke certification.** The [AgenticAdvertising.org certification program](/docs/learning/overview) runs on top of this; conformance is necessary but not sufficient.
+- **Publish reference test vectors beyond those already in the suite.** Broader test-vector corpus: [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
+
+## Further reading
+
+- **[Compliance Catalog](/docs/building/compliance-catalog)** — Full taxonomy of protocols and specialisms with storyboard IDs
+- **[Validate Your Agent](/docs/building/validate-your-agent)** — How to run the suite
+- **[Security Model](/docs/building/understanding/security-model)** — Strategic framing for the five defense layers that the security storyboards enforce
+- **[Security (implementation reference)](/docs/building/implementation/security)** — Normative rules cited by the storyboards
+- **[Versioning](/docs/reference/versioning)** — Major-version support windows
+- **[Known Limitations](/docs/reference/known-limitations)** — Visible edges of the specification

--- a/docs/reference/known-limitations.mdx
+++ b/docs/reference/known-limitations.mdx
@@ -37,7 +37,7 @@ Each limitation below is either a visible edge of the specification or a tracked
 
 ## Conformance and testing
 
-- **No canonical conformance specification yet.** The compliance suite tests behavior; the formal spec naming every MUST that an "AdCP-compliant" implementation must satisfy is tracked in [#2380](https://github.com/adcontextprotocol/adcp/issues/2380). Reference test vectors are tracked in [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
+- **Reference test vectors are partial.** [Conformance](/docs/building/conformance) is defined by the storyboard suite, and the suite publishes request-signing and canonicalization vectors today — but a broader corpus of reference test vectors is tracked in [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
 - **No automated enforcement of platform agnosticism** beyond the `check:platform-agnostic` lint scanning property names. A richer check covering schema semantics is future work.
 
 ## What is outside the protocol


### PR DESCRIPTION
## Summary

- New `docs/building/conformance.mdx` — storyboards are the source of truth for what "conformant" means; this doc is a navigational index to them, not a restatement.
- Separates three terms: **conformant** (wire behavior verified by the suite), **verified** (AAO-signed attestation with a live heartbeat), and retires **"compliant"** as a self-claim with no external check.
- Keeps a focused "outside the wire" section for operator-level controls the storyboards can't verify (secret storage, rotation, personnel, LLM DPA, incident response).
- SOC 2 / ISO 27001 / NIST CSF overlap-and-gap table so external assurance and AdCP conformance aren't conflated.
- Retires the "no canonical conformance spec" bullet in `known-limitations.mdx`. The remaining conformance-and-testing limitation is the partial reference test-vector corpus (#2383).

## Why this shape

The earlier draft restated MUSTs in prose, which creates two sources of truth that will drift. The storyboards already encode every wire-testable rule and ship versioned with the protocol. Pointing at them — rather than paraphrasing them — makes drift structurally impossible for the verified set. Prose remains only where wire verification isn't possible.

## Out of scope (by design)

- Certification outcomes (AAO program owns those)
- Reference test vectors beyond the existing request-signing / canonicalization sets — #2383
- AAO Verified badge UX / JWT / embed mechanics — that ships with #2153

Closes #2380.

## Test plan

- [x] `npm run test:unit` — 587/587 pass
- [x] `npm run typecheck` — clean
- [x] `npm run test:docs-nav` — 15/15 pass (new page registered in v3-rc and latest)
- [x] `npm run test:platform-agnostic` — clean
- [x] SEO metadata check — description under 160 chars
- [x] All internal anchors resolve (spot-checked against `security.mdx`, `security-model.mdx`, `validate-your-agent.mdx`)
- [x] Mintlify validation passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)