### PR TITLE
fix(admin): review modal renders submissions; admins can preview draft events

### DIFF
--- a/.changeset/fix-review-modal-and-draft-event-preview.md
+++ b/.changeset/fix-review-modal-and-draft-event-preview.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix editorial review modal (#2539) so reviewers see the full submission — the pending-content API now returns `subtitle`, `external_url`, and `external_site_name`; the modal renders link-type submissions, falls back to an explicit "no body" placeholder, and scrolls long articles via `max-height: 90vh`.
+
+Let admins preview draft events via `/events/:slug` (#2536). The public endpoint now 404s only for non-admins when an event is still in draft; admins get the full detail page with a `draft_preview` flag and an in-page "Draft preview — not yet published" banner that points them to admin → events to change status.

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -582,15 +582,17 @@
 
   <!-- Review Modal -->
   <div id="reviewModal" class="modal-overlay">
-    <div class="modal" style="max-width: 800px;">
+    <div class="modal" style="max-width: 800px; max-height: 90vh; overflow-y: auto;">
       <button class="modal-close" onclick="closeReviewModal()" aria-label="Close">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
       <h2>Review Content</h2>
       <div id="reviewContent">
         <h3 id="reviewTitle"></h3>
+        <p id="reviewSubtitle" style="color: var(--color-text-secondary); margin: var(--space-2) 0 var(--space-3);"></p>
         <p id="reviewExcerpt" style="color: var(--color-text-secondary); margin: var(--space-4) 0; font-style: italic;"></p>
         <div id="reviewDetails" style="font-size: var(--text-sm); color: var(--color-text-secondary);"></div>
+        <div id="reviewExternalLink" style="margin-top: var(--space-4); display: none;"></div>
         <div id="reviewArticleContent" class="article-content" style="margin-top: var(--space-5); padding-top: var(--space-5); border-top: 1px solid var(--color-border);"></div>
       </div>
       <div class="modal-buttons" id="reviewButtons">
@@ -1692,15 +1694,37 @@
       const item = pendingContent.find(c => c.id === id);
       if (!item) return;
       reviewingContent = item;
-      document.getElementById('reviewTitle').textContent = item.title;
+      document.getElementById('reviewTitle').textContent = item.title || '(untitled)';
+      const subtitleEl = document.getElementById('reviewSubtitle');
+      if (item.subtitle) { subtitleEl.textContent = item.subtitle; subtitleEl.style.display = ''; }
+      else { subtitleEl.textContent = ''; subtitleEl.style.display = 'none'; }
       document.getElementById('reviewExcerpt').textContent = item.excerpt || '';
       document.getElementById('reviewDetails').innerHTML = DOMPurify.sanitize(`
-        <p><strong>Type:</strong> ${item.content_type} <strong>Collection:</strong> ${item.collection?.committee_name || 'Personal'}</p>
-        <p><strong>Proposed by:</strong> ${item.proposer?.name || 'Unknown'} on ${formatDate(item.proposed_at)}</p>
+        <p><strong>Type:</strong> ${esc(item.content_type)} <strong>Collection:</strong> ${esc(item.collection?.committee_name || 'Personal')}</p>
+        <p><strong>Proposed by:</strong> ${esc(item.proposer?.name || 'Unknown')} on ${esc(formatDate(item.proposed_at))}</p>
       `);
+      const linkEl = document.getElementById('reviewExternalLink');
+      if (item.external_url) {
+        const site = item.external_site_name ? ` (${esc(item.external_site_name)})` : '';
+        linkEl.innerHTML = DOMPurify.sanitize(
+          `<strong>External link:</strong> <a href="${esc(item.external_url)}" target="_blank" rel="noopener noreferrer">${esc(item.external_url)}</a>${site}`
+        );
+        linkEl.style.display = '';
+      } else {
+        linkEl.innerHTML = '';
+        linkEl.style.display = 'none';
+      }
       const el = document.getElementById('reviewArticleContent');
-      if (item.content) { el.innerHTML = DOMPurify.sanitize(marked.parse(item.content, { async: false })); el.style.display = ''; }
-      else { el.innerHTML = ''; el.style.display = 'none'; }
+      if (item.content) {
+        el.innerHTML = DOMPurify.sanitize(marked.parse(item.content, { async: false }));
+        el.style.display = '';
+      } else if (item.content_type === 'link') {
+        el.innerHTML = '<p style="color: var(--color-text-muted); font-style: italic;">No article body — this submission links to an external URL above.</p>';
+        el.style.display = '';
+      } else {
+        el.innerHTML = '<p style="color: var(--color-text-muted); font-style: italic;">No article body was submitted.</p>';
+        el.style.display = '';
+      }
       document.getElementById('rejectionReason').value = '';
       document.getElementById('reviewButtons').classList.remove('hidden');
       document.getElementById('rejectForm').classList.add('hidden');

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -529,6 +529,9 @@
       <p>The event you're looking for doesn't exist or has been removed.</p>
       <a href="/events" class="btn btn-primary">View All Events</a>
     </div>
+    <div id="draftBanner" style="display: none; background: var(--color-warning-100, #fef3c7); border: 1px solid var(--color-warning-300, #fcd34d); color: var(--color-warning-800, #92400e); padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px;">
+      <strong>Draft preview</strong> — this event is not yet published. Only admins can see this page. Set status to <em>Published</em> in <a href="/admin/events" style="color: inherit; text-decoration: underline;">admin → events</a> to make it public.
+    </div>
     <div id="content" style="display: none;"></div>
   </div>
 
@@ -554,6 +557,9 @@
 
         renderEvent(event, sponsors, registrationCount, industryGathering, myRegistration);
 
+        if (data.draft_preview) {
+          document.getElementById('draftBanner').style.display = 'block';
+        }
         document.getElementById('loading').style.display = 'none';
         document.getElementById('content').style.display = 'block';
       } catch (error) {

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -512,7 +512,8 @@ export function createContentRouter(): Router {
       // Build query for pending content
       let query = `
         SELECT
-          p.id, p.title, p.excerpt, p.content, p.slug, p.content_type,
+          p.id, p.title, p.subtitle, p.excerpt, p.content, p.slug, p.content_type,
+          p.external_url, p.external_site_name,
           p.proposer_user_id, p.proposed_at, p.working_group_id,
           wg.name as committee_name, wg.slug as committee_slug,
           u.first_name, u.last_name, u.email as proposer_email,
@@ -547,10 +548,13 @@ export function createContentRouter(): Router {
       const items = result.rows.map(row => ({
         id: row.id,
         title: row.title,
+        subtitle: row.subtitle,
         slug: row.slug,
         excerpt: row.excerpt,
         content: row.content,
         content_type: row.content_type,
+        external_url: row.external_url,
+        external_site_name: row.external_site_name,
         proposer: {
           id: row.proposer_user_id,
           name: row.first_name && row.last_name

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -38,6 +38,7 @@ import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { createChannel, setChannelPurpose, sendDirectMessage } from "../slack/client.js";
 import { SlackDatabase } from "../db/slack-db.js";
 import { EmailPreferencesDatabase } from "../db/email-preferences-db.js";
+import { isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
 
 /**
  * Zoom participant report CSV row structure.
@@ -1640,11 +1641,30 @@ export function createEventsRouter(): {
       const { slug } = req.params;
 
       const event = await eventsDb.getEventBySlug(slug);
-      if (!event || !["published", "completed"].includes(event.status)) {
+      if (!event) {
         return res.status(404).json({
           error: "Event not found",
           message: "No event found with that slug",
         });
+      }
+
+      // Allow admins to preview events that aren't yet published (draft/cancelled)
+      // so they can verify agendas and details before publishing. Non-admins still 404.
+      let isDraftPreview = false;
+      if (!["published", "completed"].includes(event.status)) {
+        const user = req.user;
+        const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
+        const isAdmin = !!user && (
+          adminEmails.includes(user.email.toLowerCase()) ||
+          await isWebUserAAOAdmin(user.id)
+        );
+        if (!isAdmin) {
+          return res.status(404).json({
+            error: "Event not found",
+            message: "No event found with that slug",
+          });
+        }
+        isDraftPreview = true;
       }
 
       // invite_unlisted events are 404 for non-invited users
@@ -1743,6 +1763,7 @@ export function createEventsRouter(): {
           slack_channel_url: industryGathering.slack_channel_url,
         } : null,
         my_registration: myRegistration,
+        draft_preview: isDraftPreview,
       });
     } catch (error) {
       logger.error({ err: error }, "Error getting event");

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -373,4 +373,57 @@ describe('My Content — body, admin scope, status, delete', () => {
       await request(app).delete(`/api/me/content/${id}`).expect(403);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #2539 — review modal needs enough fields to actually review a submission
+  // ---------------------------------------------------------------------------
+
+  describe('GET /api/content/pending', () => {
+    async function insertLinkPerspective(opts: {
+      slug: string;
+      title: string;
+      subtitle?: string;
+      externalUrl: string;
+      externalSiteName?: string;
+      workingGroupId?: string | null;
+    }) {
+      const result = await pool.query(
+        `INSERT INTO perspectives
+           (slug, content_type, title, subtitle, content, excerpt, category,
+            status, external_url, external_site_name, working_group_id,
+            content_origin, proposer_user_id, author_name, proposed_at)
+         VALUES ($1, 'link', $2, $3, NULL, 'link excerpt', 'Perspective',
+                 'pending_review', $4, $5, $6, 'member', $7, 'Author', NOW())
+         RETURNING id`,
+        [
+          opts.slug,
+          opts.title,
+          opts.subtitle ?? null,
+          opts.externalUrl,
+          opts.externalSiteName ?? null,
+          opts.workingGroupId ?? wgId,
+          USER_ID,
+        ]
+      );
+      return result.rows[0].id as string;
+    }
+
+    it('surfaces external_url and subtitle so reviewers can evaluate link submissions', async () => {
+      await insertLinkPerspective({
+        slug: 'mc-test-pending-link',
+        title: 'An external read',
+        subtitle: 'Why agents matter',
+        externalUrl: 'https://example.com/article',
+        externalSiteName: 'Example Blog',
+      });
+
+      const response = await request(app).get('/api/content/pending').expect(200);
+      const item = response.body.items.find((i: any) => i.slug === 'mc-test-pending-link');
+      expect(item).toBeDefined();
+      expect(item.external_url).toBe('https://example.com/article');
+      expect(item.external_site_name).toBe('Example Blog');
+      expect(item.subtitle).toBe('Why agents matter');
+      expect(item.content_type).toBe('link');
+    });
+  });
 });

--- a/server/tests/integration/events-draft-preview.test.ts
+++ b/server/tests/integration/events-draft-preview.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// WorkOS mock — must be registered before any module that reads from it.
+vi.mock('../../src/auth/workos-client.js', () => ({
+  workos: {
+    userManagement: {
+      getUser: vi.fn().mockResolvedValue({ id: 'user_evt_admin', email: 'evt-admin@example.com', firstName: 'Evt', lastName: 'Admin' }),
+      listUsers: vi.fn().mockResolvedValue({ data: [], listMetadata: {} }),
+    },
+    organizations: {
+      getOrganization: vi.fn().mockResolvedValue({ id: 'org_test', name: 'Test Org' }),
+    },
+  },
+}));
+
+const authState = {
+  userId: 'user_evt_admin',
+  email: 'evt-admin@example.com',
+  authed: true,
+};
+
+vi.mock('../../src/middleware/auth.js', () => {
+  const setTestUser = (req: any) => {
+    if (!authState.authed) return;
+    req.user = { id: authState.userId, email: authState.email, firstName: 'Evt' };
+  };
+  const passthrough = (_req: any, _res: any, next: any) => next();
+  return {
+    requireAuth: (req: any, _res: any, next: any) => { setTestUser(req); next(); },
+    requireAdmin: passthrough,
+    optionalAuth: (req: any, _res: any, next: any) => { setTestUser(req); next(); },
+    requireCompanyAccess: passthrough,
+    requireActiveSubscription: passthrough,
+    requireSignedAgreement: passthrough,
+    requireRole: () => passthrough,
+    createRequireWorkingGroupLeader: () => passthrough,
+    createRequireWorkingGroupMember: () => passthrough,
+    invalidateSessionCache: vi.fn(),
+    invalidateBanCache: vi.fn(),
+    isDevModeEnabled: () => false,
+    getDevUser: () => null,
+    getAvailableDevUsers: () => ({}),
+    getDevSessionCookieName: () => 'dev_session',
+    DEV_USERS: {},
+  };
+});
+
+vi.mock('../../src/mcp/routes.js', () => ({
+  configureMCPRoutes: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/csrf.js', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+
+const adminState = { isAdmin: false };
+vi.mock('../../src/addie/mcp/admin-tools.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    isWebUserAAOAdmin: vi.fn(async () => adminState.isAdmin),
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+  createEventSponsorshipProduct: vi.fn().mockResolvedValue(null),
+  createCheckoutSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import request from 'supertest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import type { Pool } from 'pg';
+
+describe('GET /api/events/:slug — draft preview for admins (#2536)', () => {
+  let server: HTTPServer;
+  let app: any;
+  let pool: Pool;
+  const USER_ID = 'user_evt_admin';
+  const DRAFT_SLUG = 'evt-draft-preview-test';
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name)
+       VALUES ($1, 'evt-admin@example.com', 'Evt', 'Admin')
+       ON CONFLICT (workos_user_id) DO NOTHING`,
+      [USER_ID]
+    );
+
+    server = new HTTPServer();
+    await server.start(0);
+    app = server.app;
+  }, 30000);
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM events WHERE slug = $1`, [DRAFT_SLUG]);
+    await pool.query(`DELETE FROM users WHERE workos_user_id = $1`, [USER_ID]);
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    adminState.isAdmin = false;
+    authState.authed = true;
+    await pool.query(`DELETE FROM events WHERE slug = $1`, [DRAFT_SLUG]);
+    await pool.query(
+      `INSERT INTO events (slug, title, start_time, status, visibility, event_format, event_type)
+       VALUES ($1, 'Draft Event', NOW() + INTERVAL '7 days', 'draft', 'public', 'in_person', 'summit')`,
+      [DRAFT_SLUG]
+    );
+  });
+
+  it('returns 404 for anonymous viewers of a draft event', async () => {
+    authState.authed = false;
+    await request(app).get(`/api/events/${DRAFT_SLUG}`).expect(404);
+  });
+
+  it('returns 404 for signed-in non-admins of a draft event', async () => {
+    authState.authed = true;
+    adminState.isAdmin = false;
+    await request(app).get(`/api/events/${DRAFT_SLUG}`).expect(404);
+  });
+
+  it('lets admins preview a draft event and flags it with draft_preview=true', async () => {
+    authState.authed = true;
+    adminState.isAdmin = true;
+
+    const response = await request(app).get(`/api/events/${DRAFT_SLUG}`).expect(200);
+    expect(response.body.event.slug).toBe(DRAFT_SLUG);
+    expect(response.body.event.status).toBe('draft');
+    expect(response.body.draft_preview).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2539. Partially addresses #2536 (visibility-vs-status confusion). Second half of #2536 (speaker headshots/bios) split to #2552.

## Summary

- **#2539 — editorial review modal was effectively empty.** `/api/content/pending` now returns `subtitle`, `external_url`, and `external_site_name`, so reviewers can actually evaluate link-type submissions. The modal renders link URLs, falls back to an explicit "no body submitted" placeholder instead of showing nothing, and scrolls long articles via `max-height: 90vh` (admin-content.html was missing the scroll constraint that my-content.html already has).
- **#2536 (first half) — admins couldn't preview unpublished events.** The public `/api/events/:slug` endpoint 404'd for everyone whenever `status != published|completed`, even admins, which is why Mary's "I made it public on the backend" didn't help (she needed to change *status*, not *visibility*). Now admins get the detail page with a `draft_preview: true` flag and an in-page "Draft preview — not yet published" banner pointing them to `/admin/events`. Non-admin semantics unchanged — drafts still 404 so their existence isn't revealed.
- **#2536 (second half)** — net-new speakers/headshots/bios feature split to #2552 with a spec outline. It needs schema + admin UI + public render and shouldn't block the visibility fix.

## Test plan

- [x] `npm run test:server-unit` — 1604 passed
- [x] Precommit hook (vitest + typecheck) — 587 passed
- [x] New integration test: `server/tests/integration/events-draft-preview.test.ts` verifies 404 for anon + non-admin, 200 + `draft_preview:true` for admin
- [x] New integration test in `content-my-content.test.ts` verifies `external_url`, `external_site_name`, `subtitle` are surfaced by `/api/content/pending`
- [ ] Visual smoke test in dev: open a pending link-type article as an admin, confirm the review modal now shows the external URL + placeholder body

🤖 Generated with [Claude Code](https://claude.com/claude-code)