### PR TITLE
docs(security): use Set.has() in auth-precheck example

### DIFF
--- a/.changeset/sec-set-has-for-auth-precheck.md
+++ b/.changeset/sec-set-has-for-auth-precheck.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update the two-step auth-precheck code example in `docs/building/implementation/security.mdx` to use `Set.has()` instead of `Array.includes()` on `authorizedAccountIds`. Reasons inlined as a comment: `Set.has()` is O(1) while `Array.includes()` is O(n) and introduces a measurable timing difference across requests for large authorized-account sets. Extracted from PR #2433.

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -166,9 +166,13 @@ Every request carries an explicit `account` (via `account_id` for explicit-accou
 
 ```javascript
 // Two-step: precheck request account is authorized, then scope the query to it.
+// authorizedAccountIds is a Set<string> populated once at auth-time, not an Array.
+// Set.has() is O(1); Array.includes() is O(n) and scans element-by-element, which
+// on large authorized-account sets introduces a timing difference between early
+// and late matches that a caller can probe across requests.
 async function getMediaBuy(mediaBuyId, requestAccountId, authAgent) {
   // Step 1: auth precheck
-  if (!authAgent.authorizedAccountIds.includes(requestAccountId)) {
+  if (!authAgent.authorizedAccountIds.has(requestAccountId)) {
     // Generic error - don't reveal whether the account exists
     throw new NotFoundError("Media buy not found");
   }


### PR DESCRIPTION
## Summary

Small code-example update to the two-step auth-precheck pattern in `docs/building/implementation/security.mdx`: model `authorizedAccountIds` as a `Set<string>` and use `Set.has()` rather than `Array.includes()`. Reasons inlined as a comment:

- `Set.has()` is O(1); `Array.includes()` is O(n) and scans element-by-element, which on large authorized-account sets introduces a measurable timing difference between early and late matches that a caller can probe across requests.

Extracted from #2433 as a standalone code-example improvement. Co-authored with @EmmaLouise2018.

## Test plan

- [x] Pre-commit hook: 587 unit tests pass, `tsc --noEmit` passes
- [x] Doc-only change; no wire-schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)