### PR TITLE
fix(schema): add targeting_overlay to PackageStatus (#2488)

### DIFF
--- a/.changeset/package-status-targeting-overlay.md
+++ b/.changeset/package-status-targeting-overlay.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": minor
 ---
 
-Add optional `targeting_overlay` to the `PackageStatus` shape returned by `get_media_buys`. Sellers SHOULD echo persisted targeting from `create_media_buy` / `update_media_buy` so buyers can verify what was stored without replaying the original request, mirroring the echo pattern already used for budget, pricing, and dates. Sellers claiming the `property-lists` or `collection-lists` specialisms MUST echo the persisted `PropertyListReference` / `CollectionListReference`. Resolves #2488.
+Add optional `targeting_overlay` to the `PackageStatus` shape returned by `get_media_buys`. Sellers SHOULD echo persisted targeting from `create_media_buy` / `update_media_buy` so buyers can verify what was stored without replaying the original request, mirroring the echo pattern already used for budget, pricing, and dates. Sellers claiming the `property-lists` or `collection-lists` specialisms MUST include, within this `targeting_overlay`, the `PropertyListReference` / `CollectionListReference` they persisted. Resolves #2488.

--- a/.changeset/package-status-targeting-overlay.md
+++ b/.changeset/package-status-targeting-overlay.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `targeting_overlay` to the `PackageStatus` shape returned by `get_media_buys`. Sellers SHOULD echo persisted targeting from `create_media_buy` / `update_media_buy` so buyers can verify what was stored without replaying the original request, mirroring the echo pattern already used for budget, pricing, and dates. Sellers claiming the `property-lists` or `collection-lists` specialisms MUST echo the persisted `PropertyListReference` / `CollectionListReference`. Resolves #2488.

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -155,8 +155,8 @@ phases:
         comply_scenario: media_buy_lifecycle
         stateful: true
         expected: |
-          Return the media buy with packages[0].targeting.property_list and
-          .collection_list populated with the list_id values sent on create.
+          Return the media buy with packages[0].targeting_overlay.property_list
+          and .collection_list populated with the list_id values sent on create.
 
         sample_request:
           media_buy_ids:

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -193,7 +193,7 @@
                 },
                 "targeting_overlay": {
                   "$ref": "/schemas/core/targeting.json",
-                  "description": "Targeting overlay applied to this package, echoed from the most recent create_media_buy or update_media_buy. Sellers SHOULD echo any persisted targeting so buyers can verify what was stored without replaying their own request. Sellers claiming the property-lists or collection-lists specialisms MUST echo the persisted PropertyListReference / CollectionListReference."
+                  "description": "Targeting overlay applied to this package, echoed from the most recent create_media_buy or update_media_buy. Sellers SHOULD echo any persisted targeting so buyers can verify what was stored without replaying their own request. Sellers claiming the property-lists or collection-lists specialisms MUST include, within this targeting_overlay, the PropertyListReference / CollectionListReference they persisted."
                 },
                 "start_time": {
                   "type": "string",

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -191,6 +191,10 @@
                   "description": "Goal impression count for impression-based packages",
                   "minimum": 0
                 },
+                "targeting_overlay": {
+                  "$ref": "/schemas/core/targeting.json",
+                  "description": "Targeting overlay applied to this package, echoed from the most recent create_media_buy or update_media_buy. Sellers SHOULD echo any persisted targeting so buyers can verify what was stored without replaying their own request. Sellers claiming the property-lists or collection-lists specialisms MUST echo the persisted PropertyListReference / CollectionListReference."
+                },
                 "start_time": {
                   "type": "string",
                   "format": "date-time",


### PR DESCRIPTION
## Summary

- Add optional `targeting_overlay` to the `PackageStatus` shape in `get-media-buys-response.json` so sellers can echo applied targeting back to buyers — closes the gap that made storyboard assertions on `media_buys[0].packages[0].targeting_overlay.property_list.list_id` unreachable at the schema layer
- Normative wording: `SHOULD` echo for all sellers, `MUST` echo `PropertyListReference` / `CollectionListReference` for sellers claiming the `property-lists` / `collection-lists` specialisms
- Fix storyboard narrative drift in `inventory_list_targeting.yaml` (`packages[0].targeting` → `targeting_overlay`) so the prose matches the already-correct validation paths

Resolves #2488.

## Why this is a `minor` bump

Per `.agents/playbook.md`: "MINOR: Add optional fields, new enum values, new tasks." Purely additive, `additionalProperties: true` already on PackageStatus, and `create_media_buy_response` / `update_media_buy_response` already carry the field via `$ref` to `core/package.json` — so consumers generating types from the schema see an additive `Optional[TargetingOverlay]` on `PackageStatus` and no breakage elsewhere.

## Expert review notes

Ran the change past the protocol expert and the product expert. Both said ship. Applied their converging feedback:

- Tightened the `MUST` → `SHOULD`+`MUST` split (protocol expert flagged the original wording was too narrow for non-specialism sellers; product expert wanted universal `MUST` but agreed `SHOULD` at 3.0 GA with a promotion path is the safer compat call)
- Mirrored the wording change in the changeset
- Fixed the storyboard narrative drift the product expert flagged

Deferred follow-ups (not this PR):
- `measurement_terms` and `performance_standards` are likely the next PackageStatus echo gaps, following the same pattern — separate issue worth filing
- Docs paragraph in `get_media_buys.mdx` calling out `targeting_overlay` as the verification surface — schema-only is fine for now since task-ref docs are largely schema-generated

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run build:compliance` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:examples` — 31/31
- [ ] Storyboard re-run against a conformant seller agent should now grade the four previously-unreachable `field_value` assertions on `media_buys[0].packages[0].targeting_overlay.{property_list,collection_list}.list_id`
- [ ] `adcp-client` can narrow its `storyboard-drift.test.js` allowlist to the specific four paths once this lands (noted in #2488)

## Note on commit hook

Committed with `--no-verify` (author-authorized). The Husky precommit hook runs the full vitest unit suite, which hung on infra (DB connection in an addie escalation test) for ~10 minutes at 0% CPU. Unrelated to this change — the diff is schema JSON + storyboard YAML + changeset, no server code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)