### PR TITLE
fix(addie): extend URL health check to Addie KB + fix logo alert link

### DIFF
--- a/.changeset/addie-url-health-check.md
+++ b/.changeset/addie-url-health-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Extend the owned-links CI check to scan Addie's KB rules and source, cover `docs.adcontextprotocol.org`, and treat HTTP 405 as reachable (MCP endpoints legitimately reject GET). Fix a broken "Add Your Company Logo" alert link in Addie Home that pointed to a non-existent `/dashboard-settings` page — now links to `/member-profile`.

--- a/scripts/check-owned-links.js
+++ b/scripts/check-owned-links.js
@@ -2,28 +2,40 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { globSync } from 'glob';
 
-const LINK_HOST = 'agenticadvertising.org';
+const LINK_HOSTS = new Set(['agenticadvertising.org', 'docs.adcontextprotocol.org']);
 const SKIPPED_PATH_PREFIXES = ['/api/'];
 const ROOT = process.cwd();
 
 function getCandidateFiles() {
-  return globSync(['docs/**/*.{md,mdx}', 'dist/docs/**/*.{md,mdx}', 'README.md'], {
-    cwd: ROOT,
-    nodir: true,
-  });
+  return globSync(
+    [
+      'docs/**/*.{md,mdx}',
+      'dist/docs/**/*.{md,mdx}',
+      'README.md',
+      'server/src/addie/rules/*.md',
+      'server/src/addie/**/*.ts',
+    ],
+    { cwd: ROOT, nodir: true },
+  );
 }
 
+// Match http(s) URLs but stop at characters that typically wrap them in source:
+// whitespace, quotes, closing brackets, backticks, markdown/slack link syntax (|, ]),
+// template interpolation starts (${), and escape starts (\).
 function extractUrls(file) {
   const text = readFileSync(join(ROOT, file), 'utf8');
-  const matches = text.match(/https?:\/\/[^\s)"'>`]+/g) ?? [];
+  const matches = text.match(/https?:\/\/[^\s)"'>`\\|\]]+/g) ?? [];
 
-  return [...new Set(matches)].filter((url) => {
-    try {
-      return new URL(url).hostname === LINK_HOST;
-    } catch {
-      return false;
-    }
-  });
+  return [...new Set(matches)]
+    .map((url) => url.replace(/[.,;:!?]+$/, ''))
+    .filter((url) => !url.includes('${'))
+    .filter((url) => {
+      try {
+        return LINK_HOSTS.has(new URL(url).hostname);
+      } catch {
+        return false;
+      }
+    });
 }
 
 function shouldCheck(url) {
@@ -56,15 +68,21 @@ async function fetchStatus(url, method, retries = 3) {
   }
 }
 
+// 405 means the endpoint exists but rejects this HTTP method (e.g. MCP
+// Streamable-HTTP endpoints reject GET). Treat as reachable.
+function isReachableStatus(status) {
+  return status < 400 || status === 405;
+}
+
 async function checkUrl(url) {
   try {
     const headStatus = await fetchStatus(url, 'HEAD');
-    if (headStatus < 400) {
+    if (isReachableStatus(headStatus)) {
       return { ok: true, status: headStatus, method: 'HEAD' };
     }
 
     const getStatus = await fetchStatus(url, 'GET');
-    return { ok: getStatus < 400, status: getStatus, method: 'GET' };
+    return { ok: isReachableStatus(getStatus), status: getStatus, method: 'GET' };
   } catch (error) {
     return {
       ok: false,
@@ -100,11 +118,12 @@ async function main() {
   }
 
   if (broken.length === 0) {
-    console.log('All browser-facing agenticadvertising.org links are reachable.');
+    const hosts = [...LINK_HOSTS].join(', ');
+    console.log(`All browser-facing links are reachable (${hosts}).`);
     return;
   }
 
-  console.error('Broken browser-facing agenticadvertising.org links found:');
+  console.error('Broken browser-facing links found:');
   for (const { url, result, files } of broken) {
     const detail =
       'status' in result

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -2103,7 +2103,7 @@
             title: 'Add your company logo',
             message: 'Upload a logo so your company appears in the member directory and on the homepage. <a href="/logo-preview" style="color:inherit;text-decoration:underline">Preview how logos look</a>.',
             actionLabel: 'Add logo',
-            actionUrl: '/dashboard-settings#logo'
+            actionUrl: '/member-profile#logo'
           });
         } else if (!isPersonalAccount && profile.resolved_brand?.logo_url && !profile.resolved_brand?.logo_url_dark && !dismissedAlerts.includes('missing-logo-dark')) {
           alerts.push({
@@ -2126,7 +2126,7 @@
               ? 'Help others learn about you by adding a description.'
               : 'Help others learn about your organization by adding a tagline.',
             actionLabel: 'Add Description',
-            actionUrl: '/dashboard-settings#profile'
+            actionUrl: '/member-profile#tagline'
           });
         }
 

--- a/server/src/addie/home/builders/alerts.ts
+++ b/server/src/addie/home/builders/alerts.ts
@@ -72,7 +72,7 @@ export async function buildAlerts(memberContext: MemberContext): Promise<AlertSe
       title: 'Add Your Company Logo',
       message: 'Upload a logo to appear on the member directory and homepage',
       actionLabel: 'Add Logo',
-      actionUrl: 'https://agenticadvertising.org/dashboard-settings',
+      actionUrl: 'https://agenticadvertising.org/member-profile',
     });
   }
 


### PR DESCRIPTION
## Summary
- Extend `scripts/check-owned-links.js` to scan Addie rules and source (`server/src/addie/rules/*.md`, `server/src/addie/**/*.ts`) so URLs Addie cites are validated in CI.
- Cover `docs.adcontextprotocol.org` as a second owned host; tighten URL extraction to skip template interpolations (`${...}`) and markdown/slack link boundaries; treat HTTP 405 as reachable (MCP endpoints legitimately reject GET).
- Fix three broken `/dashboard-settings*` alert URLs — they 404 because `/dashboard-*` paths bypass the HTML auto-resolve middleware. Routed to `/member-profile` (where logo + tagline editing live):
  - `server/src/addie/home/builders/alerts.ts:75` — "Add Your Company Logo" → `/member-profile`
  - `server/public/dashboard.html:2106` — "Add your company logo" → `/member-profile#logo`
  - `server/public/dashboard.html:2129` — "Add Description" → `/member-profile#tagline`

Refs #2564.

## Context
Addie's weekly insights (Apr 11–18) flagged `/terms` as a broken URL source causing escalations. Investigation found `/terms` was already fixed in main via commit 4ff4e0197 (Apr 13, mid-report-window). Surveying all URLs Addie cites — plus expert review — surfaced three dead `/dashboard-settings*` alert links; the remainder of Addie-cited URLs are live.

The existing owned-links CI check only scanned `docs/` and `README.md`, so Addie's KB could silently drift from production URLs. This PR closes that gap.

Placeholder ToS content at `server/public/legal/terms.html` remains — that's a legal/product decision, tracked separately on #2564.

### Known follow-ups (not in this PR)
- Extend the URL scanner to `.html` files — would have caught the dashboard.html links automatically. Scoped to follow-up to avoid broadening this PR's surface.
- Security-reviewer noted defense-in-depth options on the CI script: manual redirect handling + hostname re-validation on redirects; strip query strings before logging failed URLs. Both low priority for a CI-only utility with no credentials.

## Test plan
- [x] `npm run check:owned-links` passes locally — all 14 Addie-cited URLs reachable
- [ ] CI: `broken-links.yml` workflow green
- [ ] Spot-check: Addie Home "Add Your Company Logo" alert renders with corrected URL
- [ ] Spot-check: Dashboard missing-logo and missing-tagline alerts route to `/member-profile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)