### PR TITLE
docs(reference): add test-vectors index page + fix broken canonical URLs

### DIFF
--- a/.changeset/test-vectors-index-page.md
+++ b/.changeset/test-vectors-index-page.md
@@ -1,0 +1,18 @@
+---
+---
+
+docs: add `/docs/reference/test-vectors/` index page cataloging the 8 reference vector sets that ship today, and fix three broken canonical-URL sites discovered while drafting it.
+
+**New page** (`docs/reference/test-vectors/index.mdx`): catalogs `request-signing`, `webhook-signing`, `plan-hash` (compliance-tree, versioned) and `transport-error-mapping`, `mcp-response-extraction`, `a2a-response-extraction`, `webhook-payload-extraction`, `webhook-hmac-sha256` (transport fixtures, unversioned). Frames vectors as complements to storyboards without making a conformance claim, states honest versioning policy (compliance-tree sets frozen per GA at `/compliance/{version}/test-vectors/{set}/`; transport fixtures unversioned and SHOULD be vendored by SHA), enumerates the 8 public `kid`s currently published across the two signing sets with a "present or future, any kid in any `keys.json`" non-trust rule, and points `#2383` / 3.1 as the home for task-level fill-in. Wired into the sidebar under Reference.
+
+**Bug fix — three broken canonical-URL sites** found by curling against the live CDN. The signing READMEs and one `security.mdx` link pointed at `https://adcontextprotocol.org/test-vectors/{request,webhook}-signing/` paths that return 404; the resolvable canonical is `/compliance/{version}/test-vectors/{set}/`, served by `server/src/schemas-middleware.ts` from `dist/compliance/` (built by `scripts/build-compliance.cjs` from `static/compliance/source/`). Fixed in:
+
+- `docs/building/implementation/security.mdx:840` — `canonicalization.json` link
+- `static/compliance/source/test-vectors/request-signing/README.md:7` — "Canonical URLs" paragraph
+- `static/compliance/source/test-vectors/webhook-signing/README.md:7` — same
+
+Any SDK, CI config, or cached doc that was consuming the old `/test-vectors/{request,webhook}-signing/…` path was already 404ing. No behavior change on URLs that actually resolved.
+
+**Backlink** from `docs/building/conformance.mdx:130` so readers land on the new index when the conformance doc mentions reference vectors.
+
+No spec/schema changes. No change to the compliance build. Deferred out of scope and noted in this PR's description: README structural parallelism (symmetric section headings across the two signing READMEs), a sibling machine-readable `index.json`, and a task-level vector corpus.

--- a/docs.json
+++ b/docs.json
@@ -496,6 +496,7 @@
                   "docs/reference/media-channel-taxonomy",
                   "docs/reference/roadmap",
                   "docs/reference/versioning",
+                  "docs/reference/test-vectors/index",
                   "docs/reference/experimental-status",
                   "docs/reference/v2-sunset",
                   "docs/reference/known-limitations",

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -127,7 +127,7 @@ Conformance is per-version; the suite is per-version. A 3.0-conformant agent is 
 
 - **Define individual MUSTs.** The storyboards do. If a rule isn't in a storyboard, it isn't part of conformance.
 - **Grant or revoke certification.** The [AgenticAdvertising.org certification program](/docs/learning/overview) runs on top of this; conformance is necessary but not sufficient.
-- **Publish reference test vectors beyond those already in the suite.** Broader test-vector corpus: [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
+- **Publish reference test vectors beyond those already in the suite.** The [Reference Test Vectors index](/docs/reference/test-vectors) catalogs the vector sets that ship today; broader task-level corpus lands incrementally between 3.0 GA and 3.1, scoped in [#2383](https://github.com/adcontextprotocol/adcp/issues/2383).
 
 ## Further reading
 

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -837,7 +837,7 @@ This profile constrains RFC 9421 to a single canonical shape so cross-implementa
 
 Signers that canonicalize and verifiers that canonicalize MUST produce identical bytes for the same logical request. If your 9421 library applies different rules, either configure it to match this profile or normalize before handing the URL to the library.
 
-The [`canonicalization.json`](https://adcontextprotocol.org/test-vectors/request-signing/canonicalization.json) conformance set exercises every rule above with fixed inputs and expected outputs, plus malformed-authority rejection cases. SDKs SHOULD run this set on every commit — canonicalization divergence between signers is silent until it isn't, and then it's a production interop bug that's painful to diagnose.
+The [`canonicalization.json`](https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/canonicalization.json) conformance set exercises every rule above with fixed inputs and expected outputs, plus malformed-authority rejection cases. SDKs SHOULD run this set on every commit — canonicalization divergence between signers is silent until it isn't, and then it's a production interop bug that's painful to diagnose.
 
 Verifiers MUST reject signatures whose covered-component list omits any required component for the request type. Signers MUST NOT cover additional headers without coordination — extra components silently invalidate signatures across implementations that don't include them.
 

--- a/docs/reference/test-vectors/index.mdx
+++ b/docs/reference/test-vectors/index.mdx
@@ -1,0 +1,56 @@
+---
+title: Reference Test Vectors
+sidebarTitle: Reference test vectors
+description: "Machine-readable fixtures SDKs and implementations diff against to confirm wire-format agreement. Versioned alongside the spec; frozen at each release."
+"og:title": "AdCP — Reference Test Vectors"
+---
+
+**Status**: Request for Comments
+**Last Updated**: April 20, 2026
+
+## What these are
+
+Reference test vectors are machine-readable JSON fixtures pinned to specific wire-format rules in the spec. An SDK whose output matches a vector's `expected_*` field byte-for-byte has agreed with the reference on that rule's wire format — not a conformance claim (only [storyboards](/docs/building/conformance) decide that), but a necessary precondition for interop. An SDK that diverges has an interop bug, even if its own tests pass.
+
+Vectors complement [storyboards](/docs/building/conformance). Storyboards exercise an agent end-to-end to produce a pass/fail verdict; vectors exercise a library in isolation against frozen inputs. A vector tells a signer "this 9421 request MUST produce this signature base"; a storyboard tells an agent "when the buyer sends this request, you MUST respond with a result shaped like this." Most conformant stacks need both — vectors catch canonicalization drift inside a library; storyboards catch behavior drift at the wire.
+
+Vectors are not the conformance specification — the [storyboards](/docs/building/conformance) are. Vectors are reference inputs the storyboards and SDK unit tests consume.
+
+## Versioning
+
+Vector sets published under the compliance tree — `request-signing`, `webhook-signing`, `plan-hash` — are versioned alongside the spec. The copy served at `/compliance/{version}/test-vectors/{set}/` is frozen at the GA release of that version; fixes that change a vector's bytes ship in the next AdCP minor release. `/compliance/latest/test-vectors/{set}/` tracks the most recent GA and moves under you between releases.
+
+The transport and response-extraction vectors served at `/test-vectors/{name}.json` are currently unversioned: each file is overwritten in place when it changes. SDKs that consume these fixtures SHOULD vendor a commit-pinned copy, for example fetching from `https://raw.githubusercontent.com/adcontextprotocol/adcp/<sha>/static/test-vectors/<name>.json` and recording `<sha>` in their lockfile, until these files are rolled into the versioned compliance tree.
+
+SDKs SHOULD fetch versioned paths where available and record the version under test. For pinned versions, the CDN copy at `/compliance/{version}/...` is the source of truth; `/compliance/latest/...` is a convenience alias, not a stable pin.
+
+## Published sets
+
+| Set | What it pins | Source | CDN |
+|---|---|---|---|
+| [`request-signing`](https://github.com/adcontextprotocol/adcp/tree/main/static/compliance/source/test-vectors/request-signing) | RFC 9421 request-signing profile: canonical signature base, covered components, signature params, tag namespace, alg allowlist, `adcp_use` discriminator, replay dedup, revocation, content-digest semantics, and URL canonicalization | `static/compliance/source/test-vectors/request-signing/` | `/compliance/latest/test-vectors/request-signing/` |
+| [`webhook-signing`](https://github.com/adcontextprotocol/adcp/tree/main/static/compliance/source/test-vectors/webhook-signing) | RFC 9421 webhook-signing profile: required covered components (content-digest mandatory — no `forbidden` opt-out), `adcp/webhook-signing/v1` tag, `adcp_use: "webhook-signing"` discriminator, `webhook_signature_*` error taxonomy; shares `@target-uri` canonicalization with `request-signing` | `static/compliance/source/test-vectors/webhook-signing/` | `/compliance/latest/test-vectors/webhook-signing/` |
+| [`plan-hash`](https://github.com/adcontextprotocol/adcp/tree/main/static/compliance/source/test-vectors/plan-hash) | JCS canonicalization of the `plan_hash` preimage: required-only baseline, full-optional, bookkeeping-stripped, omitted-vs-explicit-null, array-order sensitivity, `ext.trace_id` distinctness, Unicode non-normalization (RFC 8785 §3.2.5) | `static/compliance/source/test-vectors/plan-hash/` | `/compliance/latest/test-vectors/plan-hash/` |
+| [`transport-error-mapping`](https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/transport-error-mapping.json) | Transport-layer error envelope shapes: the JSON-RPC (`error.code` / `data`) and A2A (task `status.message`) carriers for each documented AdCP transport error | `static/test-vectors/transport-error-mapping.json` | [`/test-vectors/transport-error-mapping.json`](https://adcontextprotocol.org/test-vectors/transport-error-mapping.json) |
+| [`mcp-response-extraction`](https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/mcp-response-extraction.json) | Client extraction of the AdCP payload from MCP `tools/call` envelopes | `static/test-vectors/mcp-response-extraction.json` | [`/test-vectors/mcp-response-extraction.json`](https://adcontextprotocol.org/test-vectors/mcp-response-extraction.json) |
+| [`a2a-response-extraction`](https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/a2a-response-extraction.json) | Client extraction of the AdCP payload from A2A task statuses and artifacts | `static/test-vectors/a2a-response-extraction.json` | [`/test-vectors/a2a-response-extraction.json`](https://adcontextprotocol.org/test-vectors/a2a-response-extraction.json) |
+| [`webhook-payload-extraction`](https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/webhook-payload-extraction.json) | Receiver-side format detection and payload extraction for inbound AdCP webhooks | `static/test-vectors/webhook-payload-extraction.json` | [`/test-vectors/webhook-payload-extraction.json`](https://adcontextprotocol.org/test-vectors/webhook-payload-extraction.json) |
+| [`webhook-hmac-sha256`](https://github.com/adcontextprotocol/adcp/blob/main/static/test-vectors/webhook-hmac-sha256.json) *(legacy)* | HMAC-SHA-256 signature computation and byte-equality invariants for the legacy HMAC webhook profile. Deprecated in 3.x, removed in 4.0 per [Webhook callbacks](/docs/building/implementation/webhooks#legacy-hmac-sha256-fallback-deprecated); new integrations use `webhook-signing` | `static/test-vectors/webhook-hmac-sha256.json` | [`/test-vectors/webhook-hmac-sha256.json`](https://adcontextprotocol.org/test-vectors/webhook-hmac-sha256.json) |
+
+**Start here**: every set's `README.md` in the source column documents file layout, key material, preconditions (e.g., runner state required for replay vectors), and how to wire the set into an SDK test loop. The README in the source tree is authoritative; the index on this page is a catalog, not an integration guide.
+
+Directory CDN paths (the three compliance-tree rows) are base paths for programmatic use — the CDN serves individual files, not directory listings. Browse the tree via the source column.
+
+## Test keys are public
+
+Every signing vector set ships private key material in `keys.json` so libraries can exercise signer and verifier roles against identical inputs. These keys are **valid only for grading against this suite**.
+
+Any production verifier that trusts a `kid` declared in one of the published `keys.json` files is exploitable — the private key is on the public CDN and anyone can forge signatures under that kid. At time of writing this includes `test-ed25519-2026`, `test-es256-2026`, `test-gov-2026`, `test-revoked-2026` (request-signing) and `test-ed25519-webhook-2026`, `test-es256-webhook-2026`, `test-wrong-purpose-2026`, `test-revoked-webhook-2026` (webhook-signing). Treat every `kid` that appears in any suite `keys.json` as untrusted outside grading, present or future.
+
+Production signers mint their own keypairs and publish under their own `jwks_uri`; production verifiers MUST NOT register any test `kid` in a trust store exposed to live traffic.
+
+## Planned coverage
+
+The sets above exercise transport, signing, and canonicalization rules that cross every surface. Task-level vectors — per-task request/response pairs covering happy path, each documented error code, lifecycle transitions, and idempotency replay/conflict/expired cases across the `media-buy/`, `creative/`, `signals/`, `curation/`, `brand-protocol/`, `trusted-match/`, and `sponsored-intelligence/` task directories — are scoped in [issue #2383](https://github.com/adcontextprotocol/adcp/issues/2383) against the **3.1** milestone and will land incrementally under this path between 3.0 GA and 3.1 release. (These are task directory names, not `supported_protocols` values; see the [Conformance Specification](/docs/building/conformance#protocol-conformance) for the protocol taxonomy.)
+
+Until task-level vectors ship, the authoritative source for task shapes is the pair of [conformance storyboards](https://adcontextprotocol.org/compliance/latest/) (wire behavior) and [JSON Schemas](https://github.com/adcontextprotocol/adcp/tree/main/static/schemas/source) (request/response shapes). Neither yields ready-made fixtures — implementers derive expected shapes from the schema and confirm wire behavior by running the storyboards against their agent.

--- a/static/compliance/source/test-vectors/request-signing/README.md
+++ b/static/compliance/source/test-vectors/request-signing/README.md
@@ -4,7 +4,7 @@ Test vectors for the AdCP RFC 9421 request-signing profile. These fixtures drive
 
 Specification: [Signed Requests (Transport Layer)](https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer) in `docs/building/implementation/security.mdx`.
 
-**Canonical URLs.** These vectors are served at `https://adcontextprotocol.org/test-vectors/request-signing/` (tree preserved — `keys.json`, `negative/*.json`, `positive/*.json` all resolvable). SDKs SHOULD fetch from the CDN path rather than requiring a checkout of the spec repo. Example: `https://adcontextprotocol.org/test-vectors/request-signing/positive/001-basic-post.json`.
+**Canonical URLs.** These vectors are served at `https://adcontextprotocol.org/compliance/{version}/test-vectors/request-signing/`, with `{version}` being either a specific release (e.g. `3.0.0`) or `latest` (tracks the most recent GA). Tree preserved — `keys.json`, `negative/*.json`, `positive/*.json` all resolvable. SDKs SHOULD fetch from the versioned CDN path and record the version under test rather than requiring a checkout of the spec repo. Example: `https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/positive/001-basic-post.json`.
 
 ## Scope
 

--- a/static/compliance/source/test-vectors/webhook-signing/README.md
+++ b/static/compliance/source/test-vectors/webhook-signing/README.md
@@ -4,7 +4,7 @@ Test vectors for the AdCP RFC 9421 webhook-signing profile. These fixtures drive
 
 Specification: [Webhook callbacks](https://adcontextprotocol.org/docs/building/implementation/security#webhook-callbacks) in `docs/building/implementation/security.mdx`.
 
-**Canonical URLs.** These vectors are served at `https://adcontextprotocol.org/test-vectors/webhook-signing/` (tree preserved — `keys.json`, `negative/*.json`, `positive/*.json` all resolvable). SDKs SHOULD fetch from the CDN path rather than requiring a checkout of the spec repo. Example: `https://adcontextprotocol.org/test-vectors/webhook-signing/positive/001-basic-post.json`.
+**Canonical URLs.** These vectors are served at `https://adcontextprotocol.org/compliance/{version}/test-vectors/webhook-signing/`, with `{version}` being either a specific release (e.g. `3.0.0`) or `latest` (tracks the most recent GA). Tree preserved — `keys.json`, `negative/*.json`, `positive/*.json` all resolvable. SDKs SHOULD fetch from the versioned CDN path and record the version under test rather than requiring a checkout of the spec repo. Example: `https://adcontextprotocol.org/compliance/latest/test-vectors/webhook-signing/positive/001-basic-post.json`.
 
 ## ⚠️ Security — test keys are public
 


### PR DESCRIPTION
## Summary

- Adds `/docs/reference/test-vectors/` landing page that catalogs the 8 reference vector sets that ship today and explains how vectors complement (not replace) the conformance storyboards — closes the discoverability acceptance bullet on #2383.
- Fixes **three broken canonical-URL sites** I found by curling the live CDN while drafting the index: `security.mdx:840` plus both signing READMEs were pointing at `https://adcontextprotocol.org/test-vectors/{request,webhook}-signing/` paths that 404; the resolvable canonical is the versioned `/compliance/{version}/test-vectors/{set}/` (verified 200 via the `dist/compliance` mount in `server/src/schemas-middleware.ts`).
- Adds a backlink from `conformance.mdx:130` so readers land on the new index when the conformance doc mentions reference vectors.

No spec, schema, or build changes.

## Scope

- **In scope**: index page, broken-URL fixes, backlink, sidebar wiring, changeset.
- **Deferred** (called out in the page itself): task-level vector corpus (per-task request/response pairs for `media-buy/`, `creative/`, etc.) is scoped against the **3.1** milestone on #2383 and lands incrementally between 3.0 GA and 3.1. README structural parallelism between the two signing sets and a machine-readable `index.json` sibling are both noted as follow-ups.

## Accuracy notes (worth a reviewer eyeball)

- The "What these are" framing at `index.mdx:13-17` claims vectors are a **precondition** for interop but not themselves a conformance claim — storyboards are the conformance spec (`conformance.mdx:128`). If that reads wrong to you, flag it.
- The public-keys warning at `index.mdx:44-50` enumerates all 8 published `kid`s (`test-ed25519-2026`, `test-es256-2026`, `test-gov-2026`, `test-revoked-2026` for request-signing; the four `*-webhook-2026` kids for webhook-signing) with a "present or future, any `kid` in any suite `keys.json`" catch-all. The enumeration is a snapshot; the catch-all is the load-bearing rule.
- `webhook-hmac-sha256` is flagged `*(legacy)*` in the table and links to `webhooks.mdx#legacy-hmac-sha256-fallback-deprecated` per the 4.0 removal plan.

## Bug-fix detail (items 2, 3, 4)

Old text (all three sites):
`https://adcontextprotocol.org/test-vectors/{request,webhook}-signing/…`  ← **404**

New text:
`https://adcontextprotocol.org/compliance/{version}/test-vectors/{set}/…`  ← verified **200**

The old path was never served — `server/src/schemas-middleware.ts` only mounts `/compliance/…`, and `static/test-vectors/…` is root-mounted via express for the five unversioned transport fixtures. Any SDK that was consuming the old URL was already failing.

## Test plan

- [ ] Mintlify build renders the new page at `/docs/reference/test-vectors` with the sidebar entry under the Reference group
- [ ] `docs/building/conformance.mdx` backlink on L130 resolves to the new page
- [ ] `docs/building/implementation/security.mdx:840` `canonicalization.json` link returns 200 (verified against live CDN)
- [ ] Both signing READMEs render cleanly on GitHub and via the `/compliance/latest/...` CDN path
- [ ] No broken internal anchors introduced (`#protocol-conformance` in conformance.mdx, `#legacy-hmac-sha256-fallback-deprecated` in webhooks.mdx)

Closes acceptance bullet on #2383 (discoverability); task-level corpus continues on 3.1 under the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)