### PR TITLE
spec(compliance): fix webhook-emission capability-discovery check

### DIFF
--- a/.changeset/fix-webhook-emission-capabilities-check.md
+++ b/.changeset/fix-webhook-emission-capabilities-check.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix `webhook-emission.yaml` capability-discovery sanity check to validate a field that actually exists.
+
+The `get_capabilities` step asserted `field_present: "operations"` on the `get_adcp_capabilities` response, but the response schema has no `operations` field — webhook-emitting operations are advertised at the transport handshake (MCP `tools/list`, A2A skills), not in the capabilities body. The runner already keys off `options.agentTools` for that, making the validation both incorrect and redundant.
+
+Swapped to `field_present: "supported_protocols"`, which is a required top-level field in `get-adcp-capabilities-response.json`. Preserves the capabilities-body sanity check without asserting a field that was never meant to live there.

--- a/.changeset/fix-webhook-emission-capabilities-check.md
+++ b/.changeset/fix-webhook-emission-capabilities-check.md
@@ -1,8 +1,9 @@
 ---
+"adcontextprotocol": patch
 ---
 
 Fix `webhook-emission.yaml` capability-discovery sanity check to validate a field that actually exists.
 
 The `get_capabilities` step asserted `field_present: "operations"` on the `get_adcp_capabilities` response, but the response schema has no `operations` field — webhook-emitting operations are advertised at the transport handshake (MCP `tools/list`, A2A skills), not in the capabilities body. The runner already keys off `options.agentTools` for that, making the validation both incorrect and redundant.
 
-Swapped to `field_present: "supported_protocols"`, which is a required top-level field in `get-adcp-capabilities-response.json`. Preserves the capabilities-body sanity check without asserting a field that was never meant to live there.
+Swapped to `field_present: "supported_protocols"`, which is a required top-level field in `get-adcp-capabilities-response.json`. Preserves the capabilities-body sanity check without asserting a field that was never meant to live there. Also tightened the step's `expected:` prose to reflect where the webhook-emitter gate actually lives (`$test_kit.operations.primary_webhook_emitter` resolution).

--- a/static/compliance/source/universal/webhook-emission.yaml
+++ b/static/compliance/source/universal/webhook-emission.yaml
@@ -103,9 +103,12 @@ phases:
         comply_scenario: capability_discovery
         stateful: false
         expected: |
-          Return capabilities block declaring at least one async operation that
-          accepts push_notification_config. If none, grading returns a stable
-          not_applicable marker.
+          Return a capabilities block including supported_protocols. Webhook-
+          emitting operations are discovered via the transport handshake
+          (MCP tools/list, A2A skills), not the capabilities body; grading
+          returns a stable not_applicable marker downstream when no webhook-
+          emitting operation resolves through
+          $test_kit.operations.primary_webhook_emitter.
         sample_request:
           context:
             correlation_id: "webhook_emission--get_capabilities"

--- a/static/compliance/source/universal/webhook-emission.yaml
+++ b/static/compliance/source/universal/webhook-emission.yaml
@@ -111,8 +111,8 @@ phases:
             correlation_id: "webhook_emission--get_capabilities"
         validations:
           - check: field_present
-            path: "operations"
-            description: "Agent declares its supported operations"
+            path: "supported_protocols"
+            description: "Agent declares its supported AdCP protocols"
 
   - id: idempotency_key_presence
     title: "Every webhook payload carries idempotency_key"


### PR DESCRIPTION
## Summary

The `get_capabilities` phase in `webhook-emission.yaml` asserted `field_present: \"operations\"` on the `get_adcp_capabilities` response. That field does not exist in `get-adcp-capabilities-response.json` — required top-level fields are `adcp` and `supported_protocols`. Webhook-emitting operations are advertised at the transport handshake (MCP `tools/list` / A2A skills), not in the capabilities body. The runner already keys off `options.agentTools` for that.

Swap the validation to `field_present: \"supported_protocols\"` so the capabilities-body sanity check asserts a field that actually exists and is schema-required.

## Why this is scoped correctly

- Grep across `static/compliance/**` confirms this was the only `field_present: operations` assertion. Other `operations` matches are prose or `$test_kit.operations.*` template refs (different concept).
- The `expected:` prose in the same step ("async operation that accepts push_notification_config") is descriptive framing, not an assertion — runner gating happens downstream via `$test_kit.operations.primary_webhook_emitter`, which fails resolution to `not_applicable` if no emitter exists.
- Load-bearing phases (`idempotency_key_presence`, `idempotency_key_stability`, `signature_validity`) are unchanged and don't reference `operations`.

## Test plan

- [x] Precommit (`npm run test:unit` + `npm run typecheck`) — 587 tests passed
- [x] Grep confirms no other `field_present: operations` assertions in `static/compliance/**`
- [x] Reviewed by code-reviewer, security-reviewer, and ad-tech-protocol-expert — all approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)