### PR TITLE
schemas(push-notification-config): state legacy/9421 precedence in authentication field

### DIFF
--- a/.changeset/webhook-auth-precedence-schema.md
+++ b/.changeset/webhook-auth-precedence-schema.md
@@ -1,0 +1,15 @@
+---
+---
+
+schemas(push-notification-config): state legacy/9421 precedence in the `authentication` field description
+
+Schema-only readers (SDK authors building off `push-notification-config.json` without cross-referencing `security.mdx`) previously had to infer the precedence rule for the both-present case: seller publishes a 9421 webhook-signing key in adagents.json AND buyer populates `authentication.schemes`. The normative answer already lives in `security.mdx` §Webhook callbacks ("Mode selection is a switch, not both"), but was invisible from the schema alone.
+
+The `authentication` field description now states:
+
+- Presence of the block selects the legacy scheme; absence selects 9421 — a switch, not a fallback.
+- Sellers MUST NOT sign both ways; buyers MUST NOT attempt try-9421-then-HMAC verification.
+- The seller's always-discoverable baseline 9421 key is not a selector.
+- Points at `security.mdx#webhook-callbacks` for the full downgrade-resistance rules (including `webhook_mode_mismatch`).
+
+No normative change — this surfaces existing security.mdx rules at the schema where SDK authors read them. Closes #2503.

--- a/static/schemas/source/core/push-notification-config.json
+++ b/static/schemas/source/core/push-notification-config.json
@@ -17,7 +17,7 @@
     },
     "authentication": {
       "type": "object",
-      "description": "Legacy authentication configuration (A2A-compatible). Opts the seller into Bearer or HMAC-SHA256 signing instead of the default RFC 9421 webhook profile. Deprecated; removed in AdCP 4.0. When omitted, the seller MUST sign webhooks with the 9421 profile.",
+      "description": "Legacy authentication configuration (A2A-compatible). Opts the seller into Bearer or HMAC-SHA256 signing instead of the default RFC 9421 webhook profile. Deprecated; removed in AdCP 4.0. **Precedence is a switch, not a fallback:** presence of this block selects the legacy scheme; absence selects 9421. A seller MUST NOT sign the same webhook both ways, and a buyer MUST NOT attempt 'try 9421 first, fall back to HMAC' verification — signature mode is determined solely by whether this block was present at registration time. The seller's baseline 9421 webhook-signing key published at its brand.json `agents[]` `jwks_uri` does not override this selector; it is always discoverable but only used when `authentication` is omitted. See docs/building/implementation/security.mdx#webhook-callbacks for the full precedence and downgrade-resistance rules (including the `webhook_mode_mismatch` rejection a buyer MUST apply when a received webhook's signing mode does not match the registered mode).",
       "properties": {
         "schemes": {
           "type": "array",


### PR DESCRIPTION
## Summary

- Issue #2503 asks which webhook-signing scheme wins when a seller publishes a 9421 key in adagents.json (baseline, always discoverable for 3.0 sellers) AND the buyer populates `push_notification_config.authentication`.
- The normative answer already lives in `security.mdx` §Webhook callbacks — "Mode selection is a switch, not both" at line 1039, plus the `webhook_mode_mismatch` rules at lines 1073–1077 — but was invisible from the schema alone, so an SDK author reading `push-notification-config.json` could reasonably think the spec is silent (as surfaced in adcp-client-python PR #213).
- This PR tightens the `authentication` field description to surface the existing rules at the schema. **No normative change.**

The new description says:

- Presence of the block selects the legacy scheme; absence selects 9421 — a switch, not a fallback.
- Sellers MUST NOT sign both ways; buyers MUST NOT attempt 'try 9421 first, fall back to HMAC' verification.
- The seller's always-discoverable baseline 9421 key does not override this selector.
- Points at `docs/building/implementation/security.mdx#webhook-callbacks` for the full precedence and downgrade-resistance rules (including `webhook_mode_mismatch`).

## Expert review

- **ad-tech-protocol-expert**: Clean. Every MUST maps to an existing clause in `security.mdx:1037/1039/1073/1077`. No new normative content. `authentication: {}` is not an ambiguous state because the schema already requires both `schemes` and `credentials` inside `authentication` with `additionalProperties: false`.
- **security-reviewer**: No downgrade daylight in the new wording. Flagged three nice-to-haves that would require updates to `security.mdx` (mid-task re-registration semantics via `tasks/pushNotificationConfig/set`, seller-side log-and-require-9421-on-registration mitigation pointer, and a forbid-concurrent-emission clause). Out of scope for a schema-description PR; filing as follow-up.

## Test plan

- [x] 587 unit tests pass
- [x] typecheck clean
- [x] JSON schema still parses
- [ ] CI green

Closes #2503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)