### PR TITLE
c2pa: sign hero illustrations + newsletter covers (#2370 stage 2)

### DIFF
--- a/.changeset/c2pa-illustration-signing.md
+++ b/.changeset/c2pa-illustration-signing.md
@@ -1,0 +1,8 @@
+---
+---
+
+Stage 2 of C2PA provenance signing (#2370): wire `signC2PA()` into the illustration generator so every hero image and newsletter cover produced by Gemini carries an embedded C2PA manifest when the feature flag is on.
+
+The manifest declares AAO as the issuer, identifies `gemini-3.1-flash-image-preview` as the software agent, marks the asset as `trainedAlgorithmicMedia` (Art 50 / SB 942 machine-readable disclosure), and carries a SHA-256 of the prompt (not the prompt itself — hero prompts can include author-private visual descriptions). `c2pa_signed_at` and `c2pa_manifest_digest` are persisted alongside the illustration and newsletter-cover rows so admin tooling can distinguish signed from unsigned without parsing every PNG.
+
+Failure policy is env-gated: default returns the unsigned buffer so a transient C2PA failure never blocks a newsletter send, and `C2PA_STRICT=true` converts failures into generation errors for canary rollouts. Every failure fires a throttled system-error alert via `notifySystemError` (one per 5 min per source) so sustained failures surface immediately. Closes #2465.

--- a/server/src/addie/mcp/illustration-tools.ts
+++ b/server/src/addie/mcp/illustration-tools.ts
@@ -143,7 +143,7 @@ export function createIllustrationToolHandlers(
       }
 
       // Generate
-      const { imageBuffer, promptUsed } = await generateIllustration({
+      const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
         title: perspective.title,
         category: perspective.category || undefined,
         authorDescription: visualDescription,
@@ -156,6 +156,8 @@ export function createIllustrationToolHandlers(
         prompt_used: promptUsed,
         author_description: visualDescription,
         status: 'generated',
+        c2pa_signed_at: c2pa?.signedAt,
+        c2pa_manifest_digest: c2pa?.manifestDigest,
       });
 
       // Auto-approve (the author generated it, they can see the preview)

--- a/server/src/addie/services/digest-publisher.ts
+++ b/server/src/addie/services/digest-publisher.ts
@@ -168,7 +168,7 @@ async function generateCoverImage(
   excerpt: string,
   editionDate?: string,
 ): Promise<void> {
-  const { imageBuffer, promptUsed } = await generateIllustration({
+  const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
     title,
     category: 'The Prompt',
     excerpt,
@@ -180,6 +180,8 @@ async function generateCoverImage(
     image_data: imageBuffer,
     prompt_used: promptUsed,
     status: 'generated',
+    c2pa_signed_at: c2pa?.signedAt,
+    c2pa_manifest_digest: c2pa?.manifestDigest,
   });
 
   await approveIllustration(illustration.id, perspectiveId);

--- a/server/src/db/build-db.ts
+++ b/server/src/db/build-db.ts
@@ -290,24 +290,38 @@ export async function setBuildCoverImage(
   editionId: number,
   imageData: Buffer,
   promptUsed: string,
+  c2paSignedAt?: Date,
+  c2paManifestDigest?: string,
 ): Promise<boolean> {
   if (imageData.length > MAX_COVER_IMAGE_SIZE) {
     throw new Error(`Cover image too large: ${(imageData.length / 1024 / 1024).toFixed(1)} MB`);
   }
   const result = await query(
     `UPDATE build_editions
-     SET cover_image_data = $2, cover_prompt_used = $3
+     SET cover_image_data = $2, cover_prompt_used = $3,
+         cover_c2pa_signed_at = $4, cover_c2pa_manifest_digest = $5
      WHERE id = $1 AND status = 'draft'`,
-    [editionId, imageData, promptUsed],
+    [editionId, imageData, promptUsed, c2paSignedAt ?? null, c2paManifestDigest ?? null],
   );
   return (result.rowCount ?? 0) > 0;
 }
 
 export async function getBuildCoverImageWithPrompt(
   editionDate: string,
-): Promise<{ imageData: Buffer; promptUsed: string } | null> {
-  const result = await query<{ cover_image_data: Buffer; cover_prompt_used: string | null }>(
-    `SELECT cover_image_data, cover_prompt_used FROM build_editions
+): Promise<{
+  imageData: Buffer;
+  promptUsed: string;
+  c2paSignedAt: Date | null;
+  c2paManifestDigest: string | null;
+} | null> {
+  const result = await query<{
+    cover_image_data: Buffer;
+    cover_prompt_used: string | null;
+    cover_c2pa_signed_at: Date | null;
+    cover_c2pa_manifest_digest: string | null;
+  }>(
+    `SELECT cover_image_data, cover_prompt_used, cover_c2pa_signed_at, cover_c2pa_manifest_digest
+     FROM build_editions
      WHERE edition_date = $1 AND cover_image_data IS NOT NULL`,
     [editionDate],
   );
@@ -315,6 +329,8 @@ export async function getBuildCoverImageWithPrompt(
   return {
     imageData: result.rows[0].cover_image_data,
     promptUsed: result.rows[0].cover_prompt_used || 'Unknown',
+    c2paSignedAt: result.rows[0].cover_c2pa_signed_at,
+    c2paManifestDigest: result.rows[0].cover_c2pa_manifest_digest,
   };
 }
 

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -651,15 +651,18 @@ export async function setDigestCoverImage(
   digestId: number,
   imageData: Buffer,
   promptUsed: string,
+  c2paSignedAt?: Date,
+  c2paManifestDigest?: string,
 ): Promise<boolean> {
   if (imageData.length > MAX_COVER_IMAGE_SIZE) {
     throw new Error(`Cover image too large: ${(imageData.length / 1024 / 1024).toFixed(1)} MB`);
   }
   const result = await query(
     `UPDATE weekly_digests
-     SET cover_image_data = $2, cover_prompt_used = $3
+     SET cover_image_data = $2, cover_prompt_used = $3,
+         cover_c2pa_signed_at = $4, cover_c2pa_manifest_digest = $5
      WHERE id = $1 AND status = 'draft'`,
-    [digestId, imageData, promptUsed],
+    [digestId, imageData, promptUsed, c2paSignedAt ?? null, c2paManifestDigest ?? null],
   );
   return (result.rowCount ?? 0) > 0;
 }
@@ -670,9 +673,20 @@ export async function setDigestCoverImage(
  */
 export async function getDigestCoverImageWithPrompt(
   editionDate: string,
-): Promise<{ imageData: Buffer; promptUsed: string } | null> {
-  const result = await query<{ cover_image_data: Buffer; cover_prompt_used: string | null }>(
-    `SELECT cover_image_data, cover_prompt_used FROM weekly_digests
+): Promise<{
+  imageData: Buffer;
+  promptUsed: string;
+  c2paSignedAt: Date | null;
+  c2paManifestDigest: string | null;
+} | null> {
+  const result = await query<{
+    cover_image_data: Buffer;
+    cover_prompt_used: string | null;
+    cover_c2pa_signed_at: Date | null;
+    cover_c2pa_manifest_digest: string | null;
+  }>(
+    `SELECT cover_image_data, cover_prompt_used, cover_c2pa_signed_at, cover_c2pa_manifest_digest
+     FROM weekly_digests
      WHERE edition_date = $1 AND cover_image_data IS NOT NULL`,
     [editionDate],
   );
@@ -680,6 +694,8 @@ export async function getDigestCoverImageWithPrompt(
   return {
     imageData: result.rows[0].cover_image_data,
     promptUsed: result.rows[0].cover_prompt_used || 'Unknown',
+    c2paSignedAt: result.rows[0].cover_c2pa_signed_at,
+    c2paManifestDigest: result.rows[0].cover_c2pa_manifest_digest,
   };
 }
 

--- a/server/src/db/illustration-db.ts
+++ b/server/src/db/illustration-db.ts
@@ -20,11 +20,13 @@ export interface PerspectiveIllustration {
   approved_at: string | null;
   created_at: string;
   updated_at: string;
+  c2pa_signed_at: string | null;
+  c2pa_manifest_digest: string | null;
 }
 
 type IllustrationMetadata = Omit<PerspectiveIllustration, 'image_data'>;
 
-const METADATA_COLUMNS = `id, perspective_id, prompt_used, author_description, status, approved_at, created_at, updated_at`;
+const METADATA_COLUMNS = `id, perspective_id, prompt_used, author_description, status, approved_at, created_at, updated_at, c2pa_signed_at, c2pa_manifest_digest`;
 
 /** Get illustration metadata by ID (no binary data) */
 export async function getIllustrationById(id: string): Promise<IllustrationMetadata | null> {
@@ -75,17 +77,21 @@ export async function createIllustration(data: {
   prompt_used?: string;
   author_description?: string;
   status?: 'pending' | 'generated' | 'approved';
+  c2pa_signed_at?: Date;
+  c2pa_manifest_digest?: string;
 }): Promise<PerspectiveIllustration> {
   const result = await query<PerspectiveIllustration>(
-    `INSERT INTO perspective_illustrations (perspective_id, image_data, prompt_used, author_description, status)
-     VALUES ($1, decode($2, 'base64'), $3, $4, $5)
-     RETURNING id, perspective_id, prompt_used, author_description, status, approved_at, created_at, updated_at`,
+    `INSERT INTO perspective_illustrations (perspective_id, image_data, prompt_used, author_description, status, c2pa_signed_at, c2pa_manifest_digest)
+     VALUES ($1, decode($2, 'base64'), $3, $4, $5, $6, $7)
+     RETURNING ${METADATA_COLUMNS}`,
     [
       data.perspective_id,
       data.image_data ? data.image_data.toString('base64') : null,
       data.prompt_used || null,
       data.author_description || null,
       data.status || 'generated',
+      data.c2pa_signed_at ?? null,
+      data.c2pa_manifest_digest ?? null,
     ]
   );
   return result.rows[0];

--- a/server/src/db/migrations/415_c2pa_newsletter_covers.sql
+++ b/server/src/db/migrations/415_c2pa_newsletter_covers.sql
@@ -1,0 +1,14 @@
+-- C2PA provenance signing metadata for newsletter cover images.
+--
+-- Mirrors migration 414 (perspective_illustrations) but on the two newsletter
+-- cover stores. Covers ship in subscriber emails and as OpenGraph share cards;
+-- they are the most-distributed AAO AI imagery and should carry provenance
+-- from draft time rather than being reconciled by a later backfill.
+
+ALTER TABLE weekly_digests
+  ADD COLUMN IF NOT EXISTS cover_c2pa_signed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS cover_c2pa_manifest_digest TEXT;
+
+ALTER TABLE build_editions
+  ADD COLUMN IF NOT EXISTS cover_c2pa_signed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS cover_c2pa_manifest_digest TEXT;

--- a/server/src/newsletters/config.ts
+++ b/server/src/newsletters/config.ts
@@ -137,11 +137,22 @@ export interface NewsletterEditionDB {
 
   // ─── Cover Image (optional) ──────────────────────────────────────────
   /** Store a cover image for a draft edition. Returns false if not a draft. */
-  setCoverImage?(id: number, imageData: Buffer, promptUsed: string): Promise<boolean>;
+  setCoverImage?(
+    id: number,
+    imageData: Buffer,
+    promptUsed: string,
+    c2paSignedAt?: Date,
+    c2paManifestDigest?: string,
+  ): Promise<boolean>;
   /** Get the cover image binary by edition date. */
   getCoverImage?(editionDate: string): Promise<Buffer | null>;
-  /** Get cover image + prompt (for reuse when publishing as perspective). */
-  getCoverImageWithPrompt?(editionDate: string): Promise<{ imageData: Buffer; promptUsed: string } | null>;
+  /** Get cover image + prompt + C2PA provenance (for reuse when publishing as perspective). */
+  getCoverImageWithPrompt?(editionDate: string): Promise<{
+    imageData: Buffer;
+    promptUsed: string;
+    c2paSignedAt: Date | null;
+    c2paManifestDigest: string | null;
+  } | null>;
 }
 
 // ─── Newsletter Config ─────────────────────────────────────────────────

--- a/server/src/newsletters/cover.ts
+++ b/server/src/newsletters/cover.ts
@@ -85,7 +85,7 @@ export async function generateCoverForEdition(
 ): Promise<CoverResult | null> {
   if (!config.db.setCoverImage) return null;
 
-  const { imageBuffer, promptUsed } = await generateIllustration({
+  const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
     title: subject,
     category: config.perspectiveCategory,
     excerpt,
@@ -93,7 +93,13 @@ export async function generateCoverForEdition(
     dateFlavor,
   });
 
-  const stored = await config.db.setCoverImage(editionId, imageBuffer, promptUsed);
+  const stored = await config.db.setCoverImage(
+    editionId,
+    imageBuffer,
+    promptUsed,
+    c2pa?.signedAt,
+    c2pa?.manifestDigest,
+  );
   if (!stored) {
     logger.warn({ editionId, newsletterId: config.id }, 'Could not store cover — edition may no longer be a draft');
     return null;

--- a/server/src/newsletters/send-pipeline.ts
+++ b/server/src/newsletters/send-pipeline.ts
@@ -162,9 +162,13 @@ async function reuseOrGenerateCoverImage(
   const existing = await config.db.getCoverImageWithPrompt?.(editionDate) ?? null;
   let imageBuffer: Buffer;
   let promptUsed: string;
+  let c2paSignedAt: Date | undefined;
+  let c2paManifestDigest: string | undefined;
   if (existing) {
     imageBuffer = existing.imageData;
     promptUsed = existing.promptUsed;
+    c2paSignedAt = existing.c2paSignedAt ?? undefined;
+    c2paManifestDigest = existing.c2paManifestDigest ?? undefined;
   } else {
     const generated = await generateIllustration({
       title,
@@ -173,6 +177,8 @@ async function reuseOrGenerateCoverImage(
     });
     imageBuffer = generated.imageBuffer;
     promptUsed = generated.promptUsed;
+    c2paSignedAt = generated.c2pa?.signedAt;
+    c2paManifestDigest = generated.c2pa?.manifestDigest;
   }
 
   const illustration = await createIllustration({
@@ -180,6 +186,8 @@ async function reuseOrGenerateCoverImage(
     image_data: imageBuffer,
     prompt_used: promptUsed,
     status: 'generated',
+    c2pa_signed_at: c2paSignedAt,
+    c2pa_manifest_digest: c2paManifestDigest,
   });
 
   await approveIllustration(illustration.id, perspectiveId);

--- a/server/src/newsletters/the-build/index.ts
+++ b/server/src/newsletters/the-build/index.ts
@@ -130,8 +130,8 @@ const buildDB: NewsletterEditionDB = {
   async getUserWorkingGroupMap() {
     return getUserWorkingGroupMap();
   },
-  async setCoverImage(id, imageData, promptUsed) {
-    return setBuildCoverImage(id, imageData, promptUsed);
+  async setCoverImage(id, imageData, promptUsed, c2paSignedAt, c2paManifestDigest) {
+    return setBuildCoverImage(id, imageData, promptUsed, c2paSignedAt, c2paManifestDigest);
   },
   async getCoverImage(editionDate) {
     return getBuildCoverImage(editionDate);

--- a/server/src/newsletters/the-prompt/index.ts
+++ b/server/src/newsletters/the-prompt/index.ts
@@ -133,8 +133,8 @@ const promptDB: NewsletterEditionDB = {
   async getUserWorkingGroupMap() {
     return getUserWorkingGroupMap();
   },
-  async setCoverImage(id, imageData, promptUsed) {
-    return setDigestCoverImage(id, imageData, promptUsed);
+  async setCoverImage(id, imageData, promptUsed, c2paSignedAt, c2paManifestDigest) {
+    return setDigestCoverImage(id, imageData, promptUsed, c2paSignedAt, c2paManifestDigest);
   },
   async getCoverImage(editionDate) {
     return getDigestCoverImage(editionDate);

--- a/server/src/routes/admin/illustrations.ts
+++ b/server/src/routes/admin/illustrations.ts
@@ -91,7 +91,7 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
         try {
           logger.info({ slug: perspective.slug }, 'Generating illustration');
 
-          const { imageBuffer, promptUsed } = await generateIllustration({
+          const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
             title: perspective.title,
             category: perspective.category || undefined,
             excerpt: perspective.excerpt || undefined,
@@ -102,6 +102,8 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
             image_data: imageBuffer,
             prompt_used: promptUsed,
             status: 'approved',
+            c2pa_signed_at: c2pa?.signedAt,
+            c2pa_manifest_digest: c2pa?.manifestDigest,
           });
 
           await illustrationDb.approveIllustration(illustration.id, perspective.id);
@@ -156,7 +158,7 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
 
       const perspective = rows[0];
 
-      const { imageBuffer, promptUsed } = await generateIllustration({
+      const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
         title: perspective.title,
         category: perspective.category || undefined,
         excerpt: perspective.excerpt || undefined,
@@ -167,6 +169,8 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
         image_data: imageBuffer,
         prompt_used: promptUsed,
         status: 'approved',
+        c2pa_signed_at: c2pa?.signedAt,
+        c2pa_manifest_digest: c2pa?.manifestDigest,
       });
 
       await illustrationDb.approveIllustration(illustration.id, perspective.id);

--- a/server/src/scripts/generate-perspective-heroes.ts
+++ b/server/src/scripts/generate-perspective-heroes.ts
@@ -56,7 +56,7 @@ async function main() {
       console.log(`Generating illustration for: ${perspective.title}`);
 
       try {
-        const { imageBuffer, promptUsed } = await generateIllustration({
+        const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
           title: perspective.title,
           category: perspective.category || undefined,
           excerpt: perspective.excerpt || undefined,
@@ -67,6 +67,8 @@ async function main() {
           image_data: imageBuffer,
           prompt_used: promptUsed,
           status: 'generated',
+          c2pa_signed_at: c2pa?.signedAt,
+          c2pa_manifest_digest: c2pa?.manifestDigest,
         });
 
         await illustrationDb.approveIllustration(illustration.id, perspective.id);

--- a/server/src/services/illustration-generator.ts
+++ b/server/src/services/illustration-generator.ts
@@ -6,11 +6,18 @@
  * authors can describe the subject matter they want depicted.
  */
 
+import { createHash } from 'crypto';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { createLogger } from '../logger.js';
 import { withGeminiRetry } from '../utils/gemini-retry.js';
 import { getAllNewsletters } from '../newsletters/registry.js';
 import type { NewsletterConfig } from '../newsletters/config.js';
+import { signC2PA, isC2PASigningEnabled } from './c2pa.js';
+import { notifySystemError } from '../addie/error-notifier.js';
+
+const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
+// Matches the -preview suffix above; bump together when promoting to a stable Gemini release.
+const GEMINI_IMAGE_VERSION = 'preview';
 
 function findNewsletterByCategory(category: string): NewsletterConfig | null {
   return getAllNewsletters().find((n) => n.perspectiveCategory === category) || null;
@@ -63,6 +70,16 @@ export interface GenerateIllustrationOptions {
 export interface GenerateIllustrationResult {
   imageBuffer: Buffer;
   promptUsed: string;
+  /**
+   * C2PA provenance metadata, present when signing is enabled and succeeded.
+   * The imageBuffer already carries the embedded manifest; these fields are
+   * for persisting alongside the row so admin tools can find unsigned rows
+   * without parsing every PNG.
+   */
+  c2pa?: {
+    signedAt: Date;
+    manifestDigest: string;
+  };
 }
 
 let genAI: GoogleGenerativeAI | null = null;
@@ -130,7 +147,7 @@ export async function generateIllustration(options: GenerateIllustrationOptions)
   const ai = getGenAI();
   const model = ai.getGenerativeModel(
     {
-      model: 'gemini-3.1-flash-image-preview',
+      model: GEMINI_IMAGE_MODEL,
       generationConfig: {
         // @ts-expect-error - responseModalities not in SDK types yet
         responseModalities: ['TEXT', 'IMAGE'],
@@ -156,10 +173,58 @@ export async function generateIllustration(options: GenerateIllustrationOptions)
         throw new Error(`Gemini returned non-image content: ${mimeType}`);
       }
       logger.info({ sizeKB: (imageBuffer.length / 1024).toFixed(0), mimeType }, 'Illustration generated');
-      return { imageBuffer, promptUsed: prompt };
+      return attachC2PAIfEnabled({ imageBuffer, promptUsed: prompt }, { title, category, editionDate });
     }
   }
 
   const text = response.text?.() || 'No response';
   throw new Error(`Gemini did not return an image. Response: ${text.slice(0, 200)}`);
+}
+
+/**
+ * Sign the generated PNG with an AAO C2PA manifest when signing is enabled.
+ *
+ * Failure policy is env-gated:
+ *   - `C2PA_STRICT=true` — rethrow so the generation fails (useful for canary
+ *     rollouts where we want to prove signing works end-to-end).
+ *   - otherwise — return the unsigned buffer so a transient C2PA failure
+ *     never blocks a newsletter send. The row lands with c2pa_signed_at NULL
+ *     and stage 5 backfill reconciles.
+ *
+ * Every failure fires a throttled system-error alert (one per 5 min per source,
+ * via notifySystemError) so sustained failures surface rather than hiding in logs.
+ */
+export function attachC2PAIfEnabled(
+  result: { imageBuffer: Buffer; promptUsed: string },
+  manifest: { title: string; category?: string; editionDate?: string },
+): GenerateIllustrationResult {
+  if (!isC2PASigningEnabled()) return result;
+  try {
+    const signed = signC2PA(result.imageBuffer, {
+      claimGenerator: 'AAO Illustration Generator',
+      title: manifest.title,
+      softwareAgent: { name: GEMINI_IMAGE_MODEL, version: GEMINI_IMAGE_VERSION },
+      attributes: {
+        ...(manifest.category ? { category: manifest.category } : {}),
+        ...(manifest.editionDate ? { edition_date: manifest.editionDate } : {}),
+        prompt_sha256: createHash('sha256').update(result.promptUsed).digest('hex'),
+      },
+    });
+    return {
+      imageBuffer: signed.signedBuffer,
+      promptUsed: result.promptUsed,
+      c2pa: { signedAt: new Date(), manifestDigest: signed.manifestDigest },
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    logger.error({ err, title: manifest.title }, 'C2PA signing failed');
+    notifySystemError({
+      source: 'c2pa-illustration-signing',
+      errorMessage: `Illustration signing failed for "${manifest.title}": ${errorMessage}`,
+    });
+    if (process.env.C2PA_STRICT === 'true') {
+      throw err;
+    }
+    return result;
+  }
 }

--- a/server/tests/unit/illustration-c2pa-wiring.test.ts
+++ b/server/tests/unit/illustration-c2pa-wiring.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { Buffer } from 'buffer';
+import sharp from 'sharp';
+import { Reader } from '@contentauth/c2pa-node';
+import { attachC2PAIfEnabled } from '../../src/services/illustration-generator.js';
+import { resetC2PASignerCache } from '../../src/services/c2pa.js';
+import * as errorNotifier from '../../src/addie/error-notifier.js';
+
+const FIXTURE_DIR = join(__dirname, '..', 'fixtures', 'c2pa');
+const CERT_PATH = join(FIXTURE_DIR, 'aao-c2pa.cert.pem');
+const KEY_PATH = join(FIXTURE_DIR, 'aao-c2pa.key.pem');
+
+let testPng: Buffer;
+let CERT_B64: string;
+let KEY_B64: string;
+
+beforeAll(async () => {
+  if (existsSync(CERT_PATH)) rmSync(CERT_PATH);
+  if (existsSync(KEY_PATH)) rmSync(KEY_PATH);
+  execFileSync('bash', [join(__dirname, '..', '..', '..', 'scripts', 'generate-c2pa-cert.sh'), FIXTURE_DIR], {
+    stdio: 'pipe',
+  });
+  CERT_B64 = readFileSync(CERT_PATH).toString('base64');
+  KEY_B64 = readFileSync(KEY_PATH).toString('base64');
+
+  testPng = await sharp({
+    create: { width: 64, height: 64, channels: 4, background: { r: 212, g: 160, b: 23, alpha: 1 } },
+  })
+    .png()
+    .toBuffer();
+});
+
+const originalEnv = {
+  enabled: process.env.C2PA_SIGNING_ENABLED,
+  cert: process.env.C2PA_CERT_PEM_B64,
+  key: process.env.C2PA_PRIVATE_KEY_PEM_B64,
+  strict: process.env.C2PA_STRICT,
+};
+
+beforeEach(() => {
+  resetC2PASignerCache();
+  vi.spyOn(errorNotifier, 'notifySystemError').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  process.env.C2PA_SIGNING_ENABLED = originalEnv.enabled;
+  process.env.C2PA_CERT_PEM_B64 = originalEnv.cert;
+  process.env.C2PA_PRIVATE_KEY_PEM_B64 = originalEnv.key;
+  process.env.C2PA_STRICT = originalEnv.strict;
+  resetC2PASignerCache();
+  vi.restoreAllMocks();
+});
+
+describe('attachC2PAIfEnabled', () => {
+  it('returns the input unchanged when signing is disabled', () => {
+    delete process.env.C2PA_SIGNING_ENABLED;
+    const input = { imageBuffer: testPng, promptUsed: 'test prompt' };
+    const result = attachC2PAIfEnabled(input, { title: 'Test hero' });
+    expect(result.imageBuffer).toBe(testPng);
+    expect(result.c2pa).toBeUndefined();
+  });
+
+  it('signs the buffer and populates c2pa metadata when enabled', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+
+    const result = attachC2PAIfEnabled(
+      { imageBuffer: testPng, promptUsed: 'test prompt with private bits' },
+      { title: 'Test hero', category: 'The Prompt', editionDate: '2026-04-20' },
+    );
+
+    expect(result.imageBuffer.length).toBeGreaterThan(testPng.length);
+    expect(result.c2pa).toBeDefined();
+    expect(result.c2pa?.manifestDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.c2pa?.signedAt).toBeInstanceOf(Date);
+
+    const reader = await Reader.fromAsset({ buffer: result.imageBuffer, mimeType: 'image/png' });
+    const active = reader.getActive();
+    expect(active?.title).toBe('Test hero');
+
+    const custom = active?.assertions?.find(
+      (a) => a.label === 'org.agenticadvertising.generation',
+    );
+    expect(custom).toBeDefined();
+  });
+
+  it('hashes the prompt instead of embedding it verbatim', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+
+    const secretPrompt = 'author-private visual-description-that-should-not-leak';
+    const result = attachC2PAIfEnabled(
+      { imageBuffer: testPng, promptUsed: secretPrompt },
+      { title: 'Hero' },
+    );
+
+    const reader = await Reader.fromAsset({ buffer: result.imageBuffer, mimeType: 'image/png' });
+    const serialized = JSON.stringify(reader.json());
+    expect(serialized).not.toContain('author-private');
+    expect(serialized).toContain('prompt_sha256');
+  });
+
+  it('returns the unsigned result and alerts when signing throws on malformed input', () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    delete process.env.C2PA_STRICT;
+
+    // Valid cert/key but the buffer is not a PNG — Builder.sign throws when
+    // trying to parse the PNG ancillary-chunk structure. This exercises the
+    // real sign-failure fallback, not a startup-config error.
+    const notAPng = Buffer.from('this is plain text, definitely not PNG bytes');
+    const input = { imageBuffer: notAPng, promptUsed: 'test' };
+    const result = attachC2PAIfEnabled(input, { title: 'Hero' });
+
+    expect(result.imageBuffer).toBe(notAPng);
+    expect(result.c2pa).toBeUndefined();
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'c2pa-illustration-signing' }),
+    );
+  });
+
+  it('rethrows the signing error in strict mode', () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    process.env.C2PA_STRICT = 'true';
+
+    const notAPng = Buffer.from('not PNG');
+    const input = { imageBuffer: notAPng, promptUsed: 'test' };
+
+    expect(() => attachC2PAIfEnabled(input, { title: 'Hero' })).toThrow();
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire the error alert on the happy path', () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    delete process.env.C2PA_STRICT;
+
+    const result = attachC2PAIfEnabled(
+      { imageBuffer: testPng, promptUsed: 'ok' },
+      { title: 'Hero' },
+    );
+    expect(result.c2pa).toBeDefined();
+    expect(errorNotifier.notifySystemError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2 of #2370 — wire `signC2PA()` into `generateIllustration()` so every Gemini-produced hero image and newsletter cover carries an embedded C2PA manifest when the feature flag is on. Stacked on #2453 (stage 1); will rebase onto main once stage 1 lands.

## What's in this PR

**Signing at the boundary**
- `server/src/services/illustration-generator.ts` — `attachC2PAIfEnabled()` signs the Gemini PNG before return. Extended `GenerateIllustrationResult` with optional `c2pa?: { signedAt, manifestDigest }`. Prompt is SHA-256'd into the assertion (not embedded verbatim) since hero prompts can include author-private visual descriptions.

**Failure policy**
- Default: return the unsigned buffer so a transient C2PA failure never blocks a newsletter send. Row lands with `c2pa_signed_at NULL` and stage 5 backfill reconciles.
- `C2PA_STRICT=true`: rethrow so the generation fails. Useful for canary rollouts where we want to prove signing works end-to-end before committing.
- Every failure fires a throttled `notifySystemError` alert (one per 5 min per source) — sustained failures surface immediately rather than hiding in logs. **Closes #2465.**

**Persistence**
- Migration 415: `cover_c2pa_signed_at` + `cover_c2pa_manifest_digest` on `weekly_digests` and `build_editions` (mirrors 414 for `perspective_illustrations`).
- Piped c2pa metadata through every persistence path so admin tooling can spot unsigned rows without parsing every PNG:
  - `server/src/routes/admin/illustrations.ts` (2 sites)
  - `server/src/newsletters/send-pipeline.ts` (reuse path preserves c2pa from the draft-time store)
  - `server/src/newsletters/cover.ts` (draft-time storage)
  - `server/src/newsletters/the-prompt/index.ts` + `the-build/index.ts` (newsletter cover adapter impls)
  - `server/src/addie/services/digest-publisher.ts`
  - `server/src/addie/mcp/illustration-tools.ts`
  - `server/src/scripts/generate-perspective-heroes.ts`

**Tests** — `server/tests/unit/illustration-c2pa-wiring.test.ts`, 6 cases:
1. Flag-off passthrough (no mutation, no `c2pa`).
2. Flag-on signing produces a larger buffer + populated `c2pa` + manifest readable by `Reader`.
3. Prompt is SHA-256'd, not embedded verbatim (asserts the secret string doesn't appear in the serialized manifest).
4. Malformed input triggers real `Builder.sign` failure → returns unsigned + fires `notifySystemError`.
5. Strict mode rethrows the error.
6. Happy path does not fire the error alert.

## Expert review addressed pre-push

Ran code-reviewer. Addressed all findings:
- **Must-fix**: missed caller in `newsletters/cover.ts` — extended the newsletter cover DB (migration + config interface + both adapter impls) so c2pa carries through the reuse flow without needing backfill reconciliation.
- **Should-fix**: replaced the "invalid-base64" failure-path test with a malformed-PNG input that exercises the actual `Builder.sign` failure branch. Dropped the hardcoded `'preview'` in favor of a `GEMINI_IMAGE_VERSION` constant next to `GEMINI_IMAGE_MODEL` (documented to bump together when promoting to stable). Removed the "only for tests" fiction from the exported helper's doc comment.
- **Consider**: strict mode + alerting rolled in here rather than deferred to #2465 (now closed by this PR).

## Test plan

- [x] `npm run test:server-unit` — 1585/1585 passing including the 6 new wiring tests.
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean.
- [x] `npm run test:migrations` — pattern + numbering validation pass.
- [ ] Fly deploy — stage 1 must land first. Migration 415 only adds nullable columns. No behavior change until `C2PA_SIGNING_ENABLED=true` is set in Fly secrets; today it's unset and the generator path returns unchanged.

## Safe to merge

Behavior is identical to today when the feature flag is off (default). Flag-on is a deliberate canary gate that surfaces any issues via the new `notifySystemError` alert before we'd notice them externally.

Refs #2370
Closes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)