### PR TITLE
fix(compliance): thread brand through session-scoped storyboard steps (#2236)

### DIFF
--- a/.changeset/thread-brand-through-media-buy-seller-storyboards.md
+++ b/.changeset/thread-brand-through-media-buy-seller-storyboards.md
@@ -1,0 +1,13 @@
+---
+---
+
+Storyboard fix: three `media_buy_seller` scenarios now thread `brand: { domain: "acmeoutdoor.example" }` on every session-scoped step's `sample_request`, instead of only on the opening `get_products` / `create_media_buy` steps.
+
+Affected storyboards:
+- `media_buy_seller/inventory_list_targeting` — `get_after_create`, `update_buy_swap_lists`, `get_after_update`
+- `media_buy_seller/invalid_transitions` — `update_unknown_package`, `first_cancel`, `second_cancel`
+- `media_buy_seller/pending_creatives_to_start` — `sync_creative`, `assign_creative_to_package`, `get_media_buy_after_sync`
+
+Without this, the later steps landed in `open:default` while the `create_media_buy` step wrote to `open:acmeoutdoor.example`, so any seller that scopes session state by brand (spec-required for multi-tenant isolation) correctly refused to return the buy and the storyboard scored it as a failure.
+
+Unblocks end-to-end verification for the collection-list CRUD complaint in adcontextprotocol/adcp#2236 (training-agent server handlers were always correct — the test harness was asking the wrong session). Latent CLI bug in the runner filed as adcontextprotocol/adcp-client#637: `adcp storyboard run <agent> --file <path>` doesn't strip the file path from positional args, so a local YAML edit can't currently be verified end-to-end via the CLI.

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -177,6 +177,8 @@ phases:
           - context echoed unchanged
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "does-not-exist-package-invalid-transitions-v1"
@@ -216,6 +218,8 @@ phases:
           Seller acknowledges the cancellation and transitions the buy to canceled.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Testing NOT_CANCELLABLE on re-cancel"
@@ -241,6 +245,8 @@ phases:
           - context echoed unchanged
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Deliberate re-cancel to force NOT_CANCELLABLE"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -159,6 +159,8 @@ phases:
           .collection_list populated with the list_id values sent on create.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_ids:
             - "$context.media_buy_id"
 
@@ -198,6 +200,8 @@ phases:
           collection_list are replaced (not merged) with the new list_id values.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "$context.package_id"
@@ -229,6 +233,8 @@ phases:
           in persistent state just like fields on create_media_buy.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_ids:
             - "$context.media_buy_id"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -149,6 +149,8 @@ phases:
         expected: |
           The seller ingests the creative and returns status active (or approved).
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           creatives:
             - creative_id: "acme-outdoor-display-q3"
               name: "Acme Outdoor Q3 display"
@@ -175,6 +177,8 @@ phases:
           status should be pending_start (or active if the flight has started).
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "$context.package_id"
@@ -211,6 +215,8 @@ phases:
           The media buy's persisted status is pending_start (or active). valid_actions
           no longer includes sync_creatives as a required next step.
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           media_buy_ids:
             - "$context.media_buy_id"
 


### PR DESCRIPTION
## Summary

- Three `media_buy_seller` scenarios had `brand: { domain: "acmeoutdoor.example" }` on the opening `get_products` / `create_media_buy` step but omitted it on the follow-up `get_media_buys` / `update_media_buy` / `sync_creatives` steps. That made each run land in `open:default` for the later calls while `create_media_buy` wrote to `open:acmeoutdoor.example`, so any seller scoping session state by brand (spec-required for multi-tenant isolation) correctly refused to return the buy — and the storyboard scored it as a failure.
- Added `brand: { domain: "acmeoutdoor.example" }` to every session-scoped step across `inventory_list_targeting`, `invalid_transitions`, `pending_creatives_to_start` (9 steps, matching the already-passing `inventory_list_no_match` pattern).
- Left `sync_accounts` / `sync_governance` / `comply_test_controller` steps alone — their handlers are global / test-control and don't derive from `sessionKeyFromArgs`.

## Why

Closes the verification gap in #2236. Training-agent handlers for `get_collection_list` / `update_collection_list` / `create_media_buy` with `targeting.collection_list` are correct (see `server/src/training-agent/inventory-governance-handlers.ts` and `task-handlers.ts:138-149`). The remaining failures on live `test-agent.adcontextprotocol.org` were entirely driven by the storyboard harness asking the wrong session.

`@adcp/client` 5.2.0 added `applyBrandInvariant` as a runner-layer safety net (PR adcp-client#586), but it only fires when the caller sets `options.brand` — the CLI doesn't currently expose that flag, so each step's `sample_request.brand` is authoritative in the typical invocation. Fixing the YAMLs is the right layer until the CLI lands a passthrough.

## Protocol review

ad-tech-protocol-expert confirmed per-request brand is spec-correct — AdCP has no session-login primitive, MCP is stateless per call, and relying on prior-step brand would break horizontal scaling. Task classification (which tasks need tenant scoping vs. which don't) matches `sessionKeyFromArgs` semantics in `server/src/training-agent/state.ts:307-330`.

## Follow-ups (filed, non-blocking)

- #2527 — storyboard lint rule: any `stateful: true` step on a tenant-scoped task must carry `brand` or `account.brand`.
- #2528 — standardize buyer-side storyboards on `account { brand, operator }` (currently mixed with top-level `brand`).
- adcontextprotocol/adcp-client#637 — CLI `--file <path>` lands in positional args, blocks local-YAML verification.
- adcontextprotocol/adcp-client#639 — CLI `--brand` passthrough so `applyBrandInvariant` fires from `adcp storyboard run` (defense-in-depth behind the storyboard lint).

Close #2236 once the next `@adcp/client` release pulls this into the compliance cache and `inventory_list_targeting` scores green end-to-end.

## Test plan

- [x] `npm run build:compliance` succeeds with the edited YAMLs.
- [x] `node -e` parses all three files via `js-yaml`; every session-scoped step's `sample_request.brand.domain` === `"acmeoutdoor.example"`.
- [x] Precommit hook passed (587 tests, typecheck clean).
- [ ] After release + cache sync, re-run `npx @adcp/client storyboard run test-mcp media_buy_seller/inventory_list_targeting` against `test-agent.adcontextprotocol.org` and confirm 5/5 steps pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)