### PR TITLE
c2pa: declare signing live in /ai-disclosure (#2370 stage 5)

### DIFF
--- a/.changeset/c2pa-disclosure-update.md
+++ b/.changeset/c2pa-disclosure-update.md
@@ -1,0 +1,8 @@
+---
+---
+
+Stage 5 of C2PA provenance signing (#2370): update the `/ai-disclosure` page (docs MDX + main-site HTML) to declare signing as live rather than on-roadmap.
+
+The new "Content provenance (C2PA)" section enumerates the four signed surfaces (portraits, newsletter covers, perspective hero images, docs storyboards), names Google Gemini as the software agent, links to `contentcredentials.org/verify` for user-side verification, and is honest about the self-signed-cert status and CAI trust-list follow-up. The old roadmap bullet is replaced with a cross-link to the new section. Sub-nav on the HTML page now includes a "Provenance" anchor between "Human review" and "Regulatory."
+
+This closes the "AAO doesn't meet its own provenance standard" gap the original issue framed — with stages 2–4 shipping the actual signing, stage 5 is the public statement that we do.

--- a/docs/ai-disclosure.mdx
+++ b/docs/ai-disclosure.mdx
@@ -50,11 +50,28 @@ You can request human review on any AI-generated surface. Target turnaround is *
 - **Content corrections** — factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via [GitHub issues](https://github.com/adcontextprotocol/adcp/issues) or [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg).
 - **Protocol guidance** — Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.
 
+## Content provenance (C2PA)
+
+Every AI-generated image AAO publishes carries an embedded [C2PA](https://c2pa.org/) manifest signed by AAO:
+
+- **Member portraits** — also carry a visible "AI" badge in the bottom-right corner (CA SB 942 visible-disclosure path).
+- **Newsletter cover art** — The Prompt and The Build covers, including the copies that ship in subscriber email and render as OpenGraph share cards.
+- **Perspective article hero images** — every editorial illustration attached to a published perspective.
+- **Docs walkthrough and concept illustrations** — the panel PNGs embedded throughout this site's walkthroughs and concept explainers.
+
+The manifest identifies Google Gemini as the generating software agent, marks the asset as `trainedAlgorithmicMedia` per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself — portraits are generated from member-provided descriptions we do not want to republish). AAO signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag *"issuer not on trust list."*
+
+**Verify any AAO image** at [contentcredentials.org/verify](https://contentcredentials.org/verify) by uploading the file or pasting its URL.
+
+For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AAO — but it is a deliberate choice, not an oversight.
+
+If you find an AAO-generated image that does not carry a manifest, please [open an issue](https://github.com/adcontextprotocol/adcp/issues) — we treat missing provenance as a bug.
+
 ## Regulatory posture
 
-This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel. Specific obligations that go beyond what this page provides:
+This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel.
 
-- **EU AI Act Art 50(2)** and **CA SB 942** require machine-readable provenance (e.g., C2PA manifests) on AI-generated images and video. We do not currently apply C2PA manifests to member portraits; adding provenance metadata is on the roadmap.
+- **EU AI Act Art 50(2)** and **CA SB 942** require machine-readable provenance on AI-generated images and video — see the [content provenance](#content-provenance-c2pa) section above for how we satisfy this.
 - **FTC Endorsement Guides** apply to endorsements and testimonials for compensation. They are not activated by general AI authorship; we call them out here for completeness, not because we claim they are satisfied by this page alone.
 
 If you believe a specific AI surface falls short of an applicable standard, let us know.

--- a/server/public/ai-disclosure.html
+++ b/server/public/ai-disclosure.html
@@ -68,6 +68,7 @@
         <a href="#models">Models</a>
         <a href="#data">Data</a>
         <a href="#review">Human review</a>
+        <a href="#provenance">Provenance</a>
         <a href="#regulatory">Regulatory</a>
         <a href="#conflicts">Conflicts</a>
       </div>
@@ -121,10 +122,23 @@
         <li><strong>Protocol guidance</strong> &mdash; Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.</li>
       </ul>
 
-      <h2 id="regulatory">Regulatory posture</h2>
-      <p>This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel. Specific obligations that go beyond what this page provides:</p>
+      <h2 id="provenance">Content provenance (C2PA)</h2>
+      <p>Every AI-generated image AAO publishes carries an embedded <a href="https://c2pa.org/" target="_blank" rel="noopener noreferrer">C2PA</a> manifest signed by AAO:</p>
       <ul>
-        <li><strong>EU AI Act Art 50(2)</strong> and <strong>CA SB 942</strong> require machine-readable provenance (e.g., C2PA manifests) on AI-generated images and video. We do not currently apply C2PA manifests to member portraits; adding provenance metadata is on the roadmap.</li>
+        <li><strong>Member portraits</strong> &mdash; also carry a visible &ldquo;AI&rdquo; badge in the bottom-right corner (CA SB 942 visible-disclosure path).</li>
+        <li><strong>Newsletter cover art</strong> &mdash; The Prompt and The Build covers, including the copies that ship in subscriber email and render as OpenGraph share cards.</li>
+        <li><strong>Perspective article hero images</strong> &mdash; every editorial illustration attached to a published perspective.</li>
+        <li><strong>Docs walkthrough and concept illustrations</strong> &mdash; the panel PNGs embedded throughout the docs site's walkthroughs and concept explainers.</li>
+      </ul>
+      <p>The manifest identifies Google Gemini as the generating software agent, marks the asset as <code>trainedAlgorithmicMedia</code> per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself &mdash; portraits are generated from member-provided descriptions we do not want to republish). AAO signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag <em>&ldquo;issuer not on trust list.&rdquo;</em></p>
+      <p><strong>Verify any AAO image</strong> at <a href="https://contentcredentials.org/verify" target="_blank" rel="noopener noreferrer">contentcredentials.org/verify</a> by uploading the file or pasting its URL.</p>
+      <p>For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AAO &mdash; but it is a deliberate choice, not an oversight.</p>
+      <p>If you find an AAO-generated image that does not carry a manifest, please <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">open an issue</a> &mdash; we treat missing provenance as a bug.</p>
+
+      <h2 id="regulatory">Regulatory posture</h2>
+      <p>This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel.</p>
+      <ul>
+        <li><strong>EU AI Act Art 50(2)</strong> and <strong>CA SB 942</strong> require machine-readable provenance on AI-generated images and video &mdash; see the <a href="#provenance">content provenance</a> section above for how we satisfy this.</li>
         <li><strong>FTC Endorsement Guides</strong> apply to endorsements and testimonials for compensation. They are not activated by general AI authorship; we call them out here for completeness, not because we claim they are satisfied by this page alone.</li>
       </ul>
       <p>If you believe a specific AI surface falls short of an applicable standard, let us know.</p>


### PR DESCRIPTION
## Summary

Stage 5 of #2370 — replace the "on the roadmap" bullet in `/ai-disclosure` with a substantive "Content provenance (C2PA)" section that declares signing live.

## What's in this PR

**Both files updated:**
- `docs/ai-disclosure.mdx` (docs-site version)
- `server/public/ai-disclosure.html` (main-site static page)

**New "Content provenance (C2PA)" section covers:**
- The four signed surfaces — portraits, newsletter covers, perspective hero images, docs storyboards.
- What the manifest carries — Gemini as software agent, `trainedAlgorithmicMedia` digital source type, timestamp, SHA-256 of the prompt (explicitly NOT the prompt itself, since portraits use member-provided descriptions).
- Signing identity — self-signed P-256 cert; CAI trust-list inclusion is a future step; public verifiers will show "issuer not on trust list" but signatures are cryptographically valid.
- Verify-yourself link — `contentcredentials.org/verify`.
- Visible-badge policy — members get a corner "AI" badge (SB 942 visible path); editorial illustrations rely on the manifest alone, with reasoning around SB 942's upstream-provider scope.
- Bug-report ask — if you find an AAO image without a manifest, open an issue.

**Sub-nav** on the HTML page now includes a "Provenance" anchor between "Human review" and "Regulatory." The old "on the roadmap" bullet under Regulatory is replaced with a cross-link up to the new section.

## Closes the narrative gap

This is the public statement that earns the full-credit version of the Mozilla/EFF-adjacent review: stages 2–4 shipped the actual signing; stage 5 is the page we'd point the commentator at.

## Test plan

- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean.
- [x] Manual render check: docs MDX compiles, HTML renders with updated TOC.
- [ ] Fly deploy — static content only; no runtime behavior change.

Refs #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)