### PR TITLE
feat(training-agent): migrate to @adcp/client 5.2 + storyboard compliance pass

### DIFF
--- a/.changeset/training-agent-5.2-migration.md
+++ b/.changeset/training-agent-5.2-migration.md
@@ -1,0 +1,23 @@
+---
+---
+
+Training agent: migrate to @adcp/client 5.2.0.
+
+- Replace the hand-rolled idempotency module with `createIdempotencyStore`
+  (JCS canonical hashing, atomic `putIfAbsent` claim, ±60s skew TTL,
+  Postgres + in-memory backends). Keep the `MUTATING_TOOLS` drift guard
+  and the account-partitioning `scopedPrincipal` composition, since the
+  SDK's `resolveIdempotencyPrincipal` hook accepts that exact shape.
+- Replace the bespoke bearer-token middleware with
+  `verifyApiKey` + `anyOf`, routing WorkOS validation through the
+  `verify` callback and returning RFC 6750-compliant 401s via
+  `respondUnauthorized`.
+- Wire `createWebhookEmitter` with an Ed25519 signing key (env
+  `WEBHOOK_SIGNING_KEY_JWK`, else ephemeral). Publish the public JWKS at
+  `/.well-known/jwks.json`. Dispatch fires a signed completion webhook
+  whenever a mutating tool's request carries
+  `push_notification_config.url`.
+- New migration `416_adcp_idempotency.sql` + periodic
+  `cleanupExpiredIdempotency` cleanup.
+- Rename `ComplianceIndex.domains` → `protocols` consumer in
+  `member-tools.ts` to match the 5.2 cache layout.

--- a/.changeset/training-agent-storyboard-compliance.md
+++ b/.changeset/training-agent-storyboard-compliance.md
@@ -1,0 +1,63 @@
+---
+---
+
+Training agent: storyboard compliance pass on top of the 5.2 migration.
+
+- **Runner brand injection.** `run-storyboards.ts` and `run-one-storyboard.ts`
+  now resolve each storyboard's brand from its `prerequisites.test_kit` and
+  pass it via `runStoryboard({ brand })`. Without this, the SDK's
+  `applyBrandInvariant` is a no-op and bare steps land in
+  `open:default` while branded writes land in `open:<domain>` —
+  surfacing as `MEDIA_BUY_NOT_FOUND` on every read. Step pass count went
+  from 0 → 208 once this landed.
+- **Runner non-strict request validation.** Local monkey-patch of
+  `SingleAgentClient.validateRequest` swaps `schema.strict()` for the default
+  parse so tools whose schemas don't declare a top-level `brand` (e.g.
+  `list_creative_formats`, `get_signals`, `sync_creatives`) tolerate the
+  invariant injection. Required-field enforcement still works because
+  schemas declare their own requireds. Filed as upstream issue against
+  `@adcp/client`.
+- **Session-keying preference.** `sessionKeyFromArgs` now prefers
+  `brand.domain` over `account.account_id` in open mode. Storyboards mix the
+  two shapes across steps in a single run; preferring brand keeps writes
+  and reads on the same key.
+- **Seven new creative formats** in `server/src/shared/formats.ts`:
+  `broadcast_30s`, `broadcast_15s`, `ssai_30s`, `preroll_15s`,
+  `native_feed`, `display_300x250_generative`, `video_30s_generative`.
+  Channel map updated.
+- **Governance findings + conditions on the wire.**
+  `governance-handlers.ts` now surfaces `customPolicies` with
+  `enforcement: 'must'` as both warning findings and binding `conditions[]`
+  entries on proposed-binding checks; the delivery phase emits findings
+  for `pacing` drift and overconcentrated `channel_distribution`. The
+  `GOVERNANCE_DENIED` errors on `create_media_buy` and (newly enforced)
+  `acquire_rights` carry `details.findings` so storyboards reading
+  `field_present: findings` on the error envelope pass.
+- **`handleAcquireRights`** now consults `session.governancePlans` and
+  rejects with `GOVERNANCE_DENIED` when the rights price exceeds remaining
+  authorised budget. Closes `brand_rights/governance_denied`.
+
+After these changes: 208 storyboard steps passing (from 0 at the migration
+baseline), ~25/54 storyboards fully clean. Remaining gaps tracked
+separately:
+
+1. Upstream `@adcp/client` SDK bug — `applyBrandInvariant` injects only
+   top-level `brand`, never `account.brand`. Tools whose request-builders
+   omit `account` (e.g. `get_media_buys`, `get_media_buy_delivery`) lose
+   all scoping when the SDK strips the unrecognised top-level `brand`.
+   Local workaround in the runner; fix belongs in the SDK.
+2. Storyboard YAML bugs (filed upstream): `pending_creatives_to_start`
+   sends `creatives[].content.media_url` instead of the schema-required
+   `assets`; `sales_catalog_driven` sends `catalogs[].catalog_type`
+   instead of `type`; `governance_spend_authority/*` and
+   `governance_delivery_monitor` omit the schema-required `caller` on
+   `check_governance`; `report_usage` in `creative_ad_server` sends a
+   negative `performance_index` (spec requires ≥0).
+3. Seeding gaps in the training agent: `creative_ad_server` references
+   a creative `campaign_hero_video` not in the seed; `sales_non_guaranteed`
+   references `mb_acme_q2_2026_auction`; `governance_spend_authority`
+   references product `sports_ctv_q2`. These are training-agent
+   convenience seeds, not protocol gaps.
+4. `signed_requests` specialism (37 step failures) — RFC 9421
+   transport-layer verification is a new capability the training agent
+   doesn't implement yet. Out of scope for the 5.2 migration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-rc.3",
       "dependencies": {
-        "@adcp/client": "^5.1.0",
+        "@adcp/client": "^5.2.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,11 +120,14 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.1.0.tgz",
-      "integrity": "sha512-DCZ6EeMim+LPf0GD4f1OUQruoejnL0QAcV9a6o+qM7yBQ6cDArF6j/F/So6aXmg3+Zh8URnQaAt8M0Dj+8ITDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.2.0.tgz",
+      "integrity": "sha512-DGpYjvzKGipZMpz6bclAAfv0ZRxcFzOy4NNcOPzRgz/YlvfqwkpySAfKyT8aHnEnYeVPeUHTnR76Y8iLxU0DVg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "jose": "^6.2.2",
+        "structured-headers": "^2.0.2",
+        "undici": "^6.25.0",
         "yaml": "^2.7.1"
       },
       "bin": {
@@ -146,6 +149,15 @@
         "pg": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@adcp/client/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -22299,6 +22311,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/structured-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
       }
     },
     "node_modules/style-to-js": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "^5.1.0",
+    "@adcp/client": "^5.2.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3303,11 +3303,7 @@ export function createMemberToolHandlers(
     const docsVersion = index?.adcp_version || 'latest';
     const indexUrl = `https://adcontextprotocol.org/compliance/${docsVersion}/index.json`;
 
-    // Index emits both `protocols` (new) and `domains` (transitional alias) during the
-    // @adcp/client 5.x → 6.x coordinated release. Read whichever key is present.
-    const protocolEntries: Array<{ id: string }> | undefined =
-      (index as { protocols?: Array<{ id: string }> } | undefined)?.protocols ?? index?.domains;
-    const knownProtocolIds = protocolEntries?.map(d => d.id.replace(/-/g, '_')) ?? [
+    const knownProtocolIds = index?.protocols?.map(p => p.id.replace(/-/g, '_')) ?? [
       'media_buy', 'creative', 'signals', 'governance', 'brand', 'sponsored_intelligence',
     ];
     const protocolExamples = knownProtocolIds.map(id => `\`${id}\``).join(', ');

--- a/server/src/db/migrations/416_adcp_idempotency.sql
+++ b/server/src/db/migrations/416_adcp_idempotency.sql
@@ -1,0 +1,13 @@
+-- Idempotency replay cache for the training agent (AdCP v3 §idempotency).
+-- Table name and schema come from @adcp/client/server's getIdempotencyMigration()
+-- so any future schema change in the SDK requires a follow-up migration here.
+CREATE TABLE IF NOT EXISTS "adcp_idempotency" (
+  scoped_key    TEXT PRIMARY KEY,
+  payload_hash  TEXT NOT NULL,
+  response      JSONB NOT NULL,
+  expires_at    TIMESTAMPTZ NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_idempotency_expires_at
+  ON "adcp_idempotency"(expires_at);

--- a/server/src/shared/formats.ts
+++ b/server/src/shared/formats.ts
@@ -456,6 +456,90 @@ export function buildFormats(agentUrl: string): TrainingFormat[] {
           requirements: { mime_types: ['audio/wav', 'audio/mpeg'], max_file_size_bytes: 20000000 } },
       ],
     },
+
+    // ── Linear / broadcast TV ─────────────────────────────
+    {
+      format_id: { agent_url: agentUrl, id: 'broadcast_30s' },
+      name: 'Broadcast TV 30s',
+      description: 'Linear broadcast TV spot, 30 seconds. Broadcast-quality video delivered per network trafficking specs.',
+      renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 }, duration_ms: 30000 }],
+      assets: [
+        { item_type: 'individual', asset_id: 'video_file', asset_type: 'video', asset_role: 'broadcast_spot', required: true,
+          requirements: { mime_types: ['video/mp4', 'video/quicktime'], min_width: 1920, min_height: 1080, min_duration_ms: 30000, max_duration_ms: 30000, max_file_size_bytes: 500_000_000 } },
+      ],
+    },
+    {
+      format_id: { agent_url: agentUrl, id: 'broadcast_15s' },
+      name: 'Broadcast TV 15s',
+      description: 'Linear broadcast TV spot, 15 seconds. Broadcast-quality video delivered per network trafficking specs.',
+      renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 }, duration_ms: 15000 }],
+      assets: [
+        { item_type: 'individual', asset_id: 'video_file', asset_type: 'video', asset_role: 'broadcast_spot', required: true,
+          requirements: { mime_types: ['video/mp4', 'video/quicktime'], min_width: 1920, min_height: 1080, min_duration_ms: 15000, max_duration_ms: 15000, max_file_size_bytes: 300_000_000 } },
+      ],
+    },
+
+    // ── CTV / streaming video ─────────────────────────────
+    {
+      format_id: { agent_url: agentUrl, id: 'ssai_30s' },
+      name: 'SSAI video 30s',
+      description: 'Server-side ad insertion video spot, 30 seconds. CTV/OTT delivery via VAST/SSAI.',
+      renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 }, duration_ms: 30000 }],
+      assets: [
+        { item_type: 'individual', asset_id: 'video', asset_type: 'video', asset_role: 'video_ad', required: true,
+          requirements: { mime_types: ['video/mp4'], min_width: 1280, min_height: 720, min_duration_ms: 30000, max_duration_ms: 30000, max_file_size_bytes: 200_000_000 } },
+      ],
+    },
+    {
+      format_id: { agent_url: agentUrl, id: 'preroll_15s' },
+      name: 'Pre-roll video 15s',
+      description: 'Online video pre-roll ad, 15 seconds.',
+      renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 }, duration_ms: 15000 }],
+      assets: [
+        { item_type: 'individual', asset_id: 'video', asset_type: 'video', asset_role: 'video_ad', required: true,
+          requirements: { mime_types: ['video/mp4'], min_width: 1280, min_height: 720, min_duration_ms: 15000, max_duration_ms: 15000, max_file_size_bytes: 100_000_000 } },
+      ],
+    },
+
+    // ── Social ────────────────────────────────────────────
+    {
+      format_id: { agent_url: agentUrl, id: 'native_feed' },
+      name: 'Native social feed',
+      description: 'Native in-feed social post with image, headline, and click URL.',
+      renders: [{ role: 'primary', dimensions: { width: 1080, height: 1080 } }],
+      assets: [
+        { item_type: 'individual', asset_id: 'image', asset_type: 'image', asset_role: 'hero_image', required: true,
+          requirements: { mime_types: ['image/jpeg', 'image/png'], min_width: 1080, min_height: 1080, max_file_size_bytes: 10_000_000 } },
+        { item_type: 'individual', asset_id: 'headline', asset_type: 'text', asset_role: 'headline', required: true,
+          requirements: { max_file_size_bytes: 40 } },
+        { item_type: 'individual', asset_id: 'click_url', asset_type: 'url', asset_role: 'clickthrough', required: true, requirements: { url_type: 'clickthrough' } },
+      ],
+    },
+
+    // ── Generative creative ───────────────────────────────
+    {
+      format_id: { agent_url: agentUrl, id: 'display_300x250_generative' },
+      name: 'Generative display 300x250',
+      description: 'Display ad generated from a creative brief, 300x250. Brief describes copy + visual direction; optional logo + click URL are seeded to the generator.',
+      renders: [{ role: 'primary', dimensions: { width: 300, height: 250 } }],
+      assets: [
+        { item_type: 'individual', asset_id: 'brief', asset_type: 'text', asset_role: 'creative_brief', required: true },
+        { item_type: 'individual', asset_id: 'logo', asset_type: 'image', asset_role: 'logo', required: false,
+          requirements: { mime_types: ['image/png', 'image/svg+xml'], max_file_size_bytes: 5_000_000 } },
+        { item_type: 'individual', asset_id: 'click_url', asset_type: 'url', asset_role: 'clickthrough', required: false },
+      ],
+    },
+    {
+      format_id: { agent_url: agentUrl, id: 'video_30s_generative' },
+      name: 'Generative video 30s',
+      description: 'Video spot generated from a creative brief, 1920x1080 @30s. Brief describes the narrative; optional logo is seeded to the generator.',
+      renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 }, duration_ms: 30000 }],
+      assets: [
+        { item_type: 'individual', asset_id: 'brief', asset_type: 'text', asset_role: 'creative_brief', required: true },
+        { item_type: 'individual', asset_id: 'logo', asset_type: 'image', asset_role: 'logo', required: false,
+          requirements: { mime_types: ['image/png', 'image/svg+xml'], max_file_size_bytes: 5_000_000 } },
+      ],
+    },
   ];
 }
 
@@ -490,4 +574,11 @@ export const FORMAT_CHANNEL_MAP: Record<string, string[]> = {
   ai_sponsored_agent: ['display'],
   print_full_page: ['print'],
   radio_spot: ['radio'],
+  broadcast_30s: ['linear_tv'],
+  broadcast_15s: ['linear_tv'],
+  ssai_30s: ['ctv'],
+  preroll_15s: ['olv'],
+  native_feed: ['social'],
+  display_300x250_generative: ['display'],
+  video_30s_generative: ['olv', 'ctv'],
 };

--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -8,6 +8,7 @@
 
 import type { TrainingContext, ToolArgs } from './types.js';
 import { getSandboxBrands } from '@adcp/client/testing';
+import { getSession, sessionKeyFromArgs } from './state.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -886,9 +887,9 @@ interface AcquireRightsArgs {
   };
 }
 
-export function handleAcquireRights(
+export async function handleAcquireRights(
   args: ToolArgs,
-  _ctx: TrainingContext,
+  ctx: TrainingContext,
 ) {
   const req = args as AcquireRightsArgs;
   const rightsId = req.rights_id;
@@ -922,6 +923,42 @@ export function handleAcquireRights(
 
   if (!campaign?.description) {
     return { errors: [{ code: 'invalid_request', message: 'campaign.description is required' }] };
+  }
+
+  // Governance enforcement: if plans are active in this session, the rights
+  // price must fit within remaining authorised budget. Rights acquisitions
+  // are spending events and MUST be governed under the same plan as media
+  // buys. Without this check, the brand_rights/governance_denied storyboard
+  // gets a success response instead of GOVERNANCE_DENIED.
+  const session = await getSession(sessionKeyFromArgs(req as { account?: import('./types.js').AccountRef; brand?: import('./types.js').BrandRef }, ctx.mode, ctx.userId, ctx.moduleId));
+  if (session.governancePlans.size > 0) {
+    const price = pricingOption.price;
+    for (const plan of session.governancePlans.values()) {
+      const remaining = plan.budget.total - plan.committedBudget;
+      const typeAlloc = plan.budget.allocations?.rights_license;
+      const typeRemaining = typeAlloc?.amount !== undefined
+        ? typeAlloc.amount - (plan.committedByType?.rights_license ?? 0)
+        : undefined;
+      if (price > remaining || (typeRemaining !== undefined && price > typeRemaining)) {
+        const msg = typeRemaining !== undefined && price > typeRemaining
+          ? `Rights price $${price} exceeds remaining rights_license allocation $${typeRemaining} on plan "${plan.planId}".`
+          : `Rights price $${price} exceeds remaining budget $${remaining} on plan "${plan.planId}".`;
+        return {
+          errors: [{
+            code: 'GOVERNANCE_DENIED',
+            message: msg,
+            details: {
+              findings: [{
+                category_id: 'budget_authority',
+                severity: 'critical',
+                explanation: msg,
+              }],
+              plan_id: plan.planId,
+            },
+          }],
+        };
+      }
+    }
   }
 
   const descLower = campaign.description.toLowerCase();

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -197,6 +197,8 @@ interface PlannedDeliveryInput {
 interface DeliveryMetricsInput {
   cumulative_spend?: number;
   geo_distribution?: Record<string, number>;
+  channel_distribution?: Record<string, number>;
+  pacing?: 'ahead' | 'on_track' | 'behind';
 }
 
 interface ReportPlanOutcomeInput extends ToolArgs {
@@ -900,6 +902,30 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     }
   }
 
+  // Custom policies declared on the plan with `must` enforcement become binding
+  // conditions on every proposed action. Buyers honor them by passing the
+  // governance_context to the seller and complying off-protocol; the governance
+  // agent re-evaluates compliance during delivery-phase checks.
+  if (binding === 'proposed' && plan.customPolicies?.length) {
+    categoriesEvaluated.push('custom_policy');
+    for (const cp of plan.customPolicies) {
+      if (cp.enforcement === 'may') continue;
+      const isBinding = cp.enforcement === 'must' || cp.enforcement === undefined;
+      if (isBinding) {
+        conditions.push({
+          field: 'campaign',
+          reason: cp.policy,
+        });
+      }
+      findings.push({
+        categoryId: 'custom_policy',
+        severity: isBinding ? 'warning' : 'info',
+        explanation: cp.policy,
+        ...(cp.policy_id && { policyId: cp.policy_id }),
+      });
+    }
+  }
+
   // Committed binding: validate planned_delivery
   if (binding === 'committed' && plannedDelivery) {
     categoriesEvaluated.push('geo_compliance', 'channel_compliance', 'flight_compliance');
@@ -978,6 +1004,32 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
             explanation: `${pct}% of delivery in unauthorized market ${country}.`,
           });
         }
+      }
+    }
+
+    const pacing = deliveryMetrics.pacing;
+    if (pacing === 'ahead' || pacing === 'behind') {
+      findings.push({
+        categoryId: 'delivery_pacing',
+        severity: 'warning',
+        explanation: `Pacing reported as ${pacing} — line items are drifting from the planned schedule.`,
+        confidence: 0.85,
+      });
+    }
+
+    const channelDistribution = deliveryMetrics.channel_distribution;
+    if (channelDistribution) {
+      const overweight: string[] = [];
+      for (const [channel, pct] of Object.entries(channelDistribution)) {
+        if (pct >= 60) overweight.push(`${channel} at ${pct}%`);
+      }
+      if (overweight.length > 0) {
+        findings.push({
+          categoryId: 'delivery_pacing',
+          severity: 'warning',
+          explanation: `Channel mix concentrated: ${overweight.join(', ')}. Re-evaluate against plan reallocation threshold.`,
+          confidence: 0.8,
+        });
       }
     }
   }

--- a/server/src/training-agent/idempotency.ts
+++ b/server/src/training-agent/idempotency.ts
@@ -1,34 +1,40 @@
 /**
- * Idempotency middleware for the training agent.
+ * Idempotency wiring for the training agent.
  *
- * Enforces AdCP's at-most-once semantics on mutating tool calls per
- * `docs/building/implementation/security.mdx` and the `idempotency.yaml`
- * compliance storyboard:
- *
- * - Same `(principal, idempotency_key)` + equivalent canonical payload →
- *   return the cached inner response with `replayed: true` on the envelope.
- * - Same key + different canonical payload → `IDEMPOTENCY_CONFLICT`.
- * - Key past TTL → `IDEMPOTENCY_EXPIRED`.
- * - Missing key on a mutating request → `INVALID_REQUEST`.
- *
- * Canonicalization is RFC 8785 JSON Canonicalization Scheme (JCS) via the
- * `canonicalize` package, hashed with SHA-256. Excluded from the hash:
+ * Thin facade over `@adcp/client/server`'s `createIdempotencyStore`, which
+ * implements the spec behaviour (RFC 8785 JCS payload hash, atomic
+ * putIfAbsent claim, ±60s clock-skew TTL, exclusion list for
  * `idempotency_key`, `context`, `governance_context`, and
- * `push_notification_config.authentication.credentials`.
+ * `push_notification_config.authentication.credentials`).
+ *
+ * What this module adds on top:
+ *
+ * - `MUTATING_TOOLS` / `isMutatingTool` — the spec-wired set of tools that
+ *   require `idempotency_key`. Derived from
+ *   `static/schemas/source/**\/*-request.json` at test time (see
+ *   `idempotency.test.ts` drift guard).
+ * - `validateKeyFormat` — the regex gate applied before the store is
+ *   touched, so a malformed key never influences cache timing.
+ * - `scopedPrincipal` — account-partitions the cache when the shared
+ *   public sandbox token is in use (otherwise every caller on that token
+ *   sees the same oracle).
+ * - `getIdempotencyStore` — returns a process-wide store backed by
+ *   Postgres when a DB pool is available, in-memory otherwise.
  */
 
-import { createHash, timingSafeEqual } from 'node:crypto';
-import { Buffer } from 'node:buffer';
-import canonicalize from 'canonicalize';
+import {
+  createIdempotencyStore,
+  memoryBackend,
+  pgBackend,
+  hashPayload,
+  type IdempotencyStore,
+  type IdempotencyCheckResult,
+} from '@adcp/client/server';
+import { isDatabaseInitialized, getPool } from '../db/client.js';
 
 export const REPLAY_TTL_SECONDS = 86400;
-const REPLAY_TTL_MS = REPLAY_TTL_SECONDS * 1000;
-// ±60s clock-skew tolerance per security.mdx rule 6.
-const TTL_SKEW_MS = 60_000;
 
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_.:-]{16,255}$/;
-
-const MAX_ENTRIES_PER_PRINCIPAL = 10_000;
 
 /**
  * Tasks whose request schemas require `idempotency_key`.
@@ -74,11 +80,9 @@ export function isMutatingTool(name: string): boolean {
   return MUTATING_TOOLS.has(name);
 }
 
-const EXCLUDED_FROM_HASH = new Set([
-  'idempotency_key',
-  'context',
-  'governance_context',
-]);
+export function validateKeyFormat(key: unknown): key is string {
+  return typeof key === 'string' && IDEMPOTENCY_KEY_PATTERN.test(key);
+}
 
 /**
  * Build a cache-scoping principal from the auth layer's principal string
@@ -90,10 +94,6 @@ const EXCLUDED_FROM_HASH = new Set([
  * would then be an observable oracle across callers (security.mdx
  * §"three-state response"). Account-level partitioning contains the
  * oracle to keys a caller could already enumerate for their own account.
- *
- * The shape matches `sessionKeyFromArgs` conceptually: account_id wins
- * over brand.domain; both are already length/charset bounded upstream so
- * this layer just consumes whatever string it receives.
  */
 export function scopedPrincipal(
   authPrincipal: string,
@@ -104,176 +104,29 @@ export function scopedPrincipal(
   return `${authPrincipal}\u001F${accountScope ?? ''}`;
 }
 
-interface CacheEntry {
-  requestHash: string;
-  response: Record<string, unknown>;
-  createdAt: number;
-  expiresAt: number;
+/** Canonical payload hash used for idempotency equivalence (delegates to SDK). */
+export function payloadHash(payload: unknown): string {
+  return hashPayload(payload);
 }
 
-const cache = new Map<string, CacheEntry>();
-const entriesPerPrincipal = new Map<string, number>();
+// ── Store factory ────────────────────────────────────────────────
 
-function strippedForHash(payload: Record<string, unknown>): Record<string, unknown> {
-  const filtered: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(payload)) {
-    if (EXCLUDED_FROM_HASH.has(k)) continue;
-    filtered[k] = v;
-  }
-  // Strip push_notification_config.authentication.credentials (may rotate)
-  const pnc = filtered.push_notification_config as
-    | { authentication?: { credentials?: unknown; [k: string]: unknown }; [k: string]: unknown }
-    | undefined;
-  if (pnc && typeof pnc === 'object' && pnc.authentication && typeof pnc.authentication === 'object') {
-    const { credentials: _drop, ...rest } = pnc.authentication;
-    filtered.push_notification_config = { ...pnc, authentication: rest };
-  }
-  return filtered;
+let storeInstance: IdempotencyStore | null = null;
+
+export function getIdempotencyStore(): IdempotencyStore {
+  if (storeInstance) return storeInstance;
+  const backend = isDatabaseInitialized()
+    ? pgBackend(getPool())
+    : memoryBackend();
+  storeInstance = createIdempotencyStore({ backend, ttlSeconds: REPLAY_TTL_SECONDS });
+  return storeInstance;
 }
 
-export function payloadHash(payload: Record<string, unknown>): string {
-  const filtered = strippedForHash(payload);
-  const canonical = canonicalize(filtered);
-  if (canonical === undefined) {
-    // RFC 8785 inputs must be canonicalizable JSON. Unreachable for valid
-    // schema-checked payloads; throw loudly so two non-canonicalizable
-    // payloads can't silently hash-equal to the empty string.
-    throw new Error('Cannot canonicalize payload for idempotency hash');
-  }
-  return createHash('sha256').update(canonical).digest('hex');
+/** Reset the store — tests only. Safe to call when no store has been created. */
+export async function clearIdempotencyCache(): Promise<void> {
+  const current = storeInstance;
+  storeInstance = null;
+  if (current) await current.close();
 }
 
-function cacheKey(principal: string, idempotencyKey: string): string {
-  return `${principal}\u0000${idempotencyKey}`;
-}
-
-export function validateKeyFormat(key: unknown): key is string {
-  return typeof key === 'string' && IDEMPOTENCY_KEY_PATTERN.test(key);
-}
-
-/**
- * Constant-time comparison of two hex SHA-256 digests. The attacker-control
- * surface here is low — an attacker who sees a timing leak still needs to
- * iterate payloads, not hash prefixes — but the secure posture is cheap.
- */
-function hashesEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
-}
-
-export type IdempotencyOutcome =
-  | { kind: 'miss' }
-  | { kind: 'replay'; response: Record<string, unknown> }
-  | { kind: 'conflict' }
-  | { kind: 'expired' }
-  | { kind: 'rate_limited' };
-
-/**
- * Look up `(principal, key)` and classify the outcome.
- *
- * - `miss`: no prior entry — the caller should execute the handler and then
- *   call `cacheResponse(...)` on success.
- * - `replay`: exact canonical-payload match — return the stored response
- *   with `replayed: true` injected on the envelope.
- * - `conflict`: same key, different canonical payload, still within TTL —
- *   return `IDEMPOTENCY_CONFLICT`.
- * - `expired`: same key, past TTL (with ±60s skew) — return `IDEMPOTENCY_EXPIRED`.
- */
-export function lookupIdempotency(
-  principal: string,
-  idempotencyKey: string,
-  requestPayload: Record<string, unknown>,
-  now: number = Date.now(),
-): IdempotencyOutcome {
-  const entry = cache.get(cacheKey(principal, idempotencyKey));
-  if (!entry) return { kind: 'miss' };
-
-  if (entry.expiresAt + TTL_SKEW_MS < now) {
-    // Past TTL → return EXPIRED and evict so a fresh request with the same
-    // key can eventually succeed once the buyer realises their error.
-    cache.delete(cacheKey(principal, idempotencyKey));
-    decrementPrincipalCount(principal);
-    return { kind: 'expired' };
-  }
-
-  const incomingHash = payloadHash(requestPayload);
-  if (!hashesEqual(incomingHash, entry.requestHash)) return { kind: 'conflict' };
-
-  return { kind: 'replay', response: entry.response };
-}
-
-/**
- * Store a successful response so subsequent replays with the same key and
- * canonical payload return the same bytes. Only call this for successful
- * executions — errors must re-execute on retry (security.mdx rule 2 + 3).
- *
- * Returns `true` on insert, `false` when the per-principal cap blocked the
- * insert. Callers who cannot afford a silent-drop-into-re-execution on
- * retry SHOULD surface `RATE_LIMITED` when this returns `false`
- * (security.mdx rule 8).
- */
-export function cacheResponse(
-  principal: string,
-  idempotencyKey: string,
-  requestPayload: Record<string, unknown>,
-  response: Record<string, unknown>,
-  now: number = Date.now(),
-): boolean {
-  let used = entriesPerPrincipal.get(principal) ?? 0;
-  if (used >= MAX_ENTRIES_PER_PRINCIPAL) {
-    // Opportunistic eviction: sweep this principal's expired entries before
-    // giving up. Avoids wedging a principal for 24h once they briefly burst
-    // past the cap on stale keys.
-    used = evictExpiredForPrincipal(principal, now);
-    if (used >= MAX_ENTRIES_PER_PRINCIPAL) return false;
-  }
-  const requestHash = payloadHash(requestPayload);
-  cache.set(cacheKey(principal, idempotencyKey), {
-    requestHash,
-    response,
-    createdAt: now,
-    expiresAt: now + REPLAY_TTL_MS,
-  });
-  entriesPerPrincipal.set(principal, used + 1);
-  return true;
-}
-
-/** Check whether a fresh insert would succeed without actually inserting. */
-export function isPrincipalAtCap(principal: string, now: number = Date.now()): boolean {
-  const used = entriesPerPrincipal.get(principal) ?? 0;
-  if (used < MAX_ENTRIES_PER_PRINCIPAL) return false;
-  const after = evictExpiredForPrincipal(principal, now);
-  return after >= MAX_ENTRIES_PER_PRINCIPAL;
-}
-
-function evictExpiredForPrincipal(principal: string, now: number): number {
-  const prefix = `${principal}\u0000`;
-  let count = entriesPerPrincipal.get(principal) ?? 0;
-  for (const [key, entry] of cache) {
-    if (!key.startsWith(prefix)) continue;
-    if (entry.expiresAt + TTL_SKEW_MS < now) {
-      cache.delete(key);
-      count--;
-    }
-  }
-  if (count <= 0) entriesPerPrincipal.delete(principal);
-  else entriesPerPrincipal.set(principal, count);
-  return Math.max(count, 0);
-}
-
-function decrementPrincipalCount(principal: string): void {
-  const v = entriesPerPrincipal.get(principal) ?? 0;
-  if (v <= 1) entriesPerPrincipal.delete(principal);
-  else entriesPerPrincipal.set(principal, v - 1);
-}
-
-/** Clear the entire cache. Tests only. */
-export function clearIdempotencyCache(): void {
-  cache.clear();
-  entriesPerPrincipal.clear();
-}
-
-/** Test-only introspection. */
-export function _cacheSize(): number {
-  return cache.size;
-}
+export type { IdempotencyCheckResult };

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -7,16 +7,25 @@
 
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { createHash, timingSafeEqual } from 'node:crypto';
 import rateLimit from 'express-rate-limit';
 import { WorkOS } from '@workos-inc/node';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import {
+  anyOf,
+  verifyApiKey,
+  extractBearerToken,
+  respondUnauthorized,
+  AuthError,
+  type Authenticator,
+  type AuthPrincipal,
+} from '@adcp/client/server';
 import { createLogger } from '../logger.js';
 import { createTrainingAgentServer } from './task-handlers.js';
 import { startSessionCleanup } from './state.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
+import { getPublicJwks } from './webhooks.js';
 import { isWorkOSApiKeyFormat } from '../middleware/api-key-format.js';
 import { PUBLIC_TEST_AGENT } from '../config/test-agent.js';
 import type { TrainingContext } from './types.js';
@@ -41,72 +50,71 @@ function setCORSHeaders(res: Response): void {
   res.setHeader('Access-Control-Expose-Headers', 'Content-Type');
 }
 
-function constantTimeEqual(a: string, b: string): boolean {
-  const ha = createHash('sha256').update(a).digest();
-  const hb = createHash('sha256').update(b).digest();
-  return timingSafeEqual(ha, hb);
+function buildAuthenticator(): Authenticator | null {
+  if (!TRAINING_AGENT_TOKEN && !PUBLIC_TEST_AGENT_TOKEN && !workos) {
+    return null; // dev mode: open
+  }
+  const staticKeys: Record<string, AuthPrincipal> = {};
+  if (TRAINING_AGENT_TOKEN) staticKeys[TRAINING_AGENT_TOKEN] = { principal: 'static:primary' };
+  if (PUBLIC_TEST_AGENT_TOKEN) staticKeys[PUBLIC_TEST_AGENT_TOKEN] = { principal: 'static:public' };
+
+  const authenticators: Authenticator[] = [];
+  if (Object.keys(staticKeys).length > 0) {
+    authenticators.push(verifyApiKey({ keys: staticKeys }));
+  }
+  if (workos) {
+    const workosClient = workos; // narrow for closure
+    authenticators.push(verifyApiKey({
+      verify: async (token) => {
+        if (!isWorkOSApiKeyFormat(token)) return null;
+        const result = await workosClient.apiKeys.validateApiKey({ value: token });
+        if (!result.apiKey) return null;
+        const orgId = result.apiKey.owner.id;
+        logger.info({ orgId }, 'Training agent: authenticated via AAO API key');
+        return { principal: `workos:${orgId}` };
+      },
+    }));
+  }
+  if (authenticators.length === 0) return null;
+  return authenticators.length === 1 ? authenticators[0] : anyOf(...authenticators);
 }
 
+const authenticator = buildAuthenticator();
+
 async function requireToken(req: Request, res: Response, next: NextFunction): Promise<void> {
-  if (!TRAINING_AGENT_TOKEN && !PUBLIC_TEST_AGENT_TOKEN && !workos) {
+  if (!authenticator) {
     // No tokens configured and no WorkOS = dev mode, allow all
     res.locals.trainingPrincipal = 'anonymous';
     return next();
   }
-  const auth = req.headers.authorization;
-  if (!auth || !auth.startsWith('Bearer ')) {
-    res.status(401).json({
-      jsonrpc: '2.0',
-      id: null,
-      error: { code: -32000, message: 'Invalid or missing bearer token. Use an AAO API key (from your dashboard) or a static test token.' },
+  // The SDK's authenticators read from a raw Node IncomingMessage — Express's
+  // Request extends it, so we pass `req` directly.
+  let principal: AuthPrincipal | null;
+  try {
+    principal = await authenticator(req);
+  } catch (err) {
+    const publicMessage = err instanceof AuthError
+      ? err.publicMessage
+      : 'Authentication failed';
+    logger.warn({ err }, 'Training agent: authentication error');
+    respondUnauthorized(req, res, {
+      error: 'invalid_token',
+      errorDescription: publicMessage,
     });
     return;
   }
-  const token = auth.slice(7);
-
-  // Accept static tokens (primary or public test agent).
-  // Principal for idempotency scoping: distinct per token tier but shared
-  // across all callers using that tier. Prefix-stable, no tenant bleed.
-  if (TRAINING_AGENT_TOKEN && constantTimeEqual(token, TRAINING_AGENT_TOKEN)) {
-    res.locals.trainingPrincipal = 'static:primary';
-    return next();
-  }
-  if (PUBLIC_TEST_AGENT_TOKEN && constantTimeEqual(token, PUBLIC_TEST_AGENT_TOKEN)) {
-    res.locals.trainingPrincipal = 'static:public';
-    return next();
-  }
-
-  // Accept WorkOS API keys (AAO dashboard API keys with sk_ or wos_api_key_ prefix)
-  if (workos && isWorkOSApiKeyFormat(token)) {
-    try {
-      const result = await workos.apiKeys.validateApiKey({ value: token });
-      if (result.apiKey) {
-        const orgId = result.apiKey.owner.id;
-        logger.info({ orgId }, 'Training agent: authenticated via AAO API key');
-        res.locals.trainingPrincipal = `workos:${orgId}`;
-        return next();
-      }
-      res.status(401).json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32000, message: 'Invalid API key. Generate a new key from your AAO dashboard.' },
-      });
-    } catch (err) {
-      logger.warn({ err }, 'Training agent: WorkOS API key validation failed');
-      res.status(401).json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32000, message: 'API key validation failed. Please try again.' },
-      });
-    }
+  if (!principal) {
+    const hasCredentials = !!extractBearerToken(req);
+    respondUnauthorized(req, res, {
+      error: hasCredentials ? 'invalid_token' : 'invalid_request',
+      errorDescription: hasCredentials
+        ? 'Invalid bearer token. Use an AAO API key (from your dashboard) or a static test token.'
+        : 'Missing bearer token. Use an AAO API key (from your dashboard) or a static test token.',
+    });
     return;
   }
-
-  res.status(401).json({
-    jsonrpc: '2.0',
-    id: null,
-    error: { code: -32000, message: 'Invalid or missing bearer token. Use an AAO API key (from your dashboard) or a static test token.' },
-  });
+  res.locals.trainingPrincipal = principal.principal;
+  next();
 }
 
 function getBaseUrl(req: Request): string {
@@ -125,6 +133,13 @@ export function createTrainingAgentRouter(): Router {
   // Health check
   router.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'healthy', service: 'training-agent' });
+  });
+
+  // JWKS for webhook-signature verification by buyers (RFC 7517).
+  // Public keys only — the emitter holds the private half.
+  router.get('/.well-known/jwks.json', (_req: Request, res: Response) => {
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.json(getPublicJwks());
   });
 
   // adagents.json discovery

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -304,6 +304,15 @@ function safeKey(value: string | undefined, max: number, pattern: RegExp): strin
  * Rejects malformed domain/account_id values — they become part of a Postgres
  * primary key, so we bound length and restrict charset to prevent bloating
  * the adcp_state table with arbitrary caller-supplied data.
+ *
+ * Open mode preference order: brand.domain (when present) > account.account_id
+ * > 'default'. Brand-domain-first matches what the @adcp/client storyboard
+ * runner injects via `applyBrandInvariant` on every request — so a chain
+ * like `create_media_buy(account.account_id+brand)` → `get_media_buys(brand only)`
+ * stays in one session instead of writing to `open:<account_id>` and then
+ * reading from `open:<brand.domain>`. Sandbox-style storyboards mix the two
+ * shapes across steps; production sellers that key by account_id should run
+ * outside this codepath (or set the spec's `account` invariant on every step).
  */
 export function sessionKeyFromArgs(
   args: { account?: AccountRef; brand?: BrandRef },
@@ -317,17 +326,20 @@ export function sessionKeyFromArgs(
     return `training:${safeUser}:${safeModule}`;
   }
   const account = args.account;
+  const domain = account?.brand?.domain ?? args.brand?.domain;
+  const safeDomain = safeKey(domain, MAX_DOMAIN_LEN, SAFE_DOMAIN_RE);
+  if (safeDomain) {
+    // DNS is case-insensitive — normalise so Example.com and example.com share a session.
+    return `open:${safeDomain.toLowerCase()}`;
+  }
+  if (domain && !safeDomain) {
+    logger.debug({ domain }, 'Rejected brand.domain as session key; falling back');
+  }
   if (account?.account_id) {
     const safe = safeKey(account.account_id, MAX_ACCOUNT_ID_LEN, SAFE_ACCOUNT_ID_RE);
     if (safe) return `open:${safe}`;
   }
-  const domain = account?.brand?.domain ?? args.brand?.domain;
-  const safeDomain = safeKey(domain, MAX_DOMAIN_LEN, SAFE_DOMAIN_RE);
-  if (domain && !safeDomain) {
-    logger.debug({ domain }, 'Rejected brand.domain as session key; collapsing to open:default');
-  }
-  // DNS is case-insensitive — normalise so Example.com and example.com share a session.
-  return `open:${safeDomain ? safeDomain.toLowerCase() : 'default'}`;
+  return 'open:default';
 }
 
 // ── TTL cleanup ──────────────────────────────────────────────────

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -22,6 +22,7 @@ import {
   PostgresStateStore,
   structuredSerialize,
   structuredDeserialize,
+  cleanupExpiredIdempotency,
   type AdcpStateStore,
 } from '@adcp/client/server';
 import { isDatabaseInitialized, getPool } from '../db/client.js';
@@ -349,6 +350,10 @@ export function startSessionCleanup(): void {
         const taskDeleted = await cleanupExpiredTasks(getPool());
         if (taskDeleted > 0) {
           logger.info({ deleted: taskDeleted }, 'Cleaned up expired MCP tasks');
+        }
+        const idempDeleted = await cleanupExpiredIdempotency(getPool());
+        if (idempDeleted > 0) {
+          logger.info({ deleted: idempDeleted }, 'Cleaned up expired idempotency entries');
         }
       }
     } catch (err) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -233,11 +233,19 @@ import { PUBLISHERS } from './publishers.js';
 import {
   isMutatingTool,
   validateKeyFormat,
-  lookupIdempotency,
-  cacheResponse,
   scopedPrincipal,
-  isPrincipalAtCap,
+  getIdempotencyStore,
 } from './idempotency.js';
+import { getWebhookEmitter } from './webhooks.js';
+
+// MCP webhook envelope's `task_type` enum (core.generated TaskType — not re-exported).
+type WebhookTaskType =
+  | 'create_media_buy' | 'update_media_buy' | 'sync_creatives' | 'activate_signal'
+  | 'get_signals' | 'create_property_list' | 'update_property_list' | 'get_property_list'
+  | 'list_property_lists' | 'delete_property_list' | 'sync_accounts'
+  | 'get_account_financials' | 'get_creative_delivery' | 'sync_event_sources'
+  | 'sync_audiences' | 'sync_catalogs' | 'log_event' | 'get_brand_identity'
+  | 'get_rights' | 'acquire_rights';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
 const MAX_PACKAGES_PER_BUY = 50;
@@ -299,6 +307,62 @@ function deriveAccountScope(args: Record<string, unknown>): string | undefined {
 export function clearTaskStore(): void {
   sdkTaskStore?.cleanup();
   sdkTaskStore = null;
+}
+
+/** Map tool name → TaskType for webhook envelopes. Only tools that emit
+ * webhooks need an entry — tools absent from this map never fire an emission
+ * even if the caller supplies a push_notification_config.url. */
+const TOOL_TO_TASK_TYPE: Readonly<Record<string, WebhookTaskType>> = {
+  create_media_buy: 'create_media_buy',
+  update_media_buy: 'update_media_buy',
+  sync_creatives: 'sync_creatives',
+  activate_signal: 'activate_signal',
+  get_signals: 'get_signals',
+  create_property_list: 'create_property_list',
+  update_property_list: 'update_property_list',
+  get_property_list: 'get_property_list',
+  list_property_lists: 'list_property_lists',
+  delete_property_list: 'delete_property_list',
+  sync_accounts: 'sync_accounts',
+  get_account_financials: 'get_account_financials',
+  get_creative_delivery: 'get_creative_delivery',
+  sync_event_sources: 'sync_event_sources',
+  sync_audiences: 'sync_audiences',
+  sync_catalogs: 'sync_catalogs',
+  log_event: 'log_event',
+  get_brand_identity: 'get_brand_identity',
+  get_rights: 'get_rights',
+  acquire_rights: 'acquire_rights',
+};
+
+function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
+  const pnc = args.push_notification_config as { url?: unknown } | undefined;
+  if (!pnc || typeof pnc !== 'object') return undefined;
+  return typeof pnc.url === 'string' && pnc.url.length > 0 ? pnc.url : undefined;
+}
+
+/**
+ * Derive a stable logical event id for webhook idempotency.
+ *
+ * The `operation_id` feeds `WebhookIdempotencyKeyStore` — two emissions with
+ * the same operation_id reuse the same `idempotency_key`, which is the
+ * cross-attempt invariant receiver-side dedup depends on. We prefer a
+ * buyer-facing entity id from the response (media_buy_id, creative_id,
+ * activation_id, etc.) so retries from the same buyer collapse; if the
+ * response has none, we fall back to the request's idempotency_key which
+ * is already unique per logical submission.
+ */
+function deriveWebhookOperationId(
+  toolName: string,
+  response: Record<string, unknown>,
+  requestIdempotencyKey: string | undefined,
+): string {
+  for (const field of ['media_buy_id', 'creative_id', 'activation_id', 'signal_activation_id', 'task_id', 'list_id', 'account_id']) {
+    const v = response[field];
+    if (typeof v === 'string' && v.length > 0) return `${toolName}.${v}`;
+  }
+  if (requestIdempotencyKey) return `${toolName}.${requestIdempotencyKey}`;
+  return `${toolName}.${randomUUID()}`;
 }
 
 /** Wire-format error shared by all training agent responses. */
@@ -3110,6 +3174,8 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     let handlerThrew = false;
     let cachableResponse: Record<string, unknown> | null = null;
     let skipHandler = false;
+    let idempotencyPayloadHash: string | undefined;
+    let idempotencyClaimed = false;
 
     if (isMutatingTool(name)) {
       if (idempotencyKey === undefined || idempotencyKey === null) {
@@ -3132,19 +3198,12 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           flushable: true,
         };
       }
-      // Fail closed when the cache bucket for this principal is full —
-      // silently dropping the insert would let a retry re-execute and
-      // double-book (security.mdx rule 8).
-      if (isPrincipalAtCap(idempotencyPrincipal)) {
-        return {
-          result: adcpError('RATE_LIMITED', {
-            message: 'Idempotency cache capacity exceeded for this principal. Retry after existing keys expire.',
-            recovery: 'transient',
-          }, callerContext),
-          flushable: true,
-        };
-      }
-      const outcome = lookupIdempotency(idempotencyPrincipal, idempotencyKey, handlerArgs);
+      const store = getIdempotencyStore();
+      const outcome = await store.check({
+        principal: idempotencyPrincipal,
+        key: idempotencyKey,
+        payload: handlerArgs,
+      });
       if (outcome.kind === 'expired') {
         return {
           result: adcpError('IDEMPOTENCY_EXPIRED', {
@@ -3166,17 +3225,35 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           flushable: true,
         };
       }
+      if (outcome.kind === 'in-flight') {
+        // A parallel request with the same key is executing. Retries should
+        // back off and see 'replay' once the in-flight handler saves. Return
+        // a transient error so the caller retries after a brief delay.
+        return {
+          result: adcpError('RATE_LIMITED', {
+            message: 'A concurrent request with this idempotency_key is already in progress. Retry after a short delay.',
+            recovery: 'transient',
+          }, callerContext),
+          flushable: true,
+        };
+      }
       if (outcome.kind === 'replay') {
         // Cached inner response; envelope fields (`replayed`, `context`) are
         // produced fresh on every response per security.mdx. Replayed
         // responses bypass the handler entirely — no mutations, no flush.
-        const body: Record<string, unknown> = { ...outcome.response, replayed: true };
+        const body: Record<string, unknown> = { ...(outcome.response as Record<string, unknown>), replayed: true };
         if (callerContext !== undefined) body.context = callerContext;
         toolResult = {
           content: [{ type: 'text', text: JSON.stringify(body) }],
           structuredContent: body,
         };
         skipHandler = true;
+      } else {
+        // 'miss' → the store reserved the claim via putIfAbsent. We must
+        // call save() on success or release() on any other path so the
+        // placeholder doesn't leak.
+        idempotencyPayloadHash = outcome.payloadHash;
+        idempotencyClaimed = true;
       }
     }
 
@@ -3244,30 +3321,60 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       throw new Error('Internal error: toolResult missing after dispatch');
     }
 
-    // Cache ONLY successful inner responses (security.mdx rule 2+3).
-    // Errors re-execute on retry; structured { errors: [...] } responses
-    // are errors from the buyer's perspective and are not cached either.
+    // Resolve the in-flight claim from check(). Cache only successful inner
+    // responses (security.mdx rule 2+3); errors, structured { errors: [...] }
+    // bodies, and exceptions all release the claim so a retry re-executes.
+    if (idempotencyClaimed && typeof idempotencyKey === 'string') {
+      const store = getIdempotencyStore();
+      const shouldSave =
+        cachableResponse !== null
+        && !toolResult.isError
+        && !handlerThrew;
+      if (shouldSave && idempotencyPayloadHash) {
+        await store.save({
+          principal: idempotencyPrincipal,
+          key: idempotencyKey,
+          payloadHash: idempotencyPayloadHash,
+          response: cachableResponse,
+        });
+      } else {
+        await store.release({
+          principal: idempotencyPrincipal,
+          key: idempotencyKey,
+        });
+      }
+    }
+
+    // Fire completion webhook if the buyer supplied a push URL and the tool
+    // mapped to a TaskType. Emission is fire-and-forget so the sync response
+    // doesn't wait on the receiver; retries/backoff live inside the emitter.
+    const webhookUrl = extractWebhookUrl(handlerArgs);
+    const taskType = TOOL_TO_TASK_TYPE[name];
     if (
-      isMutatingTool(name)
-      && typeof idempotencyKey === 'string'
+      webhookUrl
+      && taskType
       && cachableResponse !== null
       && !toolResult.isError
       && !handlerThrew
     ) {
-      const inserted = cacheResponse(idempotencyPrincipal, idempotencyKey, handlerArgs, cachableResponse);
-      if (!inserted) {
-        // Cap was hit between the pre-check and post-execution insert.
-        // The handler already ran and (likely) mutated state — we can't
-        // undo that. Return RATE_LIMITED so a retry with the same key
-        // doesn't silently re-execute and double-book.
-        return {
-          result: adcpError('RATE_LIMITED', {
-            message: 'Idempotency cache capacity exceeded after request completed. The request succeeded but was not cached; a retry with the same idempotency_key may re-execute.',
-            recovery: 'transient',
-          }, callerContext),
-          flushable: !handlerThrew,
-        };
-      }
+      const emitter = getWebhookEmitter();
+      const operationId = deriveWebhookOperationId(
+        name,
+        cachableResponse,
+        typeof idempotencyKey === 'string' ? idempotencyKey : undefined,
+      );
+      const webhookTaskId = (cachableResponse.task_id as string | undefined)
+        ?? `tsk_${operationId.slice(0, 32).replace(/[^A-Za-z0-9_.:-]/g, '_')}`;
+      const payload: Record<string, unknown> = {
+        task_id: webhookTaskId,
+        task_type: taskType,
+        protocol: 'mcp',
+        status: 'completed',
+        timestamp: new Date().toISOString(),
+        result: cachableResponse,
+      };
+      void emitter.emit({ url: webhookUrl, payload, operation_id: operationId })
+        .catch(err => logger.warn({ err, tool: name, url: webhookUrl }, 'Webhook emission failed'));
     }
 
     // If not task-augmented, return result directly.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -309,6 +309,32 @@ export function clearTaskStore(): void {
   sdkTaskStore = null;
 }
 
+/** Translate the agent's internal governance check shape into the wire-format
+ * details block carried on a GOVERNANCE_DENIED error. Storyboards assert
+ * `findings[]` and (when status is `conditions`) `conditions[]` on the error,
+ * so surfacing them here is load-bearing. */
+function governanceErrorDetails(check: import('./types.js').GovernanceCheckState): Record<string, unknown> {
+  const details: Record<string, unknown> = {
+    findings: check.findings.map(f => ({
+      category_id: f.categoryId,
+      severity: f.severity,
+      explanation: f.explanation,
+      ...(f.policyId && { policy_id: f.policyId }),
+      ...(f.confidence !== undefined && { confidence: f.confidence }),
+    })),
+    plan_id: check.planId,
+    check_id: check.checkId,
+  };
+  if (check.conditions?.length) {
+    details.conditions = check.conditions.map(c => ({
+      field: c.field,
+      ...(c.requiredValue !== undefined && { required_value: c.requiredValue }),
+      reason: c.reason,
+    }));
+  }
+  return details;
+}
+
 /** Map tool name → TaskType for webhook envelopes. Only tools that emit
  * webhooks need an entry — tools absent from this map never fire an emission
  * even if the caller supplies a push_notification_config.url. */
@@ -1199,7 +1225,7 @@ async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
   const govCtx = typeof rawGovCtx === 'string' && rawGovCtx ? rawGovCtx : undefined;
   if (govCtx) {
     // Find the latest check for this governance_context (Map iterates in insertion order)
-    let latestCheck: { status: string; explanation: string } | undefined;
+    let latestCheck: import('./types.js').GovernanceCheckState | undefined;
     for (const check of session.governanceChecks.values()) {
       if (check.governanceContext === govCtx) {
         latestCheck = check;
@@ -1210,6 +1236,7 @@ async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
         errors: [{
           code: 'GOVERNANCE_DENIED',
           message: latestCheck.explanation || 'Governance check denied this purchase.',
+          details: governanceErrorDetails(latestCheck),
         }] as TaskError[],
       };
     }
@@ -1230,10 +1257,19 @@ async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
       for (const plan of session.governancePlans.values()) {
         const remaining = plan.budget.total - plan.committedBudget;
         if (buyBudget > remaining) {
+          const msg = `Buy budget $${buyBudget} exceeds governance plan "${plan.planId}" remaining budget $${remaining}. Call check_governance first.`;
           return {
             errors: [{
               code: 'GOVERNANCE_DENIED',
-              message: `Buy budget $${buyBudget} exceeds governance plan "${plan.planId}" remaining budget $${remaining}. Call check_governance first.`,
+              message: msg,
+              details: {
+                findings: [{
+                  category_id: 'budget_authority',
+                  severity: 'critical',
+                  explanation: msg,
+                }],
+                plan_id: plan.planId,
+              },
             }] as TaskError[],
           };
         }
@@ -1242,10 +1278,19 @@ async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
           const typeCommitted = plan.committedByType?.media_buy ?? 0;
           const typeRemaining = typeAllocation.amount - typeCommitted;
           if (buyBudget > typeRemaining) {
+            const msg = `Buy budget $${buyBudget} exceeds media_buy allocation $${typeRemaining} remaining in plan "${plan.planId}". Call check_governance first.`;
             return {
               errors: [{
                 code: 'GOVERNANCE_DENIED',
-                message: `Buy budget $${buyBudget} exceeds media_buy allocation $${typeRemaining} remaining in plan "${plan.planId}". Call check_governance first.`,
+                message: msg,
+                details: {
+                  findings: [{
+                    category_id: 'budget_authority',
+                    severity: 'critical',
+                    explanation: msg,
+                  }],
+                  plan_id: plan.planId,
+                },
               }] as TaskError[],
             };
           }

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -1,0 +1,122 @@
+/**
+ * Webhook signing and emission for the training agent.
+ *
+ * Uses `@adcp/client/server`'s `createWebhookEmitter` to post RFC 9421-signed
+ * completion webhooks with stable `idempotency_key` per logical event and
+ * retry/backoff on 5xx/429. The signer uses a single Ed25519 keypair sourced
+ * from `WEBHOOK_SIGNING_KEY_JWK` (a private JWK) when configured, or a
+ * freshly-generated key at startup for dev mode.
+ *
+ * Public key is published at `/.well-known/jwks.json` on the training agent
+ * router so buyers can verify incoming webhooks against a real JWKS endpoint.
+ */
+
+import { createHash, generateKeyPairSync } from 'node:crypto';
+import {
+  createWebhookEmitter,
+  memoryWebhookKeyStore,
+  type WebhookEmitter,
+} from '@adcp/client/server';
+import type { SignerKey } from '@adcp/client/signing';
+import type { AdcpJsonWebKey } from '@adcp/client/signing';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('training-agent-webhooks');
+
+const ENV_KEY = 'WEBHOOK_SIGNING_KEY_JWK';
+
+let signerKey: SignerKey | null = null;
+let publicJwk: AdcpJsonWebKey | null = null;
+let emitter: WebhookEmitter | null = null;
+
+function generateEphemeralKey(): { signer: SignerKey; publicJwk: AdcpJsonWebKey } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const privateJwkRaw = privateKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  const publicJwkRaw = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  const keyMaterial = String(publicJwkRaw.x ?? '');
+  const kid = `training-${createHash('sha256').update(keyMaterial).digest('hex').slice(0, 16)}`;
+  const privateJwk: AdcpJsonWebKey = {
+    ...privateJwkRaw as AdcpJsonWebKey,
+    kid,
+    alg: 'EdDSA',
+    adcp_use: 'webhook-signing',
+    key_ops: ['sign'],
+  };
+  const pubJwk: AdcpJsonWebKey = {
+    ...publicJwkRaw as AdcpJsonWebKey,
+    kid,
+    alg: 'EdDSA',
+    adcp_use: 'webhook-signing',
+    key_ops: ['verify'],
+    use: 'sig',
+  };
+  return {
+    signer: { keyid: kid, alg: 'ed25519', privateKey: privateJwk },
+    publicJwk: pubJwk,
+  };
+}
+
+function loadConfiguredKey(raw: string): { signer: SignerKey; publicJwk: AdcpJsonWebKey } {
+  const jwk = JSON.parse(raw) as AdcpJsonWebKey;
+  if (!jwk.kid || !jwk.kty || !jwk.d || !jwk.x) {
+    throw new Error(`${ENV_KEY} must be a full private JWK with kid, kty, x, d fields`);
+  }
+  const signer: SignerKey = {
+    keyid: jwk.kid,
+    alg: 'ed25519',
+    privateKey: {
+      ...jwk,
+      alg: 'EdDSA',
+      adcp_use: 'webhook-signing',
+      key_ops: ['sign'],
+    },
+  };
+  // Public JWK is the private JWK minus `d`.
+  const { d: _drop, ...publicOnly } = jwk;
+  const pubJwk: AdcpJsonWebKey = {
+    ...publicOnly,
+    alg: 'EdDSA',
+    adcp_use: 'webhook-signing',
+    key_ops: ['verify'],
+    use: 'sig',
+  };
+  return { signer, publicJwk: pubJwk };
+}
+
+function ensureKey(): { signer: SignerKey; publicJwk: AdcpJsonWebKey } {
+  if (signerKey && publicJwk) return { signer: signerKey, publicJwk };
+  const raw = process.env[ENV_KEY];
+  const material = raw ? loadConfiguredKey(raw) : generateEphemeralKey();
+  signerKey = material.signer;
+  publicJwk = material.publicJwk;
+  if (!raw) {
+    logger.warn(
+      { kid: signerKey.keyid },
+      `Training agent webhook signing key generated ephemerally. Set ${ENV_KEY} for stable keys across restarts.`,
+    );
+  }
+  return material;
+}
+
+export function getPublicJwks(): { keys: AdcpJsonWebKey[] } {
+  const { publicJwk: pub } = ensureKey();
+  return { keys: [pub] };
+}
+
+export function getWebhookEmitter(): WebhookEmitter {
+  if (emitter) return emitter;
+  const { signer } = ensureKey();
+  emitter = createWebhookEmitter({
+    signerKey: signer,
+    idempotencyKeyStore: memoryWebhookKeyStore(),
+    userAgent: 'adcp-training-agent/1.0',
+  });
+  return emitter;
+}
+
+/** Reset state — tests only. */
+export function resetWebhookSigning(): void {
+  signerKey = null;
+  publicJwk = null;
+  emitter = null;
+}

--- a/server/tests/integration/training-agent-webhooks.test.ts
+++ b/server/tests/integration/training-agent-webhooks.test.ts
@@ -1,0 +1,190 @@
+/**
+ * End-to-end webhook emission for the training agent.
+ *
+ * Spins up an ephemeral HTTP receiver, posts a mutating tool request with
+ * `push_notification_config.url` set to the receiver, and asserts the
+ * training agent delivers a signed MCP webhook envelope with a stable
+ * idempotency_key.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { randomUUID } from 'node:crypto';
+import { verifyWebhookSignature, StaticJwksResolver, InMemoryReplayStore, InMemoryRevocationStore } from '@adcp/client/signing';
+import type { AdcpJsonWebKey } from '@adcp/client/signing';
+import { buildCatalog } from '../../src/training-agent/product-factory.js';
+
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-webhook';
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+const { resetWebhookSigning, getPublicJwks } = await import('../../src/training-agent/webhooks.js');
+
+const AUTH = 'Bearer test-token-webhook';
+
+interface CapturedDelivery {
+  headers: http.IncomingHttpHeaders;
+  body: string;
+  url: string;
+}
+
+function startReceiver(handle: (delivery: CapturedDelivery, res: http.ServerResponse) => void): Promise<http.Server> {
+  return new Promise(resolve => {
+    const srv = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', c => { body += c; });
+      req.on('end', () => {
+        const host = req.headers.host ?? '127.0.0.1';
+        handle({ headers: req.headers, body, url: `http://${host}${req.url ?? ''}` }, res);
+      });
+    });
+    srv.listen(0, '127.0.0.1', () => resolve(srv));
+  });
+}
+
+describe('Training Agent webhook emission', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    resetWebhookSigning(); // fresh key for this test run
+    app = express();
+    app.use(express.json());
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+    resetWebhookSigning();
+  });
+
+  it('delivers a signed completion webhook when push_notification_config.url is set', async () => {
+    // Capture the delivery
+    const deliveries: CapturedDelivery[] = [];
+    const done = new Promise<void>(resolve => {
+      const srv = startReceiver((d, res) => {
+        deliveries.push(d);
+        res.writeHead(200); res.end();
+        srv.then(s => s.close());
+        resolve();
+      });
+      // Kick off MCP request once the receiver is listening
+      srv.then(async s => {
+        const addr = s.address() as AddressInfo;
+        const webhookUrl = `http://127.0.0.1:${addr.port}/hook/create_media_buy`;
+        const catalog = buildCatalog();
+        const product = catalog[0].product as { product_id: string; pricing_options: Array<{ pricing_option_id: string }> };
+        await request(app)
+          .post('/api/training-agent/mcp')
+          .set('Authorization', AUTH)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json, text/event-stream')
+          .send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: {
+              name: 'create_media_buy',
+              arguments: {
+                idempotency_key: randomUUID(),
+                adcp_major_version: 3,
+                account: { brand: { domain: 'webhook-test.example' }, operator: 'webhook-test.example' },
+                brand: { domain: 'webhook-test.example' },
+                start_time: '2027-06-01T00:00:00Z',
+                end_time: '2027-07-01T00:00:00Z',
+                packages: [{
+                  product_id: product.product_id,
+                  pricing_option_id: product.pricing_options[0].pricing_option_id,
+                  budget: 50000,
+                  start_time: '2027-06-01T00:00:00Z',
+                  end_time: '2027-07-01T00:00:00Z',
+                }],
+                push_notification_config: { url: webhookUrl },
+              },
+            },
+          });
+      });
+    });
+
+    // Cap the wait so a silent drop doesn't hang the suite.
+    await Promise.race([
+      done,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('webhook never arrived')), 5000)),
+    ]);
+
+    expect(deliveries.length).toBe(1);
+    const delivery = deliveries[0];
+    const body = JSON.parse(delivery.body) as Record<string, unknown>;
+    expect(body.task_id).toBeDefined();
+    expect(body.task_type).toBe('create_media_buy');
+    expect(body.status).toBe('completed');
+    expect(body.idempotency_key).toMatch(/^[A-Za-z0-9_.:-]{16,255}$/);
+    expect(delivery.headers['signature-input']).toBeDefined();
+    expect(delivery.headers['signature']).toBeDefined();
+    expect(delivery.headers['content-digest']).toBeDefined();
+
+    // Verify against the agent's published JWKS — end-to-end proof the
+    // signature is actually valid, not just present.
+    const jwks = getPublicJwks();
+    const jwksResolver = new StaticJwksResolver(jwks.keys as AdcpJsonWebKey[]);
+    await expect(verifyWebhookSignature({
+      method: 'POST',
+      url: delivery.url,
+      headers: delivery.headers as Record<string, string>,
+      body: delivery.body,
+    }, {
+      jwks: jwksResolver,
+      replayStore: new InMemoryReplayStore(),
+      revocationStore: new InMemoryRevocationStore(),
+    })).resolves.toMatchObject({ keyid: expect.any(String) });
+  }, 15000);
+
+  it('publishes its webhook-signing public key at /.well-known/jwks.json', async () => {
+    const response = await request(app).get('/api/training-agent/.well-known/jwks.json');
+    expect(response.status).toBe(200);
+    const jwks = response.body as { keys: AdcpJsonWebKey[] };
+    expect(Array.isArray(jwks.keys)).toBe(true);
+    expect(jwks.keys.length).toBeGreaterThan(0);
+    const key = jwks.keys[0];
+    expect(key.adcp_use).toBe('webhook-signing');
+    expect(key.key_ops).toContain('verify');
+    expect(key.kid).toBeTruthy();
+    expect(key.d).toBeUndefined(); // never publish the private scalar
+  });
+
+  it('does not emit when push_notification_config is absent', async () => {
+    // Nothing to receive — just verify the MCP call succeeds without webhook plumbing.
+    const response = await request(app)
+      .post('/api/training-agent/mcp')
+      .set('Authorization', AUTH)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0', id: 2, method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            idempotency_key: randomUUID(),
+            adcp_major_version: 3,
+            account: { account_id: 'acct_no_webhook' },
+            buyer_ref: 'test_buyer_002',
+            total_budget: { amount: 500, currency: 'USD' },
+            start_time: '2026-05-01T00:00:00Z',
+            end_time: '2026-05-08T00:00:00Z',
+            packages: [],
+          },
+        },
+      });
+    expect(response.status).toBe(200);
+  });
+});

--- a/server/tests/manual/run-one-storyboard.ts
+++ b/server/tests/manual/run-one-storyboard.ts
@@ -5,9 +5,32 @@
 
 import express from 'express';
 import http from 'node:http';
-import { listAllComplianceStoryboards, runStoryboard } from '@adcp/client/testing';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import YAML from 'yaml';
+import { listAllComplianceStoryboards, runStoryboard, getComplianceCacheDir } from '@adcp/client/testing';
+import type { Storyboard, StoryboardRunOptions } from '@adcp/client/testing';
 import { StaticJwksResolver, InMemoryReplayStore, InMemoryRevocationStore } from '@adcp/client/signing';
 import type { AdcpJsonWebKey } from '@adcp/client/signing';
+import { SingleAgentClient } from '@adcp/client';
+
+// See run-storyboards.ts for why this monkey-patch is necessary.
+const ProtoAny = SingleAgentClient.prototype as unknown as {
+  getRequestSchema: (t: string) => unknown;
+  validateRequest: (t: string, p: Record<string, unknown>) => void;
+};
+ProtoAny.validateRequest = function (taskType: string, params: Record<string, unknown>): void {
+  const schema = this.getRequestSchema(taskType) as { parse?: (p: unknown) => unknown } | null | undefined;
+  if (!schema || typeof schema.parse !== 'function') return;
+  try {
+    const { brand_manifest: _bm, buyer_ref: _br, ...rest } = params;
+    schema.parse(rest);
+  } catch (err) {
+    const issues = (err as { issues?: Array<{ path: Array<string|number>; message: string }> }).issues
+      ?.map(i => `${i.path.join('.')}: ${i.message}`).join('; ') ?? String(err);
+    throw new Error(`Request validation failed for ${taskType}: ${issues}`);
+  }
+};
 
 const AUTH_TOKEN = process.env.PUBLIC_TEST_AGENT_TOKEN ?? 'storyboard-diag-token';
 process.env.PUBLIC_TEST_AGENT_TOKEN = AUTH_TOKEN;
@@ -23,6 +46,18 @@ const { getPublicJwks } = await import('../../src/training-agent/webhooks.js');
 const sb = listAllComplianceStoryboards().find(s => s.id === id);
 if (!sb) { console.error(`storyboard ${id} not found`); process.exit(2); }
 
+function brandForStoryboard(s: Storyboard): StoryboardRunOptions['brand'] | undefined {
+  const kitRef = s.prerequisites?.test_kit;
+  if (!kitRef) return undefined;
+  const path = join(getComplianceCacheDir(), kitRef);
+  if (!existsSync(path)) return undefined;
+  const kit = YAML.parse(readFileSync(path, 'utf-8')) as {
+    brand?: { house?: { domain?: string } };
+  };
+  const domain = kit.brand?.house?.domain;
+  return domain ? { domain } : undefined;
+}
+
 const app = express();
 app.use(express.json({ limit: '5mb' }));
 app.use('/api/training-agent', createTrainingAgentRouter());
@@ -32,6 +67,7 @@ server.listen(0, '127.0.0.1', async () => {
   const url = `http://127.0.0.1:${port}/api/training-agent/mcp`;
   // Intentionally do not log agent URL to stdout — this script's stdout is
   // piped through `jq` / `python -c` by the storyboard debugging workflow.
+  const brand = brandForStoryboard(sb);
   const result = await runStoryboard(url, sb, {
     auth: { type: 'bearer', token: AUTH_TOKEN },
     allow_http: true,
@@ -42,6 +78,7 @@ server.listen(0, '127.0.0.1', async () => {
       replayStore: new InMemoryReplayStore(),
       revocationStore: new InMemoryRevocationStore(),
     },
+    ...(brand && { brand }),
   });
   console.log(JSON.stringify(result, null, 2));
   stopSessionCleanup();

--- a/server/tests/manual/run-one-storyboard.ts
+++ b/server/tests/manual/run-one-storyboard.ts
@@ -1,0 +1,49 @@
+/**
+ * Diagnostic: dump the raw runStoryboard() result for a single storyboard.
+ *   npx tsx server/tests/manual/run-one-storyboard.ts capability_discovery
+ */
+
+import express from 'express';
+import http from 'node:http';
+import { listAllComplianceStoryboards, runStoryboard } from '@adcp/client/testing';
+import { StaticJwksResolver, InMemoryReplayStore, InMemoryRevocationStore } from '@adcp/client/signing';
+import type { AdcpJsonWebKey } from '@adcp/client/signing';
+
+const AUTH_TOKEN = process.env.PUBLIC_TEST_AGENT_TOKEN ?? 'storyboard-diag-token';
+process.env.PUBLIC_TEST_AGENT_TOKEN = AUTH_TOKEN;
+if (!process.env.LOG_STORYBOARDS) process.env.LOG_LEVEL = 'silent';
+
+const id = process.argv[2];
+if (!id) { console.error('usage: run-one-storyboard.ts <storyboard_id>'); process.exit(2); }
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+const { getPublicJwks } = await import('../../src/training-agent/webhooks.js');
+
+const sb = listAllComplianceStoryboards().find(s => s.id === id);
+if (!sb) { console.error(`storyboard ${id} not found`); process.exit(2); }
+
+const app = express();
+app.use(express.json({ limit: '5mb' }));
+app.use('/api/training-agent', createTrainingAgentRouter());
+const server = http.createServer(app);
+server.listen(0, '127.0.0.1', async () => {
+  const port = (server.address() as { port: number }).port;
+  const url = `http://127.0.0.1:${port}/api/training-agent/mcp`;
+  // Intentionally do not log agent URL to stdout — this script's stdout is
+  // piped through `jq` / `python -c` by the storyboard debugging workflow.
+  const result = await runStoryboard(url, sb, {
+    auth: { type: 'bearer', token: AUTH_TOKEN },
+    allow_http: true,
+    contracts: ['webhook_receiver_runner'],
+    webhook_receiver: { mode: 'loopback_mock' },
+    webhook_signing: {
+      jwks: new StaticJwksResolver(getPublicJwks().keys as AdcpJsonWebKey[]),
+      replayStore: new InMemoryReplayStore(),
+      revocationStore: new InMemoryRevocationStore(),
+    },
+  });
+  console.log(JSON.stringify(result, null, 2));
+  stopSessionCleanup();
+  server.close();
+});

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -13,11 +13,43 @@
 
 import express from 'express';
 import http from 'node:http';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import YAML from 'yaml';
 import {
   listAllComplianceStoryboards,
   runStoryboard,
+  getComplianceCacheDir,
 } from '@adcp/client/testing';
-import type { StoryboardResult, Storyboard } from '@adcp/client/testing';
+import type { StoryboardResult, Storyboard, StoryboardRunOptions } from '@adcp/client/testing';
+import { SingleAgentClient } from '@adcp/client';
+
+// SDK workaround: `applyBrandInvariant` injects top-level `brand` on every
+// outgoing request, but `SingleAgentClient.validateRequest` calls
+// `schema.strict().parse(...)` — so every tool whose request schema doesn't
+// declare `brand` (list_creative_formats, get_signals, sync_creatives, …)
+// rejects the runner's own request. Replace with a non-strict parse: known
+// fields are still validated, unknown keys (like a brand injected on a tool
+// that doesn't care about it) are ignored. Tools that require brand still
+// enforce it because their schema declares it.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ProtoAny = SingleAgentClient.prototype as unknown as {
+  getRequestSchema: (t: string) => unknown;
+  validateRequest: (t: string, p: Record<string, unknown>) => void;
+};
+ProtoAny.validateRequest = function (taskType: string, params: Record<string, unknown>): void {
+  const schema = this.getRequestSchema(taskType) as { parse?: (p: unknown) => unknown } | null | undefined;
+  if (!schema || typeof schema.parse !== 'function') return;
+  try {
+    // Strip the legacy compat fields the upstream validator also strips.
+    const { brand_manifest: _bm, buyer_ref: _br, ...rest } = params;
+    schema.parse(rest); // non-strict: unknown keys are ignored
+  } catch (err) {
+    const issues = (err as { issues?: Array<{ path: Array<string|number>; message: string }> }).issues
+      ?.map(i => `${i.path.join('.')}: ${i.message}`).join('; ') ?? String(err);
+    throw new Error(`Request validation failed for ${taskType}: ${issues}`);
+  }
+};
 import {
   StaticJwksResolver,
   InMemoryReplayStore,
@@ -82,6 +114,30 @@ function isApplicable(sb: Storyboard): boolean {
   return true;
 }
 
+/**
+ * Resolve a storyboard's brand from its declared test_kit.
+ *
+ * Without this, `applyBrandInvariant` in the SDK's runner is a no-op: steps
+ * that omit `brand`/`account` land in `open:default` while branded steps
+ * (e.g. create_media_buy declaring `brand.domain`) land in
+ * `open:<domain>`. The session key divergence surfaces as
+ * `MEDIA_BUY_NOT_FOUND` on every subsequent read. Threading the test kit's
+ * brand into options.brand forces every outgoing request onto the same
+ * session key.
+ */
+function brandForStoryboard(sb: Storyboard): StoryboardRunOptions['brand'] | undefined {
+  const kitRef = sb.prerequisites?.test_kit;
+  if (!kitRef) return undefined;
+  const path = join(getComplianceCacheDir(), kitRef);
+  if (!existsSync(path)) return undefined;
+  const kit = YAML.parse(readFileSync(path, 'utf-8')) as {
+    brand?: { house?: { domain?: string }; brand_id?: string };
+  };
+  const domain = kit.brand?.house?.domain;
+  if (!domain) return undefined;
+  return { domain };
+}
+
 function stepStatus(s: { passed?: boolean; skipped?: boolean; not_applicable?: boolean; validations?: Array<{ passed: boolean }>; error?: string }): 'passed' | 'failed' | 'skipped' | 'not_applicable' {
   if (s.not_applicable) return 'not_applicable';
   if (s.skipped) return 'skipped';
@@ -129,6 +185,7 @@ async function main() {
   for (const sb of all) {
     process.stdout.write(`  ${sb.id.padEnd(40)} `);
     try {
+      const brand = brandForStoryboard(sb);
       const result = await runStoryboard(agentUrl, sb, {
         auth: { type: 'bearer', token: AUTH_TOKEN },
         allow_http: true,
@@ -139,6 +196,7 @@ async function main() {
           replayStore: new InMemoryReplayStore(),
           revocationStore: new InMemoryRevocationStore(),
         },
+        ...(brand && { brand }),
       });
       const summary = summarize(sb, result);
       results.push(summary);

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -1,0 +1,202 @@
+/**
+ * Run all applicable storyboards against the training agent.
+ *
+ *   TRAINING_AGENT_PORT=4444 npx tsx server/tests/manual/run-storyboards.ts
+ *   TRAINING_AGENT_PORT=4444 npx tsx server/tests/manual/run-storyboards.ts --filter signal-marketplace
+ *   TRAINING_AGENT_PORT=4444 npx tsx server/tests/manual/run-storyboards.ts --filter governance --verbose
+ *
+ * Expects a training agent already running at `http://127.0.0.1:${PORT}/api/training-agent/mcp`.
+ * Start one in a separate terminal with:
+ *
+ *   PUBLIC_TEST_AGENT_TOKEN=test-token PORT=4444 npm run start
+ */
+
+import express from 'express';
+import http from 'node:http';
+import {
+  listAllComplianceStoryboards,
+  runStoryboard,
+} from '@adcp/client/testing';
+import type { StoryboardResult, Storyboard } from '@adcp/client/testing';
+import {
+  StaticJwksResolver,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+} from '@adcp/client/signing';
+import type { AdcpJsonWebKey } from '@adcp/client/signing';
+
+// Set auth env BEFORE loading the training-agent router. The router captures
+// PUBLIC_TEST_AGENT_TOKEN / TRAINING_AGENT_TOKEN into its authenticator at
+// module load, so this assignment must happen before the dynamic imports
+// below.
+const AUTH_TOKEN = process.env.PUBLIC_TEST_AGENT_TOKEN ?? 'storyboard-runner-test-token';
+process.env.PUBLIC_TEST_AGENT_TOKEN = AUTH_TOKEN;
+// Silence pino logger noise so the progress table stays readable. Set
+// LOG_STORYBOARDS=1 to get full log output for diagnosis.
+if (!process.env.LOG_STORYBOARDS) process.env.LOG_LEVEL = 'silent';
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+const { getPublicJwks } = await import('../../src/training-agent/webhooks.js');
+
+const args = process.argv.slice(2);
+const verbose = args.includes('--verbose');
+const filter = args.includes('--filter') ? args[args.indexOf('--filter') + 1] : undefined;
+
+interface Summary {
+  id: string;
+  title: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  not_applicable: number;
+  error?: string;
+  failures: Array<{ step: string; error: string }>;
+}
+
+async function startLocalAgent(): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json({ limit: '5mb' }));
+  app.use('/api/training-agent', createTrainingAgentRouter());
+  return await new Promise((resolve, reject) => {
+    const srv = http.createServer(app);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('listen returned no address'));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}/api/training-agent/mcp`,
+        close: () => new Promise<void>(res => {
+          stopSessionCleanup();
+          srv.close(() => res());
+        }),
+      });
+    });
+  });
+}
+
+function isApplicable(sb: Storyboard): boolean {
+  if (filter && !sb.id.includes(filter) && !(sb.category ?? '').includes(filter)) return false;
+  return true;
+}
+
+function stepStatus(s: { passed?: boolean; skipped?: boolean; not_applicable?: boolean; validations?: Array<{ passed: boolean }>; error?: string }): 'passed' | 'failed' | 'skipped' | 'not_applicable' {
+  if (s.not_applicable) return 'not_applicable';
+  if (s.skipped) return 'skipped';
+  if (s.passed === false || s.error) return 'failed';
+  const validations = s.validations ?? [];
+  if (validations.some(v => !v.passed)) return 'failed';
+  return 'passed';
+}
+
+function summarize(sb: Storyboard, result: StoryboardResult | { error: string }): Summary {
+  const base: Summary = { id: sb.id, title: sb.title, passed: 0, failed: 0, skipped: 0, not_applicable: 0, failures: [] };
+  if ('error' in result) {
+    base.error = result.error;
+    return base;
+  }
+  for (const phase of result.phases ?? []) {
+    for (const step of phase.steps ?? []) {
+      const status = stepStatus(step as Parameters<typeof stepStatus>[0]);
+      base[status] += 1;
+      if (status === 'failed') {
+        const s = step as { id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
+        const validationFails = (s.validations ?? []).filter(v => !v.passed).map(v => v.description ?? '(validation failed)').join('; ');
+        base.failures.push({
+          step: s.id ?? '(unknown step)',
+          error: s.error ?? validationFails ?? '(failed without message)',
+        });
+      }
+    }
+  }
+  return base;
+}
+
+async function main() {
+  const { url: agentUrl, close } = await startLocalAgent();
+  // eslint-disable-next-line no-console
+  console.log(`\nTraining agent running at ${agentUrl}`);
+  // eslint-disable-next-line no-console
+  console.log(`Filter: ${filter ?? '(all storyboards)'}\n`);
+
+  const all = listAllComplianceStoryboards().filter(isApplicable);
+  const results: Summary[] = [];
+
+  const jwksResolver = new StaticJwksResolver(getPublicJwks().keys as AdcpJsonWebKey[]);
+
+  for (const sb of all) {
+    process.stdout.write(`  ${sb.id.padEnd(40)} `);
+    try {
+      const result = await runStoryboard(agentUrl, sb, {
+        auth: { type: 'bearer', token: AUTH_TOKEN },
+        allow_http: true,
+        contracts: ['webhook_receiver_runner'],
+        webhook_receiver: { mode: 'loopback_mock' },
+        webhook_signing: {
+          jwks: jwksResolver,
+          replayStore: new InMemoryReplayStore(),
+          revocationStore: new InMemoryRevocationStore(),
+        },
+      });
+      const summary = summarize(sb, result);
+      results.push(summary);
+      const pill = summary.failed === 0
+        ? `✓ ${summary.passed}P / ${summary.skipped}S / ${summary.not_applicable}N/A`
+        : `✗ ${summary.passed}P / ${summary.failed}F / ${summary.skipped}S / ${summary.not_applicable}N/A`;
+      // eslint-disable-next-line no-console
+      console.log(pill);
+    } catch (err) {
+      const summary = summarize(sb, { error: err instanceof Error ? err.message : String(err) });
+      results.push(summary);
+      // eslint-disable-next-line no-console
+      console.log(`⚠ ${summary.error}`);
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('\n--- Failures ---');
+  const failing = results.filter(r => r.failed > 0 || r.error);
+  if (failing.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('  (none — clean run)');
+  } else {
+    for (const r of failing) {
+      // eslint-disable-next-line no-console
+      console.log(`\n  ${r.id}: ${r.title}`);
+      if (r.error) console.log(`    ! ${r.error}`);
+      for (const f of r.failures.slice(0, verbose ? undefined : 5)) {
+        // eslint-disable-next-line no-console
+        console.log(`    × ${f.step}: ${f.error.slice(0, 160)}`);
+      }
+      if (!verbose && r.failures.length > 5) {
+        // eslint-disable-next-line no-console
+        console.log(`    … +${r.failures.length - 5} more (run with --verbose)`);
+      }
+    }
+  }
+
+  const totals = results.reduce((acc, r) => ({
+    passed: acc.passed + r.passed,
+    failed: acc.failed + r.failed,
+    skipped: acc.skipped + r.skipped,
+    not_applicable: acc.not_applicable + r.not_applicable,
+  }), { passed: 0, failed: 0, skipped: 0, not_applicable: 0 });
+
+  // eslint-disable-next-line no-console
+  console.log(`\n--- Totals ---`);
+  // eslint-disable-next-line no-console
+  console.log(`  storyboards: ${results.length - failing.length}/${results.length} clean`);
+  // eslint-disable-next-line no-console
+  console.log(`  steps: ${totals.passed} passed | ${totals.failed} failed | ${totals.skipped} skipped | ${totals.not_applicable} not applicable`);
+
+  await close();
+  process.exit(totals.failed > 0 || failing.some(r => r.error) ? 1 : 0);
+}
+
+main().catch(err => {
+  // eslint-disable-next-line no-console
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/server/tests/unit/idempotency.test.ts
+++ b/server/tests/unit/idempotency.test.ts
@@ -1,8 +1,18 @@
 /**
- * Direct unit tests for the idempotency module. The end-to-end middleware
- * behavior is covered by training-agent-idempotency.test.ts; this file
- * exercises paths that are awkward to reach through the full dispatcher
- * (clock-skew arithmetic, per-principal cache cap, payload-exclusion list).
+ * Unit tests for the training agent's idempotency facade.
+ *
+ * The behaviour tests (miss / replay / conflict / expired, TTL skew, JCS
+ * exclusion list) live in `@adcp/client`'s own test suite — the facade just
+ * delegates. What this file covers:
+ *
+ * - `MUTATING_TOOLS` drift against the request schemas (security-critical —
+ *   a missing entry means a mutating tool silently bypasses idempotency).
+ * - `validateKeyFormat` — the regex gate we apply before the store is
+ *   touched, so a malformed key never influences cache timing.
+ * - `scopedPrincipal` — the account-partitioning composition for the shared
+ *   public sandbox token, verified end-to-end against the live store.
+ * - `payloadHash` exclusion list — verifies the SDK's `hashPayload` honours
+ *   the spec-required exclusions so callers can rely on them.
  */
 
 import * as fs from 'node:fs';
@@ -14,19 +24,18 @@ import {
   isMutatingTool,
   validateKeyFormat,
   payloadHash,
-  lookupIdempotency,
-  cacheResponse,
-  clearIdempotencyCache,
   scopedPrincipal,
-  isPrincipalAtCap,
-  REPLAY_TTL_SECONDS,
+  getIdempotencyStore,
+  clearIdempotencyCache,
 } from '../../src/training-agent/idempotency.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-describe('idempotency primitives', () => {
-  beforeEach(() => clearIdempotencyCache());
+describe('idempotency facade', () => {
+  beforeEach(async () => {
+    await clearIdempotencyCache();
+  });
 
   describe('MUTATING_TOOLS', () => {
     it('matches the set derived from request schemas', () => {
@@ -100,7 +109,7 @@ describe('idempotency primitives', () => {
     });
   });
 
-  describe('payloadHash', () => {
+  describe('payloadHash (SDK hashPayload)', () => {
     it('ignores idempotency_key, context, governance_context', () => {
       const base = { account_id: 'acme', amount: 100 };
       expect(payloadHash({ ...base, idempotency_key: 'aaaaaaaaaaaaaaaa' }))
@@ -131,58 +140,37 @@ describe('idempotency primitives', () => {
     });
   });
 
-  describe('lookupIdempotency TTL behavior', () => {
-    it('returns replay within TTL', () => {
-      const payload = { foo: 'bar' };
-      cacheResponse('p', 'key-aaaaaaaaaaaa01', payload, { media_buy_id: 'mb_1' });
-      const outcome = lookupIdempotency('p', 'key-aaaaaaaaaaaa01', payload);
-      expect(outcome.kind).toBe('replay');
-      if (outcome.kind === 'replay') {
-        expect(outcome.response.media_buy_id).toBe('mb_1');
-      }
-    });
-
-    it('returns conflict when canonical payload drifts', () => {
-      cacheResponse('p', 'key-aaaaaaaaaaaa02', { foo: 'bar' }, { media_buy_id: 'mb_1' });
-      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa02', { foo: 'baz' }).kind).toBe('conflict');
-    });
-
-    it('returns expired past TTL + 60s skew, and evicts so the key can be reused', () => {
-      const now = 1_000_000_000_000;
-      const payload = { foo: 'bar' };
-      cacheResponse('p', 'key-aaaaaaaaaaaa03', payload, { media_buy_id: 'mb_1' }, now);
-
-      const beforeExpiry = now + REPLAY_TTL_SECONDS * 1000 + 30_000; // +30s < 60s skew
-      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, beforeExpiry).kind).toBe('replay');
-
-      const afterExpiry = now + REPLAY_TTL_SECONDS * 1000 + 61_000; // +61s > 60s skew
-      expect(lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, afterExpiry).kind).toBe('expired');
-
-      // Evicted — a fresh insert with the same key should now succeed
-      cacheResponse('p', 'key-aaaaaaaaaaaa03', payload, { media_buy_id: 'mb_2' }, afterExpiry);
-      const second = lookupIdempotency('p', 'key-aaaaaaaaaaaa03', payload, afterExpiry);
-      expect(second.kind).toBe('replay');
-      if (second.kind === 'replay') {
-        expect(second.response.media_buy_id).toBe('mb_2');
-      }
-    });
-
-    it('returns miss for unknown key', () => {
-      expect(lookupIdempotency('p', 'never-seen-1234567', { foo: 1 }).kind).toBe('miss');
-    });
-  });
-
-  describe('scopedPrincipal', () => {
-    it('partitions shared auth tokens by account scope', () => {
+  describe('scopedPrincipal partitioning', () => {
+    it('partitions shared auth tokens by account scope, end-to-end via the store', async () => {
       const a = scopedPrincipal('static:public', 'b:acme.example');
       const b = scopedPrincipal('static:public', 'b:beta.example');
       expect(a).not.toBe(b);
 
-      cacheResponse(a, 'shared-key-uuuuu01', { x: 1 }, { id: 'acme' });
-      // Same key on a different account scope is a miss — closes the
-      // cross-caller oracle on the public sandbox token.
-      expect(lookupIdempotency(b, 'shared-key-uuuuu01', { x: 1 }).kind).toBe('miss');
-      expect(lookupIdempotency(a, 'shared-key-uuuuu01', { x: 1 }).kind).toBe('replay');
+      const store = getIdempotencyStore();
+      const payload = { x: 1 };
+
+      // Insert under account A
+      const firstCheck = await store.check({ principal: a, key: 'shared-key-uuuuu01', payload });
+      expect(firstCheck.kind).toBe('miss');
+      if (firstCheck.kind === 'miss') {
+        await store.save({
+          principal: a,
+          key: 'shared-key-uuuuu01',
+          payloadHash: firstCheck.payloadHash,
+          response: { id: 'acme' },
+        });
+      }
+
+      // Same key under account B is a miss (the public-token oracle is closed).
+      const otherAccount = await store.check({ principal: b, key: 'shared-key-uuuuu01', payload });
+      expect(otherAccount.kind).toBe('miss');
+      if (otherAccount.kind === 'miss') {
+        await store.release({ principal: b, key: 'shared-key-uuuuu01' });
+      }
+
+      // Same key under account A replays.
+      const sameAccount = await store.check({ principal: a, key: 'shared-key-uuuuu01', payload });
+      expect(sameAccount.kind).toBe('replay');
     });
 
     it('keeps auth principals that contain colons unambiguous', () => {
@@ -190,16 +178,6 @@ describe('idempotency primitives', () => {
       const p1 = scopedPrincipal('workos:org_abc', 'b:x.example');
       const p2 = scopedPrincipal('workos:org_abcdef', '');
       expect(p1).not.toBe(p2);
-    });
-  });
-
-  describe('cache cap', () => {
-    it('isPrincipalAtCap is false by default', () => {
-      expect(isPrincipalAtCap('fresh')).toBe(false);
-    });
-
-    it('cacheResponse returns true on normal inserts', () => {
-      expect(cacheResponse('p', 'unique-key-aaaaaa01', { a: 1 }, { id: 1 })).toBe(true);
     });
   });
 });

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -8,7 +8,7 @@ import {
 
 const ctx = { mode: 'training' as const };
 
-type Handler = (args: Record<string, unknown>, ctx: { mode: string }) => Record<string, unknown>;
+type Handler = (args: Record<string, unknown>, ctx: { mode: string }) => Record<string, unknown> | Promise<Record<string, unknown>>;
 
 const handlers: Record<string, Handler> = {
   get_brand_identity: handleGetBrandIdentity,
@@ -17,31 +17,31 @@ const handlers: Record<string, Handler> = {
   update_rights: handleUpdateRights,
 };
 
-function call(tool: string, args: Record<string, unknown>) {
-  return handlers[tool](args, ctx);
+async function call(tool: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return await handlers[tool](args, ctx);
 }
 
 describe('brand protocol tools (training agent)', () => {
 
   describe('get_brand_identity', () => {
 
-    it('returns core fields for a valid brand', () => {
-      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
+    it('returns core fields for a valid brand', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.brand_id).toBe('daan_janssen');
       expect(result.house).toEqual({ domain: 'lotientertainment.com', name: 'Loti Entertainment' });
       expect(result.names).toEqual([{ en: 'Daan Janssen' }]);
     });
 
-    it('returns public fields without authorization', () => {
-      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
+    it('returns public fields without authorization', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.description).toBe('Dutch Olympic speed skater, 2x gold medalist');
       expect(result.industries).toEqual(['sports']);
       expect(result.tagline).toBe('Speed is a choice');
       expect(result.logos).toBeDefined();
     });
 
-    it('withholds authorized fields and lists them in available_fields', () => {
-      const result = call('get_brand_identity', { brand_id: 'daan_janssen' });
+    it('withholds authorized fields and lists them in available_fields', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'daan_janssen' });
       expect(result.colors).toBeUndefined();
       expect(result.tone).toBeUndefined();
       expect(result.voice_synthesis).toBeUndefined();
@@ -51,8 +51,8 @@ describe('brand protocol tools (training agent)', () => {
       );
     });
 
-    it('returns authorized fields with authorized=true', () => {
-      const result = call('get_brand_identity', { brand_id: 'daan_janssen', authorized: true });
+    it('returns authorized fields with authorized=true', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'daan_janssen', authorized: true });
       expect(result.colors).toBeDefined();
       expect(result.tone).toBeDefined();
       expect(result.voice_synthesis).toBeDefined();
@@ -60,8 +60,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.available_fields).toBeUndefined();
     });
 
-    it('returns only requested fields', () => {
-      const result = call('get_brand_identity', {
+    it('returns only requested fields', async () => {
+      const result = await call('get_brand_identity', {
         brand_id: 'daan_janssen',
         fields: ['description', 'tagline'],
       });
@@ -71,14 +71,14 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.logos).toBeUndefined();
     });
 
-    it('returns error for unknown brand', () => {
-      const result = call('get_brand_identity', { brand_id: 'nonexistent' });
+    it('returns error for unknown brand', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'nonexistent' });
       expect(result.errors).toBeDefined();
       expect((result.errors as Array<{ code: string }>)[0].code).toBe('brand_not_found');
     });
 
-    it('omits available_fields when talent lacks the requested authorized field', () => {
-      const result = call('get_brand_identity', {
+    it('omits available_fields when talent lacks the requested authorized field', async () => {
+      const result = await call('get_brand_identity', {
         brand_id: 'sofia_reyes',
         fields: ['voice_synthesis'],
       });
@@ -86,18 +86,18 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.available_fields).toBeUndefined();
     });
 
-    it('loads all sandbox advertiser brands from @adcp/client', () => {
+    it('loads all sandbox advertiser brands from @adcp/client', async () => {
       const expectedIds = ['acme_outdoor', 'nova_motors', 'bistro_oranje', 'osei_natural', 'summit_foods'];
       for (const id of expectedIds) {
-        const result = call('get_brand_identity', { brand_id: id });
+        const result = await call('get_brand_identity', { brand_id: id });
         expect(result.brand_id).toBe(id);
         expect(result.description).toBeDefined();
         expect((result.industries as string[]).length).toBeGreaterThan(0);
       }
     });
 
-    it('returns authorized fields for sandbox advertiser brands', () => {
-      const result = call('get_brand_identity', { brand_id: 'nova_motors', authorized: true });
+    it('returns authorized fields for sandbox advertiser brands', async () => {
+      const result = await call('get_brand_identity', { brand_id: 'nova_motors', authorized: true });
       expect(result.colors).toBeDefined();
       expect(result.tone).toBeDefined();
       expect(result.fonts).toBeDefined();
@@ -106,8 +106,8 @@ describe('brand protocol tools (training agent)', () => {
 
   describe('get_rights', () => {
 
-    it('returns Daan Janssen as top match for Amsterdam steakhouse', () => {
-      const result = call('get_rights', {
+    it('returns Daan Janssen as top match for Amsterdam steakhouse', async () => {
+      const result = await call('get_rights', {
         query: 'Dutch athlete for restaurant brand in Amsterdam',
         uses: ['likeness'],
       });
@@ -115,8 +115,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.rights as Array<{ brand_id: string }>)[0].brand_id).toBe('daan_janssen');
     });
 
-    it('excludes van Dijk for steakhouse queries', () => {
-      const result = call('get_rights', {
+    it('excludes van Dijk for steakhouse queries', async () => {
+      const result = await call('get_rights', {
         query: 'Dutch athlete for steakhouse in Amsterdam',
         uses: ['likeness'],
       });
@@ -124,8 +124,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(brandIds).not.toContain('pieter_van_dijk');
     });
 
-    it('shows exclusion reasons with include_excluded=true and includes suggestions', () => {
-      const result = call('get_rights', {
+    it('shows exclusion reasons with include_excluded=true and includes suggestions', async () => {
+      const result = await call('get_rights', {
         query: 'Dutch athlete for steakhouse in Amsterdam',
         uses: ['likeness'],
         include_excluded: true,
@@ -138,8 +138,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(excluded[0].suggestions![0]).toContain('plant-based');
     });
 
-    it('filters by country', () => {
-      const result = call('get_rights', {
+    it('filters by country', async () => {
+      const result = await call('get_rights', {
         query: 'athlete for food brand',
         uses: ['likeness'],
         countries: ['JP'],
@@ -149,8 +149,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(brandIds).not.toContain('daan_janssen');
     });
 
-    it('filters by specific brand_id', () => {
-      const result = call('get_rights', {
+    it('filters by specific brand_id', async () => {
+      const result = await call('get_rights', {
         query: 'athlete',
         uses: ['likeness'],
         brand_id: 'sofia_reyes',
@@ -159,8 +159,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.rights as Array<{ brand_id: string }>)[0].brand_id).toBe('sofia_reyes');
     });
 
-    it('includes pricing options', () => {
-      const result = call('get_rights', {
+    it('includes pricing options', async () => {
+      const result = await call('get_rights', {
         query: 'Dutch athlete for food brand',
         uses: ['likeness'],
       });
@@ -172,8 +172,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(cpm!.currency).toBe('EUR');
     });
 
-    it('sorts by match score descending', () => {
-      const result = call('get_rights', {
+    it('sorts by match score descending', async () => {
+      const result = await call('get_rights', {
         query: 'Dutch athlete for food brand in Netherlands, budget 400 EUR',
         uses: ['likeness'],
       });
@@ -187,8 +187,8 @@ describe('brand protocol tools (training agent)', () => {
   describe('acquire_rights', () => {
     const baseBuyer = { domain: 'bistro-oranje.nl', brand_id: 'bistro_oranje' };
 
-    it('auto-approves food category for Daan Janssen', () => {
-      const result = call('acquire_rights', {
+    it('auto-approves food category for Daan Janssen', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -204,8 +204,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.rights_constraint).toBeDefined();
     });
 
-    it('returns pending_approval for alcohol campaigns', () => {
-      const result = call('acquire_rights', {
+    it('returns pending_approval for alcohol campaigns', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         buyer: { domain: 'brouwerij-test.nl' },
@@ -218,8 +218,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.estimated_response_time).toBe('48h');
     });
 
-    it('rejects sportswear campaigns for Janssen with actionable suggestions', () => {
-      const result = call('acquire_rights', {
+    it('rejects sportswear campaigns for Janssen with actionable suggestions', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         buyer: { domain: 'sportswear-test.com' },
@@ -234,8 +234,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.suggestions as string[]).length).toBeGreaterThan(0);
     });
 
-    it('rejects confidential rule violations without suggestions', () => {
-      const result = call('acquire_rights', {
+    it('rejects confidential rule violations without suggestions', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'vandijk_likeness',
         pricing_option_id: 'cpm_likeness',
         buyer: baseBuyer,
@@ -249,8 +249,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(result.suggestions).toBeUndefined();
     });
 
-    it('includes voice credentials when voice is requested and talent has voice_synthesis', () => {
-      const result = call('acquire_rights', {
+    it('includes voice credentials when voice is requested and talent has voice_synthesis', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -265,8 +265,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(providers).toContain('elevenlabs');
     });
 
-    it('generation credentials match schema (uses, not scope)', () => {
-      const result = call('acquire_rights', {
+    it('generation credentials match schema (uses, not scope)', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -283,8 +283,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(cred.expires_at).toMatch(/T\d{2}:\d{2}:\d{2}Z$/);
     });
 
-    it('approval_webhook uses push-notification-config with authentication', () => {
-      const result = call('acquire_rights', {
+    it('approval_webhook uses push-notification-config with authentication', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -301,8 +301,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(webhook.authentication.credentials.length).toBeGreaterThanOrEqual(32);
     });
 
-    it('rights_constraint includes verification_url', () => {
-      const result = call('acquire_rights', {
+    it('rights_constraint includes verification_url', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -316,8 +316,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(constraint.verification_url).toContain('/verify');
     });
 
-    it('rights_constraint uses date-time format', () => {
-      const result = call('acquire_rights', {
+    it('rights_constraint uses date-time format', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
         buyer: baseBuyer,
@@ -333,8 +333,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(constraint.valid_until).toBe('2026-06-30T23:59:59Z');
     });
 
-    it('returns error for unknown rights_id', () => {
-      const result = call('acquire_rights', {
+    it('returns error for unknown rights_id', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'nonexistent',
         pricing_option_id: 'cpm_endorsement',
         buyer: baseBuyer,
@@ -343,8 +343,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.errors as Array<{ code: string }>)[0].code).toBe('rights_not_found');
     });
 
-    it('returns error for invalid pricing option', () => {
-      const result = call('acquire_rights', {
+    it('returns error for invalid pricing option', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'nonexistent',
         buyer: baseBuyer,
@@ -353,8 +353,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_pricing_option');
     });
 
-    it('returns error when buyer is missing', () => {
-      const result = call('acquire_rights', {
+    it('returns error when buyer is missing', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'cpm_endorsement',
         campaign: { description: 'test', uses: ['likeness'] },
@@ -362,8 +362,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.errors as Array<{ code: string }>)[0].code).toBe('invalid_request');
     });
 
-    it('rejects cosmetics for Yuki Tanaka', () => {
-      const result = call('acquire_rights', {
+    it('rejects cosmetics for Yuki Tanaka', async () => {
+      const result = await call('acquire_rights', {
         rights_id: 'tanaka_likeness_voice',
         pricing_option_id: 'cpm_voice',
         buyer: { domain: 'beauty-test.jp' },
@@ -379,8 +379,8 @@ describe('brand protocol tools (training agent)', () => {
 
   describe('update_rights', () => {
 
-    it('returns updated terms with extended end_date', () => {
-      const result = call('update_rights', {
+    it('returns updated terms with extended end_date', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
       });
@@ -388,8 +388,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.terms as { end_date: string }).end_date).toBe('2026-09-30');
     });
 
-    it('returns updated impression cap', () => {
-      const result = call('update_rights', {
+    it('returns updated impression cap', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         impression_cap: 200000,
       });
@@ -397,8 +397,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.rights_constraint as { impression_cap: number }).impression_cap).toBe(200000);
     });
 
-    it('returns re-issued generation credentials', () => {
-      const result = call('update_rights', {
+    it('returns re-issued generation credentials', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
       });
@@ -408,8 +408,8 @@ describe('brand protocol tools (training agent)', () => {
       expect(creds[0].rights_key).toMatch(/^rk_mj_sandbox_/);
     });
 
-    it('returns updated rights_constraint', () => {
-      const result = call('update_rights', {
+    it('returns updated rights_constraint', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2026-09-30',
         impression_cap: 200000,
@@ -420,23 +420,23 @@ describe('brand protocol tools (training agent)', () => {
       expect(constraint.rights_id).toBe('janssen_likeness_voice');
     });
 
-    it('returns paused state', () => {
-      const result = call('update_rights', {
+    it('returns paused state', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         paused: true,
       });
       expect(result.paused).toBe(true);
     });
 
-    it('omits paused when not provided', () => {
-      const result = call('update_rights', {
+    it('omits paused when not provided', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
       });
       expect(result.paused).toBeUndefined();
     });
 
-    it('returns error for unknown rights_id', () => {
-      const result = call('update_rights', {
+    it('returns error for unknown rights_id', async () => {
+      const result = await call('update_rights', {
         rights_id: 'nonexistent',
       });
       expect(result.errors).toBeDefined();
@@ -444,8 +444,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.errors as Array<{ message: string }>)[0].message).toContain('nonexistent');
     });
 
-    it('returns error for impression_cap below delivered', () => {
-      const result = call('update_rights', {
+    it('returns error for impression_cap below delivered', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         impression_cap: 10000,
       });
@@ -455,8 +455,8 @@ describe('brand protocol tools (training agent)', () => {
       expect((result.errors as Array<{ message: string }>)[0].message).toContain('50000');
     });
 
-    it('returns error for end_date before current', () => {
-      const result = call('update_rights', {
+    it('returns error for end_date before current', async () => {
+      const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
         end_date: '2025-01-01',
       });


### PR DESCRIPTION
## Summary

- **Migration to @adcp/client 5.2** (commit 532b207c8): swap our 279-LOC hand-rolled idempotency module for `createIdempotencyStore` + `pgBackend`, replace the bespoke bearer-token middleware with `verifyApiKey` + `anyOf` + `respondUnauthorized` (RFC 6750 compliant 401s), wire `createWebhookEmitter` with an Ed25519 key (env `WEBHOOK_SIGNING_KEY_JWK`, else ephemeral) and publish the public JWKS at `/.well-known/jwks.json`. Dispatch fires a signed completion webhook whenever a mutating tool's request carries `push_notification_config.url`. New migration `416_adcp_idempotency.sql`; `ComplianceIndex.domains` → `protocols` consumer update in `member-tools.ts`.
- **Storyboard compliance pass** (commit b0bd0c489): runner brand injection from `prerequisites.test_kit` (the SDK's `applyBrandInvariant` is a no-op without it — bare steps land in `open:default` while branded writes land in `open:<domain>`, surfacing as `MEDIA_BUY_NOT_FOUND` on every read). Local monkey-patch swaps the SDK's `schema.strict().parse()` for the default parse so tools that don't declare top-level `brand` tolerate the invariant injection (required fields still enforced). `sessionKeyFromArgs` prefers `brand.domain` over `account.account_id` in open mode. Seven new creative formats (`broadcast_30s`, `broadcast_15s`, `ssai_30s`, `preroll_15s`, `native_feed`, `display_300x250_generative`, `video_30s_generative`). Governance surfaces `customPolicies` with `enforcement: 'must'` as binding `conditions[]` plus warning findings on proposed-binding checks; delivery phase emits findings for `pacing` drift and overconcentrated `channel_distribution`. `GOVERNANCE_DENIED` errors on `create_media_buy` and (newly enforced) `acquire_rights` carry `details.findings`.
- **Result**: 587 unit tests green, 208 storyboard steps passing (baseline: 0), 25/54 storyboards fully clean.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run test:unit` — 587/587 passing (runs in pre-commit)
- [x] Training-agent unit + integration suite — 437 tests green (`training-agent.test.ts`, `training-agent-idempotency.test.ts`, `idempotency.test.ts`, `account-handlers.test.ts`, `comply-test-controller.test.ts`, `collection-lists-storyboard.test.ts`, `training-agent-sse.test.ts`, `training-agent-webhooks.test.ts`)
- [x] Webhook emission end-to-end verified: agent signs → receiver captures → `verifyWebhookSignature` validates against agent's published JWKS
- [x] Storyboard runner: 25/54 storyboards clean, 208 steps passing, run locally via `npx tsx server/tests/manual/run-storyboards.ts`
- [ ] CI green

## Follow-ups (tracked in the changesets, not in this PR)

1. **Upstream `@adcp/client` SDK bug** — `applyBrandInvariant` injects only top-level `brand`, never `account.brand`. Tools whose request-builders omit `account` (e.g. `get_media_buys`, `get_media_buy_delivery`) lose all scoping when the SDK strips the unrecognised top-level brand. Monkey-patched locally; filing issue upstream.
2. **Upstream storyboard YAML bugs**: `pending_creatives_to_start` asset shape, `sales_catalog_driven` `catalogs[].type` vs `catalog_type`, missing `caller` on `governance_spend_authority/*` and `governance_delivery_monitor`, negative `performance_index` in `creative_ad_server`.
3. **Training-agent seeding gaps**: `campaign_hero_video` creative, `mb_acme_q2_2026_auction` media buy, `sports_ctv_q2` product.
4. **`signed_requests` specialism** (37 step failures) — needs `verifyRequestSignature` + `createExpressVerifier` wired into the training agent's Express router, plus a `request_signing` capability declaration. The SDK ships all the pieces; it's additive capability work, not a migration gap. Follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)