### PR TITLE
chore(addie): wrap JSON example in backticks in knowledge.md

### DIFF
--- a/.changeset/addie-knowledge-json-backticks.md
+++ b/.changeset/addie-knowledge-json-backticks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Wrap the `getTargetingData` JSON example in `server/src/addie/rules/knowledge.md` in inline backticks so markdown renders the literal code instead of interpreting the curly braces.

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -479,7 +479,7 @@ An orchestrator's RTD module (e.g., `exampleRtdProvider`) implements AXE for Pre
 - Inspect bid requests in network tab for expected ortb2 data
 
 **Key-values not in ad server request:**
-- getTargetingData must return data keyed by ad unit code: {'div-gpt-ad-123': {axei: 'value'}}
+- getTargetingData must return data keyed by ad unit code: `{'div-gpt-ad-123': {axei: 'value'}}`
 - Check GAM targeting in browser: googletag.pubads().getTargeting('axei')
 - Verify line items in GAM target the correct keys (axei, axex, axem)
 


### PR DESCRIPTION
## Summary

Tiny markdown fix, split out of the closed red-team PR #2466. In `server/src/addie/rules/knowledge.md` the `getTargetingData` bullet had a raw `{...}` JSON snippet that markdown parsers try to interpret. Wrapped in inline backticks so the literal example renders.

No behavior change.

## Test plan

- [x] Rendered preview shows `{'div-gpt-ad-123': {axei: 'value'}}` as a code snippet