### PR TITLE
spec(capabilities): webhook_signing + identity blocks, account_id_is_opaque, 3 error codes

### DIFF
--- a/.changeset/capability-blocks-webhook-signing-identity.md
+++ b/.changeset/capability-blocks-webhook-signing-identity.md
@@ -4,8 +4,8 @@
 
 Add capability-discovery blocks so receivers can reason about operator posture at onboarding:
 
-- `webhook_signing` (top-level): declares RFC 9421 outbound webhook-signing support, profile id, permitted algorithms (`ed25519`, `ecdsa-p256-sha256`), and whether the agent falls back to HMAC-SHA256 on the deprecated `push_notification_config.authentication` path.
-- `identity` (top-level): declares `per_principal_key_isolation`, `key_origins` (governance/request/webhook/TMP JWKS origin separation), and `compromise_notification` emit/accept posture.
-- `adcp.idempotency.account_id_is_opaque`: advisory flag signaling that `account_id` is an HKDF-derived blind handle rather than the buyer's natural account key.
+- `webhook_signing` (top-level): declares RFC 9421 outbound webhook-signing support, closed-enum profile id (`adcp-webhook-9421-v1`), permitted algorithms (`ed25519`, `ecdsa-p256-sha256`), and whether the agent falls back to HMAC-SHA256 on the deprecated `push_notification_config.authentication` path.
+- `identity` (top-level): declares `per_principal_key_isolation`, `key_origins` (governance/request/webhook/TMP JWKS origin separation), and `compromise_notification` emit/accept posture. An empty `identity: {}` is schema-valid but advisory-neutral — receivers treat it as equivalent to omitting the block.
+- `adcp.idempotency.account_id_is_opaque`: flag signaling that `account_id` is an HKDF-derived blind handle rather than the buyer's natural account key. Wire shape is unchanged, but buyer replay/retry/logging behavior MUST change when the flag is true. Migration: sellers already deriving opaque `account_id` without declaring this flag will be misclassified by new buyers as natural-key sellers until the flag is set.
 
 Also fills the error-code enum for three governance/policy codes: `CAMPAIGN_SUSPENDED`, `GOVERNANCE_UNAVAILABLE`, `PERMISSION_DENIED`.

--- a/.changeset/capability-blocks-webhook-signing-identity.md
+++ b/.changeset/capability-blocks-webhook-signing-identity.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+Add capability-discovery blocks so receivers can reason about operator posture at onboarding:
+
+- `webhook_signing` (top-level): declares RFC 9421 outbound webhook-signing support, profile id, permitted algorithms (`ed25519`, `ecdsa-p256-sha256`), and whether the agent falls back to HMAC-SHA256 on the deprecated `push_notification_config.authentication` path.
+- `identity` (top-level): declares `per_principal_key_isolation`, `key_origins` (governance/request/webhook/TMP JWKS origin separation), and `compromise_notification` emit/accept posture.
+- `adcp.idempotency.account_id_is_opaque`: advisory flag signaling that `account_id` is an HKDF-derived blind handle rather than the buyer's natural account key.
+
+Also fills the error-code enum for three governance/policy codes: `CAMPAIGN_SUSPENDED`, `GOVERNANCE_UNAVAILABLE`, `PERMISSION_DENIED`.

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -44,7 +44,10 @@
     "IO_REQUIRED",
     "TERMS_REJECTED",
     "REQUOTE_REQUIRED",
-    "VERSION_UNSUPPORTED"
+    "VERSION_UNSUPPORTED",
+    "CAMPAIGN_SUSPENDED",
+    "GOVERNANCE_UNAVAILABLE",
+    "PERMISSION_DENIED"
   ],
   "enumDescriptions": {
     "INVALID_REQUEST": "Request is malformed, missing required fields, or violates schema constraints. Recovery: correctable (check request parameters and fix).",
@@ -86,6 +89,9 @@
     "IO_REQUIRED": "The committed proposal requires a signed insertion order but no io_acceptance was provided. Recovery: correctable (review the proposal's insertion_order, accept terms, and include io_acceptance on create_media_buy).",
     "TERMS_REJECTED": "Buyer-proposed measurement_terms were rejected by the seller. The error details SHOULD identify which specific term was rejected and the seller's acceptable range or supported vendors. Recovery: correctable (adjust the proposed terms and retry, or omit measurement_terms to accept the product's defaults).",
     "REQUOTE_REQUIRED": "An update_media_buy request changes the parameter envelope (budget, flight dates, volume, targeting) the original quote was priced against. The pricing_option remains locked; the seller is declining the requested shape at that price. Distinct from TERMS_REJECTED (measurement) and POLICY_VIOLATION (content). Sellers SHOULD populate error.details.envelope_field with the field path(s) that breached the envelope (e.g., 'packages[0].budget', 'end_time') so the buyer's agent can autonomously re-discover. Recovery: correctable (re-negotiate via get_products in 'refine' mode against the existing proposal_id to obtain a fresh quote reflecting the new parameters, then resubmit the update against the new proposal_id).",
-    "VERSION_UNSUPPORTED": "The declared adcp_major_version is not supported by this seller. Recovery: correctable (call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry with a supported version)."
+    "VERSION_UNSUPPORTED": "The declared adcp_major_version is not supported by this seller. Recovery: correctable (call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry with a supported version).",
+    "CAMPAIGN_SUSPENDED": "Campaign governance has been suspended pending human review; the governance agent MUST reject `check_governance` and `report_plan_outcome` calls on the affected plan until the escalation is resolved. Distinct from `ACCOUNT_SUSPENDED` (account-wide) — this is scoped to a single plan/campaign. Recovery: transient (wait for the escalation to resolve; contact the plan operator if the suspension persists).",
+    "GOVERNANCE_UNAVAILABLE": "A registered governance agent is unreachable (timeout, network error, or repeated failure) and the seller cannot obtain a governance decision for the spend-commit. Distinct from `GOVERNANCE_DENIED` (agent reachable and explicitly denied). Recovery: transient (retry with backoff; if the agent remains unreachable, the buyer MUST contact the plan's governance operator — the seller MUST NOT proceed with the media buy without a valid decision).",
+    "PERMISSION_DENIED": "The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). Recovery: correctable (call `check_governance` to mint a valid token, or contact the seller to resolve the underlying permission)."
   }
 }

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -35,6 +35,11 @@
                   "description": "How long the seller retains a canonical response for an idempotency_key. Within this window, a replay with the same key + equivalent canonical payload returns the cached response; a replay with a different canonical payload returns IDEMPOTENCY_CONFLICT; a replay past the window returns IDEMPOTENCY_EXPIRED when the seller can still distinguish 'seen and evicted' from 'never seen'. Minimum 3600 (1h); recommended 86400 (24h). Maximum 604800 (7 days) — longer windows force buyers to retain secret keys at rest for extended periods and grow the seller's cache table without bounded benefit.",
                   "minimum": 3600,
                   "maximum": 604800
+                },
+                "account_id_is_opaque": {
+                  "type": "boolean",
+                  "description": "When true, the seller derives `account_id` via an HKDF-based one-way transform of the buyer's natural account key rather than echoing the natural key on the wire. Buyers MUST NOT attempt to invert the opaque id and MUST treat it as a blind handle scoped to this seller. Absent or false, callers should assume account_id is the natural key (or a server-assigned but non-opaque id). Advisory capability — does not change the wire shape.",
+                  "default": false
                 }
               },
               "required": [
@@ -854,6 +859,92 @@
         }
       },
       "required": ["supported"]
+    },
+    "webhook_signing": {
+      "type": "object",
+      "description": "RFC 9421 webhook-signature support for outbound webhook callbacks (top-level peer of request_signing). Declares which AdCP webhook-signing profile version and algorithms this agent produces on delivery, and whether it supports the legacy HMAC-SHA256 fallback for receivers that have not yet adopted RFC 9421. See docs/building/implementation/webhooks.mdx.",
+      "properties": {
+        "supported": {
+          "type": "boolean",
+          "description": "Whether this agent signs outbound webhooks with the AdCP RFC 9421 webhook profile. When false or absent, webhooks are delivered with legacy Bearer or HMAC-SHA256 auth only and receivers MUST NOT expect a Signature header."
+        },
+        "profile": {
+          "type": "string",
+          "description": "Identifier of the webhook-signing profile version the agent emits. The 3.0 profile id is 'adcp-webhook-9421-v1'. Receivers use this to select a parser compatible with any future profile revisions."
+        },
+        "algorithms": {
+          "type": "array",
+          "description": "Signature algorithms this agent uses on outbound webhooks. 3.0 profile permits 'ed25519' and 'ecdsa-p256-sha256' only; other values are reserved for future profile versions and MUST NOT be emitted under adcp-webhook-9421-v1.",
+          "items": {
+            "type": "string",
+            "enum": ["ed25519", "ecdsa-p256-sha256"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "legacy_hmac_fallback": {
+          "type": "boolean",
+          "description": "Whether this agent will fall back to HMAC-SHA256 on the legacy push_notification_config.authentication path for receivers that have not adopted RFC 9421. Deprecated; removed in AdCP 4.0.",
+          "default": false
+        }
+      },
+      "required": ["supported"]
+    },
+    "identity": {
+      "type": "object",
+      "description": "Operator identity posture — key-scoping and compromise-response controls the agent operates. Fields are independent, all advisory in 3.x; receivers use them to reason about blast radius and revocation latency at onboarding rather than discovering the posture after an incident.",
+      "properties": {
+        "per_principal_key_isolation": {
+          "type": "boolean",
+          "description": "When true, this multi-principal operator scopes signing keys per-principal via the `{operator}:{principal}:{key_version}` keyid convention so a single principal's key compromise does not silently re-scope across principals served by the same operator. See docs/building/understanding/security-model.mdx.",
+          "default": false
+        },
+        "key_origins": {
+          "type": "object",
+          "description": "Map of signing-key purpose → publishing origin, so counterparties can verify origin separation (e.g., governance keys served from a separate origin than transport/webhook keys) at onboarding. Absent means the operator has not declared a separation scheme; receivers SHOULD assume shared-origin. See docs/building/implementation/security.mdx §Origin separation.",
+          "properties": {
+            "governance_signing": {
+              "type": "string",
+              "format": "uri",
+              "description": "Origin (scheme + host) serving the governance-signing JWKS."
+            },
+            "request_signing": {
+              "type": "string",
+              "format": "uri",
+              "description": "Origin (scheme + host) serving the request-signing JWKS."
+            },
+            "webhook_signing": {
+              "type": "string",
+              "format": "uri",
+              "description": "Origin (scheme + host) serving the webhook-signing JWKS."
+            },
+            "tmp_signing": {
+              "type": "string",
+              "format": "uri",
+              "description": "Origin (scheme + host) serving the TMP-signing JWKS, when this operator participates in TMP."
+            }
+          },
+          "additionalProperties": false
+        },
+        "compromise_notification": {
+          "type": "object",
+          "description": "Whether this agent emits the `identity.compromise_notification` webhook event on key revocation due to known or suspected compromise (as opposed to scheduled rotation). Subscribers use this to bound the window between compromise detected and verifiers converging on revocation. See docs/building/implementation/webhooks.mdx §identity.compromise_notification.",
+          "properties": {
+            "emits": {
+              "type": "boolean",
+              "description": "Whether this agent emits `identity.compromise_notification` events.",
+              "default": false
+            },
+            "accepts": {
+              "type": "boolean",
+              "description": "Whether this agent subscribes to `identity.compromise_notification` events from counterparties it verifies signatures from.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "compliance_testing": {
       "type": "object",

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -870,12 +870,12 @@
         },
         "profile": {
           "type": "string",
-          "enum": ["adcp-webhook-9421-v1"],
-          "description": "Identifier of the webhook-signing profile version the agent emits. Closed enum so receivers can statically validate the declared profile; future profile revisions will extend this enum in a follow-up schema bump."
+          "enum": ["adcp/webhook-signing/v1"],
+          "description": "Identifier of the webhook-signing profile version the agent emits. Value MUST match the `tag=` parameter emitted in the RFC 9421 `Signature-Input` header (see docs/building/implementation/webhooks.mdx) so receivers can statically validate the declared profile against the on-wire tag. Closed enum; future profile revisions will extend this enum in a follow-up schema bump."
         },
         "algorithms": {
           "type": "array",
-          "description": "Signature algorithms this agent uses on outbound webhooks. 3.0 profile permits 'ed25519' and 'ecdsa-p256-sha256' only; other values are reserved for future profile versions and MUST NOT be emitted under adcp-webhook-9421-v1.",
+          "description": "Signature algorithms this agent uses on outbound webhooks. 3.0 profile permits 'ed25519' and 'ecdsa-p256-sha256' only; other values are reserved for future profile versions and MUST NOT be emitted under adcp/webhook-signing/v1.",
           "items": {
             "type": "string",
             "enum": ["ed25519", "ecdsa-p256-sha256"]
@@ -897,7 +897,7 @@
       "properties": {
         "per_principal_key_isolation": {
           "type": "boolean",
-          "description": "When true, this multi-principal operator scopes signing keys per-principal via the `{operator}:{principal}:{key_version}` keyid convention so a single principal's key compromise does not silently re-scope across principals served by the same operator. See docs/building/understanding/security-model.mdx.",
+          "description": "When true, this multi-principal operator scopes signing keys per-principal so a single principal's key compromise does not silently re-scope across principals served by the same operator. `kid` values remain opaque to verifiers per RFC 7517; any operator-side naming convention (e.g., `{operator}:{principal}:{key_version}`) is internal bookkeeping and MUST NOT be parsed by verifiers. See docs/building/understanding/security-model.mdx.",
           "default": false
         },
         "key_origins": {

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -38,7 +38,7 @@
                 },
                 "account_id_is_opaque": {
                   "type": "boolean",
-                  "description": "When true, the seller derives `account_id` via an HKDF-based one-way transform of the buyer's natural account key rather than echoing the natural key on the wire. Buyers MUST NOT attempt to invert the opaque id and MUST treat it as a blind handle scoped to this seller. Absent or false, callers should assume account_id is the natural key (or a server-assigned but non-opaque id). Advisory capability — does not change the wire shape.",
+                  "description": "When true, the seller derives `account_id` via an HKDF-based one-way transform of the buyer's natural account key rather than echoing the natural key on the wire. Buyers MUST NOT attempt to invert the opaque id and MUST treat it as a blind handle scoped to this seller. Absent or false, callers should assume `account_id` is the natural key (or a server-assigned but non-opaque id). This flag does not change the wire shape, but it DOES change buyer behavior — buyers MUST NOT cache, log, or treat `account_id` as a natural-key analog when this flag is true. Migration note for sellers already returning an opaque id without this flag: set it to true at the next capabilities refresh so buyers stop inferring natural-key semantics; until set, new-buyer replay/retry logic will misclassify these ids as natural keys.",
                   "default": false
                 }
               },
@@ -870,7 +870,8 @@
         },
         "profile": {
           "type": "string",
-          "description": "Identifier of the webhook-signing profile version the agent emits. The 3.0 profile id is 'adcp-webhook-9421-v1'. Receivers use this to select a parser compatible with any future profile revisions."
+          "enum": ["adcp-webhook-9421-v1"],
+          "description": "Identifier of the webhook-signing profile version the agent emits. Closed enum so receivers can statically validate the declared profile; future profile revisions will extend this enum in a follow-up schema bump."
         },
         "algorithms": {
           "type": "array",
@@ -892,7 +893,7 @@
     },
     "identity": {
       "type": "object",
-      "description": "Operator identity posture — key-scoping and compromise-response controls the agent operates. Fields are independent, all advisory in 3.x; receivers use them to reason about blast radius and revocation latency at onboarding rather than discovering the posture after an incident.",
+      "description": "Operator identity posture — key-scoping and compromise-response controls the agent operates. Fields are independent, all advisory in 3.x; receivers use them to reason about blast radius and revocation latency at onboarding rather than discovering the posture after an incident. Semantics of an empty object: `identity: {}` means \"posture block present but no posture claimed\" — schema-valid but advisory-neutral; receivers MUST treat it as equivalent to omitting the block (no capability claim inferred). Operators SHOULD populate at least one field to make a declaration meaningful.",
       "properties": {
         "per_principal_key_isolation": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

Split from closed #2474. Narrow slice that only touches capability-discovery declarations and error-enum completeness; no normative protocol-flow changes.

- **`webhook_signing` capability block (top-level)** — receivers negotiate the outbound webhook signature parser at onboarding instead of discovering it at delivery. Declares RFC 9421 support, profile id, permitted algorithms (`ed25519`, `ecdsa-p256-sha256`), and whether the agent falls back to HMAC-SHA256 on the deprecated `push_notification_config.authentication` path.
- **`identity` capability block (top-level)** — lets counterparties reason about blast radius and revocation latency up-front: `per_principal_key_isolation` (keyid convention), `key_origins` (governance/request/webhook/TMP JWKS separation), and `compromise_notification` emit/accept posture.
- **`adcp.idempotency.account_id_is_opaque`** — advisory flag signaling the seller derives `account_id` via HKDF from the buyer's natural key rather than echoing it on the wire. Buyers MUST treat it as a blind handle scoped to this seller.
- **Error-code enum completeness** — adds `CAMPAIGN_SUSPENDED`, `GOVERNANCE_UNAVAILABLE`, `PERMISSION_DENIED` to both the enum array and `enumDescriptions`. These codes are referenced by governance / policy flows but were missing from the central enum.

## Why it was split from #2474

#2474 was a multi-concern red-team batch. This PR carries only the capability-block additions plus the three enum completeness entries; plan-hash binding, PII hashing, fragmentation defense, webhook-verifier server code, and crypto-erasure ship separately.

## Out of scope (intentionally skipped vs. source commit 48cbccd6)

- `privacy.audience_hash_schemes` block — belongs to the PII-hashing PR.
- `governance.aggregation_window_days` block — belongs to the fragmentation-defense PR.
- `MODE_MISMATCH`, `PLAN_HASH_MISMATCH`, `UPDATE_REQUIRES_GOVERNANCE` error codes — belong to the governance / plan-hash PR.
- `WEBHOOK_PAYLOAD_MISMATCH` "log event not wire error" clarification — the containing paragraph does not exist on `main` (was introduced in batch-2); skipped because the anchor text is not present.
- `push-notification-config.json` `$ref: enums/auth-scheme.json` — already on `main`, no diff.
- `server/src/training-agent/idempotency.ts` `validateKeyEntropy` deletion — the function is not present on `main` (was introduced in batch-2); nothing to delete.

## Test plan

- [x] `npm run typecheck` passes.
- [x] Pre-commit hook (unit tests + typecheck) passes on commit.
- [x] `static/schemas/source/enums/error-code.json` and `get-adcp-capabilities-response.json` are valid JSON.
- [ ] CI schema-compile / mintlify-build / link-check green.