### PR TITLE
docs(security): cross-link multi-tenancy isolation between security.mdx and accounts-and-security.mdx

### DIFF
--- a/.changeset/cross-link-multi-tenancy-isolation.md
+++ b/.changeset/cross-link-multi-tenancy-isolation.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: cross-link multi-tenancy isolation requirements between `security.mdx` and `accounts-and-security.mdx`. Surfaces the three MUST rules (bind on create, verify on access, fail closed) and projection-field leakage defense on the page a hostile reviewer reads first. Closes #2398.

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -159,7 +159,13 @@ function validateToken(token, operationType) {
 
 Every piece of state — media buys, creatives, idempotency cache entries, session IDs, governance tokens — is scoped to the [account](/docs/reference/glossary#a) that owns it. Cross-account reads MUST return a generic "not found" rather than leak existence. The authenticated [agent](/docs/reference/glossary#a) is how the seller knows *who is calling*; the `account` on the request is *what billing relationship the call is acting on*. Isolation requires both checks.
 
-See the glossary for the formal definitions of [Account](/docs/reference/glossary#a) and [Agent](/docs/reference/glossary#a).
+Sales agents MUST:
+
+1. **Bind on create** — permanently associate each object (media buy, creative, session, etc.) with the account used on the request that created it.
+2. **Verify on access** — on every subsequent read or modification, verify the authenticated agent has access to the object's bound account.
+3. **Fail closed** — when verification fails, return a generic error (status 403 or 404 is acceptable, but the body MUST NOT distinguish "unauthorized" from "not found" or name the account). Never fall through to the resource query.
+
+See [Accounts & Security — Data Isolation](/docs/media-buy/advanced-topics/accounts-and-security#data-isolation) for the billing-relationship model these rules enforce, and the glossary for the formal definitions of [Account](/docs/reference/glossary#a) and [Agent](/docs/reference/glossary#a).
 
 ### The two-step pattern
 
@@ -200,7 +206,7 @@ Filtering by the *whole* authorized set on a by-ID lookup is a regression: a `ge
 
 ### Row-Level Security
 
-Implement row-level security at the database layer so a bug in one handler cannot punch through the wall:
+The most common isolation failure is **IDOR via joined or nested relations**: a query scopes the primary table by `account_id` but joins or returns fields from a related table (line items, creatives, delivery rows) that was never filtered by the same principal. Defend per-principal at the data layer, not just in handler code, so a bug in one handler cannot punch through the wall:
 
 ```sql
 -- PostgreSQL example

--- a/docs/media-buy/advanced-topics/accounts-and-security.mdx
+++ b/docs/media-buy/advanced-topics/accounts-and-security.mdx
@@ -40,6 +40,8 @@ This model ensures that one account's data cannot be accessed by agents who lack
 
 ## Security Requirements
 
+For the full normative implementation reference — two-step authorization, row-level security, IDOR defense, and the wider security posture (webhooks, idempotency, signed governance context) — see [Security — Agent and Account Isolation](/docs/building/implementation/security#agent-and-account-isolation).
+
 ### Required Security Measures
 
 Sales agent implementations **MUST**:


### PR DESCRIPTION
## Summary
- Adds an explicit three-MUST isolation list (bind on create, verify on access, fail closed) to `security.mdx` — the page a hostile reviewer or regulator reads first.
- Adds a note on **IDOR via joined or nested relations** as the most common isolation failure mode, preceding the existing Row-Level Security code.
- Bidirectional anchored cross-links between `security.mdx#agent-and-account-isolation` and `accounts-and-security.mdx#data-isolation` so readers of either page land on the corresponding section of the other.
- Quick fix per #2398: cross-link only, no schema changes.

Applied feedback from security-reviewer and docs-expert before pushing: tightened "fail closed" to forbid body-level distinction between unauthorized/not-found, replaced non-canonical "projection-field leakage" with "IDOR via joined or nested relations", unbolded `MUST` to match file voice, anchored both cross-links.

## Test plan
- [x] `npm run test:docs-nav` — passes (15/15)
- [x] Precommit: `npm run test:unit` (587/587) + `npm run typecheck` — passes
- [x] Mintlify docs validation — passes (pre-existing a11y warnings unrelated)
- [ ] CI green
- [ ] Anchored links render correctly on preview deploy

Closes #2398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)