### PR TITLE
docs(faq): add UCP/ACP comparison entry + fix broken ACP link

### DIFF
--- a/.changeset/faq-add-ucp-acp-comparison.md
+++ b/.changeset/faq-add-ucp-acp-comparison.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(faq): add "How does AdCP compare to UCP and ACP?" entry clarifying that UCP and ACP standardize the commerce layer (checkout, payments, fulfillment) while AdCP standardizes the advertising layer, with SI Chat Protocol as the handoff point. Also fixes a broken ACP reference link in the SI Chat Protocol page (was pointing at an unrelated Anthropic Agent Client Protocol repo).

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -149,6 +149,21 @@ As of April 2026:
 We do not yet publish a formal technical comparison because AAMP is still defining its normative surface. Implementers interested in both should watch both specifications as they stabilize.
 </Accordion>
 
+<Accordion title="How does AdCP compare to UCP and ACP?">
+Google's Universal Commerce Protocol (UCP) — developed with Shopify, Walmart, Target, and others — and OpenAI and Stripe's Agentic Commerce Protocol (ACP) standardize *commerce* in AI assistants: checkout, payments, and fulfillment. AdCP standardizes *advertising*: how offers get surfaced, how a brand agent engages a user, and how attribution flows back.
+
+These are different layers, not competing specifications.
+
+| Layer | Standard | What it does |
+|---|---|---|
+| Commerce | UCP, ACP | Checkout, payments, fulfillment, order status |
+| Advertising | AdCP | Sponsored discovery, media buying, creative, brand governance, attribution |
+
+The layers meet at the handoff. The [SI Chat Protocol](/docs/sponsored-intelligence/si-chat-protocol) runs a conversational brand experience inside an AI assistant; when the user decides to buy, the host hands off to ACP or UCP for checkout, carrying the SI `session_id` through as context so the transaction can be attributed back to the sponsored conversation. The commerce protocol's own session owns the purchase flow. AdCP owns the path up to the handoff; the commerce protocol owns the transaction.
+
+A platform implementing both sees AdCP for "surface the right offer and engage the user" and UCP/ACP for "take the payment." Neither substitutes for the other.
+</Accordion>
+
 <Accordion title="Why not just roll our own protocol?">
 You can, and for some deployments that is the right call — proprietary internal protocols are fine when the scope stays inside a single organization.
 

--- a/docs/sponsored-intelligence/si-chat-protocol.mdx
+++ b/docs/sponsored-intelligence/si-chat-protocol.mdx
@@ -75,7 +75,7 @@ The `session_id` flows through to ACP checkout via `context_for_checkout`, enabl
 
 ## How It Works
 
-SI handles the engagement. The [Agentic Commerce Protocol (ACP)](https://github.com/anthropics/acp)—an open standard by OpenAI and Stripe for programmatic commerce—handles the transaction. This separation keeps the user's trusted relationship with the host while enabling seamless checkout.
+SI handles the engagement. The [Agentic Commerce Protocol (ACP)](https://agenticcommerce.dev)—an open standard by OpenAI and Stripe for programmatic commerce—handles the transaction. This separation keeps the user's trusted relationship with the host while enabling seamless checkout.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary

Closes the FAQ coverage gap flagged in #2379. The known-limitations page and the OpenRTB / AAMP / "roll our own" / MCP FAQ entries were already complete; the only missing piece was UCP.

- Adds a new FAQ entry "How does AdCP compare to UCP and ACP?" under `docs/faq.mdx`, placed after the AAMP entry. Framing: UCP (Google/Shopify/Walmart/Target) and ACP (OpenAI/Stripe) standardize the commerce layer (checkout, payments, fulfillment); AdCP standardizes the advertising layer (sponsored discovery, media buying, creative, brand governance, attribution); SI Chat Protocol is the handoff point, with the SI `session_id` carried into the commerce session as context.
- Fixes a broken ACP reference in `docs/sponsored-intelligence/si-chat-protocol.mdx:78` — the link pointed to `github.com/anthropics/acp` (Anthropic's unrelated Agent Client Protocol) while the surrounding text described OpenAI and Stripe's Agentic Commerce Protocol. Updated to `agenticcommerce.dev` (the canonical site, verified). This was discovered while working on the FAQ entry; two expert reviewers flagged it independently.

## Review notes

- Ran docs-expert, ad-tech-protocol-expert, code-reviewer, and security-reviewer before pushing. Incorporated their feedback: tightened "discovery" to "sponsored discovery" in the layer table (UCP does reach into product discovery surfaces, so the distinguishing word is *sponsored*), added a clause on session composition (SI `session_id` is carried *as context*, not replacing the commerce session), and verified the canonical UCP and ACP URLs against their official sites before restoring any links.
- Known-limitations page was already comprehensive — no edits needed there.

## Test plan

- [x] `npm run test:docs-nav` — passed
- [x] `npm run check:owned-links` — passed
- [x] Pre-commit hook (vitest + typecheck) — passed (587 tests, 29 files)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)