### PR TITLE
feat(compliance): scoping lint exempts ID-scoped tasks (#2577 Option C)

### DIFF
--- a/.changeset/scoping-lint-exempt-id-scoped-tasks.md
+++ b/.changeset/scoping-lint-exempt-id-scoped-tasks.md
@@ -1,0 +1,16 @@
+---
+---
+
+Scoping lint: exempt seven tasks whose request schema requires a globally-unique scope-ID (#2577 Option C).
+
+Moving from `TENANT_SCOPED_TASKS` to `EXEMPT_FROM_LINT`:
+
+- `check_governance`, `report_plan_outcome` — required `plan_id`
+- `acquire_rights` — required `rights_id`, `buyer`, `campaign`
+- `log_event` — required `event_source_id`
+- `calibrate_content`, `validate_content_delivery` — required `standards_id`
+- `validate_property_delivery` — required `list_id` (schema also has optional `account`)
+
+These tasks resolve the tenant from the ID alone; envelope `account` is redundant at the spec level. Storyboards may still carry identity for training-agent session routing — the lint simply doesn't require it. Authoring guide (`docs/contributing/storyboard-authoring.md`) documents the split.
+
+Spec-level follow-ups (runtime routes by ID, schema additions for the no-scope-ID tasks that stayed in `TENANT_SCOPED_TASKS`) remain tracked in #2577.

--- a/docs/contributing/storyboard-authoring.md
+++ b/docs/contributing/storyboard-authoring.md
@@ -53,7 +53,17 @@ The lint still accepts a bare top-level `brand.domain` as a fallback because the
 
 The authoritative list lives in `scripts/lint-storyboard-scoping.cjs` as `TENANT_SCOPED_TASKS`. A parity test (`tests/lint-storyboard-scoping.test.cjs`) asserts every task registered in the training agent's `HANDLER_MAP` appears in either `TENANT_SCOPED_TASKS` or `EXEMPT_FROM_LINT`. If you add a new tool to the dispatch table and forget to classify it, the parity test fails — you won't get silent drift.
 
-Rule of thumb: if the handler calls `getSession(sessionKeyFromArgs(...))`, it's tenant-scoped. Global discovery (`list_creative_formats`, `get_adcp_capabilities`), payload-array-keyed sync tasks (`sync_accounts`, `sync_governance`, `sync_catalogs`, `sync_event_sources`), and global catalog reads (`get_brand_identity`, `get_rights`) are exempt.
+Rule of thumb: if the task's **request schema has a required globally-unique scope-ID** (`plan_id`, `rights_id`, `standards_id`, `list_id`, `event_source_id`), the seller can resolve the tenant from that ID alone — envelope identity is redundant and the lint does not require it (see `EXEMPT_FROM_LINT` bucket (c)).
+
+Everything else falls into `TENANT_SCOPED_TASKS`: create/update mutations without a scope-ID, list/get operations that don't carry a single resource ID, resource-standards calls without `standards_id` in schema, etc. These must carry envelope `account { brand, operator }`.
+
+Other exempt categories: payload-array-keyed sync tasks (`sync_accounts`, `sync_governance`, `sync_catalogs`, `sync_event_sources`), global discovery (`list_creative_formats`, `get_adcp_capabilities`), global catalog reads (`get_brand_identity`, `get_rights`, `update_rights`), and the `comply_test_controller` sandbox primitive.
+
+### Why ID-scoped tasks are exempt but storyboards still carry identity
+
+`check_governance`, `report_plan_outcome`, `acquire_rights`, `log_event`, `calibrate_content`, `validate_content_delivery`, and `validate_property_delivery` all require a globally-unique ID (`plan_id`, `rights_id`, `standards_id`, etc.) that was previously provisioned with brand context. At the spec level, a real seller resolves the ID → tenant via their own lookup; the envelope doesn't need to repeat the identity.
+
+The training agent's `sessionKeyFromArgs` today still routes by envelope identity, so a storyboard that **drops** identity on an ID-scoped task will silently land in `open:default` and fail to find the plan/rights/standards. Carry envelope identity anyway — the lint just won't enforce it. Spec-level alignment (runtime resolves by ID) is tracked in #2577.
 
 ## Intentionally cross-tenant probes
 

--- a/scripts/lint-storyboard-scoping.cjs
+++ b/scripts/lint-storyboard-scoping.cjs
@@ -27,8 +27,8 @@ const yaml = require('js-yaml');
 const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'compliance', 'source');
 
 /**
- * Tasks whose training-agent handler calls getSession(sessionKeyFromArgs(...))
- * and depends on top-level identity to land in the right tenant session.
+ * Tasks whose request schema has no required globally-unique scope-ID and
+ * whose training-agent handler keys session state by envelope identity.
  * Storyboard steps invoking these tasks MUST carry brand/account identity.
  */
 const TENANT_SCOPED_TASKS = new Set([
@@ -42,8 +42,8 @@ const TENANT_SCOPED_TASKS = new Set([
   'sync_creatives',
   'list_creatives',
   'get_creative_delivery',
-  'build_creative',
-  'preview_creative',
+  'build_creative',       // schema has optional account + brand
+  'preview_creative',     // schema has no required scope-ID
   // Products & signals
   'get_products',
   'get_signals',
@@ -51,19 +51,13 @@ const TENANT_SCOPED_TASKS = new Set([
   'provide_performance_feedback',
   // Governance plans
   'sync_plans',
-  'check_governance',
-  'report_plan_outcome',
-  'get_plan_audit_logs',
-  'log_event',
-  // Brand rights (session-scoped grants only)
-  'acquire_rights',
+  'get_plan_audit_logs',  // schema required=[]; filters optional
   // Property lists
   'create_property_list',
   'list_property_lists',
   'get_property_list',
   'update_property_list',
   'delete_property_list',
-  'validate_property_delivery',
   // Collection lists
   'create_collection_list',
   'get_collection_list',
@@ -75,33 +69,62 @@ const TENANT_SCOPED_TASKS = new Set([
   'list_content_standards',
   'get_content_standards',
   'update_content_standards',
-  'calibrate_content',
-  'validate_content_delivery',
   // Reporting
   'report_usage',
 ]);
 
 /**
- * Tasks whose handlers either (a) don't scope by top-level identity (global
- * discovery / catalog reads) or (b) derive identity from the request payload
- * array, not the envelope. Storyboard steps invoking these tasks are
- * skipped by the lint.
+ * Tasks where envelope identity is not required by the spec. Three sub-buckets:
+ *
+ * (a) Payload-array-keyed sync tasks — identity lives in the array items, not
+ *     the envelope. `sync_accounts`, `sync_governance`, `sync_catalogs`,
+ *     `sync_event_sources`.
+ *
+ * (b) Global discovery / catalog reads. `get_adcp_capabilities`,
+ *     `list_creative_formats`, `get_brand_identity`, `get_rights`,
+ *     `update_rights`, `comply_test_controller`.
+ *
+ * (c) Identity implicit via a required globally-unique ID in the request
+ *     schema. The seller looks up the ID → resolves the tenant → applies
+ *     policy. Envelope `account` is redundant. Covers the Option C split
+ *     from #2577:
+ *       - `check_governance`       — required `plan_id`
+ *       - `report_plan_outcome`    — required `plan_id`
+ *       - `acquire_rights`         — required `rights_id` + `buyer` + `campaign`
+ *       - `log_event`              — required `event_source_id`
+ *       - `calibrate_content`      — required `standards_id`
+ *       - `validate_content_delivery` — required `standards_id`
+ *       - `validate_property_delivery` — required `list_id` (schema also
+ *                                         has optional `account`)
+ *
+ *     Storyboard authors may still carry envelope identity on these tasks for
+ *     training-agent session routing; the lint simply doesn't require it.
+ *     The training-agent runtime aligning its routing to resolve by ID is
+ *     tracked as follow-up work in #2577.
  */
 const EXEMPT_FROM_LINT = new Set([
-  // Payload-array-keyed sync tasks
+  // (a) Payload-array-keyed sync tasks
   'sync_accounts',
   'sync_governance',
   'sync_catalogs',
   'sync_event_sources',
-  // Test-control primitive (sandbox-gated, operates on its own session)
+  // (b) Test-control primitive (sandbox-gated, operates on its own session)
   'comply_test_controller',
-  // Global discovery
+  // (b) Global discovery
   'get_adcp_capabilities',
   'list_creative_formats',
-  // Global brand/rights catalog reads
+  // (b) Global brand/rights catalog reads
   'get_brand_identity',
   'get_rights',
   'update_rights',
+  // (c) Identity implicit via required globally-unique ID
+  'check_governance',
+  'report_plan_outcome',
+  'acquire_rights',
+  'log_event',
+  'calibrate_content',
+  'validate_content_delivery',
+  'validate_property_delivery',
 ]);
 
 /** Walk a directory for *.yaml files. */


### PR DESCRIPTION
## Summary

Implements the lint-classification half of [#2577](https://github.com/adcontextprotocol/adcp/issues/2577) Option C. Seven tasks whose request schema requires a globally-unique scope-ID move from `TENANT_SCOPED_TASKS` to `EXEMPT_FROM_LINT`.

| Task                          | Required scope-ID               |
|-------------------------------|---------------------------------|
| `check_governance`            | `plan_id`                       |
| `report_plan_outcome`         | `plan_id`                       |
| `acquire_rights`              | `rights_id` + `buyer` + `campaign` |
| `log_event`                   | `event_source_id`               |
| `calibrate_content`           | `standards_id`                  |
| `validate_content_delivery`   | `standards_id`                  |
| `validate_property_delivery`  | `list_id` (schema also has optional `account`) |

At the spec level, the seller resolves the ID → tenant via its own lookup. Envelope `account` is redundant.

## What this PR does *not* do

- **No schema changes.** The three tasks that stayed in `TENANT_SCOPED_TASKS` (`preview_creative`, `build_creative`, `get_plan_audit_logs`) don't have a required scope-ID. Whether they should grow an optional `account` is a spec decision; tracked in #2577 as a follow-up.
- **No runtime changes.** `sessionKeyFromArgs` today still routes by envelope identity. Storyboards should keep carrying identity on exempt tasks — the lint just stops enforcing it on tasks where the spec doesn't require it. When the runtime learns to resolve by ID, storyboards can drop the identity. Also tracked in #2577.
- **No storyboard edits.** The 7 newly-exempt tasks all already carry envelope identity from earlier work (#2562, #2563). Relaxing the lint doesn't regress any storyboard.

## Why the split matters for future authors

Before this PR the rule was "tenant-scoped at the handler level ⇒ require envelope identity." After: "required globally-unique scope-ID in schema ⇒ seller resolves by ID, lint doesn't require envelope identity."

The second rule maps cleanly to how a production seller works: auth context identifies the principal, `plan_id`/`rights_id`/`standards_id` identifies the scoped resource, envelope `account` is either absent or optional. The first rule was a sandbox artifact.

The authoring guide (`docs/contributing/storyboard-authoring.md`) documents the rule-of-thumb, the three exempt sub-buckets, and explicitly warns authors not to drop envelope identity on exempt tasks until the runtime side of #2577 lands.

## Test plan

- [x] `npm run build:compliance` (scoping lint + build)
- [x] `npm run test:storyboard-scoping` (parity test — 3/3)
- [x] `npm run test:schemas` (7/7)
- [x] SEO metadata check (253/253, exit 0)

## Related

- Closes first deliverable of #2577 (lint classification).
- Leaves #2577 open for the two remaining deliverables (runtime ID routing, schema additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)