### PR TITLE
fix(nav): admin dropdown link honors aao-admin WG + dev admin user

### DIFF
--- a/.changeset/fix-nav-admin-link-for-working-group-admins.md
+++ b/.changeset/fix-nav-admin-link-for-working-group-admins.md
@@ -1,0 +1,4 @@
+---
+---
+
+Show the "Admin" link in the account dropdown for admins whose status comes from the `aao-admin` working group (not just `ADMIN_EMAILS`), and for dev admin users. The injected `window.__APP_CONFIG__.user.isAdmin` that `nav.js` reads was only checking `ADMIN_EMAILS`, so anyone promoted via the aao-admin working group — and the `admin@test.local` dev user — lost their Admin menu item even though `requireAdmin` still let them in. Added `enrichUserWithAdmin` (same rules as `requireAdmin`) and called it everywhere the app config is built (`serveHtmlWithConfig`, both in-class and shared variants; `/api/config`).

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -116,7 +116,7 @@ import { sendWelcomeEmail, sendUserSignupEmail, emailDb } from "./notifications/
 import { emailPrefsDb } from "./db/email-preferences-db.js";
 import { pendingConfirmationsDb } from "./db/pending-confirmations-db.js";
 import { queuePerspectiveLink } from "./addie/services/content-curator.js";
-import { serveHtmlWithMetaTags, enrichUserWithMembership } from "./utils/html-config.js";
+import { serveHtmlWithMetaTags, enrichUserWithMembership, enrichUserWithAdmin } from "./utils/html-config.js";
 import { complete, isLLMConfigured } from "./utils/llm.js";
 import { notifyJoinRequest, notifyMemberAdded, notifySubscriptionThankYou } from "./slack/org-group-dm.js";
 import { BansDatabase } from "./db/bans-db.js";
@@ -313,11 +313,17 @@ async function upsertInvoiceCache(
  * Build app config object for injection into HTML pages.
  * This allows nav.js to read config synchronously instead of making an async fetch.
  */
-function buildAppConfig(user?: { id?: string; email: string; firstName?: string | null; lastName?: string | null; isMember?: boolean } | null) {
+function buildAppConfig(user?: { id?: string; email: string; firstName?: string | null; lastName?: string | null; isMember?: boolean; isAdmin?: boolean } | null) {
+  // Trust a pre-resolved isAdmin (set by enrichUserWithAdmin / dev-user flag).
+  // Fall back to ADMIN_EMAILS for callers that haven't enriched yet.
   let isAdmin = false;
   if (user) {
-    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-    isAdmin = adminEmails.includes(user.email.toLowerCase());
+    if (typeof user.isAdmin === 'boolean') {
+      isAdmin = user.isAdmin;
+    } else {
+      const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
+      isAdmin = adminEmails.includes(user.email.toLowerCase());
+    }
   }
 
   return {
@@ -340,7 +346,7 @@ function buildAppConfig(user?: { id?: string; email: string; firstName?: string 
 /**
  * Generate the script tags to inject app config and PostHog into HTML.
  */
-function getAppConfigScript(user?: { id?: string; email: string; firstName?: string | null; lastName?: string | null; isMember?: boolean } | null): string {
+function getAppConfigScript(user?: { id?: string; email: string; firstName?: string | null; lastName?: string | null; isMember?: boolean; isAdmin?: boolean } | null): string {
   const config = buildAppConfig(user);
   const configScript = `<script>window.__APP_CONFIG__=${JSON.stringify(config)};</script>`;
 
@@ -625,6 +631,7 @@ export class HTTPServer {
         // Get user from session (if authenticated), passing res to update cookie if session is refreshed
         const user = await getUserFromRequest(req, res);
         await enrichUserWithMembership(user);
+        await enrichUserWithAdmin(user);
 
         // Inject config
         const configScript = getAppConfigScript(user);
@@ -744,6 +751,7 @@ export class HTTPServer {
       // Get user from session (if authenticated), passing res to update cookie if session is refreshed
       const user = await getUserFromRequest(req, res);
       await enrichUserWithMembership(user);
+      await enrichUserWithAdmin(user);
 
       // Read and inject config
       let html = await fs.readFile(filePath, 'utf-8');
@@ -1648,6 +1656,7 @@ export class HTTPServer {
         // Inject user config for nav.js, passing res to update cookie if session is refreshed
         const user = await getUserFromRequest(req, res);
         await enrichUserWithMembership(user);
+        await enrichUserWithAdmin(user);
 
         const configScript = getAppConfigScript(user);
         if (html.includes('</head>')) {
@@ -1687,6 +1696,7 @@ export class HTTPServer {
         // Inject user config for nav.js, passing res to update cookie if session is refreshed
         const user = await getUserFromRequest(req, res);
         await enrichUserWithMembership(user);
+        await enrichUserWithAdmin(user);
 
         const configScript = getAppConfigScript(user);
         if (html.includes('</head>')) {
@@ -1750,22 +1760,16 @@ export class HTTPServer {
       res.setHeader('Pragma', 'no-cache');
       res.setHeader('Expires', '0');
 
-      // User is populated by optionalAuth middleware if authenticated
-      let isAdmin = false;
-      if (req.user) {
-        const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-        isAdmin = adminEmails.includes(req.user.email.toLowerCase());
-      }
-
       let user = null;
       if (req.user) {
         await enrichUserWithMembership(req.user as any);
+        await enrichUserWithAdmin(req.user as any);
         user = {
           id: req.user.id,
           email: req.user.email,
           firstName: req.user.firstName,
           lastName: req.user.lastName,
-          isAdmin,
+          isAdmin: !!(req.user as any).isAdmin,
           isMember: !!(req.user as any).isMember,
         };
       }

--- a/server/src/utils/html-config.ts
+++ b/server/src/utils/html-config.ts
@@ -13,6 +13,7 @@ import { getPool } from "../db/client.js";
 import { resolveEffectiveMembership } from "../db/org-filters.js";
 import { resolvePreferredOrganization, backfillPrimaryOrganization } from "../db/users-db.js";
 import { createLogger } from "../logger.js";
+import { isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
 
 const logger = createLogger('html-config');
 
@@ -36,6 +37,7 @@ interface AppUser {
   firstName?: string | null;
   lastName?: string | null;
   isMember?: boolean;
+  isAdmin?: boolean;
 }
 
 /**
@@ -47,10 +49,17 @@ export function buildAppConfig(user?: AppUser | null): {
   user: { id?: string; email: string; firstName?: string | null; lastName?: string | null; isAdmin: boolean; isMember: boolean } | null;
   posthog: { apiKey: string; host: string } | null;
 } {
+  // Trust a pre-resolved isAdmin (set by enrichUserWithAdmin / dev-user flag).
+  // Fall back to ADMIN_EMAILS for callers that haven't enriched yet so we don't
+  // regress from prior behavior.
   let isAdmin = false;
   if (user) {
-    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-    isAdmin = adminEmails.includes(user.email.toLowerCase());
+    if (typeof user.isAdmin === 'boolean') {
+      isAdmin = user.isAdmin;
+    } else {
+      const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
+      isAdmin = adminEmails.includes(user.email.toLowerCase());
+    }
   }
 
   return {
@@ -134,6 +143,34 @@ export function getPublicFilePath(filename: string): string {
 }
 
 /**
+ * Resolve the admin flag for a user using the same rules as the requireAdmin
+ * middleware: ADMIN_EMAILS env var OR membership in the aao-admin working
+ * group. If the user already has isAdmin set (e.g. a dev user), trust it.
+ */
+export async function enrichUserWithAdmin(user: AppUser | null | undefined): Promise<AppUser | null | undefined> {
+  if (!user) return user;
+  if (typeof user.isAdmin === 'boolean') return user;
+
+  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
+  if (adminEmails.includes(user.email.toLowerCase())) {
+    user.isAdmin = true;
+    return user;
+  }
+
+  if (user.id) {
+    try {
+      user.isAdmin = await isWebUserAAOAdmin(user.id);
+    } catch (error) {
+      logger.warn({ error, userId: user.id }, 'Failed to resolve isAdmin via working group; defaulting to false');
+      user.isAdmin = false;
+    }
+  } else {
+    user.isAdmin = false;
+  }
+  return user;
+}
+
+/**
  * Enrich a user object with membership status from the database.
  * Checks both direct and inherited membership via the brand registry hierarchy.
  */
@@ -193,6 +230,7 @@ export async function serveHtmlWithConfig(
   const filePath = getPublicFilePath(filename);
 
   await enrichUserWithMembership(req.user);
+  await enrichUserWithAdmin(req.user);
   const html = await fs.readFile(filePath, "utf-8");
   const injectedHtml = injectConfigIntoHtml(html, req.user);
 
@@ -351,6 +389,7 @@ export async function serveHtmlWithMetaTags(
   const filePath = getPublicFilePath(filename);
 
   await enrichUserWithMembership(req.user);
+  await enrichUserWithAdmin(req.user);
   let html = await fs.readFile(filePath, "utf-8");
 
   // Inject meta tags first (if provided)


### PR DESCRIPTION
## Problem

Visiting \`/member-hub\` while signed in as an admin — including the \`admin@test.local\` dev user — did not show the "Admin" entry in the account dropdown, even though \`requireAdmin\` still let the same user into every \`/admin/*\` page. The gap: \`window.__APP_CONFIG__.user.isAdmin\` (what \`nav.js\` reads) was computed only from \`ADMIN_EMAILS\`, missing:

1. Production admins whose status comes from the \`aao-admin\` working group (the path \`requireAdmin\` actually uses most of the time).
2. The \`admin@test.local\` dev user — \`DevUserConfig.isAdmin\` was being thrown away by the config builder.

## Fix

Added \`enrichUserWithAdmin()\` in \`server/src/utils/html-config.ts\` that applies the same rules as \`requireAdmin\`:

1. If the caller already set \`user.isAdmin\` (dev user), trust it.
2. Otherwise check \`ADMIN_EMAILS\`.
3. Otherwise check \`isWebUserAAOAdmin(user.id)\`.

Called from every site that builds the app config:

- \`server/src/utils/html-config.ts:serveHtmlWithConfig\` (used by events, billing, addie-chat, etc.)
- \`server/src/http.ts:serveHtmlWithConfig\` class method (used by \`/member-hub\`, \`/community\`, \`/dashboard/*\`)
- \`server/src/http.ts:/api/config\` endpoint (fallback for pages that fetch auth state async)

Both \`buildAppConfig\` variants now read \`user.isAdmin\` when pre-set, falling back to the prior \`ADMIN_EMAILS\`-only logic if nobody enriched — so no behavior regresses for existing call paths.

## Validation

Before: \`curl -b 'dev-session=admin' /member-hub | grep isAdmin\` → \`"isAdmin":false\`
After:  \`curl -b 'dev-session=admin' /member-hub | grep isAdmin\` → \`"isAdmin":true\`

Playwright check (\`.context/verify-admin-menu.mjs\`):
\`\`\`
Dropdown items: [ 'Your profile', 'Member settings', 'Admin', 'Log out' ]
PASS: admin link visible
\`\`\`

## Test plan

- [x] Typecheck clean
- [x] Precommit passes (587 tests)
- [x] Browser verification against local \`docker compose\` stack
- [ ] Spot-check a staging/prod aao-admin WG member after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)