### PR TITLE
fix(addie): remap phase ID to first step in run_storyboard_step

### DIFF
--- a/.changeset/addie-run-storyboard-step-phase-id-remap.md
+++ b/.changeset/addie-run-storyboard-step-phase-id-remap.md
@@ -1,0 +1,4 @@
+---
+---
+
+Addie: `run_storyboard_step` now accepts a phase ID and transparently remaps it to the first step of that phase. When a completely unknown ID is passed, the error response lists both valid step IDs and phase→first-step hints so the model can self-correct. Fixes spurious "Step not found" failures when Addie confuses phase IDs (e.g. `protocol_discovery`) with step IDs.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3565,18 +3565,49 @@ export function createMemberToolHandlers(
     const sb = getComplianceStoryboardById(storyboardId);
     if (!sb) return `Storyboard "${storyboardId}" not found.`;
 
+    // Resolve stepId: if caller passed a phase ID, remap to first step of that phase.
+    // This is a common LLM confusion because phases and steps both have `id` fields.
+    let resolvedStepId = stepId;
+    let phaseRemap: { phaseId: string; stepId: string } | null = null;
+    const stepMatch = sb.phases.flatMap(p => p.steps).find(s => s.id === stepId);
+    if (!stepMatch) {
+      const phaseMatch = sb.phases.find(p => p.id === stepId);
+      const firstStepOfPhase = phaseMatch?.steps[0];
+      if (phaseMatch && firstStepOfPhase) {
+        resolvedStepId = firstStepOfPhase.id;
+        phaseRemap = { phaseId: phaseMatch.id, stepId: firstStepOfPhase.id };
+      } else {
+        // Not a step, not a phase — return a helpful error that distinguishes the two.
+        const phaseList = sb.phases
+          .map(p => `- phase \`${p.id}\` → first step \`${p.steps[0]?.id ?? '(none)'}\``)
+          .join('\n');
+        const stepList = sb.phases
+          .flatMap(p => p.steps)
+          .map(s => `\`${s.id}\``)
+          .join(', ');
+        return (
+          `**Error:** Step "${stepId}" not found in storyboard "${storyboardId}".\n\n` +
+          `Valid steps: ${stepList}\n\n` +
+          `If you meant a phase, call again with the first step of that phase:\n${phaseList}`
+        );
+      }
+    }
+
     const organizationId = memberContext?.organization?.workos_organization_id;
     const resolved = await resolveAgentAuth(agentUrl, organizationId);
 
     try {
       const authOption = buildAuthOption(resolved);
-      const result: StoryboardStepResult = await runStoryboardStep(resolved.resolvedUrl, sb, stepId, {
+      const result: StoryboardStepResult = await runStoryboardStep(resolved.resolvedUrl, sb, resolvedStepId, {
         context,
         ...(authOption && { auth: authOption }),
       });
 
       let output = '';
       if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
+      if (phaseRemap) {
+        output += `_Note: "${stepId}" is a phase ID; ran its first step \`${phaseRemap.stepId}\` instead._\n\n`;
+      }
 
       const icon = result.skipped ? 'SKIP' : result.passed ? 'PASS' : 'FAIL';
       output += `## Step: ${result.title} [${icon}]\n\n`;


### PR DESCRIPTION
## Summary

- Addie was calling `run_storyboard_step` with a phase ID (e.g. `protocol_discovery`) instead of a step ID, which caused the runner in `@adcp/client` to throw `Step "protocol_discovery" not found in storyboard "capability_discovery"`.
- The handler now accepts phase IDs and transparently remaps to the first step of that phase. The response notes the remap so the caller can learn the correct ID.
- For IDs that match neither a step nor a phase, the error response now lists valid step IDs *and* phase→first-step hints so the model can self-correct in one round-trip.

## Test plan

- [x] `npm run precommit` (587 unit tests + `tsc --noEmit`) passes locally
- [ ] Manual: reproduce the original Slack-reported error with `run_storyboard_step(storyboard_id="capability_discovery", step_id="protocol_discovery")` and confirm it now runs `get_capabilities` instead of throwing
- [ ] Manual: call with an unknown step/phase ID and confirm the error lists valid steps and phase hints