### PR TITLE
c2pa: sign member portraits + visible AI badge (#2370 stage 4)

### DIFF
--- a/.changeset/c2pa-portrait-signing.md
+++ b/.changeset/c2pa-portrait-signing.md
@@ -1,0 +1,8 @@
+---
+---
+
+Stage 4 of C2PA provenance signing (#2370): sign member portraits, and composite a small visible "AI" badge in the bottom-right corner of every generated avatar.
+
+The badge satisfies CA SB 942's visible-disclosure requirement without dominating the portrait; it sits at ~10% of the short edge, rounded-rect dark background with white "AI" letters. The badge is composited *before* signing so the signature covers the disclosed pixels — any post-sign edit breaks the manifest.
+
+Wires the same failure policy as stage 2: `C2PA_STRICT=true` rethrows, default returns the badged-but-unsigned buffer so a transient signing failure never blocks a member from getting their portrait. Every failure fires a throttled `notifySystemError` alert under source `c2pa-portrait-signing`. Schema columns added in migration 414 (stage 1); this PR threads them through `portrait-db.createPortrait` and the `/api/portraits/generate` route.

--- a/server/src/db/portrait-db.ts
+++ b/server/src/db/portrait-db.ts
@@ -23,11 +23,13 @@ export interface MemberPortrait {
   approved_at: string | null;
   created_at: string;
   updated_at: string;
+  c2pa_signed_at: string | null;
+  c2pa_manifest_digest: string | null;
 }
 
 type PortraitMetadata = Omit<MemberPortrait, 'portrait_data'>;
 
-const METADATA_COLUMNS = `id, user_id, member_profile_id, image_url, prompt_used, vibe, palette, status, approved_at, created_at, updated_at`;
+const METADATA_COLUMNS = `id, user_id, member_profile_id, image_url, prompt_used, vibe, palette, status, approved_at, created_at, updated_at, c2pa_signed_at, c2pa_manifest_digest`;
 
 /** Get portrait metadata by ID (no binary data) */
 export async function getPortraitById(id: string): Promise<PortraitMetadata | null> {
@@ -81,10 +83,12 @@ export async function createPortrait(data: {
   vibe?: string;
   palette?: string;
   status?: 'pending' | 'generated' | 'approved';
+  c2pa_signed_at?: Date;
+  c2pa_manifest_digest?: string;
 }): Promise<PortraitMetadata> {
   const result = await query<PortraitMetadata>(
-    `INSERT INTO member_portraits (user_id, member_profile_id, image_url, portrait_data, prompt_used, vibe, palette, status)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    `INSERT INTO member_portraits (user_id, member_profile_id, image_url, portrait_data, prompt_used, vibe, palette, status, c2pa_signed_at, c2pa_manifest_digest)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
      RETURNING ${METADATA_COLUMNS}`,
     [
       data.user_id,
@@ -95,6 +99,8 @@ export async function createPortrait(data: {
       data.vibe || null,
       data.palette || 'amber',
       data.status || 'generated',
+      data.c2pa_signed_at ?? null,
+      data.c2pa_manifest_digest ?? null,
     ]
   );
   return result.rows[0];

--- a/server/src/routes/portraits.ts
+++ b/server/src/routes/portraits.ts
@@ -233,6 +233,8 @@ export function createPortraitRouter(config: PortraitRoutesConfig): Router {
         vibe,
         palette: 'amber',
         status: 'generated',
+        c2pa_signed_at: result.c2pa?.signedAt,
+        c2pa_manifest_digest: result.c2pa?.manifestDigest,
       });
 
       // Update image_url to the serving path

--- a/server/src/services/portrait-generator.ts
+++ b/server/src/services/portrait-generator.ts
@@ -6,11 +6,18 @@
  * graphic novel aesthetic with palette-specific coloring.
  */
 
+import { createHash } from 'crypto';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import sharp from 'sharp';
 import { createLogger } from '../logger.js';
 import { withGeminiRetry } from '../utils/gemini-retry.js';
+import { signC2PA, isC2PASigningEnabled } from './c2pa.js';
+import { notifySystemError } from '../addie/error-notifier.js';
 
 const logger = createLogger('portrait-generator');
+
+const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
+const GEMINI_IMAGE_VERSION = 'preview';
 
 const PALETTES: Record<string, string> = {
   amber: `Flat illustration, amber/gold-led color palette (#D4A017 primary, #F4C430 secondary, #FFE066 light accents). Graphic novel style with clean linework and subtle gradients. Circular composition centered on the subject, suitable for avatar/profile use. Warm, approachable tone.`,
@@ -36,6 +43,16 @@ export interface GeneratePortraitOptions {
 export interface GeneratePortraitResult {
   imageBuffer: Buffer;
   promptUsed: string;
+  /**
+   * C2PA provenance metadata, present when signing is enabled and succeeded.
+   * The imageBuffer already carries the embedded manifest; these fields are
+   * persisted alongside the row so admin tools can find unsigned portraits
+   * without parsing every PNG.
+   */
+  c2pa?: {
+    signedAt: Date;
+    manifestDigest: string;
+  };
 }
 
 let genAI: GoogleGenerativeAI | null = null;
@@ -117,14 +134,105 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
       if (!mimeType.startsWith('image/')) {
         throw new Error(`Gemini returned non-image content: ${mimeType}`);
       }
-      const imageBuffer = Buffer.from(part.inlineData.data, 'base64');
-      logger.info({ sizeKB: (imageBuffer.length / 1024).toFixed(0) }, 'Portrait generated');
-      return { imageBuffer, promptUsed: prompt };
+      const rawBuffer = Buffer.from(part.inlineData.data, 'base64');
+      logger.info({ sizeKB: (rawBuffer.length / 1024).toFixed(0) }, 'Portrait generated');
+      return await finalizePortrait(rawBuffer, { vibe, palette, promptUsed: prompt });
     }
   }
 
   const text = response.text?.() || 'No response';
   throw new Error(`Gemini did not return an image. Response: ${text.slice(0, 200)}`);
+}
+
+/**
+ * Composite an "AI" corner badge onto the portrait and embed an AAO C2PA
+ * manifest. The badge is CA SB 942's visible disclosure path; the manifest
+ * is Art 50's machine-readable path. Order matters: badge must go on
+ * before signing so the signature covers the disclosed pixels.
+ *
+ * Failure policy matches the illustration generator: C2PA_STRICT rethrows,
+ * default returns the unsigned-but-badged buffer so a transient signing
+ * failure never blocks a member from getting their portrait. Every failure
+ * fires a throttled notifySystemError alert.
+ */
+export async function finalizePortrait(
+  rawBuffer: Buffer,
+  meta: { vibe: string; palette: string; promptUsed: string },
+): Promise<GeneratePortraitResult> {
+  const badgedBuffer = await compositeAIBadge(rawBuffer);
+
+  if (!isC2PASigningEnabled()) {
+    return { imageBuffer: badgedBuffer, promptUsed: meta.promptUsed };
+  }
+  try {
+    const signed = signC2PA(badgedBuffer, {
+      claimGenerator: 'AAO Portrait Generator',
+      title: 'AAO Member Portrait',
+      softwareAgent: { name: GEMINI_IMAGE_MODEL, version: GEMINI_IMAGE_VERSION },
+      attributes: {
+        vibe: meta.vibe,
+        palette: meta.palette,
+        prompt_sha256: createHash('sha256').update(meta.promptUsed).digest('hex'),
+      },
+    });
+    return {
+      imageBuffer: signed.signedBuffer,
+      promptUsed: meta.promptUsed,
+      c2pa: { signedAt: new Date(), manifestDigest: signed.manifestDigest },
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    logger.error({ err, vibe: meta.vibe, palette: meta.palette }, 'C2PA signing failed for portrait');
+    notifySystemError({
+      source: 'c2pa-portrait-signing',
+      errorMessage: `Portrait signing failed (vibe=${meta.vibe}, palette=${meta.palette}): ${errorMessage}`,
+    });
+    if (process.env.C2PA_STRICT === 'true') {
+      throw err;
+    }
+    return { imageBuffer: badgedBuffer, promptUsed: meta.promptUsed };
+  }
+}
+
+/**
+ * Composite a small "AI" badge in the bottom-right corner of the portrait.
+ * Satisfies CA SB 942's visible-disclosure requirement without dominating
+ * the avatar. Uses an SVG overlay so the badge is crisp at any portrait size.
+ */
+export async function compositeAIBadge(imageBuffer: Buffer): Promise<Buffer> {
+  const metadata = await sharp(imageBuffer).metadata();
+  const shortEdge = Math.min(metadata.width ?? 512, metadata.height ?? 512);
+  const badgeSize = Math.max(32, Math.round(shortEdge * 0.1));
+  const fontSize = Math.round(badgeSize * 0.55);
+  const margin = Math.round(badgeSize * 0.25);
+
+  const badgeSvg = Buffer.from(`
+    <svg width="${badgeSize}" height="${badgeSize}" viewBox="0 0 ${badgeSize} ${badgeSize}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="${badgeSize}" height="${badgeSize}" rx="${Math.round(badgeSize * 0.2)}"
+            fill="rgba(30,30,30,0.78)" stroke="rgba(255,255,255,0.9)" stroke-width="1.5"/>
+      <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle"
+            font-family="system-ui, -apple-system, sans-serif" font-weight="700"
+            font-size="${fontSize}" fill="#ffffff">AI</text>
+    </svg>`);
+
+  // Pad the badge into a transparent canvas so sharp's southeast gravity
+  // gives us the margin we want from the edge.
+  const padded = await sharp({
+    create: {
+      width: badgeSize + margin,
+      height: badgeSize + margin,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([{ input: badgeSvg, top: 0, left: 0 }])
+    .png()
+    .toBuffer();
+
+  return sharp(imageBuffer)
+    .composite([{ input: padded, gravity: 'southeast' }])
+    .png()
+    .toBuffer();
 }
 
 /**

--- a/server/tests/unit/portrait-c2pa-wiring.test.ts
+++ b/server/tests/unit/portrait-c2pa-wiring.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { Buffer } from 'buffer';
+import sharp from 'sharp';
+import { Reader } from '@contentauth/c2pa-node';
+import { finalizePortrait, compositeAIBadge } from '../../src/services/portrait-generator.js';
+import { resetC2PASignerCache } from '../../src/services/c2pa.js';
+import * as errorNotifier from '../../src/addie/error-notifier.js';
+
+const FIXTURE_DIR = join(__dirname, '..', 'fixtures', 'c2pa');
+const CERT_PATH = join(FIXTURE_DIR, 'aao-c2pa.cert.pem');
+const KEY_PATH = join(FIXTURE_DIR, 'aao-c2pa.key.pem');
+
+let testPng: Buffer;
+let CERT_B64: string;
+let KEY_B64: string;
+
+beforeAll(async () => {
+  if (existsSync(CERT_PATH)) rmSync(CERT_PATH);
+  if (existsSync(KEY_PATH)) rmSync(KEY_PATH);
+  execFileSync('bash', [join(__dirname, '..', '..', '..', 'scripts', 'generate-c2pa-cert.sh'), FIXTURE_DIR], {
+    stdio: 'pipe',
+  });
+  CERT_B64 = readFileSync(CERT_PATH).toString('base64');
+  KEY_B64 = readFileSync(KEY_PATH).toString('base64');
+
+  // Portrait-sized: 512x512 amber square — matches the real avatar dimensions
+  // closely enough that the badge sizing logic exercises real values.
+  testPng = await sharp({
+    create: { width: 512, height: 512, channels: 4, background: { r: 212, g: 160, b: 23, alpha: 1 } },
+  })
+    .png()
+    .toBuffer();
+});
+
+const originalEnv = {
+  enabled: process.env.C2PA_SIGNING_ENABLED,
+  cert: process.env.C2PA_CERT_PEM_B64,
+  key: process.env.C2PA_PRIVATE_KEY_PEM_B64,
+  strict: process.env.C2PA_STRICT,
+};
+
+beforeEach(() => {
+  resetC2PASignerCache();
+  vi.spyOn(errorNotifier, 'notifySystemError').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  process.env.C2PA_SIGNING_ENABLED = originalEnv.enabled;
+  process.env.C2PA_CERT_PEM_B64 = originalEnv.cert;
+  process.env.C2PA_PRIVATE_KEY_PEM_B64 = originalEnv.key;
+  process.env.C2PA_STRICT = originalEnv.strict;
+  resetC2PASignerCache();
+  vi.restoreAllMocks();
+});
+
+describe('compositeAIBadge', () => {
+  it('adds visible badge pixels in the bottom-right corner', async () => {
+    const badged = await compositeAIBadge(testPng);
+    expect(badged.length).toBeGreaterThan(0);
+
+    // Badge is ~10% of the short edge with ~2.5% margin, so for a 512px
+    // portrait it sits around (440–500, 440–500). Sample the center of that
+    // range and compare to a pixel in the clean top-left region — the badge
+    // pixel should differ.
+    const raw = await sharp(badged).raw().toBuffer({ resolveWithObject: true });
+    const { data, info } = raw;
+    const topLeftIdx = 0;
+    const badgeCenterY = info.height - Math.round(info.height * 0.075);
+    const badgeCenterX = info.width - Math.round(info.width * 0.075);
+    const badgeIdx = (badgeCenterY * info.width + badgeCenterX) * info.channels;
+    const topLeftPixel = [data[topLeftIdx], data[topLeftIdx + 1], data[topLeftIdx + 2]];
+    const badgePixel = [data[badgeIdx], data[badgeIdx + 1], data[badgeIdx + 2]];
+    expect(topLeftPixel).not.toEqual(badgePixel);
+  });
+
+  it('preserves the original image dimensions', async () => {
+    const badged = await compositeAIBadge(testPng);
+    const meta = await sharp(badged).metadata();
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(512);
+  });
+});
+
+describe('finalizePortrait', () => {
+  it('badges but does not sign when the feature flag is off', async () => {
+    delete process.env.C2PA_SIGNING_ENABLED;
+    const result = await finalizePortrait(testPng, {
+      vibe: 'at-my-desk',
+      palette: 'amber',
+      promptUsed: 'a test prompt',
+    });
+    expect(result.c2pa).toBeUndefined();
+    expect(result.imageBuffer.length).toBeGreaterThan(0);
+    // Different from raw — badge was applied.
+    expect(result.imageBuffer).not.toEqual(testPng);
+  });
+
+  it('badges and signs when flag + secrets are present', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+
+    const result = await finalizePortrait(testPng, {
+      vibe: 'at-my-desk',
+      palette: 'amber',
+      promptUsed: 'a test prompt with secret content',
+    });
+
+    expect(result.c2pa).toBeDefined();
+    expect(result.c2pa?.manifestDigest).toMatch(/^[a-f0-9]{64}$/);
+
+    const reader = await Reader.fromAsset({ buffer: result.imageBuffer, mimeType: 'image/png' });
+    const active = reader.getActive();
+    expect(active?.title).toBe('AAO Member Portrait');
+
+    const custom = active?.assertions?.find(
+      (a) => a.label === 'org.agenticadvertising.generation',
+    );
+    expect(custom).toBeDefined();
+
+    // Prompt was hashed, not embedded.
+    const serialized = JSON.stringify(reader.json());
+    expect(serialized).not.toContain('secret content');
+    expect(serialized).toContain('prompt_sha256');
+  });
+
+  it('returns the badged-but-unsigned buffer when signing throws (default)', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    delete process.env.C2PA_STRICT;
+
+    // Pre-badging the "not a PNG" buffer would throw in sharp. Instead,
+    // bypass the sharp step by constructing a PNG that sharp accepts but
+    // c2pa-node will reject — a corrupted PNG payload. Easier route: run
+    // the real path but spy out signC2PA to throw.
+    const c2pa = await import('../../src/services/c2pa.js');
+    vi.spyOn(c2pa, 'signC2PA').mockImplementation(() => {
+      throw new Error('simulated sign failure');
+    });
+
+    const result = await finalizePortrait(testPng, {
+      vibe: 'at-my-desk',
+      palette: 'amber',
+      promptUsed: 'prompt',
+    });
+    expect(result.c2pa).toBeUndefined();
+    expect(result.imageBuffer.length).toBeGreaterThan(0);
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'c2pa-portrait-signing' }),
+    );
+  });
+
+  it('rethrows when C2PA_STRICT=true', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    process.env.C2PA_STRICT = 'true';
+
+    const c2pa = await import('../../src/services/c2pa.js');
+    vi.spyOn(c2pa, 'signC2PA').mockImplementation(() => {
+      throw new Error('simulated sign failure');
+    });
+
+    await expect(
+      finalizePortrait(testPng, { vibe: 'at-my-desk', palette: 'amber', promptUsed: 'p' }),
+    ).rejects.toThrow(/simulated sign failure/);
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 4 of #2370 — sign member portraits and composite a visible "AI" badge in the bottom-right corner. The badge is CA SB 942's visible-disclosure path; the C2PA manifest is Art 50's machine-readable path.

## What's in this PR

**Portrait signing + visible badge**
- `server/src/services/portrait-generator.ts` — `finalizePortrait()` runs post-Gemini: composite a small rounded-rect "AI" badge via sharp (10% of short edge, ~32px minimum), then sign with `signC2PA`. Order matters: badge goes on **before** signing so the signature covers the disclosed pixels. Any post-sign edit breaks the manifest.

**Failure policy** — mirrors stage 2 exactly
- `C2PA_STRICT=true` rethrows.
- Default returns the badged-but-unsigned buffer so a transient sign failure never blocks a member's portrait.
- Every failure fires a throttled `notifySystemError` under source `c2pa-portrait-signing`.

**Persistence**
- `server/src/db/portrait-db.ts` + `server/src/routes/portraits.ts` thread `c2pa_signed_at` + `c2pa_manifest_digest` through `createPortrait`. Schema columns already exist from migration 414 (stage 1) so no new migration needed.

**Tests** — `server/tests/unit/portrait-c2pa-wiring.test.ts`, 6 cases:
1. Badge composite adds visible pixels in the bottom-right corner (not the top-left).
2. Badge composite preserves the original dimensions.
3. Flag-off path badges but does not sign.
4. Flag-on path badges, signs, hashes the prompt (asserts secret prompt content doesn't leak into manifest), `Reader` reads back the expected assertions.
5. Default fallback returns badged-but-unsigned on sign failure + fires the system-error alert.
6. Strict mode rethrows.

## Test plan

- [x] `npm run test:server-unit` — 1606 passing (1582 baseline + 6 portrait wiring + earlier stage additions).
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean.
- [x] Fly secrets are already set from stage 2 — signing will be live on deploy without additional config.

## Interaction with existing portraits

Already-generated portraits stored in the DB keep working as-is — they do not have the badge and are not signed. As members regenerate or new portraits are created, they get the new treatment. A backfill pass for existing portraits can happen later (similar to stage 3's static-file backfill, but the portrait table requires the original photo which is not persisted — so backfill for portraits would mean re-signing the existing avatar pixels under the legacy assertion shape, without a badge).

**Deferred decision**: whether to add the AI badge to pre-existing portraits or leave them unchanged. Could be done via a one-shot that reads each portrait blob, composites the badge, signs, writes back. Not blocking — members will regenerate naturally as the feature rolls out. Can file as follow-up if needed.

Refs #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)