### PR TITLE
fix(admin): align /api/me admin flag with backend, default admins to All Content

### DIFF
--- a/.changeset/fix-admin-content-visibility.md
+++ b/.changeset/fix-admin-content-visibility.md
@@ -1,0 +1,7 @@
+---
+---
+
+Fix admin content visibility in `/dashboard/content`.
+
+- `/api/me` now returns `isAdmin: true` for users in the `aao-admin` working group, matching the `requireAdmin` middleware. Previously it only checked the `ADMIN_EMAILS` env var, so working-group admins saw no "All Content" tab and no admin filters.
+- Admins now land on the "All Content" tab by default. Editors need a full view of the library on entry, not just their own authored items.

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -693,6 +693,12 @@
 
         document.getElementById('loading').classList.add('hidden');
         document.getElementById('mainContent').classList.remove('hidden');
+
+        // Admins land on All Content — editors need a full view of the library,
+        // not just what they personally authored.
+        if (isAdmin) {
+          switchTab('all');
+        }
       } catch (err) {
         console.error('Init error:', err);
         document.getElementById('loading').innerHTML =

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6742,9 +6742,13 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           })
         );
 
-        // Check if user is admin
+        // Check if user is admin via aao-admin working group (primary) or
+        // ADMIN_EMAILS env var (fallback). Must match requireAdmin middleware
+        // so the admin UI and backend agree on who sees admin surfaces.
         const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-        const isAdmin = adminEmails.includes(user.email.toLowerCase());
+        const isAdminByEmail = adminEmails.includes(user.email.toLowerCase());
+        const isAdminByWorkingGroup = await isWebUserAAOAdmin(user.id);
+        const isAdmin = isAdminByWorkingGroup || isAdminByEmail;
         // Check Slack sync status, seat type, and read DB names (user may have
         // set a display name that differs from the WorkOS session values)
         let isLinkedToSlack = false;


### PR DESCRIPTION
## Summary

- `/api/me` was checking only `ADMIN_EMAILS`, so users admin-ed via the `aao-admin` working group got `isAdmin: false` — no "All Content" tab and no admin filters in `/dashboard/content`, even though backend routes (`requireAdmin`, `/api/me/content`) authorized them. Now matches `requireAdmin` middleware: `isAdminByWorkingGroup || isAdminByEmail`.
- Admins now land on the "All Content" tab instead of "My Content." Editors need the full library on entry, not just what they personally wrote.

## Context

Reported by Pia and Mary: navigating to admin Content showed only ~12 items (their own) with no way to reach Reports & Research, etc. Two separate admin-detection code paths had drifted apart. `/api/me:6746` used only the env var list; `requireAdmin:1141-1144` checked both sources. This PR unifies on the middleware's behavior.

## Test plan

- [ ] As a user in `aao-admin` WG but not `ADMIN_EMAILS`: `/api/me` returns `isAdmin: true`, `/dashboard/content` shows "All Content" tab and lands on it
- [ ] As a user in `ADMIN_EMAILS` only: same behavior (no regression)
- [ ] As a non-admin: still sees only "My Content" tab, no regression
- [ ] Playbook/value banner still render correctly for non-admin editors (only shown on "mine" tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)