### PR TITLE
spec(webhooks): fix vectors 004/005 to apply full @target-uri canonicalization

### DIFF
--- a/.changeset/fix-webhook-vectors-004-005-canonicalization.md
+++ b/.changeset/fix-webhook-vectors-004-005-canonicalization.md
@@ -1,7 +1,8 @@
 ---
+"adcontextprotocol": patch
 ---
 
-Fix webhook-signing positive vectors 004 and 005 to apply full `@target-uri`
+Fix webhook-signing positive vectors 004 + 005 to apply full `@target-uri`
 canonicalization per the shared rules in `request-signing/canonicalization.json`.
 Previously both vectors signed the as-received URL instead of the canonical one,
 contradicting step 4 (strip default ports) and step 6 (uppercase `%xx` hex /

--- a/.changeset/fix-webhook-vectors-004-005-canonicalization.md
+++ b/.changeset/fix-webhook-vectors-004-005-canonicalization.md
@@ -1,0 +1,29 @@
+---
+---
+
+Fix webhook-signing positive vectors 004 and 005 to apply full `@target-uri`
+canonicalization per the shared rules in `request-signing/canonicalization.json`.
+Previously both vectors signed the as-received URL instead of the canonical one,
+contradicting step 4 (strip default ports) and step 6 (uppercase `%xx` hex /
+decode percent-encoded unreserved).
+
+- 004-default-port-stripped: signature base now uses
+  `https://buyer.example.com/...` (`:443` stripped) instead of
+  `https://buyer.example.com:443/...`. Signature regenerated.
+- 005-percent-encoded-path: input URL changed from `op%2dabc` (where `%2d` is
+  unreserved `-` and by step 6 MUST decode rather than just uppercase — the
+  previous encoding overloaded the test) to `op_%e2%98%83` (reserved UTF-8
+  bytes), matching the pattern in request-signing vector 008. Signature base
+  uppercases hex to `%E2%98%83`. Signature regenerated.
+
+Both new Ed25519 signatures are deterministic and verify against the published
+`test-ed25519-webhook-2026` keypair.
+
+**Implementor note.** Any verifier that previously passed the old 004/005
+signatures has a latent canonicalization bug: it accepted signatures produced
+over the as-received URL rather than the canonical `@target-uri`. That verifier
+will silently disagree with a correctly-canonicalizing producer on any URL
+containing `:443`, `:80`, or lowercase `%xx` in the path, causing
+`webhook_signature_invalid` at step 10. Re-run the positive suite after
+pulling — vectors are frozen on commit and the fixed pair will not round-trip
+against a broken verifier.

--- a/static/compliance/source/test-vectors/webhook-signing/positive/004-default-port-stripped.json
+++ b/static/compliance/source/test-vectors/webhook-signing/positive/004-default-port-stripped.json
@@ -9,14 +9,14 @@
       "Content-Type": "application/json",
       "Content-Digest": "sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:",
       "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
-      "Signature": "sig1=:LDXEv3m5Y4-9ucM_HGM8IxxCfn0ypXkDDsQXvPRULmGTB1fN3I858RtVbYnMmNLw4cr1VsHjgMJuNs3KFpqXDw:"
+      "Signature": "sig1=:nqTKCpjlqf1OqZPuJyPeiF7HJ01G8KmPNSzzmad0PAJv7OUVKthI7ks_j4G-6x1H4mBpXDIISgX_iZQiYvG7Dg:"
     },
     "body": "{\"idempotency_key\":\"whk_01HW9D3H8FZP2N6R8T0V4X6Z9B\",\"task_id\":\"task_456\",\"operation_id\":\"op_abc\",\"status\":\"completed\",\"result\":{\"media_buy_id\":\"mb_001\"}}"
   },
   "jwks_ref": [
     "test-ed25519-webhook-2026"
   ],
-  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com:443/adcp/webhook/create_media_buy/agent_123/op_abc\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op_abc\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
   "expected_outcome": {
     "success": true
   },

--- a/static/compliance/source/test-vectors/webhook-signing/positive/005-percent-encoded-path.json
+++ b/static/compliance/source/test-vectors/webhook-signing/positive/005-percent-encoded-path.json
@@ -4,19 +4,19 @@
   "reference_now": 1776520800,
   "request": {
     "method": "POST",
-    "url": "https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op%2dabc",
+    "url": "https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op_%e2%98%83",
     "headers": {
       "Content-Type": "application/json",
       "Content-Digest": "sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:",
       "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
-      "Signature": "sig1=:zmBMAG5f2Vlh1jiBYAPI0vZKX5AZdf1zX_B2VqlhEVBF9Mxg4_jKSjTY4Gu9Xz3FPJxSRFHTteT6v9peax7OAA:"
+      "Signature": "sig1=:xVYEHK2oS2PWxIYU9iyB96ObGdP-xl-4PoNazA12JO-GLXULtEwoEd9b9yM40Y-XcZ3kTX9ZA8KMms4ZTfA2Bg:"
     },
     "body": "{\"idempotency_key\":\"whk_01HW9D3H8FZP2N6R8T0V4X6Z9B\",\"task_id\":\"task_456\",\"operation_id\":\"op_abc\",\"status\":\"completed\",\"result\":{\"media_buy_id\":\"mb_001\"}}"
   },
   "jwks_ref": [
     "test-ed25519-webhook-2026"
   ],
-  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op%2dabc\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op_%E2%98%83\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
   "expected_outcome": {
     "success": true
   },


### PR DESCRIPTION
## Summary

- Webhook-signing positive vectors 004 and 005 shipped with signatures that only verified if the signer skipped `@target-uri` canonicalization steps 4 (strip default ports) and 6 (uppercase `%xx` / decode percent-encoded unreserved). The shared rules in `request-signing/canonicalization.json` mandate both, so the two vector sets contradicted each other.
- Vector 004: signature base now uses the canonical URI with `:443` stripped (input URL unchanged).
- Vector 005: input URL changed from `op%2dabc` (`%2d` is unreserved `-`, which step 6 requires to decode — the old example overloaded "uppercase hex" with "decode unreserved") to `op_%e2%98%83` (reserved UTF-8 bytes, same pattern as `request-signing/positive/008`). Canonical `@target-uri` uppercases to `%E2%98%83`.
- Both Ed25519 signatures regenerated deterministically and verified against the published `test-ed25519-webhook-2026` keypair.

### Implementor note

Any verifier that previously passed the old 004/005 has a latent canonicalization bug: it accepted signatures produced over the as-received URL rather than the canonical `@target-uri`. That verifier will silently disagree with a correctly-canonicalizing producer on any URL containing `:443`, `:80`, or lowercase `%xx` in the path, causing `webhook_signature_invalid` at step 10. Re-run the positive suite after pulling.

## Test plan

- [x] Precommit: `npm run test:unit` (587/587) + `npm run typecheck` passing locally
- [x] Regenerated Ed25519 signatures verified against `test-ed25519-webhook-2026` public key
- [x] Confirmed untouched positive vectors (001, 002, 003, 006, 007) have canonical == as-received URLs — no latent canonicalization bug in the remaining five
- [x] Confirmed no negative vector references `:443`, `%2d`, or lowercase-hex path encoding
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)