### PR TITLE
fix(logger): skip pino-pretty transport in tests (closes #2541)

### DIFF
--- a/.changeset/fix-pino-transport-test-hang.md
+++ b/.changeset/fix-pino-transport-test-hang.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix the vitest teardown hang tracked in #2541.
+
+`server/src/logger.ts` enabled the `pino-pretty` transport whenever `NODE_ENV !== 'production'`. Pino's transport spawns a worker thread and registers `process.on('exit', ...)` — the worker thread is a held handle that prevents Node's event loop from draining at test teardown, causing vitest workers to zombie indefinitely.
+
+The logger now treats `NODE_ENV === 'test'` and the `VITEST=true` environment variable (auto-set by vitest) as non-development, so tests get the default synchronous stdout destination with no worker thread and no exit listener.
+
+Validated: 6 back-to-back runs, 587 tests each, all clean exits, no `MaxListenersExceededWarning`.

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -11,7 +11,8 @@
 
 import pino from 'pino';
 
-const isDevelopment = process.env.NODE_ENV !== 'production';
+const isTest = process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
+const isDevelopment = !isTest && process.env.NODE_ENV !== 'production';
 
 /**
  * Error hook type - called when logger.error() or logger.fatal() is invoked.


### PR DESCRIPTION
## Summary

- Fix the vitest teardown hang tracked in #2541.
- `server/src/logger.ts` enabled the `pino-pretty` transport whenever `NODE_ENV !== 'production'`. Pino's transport spawns a worker thread and registers `process.on('exit', ...)` (see `node_modules/pino/lib/transport.js:149`) — the worker thread is a held handle that prevents Node's event loop from draining at test teardown, causing vitest workers to zombie indefinitely.
- Treat `NODE_ENV=test` and `VITEST=true` (auto-set by vitest) as non-dev so tests use the default synchronous stdout destination — no worker thread, no exit listener.

## Evidence

**Hypothesis test** — 4 back-to-back runs of `npm run test:unit`:

| Condition                    | Result          |
|------------------------------|-----------------|
| Baseline (`NODE_ENV=dev`)    | 1/4 hung at 60s |
| `NODE_ENV=production`        | 0/4 hung        |
| Patch applied (6 runs)       | 0/6 hung        |

Zero `MaxListenersExceededWarning` after the fix (previously consistently emitted: "11 exit listeners added to [process]").

## Related

The defensive timeout wrapper and `--pool=threads` from #2542 stay as belt-and-suspenders against future dependency regressions.

## Test plan

- [x] `npm run test:unit` — 587 tests pass in ~1.5s
- [x] `npm run typecheck` — passes
- [x] 6 back-to-back runs, all clean exits
- [ ] Build Check CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)