### PR TITLE
docs(auth): state the three AdCP 3.x auth mechanisms up front

### DIFF
--- a/.changeset/auth-three-mechanism-baseline.md
+++ b/.changeset/auth-three-mechanism-baseline.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(auth): state the three AdCP 3.x authentication mechanisms and their normative status up front
+
+Opens `docs/building/integration/authentication.mdx` with a normative lead paragraph naming the three mechanisms (RFC 9421 request signing, mutual TLS, Bearer tokens over TLS) and their 3.0 vs 3.1 status, with cross-references to the per-mechanism matrix and the security reference. Closes the gap where a reader of the auth page had to reconstruct the baseline from scattered sections.

--- a/docs/building/integration/authentication.mdx
+++ b/docs/building/integration/authentication.mdx
@@ -5,6 +5,8 @@ description: "AdCP authentication guide: public vs authenticated operations, bea
 ---
 
 
+AdCP 3.0 supports three authentication mechanisms: (1) RFC 9421 request signing (RECOMMENDED, REQUIRED in 3.1+ for mutating operations), (2) mutual TLS, and (3) Bearer tokens over TLS (permitted in 3.0 for non-financial operations only). Implementations MUST support RFC 9421 for mutating operations by the 3.1 deprecation date. The full per-mechanism matrix is in [Authentication Method](#authentication-method) below; the implementation-reference counterpart is in the [security reference](/docs/building/implementation/security).
+
 AdCP uses a tiered authentication model where some operations are publicly accessible while others require authentication.
 
 ## When Authentication is Required


### PR DESCRIPTION
## Summary

Split out of closed PR #2466 (item **S-1**).

Opens `docs/building/integration/authentication.mdx` with a normative lead paragraph naming the three AdCP 3.x authentication mechanisms — RFC 9421 request signing, mutual TLS, Bearer tokens over TLS — and their 3.0 vs 3.1 status, with cross-references to the per-mechanism matrix below and the implementation reference in `/docs/building/implementation/security`.

Closes the gap where a reader of the auth page had to reconstruct the baseline from scattered sections later on the page.

Docs-only. No schema change.

## Test plan

- [x] `npm run typecheck` clean (pre-push)
- [ ] Review the lead paragraph for normative consistency with the later §Authentication Method table