### PR TITLE
fix(storyboards): operator = agency domain in property/collection list scenarios

### DIFF
--- a/.changeset/storyboard-operator-agency-shape.md
+++ b/.changeset/storyboard-operator-agency-shape.md
@@ -1,0 +1,6 @@
+---
+---
+
+Storyboard hygiene — property-lists and collection-lists specialism scenarios had `operator` equal to the brand's own domain (`acmeoutdoor.example`, `novamotors.example`), modeling a direct-operated buyer. Switched to `pinnacle-agency.example` to match the agency-operated pattern used across the rest of the buyer-side storyboards. No runtime behavior change — session scoping on the reference seller is keyed on `brand.domain`, not `operator`.
+
+Closes #2533.

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -116,7 +116,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           brand:
             domain: "novamotors.example"
           name: "Nova Motors approved programs"
@@ -183,7 +183,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           name_contains: "Nova Motors"
 
           context:
@@ -222,7 +222,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "collection_lists--get_collection_list"
@@ -272,7 +272,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
           base_collections:
             - selection_type: "distribution_ids"
               identifiers:
@@ -330,7 +330,7 @@ phases:
           account:
             brand:
               domain: "novamotors.example"
-            operator: "novamotors.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#collection_lists_delete_list_delete_collection_list"
           context:

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -108,7 +108,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
           name: "Acme Outdoor approved properties"
@@ -170,7 +170,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           name_contains: "Acme Outdoor"
 
           context:
@@ -207,7 +207,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           context:
             correlation_id: "property_lists--get_property_list"
@@ -249,7 +249,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           base_properties:
             - selection_type: "identifiers"
               identifiers:
@@ -304,7 +304,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -365,7 +365,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_outdoor_001"
@@ -409,7 +409,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           list_id: "$context.property_list_id"
           records:
             - record_id: "delivery_random_001"
@@ -454,7 +454,7 @@ phases:
           account:
             brand:
               domain: "acmeoutdoor.example"
-            operator: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
 
           idempotency_key: "$generate:uuid_v4#property_lists_delete_list_delete_property_list"
           context:


### PR DESCRIPTION
## Summary

- `property-lists/index.yaml` and `collection-lists/index.yaml` had `operator` equal to the brand's own domain (`acmeoutdoor.example`, `novamotors.example`), modeling a direct-operated buyer.
- Switched to `pinnacle-agency.example` so the buyer-side pattern ("agency operating under contract for a brand") is consistent across all specialism storyboards.
- No runtime behavior change — session scoping on the reference seller is keyed on `brand.domain`, not `operator`.

## Test plan

- [x] `npm run build:compliance` green (`10 universal, 6 protocols, 24 specialisms`).
- [ ] No consumers read these storyboards' `operator` field as a scoping input — verified by searching; session-key derivation in `server/src/training-agent/state.ts` (`sessionKeyFromArgs`) uses `brand.domain` / `account.brand.domain` / `account.account_id`, never `operator`.
- [ ] Spot-checked the migration-guide example in `.changeset/account-migration-property-collection-lists.md:57-58` is untouched — that example explicitly documents the direct-operated case and remains valid.

Closes #2533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)