### PR TITLE
refactor(compliance): normalize storyboard brand/account consistency (#2528, #2530, #2533)

### DIFF
--- a/.changeset/normalize-storyboard-brand-and-account.md
+++ b/.changeset/normalize-storyboard-brand-and-account.md
@@ -1,0 +1,10 @@
+---
+---
+
+Storyboard consistency pass across `static/compliance/source/`:
+
+- Normalize brand and agency domains to the RFC 2606 `.example` TLD: `acmeoutdoor.com` → `acmeoutdoor.example`, `amsterdam-steakhouse.com` → `amsterdam-steakhouse.example`, `pinnacle-agency.com` → `pinnacle-agency.example`, and fix the `acme-outdoor.example.com` typo (#2530).
+- Fix `operator: <brand.domain>` in property-lists and collection-lists specialisms — these are meant to demonstrate an agency operating on behalf of a brand, not the brand operating directly. Use `pinnacle-agency.example` (#2533).
+- Standardize buyer-side storyboards on the expressive `account: { brand, operator }` shape. Where steps already had an `account` block, drop the redundant top-level `brand`; otherwise promote the top-level `brand` into an `account` wrapper with `operator: "pinnacle-agency.example"` (#2528).
+
+Purely mechanical: no runtime behavior change, both shapes still resolve to the same session key via `sessionKeyFromArgs`.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -105,8 +105,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -148,8 +148,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "https://governance.pinnacle-agency.example"
                   authentication:
@@ -206,7 +206,7 @@ phases:
           plans:
             - plan_id: "gov_acme_q2_2027"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Q2 outdoor lifestyle campaign — display and video, Adults 25-54, US"
               budget:
                 total: 50000
@@ -273,11 +273,11 @@ phases:
           buying_mode: "brief"
           brief: "Premium CTV and video on sports publishers. Q2 flight, $50K budget. Adults 25-54, US."
           brand:
-            domain: "acmeoutdoor.com"
+            domain: "acmeoutdoor.example"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "media_buy_governance_escalation--get_products_brief"
@@ -343,8 +343,8 @@ phases:
             type: "media_buy"
             account:
               brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
             total_budget: 50000
             packages:
               - product_id: "sports_ctv_q2"
@@ -411,8 +411,8 @@ phases:
             type: "media_buy"
             account:
               brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
             total_budget: 50000
             packages:
               - product_id: "sports_ctv_q2"
@@ -420,7 +420,7 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
           human_approval:
-            approved_by: "jsmith@pinnacle-agency.com"
+            approved_by: "jsmith@pinnacle-agency.example"
             approved_at: "2026-04-03T14:22:00Z"
             conditions:
               - "Weekly delivery reporting required"
@@ -484,10 +484,10 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           brand:
-            domain: "acmeoutdoor.com"
+            domain: "acmeoutdoor.example"
           governance_context: "gov_ctx_acme_q2_approved"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"

--- a/static/compliance/source/protocols/media-buy/creative-reception.yaml
+++ b/static/compliance/source/protocols/media-buy/creative-reception.yaml
@@ -148,7 +148,7 @@ phases:
                   url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg"
                 click_url:
                   asset_type: "url"
-                  url: "https://acme-outdoor.example.com/summer-sale"
+                  url: "https://acmeoutdoor.example/summer-sale"
 
           idempotency_key: "$generate:uuid_v4#creative_sales_agent_push_creatives_sync_creatives"
           context:

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -371,6 +371,8 @@ phases:
           - Used only when the seller needs the buyer to respond (e.g., confirm a budget). If the blocker is account-level (credit application, funding), the resolution path is list_accounts / sync_accounts, where account.setup.url surfaces on the pending_approval account
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -133,8 +133,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_account_setup_sync_accounts"
@@ -185,8 +185,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "https://governance.pinnacle-agency.example"
                   authentication:
@@ -258,12 +258,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video inventory on sports and outdoor lifestyle publishers. Q2 flight, $50K budget. Adults 25-54, US and Canada."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           context:
             correlation_id: "media_buy_seller--get_products_brief"
 
@@ -375,10 +373,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -444,8 +440,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026"
           context:
@@ -554,8 +550,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
@@ -629,8 +625,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -54,8 +54,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_delivery_reporting_setup_sync_accounts"
@@ -79,12 +79,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display and video inventory on outdoor lifestyle content. Q2 flight, $25K budget. Adults 25-54, US."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -105,10 +103,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -169,8 +165,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "$context.media_buy_id"
           include_package_daily_breakdown: true

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -101,6 +101,8 @@ phases:
         expected: |
           Create the media buy. We need a media_buy_id to simulate delivery against.
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -59,7 +59,7 @@ phases:
           plans:
             - plan_id: "comply-gov-approved-plan"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Q2 outdoor lifestyle campaign — display and video"
               budget:
                 total: 100000
@@ -88,8 +88,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_approved_seller_setup_sync_accounts"
@@ -113,8 +113,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
@@ -139,12 +139,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display and video inventory on outdoor lifestyle content. Q2 flight, $25K budget. Adults 25-54, US."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -166,10 +164,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -162,6 +162,8 @@ phases:
           The buy succeeds — governance approved because the $25K buy is within
           the plan's $100K budget.
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -174,6 +174,8 @@ phases:
           - governance_context: token from the governance agent
           - conditions visible to the buyer
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -61,7 +61,7 @@ phases:
           plans:
             - plan_id: "comply-gov-conditions-plan"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Q2 CTV campaign with reporting requirements"
               budget:
                 total: 100000
@@ -97,8 +97,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_conditions_seller_setup_sync_accounts"
@@ -122,8 +122,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
@@ -148,12 +148,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "CTV and connected TV inventory on outdoor lifestyle content. Q2 flight, $25K budget. Adults 25-54, US."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -178,10 +176,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -61,7 +61,7 @@ phases:
           plans:
             - plan_id: "comply-gov-denied-plan"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Small test campaign — limited budget authority"
               budget:
                 total: 10000
@@ -90,8 +90,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_seller_setup_sync_accounts"
@@ -115,8 +115,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority", "brand_policy"]
@@ -141,12 +141,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video and display on outdoor lifestyle. Q2 flight, $50K budget. Adults 25-54, US."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -169,10 +167,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -165,6 +165,8 @@ phases:
           The buy is rejected because governance denied — the $50K buy exceeds
           the plan's $10K budget. The seller propagates the denial with findings.
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -171,6 +171,8 @@ phases:
           from the governance agent explaining which constraint was exceeded.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -211,6 +213,8 @@ phases:
           budget. The seller returns a media_buy_id.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -61,7 +61,7 @@ phases:
           plans:
             - plan_id: "comply-gov-recovery-plan"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Strict-budget plan for denial + recovery validation"
               budget:
                 total: 10000
@@ -90,8 +90,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_denied_recovery_seller_setup_sync_accounts"
@@ -115,8 +115,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]
@@ -141,12 +141,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display inventory on outdoor lifestyle content. Q2 flight."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         context_outputs:
           - path: "products[0].product_id"
             key: "product_id"
@@ -175,10 +173,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "gov-recovery-initial-denied-v1"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
@@ -217,10 +213,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "gov-recovery-retry-approved-v1"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -132,6 +132,8 @@ phases:
           Media buy created with media_buy_id and at least one package.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -69,7 +69,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           media_buy_id: "does-not-exist-invalid-transitions-v1"
           paused: true
           context:
@@ -107,8 +107,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display inventory on outdoor lifestyle content. Q3 flight."
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         context_outputs:
           - path: "products[0].product_id"
             key: "product_id"
@@ -130,8 +132,10 @@ phases:
           Media buy created with media_buy_id and at least one package.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "invalid-transitions-setup-v1"
           start_time: "2026-08-01T00:00:00Z"
           end_time: "2026-08-31T23:59:59Z"
@@ -177,8 +181,10 @@ phases:
           - context echoed unchanged
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "does-not-exist-package-invalid-transitions-v1"
@@ -218,8 +224,10 @@ phases:
           Seller acknowledges the cancellation and transitions the buy to canceled.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Testing NOT_CANCELLABLE on re-cancel"
@@ -246,8 +254,10 @@ phases:
           - context echoed unchanged
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Deliberate re-cancel to force NOT_CANCELLABLE"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -110,6 +110,8 @@ phases:
           numbers, or a crash / non-AdCP error shape.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -60,8 +60,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Video inventory on outdoor lifestyle programming. Q3 flight."
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "inventory_list_no_match--get_products_brief"
@@ -108,8 +110,10 @@ phases:
           numbers, or a crash / non-AdCP error shape.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "inventory-list-no-match-v1"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -64,8 +64,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Video inventory on outdoor lifestyle programming. Q3 flight, $30K budget."
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "inventory_list_targeting--get_products_brief"
@@ -104,8 +106,10 @@ phases:
           can read them back.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "inventory-list-targeting-create-v1"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
@@ -159,8 +163,10 @@ phases:
           and .collection_list populated with the list_id values sent on create.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "$context.media_buy_id"
 
@@ -200,8 +206,10 @@ phases:
           collection_list are replaced (not merged) with the new list_id values.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "$context.package_id"
@@ -234,8 +242,10 @@ phases:
           in persistent state just like fields on create_media_buy.
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "$context.media_buy_id"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -106,6 +106,8 @@ phases:
           can read them back.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -98,6 +98,8 @@ phases:
           - message indicating which terms are unworkable (vendor, window, or variance)
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -153,6 +155,8 @@ phases:
           normalized by the seller).
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -58,8 +58,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video inventory with measurement guarantees. Q2 flight, $50K."
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         context_outputs:
           - path: "products[0].product_id"
             key: "product_id"
@@ -96,8 +98,10 @@ phases:
           - message indicating which terms are unworkable (vendor, window, or variance)
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "measurement-terms-probe-aggressive-v1"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
@@ -149,8 +153,10 @@ phases:
           normalized by the seller).
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "measurement-terms-probe-relaxed-v1"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -97,6 +97,8 @@ phases:
           - valid_actions including sync_creatives
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -56,8 +56,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display inventory on outdoor lifestyle content. Q3 flight."
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         context_outputs:
           - path: "products[0].product_id"
             key: "product_id"
@@ -95,8 +97,10 @@ phases:
           - valid_actions including sync_creatives
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "pending-creatives-transition-v1"
           start_time: "2026-08-01T00:00:00Z"
           end_time: "2026-08-31T23:59:59Z"
@@ -149,8 +153,10 @@ phases:
         expected: |
           The seller ingests the creative and returns status active (or approved).
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "acme-outdoor-display-q3"
               name: "Acme Outdoor Q3 display"
@@ -178,8 +184,10 @@ phases:
           status should be pending_start (or active if the flight has started).
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "$context.package_id"
@@ -217,8 +225,10 @@ phases:
           The media buy's persisted status is pending_start (or active). valid_actions
           no longer includes sync_creatives as a required next step.
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "$context.media_buy_id"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -223,6 +223,8 @@ phases:
           - proposal_id: echoed back to confirm which proposal was accepted
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -57,8 +57,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -93,12 +93,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video and display across outdoor lifestyle and sports. Q2 flight, $50K budget. Adults 25-54, US and Canada."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
         validations:
           - check: response_schema
@@ -143,12 +141,10 @@ phases:
               ask: "Shift 60% of budget to CTV. Drop the display product and redistribute that budget to video."
             - scope: "request"
               ask: "All products must support frequency capping at 3 per day."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
         validations:
           - check: response_schema
@@ -190,12 +186,10 @@ phases:
             - scope: "proposal"
               proposal_id: "balanced_reach_q2"
               action: "finalize"
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
         validations:
           - check: response_schema
@@ -231,10 +225,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           proposal_id: "balanced_reach_q2"
           total_budget: 50000
           start_time: "2026-04-01T00:00:00Z"

--- a/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
@@ -54,8 +54,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -88,12 +88,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video and display on sports and outdoor lifestyle. Q2 flight, $50K budget. Adults 25-54, US and Canada."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
         validations:
           - check: response_schema
@@ -137,12 +135,10 @@ phases:
             - scope: "product"
               product_id: "sports_preroll_q2"
               ask: "Increase budget allocation to $30K"
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
         validations:
           - check: response_schema

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -102,7 +102,7 @@ phases:
           buying_mode: "brief"
           brief: "Display advertising products for state machine testing"
           brand:
-            domain: "acmeoutdoor.com"
+            domain: "acmeoutdoor.example"
 
           context:
             correlation_id: "media_buy_state_machine--discover_products"
@@ -152,7 +152,7 @@ phases:
 
         sample_request:
           brand:
-            domain: "acmeoutdoor.com"
+            domain: "acmeoutdoor.example"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -59,7 +59,7 @@ phases:
           plans:
             - plan_id: "comply-rights-gov-denied"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Restricted plan — rights licensing test"
               budget:
                 total: 50
@@ -89,8 +89,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#brand_rights_governance_denied_brand_agent_setup_sync_accounts"
@@ -114,8 +114,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -116,7 +116,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           brand:
             domain: "novamotors.example"
           name: "Nova Motors approved programs"
@@ -183,7 +183,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           name_contains: "Nova Motors"
 
           context:
@@ -222,7 +222,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "collection_lists--get_collection_list"
@@ -272,7 +272,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           base_collections:
             - selection_type: "distribution_ids"
               identifiers:
@@ -330,7 +330,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#collection_lists_delete_list_delete_collection_list"
           context:

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -127,8 +127,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -258,12 +258,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium display and video inventory on outdoor lifestyle content. Q2 flight, $50K budget. Adults 25-54, US. We want your platform to generate the creatives from our brand brief."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "creative_generative--seller--get_products_brief"
@@ -323,10 +321,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -396,8 +392,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "gen_display_summer_sale"
               name: "Summer Sale - Generated Display 300x250"
@@ -494,8 +490,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "static_display_300x250"
               name: "Trail Pro 3000 - Pre-built Display 300x250"
@@ -548,7 +544,7 @@ phases:
           account:
             brand:
               domain: "nonexistent-brand-xyz.example"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "gen_invalid_brand"
               name: "Invalid Brand Test"
@@ -617,8 +613,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "gen_display_summer_sale"
               name: "Summer Sale - Generated Display 300x250"
@@ -693,8 +689,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -319,6 +319,8 @@ phases:
           - input-required: need more information
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -169,8 +169,10 @@ phases:
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250_generative"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           quality: "draft"
           include_preview: true
 
@@ -237,8 +239,10 @@ phases:
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250_generative"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           quality: "draft"
           include_preview: true
 
@@ -313,8 +317,10 @@ phases:
               id: "display_728x90_generative"
             - agent_url: "https://your-agent.example.com"
               id: "display_320x50_generative"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           quality: "production"
 
           idempotency_key: "$generate:uuid_v4#creative_generative_multi_format_build_multi_format"
@@ -379,8 +385,10 @@ phases:
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250_generative"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           quality: "production"
           include_preview: true
 

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -229,7 +229,7 @@ phases:
                 url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-300x250.jpg"
               click_url:
                 asset_type: "url"
-                url: "https://acme-outdoor.example.com/summer-sale"
+                url: "https://acmeoutdoor.example/summer-sale"
               headline:
                 asset_type: "text"
                 text: "Summer Sale — 40% Off All Gear"
@@ -302,15 +302,17 @@ phases:
                 url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-300x250.jpg"
               click_url:
                 asset_type: "url"
-                url: "https://acme-outdoor.example.com/summer-sale"
+                url: "https://acmeoutdoor.example/summer-sale"
               headline:
                 asset_type: "text"
                 text: "Summer Sale — 40% Off All Gear"
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#creative_template_build_build_creative"
           context:
@@ -360,7 +362,7 @@ phases:
                 url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg"
               click_url:
                 asset_type: "url"
-                url: "https://acme-outdoor.example.com/summer-sale"
+                url: "https://acmeoutdoor.example/summer-sale"
               headline:
                 asset_type: "text"
                 text: "Summer Sale — 40% Off All Gear"
@@ -371,8 +373,10 @@ phases:
               id: "display_728x90"
             - agent_url: "https://your-agent.example.com"
               id: "display_320x50"
-          brand:
-            domain: "acme-outdoor.example.com"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#creative_template_build_build_multi_format"
           context:

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -105,7 +105,7 @@ phases:
           plans:
             - plan_id: "gov_acme_delivery_monitor"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Delivery-phase governance with drift detection and rebalancing"
               budget:
                 total: 40000
@@ -170,8 +170,8 @@ phases:
           payload:
             account:
               brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
             total_budget: 40000
             packages:
               - product_id: "sports_ctv_q2"
@@ -223,8 +223,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -102,7 +102,7 @@ phases:
           plans:
             - plan_id: "gov_acme_strict"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Acme Outdoor low-budget validation flight"
               budget:
                 total: 10000
@@ -168,8 +168,8 @@ phases:
           payload:
             account:
               brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
             total_budget: 50000
             packages:
               - product_id: "sports_ctv_q2"

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -107,7 +107,7 @@ phases:
           plans:
             - plan_id: "gov_acme_conditional"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Full spending authority with conditional policies on CTV reporting and UGC brand safety"
               budget:
                 total: 100000
@@ -181,8 +181,8 @@ phases:
           payload:
             account:
               brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
             total_budget: 40000
             packages:
               - product_id: "sports_ctv_q2"
@@ -242,10 +242,10 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           brand:
-            domain: "acmeoutdoor.com"
+            domain: "acmeoutdoor.example"
           governance_context: "gov_ctx_acme_conditional_approved"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -108,7 +108,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
           name: "Acme Outdoor approved properties"
@@ -170,7 +170,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           name_contains: "Acme Outdoor"
 
           context:
@@ -207,7 +207,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "property_lists--get_property_list"
@@ -249,7 +249,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           base_properties:
             - selection_type: "identifiers"
               identifiers:
@@ -304,7 +304,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -365,7 +365,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -409,7 +409,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_random_001"
@@ -454,7 +454,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#property_lists_delete_list_delete_property_list"
           context:

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -146,7 +146,7 @@ phases:
           brief: "Primetime and late fringe broadcast spots for an automotive EV launch. Q4 flight, $400K budget. Adults 25-54, national footprint. Need :30 and :15 spot lengths."
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
 
           context:
@@ -228,9 +228,11 @@ phases:
           MediaBuy.status enum. IO / traffic-manager review is modelled at the task layer.
 
         sample_request:
+          brand:
+            domain: "novamotors.example"
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
           agency_estimate_number: "PNNL-NM-2026-Q4-0847"
           start_time: "2026-10-01T00:00:00Z"
@@ -244,7 +246,7 @@ phases:
               measurement_terms:
                 billing_measurement:
                   vendor:
-                    domain: "videoamp.com"
+                    domain: "videoamp.example"
                   measurement_window: "c7"
                   max_variance_percent: 10
             - product_id: "late_fringe_15s_mf"
@@ -255,7 +257,7 @@ phases:
               measurement_terms:
                 billing_measurement:
                   vendor:
-                    domain: "videoamp.com"
+                    domain: "videoamp.example"
                   measurement_window: "c7"
                   max_variance_percent: 10
           push_notification_config:
@@ -305,7 +307,7 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"
@@ -408,7 +410,7 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "volta_ev_launch_30s"
@@ -559,7 +561,7 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"
@@ -627,7 +629,7 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "novamotors.com"
+              domain: "novamotors.example"
             operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -144,12 +144,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Primetime and late fringe broadcast spots for an automotive EV launch. Q4 flight, $400K budget. Adults 25-54, national footprint. Need :30 and :15 spot lengths."
-          brand:
-            domain: "novamotors.com"
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_broadcast_tv--get_products_brief"
@@ -233,9 +231,7 @@ phases:
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "novamotors.com"
+            operator: "pinnacle-agency.example"
           agency_estimate_number: "PNNL-NM-2026-Q4-0847"
           start_time: "2026-10-01T00:00:00Z"
           end_time: "2026-12-31T23:59:59Z"
@@ -310,7 +306,7 @@ phases:
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"
 
@@ -413,7 +409,7 @@ phases:
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "volta_ev_launch_30s"
               name: "Nova Volta EV Launch - :30"
@@ -564,7 +560,7 @@ phases:
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"
           include_package_daily_breakdown: true
@@ -632,7 +628,7 @@ phases:
           account:
             brand:
               domain: "novamotors.com"
-            operator: "pinnacle-agency.com"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_nova_q4_2026"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -357,6 +357,8 @@ phases:
           - packages with catalog references preserved
 
         sample_request:
+          brand:
+            domain: "amsterdam-steakhouse.example"
           account:
             brand:
               domain: "amsterdam-steakhouse.example"

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -113,9 +113,9 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "amsterdam-steakhouse.com"
+                domain: "amsterdam-steakhouse.example"
                 name: "Amsterdam Steakhouse"
-              operator: "pinnacle-agency.com"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               sandbox: true
 
@@ -219,8 +219,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "amsterdam-steakhouse.com"
-            operator: "pinnacle-agency.com"
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
           catalogs:
             - catalog_id: "menu_spring_2026"
               catalog_type: "product"
@@ -229,24 +229,24 @@ phases:
                 - item_id: "ribeye_36oz"
                   title: "36oz Tomahawk Ribeye"
                   description: "Dry-aged 45 days, served with truffle butter and roasted bone marrow"
-                  url: "https://amsterdam-steakhouse.com/menu/ribeye-36oz"
-                  image_url: "https://cdn.amsterdam-steakhouse.com/menu/ribeye-36oz-hero.jpg"
+                  url: "https://amsterdam-steakhouse.example/menu/ribeye-36oz"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/menu/ribeye-36oz-hero.jpg"
                   price:
                     amount: 89.00
                     currency: "USD"
                 - item_id: "seafood_tower"
                   title: "Grand Seafood Tower"
                   description: "Oysters, king crab, lobster tail, shrimp cocktail, tuna tartare"
-                  url: "https://amsterdam-steakhouse.com/menu/seafood-tower"
-                  image_url: "https://cdn.amsterdam-steakhouse.com/menu/seafood-tower-hero.jpg"
+                  url: "https://amsterdam-steakhouse.example/menu/seafood-tower"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/menu/seafood-tower-hero.jpg"
                   price:
                     amount: 145.00
                     currency: "USD"
                 - item_id: "wagyu_flight"
                   title: "A5 Wagyu Tasting Flight"
                   description: "Three cuts of Japanese A5 Wagyu — striploin, ribeye cap, tenderloin"
-                  url: "https://amsterdam-steakhouse.com/menu/wagyu-flight"
-                  image_url: "https://cdn.amsterdam-steakhouse.com/menu/wagyu-flight-hero.jpg"
+                  url: "https://amsterdam-steakhouse.example/menu/wagyu-flight"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/menu/wagyu-flight-hero.jpg"
                   price:
                     amount: 195.00
                     currency: "USD"
@@ -304,12 +304,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Dynamic product ads for a high-end steakhouse. Geo-targeted to 10 miles around Amsterdam location. Drive reservations and foot traffic."
-          brand:
-            domain: "amsterdam-steakhouse.com"
           account:
             brand:
-              domain: "amsterdam-steakhouse.com"
-            operator: "pinnacle-agency.com"
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_catalog_driven--get_products"
@@ -361,10 +359,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "amsterdam-steakhouse.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "amsterdam-steakhouse.com"
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-07T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -421,13 +417,13 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "amsterdam-steakhouse.com"
-            operator: "pinnacle-agency.com"
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
           event_sources:
             - event_source_id: "amsterdam_website"
               name: "Amsterdam Steakhouse Website"
               event_types: ["purchase", "add_to_cart", "page_view", "lead"]
-              allowed_domains: ["amsterdam-steakhouse.com", "book.amsterdam-steakhouse.com"]
+              allowed_domains: ["amsterdam-steakhouse.example", "book.amsterdam-steakhouse.example"]
 
           idempotency_key: "$generate:uuid_v4#sales_catalog_driven_event_setup_sync_event_sources"
           context:
@@ -590,8 +586,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "amsterdam-steakhouse.com"
-            operator: "pinnacle-agency.com"
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_amsterdam_spring_2026"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -257,6 +257,8 @@ phases:
           value is not in MediaBuy.status — IO review is modelled at the task layer only.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -125,8 +125,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -184,12 +184,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Guaranteed premium video on sports and outdoor lifestyle publishers. Q2 flight, $50K budget. Adults 25-54, US only. Need completion rate SLA."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_guaranteed--get_products_brief"
@@ -261,10 +259,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -331,8 +327,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026_guaranteed"
 
@@ -383,8 +379,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
@@ -443,8 +439,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026_guaranteed"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -191,6 +191,8 @@ phases:
           Bids below floor_price should be rejected with a clear error.
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -120,12 +120,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Display and video inventory across sports and outdoor lifestyle sites. Q2 flight, $25K budget. Adults 25-54, US. Auction-based, looking for competitive CPMs."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_non_guaranteed--get_products_brief"
@@ -195,10 +193,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -262,8 +258,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026_auction"
 
@@ -313,8 +309,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_id: "mb_acme_q2_2026_auction"
           packages:
             - product_id: "sports_display_auction"
@@ -368,8 +364,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026_auction"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -116,8 +116,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
 
@@ -176,12 +176,10 @@ phases:
         sample_request:
           buying_mode: "brief"
           brief: "Premium video and display across outdoor lifestyle and sports. Q2 flight, $50K total budget. Adults 25-54, US and Canada. Looking for a balanced plan across CTV, online video, and display."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_proposal_mode--get_products_brief"
@@ -250,12 +248,10 @@ phases:
               ask: "Shift 60% of budget to CTV. Drop the display product and redistribute that budget to video."
             - scope: "request"
               ask: "All products must support frequency capping at 3 per day."
-          brand:
-            domain: "acmeoutdoor.com"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_proposal_mode--get_products_refine"
@@ -319,10 +315,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
-          brand:
-            domain: "acmeoutdoor.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           proposal_id: "balanced_reach_q2"
           total_budget: 50000
           start_time: "2026-04-01T00:00:00Z"
@@ -412,8 +406,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
@@ -482,8 +476,8 @@ phases:
         sample_request:
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           media_buy_ids:
             - "mb_acme_q2_2026_proposal"
           include_package_daily_breakdown: true

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -313,6 +313,8 @@ phases:
           - valid_actions: creative sync, pause, get_delivery
 
         sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
           account:
             brand:
               domain: "acmeoutdoor.example"

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -147,11 +147,6 @@ phases:
           - Pending accounts with accounts[].setup.url populated if verification is needed
 
         sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
-
           context:
             correlation_id: "sales_social--list_accounts"
         validations:

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -147,8 +147,10 @@ phases:
           - Pending accounts with accounts[].setup.url populated if verification is needed
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "sales_social--list_accounts"

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -62,7 +62,7 @@ phases:
           plans:
             - plan_id: "comply-signal-gov-denied"
               brand:
-                domain: "acmeoutdoor.com"
+                domain: "acmeoutdoor.example"
               objectives: "Restricted plan — signals activation test"
               budget:
                 total: 100
@@ -92,8 +92,8 @@ phases:
         sample_request:
           accounts:
             - brand:
-                domain: "acmeoutdoor.com"
-              operator: "pinnacle-agency.com"
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_signal_agent_setup_sync_accounts"
@@ -117,8 +117,8 @@ phases:
           accounts:
             - account:
                 brand:
-                  domain: "acmeoutdoor.com"
-                operator: "pinnacle-agency.com"
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   categories: ["budget_authority"]
@@ -144,8 +144,8 @@ phases:
           signal_spec: "outdoor enthusiasts, age 25-54, US"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         context_outputs:
           - path: "signals[0].signal_agent_segment_id"
             key: "signal_agent_segment_id"
@@ -177,8 +177,8 @@ phases:
               account: "acmeoutdoor-ttd-seat"
           account:
             brand:
-              domain: "acmeoutdoor.com"
-            operator: "pinnacle-agency.com"
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           idempotency_key: "signal-gov-denied-v1"
 
           context:


### PR DESCRIPTION
## Summary

Mechanical storyboard consistency pass across `static/compliance/source/`. Three related cleanups bundled because they touch the same files and have zero runtime impact — both shapes still resolve to the same session key via `sessionKeyFromArgs`.

### #2530 — Normalize to RFC 2606 `.example` TLD

- `acmeoutdoor.com` → `acmeoutdoor.example`
- `amsterdam-steakhouse.com` → `amsterdam-steakhouse.example`
- `pinnacle-agency.com` → `pinnacle-agency.example`
- fix `acme-outdoor.example.com` typo (extra dot) → `acmeoutdoor.example` in creative-template and creative-generative

Spec examples should never resolve to a real third-party domain.

### #2533 — Fix `operator = brand.domain` in property-lists and collection-lists

Property-lists and collection-lists demonstrate an **agency operating on behalf of a brand**, not a brand operating directly. Setting `operator` to the brand's own domain misleads readers about the `authorized_operators` / brand.json trust model. Switched to `pinnacle-agency.example` to match the rest of the buyer-side storyboards.

### #2528 — Standardize buyer-side steps on `account { brand, operator }`

Two shapes existed in the tree:
- top-level `brand: { domain }` (shorthand)
- `account: { brand, operator }` (expressive — required for agency-on-behalf-of-brand, billing, governance trails)

Some storyboards mixed both within one file (e.g. `invalid_transitions.yaml` step 1 used the account shape, steps 2–6 used top-level brand). Standardized buyer-side to the expressive form:
- when a step already had an `account` block, dropped the redundant top-level `brand`
- otherwise, promoted the top-level `brand` into an `account` wrapper with `operator: "pinnacle-agency.example"`

Top-level `brand` remains valid as documented shorthand for minimal-identity examples — not touched in this PR.

## Closes

- #2530
- #2533
- #2528

## Test plan

- [x] `npm run build:compliance` clean (10 universal / 6 protocols / 24 specialisms)
- [x] `npm run test:schemas` passes (all 483 schemas)
- [x] `npm run test:examples` passes (31/31)
- [x] `npm run test:unit` passes (587/587)
- [x] typecheck passes
- [x] spot-checked transformed YAML — account wrapper is well-formed, redundant brand removal is correct

## Follow-up

PR B (#2527, #2529, #2531) will land the scoping lint + runtime fallback on top of this cleaned tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)