### PR TITLE
spec(compliance): RFC 9421 request-signing edge-case vectors

### DIFF
--- a/.changeset/request-signing-edgecase-vectors.md
+++ b/.changeset/request-signing-edgecase-vectors.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add 3 positive + 6 negative RFC 9421 request-signing conformance vectors covering: unreserved percent-decoding (%7E/%2D/%5F/%2E), reserved %2F preservation, IPv6 authority bracket handling, duplicate Signature-Input labels, multi-valued Content-Type/Content-Digest, unquoted sig-param strings, JWK alg/crv mismatch, and raw IDN U-label hosts.

--- a/static/compliance/source/test-vectors/request-signing/README.md
+++ b/static/compliance/source/test-vectors/request-signing/README.md
@@ -37,7 +37,13 @@ test-vectors/request-signing/
 │   ├── 017-key-revoked.json              → request_signature_key_revoked (step 9; requires test_harness_state preload)
 │   ├── 018-digest-covered-when-forbidden.json → request_signature_components_unexpected (step 6; policy 'forbidden')
 │   ├── 019-signature-without-signature-input.json → request_signature_header_malformed (pre-check; downgrade loophole)
-│   └── 020-rate-abuse.json               → request_signature_rate_abuse (step 9a cap; abuse signal)
+│   ├── 020-rate-abuse.json               → request_signature_rate_abuse (step 9a cap; abuse signal)
+│   ├── 021-duplicate-signature-input-label.json → request_signature_header_malformed (step 1; RFC 8941 dict duplicate-key)
+│   ├── 022-multi-valued-content-type.json → request_signature_header_malformed (step 1; covered non-list field must be single-valued)
+│   ├── 023-multi-valued-content-digest.json → request_signature_header_malformed (step 1; RFC 9530 dict duplicate algorithm)
+│   ├── 024-unquoted-string-param.json     → request_signature_header_malformed (step 1; RFC 8941 §3.3 string values must be quoted)
+│   ├── 025-jwk-alg-crv-mismatch.json      → request_signature_key_purpose_invalid (step 8; alg=EdDSA with crv=P-256 is impossible per RFC 8037)
+│   └── 026-non-ascii-host.json            → request_signature_header_malformed (step 1; raw IDN U-label on wire; MUST be A-label)
 └── positive/                             vectors that MUST verify successfully
     ├── 001-basic-post.json                   Ed25519, no content-digest
     ├── 002-post-with-content-digest.json     Ed25519, content-digest covered
@@ -46,7 +52,11 @@ test-vectors/request-signing/
     ├── 005-default-port-stripped.json        URL has :443; canonical strips it
     ├── 006-dot-segment-path.json             Path has /./; canonical collapses it
     ├── 007-query-byte-preserved.json         Query b=2&a=1&c=3 — preserved, not alphabetized
-    └── 008-percent-encoded-path.json         Path has lowercase %xx; canonical uppercases
+    ├── 008-percent-encoded-path.json         Path has lowercase %xx; canonical uppercases
+    ├── 009-percent-encoded-unreserved-decoded.json  Path has %7E/%2D/%5F/%2E; canonical decodes unreserved per RFC 3986 §6.2.2.2
+    ├── 010-percent-encoded-slash-preserved.json     Path has %2F (reserved); stays percent-encoded, not treated as segment separator
+    ├── 011-ipv6-authority.json                       IPv6 literal host; brackets preserved in @target-uri and @authority
+    └── 012-ipv6-authority-default-port-stripped.json IPv6 literal with :443; port stripped, brackets preserved
 ```
 
 ## Canonicalization vectors (`canonicalization.json`)

--- a/static/compliance/source/test-vectors/request-signing/negative/021-duplicate-signature-input-label.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/021-duplicate-signature-input-label.json
@@ -1,0 +1,31 @@
+{
+  "name": "Signature-Input header declares label 'sig1' twice (malformed structured dictionary)",
+  "spec_reference": "#verifier-checklist-requests step 1 (RFC 9421 §4.1 Signature-Input is a Dictionary; duplicate keys malformed)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\", sig1=(\"@method\" \"@target-uri\");created=1776520800;expires=1776521100;nonce=\"AAAAAAAAAAAAAAAAAAAAAA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_header_malformed",
+    "failed_step": 1
+  },
+  "$comment": "RFC 8941 §3.2 Dictionaries: 'When parsing, duplicate keys MUST be handled by either rejecting the input or by retaining only the last value.' Per the AdCP profile and downgrade-protection rule at step 1, verifiers MUST reject — silently retaining 'the last value' would let a proxy smuggle a weaker set of covered components past a verifier that read the first. Related cases: 011-malformed-header (unparseable) and 019-signature-without-signature-input (missing pair); this vector is the 'parseable-but-ambiguous' case the two existing vectors don't cover."
+}

--- a/static/compliance/source/test-vectors/request-signing/negative/022-multi-valued-content-type.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/022-multi-valued-content-type.json
@@ -1,0 +1,31 @@
+{
+  "name": "Content-Type header sent as multiple field values (malformed — field covered by signature must be single-valued)",
+  "spec_reference": "#verifier-checklist-requests step 1 (covered component fields must be single-valued; RFC 9421 §2.1 derivation rules do not permit concatenation for non-list headers)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json, text/plain",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_header_malformed",
+    "failed_step": 1
+  },
+  "$comment": "Content-Type is not a List-Structured-Field — it has a single canonical value with optional parameters. RFC 9421 §2.1 says covered field values are the field's canonical in-order concatenation only for fields the HTTP spec treats as list-typed. A proxy inserting a second Content-Type (or a client with a bug emitting two) leaves the field's meaning undefined relative to the signature base. Verifier MUST reject at parse time rather than pick one value and hope for the best."
+}

--- a/static/compliance/source/test-vectors/request-signing/negative/023-multi-valued-content-digest.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/023-multi-valued-content-digest.json
@@ -1,0 +1,32 @@
+{
+  "name": "Content-Digest header sent as multiple field values (malformed)",
+  "spec_reference": "#verifier-checklist-requests step 1 (Content-Digest covered in signature must be single-valued; RFC 9530)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Content-Digest": "sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:, sha-256=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "required",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_header_malformed",
+    "failed_step": 1
+  },
+  "$comment": "Content-Digest per RFC 9530 §2 is a Dictionary-Structured-Field where each member is a digest algorithm — duplicates of the same algorithm are ambiguous and undefined for signature coverage. Even if the two sha-256 values happened to be identical, permitting multiple on the wire creates a parser-differential attack: signer and verifier might disagree on which value enters the signature base. Verifier MUST reject. Distinct from 010-content-digest-mismatch (where the single declared digest doesn't match the body)."
+}

--- a/static/compliance/source/test-vectors/request-signing/negative/024-unquoted-string-param.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/024-unquoted-string-param.json
@@ -1,0 +1,31 @@
+{
+  "name": "Signature-Input sig-param string value sent unquoted (keyid=foo instead of keyid=\"foo\")",
+  "spec_reference": "#verifier-checklist-requests step 1 (RFC 9421 §2.3 sig-params; RFC 8941 §3.3 string values MUST be double-quoted)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=test-ed25519-2026;alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_header_malformed",
+    "failed_step": 1
+  },
+  "$comment": "Per RFC 8941 §3.3.3, Structured-Field string values MUST be wrapped in ASCII double-quotes. RFC 9421 §2.3 defines keyid, nonce, and tag as string-typed sig-params, so 'keyid=foo' (bare token) is not a valid string — it would parse as a token-typed value if the grammar allowed tokens there, which it does not. A verifier that tolerantly accepts bare tokens (common bug in hand-rolled parsers) introduces a parser-differential attack: one implementation sees keyid='foo', another sees keyid=undefined, and they disagree on which JWKS entry to resolve. Verifier MUST reject at parse."
+}

--- a/static/compliance/source/test-vectors/request-signing/negative/025-jwk-alg-crv-mismatch.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/025-jwk-alg-crv-mismatch.json
@@ -1,0 +1,43 @@
+{
+  "name": "JWK declares alg=EdDSA but crv=P-256 (parameter-mismatch on presented key)",
+  "spec_reference": "#verifier-checklist-requests step 8 (key-purpose + parameter consistency; RFC 8037 binds alg=EdDSA to OKP key types, not EC)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-alg-crv-mismatch-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_override": {
+    "keys": [
+      {
+        "$comment": "Malformed JWK: alg=EdDSA is valid only for kty=OKP with crv=Ed25519 or crv=Ed448 (RFC 8037 §3.1). This JWK declares alg=EdDSA with kty=EC and crv=P-256, which is an impossible combination. Key material is the real Ed25519 public key bytes from test-ed25519-2026 so the failure MUST land on parameter consistency, not on some unrelated key-material defect. Verifier MUST reject at step 8 with request_signature_key_purpose_invalid — 'key purpose' encompasses both adcp_use scoping and the fundamental alg/kty/crv consistency that makes a JWK usable at all.",
+        "kid": "test-alg-crv-mismatch-2026",
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "EdDSA",
+        "use": "sig",
+        "key_ops": ["verify"],
+        "adcp_use": "request-signing",
+        "x": "gWUqzATUcUco5Q8fZZXn8aWwb7DQbYGBiqUzLiSDDJo"
+      }
+    ]
+  },
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_key_purpose_invalid",
+    "failed_step": 8
+  },
+  "$comment": "Parameter-consistency check on the resolved JWK. A lenient verifier that picks alg from the sig-params and ignores the JWK's declared alg/crv would proceed to step 10 and reject with request_signature_invalid — a DIFFERENT (and less informative) error code. Per README 'Conformance expectations' §1, error-code mismatch is non-conformant even when the rejection lands at a different step. Uses jwks_override rather than a new keys.json entry because this key shape is deliberately malformed — polluting the canonical keys.json with impossible key parameters would risk other vectors inheriting the malformed shape through a bug."
+}

--- a/static/compliance/source/test-vectors/request-signing/negative/026-non-ascii-host.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/026-non-ascii-host.json
@@ -1,0 +1,31 @@
+{
+  "name": "URL authority contains raw IDN U-label (non-ASCII bytes in host)",
+  "spec_reference": "#adcp-rfc-9421-profile (@target-uri canonicalization: hosts MUST be ASCII A-labels; RFC 5891 §4.4)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://bücher.example.com/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_header_malformed",
+    "failed_step": 1
+  },
+  "$comment": "Host label 'bücher' is a Unicode U-label; the AdCP @target-uri algorithm requires A-label (Punycode, 'xn--bcher-kva') form. Accepting a raw U-label on the wire risks a canonicalization-differential: UTS-46 Nontransitional processing produces one A-label, naive lowercase + Punycode produces another (see canonicalization.json case 'idn-mixed-case-to-punycode'), and non-ASCII-aware libraries may round-trip the bytes unchanged. Verifier MUST reject at parse rather than guess. Companion canonicalization.json cases 'idn-to-punycode' and 'idn-mixed-case-to-punycode' exercise the SIGNER side (expect A-label output from U-label input after explicit UTS-46 processing); this vector exercises the VERIFIER side (reject U-label bytes received on the wire inside a signed request)."
+}

--- a/static/compliance/source/test-vectors/request-signing/positive/009-percent-encoded-unreserved-decoded.json
+++ b/static/compliance/source/test-vectors/request-signing/positive/009-percent-encoded-unreserved-decoded.json
@@ -1,0 +1,30 @@
+{
+  "name": "URL path percent-encoded unreserved bytes decoded per RFC 3986 §6.2.2.2",
+  "spec_reference": "#adcp-rfc-9421-profile (@target-uri canonicalization step 6: decode percent-encoded unreserved characters)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/a%7Eb%2Dc%5Fd%2Ee/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:o2kFcTvxhbtnyteqXSKBvg_WcDeh7Ev-6rmhbl5bqEa5LHEDBBQbzoB8JEgOxtYjsrANKz8qygxfc0JOUQnKBg:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://seller.example.com/adcp/a~b-c_d.e/create_media_buy\n\"@authority\": seller.example.com\n\"content-type\": application/json\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+  "expected_outcome": {
+    "success": true
+  },
+  "$comment": "Companion to 008-percent-encoded-path (which exercises the reserved-byte uppercase rule). This vector covers the decode-side of step 6: the four unreserved characters that are percent-encoded on the wire (%7E=~, %2D=-, %5F=_, %2E=.) MUST be decoded in the canonical @target-uri per RFC 3986 §6.2.2.2. A verifier that uppercases but doesn't decode will fail step 10 (signature invalid) because %7E != ~ in the canonical base. Signature generated with the test-ed25519-2026 private key from the expected_signature_base."
+}

--- a/static/compliance/source/test-vectors/request-signing/positive/010-percent-encoded-slash-preserved.json
+++ b/static/compliance/source/test-vectors/request-signing/positive/010-percent-encoded-slash-preserved.json
@@ -1,0 +1,30 @@
+{
+  "name": "URL path with %2F (reserved) preserved literally through remove_dot_segments",
+  "spec_reference": "#adcp-rfc-9421-profile (@target-uri canonicalization step 5: remove_dot_segments operates on percent-encoded form; step 6: reserved bytes stay percent-encoded)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/adcp/segment%2Fwith-encoded-slash/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:2MVpRwioVrc-gLepGnleM5Nk0hI8M-V5A9buqMly0oL5Z4p3VfPh92ijitH1fKL2o7i97160AJ0Sf_wP9Q0KCQ:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://seller.example.com/adcp/segment%2Fwith-encoded-slash/create_media_buy\n\"@authority\": seller.example.com\n\"content-type\": application/json\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+  "expected_outcome": {
+    "success": true
+  },
+  "$comment": "%2F is the percent-encoding of '/', a reserved character. Two properties MUST hold in canonical form: (a) remove_dot_segments per RFC 3986 §5.2.4 operates on the percent-encoded path and does NOT treat %2F as a segment separator, so 'segment%2Fwith-encoded-slash' stays as one path segment; (b) step 6 keeps reserved bytes percent-encoded (with uppercase hex) — the %2F does NOT decode to '/'. A verifier that decodes %2F before remove_dot_segments can produce a different path entirely (especially when combined with /./ or /../). Signature generated with the test-ed25519-2026 private key from the expected_signature_base."
+}

--- a/static/compliance/source/test-vectors/request-signing/positive/011-ipv6-authority.json
+++ b/static/compliance/source/test-vectors/request-signing/positive/011-ipv6-authority.json
@@ -1,0 +1,30 @@
+{
+  "name": "IPv6 literal authority; brackets preserved in @target-uri and @authority",
+  "spec_reference": "#adcp-rfc-9421-profile (@target-uri canonicalization step 2: IPv6 brackets preserved; @authority derivation)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://[2001:db8::1]/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:QplWbT2vVnF_TSfY5w5d8zQYkLpD7Bp4rxE9uKHl14UjBmUnF6mwKB8pEgoFTKHF1jVwwL14hx_AM6sFBtT9CA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://[2001:db8::1]/adcp/create_media_buy\n\"@authority\": [2001:db8::1]\n\"content-type\": application/json\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+  "expected_outcome": {
+    "success": true
+  },
+  "$comment": "Bare IPv6 literal in authority. RFC 9421 canonicalizes @target-uri and @authority with brackets retained; common host-parsing libraries strip brackets during authority split and must reinstate them in the canonical form. A verifier that emits '2001:db8::1' without brackets (or with an extra ':' splitting ambiguity) will fail step 10. Paired with 012-ipv6-authority-default-port-stripped to cover the '@target-uri must not strip the bracket while stripping the default port' interaction. Signature generated with the test-ed25519-2026 private key from the expected_signature_base."
+}

--- a/static/compliance/source/test-vectors/request-signing/positive/012-ipv6-authority-default-port-stripped.json
+++ b/static/compliance/source/test-vectors/request-signing/positive/012-ipv6-authority-default-port-stripped.json
@@ -1,0 +1,30 @@
+{
+  "name": "IPv6 literal authority with explicit :443; canonicalization strips port but preserves brackets",
+  "spec_reference": "#adcp-rfc-9421-profile (@target-uri canonicalization step 2 + step 4: IPv6 brackets preserved AND default ports stripped)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://[2001:db8::1]:443/adcp/create_media_buy",
+    "headers": {
+      "Content-Type": "application/json",
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+      "Signature": "sig1=:QplWbT2vVnF_TSfY5w5d8zQYkLpD7Bp4rxE9uKHl14UjBmUnF6mwKB8pEgoFTKHF1jVwwL14hx_AM6sFBtT9CA:"
+    },
+    "body": "{\"plan_id\":\"plan_001\"}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [
+      "create_media_buy"
+    ]
+  },
+  "jwks_ref": [
+    "test-ed25519-2026"
+  ],
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://[2001:db8::1]/adcp/create_media_buy\n\"@authority\": [2001:db8::1]\n\"content-type\": application/json\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\");created=1776520800;expires=1776521100;nonce=\"KXYnfEfJ0PBRZXQyVXfVQA\";keyid=\"test-ed25519-2026\";alg=\"ed25519\";tag=\"adcp/request-signing/v1\"",
+  "expected_outcome": {
+    "success": true
+  },
+  "$comment": "Intersection of bracket preservation (step 2) and default-port stripping (step 4). As-received URL has '[2001:db8::1]:443'; canonical form is '[2001:db8::1]' — port stripped, brackets retained. A naive regex that strips ':443$' from the authority string will incorrectly produce '[2001:db8::1' (eating the closing bracket) or leave the port in place. Canonical base is identical to 011-ipv6-authority by construction, so the same signature bytes verify both vectors. Signature generated with the test-ed25519-2026 private key from the expected_signature_base."
+}


### PR DESCRIPTION
## Summary

Adds 3 positive + 6 negative RFC 9421 request-signing conformance vectors covering canonicalization and parse-time rejection behaviors that the existing 28-vector suite does not exercise. Refs [adcp-go#56](https://github.com/adcontextprotocol/adcp-go/issues/56).

### New positive vectors
All signatures generated by signing `expected_signature_base` with `test-ed25519-2026`. Ed25519 is deterministic, so these bytes are reproducible across implementations.

| File | What it locks in |
|---|---|
| `positive/009-percent-encoded-unreserved-decoded.json` | `%7E` / `%2D` / `%5F` / `%2E` in path decode to `~` / `-` / `_` / `.` per RFC 3986 §6.2.2.2 |
| `positive/010-percent-encoded-slash-preserved.json` | `%2F` (reserved) stays percent-encoded and is NOT treated as a segment separator by `remove_dot_segments` |
| `positive/011-ipv6-authority.json` | Bare IPv6 literal (`https://[2001:db8::1]/...`) — brackets preserved in `@target-uri` and `@authority` |
| `positive/012-ipv6-authority-default-port-stripped.json` | IPv6 with `:443` — canonicalization strips the default port but keeps brackets (tests the step-2/step-4 intersection) |

Companion to existing vector `008-percent-encoded-path.json`, which covers only the uppercase-hex side of canonicalization step 6.

### New negative vectors

| File | Expected `error_code` | Step |
|---|---|---|
| `negative/021-duplicate-signature-input-label.json` | `request_signature_header_malformed` | 1 |
| `negative/022-multi-valued-content-type.json` | `request_signature_header_malformed` | 1 |
| `negative/023-multi-valued-content-digest.json` | `request_signature_header_malformed` | 1 |
| `negative/024-unquoted-string-param.json` | `request_signature_header_malformed` | 1 |
| `negative/025-jwk-alg-crv-mismatch.json` | `request_signature_key_purpose_invalid` | 8 |
| `negative/026-non-ascii-host.json` | `request_signature_header_malformed` | 1 |

Vector 025 ships its malformed JWK via `jwks_override` rather than polluting `keys.json` with an impossible `alg`/`crv` combination — an approach the README explicitly sanctions for non-canonical key shapes.

### Motivation

Our [adcp-go](https://github.com/adcontextprotocol/adcp-go) implementation already handles the **canonicalization** cases (009/010/011/012) defensively — they verify against the Go reference impl. The **parse-time rejection** cases (022/023/024) codify rules AdCP already normatively requires (RFC 8941 dictionary duplicate-key handling, RFC 9110 Content-Type grammar, RFC 9421 §2.3 sig-param string-typing) but which multiple implementations currently defer to the crypto step. Without vectors locking these to `request_signature_header_malformed` at step 1, each SDK can drift into silently downgrading parse-time rejects into generic `request_signature_invalid` crypto failures, which hides a real parser-differential attack surface (duplicate labels, comma-smuggled Content-Type overrides, bare-token keyid lenient-parse bypasses).

### Generator-verified checklist

- [x] Positive vectors 009/010/011/012 verify successfully against the Go reference impl (`adcp/signing`)
- [x] Positive vectors' `expected_signature_base` is byte-exact (Go canonicalizer reproduces each base from the raw URL + headers)
- [x] Ed25519 signature bytes are deterministic and reproduce from `_private_d_for_test_only` in `keys.json`
- [x] Negative vectors 021/025/026 reject with the expected `error_code` against the Go reference impl
- [ ] Negative vectors 022/023/024 require parse-strictness fixes in the Go impl (and likely in TS/Python reference impls) before they land green — intentional: the vectors are the forcing function
- [x] README "File layout" block updated with all 10 new rows
- [x] Spec-anchor references provided for every vector

### Coordination notes

- **New test-key shape added** — vector 025 introduces a malformed JWK via `jwks_override`, no change to `keys.json`. Reference impls (TypeScript, Python) need to make sure their harnesses load `jwks_override` correctly (none of the existing 28 vectors use it, though the README documents it).
- **022/023/024 intentionally expose a gap.** Reviewers should expect these to fail in the adcp-go and adcp-client conformance runs on first try. The fix is a small parse-strictness addition in each verifier, not a vector change.

## Test plan

- [ ] Run the full vector suite against the Go reference impl and confirm 009/010/011/012/021/025/026 pass, and 022/023/024 fail with the current lenient parser (driving the follow-up fix)
- [ ] Run the TS reference impl harness; expect the same shape
- [ ] Run the Python reference impl harness; expect the same shape
- [ ] Confirm the CDN mirror (`https://adcontextprotocol.org/test-vectors/request-signing/`) serves the new files after merge