### PR TITLE
feat(training-agent): close #2347 (SDK dispatcher) + #2368 (/mcp-strict grader route)

### DIFF
--- a/.changeset/training-agent-comply-test-controller-sdk-dispatcher.md
+++ b/.changeset/training-agent-comply-test-controller-sdk-dispatcher.md
@@ -1,0 +1,27 @@
+---
+---
+
+Training agent: swap local `comply_test_controller` dispatcher for the SDK's.
+
+`server/src/training-agent/comply-test-controller.ts` now imports
+`handleTestControllerRequest`, `CONTROLLER_SCENARIOS`, and `enforceMapCap`
+from `@adcp/client` (all shipped in 5.x). The ~80-line scenario-routing
+`SCENARIO_MAP` / `dispatch` / `listScenarios` block is gone, as is the
+bespoke `enforceComplyCap` / `MAX_COMPLY_ENTRIES_PER_MAP` quota guard and
+the hardcoded scenario enum in `COMPLY_TEST_CONTROLLER_TOOL.inputSchema`.
+
+Behavior change: status strings are now validated via the SDK's
+`AccountStatusSchema` / `CreativeStatusSchema` / `MediaBuyStatusSchema`
+before reaching the store — invalid values now surface `INVALID_PARAMS`
+uniformly instead of slipping into the transition table as unknown keys.
+
+The training-agent-specific wrapper stays: sandbox gate on
+`account.sandbox`, session binding via `sessionKeyFromArgs`, domain
+state-machine transitions live in the store factory. This is the custom
+MCP-wrapper pattern documented on `TOOL_INPUT_SHAPE` — store is our
+concern, dispatch is the SDK's.
+
+Closes #2347 (in-repo asks). All 7 SDK asks from the issue shipped in
+`@adcp/client` 5.x (handleTestControllerRequest, toMcpResponse,
+TOOL_INPUT_SHAPE, CONTROLLER_SCENARIOS, enforceMapCap, SESSION_ENTRY_CAP,
+factory-form stores).

--- a/.changeset/training-agent-mcp-strict-route-for-grader.md
+++ b/.changeset/training-agent-mcp-strict-route-for-grader.md
@@ -1,0 +1,26 @@
+---
+---
+
+Training agent: add `/mcp-strict` route for the conformance grader.
+
+The public sandbox `/mcp` route stays at `required_for: []` — unsigned
+bearer callers (Addie, demos, quickstart users) keep working without
+signing infrastructure. A new `/mcp-strict` route advertises
+`required_for: ['create_media_buy']` and enforces it with a presence-
+gated authenticator so `adcp grade request-signing` vector 001
+(`request_signature_required`) fires against a real deployment.
+
+The strict authenticator closes the two gaps in the default route's
+`anyOf(bearers, signing)` composition:
+
+- Present-but-invalid signatures no longer fall through to bearer.
+- Unsigned calls to ops in `required_for` return the canonical AdCP
+  error code in the 401 body, not the generic RFC 6750 `invalid_token`.
+
+Non-required ops still accept bearer on the strict route, so grader
+setup (list_tools, get_products, discovery probes) works without
+signing infrastructure.
+
+Closes #2368 via dual-routing (Option 3 in the issue thread). Upstream
+SDK helper for the presence-gated composition pattern is tracked as
+adcp-client#659.

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -1,13 +1,20 @@
 /**
- * Comply test controller for the training agent.
+ * Training-agent wrapper around the SDK's comply_test_controller.
  *
- * Implements the TestControllerStore interface from @adcp/client backed
- * by session state — state machine transition tables, delivery/budget
- * simulations, etc. Dispatch and error handling are local since the
- * SDK's handleTestControllerRequest is not publicly exported.
+ * The SDK owns the scenario dispatcher, response envelope, and per-scenario
+ * enum validation (`@adcp/client` exports `handleTestControllerRequest`,
+ * `CONTROLLER_SCENARIOS`, `TOOL_INPUT_SHAPE`, `enforceMapCap`). This file
+ * adds the two things the SDK intentionally leaves to the seller: a sandbox
+ * gate on the top-level `account.sandbox` flag, and a per-request
+ * `TestControllerStore` bound to our JSONB-persisted `SessionState`.
  */
 
-import { TestControllerError } from '@adcp/client';
+import {
+  CONTROLLER_SCENARIOS,
+  TestControllerError,
+  enforceMapCap,
+  handleTestControllerRequest,
+} from '@adcp/client';
 import type { TestControllerStore } from '@adcp/client';
 import type {
   TrainingContext,
@@ -18,7 +25,6 @@ import type {
   ComplyBudgetSimulation,
 } from './types.js';
 import { getSession, sessionKeyFromArgs } from './state.js';
-import { deriveStatus } from './task-handlers.js';
 
 // ── State machine transition tables ───────────────────────────────
 
@@ -62,26 +68,7 @@ const SI_SESSION_TRANSITIONS: Record<string, string[]> = {
 
 const SI_SESSION_TERMINAL = new Set(['complete', 'terminated']);
 
-/**
- * Per-Map cap on `complyExtensions`. These Maps are keyed by caller-supplied
- * IDs (account_id, session_id, media_buy_id) and, since they are persisted
- * with the session, a sandbox caller could otherwise loop with fresh IDs
- * until the SDK's 5 MB session cap throws `PAYLOAD_TOO_LARGE` at flush —
- * which aborts the request after the response was sent. Cap here so the
- * rejection happens at the mutation site with a clear error code.
- */
-const MAX_COMPLY_ENTRIES_PER_MAP = 1000;
-
-function enforceComplyCap<V>(map: Map<string, V>, key: string, kind: string): void {
-  if (!map.has(key) && map.size >= MAX_COMPLY_ENTRIES_PER_MAP) {
-    throw new TestControllerError(
-      'INVALID_STATE',
-      `Too many ${kind} entries in this sandbox session (limit ${MAX_COMPLY_ENTRIES_PER_MAP}). Clear the session or reuse an existing id.`,
-    );
-  }
-}
-
-// ── Session extensions ────────────────────────────────────────────
+// ── Session accessors (used by other handlers) ──────────────────────
 
 /** Get delivery simulation data for a media buy (used by get_media_buy_delivery). */
 export function getDeliverySimulation(session: SessionState, mediaBuyId: string): ComplyDeliveryAccumulator | undefined {
@@ -154,7 +141,7 @@ function createStore(session: SessionState): TestControllerStore {
       }
 
       validateTransition(ACCOUNT_TRANSITIONS, ACCOUNT_TERMINAL, prev, status, 'account');
-      enforceComplyCap(ext.accountStatuses, accountId, 'account status');
+      enforceMapCap(ext.accountStatuses, accountId, 'account statuses');
       ext.accountStatuses.set(accountId, status);
       return { success: true, previous_state: prev, current_state: status, message: `Account ${accountId} transitioned from ${prev} to ${status}` };
     },
@@ -206,7 +193,7 @@ function createStore(session: SessionState): TestControllerStore {
         if (status === 'terminated' && !terminationReason) {
           throw new TestControllerError('INVALID_PARAMS', 'termination_reason is required when status = terminated');
         }
-        enforceComplyCap(ext.siSessions, sessionId, 'si session');
+        enforceMapCap(ext.siSessions, sessionId, 'si sessions');
         ext.siSessions.set(sessionId, { status, terminationReason });
         return { success: true, previous_state: 'active', current_state: status, message: `Session ${sessionId} transitioned from active to ${status}` };
       }
@@ -245,7 +232,7 @@ function createStore(session: SessionState): TestControllerStore {
       const ext = session.complyExtensions;
       let cumulative = ext.deliverySimulations.get(mediaBuyId);
       if (!cumulative) {
-        enforceComplyCap(ext.deliverySimulations, mediaBuyId, 'delivery simulation');
+        enforceMapCap(ext.deliverySimulations, mediaBuyId, 'delivery simulations');
         cumulative = {
           impressions: 0,
           clicks: 0,
@@ -316,7 +303,7 @@ function createStore(session: SessionState): TestControllerStore {
       const computedSpend = Math.round(budgetAmount * (spendPercentage / 100) * 100) / 100;
 
       const ext = session.complyExtensions;
-      enforceComplyCap(ext.budgetSimulations, entityId, 'budget simulation');
+      enforceMapCap(ext.budgetSimulations, entityId, 'budget simulations');
       ext.budgetSimulations.set(entityId, {
         spendPercentage,
         computedSpend: { amount: computedSpend, currency },
@@ -338,6 +325,11 @@ function createStore(session: SessionState): TestControllerStore {
 
 // ── Tool definition ───────────────────────────────────────────────
 
+const SCENARIO_ENUM = ['list_scenarios', ...Object.values(CONTROLLER_SCENARIOS)] as const;
+
+// JSON Schema equivalent of the SDK's `TOOL_INPUT_SHAPE`, extended with
+// top-level `account` (sandbox gate) and `brand` (session keying) — both
+// exempt extensions per the SDK's documented wrapper pattern.
 export const COMPLY_TEST_CONTROLLER_TOOL = {
   name: 'comply_test_controller',
   description: 'Forces seller-side state transitions that a buyer agent cannot trigger directly — creative review outcomes, account status changes, delivery data, budget consumption. Sandbox only (requires account.sandbox: true). NOT for normal buyer operations. Call with scenario: "list_scenarios" first to see available scenarios and required params.',
@@ -348,15 +340,7 @@ export const COMPLY_TEST_CONTROLLER_TOOL = {
     properties: {
       scenario: {
         type: 'string',
-        enum: [
-          'list_scenarios',
-          'force_creative_status',
-          'force_account_status',
-          'force_media_buy_status',
-          'force_session_status',
-          'simulate_delivery',
-          'simulate_budget_spend',
-        ],
+        enum: [...SCENARIO_ENUM],
         description: 'The seller-side transition to trigger.',
       },
       params: {
@@ -369,90 +353,6 @@ export const COMPLY_TEST_CONTROLLER_TOOL = {
     required: ['scenario'],
   },
 };
-
-// ── Scenario dispatch ─────────────────────────────────────────────
-
-const SCENARIO_MAP: Array<[keyof TestControllerStore, string]> = [
-  ['forceCreativeStatus', 'force_creative_status'],
-  ['forceAccountStatus', 'force_account_status'],
-  ['forceMediaBuyStatus', 'force_media_buy_status'],
-  ['forceSessionStatus', 'force_session_status'],
-  ['simulateDelivery', 'simulate_delivery'],
-  ['simulateBudgetSpend', 'simulate_budget_spend'],
-];
-
-function listScenarios(store: TestControllerStore): string[] {
-  return SCENARIO_MAP
-    .filter(([method]) => typeof store[method] === 'function')
-    .map(([, scenario]) => scenario);
-}
-
-async function dispatch(store: TestControllerStore, input: Record<string, unknown>): Promise<object> {
-  const scenario = input.scenario as string;
-  if (!scenario) {
-    return { success: false, error: 'INVALID_PARAMS', error_detail: 'Missing required field: scenario' };
-  }
-
-  if (scenario === 'list_scenarios') {
-    return { success: true, scenarios: listScenarios(store) };
-  }
-
-  const params = input.params as Record<string, unknown> | undefined;
-  try {
-    switch (scenario) {
-      case 'force_creative_status':
-        if (!store.forceCreativeStatus) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (!params?.creative_id || !params?.status) return { success: false, error: 'INVALID_PARAMS', error_detail: 'force_creative_status requires params.creative_id and params.status' };
-        return await store.forceCreativeStatus(params.creative_id as string, params.status as never, params.rejection_reason as string | undefined);
-
-      case 'force_account_status':
-        if (!store.forceAccountStatus) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (!params?.account_id || !params?.status) return { success: false, error: 'INVALID_PARAMS', error_detail: 'force_account_status requires params.account_id and params.status' };
-        return await store.forceAccountStatus(params.account_id as string, params.status as never);
-
-      case 'force_media_buy_status':
-        if (!store.forceMediaBuyStatus) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (!params?.media_buy_id || !params?.status) return { success: false, error: 'INVALID_PARAMS', error_detail: 'force_media_buy_status requires params.media_buy_id and params.status' };
-        return await store.forceMediaBuyStatus(params.media_buy_id as string, params.status as never, params.rejection_reason as string | undefined);
-
-      case 'force_session_status': {
-        if (!store.forceSessionStatus) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (!params?.session_id || !params?.status) return { success: false, error: 'INVALID_PARAMS', error_detail: 'force_session_status requires params.session_id and params.status' };
-        const validSessionStatuses = ['complete', 'terminated'];
-        if (!validSessionStatuses.includes(params.status as string)) return { success: false, error: 'INVALID_PARAMS', error_detail: `Invalid session status: ${params.status}` };
-        return await store.forceSessionStatus(params.session_id as string, params.status as 'complete' | 'terminated', params.termination_reason as string | undefined);
-      }
-
-      case 'simulate_delivery':
-        if (!store.simulateDelivery) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (!params?.media_buy_id) return { success: false, error: 'INVALID_PARAMS', error_detail: 'simulate_delivery requires params.media_buy_id' };
-        return await store.simulateDelivery(params.media_buy_id as string, {
-          impressions: params.impressions as number | undefined,
-          clicks: params.clicks as number | undefined,
-          reported_spend: params.reported_spend as { amount: number; currency: string } | undefined,
-          conversions: params.conversions as number | undefined,
-        });
-
-      case 'simulate_budget_spend':
-        if (!store.simulateBudgetSpend) return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: `Scenario not supported: ${scenario}` };
-        if (params?.spend_percentage === undefined || params?.spend_percentage === null) return { success: false, error: 'INVALID_PARAMS', error_detail: 'simulate_budget_spend requires params.spend_percentage' };
-        if (!params?.account_id && !params?.media_buy_id) return { success: false, error: 'INVALID_PARAMS', error_detail: 'simulate_budget_spend requires params.account_id or params.media_buy_id' };
-        return await store.simulateBudgetSpend({
-          account_id: params.account_id as string | undefined,
-          media_buy_id: params.media_buy_id as string | undefined,
-          spend_percentage: params.spend_percentage as number,
-        });
-
-      default:
-        return { success: false, error: 'UNKNOWN_SCENARIO', error_detail: 'Unrecognized scenario name' };
-    }
-  } catch (err) {
-    if (err instanceof TestControllerError) {
-      return { success: false, error: err.code, error_detail: err.message, ...(err.currentState !== undefined && { current_state: err.currentState }) };
-    }
-    return { success: false, error: 'INTERNAL_ERROR', error_detail: 'An unexpected error occurred in the test controller store' };
-  }
-}
 
 // ── Main handler ──────────────────────────────────────────────────
 
@@ -469,6 +369,5 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
 
   const session = await getSession(sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId));
   const store = createStore(session);
-  return dispatch(store, args as Record<string, unknown>);
+  return handleTestControllerRequest(store, args as Record<string, unknown>);
 }
-

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -27,7 +27,7 @@ import { z } from 'zod';
 import type { TrainingContext, ToolArgs } from './types.js';
 import { getIdempotencyStore } from './idempotency.js';
 import { getWebhookSigningKey } from './webhooks.js';
-import { getRequestSigningCapability } from './request-signing.js';
+import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
 import { PUBLISHERS } from './publishers.js';
 import { createLogger } from '../logger.js';
 
@@ -242,8 +242,8 @@ function deriveAccountScope(params: Record<string, unknown>): string | undefined
  * opaque `AdcpServer` handle from `@adcp/client/server` — no SDK types
  * escape our module boundary.
  */
-export function createFrameworkTrainingAgentServer(_ctx: TrainingContext): AdcpServer {
-  const signingCap = getRequestSigningCapability();
+export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpServer {
+  const signingCap = ctx.strict ? getStrictRequestSigningCapability() : getRequestSigningCapability();
 
   // ── Custom tools outside AdcpToolMap ─────────────────────────
   // Registered through the framework's `customTools` config (5.4). Each

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -27,7 +27,8 @@ import { startSessionCleanup } from './state.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
 import { getPublicJwks } from './webhooks.js';
-import { buildRequestSigningAuthenticator } from './request-signing.js';
+import { buildRequestSigningAuthenticator, STRICT_REQUIRED_FOR } from './request-signing.js';
+import { strictSignatureAuthenticator, RequestSignatureRequiredError } from './strict-auth.js';
 import { isWorkOSApiKeyFormat } from '../middleware/api-key-format.js';
 import { PUBLIC_TEST_AGENT } from '../config/test-agent.js';
 import type { TrainingContext } from './types.js';
@@ -65,7 +66,7 @@ function setCORSHeaders(res: Response): void {
  * check (e.g., `if (!allowedOrgs.has(result.apiKey.owner.id)) return null`)
  * or layer an `anyOf` with a separate scope-aware authenticator.
  */
-function buildAuthenticator(): Authenticator | null {
+function buildBearerAuthenticator(): Authenticator | null {
   if (!TRAINING_AGENT_TOKEN && !PUBLIC_TEST_AGENT_TOKEN && !workos) {
     return null; // dev mode: open
   }
@@ -90,11 +91,6 @@ function buildAuthenticator(): Authenticator | null {
       },
     }));
   }
-  // Signed requests: valid RFC 9421 signatures authenticate without a bearer.
-  // `signed-requests` specialism vectors POST signed-but-bearerless requests;
-  // this composition lets them reach the verifier instead of dying at the
-  // bearer gate. 5.5+ feature.
-  authenticators.push(verifySignatureAsAuthenticator_());
   if (authenticators.length === 0) return null;
   return authenticators.length === 1 ? authenticators[0] : anyOf(...authenticators);
 }
@@ -103,50 +99,96 @@ function buildAuthenticator(): Authenticator | null {
 // avoids reading the compliance test JWKS at module import time, which would
 // break test setups that mock the compliance cache.
 let _signingAuth: Authenticator | null = null;
-function verifySignatureAsAuthenticator_(): Authenticator {
+function lazySigningAuth(): Authenticator {
   return (req) => {
     if (!_signingAuth) _signingAuth = buildRequestSigningAuthenticator();
     return _signingAuth(req);
   };
 }
 
-const authenticator = buildAuthenticator();
-
-async function requireToken(req: Request, res: Response, next: NextFunction): Promise<void> {
-  if (!authenticator) {
-    // No tokens configured and no WorkOS = dev mode, allow all
-    res.locals.trainingPrincipal = 'anonymous';
-    return next();
-  }
-  // The SDK's authenticators read from a raw Node IncomingMessage — Express's
-  // Request extends it, so we pass `req` directly.
-  let principal: AuthPrincipal | null;
-  try {
-    principal = await authenticator(req);
-  } catch (err) {
-    const publicMessage = err instanceof AuthError
-      ? err.publicMessage
-      : 'Authentication failed';
-    logger.warn({ err }, 'Training agent: authentication error');
-    respondUnauthorized(req, res, {
-      error: 'invalid_token',
-      errorDescription: publicMessage,
-    });
-    return;
-  }
-  if (!principal) {
-    const hasCredentials = !!extractBearerToken(req);
-    respondUnauthorized(req, res, {
-      error: hasCredentials ? 'invalid_token' : 'invalid_request',
-      errorDescription: hasCredentials
-        ? 'Invalid bearer token. Use an AAO API key (from your dashboard) or a static test token.'
-        : 'Missing bearer token. Use an AAO API key (from your dashboard) or a static test token.',
-    });
-    return;
-  }
-  res.locals.trainingPrincipal = principal.principal;
-  next();
+/**
+ * Default `/mcp` route: bearer OR valid signature. Unsigned bearer callers
+ * pass through verifyApiKey; signed requests compose via anyOf. Present-but-
+ * invalid signatures fall through to bearer (a known gap — closed on the
+ * strict route, tracked upstream as adcp-client#659).
+ */
+function buildDefaultAuthenticator(): Authenticator | null {
+  const bearerAuth = buildBearerAuthenticator();
+  if (!bearerAuth) return null;
+  return anyOf(bearerAuth, lazySigningAuth());
 }
+
+/**
+ * Strict `/mcp-strict` route (grader target): presence-gated signature
+ * with `required_for: ['create_media_buy']`. See `strict-auth.ts` for the
+ * full behaviour matrix.
+ */
+function buildStrictAuthenticator(): Authenticator | null {
+  const bearerAuth = buildBearerAuthenticator();
+  if (!bearerAuth) return null;
+  return strictSignatureAuthenticator({
+    bearerAuth,
+    signingAuth: lazySigningAuth(),
+    requiredFor: STRICT_REQUIRED_FOR,
+  });
+}
+
+const defaultAuthenticator = buildDefaultAuthenticator();
+const strictAuthenticator = buildStrictAuthenticator();
+
+function buildRequireToken(authenticator: Authenticator | null) {
+  return async function requireToken(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (!authenticator) {
+      // No tokens configured and no WorkOS = dev mode, allow all
+      res.locals.trainingPrincipal = 'anonymous';
+      return next();
+    }
+    let principal: AuthPrincipal | null;
+    try {
+      principal = await authenticator(req);
+    } catch (err) {
+      // The strict authenticator throws this sentinel when an unsigned
+      // request targets an op in `required_for`. Surface the canonical
+      // spec error code so grader vector 001 sees what it expects.
+      // `respondUnauthorized`'s `error` field is typed to RFC 6750 codes
+      // only — `request_signature_required` is an AdCP-specific code that
+      // needs to land in the JSON body, so we write the 401 directly.
+      if (err instanceof RequestSignatureRequiredError) {
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('WWW-Authenticate', 'Bearer realm="mcp", error="invalid_token"');
+        res.status(401).json({
+          error: 'request_signature_required',
+          error_description: err.publicMessage,
+        });
+        return;
+      }
+      const publicMessage = err instanceof AuthError
+        ? err.publicMessage
+        : 'Authentication failed';
+      logger.warn({ err }, 'Training agent: authentication error');
+      respondUnauthorized(req, res, {
+        error: 'invalid_token',
+        errorDescription: publicMessage,
+      });
+      return;
+    }
+    if (!principal) {
+      const hasCredentials = !!extractBearerToken(req);
+      respondUnauthorized(req, res, {
+        error: hasCredentials ? 'invalid_token' : 'invalid_request',
+        errorDescription: hasCredentials
+          ? 'Invalid bearer token. Use an AAO API key (from your dashboard) or a static test token.'
+          : 'Missing bearer token. Use an AAO API key (from your dashboard) or a static test token.',
+      });
+      return;
+    }
+    res.locals.trainingPrincipal = principal.principal;
+    next();
+  };
+}
+
+const requireTokenDefault = buildRequireToken(defaultAuthenticator);
+const requireTokenStrict = buildRequireToken(strictAuthenticator);
 
 function getBaseUrl(req: Request): string {
   if (process.env.BASE_URL) return process.env.BASE_URL.replace(/\/$/, '');
@@ -248,50 +290,73 @@ export function createTrainingAgentRouter(): Router {
     },
   });
 
-  // MCP endpoint
-  // Auth is composed in `buildAuthenticator`:
-  //   anyOf(verifyApiKey(static), verifyApiKey(workos), verifySignatureAsAuthenticator(...))
-  // Bearer-OR-signature is accepted; neither short-circuits the other.
-  router.post('/mcp', mcpRateLimiter, requireToken, async (req: Request, res: Response) => {
-    setCORSHeaders(res);
+  // MCP endpoint factory. Two routes share the same body:
+  //   /mcp — sandbox. anyOf(bearers, signing). required_for=[].
+  //   /mcp-strict — grader target. presence-gated signing. required_for=['create_media_buy'].
+  // The `strict` flag flows into TrainingContext so get_adcp_capabilities
+  // advertises the correct request_signing block per route.
+  function mcpHandler(strict: boolean) {
+    return async (req: Request, res: Response) => {
+      setCORSHeaders(res);
 
-    // The framework returns `AdcpServer` (5.4+); the legacy factory returns
-    // the SDK's `Server`. Both satisfy the transport contract at runtime
-    // but have incompatible nominal types (different private fields).
-    // `any` stays until the flip-default PR deletes the legacy path.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let server: any = null;
-    try {
-      // Build training context (open mode for now; training mode in Stage 2).
-      // Principal is set by requireToken; defaults to 'anonymous' in dev mode
-      // when no tokens are configured.
-      const principal = (res.locals.trainingPrincipal as string | undefined) ?? 'anonymous';
-      const ctx: TrainingContext = { mode: 'open', principal };
+      // The framework returns `AdcpServer` (5.4+); the legacy factory returns
+      // the SDK's `Server`. Both satisfy the transport contract at runtime
+      // but have incompatible nominal types (different private fields).
+      // `any` stays until the flip-default PR deletes the legacy path.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let server: any = null;
+      try {
+        // Principal is set by requireToken; defaults to 'anonymous' in dev mode
+        // when no tokens are configured.
+        const principal = (res.locals.trainingPrincipal as string | undefined) ?? 'anonymous';
+        const ctx: TrainingContext = { mode: 'open', principal, strict };
 
-      server = useFrameworkServer()
-        ? createFrameworkTrainingAgentServer(ctx)
-        : createTrainingAgentServer(ctx);
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined, // Stateless
-      });
-
-      await server.connect(transport);
-
-      logger.debug({ method: req.body?.method, ip: req.ip }, 'Training agent: handling request');
-
-      await transport.handleRequest(req, res, req.body);
-    } catch (error) {
-      logger.error({ error }, 'Training agent: request error');
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          id: null,
-          error: { code: -32603, message: 'Internal server error' },
+        server = useFrameworkServer()
+          ? createFrameworkTrainingAgentServer(ctx)
+          : createTrainingAgentServer(ctx);
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined, // Stateless
         });
+
+        await server.connect(transport);
+
+        logger.debug({ method: req.body?.method, ip: req.ip, strict }, 'Training agent: handling request');
+
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        logger.error({ error, strict }, 'Training agent: request error');
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32603, message: 'Internal server error' },
+          });
+        }
+      } finally {
+        await server?.close().catch(() => {});
       }
-    } finally {
-      await server?.close().catch(() => {});
-    }
+    };
+  }
+
+  router.post('/mcp', mcpRateLimiter, requireTokenDefault, mcpHandler(false));
+
+  // Strict endpoint for `adcp grade request-signing` and the AAO Verified
+  // compliance dashboard. Enforces `required_for: ['create_media_buy']` with
+  // presence-gated auth so vector 001 (`request_signature_required`) fires
+  // instead of being swallowed by the bearer fallthrough on /mcp.
+  router.options('/mcp-strict', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.status(204).end();
+  });
+  router.post('/mcp-strict', mcpRateLimiter, requireTokenStrict, mcpHandler(true));
+  router.get('/mcp-strict', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.setHeader('Allow', 'POST, OPTIONS');
+    res.status(405).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
+    });
   });
 
   // GET/DELETE not supported in stateless mode
@@ -338,7 +403,7 @@ export function createTrainingAgentRouter(): Router {
     res.status(204).end();
   });
 
-  router.get('/sse', mcpRateLimiter, requireToken, async (req: Request, res: Response) => {
+  router.get('/sse', mcpRateLimiter, requireTokenDefault, async (req: Request, res: Response) => {
     setCORSHeaders(res);
 
     if (sseSessions.size >= SSE_MAX_SESSIONS) {
@@ -388,7 +453,7 @@ export function createTrainingAgentRouter(): Router {
     }
   });
 
-  router.post('/message', mcpRateLimiter, requireToken, async (req: Request, res: Response) => {
+  router.post('/message', mcpRateLimiter, requireTokenDefault, async (req: Request, res: Response) => {
     setCORSHeaders(res);
 
     const sessionId = req.query.sessionId as string;

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -37,7 +37,13 @@ const logger = createLogger('training-agent-request-signing');
 
 const TEST_REVOKED_KID = 'test-revoked-2026';
 
-let capabilityDeclaration: VerifierCapability | null = null;
+/** Operations that the grader-targeted strict route declares as requiring
+ *  a signed request. Kept narrow so the strict route can still run
+ *  discovery / list_tools / get_products without signing. */
+export const STRICT_REQUIRED_FOR: readonly string[] = ['create_media_buy'];
+
+let defaultCapability: VerifierCapability | null = null;
+let strictCapability: VerifierCapability | null = null;
 
 function loadTestJwks(): AdcpJsonWebKey[] {
   const path = join(getComplianceCacheDir(), 'test-vectors', 'request-signing', 'keys.json');
@@ -56,22 +62,44 @@ function loadTestJwks(): AdcpJsonWebKey[] {
 }
 
 /**
- * Get the capability block we advertise on `get_adcp_capabilities`.
+ * Capability block for the public sandbox `/mcp` route.
  *
- * `required_for` is empty (3.0 default): signed callers are verified, but
- * unsigned callers fall through to `verifyApiKey` in the `anyOf` chain —
- * neither path short-circuits the other.
+ * `required_for: []` so unsigned bearer callers keep working — this endpoint
+ * is a learning sandbox, not a conformance target. Signed callers are still
+ * verified end-to-end (signature composes via `anyOf(verifyApiKey, ...)`).
  */
 export function getRequestSigningCapability(): VerifierCapability {
-  if (!capabilityDeclaration) {
-    capabilityDeclaration = {
+  if (!defaultCapability) {
+    defaultCapability = {
       supported: true,
       covers_content_digest: 'either',
       required_for: [],
       supported_for: [...MUTATING_TOOLS],
     };
   }
-  return capabilityDeclaration;
+  return defaultCapability;
+}
+
+/**
+ * Capability block for the grader-targeted `/mcp-strict` route.
+ *
+ * `required_for: STRICT_REQUIRED_FOR` so the conformance grader's vector 001
+ * (`request_signature_required`) fires. The strict route enforces presence-
+ * gated signing: invalid signatures 401 without falling through to bearer,
+ * unsigned calls to required ops 401 with the `request_signature_required`
+ * error code. Non-required ops still accept bearer so grader setup (list
+ * tools, discovery, get_products) works without signing infrastructure.
+ */
+export function getStrictRequestSigningCapability(): VerifierCapability {
+  if (!strictCapability) {
+    strictCapability = {
+      supported: true,
+      covers_content_digest: 'either',
+      required_for: [...STRICT_REQUIRED_FOR],
+      supported_for: [...MUTATING_TOOLS],
+    };
+  }
+  return strictCapability;
 }
 
 /**
@@ -145,5 +173,6 @@ function headerFirst(value: string | string[] | undefined): string | undefined {
 
 /** Reset state — tests only. */
 export function resetRequestSigning(): void {
-  capabilityDeclaration = null;
+  defaultCapability = null;
+  strictCapability = null;
 }

--- a/server/src/training-agent/strict-auth.ts
+++ b/server/src/training-agent/strict-auth.ts
@@ -1,0 +1,111 @@
+/**
+ * Presence-gated authenticator for the grader-targeted `/mcp-strict` route.
+ *
+ * Behaviour matrix (vs. the default `/mcp` route's `anyOf(bearers, signing)`):
+ *
+ * | Signature header | Signature valid | Bearer | Strict result                          |
+ * |------------------|-----------------|--------|----------------------------------------|
+ * | yes              | yes             | *      | accept (signing principal)             |
+ * | yes              | no              | *      | 401 (do not fall through to bearer)    |
+ * | no               | —               | yes    | bearer accepted if op ∉ required_for;  |
+ * |                  |                 |        | otherwise 401 `request_signature_required` |
+ * | no               | —               | no     | 401 (unauthorized)                     |
+ *
+ * The default `/mcp` route uses `anyOf(bearers, signingAuth)` which (a) lets
+ * present-but-invalid signatures fall through to bearer and (b) doesn't
+ * enforce `required_for` because `verifySignatureAsAuthenticator` returns
+ * `null` on unsigned requests before the verifier's `required_for` check
+ * runs. Strict mode closes both gaps locally; upstream SDK helper tracked in
+ * adcp-client#659.
+ */
+
+import { AuthError, type Authenticator, type AuthPrincipal } from '@adcp/client/server';
+import type { IncomingMessage } from 'node:http';
+
+/** Extract the MCP operation name from a JSON-RPC `tools/call` request body.
+ *  Prefers `req.body` (populated by `express.json()`) and falls back to
+ *  `req.rawBody` when body parsing ran after this authenticator (raw HTTP
+ *  paths). Returns `undefined` for non-tools/call methods or unparseable
+ *  bodies — those are not covered by `required_for`, so the caller falls
+ *  through to bearer. */
+function extractOperation(req: IncomingMessage & { body?: unknown; rawBody?: string }): string | undefined {
+  const parsed = req.body as { method?: string; params?: { name?: string } } | undefined;
+  if (parsed && typeof parsed === 'object' && parsed.method === 'tools/call' && typeof parsed.params?.name === 'string') {
+    return parsed.params.name;
+  }
+  const raw = req.rawBody;
+  if (!raw) return undefined;
+  try {
+    const body = JSON.parse(raw) as { method?: string; params?: { name?: string } };
+    if (body.method === 'tools/call' && typeof body.params?.name === 'string') {
+      return body.params.name;
+    }
+  } catch {
+    // Malformed body — MCP transport will reject downstream.
+  }
+  return undefined;
+}
+
+function hasSignatureHeader(req: IncomingMessage): boolean {
+  const v = req.headers['signature-input'];
+  if (typeof v === 'string') return v.length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  return false;
+}
+
+/**
+ * Sentinel thrown when an unsigned request targets an operation listed in
+ * `required_for`. The route's `requireToken` wrapper catches this and
+ * surfaces error code `request_signature_required` in the 401 body
+ * (instead of the generic `invalid_token` / `Credentials rejected.` that
+ * `anyOf` would produce).
+ */
+export class RequestSignatureRequiredError extends AuthError {
+  readonly operation: string;
+  constructor(operation: string) {
+    super(`Operation "${operation}" requires a signed request.`);
+    this.name = 'RequestSignatureRequiredError';
+    this.operation = operation;
+  }
+}
+
+export interface StrictAuthenticatorOptions {
+  /** Bearer authenticator chain (typically `anyOf(verifyApiKey(...), verifyApiKey(workos))`).
+   *  Runs only when the request is unsigned AND the operation is not in `requiredFor`. */
+  bearerAuth: Authenticator;
+  /** Signing authenticator (typically `verifySignatureAsAuthenticator(...)`).
+   *  Runs only when the request carries `Signature-Input` — throws `AuthError`
+   *  on verification failure, which the wrapper re-throws without bearer fallthrough. */
+  signingAuth: Authenticator;
+  /** Operations that MUST be signed on this route. Unsigned calls to any
+   *  listed op throw `RequestSignatureRequiredError`. */
+  requiredFor: readonly string[];
+}
+
+/**
+ * Compose a presence-gated authenticator. See file header for the behaviour
+ * matrix. The returned `Authenticator` is drop-in compatible with the
+ * SDK's middleware (same signature as `anyOf` / `verifyApiKey` etc.).
+ */
+export function strictSignatureAuthenticator(options: StrictAuthenticatorOptions): Authenticator {
+  const requiredForSet = new Set(options.requiredFor);
+
+  return async (req): Promise<AuthPrincipal | null> => {
+    if (hasSignatureHeader(req)) {
+      // Signature present → MUST verify. Invalid signatures throw AuthError
+      // and the 401 propagates without bearer fallthrough.
+      return await options.signingAuth(req);
+    }
+
+    // Unsigned. Fire `request_signature_required` before the bearer chain
+    // so grader vector 001 sees the canonical error code.
+    const operation = extractOperation(req);
+    if (operation && requiredForSet.has(operation)) {
+      throw new RequestSignatureRequiredError(operation);
+    }
+
+    // Not required — fall through to bearer. Discovery probes, list_tools,
+    // and non-mutating reads keep working without signing infrastructure.
+    return await options.bearerAuth(req);
+  };
+}

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -237,7 +237,7 @@ import {
   getIdempotencyStore,
 } from './idempotency.js';
 import { getWebhookEmitter } from './webhooks.js';
-import { getRequestSigningCapability } from './request-signing.js';
+import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
 
 // MCP webhook envelope's `task_type` enum (core.generated TaskType — not re-exported).
 type WebhookTaskType =
@@ -2212,13 +2212,13 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   return result;
 }
 
-export async function handleGetAdcpCapabilities(_args: ToolArgs, _ctx: TrainingContext): Promise<Record<string, unknown>> {
+export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingContext): Promise<Record<string, unknown>> {
   const tasks = TOOLS
     .map(t => t.name)
     .filter(name => name !== 'get_adcp_capabilities');
   const channels = [...new Set(PUBLISHERS.flatMap(p => p.channels))].sort();
   const publisherDomains = PUBLISHERS.map(p => p.domain);
-  const signingCap = getRequestSigningCapability();
+  const signingCap = ctx.strict ? getStrictRequestSigningCapability() : getRequestSigningCapability();
   return {
     adcp: {
       major_versions: [...SUPPORTED_MAJOR_VERSIONS],

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -24,6 +24,11 @@ export interface TrainingContext {
    *  Derived from the bearer token in the MCP route; defaults to `anonymous`
    *  when no auth is configured (dev / test). */
   principal?: string;
+  /** Route is the grader-targeted `/mcp-strict` endpoint. Advertises
+   *  `required_for: ['create_media_buy']` in capabilities and enforces
+   *  presence-gated signing at the auth layer. Default `/mcp` leaves
+   *  `required_for` empty so unsigned bearer callers keep working. */
+  strict?: boolean;
 }
 
 export interface ShowSpecial {

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration tests for the `/mcp-strict` grader-targeted route.
+ *
+ * Covers the capability declaration difference vs. `/mcp` and the presence-
+ * gated enforcement of `required_for`. Signed-request verification is
+ * exercised end-to-end by the storyboard runner against the signing vectors;
+ * these tests focus on the route-level plumbing.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Set token before module loads so the static-key authenticator picks it up.
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-strict';
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+const AUTH = 'Bearer test-token-for-strict';
+
+/** Call a tool via MCP JSON-RPC and return the parsed inner response. */
+async function callTool(
+  app: express.Application,
+  route: '/mcp' | '/mcp-strict',
+  tool: string,
+  args: Record<string, unknown>,
+  opts: { auth?: boolean } = { auth: true },
+) {
+  const req = request(app)
+    .post(`/api/training-agent${route}`)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream');
+  if (opts.auth !== false) req.set('Authorization', AUTH);
+  return req.send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name: tool, arguments: args },
+  });
+}
+
+/** Parse a StreamableHTTP `text/event-stream` response into the JSON-RPC
+ *  envelope. The transport writes `event: message\ndata: {...}\n\n` for
+ *  successful tools/call responses. */
+function parseSse(res: request.Response): Record<string, unknown> {
+  const text = res.text ?? '';
+  const match = text.match(/^data: (.*)$/m);
+  if (!match) throw new Error(`No data line in SSE response: ${text.slice(0, 200)}`);
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
+/** Extract the tool's inner response (parsed from the MCP text content). */
+function innerResponse(res: request.Response): Record<string, unknown> {
+  const envelope = parseSse(res) as { result?: { content?: Array<{ text?: string }> } };
+  const text = envelope.result?.content?.[0]?.text;
+  if (!text) throw new Error(`No content text in envelope: ${JSON.stringify(envelope)}`);
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('Training Agent /mcp-strict route', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  describe('capability declaration', () => {
+    it('/mcp returns required_for: [] (sandbox)', async () => {
+      const res = await callTool(app, '/mcp', 'get_adcp_capabilities', {});
+      expect(res.status).toBe(200);
+      const inner = innerResponse(res) as { request_signing: { required_for: string[] }; specialisms: string[] };
+      expect(inner.request_signing.required_for).toEqual([]);
+      expect(inner.specialisms).toContain('signed-requests');
+    });
+
+    it('/mcp-strict returns required_for: ["create_media_buy"] (grader target)', async () => {
+      const res = await callTool(app, '/mcp-strict', 'get_adcp_capabilities', {});
+      expect(res.status).toBe(200);
+      const inner = innerResponse(res) as { request_signing: { required_for: string[] }; specialisms: string[] };
+      expect(inner.request_signing.required_for).toEqual(['create_media_buy']);
+      expect(inner.specialisms).toContain('signed-requests');
+    });
+  });
+
+  describe('presence-gated enforcement', () => {
+    it('unsigned create_media_buy on /mcp-strict returns 401 request_signature_required', async () => {
+      const res = await callTool(app, '/mcp-strict', 'create_media_buy', {
+        account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },
+        idempotency_key: '550e8400-e29b-41d4-a716-446655440000',
+      });
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('request_signature_required');
+      expect(res.body.error_description).toMatch(/create_media_buy.*signed/);
+      expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+    });
+
+    it('unsigned create_media_buy on /mcp still accepted (bearer fallthrough)', async () => {
+      // Not asserting success (depends on product catalog state); only that
+      // the auth layer doesn't reject it with request_signature_required.
+      const res = await callTool(app, '/mcp', 'create_media_buy', {
+        account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },
+        idempotency_key: '550e8400-e29b-41d4-a716-446655440001',
+      });
+      expect(res.status).not.toBe(401);
+    });
+
+    it('unsigned get_products on /mcp-strict is allowed (not in required_for)', async () => {
+      const res = await callTool(app, '/mcp-strict', 'get_products', {
+        account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },
+        brand: { domain: 'strict-test.example.com' },
+        buying_mode: 'wholesale',
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('route contract', () => {
+    it('GET /mcp-strict returns 405', async () => {
+      const res = await request(app).get('/api/training-agent/mcp-strict');
+      expect(res.status).toBe(405);
+      expect(res.headers['allow']).toMatch(/POST/);
+    });
+
+    it('POST /mcp-strict without auth returns 401', async () => {
+      const res = await callTool(app, '/mcp-strict', 'get_adcp_capabilities', {}, { auth: false });
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the in-repo asks on both issues.

### #2347 — comply_test_controller onto SDK dispatcher

Swap the local 80-LOC dispatcher for `@adcp/client`'s `handleTestControllerRequest` + `enforceMapCap` + `CONTROLLER_SCENARIOS`. All 7 SDK asks from the issue shipped in 5.x. Behavior gain: per-scenario status-enum validation (`AccountStatusSchema` / `CreativeStatusSchema` / `MediaBuyStatusSchema`) that the local dispatcher was skipping. Kept local: sandbox gate on `account.sandbox`, session binding, state-machine transitions — the "custom MCP wrapper" pattern the SDK documents on `TOOL_INPUT_SHAPE`. Net −101 LOC in the handler.

### #2368 — /mcp-strict route for the conformance grader

The issue's acceptance criterion #2 (`adcp grade request-signing` passes vector 001) requires the agent to reject unsigned calls to an operation in `required_for` with the canonical `request_signature_required` error code. Flipping `required_for: []` → `['create_media_buy']` on the public `/mcp` route would break every unsigned bearer caller (Addie, demos, quickstart users) — `test-agent.adcontextprotocol.org` is the only public sandbox.

Dual-routing preserves both:

- **`/mcp`** (sandbox): `required_for: []`. `anyOf(bearers, signing)`. Unchanged behavior — existing callers unaffected.
- **`/mcp-strict`** (grader target): `required_for: ['create_media_buy']`. Presence-gated authenticator enforces it. Vector 001 fires.

The strict authenticator (`strict-auth.ts`) also closes the two gaps in the default route's `anyOf` composition that the upstream SDK tracks as adcp-client#659:

| Scenario | `/mcp` result | `/mcp-strict` result |
|---|---|---|
| Signature present, valid | accept (signing principal) | accept (signing principal) |
| Signature present, invalid, bearer valid | accept (bearer wins in `anyOf`) | **401, no bearer fallthrough** |
| No signature, op ∈ `required_for`, bearer valid | accept (no enforcement) | **401 `request_signature_required`** |
| No signature, op ∉ `required_for`, bearer valid | accept | accept |

Non-required ops still accept bearer on `/mcp-strict` so grader setup calls (`list_tools`, `get_products`, discovery) work without signing infrastructure.

## Files

**#2347**
- `server/src/training-agent/comply-test-controller.ts` — -101 LOC net.

**#2368**
- `server/src/training-agent/strict-auth.ts` (new) — `strictSignatureAuthenticator` + `RequestSignatureRequiredError` sentinel.
- `server/src/training-agent/request-signing.ts` — parallel `getStrictRequestSigningCapability()` returning `required_for: ['create_media_buy']`.
- `server/src/training-agent/types.ts` — `TrainingContext.strict?: boolean` flag.
- `server/src/training-agent/task-handlers.ts` / `framework-server.ts` — `get_adcp_capabilities` selects the strict capability when `ctx.strict`.
- `server/src/training-agent/index.ts` — split bearer vs. signing authenticator builders; mount `/mcp-strict` POST/OPTIONS/GET-405; custom 401 handler surfacing `request_signature_required` in the JSON body (bypassing the SDK's RFC-6750-typed `respondUnauthorized`).
- `server/tests/integration/training-agent-strict.test.ts` (new) — 7 integration tests.

## Test plan

- [x] `npm run test:unit` (pre-commit) — 627/627 passing on both commits.
- [x] `npm run typecheck` — green.
- [x] `npx vitest run server/tests/unit/comply-test-controller.test.ts` — 36/36.
- [x] `npx vitest run server/tests/integration/training-agent-strict.test.ts server/tests/integration/training-agent-sse.test.ts server/tests/integration/training-agent-webhooks.test.ts` — 17/17.
- [ ] CI green.
- [ ] Post-deploy: `curl -X POST https://test-agent.adcontextprotocol.org/mcp-strict -H 'Authorization: Bearer <public-token>' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_adcp_capabilities","arguments":{}}}'` should return `required_for: ["create_media_buy"]`.
- [ ] Post-deploy: grader smoke run against `https://test-agent.adcontextprotocol.org/mcp-strict`.

## Follow-ups (not in this PR)

- Write up the `TestControllerStore` as a 3rd-party seller reference — SDK JSDoc on `handleTestControllerRequest` already documents the factory + custom-wrapper patterns; a standalone guide is optional.
- Point the AAO Verified compliance dashboard at `/mcp-strict` when it's wired up (issue #2368 acceptance #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)