### PR TITLE
docs(auth): tenant resolution + close #2577 runtime follow-ups

### DIFF
--- a/.changeset/scoping-lint-2577-wontfix.md
+++ b/.changeset/scoping-lint-2577-wontfix.md
@@ -1,0 +1,8 @@
+---
+---
+
+Storyboard authoring: document that envelope identity on ID-scoped tasks (`check_governance`, `report_plan_outcome`, `acquire_rights`, `log_event`, `calibrate_content`, `validate_content_delivery`, `validate_property_delivery`) is a sandbox routing convention, not a spec claim.
+
+Production sellers resolve tenant from the authenticated principal (bearer/OAuth/HMAC), not from envelope payload, so there is no spec-level gap to close. The previously-tracked runtime follow-up (cross-session reverse index for ID → session routing) would be sandbox plumbing without spec meaning and is not being pursued.
+
+Docs and lint comments updated; closes the open runtime/cleanup follow-ups from #2577.

--- a/docs/building/integration/authentication.mdx
+++ b/docs/building/integration/authentication.mdx
@@ -98,6 +98,12 @@ An agent may have access to multiple accounts (e.g., an agency managing several 
 
 For schema definitions, see [`account.json`](https://adcontextprotocol.org/schemas/v3/core/account.json).
 
+## Tenant resolution
+
+AdCP resolves tenant from the authenticated principal, not from request payloads. Seller agents map the authenticated identity (bearer token, mTLS client cert, or RFC 9421 key) to the originating buyer's account via their own authorization context. Task payloads never carry tenant identity as a substitute for authentication — when a schema requires a globally-unique resource ID (`plan_id`, `rights_id`, `standards_id`, `event_source_id`, `list_id`) rather than an `account` envelope, the seller resolves ID → tenant via the same authorization context. The authenticated principal must hold access to the referenced resource, and the resource itself carries the brand it was provisioned for; envelope identity on those calls would be redundant and, if it disagreed with the authenticated principal, a spoofing vector.
+
+Compliance storyboards in the training agent inject envelope identity on these calls as a sandbox routing convention, because the training agent has no authenticated-principal layer of its own — see [Storyboard authoring](/docs/contributing/storyboard-authoring). Production sellers do not require it.
+
 ## Protocol Configuration
 
 Both MCP and A2A protocols use the same authentication header. Configure your client with:

--- a/docs/contributing/storyboard-authoring.md
+++ b/docs/contributing/storyboard-authoring.md
@@ -63,7 +63,9 @@ Other exempt categories: payload-array-keyed sync tasks (`sync_accounts`, `sync_
 
 `check_governance`, `report_plan_outcome`, `acquire_rights`, `log_event`, `calibrate_content`, `validate_content_delivery`, and `validate_property_delivery` all require a globally-unique ID (`plan_id`, `rights_id`, `standards_id`, etc.) that was previously provisioned with brand context. At the spec level, a real seller resolves the ID → tenant via their own lookup; the envelope doesn't need to repeat the identity.
 
-The training agent's `sessionKeyFromArgs` today still routes by envelope identity, so a storyboard that **drops** identity on an ID-scoped task will silently land in `open:default` and fail to find the plan/rights/standards. Carry envelope identity anyway — the lint just won't enforce it. Spec-level alignment (runtime resolves by ID) is tracked in #2577.
+The training agent's `sessionKeyFromArgs` routes by envelope identity. A storyboard that **drops** identity on an ID-scoped task lands in `open:default` and fails to find the plan/rights/standards — so storyboards carry envelope identity anyway, and the lint just won't enforce it.
+
+This is a sandbox routing convention, not a spec claim. Production sellers resolve tenant from the authenticated principal (bearer/OAuth/HMAC), not from envelope payload — see [Tenant resolution](/docs/building/integration/authentication#tenant-resolution). They don't need envelope identity on ID-scoped tasks and wouldn't rely on it if present. Building a cross-session reverse index in the training agent just to move identity off the wire would be sandbox plumbing without spec meaning.
 
 ## Intentionally cross-tenant probes
 

--- a/scripts/lint-storyboard-scoping.cjs
+++ b/scripts/lint-storyboard-scoping.cjs
@@ -97,10 +97,12 @@ const TENANT_SCOPED_TASKS = new Set([
  *       - `validate_property_delivery` — required `list_id` (schema also
  *                                         has optional `account`)
  *
- *     Storyboard authors may still carry envelope identity on these tasks for
- *     training-agent session routing; the lint simply doesn't require it.
- *     The training-agent runtime aligning its routing to resolve by ID is
- *     tracked as follow-up work in #2577.
+ *     Storyboard authors still carry envelope identity on these tasks as a
+ *     sandbox routing convention — `sessionKeyFromArgs` routes by envelope
+ *     identity, so a storyboard that drops it would land in `open:default`.
+ *     The lint simply doesn't require it. Production sellers resolve the ID
+ *     via the authenticated principal, not the envelope payload, so there is
+ *     no spec-level gap to close. See docs/contributing/storyboard-authoring.md.
  */
 const EXEMPT_FROM_LINT = new Set([
   // (a) Payload-array-keyed sync tasks


### PR DESCRIPTION
## Summary

Reframes the ID-scoped-task envelope-identity injection in compliance storyboards as a **sandbox routing convention**, not a pending spec follow-up, and closes the open runtime/cleanup items from #2577.

After reviewing the runtime reverse-index proposal with protocol-design and product lenses:

- Production sellers resolve tenant from the authenticated principal (bearer / mTLS / RFC 9421), not envelope payload. Adding a cross-session reverse index in the training agent just to move identity off the wire in storyboards would be sandbox plumbing without spec meaning.
- Storyboards keep carrying envelope identity on the seven ID-scoped exempt tasks because `sessionKeyFromArgs` routes by payload; the lint (already relaxed in #2578) just stops enforcing it.
- The three tasks without a required globally-unique scope-ID (`preview_creative`, `build_creative`, `get_plan_audit_logs`) stay in `TENANT_SCOPED_TASKS` — lint-enforced envelope identity matches how sandbox storyboards have to work anyway. Schema adjustments remain a separate design call.

## Docs changes

- **New `Tenant resolution` section** in `docs/building/integration/authentication.mdx` — normative statement that AdCP resolves tenant from the authenticated principal, with the ID-scoped-tasks rationale called out so production implementors and certification candidates don't absorb the sandbox convention as the spec.
- `docs/contributing/storyboard-authoring.md` now labels envelope-identity injection on the seven ID-scoped tasks as a sandbox routing convention and links to the auth doc.
- `scripts/lint-storyboard-scoping.cjs` header comment matches.

## Expert review incorporated

- **Protocol-design review** confirmed the framing is correct and analogous to OpenRTB (seat from connection/TLS, not payload), sellers.json, and ads.txt (identity resolved out-of-band, not in-payload). Flagged routed/brokered topologies as the one real exception — that's a schain-equivalent design question, not this one.
- **Product review** flagged storyboard-author confusion and certification mental-model risk as real-but-low cost. Mitigated here by the new auth-doc section (one link, one sentence inoculates the cohort), the storyboard-authoring reframing, and the matching lint header comment.

## Test plan

- [x] `npm run build:compliance` — storyboard scoping lint passes, compliance builds clean
- [x] `npm run build` — full site build succeeds
- [x] `npm run test:unit` — 587/587 pass
- [x] `tsc --project server/tsconfig.json --noEmit` — clean
- [ ] CI green on GitHub
- [ ] `#2577` closed with the summary comment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)