### PR TITLE
spec(errors): REQUOTE_REQUIRED for envelope-breach on update_media_buy

### DIFF
--- a/.changeset/requote-required-error.md
+++ b/.changeset/requote-required-error.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `REQUOTE_REQUIRED` error code to the standard vocabulary. Sellers return this on `update_media_buy` when a requested change (budget, flight dates, volume, targeting) falls outside the parameter envelope the original quote was priced against. The `pricing_option_id` remains immutable on update; this code covers the case where the seller will not honor the existing price for the requested new shape of the buy.
+
+Recovery is deterministic: the buyer calls `get_products` with `buying_mode: "refine"` against the existing `proposal_id` to obtain a fresh quote reflecting the new parameters, then resubmits the update against the new `proposal_id`. Sellers SHOULD populate `error.details.envelope_field` with the field path(s) that breached the envelope so the buyer's agent can autonomously re-discover.
+
+Distinct from `TERMS_REJECTED` (measurement terms) and `POLICY_VIOLATION` (content). Recovery classification: correctable.
+
+Closes #2456 (3.1 scope). The 4.0 `report_usage` counter-attestation portion (post-hoc delivery reconciliation) remains a separate RFC and should not overload this code.

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -122,6 +122,7 @@ AdCP defines 20 standard error codes in [`error-code.json`](https://adcontextpro
 | `PRODUCT_NOT_FOUND` | correctable | Referenced product IDs are unknown or expired | Remove invalid IDs, or re-discover with `get_products` |
 | `PRODUCT_UNAVAILABLE` | correctable | Product is sold out or no longer available | Choose a different product |
 | `PROPOSAL_EXPIRED` | correctable | Referenced proposal has passed its `expires_at` | Run `get_products` to get a fresh proposal |
+| `REQUOTE_REQUIRED` | correctable | Requested update falls outside the envelope (budget, dates, volume, targeting) the original quote was priced against; `pricing_option` remains locked | Call `get_products` with `buying_mode: "refine"` against the existing `proposal_id`, then resubmit against the new `proposal_id` |
 | `SIGNAL_NOT_FOUND` | correctable | Referenced signal does not exist in the catalog | Verify `signal_id` via `get_signals`, or confirm availability from this agent |
 | `AUDIENCE_TOO_SMALL` | correctable | Audience segment below minimum size | Broaden targeting or upload more audience members |
 

--- a/docs/building/implementation/transport-errors.mdx
+++ b/docs/building/implementation/transport-errors.mdx
@@ -316,6 +316,7 @@ const CODE_RECOVERY = {
   PRODUCT_NOT_FOUND: 'correctable',
   PRODUCT_UNAVAILABLE: 'correctable',
   PROPOSAL_EXPIRED: 'correctable',
+  REQUOTE_REQUIRED: 'correctable',
   BUDGET_TOO_LOW: 'correctable',
   CREATIVE_REJECTED: 'correctable',
   UNSUPPORTED_FEATURE: 'correctable',

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -415,6 +415,7 @@ Common error codes:
 - `NOT_CANCELLABLE`: Media buy or package cannot be canceled in its current state
 - `GOVERNANCE_DENIED`: A registered governance agent denied the transaction. Buyer may restructure the buy, escalate to human spending authority, or contact the governance agent.
 - `TERMS_REJECTED`: Buyer-proposed `measurement_terms` were rejected by the seller. Error details SHOULD identify which term failed and the seller's acceptable range or supported vendors. Recovery: adjust the proposed terms and retry, or omit `measurement_terms` to accept the product's defaults.
+- `REQUOTE_REQUIRED`: An `update_media_buy` request changes the parameter envelope (budget, flight dates, volume, targeting) the original quote was priced against. The `pricing_option` remains locked; the seller is declining the requested shape at that price. Distinct from `TERMS_REJECTED` (measurement) and `POLICY_VIOLATION` (content). Recovery: re-negotiate via `get_products` in `refine` mode against the existing `proposal_id` to obtain a fresh quote reflecting the new parameters, then resubmit the update against the new `proposal_id`. Sellers SHOULD populate `error.details.envelope_field` with the field path(s) that breached the envelope (e.g., `packages[0].budget`, `end_time`) so the buyer's agent can autonomously re-discover.
 - `VALIDATION_ERROR`: Request format or parameter errors
 - `AUTH_REQUIRED`: Authentication is required to access this resource
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -594,6 +594,21 @@ Cancel an entire media buy:
 }
 ```
 
+**`REQUOTE_REQUIRED` error response** (update changes the parameter envelope the quote was priced against):
+```json
+{
+  "errors": [{
+    "code": "REQUOTE_REQUIRED",
+    "message": "Doubling budget and extending end_time into Q4 changes the pricing basis of proposal prop_abc123",
+    "details": {
+      "proposal_id": "prop_abc123",
+      "envelope_field": ["packages[0].budget", "end_time"]
+    },
+    "suggestion": "Call get_products with buying_mode='refine' against proposal_id prop_abc123 to obtain a fresh quote, then resubmit this update against the new proposal_id"
+  }]
+}
+```
+
 ### Cancel a Package
 
 Cancel a single package while the media buy remains active:
@@ -663,6 +678,7 @@ Common errors and resolutions:
 | `CREATIVE_ID_EXISTS` | Creative ID already exists in library | Use a different `creative_id`, assign existing creatives via `creative_assignments`, or update via `sync_creatives` |
 | `BUDGET_EXCEEDED` | Operation would exceed allocated budget | Reduce the amount or increase media buy total budget |
 | `CONFLICT` | Revision mismatch — another update was applied since you last read | Re-read via `get_media_buys` and retry with current `revision` |
+| `REQUOTE_REQUIRED` | Requested change (budget, dates, volume, targeting) falls outside the envelope the original quote was priced against | Call `get_products` with `buying_mode: "refine"` against the existing `proposal_id` to obtain a fresh quote, then resubmit the update against the new `proposal_id`. Seller's `error.details.envelope_field` names which fields breached. |
 | `VALIDATION_ERROR` | Request format or business rule violation | Check error `field` and `message` for specifics |
 
 Example error response:

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -43,6 +43,7 @@
     "PROPOSAL_NOT_COMMITTED",
     "IO_REQUIRED",
     "TERMS_REJECTED",
+    "REQUOTE_REQUIRED",
     "VERSION_UNSUPPORTED"
   ],
   "enumDescriptions": {
@@ -84,6 +85,7 @@
     "PROPOSAL_NOT_COMMITTED": "The referenced proposal has proposal_status 'draft' and cannot be used to create a media buy. Recovery: correctable (finalize the proposal first using get_products with buying_mode 'refine' and action 'finalize').",
     "IO_REQUIRED": "The committed proposal requires a signed insertion order but no io_acceptance was provided. Recovery: correctable (review the proposal's insertion_order, accept terms, and include io_acceptance on create_media_buy).",
     "TERMS_REJECTED": "Buyer-proposed measurement_terms were rejected by the seller. The error details SHOULD identify which specific term was rejected and the seller's acceptable range or supported vendors. Recovery: correctable (adjust the proposed terms and retry, or omit measurement_terms to accept the product's defaults).",
+    "REQUOTE_REQUIRED": "An update_media_buy request changes the parameter envelope (budget, flight dates, volume, targeting) the original quote was priced against. The pricing_option remains locked; the seller is declining the requested shape at that price. Distinct from TERMS_REJECTED (measurement) and POLICY_VIOLATION (content). Sellers SHOULD populate error.details.envelope_field with the field path(s) that breached the envelope (e.g., 'packages[0].budget', 'end_time') so the buyer's agent can autonomously re-discover. Recovery: correctable (re-negotiate via get_products in 'refine' mode against the existing proposal_id to obtain a fresh quote reflecting the new parameters, then resubmit the update against the new proposal_id).",
     "VERSION_UNSUPPORTED": "The declared adcp_major_version is not supported by this seller. Recovery: correctable (call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry with a supported version)."
   }
 }

--- a/tests/transport-error-mapping.test.cjs
+++ b/tests/transport-error-mapping.test.cjs
@@ -96,6 +96,7 @@ const CODE_RECOVERY = {
   PRODUCT_NOT_FOUND: 'correctable',
   PRODUCT_UNAVAILABLE: 'correctable',
   PROPOSAL_EXPIRED: 'correctable',
+  REQUOTE_REQUIRED: 'correctable',
   BUDGET_TOO_LOW: 'correctable',
   CREATIVE_REJECTED: 'correctable',
   UNSUPPORTED_FEATURE: 'correctable',


### PR DESCRIPTION
## Summary

Closes #2456 (3.1 scope). Adds a single new error code, `REQUOTE_REQUIRED`, for the case where an `update_media_buy` request changes the parameter envelope (budget, flight dates, volume, targeting) the original quote was priced against.

## Why not the original proposal

#2456 proposed new `price_quote_id` + `price_quote_hash` fields and quote-TTL plumbing. On reading the schemas:

- `pricing_option_id` is already immutable on `update_media_buy` (see `package-update.json` line 5). The **price** is already locked.
- The buyer doesn't send a price on update at all; the seller owns yes/no on every field.
- Existing codes cover most of the surface (`TERMS_REJECTED`, `VALIDATION_ERROR`, `CONFLICT`, `UNSUPPORTED_FEATURE`, `NOT_CANCELLABLE`); `revision` + `idempotency_key` handle concurrency and audit.

"Pricing lock" was the wrong framing. The real gap was that the quote is priced against an **envelope of parameters** the buyer can drift outside of, and a generic `TERMS_REJECTED` didn't tell the buyer's agent "re-propose, don't just retry."

## What this PR adds

- `REQUOTE_REQUIRED` enum entry in `static/schemas/source/enums/error-code.json`
- Normative recovery path: `get_products` with `buying_mode: "refine"` against the existing `proposal_id`, then resubmit against the fresh `proposal_id`. This matches IO/PG amendment flows rather than implying fresh re-discovery.
- `error.details.envelope_field` convention so buyer agents can autonomously construct the replacement call without parsing the `message`.
- Documented in: task reference, transport-errors CODE_RECOVERY table + test fixture, canonical error list in `specification.mdx`, and error-handling cross-reference.
- Changeset: minor bump.

## Out of scope (deferred to 4.0 RFC)

The second half of #2456 — seller-attested `report_usage` counter-signatures for post-hoc delivery reconciliation — is a distinct trust-model change and should not overload this code. A sibling code (e.g., `RECONCILIATION_REQUIRED`) is the natural 4.0 surface.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:error-handling` — pass
- [x] `npx mocha tests/transport-error-mapping.test.cjs` — 83/83
- [x] Precommit: `test:unit` 587/587, typecheck clean
- [ ] Verify docs render with refine-mode example
- [ ] Confirm no downstream SDK/schemas miss the new enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)