### PR TITLE
spec(compliance): positive schema_ref lint on mutating storyboard steps

### DIFF
--- a/.changeset/storyboard-schema-ref-positive-lint.md
+++ b/.changeset/storyboard-schema-ref-positive-lint.md
@@ -1,0 +1,6 @@
+---
+---
+
+Storyboard lint: positively require `schema_ref` on any step whose `task` is a known mutating tool. The existing idempotency-key check only runs on steps that declare a `schema_ref`, so a storyboard step calling a mutating tool without one would silently skip the check. This positive check catches the missing `schema_ref` itself as a lint error and identifies three pre-existing omissions in `deterministic-testing.yaml` (`sync_accounts_for_state`, `initiate_session`, `verify_terminated_session`), which are fixed in the same change.
+
+Extracted from the red-team follow-up work in PR #2433 (finding I-9) as a standalone low-risk tooling fix.

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -178,6 +178,7 @@ function discoverProtocols(sourceDir, specialisms) {
 
 function loadMutatingSchemaRefs(schemasDir) {
   const refs = new Set();
+  const tools = new Set();
   function walk(d) {
     for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
       const p = path.join(d, entry.name);
@@ -189,16 +190,19 @@ function loadMutatingSchemaRefs(schemasDir) {
       const required = Array.isArray(schema.required) ? schema.required : [];
       if (required.includes('idempotency_key')) {
         refs.add(path.relative(schemasDir, p));
+        // Task name ↔ filename: "create-media-buy-request.json" → "create_media_buy"
+        tools.add(entry.name.replace(/-request\.json$/, '').replace(/-/g, '_'));
       }
     }
   }
   walk(schemasDir);
-  return refs;
+  return { refs, tools };
 }
 
 function lintStoryboardIdempotency(sourceDir, schemasDir) {
-  const mutatingRefs = loadMutatingSchemaRefs(schemasDir);
+  const { refs: mutatingRefs, tools: mutatingTools } = loadMutatingSchemaRefs(schemasDir);
   const violations = [];
+  const missingSchemaRefs = [];
 
   function lintFile(p) {
     const rel = path.relative(sourceDir, p);
@@ -222,7 +226,17 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
         // synthetic invocations (e.g., comply_test_controller's
         // simulate_budget scenarios, universal/security.yaml's probe steps)
         // that don't send a task request schema. They're out of scope for
-        // this lint.
+        // this lint — UNLESS the task name itself is a known mutating tool,
+        // in which case the missing schema_ref is itself a storyboard bug
+        // (the step would bypass the idempotency_key lint above). Positive
+        // check per red-team I-9 / security.mdx storyboard hygiene.
+        if (step.task && mutatingTools.has(step.task) && !step.schema_ref) {
+          missingSchemaRefs.push({
+            file: rel,
+            step: step.id,
+            msg: `Step uses mutating tool "${step.task}" but has no schema_ref`,
+          });
+        }
         const schemaRef = step.schema_ref;
         if (!schemaRef || !mutatingRefs.has(schemaRef)) continue;
         const hasKey =
@@ -263,6 +277,15 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
       `static/compliance/source/universal/idempotency.yaml for the convention, ` +
       `and note the deliberate alias-reuse pattern there when two steps must ` +
       `share a key (replay tests).`
+    );
+  }
+
+  if (missingSchemaRefs.length > 0) {
+    const lines = missingSchemaRefs.map(v => `  ${v.file} step=${v.step}: ${v.msg}`);
+    throw new Error(
+      `Storyboard schema_ref lint: ${missingSchemaRefs.length} step(s) call a mutating tool without a schema_ref, which would silently skip the idempotency_key check.\n\n` +
+      lines.join('\n') +
+      `\n\nAdd the matching \`schema_ref:\` (e.g. "media-buy/create-media-buy-request.json") to each step.`
     );
   }
 }

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -270,6 +270,8 @@ phases:
           Sync a sandbox account so the state machine has an entity to
           force transitions on.
         task: sync_accounts
+        schema_ref: 'account/sync-accounts-request.json'
+        response_schema_ref: 'account/sync-accounts-response.json'
         comply_scenario: deterministic_account
         stateful: true
 
@@ -279,6 +281,7 @@ phases:
           operator: 'test.example'
           sandbox: true
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_account_sync_accounts_for_state"
           context:
             correlation_id: "deterministic_testing--sync_accounts_for_state"
         validations:
@@ -903,6 +906,8 @@ phases:
           Create an SI session via si_initiate_session. The session_id is captured
           for controller-driven termination.
         task: si_initiate_session
+        schema_ref: 'sponsored-intelligence/si-initiate-session-request.json'
+        response_schema_ref: 'sponsored-intelligence/si-initiate-session-response.json'
         comply_scenario: deterministic_session
         stateful: true
         context_outputs:
@@ -918,6 +923,7 @@ phases:
             response_formats:
               - 'text'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_session_initiate_session"
           context:
             correlation_id: "deterministic_testing--initiate_session"
         validations:
@@ -974,6 +980,8 @@ phases:
           Attempt to send a message on the terminated session. The agent should
           return an error or terminated status.
         task: si_send_message
+        schema_ref: 'sponsored-intelligence/si-send-message-request.json'
+        response_schema_ref: 'sponsored-intelligence/si-send-message-response.json'
         comply_scenario: deterministic_session
         stateful: true
         expected: |
@@ -984,6 +992,7 @@ phases:
           session_id: '$context.session_id'
           message: 'comply test — session should be terminated'
 
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_session_verify_terminated_session"
           context:
             correlation_id: "deterministic_testing--verify_terminated_session"
         validations:


### PR DESCRIPTION
## Summary

- Positive storyboard lint: if a step's `task` is a known mutating tool (i.e. its request schema declares `idempotency_key` as `required`), the step MUST declare a matching `schema_ref`.
- Without this, a step calling a mutating tool without a `schema_ref` silently bypassed the existing `idempotency_key` check — the lint keyed off `schema_ref` presence to decide whether to enforce.
- Caught three pre-existing omissions in `deterministic-testing.yaml` (`sync_accounts_for_state`, `initiate_session`, `verify_terminated_session`), fixed in the same change.

Extracted from #2433 red-team finding **I-9** as a standalone low-risk tooling change. No spec wire changes; touches compliance lint + three storyboard step fixes.

Co-authored with @EmmaLouise2018 who did the original red-team analysis.

## Test plan

- [x] `node scripts/build-compliance.cjs` passes on this branch
- [x] Stashing the yaml fixes reproduces the lint failure with the expected error message (`Step uses mutating tool "si_send_message" but has no schema_ref`)
- [x] Pre-commit hook: 587 unit tests pass, `tsc --noEmit` passes
- [x] Pre-push hook: Mintlify validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)