### PR TITLE
chore(gitguardian): whitelist HMAC test-vector secret (unblocks #2460)

### DIFF
--- a/.changeset/gitguardian-whitelist-hmac-testvector.md
+++ b/.changeset/gitguardian-whitelist-hmac-testvector.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore(gitguardian): whitelist webhook HMAC test-vector secret
+
+Unblocks the high-entropy webhook HMAC test-vector secret at
+`static/test-vectors/webhook-hmac-sha256.json` from GitGuardian's
+generic-high-entropy detector. The secret is deterministically derived
+from a documented preimage and the test-vector file carries explicit
+WARNING + `secret_provenance` fields documenting non-production status.

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -20,3 +20,14 @@ matches-ignore:
     comment: |
       This is a placeholder API key used in documentation examples.
       It's not a real credential.
+  - name: Webhook HMAC-SHA256 Test Vector Secret
+    match: cc237f7fe354609bb41360c6530a2deb7926f3cc55e91df3ff90e37202950b6c
+    comment: |
+      High-entropy test secret for the HMAC-SHA256 webhook test vectors
+      at static/test-vectors/webhook-hmac-sha256.json. Derived
+      deterministically from a documented preimage (SHA-256 of
+      "adcp-webhook-hmac-test-vector-v1-DO-NOT-USE-IN-PRODUCTION") so
+      cross-language test runs are reproducible. The file carries an
+      explicit WARNING field and secret_provenance field documenting
+      non-production status; negative vectors verify the WARNING remains
+      present and that weak-secret configurations are rejected.


### PR DESCRIPTION
## Summary
Whitelists the webhook HMAC test-vector secret in `.gitguardian.yaml` so GitGuardian's generic high-entropy-secret detector stops flagging it on #2460.

The secret is:
- Deterministically derived from a documented preimage (SHA-256 of `adcp-webhook-hmac-test-vector-v1-DO-NOT-USE-IN-PRODUCTION`)
- Accompanied by an explicit top-level `WARNING` field calling out non-production status
- Guarded by negative vectors in `tests/webhook-hmac-vectors.test.cjs` that require the WARNING to remain present

Follows the existing pattern for test-token whitelisting (`1v8tAhAS…` test-agent token, `aao_xxx` placeholder).

## Why now
#2460 is blocked on this check. GitGuardian's `matches-ignore` config is read from the default branch, so the whitelist has to land on main before the scan on #2460 can pass — landing the config separately first.

## Test plan
- [x] `.gitguardian.yaml` parses as valid YAML
- [ ] CI green on this PR
- [ ] After merge, GitGuardian re-run on #2460 passes