### PR TITLE
fix(auth): lazy-create local org row on login, paginate WorkOS sync

### DIFF
--- a/.changeset/fix-org-activities-fk-on-login.md
+++ b/.changeset/fix-org-activities-fk-on-login.md
@@ -1,0 +1,11 @@
+---
+---
+
+Fix `org_activities_organization_id_fkey` violation on user login.
+
+Local `organizations` rows are created lazily (first billing/agreement event) and the startup `syncFromWorkOS` was both startup-only and non-paginating (`limit: 100`), so orgs created in WorkOS after boot — or beyond the first page — were missing locally. `recordUserLogin` then blew up on the FK.
+
+- Fix pagination in `OrganizationDatabase.syncFromWorkOS` (loop on `listMetadata.after`).
+- Add `OrganizationDatabase.ensureOrganizationExists` — lazy-creates the local row from WorkOS data on demand, with race-safe fallback.
+- Call it from the auth callback before `recordUserLogin`.
+- Keep a `WHERE EXISTS` guard in `recordUserLogin` as belt-and-suspenders.

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1439,26 +1439,31 @@ export class OrganizationDatabase {
     let existing = 0;
 
     try {
-      // List all organizations from WorkOS
-      const orgs = await workos.organizations.listOrganizations({
-        limit: 100, // Paginate if needed in the future
-      });
+      // Paginate through all organizations from WorkOS (limit is per-page max)
+      let after: string | undefined;
+      do {
+        const orgs = await workos.organizations.listOrganizations({
+          limit: 100,
+          after,
+        });
 
-      for (const workosOrg of orgs.data) {
-        const localOrg = await this.getOrganization(workosOrg.id);
+        for (const workosOrg of orgs.data) {
+          const localOrg = await this.getOrganization(workosOrg.id);
 
-        if (!localOrg) {
-          // Create the org locally
-          await this.createOrganization({
-            workos_organization_id: workosOrg.id,
-            name: workosOrg.name,
-          });
-          synced++;
-          logger.info({ orgId: workosOrg.id, name: workosOrg.name }, 'Synced organization from WorkOS');
-        } else {
-          existing++;
+          if (!localOrg) {
+            await this.createOrganization({
+              workos_organization_id: workosOrg.id,
+              name: workosOrg.name,
+            });
+            synced++;
+            logger.info({ orgId: workosOrg.id, name: workosOrg.name }, 'Synced organization from WorkOS');
+          } else {
+            existing++;
+          }
         }
-      }
+
+        after = orgs.listMetadata?.after ?? undefined;
+      } while (after);
 
       if (synced > 0) {
         logger.info({ synced, existing }, 'WorkOS organization sync complete');
@@ -1467,6 +1472,37 @@ export class OrganizationDatabase {
       return { synced, existing };
     } catch (error) {
       logger.error({ error }, 'Failed to sync organizations from WorkOS');
+      throw error;
+    }
+  }
+
+  /**
+   * Ensure a local organizations row exists for a WorkOS organization.
+   * Fetches the org from WorkOS (for its name) and creates the local row if missing.
+   * Safe to call on every login — cheap no-op when the row already exists.
+   */
+  async ensureOrganizationExists(
+    workos: WorkOS,
+    workos_organization_id: string
+  ): Promise<Organization> {
+    const existing = await this.getOrganization(workos_organization_id);
+    if (existing) return existing;
+
+    const workosOrg = await workos.organizations.getOrganization(workos_organization_id);
+    try {
+      const created = await this.createOrganization({
+        workos_organization_id,
+        name: workosOrg.name,
+      });
+      logger.info(
+        { orgId: workos_organization_id, name: workosOrg.name },
+        'Lazily created local organization row from WorkOS'
+      );
+      return created;
+    } catch (error) {
+      // Race: another request may have created it between our check and insert.
+      const afterRace = await this.getOrganization(workos_organization_id);
+      if (afterRace) return afterRace;
       throw error;
     }
   }
@@ -1547,11 +1583,20 @@ export class OrganizationDatabase {
     user_name?: string;
   }): Promise<void> {
     const pool = getPool();
-    await pool.query(
+    // Only record if the organization exists locally. The local row is created
+    // on first billing/agreement event, so early logins may arrive before it.
+    const result = await pool.query(
       `INSERT INTO org_activities (organization_id, activity_type, logged_by_user_id, logged_by_name, activity_date)
-       VALUES ($1, 'dashboard_login', $2, $3, NOW())`,
+       SELECT $1, 'dashboard_login', $2, $3, NOW()
+       WHERE EXISTS (SELECT 1 FROM organizations WHERE workos_organization_id = $1)`,
       [data.workos_organization_id, data.workos_user_id, data.user_name || null]
     );
+    if (result.rowCount === 0) {
+      logger.debug(
+        { workos_organization_id: data.workos_organization_id, workos_user_id: data.workos_user_id },
+        'Skipped login activity record: organization not present in local DB yet'
+      );
+    }
   }
 
   /**

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6173,13 +6173,17 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         if (memberships.data.length > 0) {
           const primaryOrgId = memberships.data[0].organizationId;
           const userName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.email;
-          orgDb.recordUserLogin({
-            workos_user_id: user.id,
-            workos_organization_id: primaryOrgId,
-            user_name: userName,
-          }).catch((err) => {
-            logger.error({ error: err, userId: user.id }, 'Failed to record user login');
-          });
+          // Ensure the org exists locally first — startup sync can miss orgs
+          // created in WorkOS after boot, and org_activities FKs to organizations.
+          orgDb.ensureOrganizationExists(workos!, primaryOrgId)
+            .then(() => orgDb.recordUserLogin({
+              workos_user_id: user.id,
+              workos_organization_id: primaryOrgId,
+              user_name: userName,
+            }))
+            .catch((err) => {
+              logger.error({ error: err, userId: user.id }, 'Failed to record user login');
+            });
 
           // Update relationship model from web login (fire and forget)
           relationshipDb.resolvePersonId({ workos_user_id: user.id, email: user.email })


### PR DESCRIPTION
## Summary

Login on a WorkOS org that isn't yet in the local `organizations` table was blowing up with:

```
insert or update on table "org_activities" violates foreign key constraint "org_activities_organization_id_fkey"
```

Two underlying gaps caused this:

- `syncFromWorkOS` ran **at startup only** and **did not paginate** (`limit: 100` with a `"Paginate if needed in the future"` TODO). Orgs created in WorkOS after boot — or past the first page — never landed locally.
- The auth callback called `recordUserLogin` unconditionally, trusting the FK target to exist.

## Changes

- `server/src/db/organization-db.ts`
  - `syncFromWorkOS`: paginate via `listMetadata.after`.
  - New `ensureOrganizationExists(workos, orgId)`: lazy-creates the local `organizations` row from WorkOS data, race-safe via post-insert re-check.
  - `recordUserLogin`: `INSERT … SELECT … WHERE EXISTS (…)` guard so an unexpectedly-missing org degrades to a skipped debug log instead of an error.
- `server/src/http.ts`
  - Auth callback calls `ensureOrganizationExists` before `recordUserLogin`.

## Test plan

- [ ] Fresh WorkOS org logs in for the first time → local `organizations` row created, `org_activities` row recorded, no FK error in logs.
- [ ] Existing org logs in → no extra WorkOS API call beyond the existing membership lookup (ensure is a cheap no-op).
- [ ] Startup sync with >100 WorkOS orgs → all pages synced (check log line count vs. WorkOS dashboard).
- [ ] Race: two simultaneous logins on a brand-new org don't double-insert (race fallback kicks in).
- [ ] `npm run typecheck` + `npm run test:unit` green (precommit already ran these locally).