### PR TITLE
docker: switch base image to node:22-bookworm-slim (glibc)

### DIFF
--- a/.changeset/switch-runtime-to-bookworm-slim.md
+++ b/.changeset/switch-runtime-to-bookworm-slim.md
@@ -1,0 +1,6 @@
+---
+---
+
+Switch Docker base image from `node:22-alpine` (musl) to `node:22-bookworm-slim` (glibc) for the builder and runtime stages, pinned by digest. The repos cloner stage stays on Alpine since it only needs `git`.
+
+Unblocks native dependencies that ship glibc-only prebuilds — notably the C2PA signing libraries for AI-generated imagery (portraits, hero illustrations, docs storyboards) tracked in #2370. Also installs `unzip` explicitly for the Tranco ingestion path (previously satisfied by busybox on Alpine) and pins `TZ=UTC` so time math does not drift with container defaults.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Use Node.js 22 Alpine for building
-FROM node:22-alpine AS builder
+FROM node:22-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -82,17 +81,21 @@ CLONE
 RUN sh /repos/clone.sh
 
 # Production stage
-FROM node:22-alpine
+FROM node:22-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
+# unzip is used by the Tranco ingestion path at runtime. Alpine bundled it via
+# busybox; Debian slim does not. ca-certificates is present in the base image
+# but reinstalled here as belt-and-suspenders for TLS trust.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends unzip ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY package*.json ./
 
-# Install only production dependencies
-# --ignore-scripts is used to skip arbitrary lifecycle scripts, but sharp
-# needs its install script to download platform-specific native binaries.
+# --ignore-scripts blocks arbitrary postinstall lifecycle scripts from the full
+# dep tree; native deps are rebuilt explicitly per-package.
 RUN npm ci --omit=dev --ignore-scripts && npm rebuild sharp
 
 # Copy built files from builder
@@ -110,6 +113,7 @@ COPY --from=repos /repos ./.addie-repos
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=8080
+ENV TZ=UTC
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
## Summary

- Swap builder + runtime Docker stages from `node:22-alpine` (musl) to `node:22-bookworm-slim` (glibc), pinned by digest.
- Install `unzip` explicitly (Alpine provided it via busybox; Debian slim does not) and pin `TZ=UTC` so time math does not drift with container defaults.
- Repos cloner stage stays on Alpine — it only needs `git` to clone markdown and is ~30MB smaller.

## Why

C2PA signing libraries (`@contentauth/c2pa-node`, `c2patool`) only ship glibc prebuilds — no musl binaries. We need them for #2370 (Art 50 / C2PA provenance on AAO-generated imagery). Rather than building c2pa-rs from source in CI or installing gcompat as a workaround, swap to bookworm-slim so native deps land on first-class ground. Bonus: removes the ongoing musl friction behind the existing `npm rebuild sharp` workaround.

## Expert review findings addressed

Ran code-reviewer and security-reviewer in parallel before pushing.

**Must-fix (both addressed):**
- `unzip` absent in bookworm-slim — used at runtime by the Tranco ingestion path (`server/src/services/tranco-ingestion.ts:154`, imported by `routes/catalog-api.ts`). Installed via `apt-get install --no-install-recommends unzip ca-certificates`.
- Base image pinned by digest (`sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383`) on both stages. Dependabot will track updates. Especially relevant since this image will soon carry the AAO C2PA signing keypair.

**Should-fix (addressed):**
- `TZ=UTC` set explicitly — Debian ships full zoneinfo and could pick up a different container default if anything downstream defaults to the process TZ.
- Kept `--ignore-scripts` + explicit `npm rebuild sharp` pattern — still the right hardening default on glibc. When C2PA lands we'll extend to `npm rebuild sharp @contentauth/c2pa-node` (or whatever the final package name), not a bare rebuild.

**Considered, deferred to follow-up:**
- Run as non-root (`USER node`) — flagged by security review as not introduced by this change. Worth doing, but mixing it into the base-image swap muddies rollback. Happy to open a follow-up issue.
- Pin the 27 cloned external repos in the repos stage to commit SHAs — pre-existing supply-chain risk, unchanged by this swap. Also follow-up material.

## Test plan

- [x] Local `docker build -t adcp-docs:bookworm-full-test .` — full build, all stages, exit 0.
- [x] Runtime smoke test in container: `sharp` loads, `unzip` present at `/usr/bin/unzip`, `TZ=UTC` in effect.
- [x] `npm run precommit` (test:unit + typecheck) — 587/587 passing.
- [ ] Fly deploy (release_command runs migrations, then `node dist/index.js` on web + worker processes). Monitor for any `ENOENT` or libc-related surprises in the first minutes of traffic.

Refs #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)