### PR TITLE
docs: link schemas to /latest/ instead of /v3/ in live docs

### DIFF
--- a/.changeset/docs-schema-links-latest.md
+++ b/.changeset/docs-schema-links-latest.md
@@ -1,0 +1,6 @@
+---
+---
+
+Point docs schema links at `/schemas/latest/` instead of `/schemas/v3/` so the `latest` docs channel links to the live development schemas (where newly added fields like `reporting_delivery_methods` actually live) rather than the last-cut RC.
+
+`/schemas/v3/` resolves to the highest released 3.x version (currently `3.0.0-rc.3`) and is immutable relative to that cut. Live docs describe the moving target, so they now link to `/schemas/latest/`. `scripts/rewrite-dist-links.sh` rewrites `/schemas/latest/` → `/schemas/$VERSION/` when building frozen docs snapshots under `dist/docs/$VERSION/`, so released docs still pin to their own schema version.

--- a/docs/accounts/tasks/list_accounts.mdx
+++ b/docs/accounts/tasks/list_accounts.mdx
@@ -11,8 +11,8 @@ Returns all accounts the authenticated agent can operate on this vendor agent. U
 
 **Response Time**: ~1s.
 
-**Request Schema**: [`/schemas/v3/account/list-accounts-request.json`](https://adcontextprotocol.org/schemas/v3/account/list-accounts-request.json)
-**Response Schema**: [`/schemas/v3/account/list-accounts-response.json`](https://adcontextprotocol.org/schemas/v3/account/list-accounts-response.json)
+**Request Schema**: [`/schemas/latest/account/list-accounts-request.json`](https://adcontextprotocol.org/schemas/latest/account/list-accounts-request.json)
+**Response Schema**: [`/schemas/latest/account/list-accounts-response.json`](https://adcontextprotocol.org/schemas/latest/account/list-accounts-response.json)
 
 ## Quick Start
 

--- a/docs/accounts/tasks/sync_accounts.mdx
+++ b/docs/accounts/tasks/sync_accounts.mdx
@@ -11,8 +11,8 @@ Sync advertiser accounts with a seller for one or more brand/operator pairs. The
 
 **Response Time**: ~1s. Account provisioning is synchronous; credit and legal review may require human action (indicated by `status: "pending_approval"` with a `setup.url`).
 
-**Request Schema**: [`/schemas/v3/account/sync-accounts-request.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-request.json)
-**Response Schema**: [`/schemas/v3/account/sync-accounts-response.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-response.json)
+**Request Schema**: [`/schemas/latest/account/sync-accounts-request.json`](https://adcontextprotocol.org/schemas/latest/account/sync-accounts-request.json)
+**Response Schema**: [`/schemas/latest/account/sync-accounts-response.json`](https://adcontextprotocol.org/schemas/latest/account/sync-accounts-response.json)
 
 ## Quick start
 

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -30,7 +30,7 @@ Points to a hosted brand.json at another URL:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "authoritative_location": "https://adcontextprotocol.org/brand/abc123/brand.json"
 }
 ```
@@ -46,7 +46,7 @@ Points to the house domain that contains the full brand portfolio:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "house": "nikeinc.com",
   "note": "Regional site - see house for brand portfolio"
 }
@@ -67,7 +67,7 @@ Designates an MCP agent that provides brand information:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://agent.acme.com/mcp",
@@ -87,7 +87,7 @@ Contains the full brand hierarchy with all brands and properties:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -719,7 +719,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "bobsburgers.com",
@@ -746,7 +746,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://brand-agent.enterprise.com/mcp",
@@ -763,7 +763,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -814,7 +814,7 @@ A talent agency managing athlete brands with licensable rights:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "lotientertainment.com",
@@ -857,7 +857,7 @@ On `nike.cn/.well-known/brand.json`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "house": "nikeinc.com",
   "region": "CN"
 }

--- a/docs/brand-protocol/index.mdx
+++ b/docs/brand-protocol/index.mdx
@@ -55,7 +55,7 @@ The smallest useful `brand.json` is just a name and a logo:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": { "domain": "novabrands.com", "name": "Nova Brands" },
   "brands": [{

--- a/docs/brand-protocol/key-concepts.mdx
+++ b/docs/brand-protocol/key-concepts.mdx
@@ -66,7 +66,7 @@ A house domain with multiple brands:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -107,7 +107,7 @@ A brand with an MCP agent that provides brand information:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://agent.acme.com/mcp",
@@ -124,7 +124,7 @@ A brand domain pointing to its house:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "house": "nikeinc.com"
 }
 ```

--- a/docs/brand-protocol/walkthrough-rights-licensing.mdx
+++ b/docs/brand-protocol/walkthrough-rights-licensing.mdx
@@ -55,7 +55,7 @@ The `rights_agent` field tells the buyer agent everything it needs to know befor
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "version": "1.0",
   "house": {
     "domain": "lotientertainment.com",

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -35,7 +35,7 @@ If a `comply_test_controller` call references a non-sandbox account, the control
 
 ## Tool definition
 
-**Schemas**: [`comply-test-controller-request.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-request.json) | [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-response.json)
+**Schemas**: [`comply-test-controller-request.json`](https://adcontextprotocol.org/schemas/latest/compliance/comply-test-controller-request.json) | [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/latest/compliance/comply-test-controller-response.json)
 
 Sellers that implement compliance test controller MUST:
 - Only expose the tool in sandbox mode (see sandbox gating above)

--- a/docs/building/integration/a2a-guide.mdx
+++ b/docs/building/integration/a2a-guide.mdx
@@ -408,7 +408,7 @@ During execution, interim status updates can include optional data in `status.me
 }
 ```
 
-**All status payloads use AdCP schemas**: Both final statuses (completed/failed) and interim statuses (working, input-required, submitted) have corresponding AdCP schemas referenced in [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json). Note that interim status schemas are evolving and may change in future versions, so implementors may choose to handle them more loosely.
+**All status payloads use AdCP schemas**: Both final statuses (completed/failed) and interim statuses (working, input-required, submitted) have corresponding AdCP schemas referenced in [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json). Note that interim status schemas are evolving and may change in future versions, so implementors may choose to handle them more loosely.
 
 ### A2A Webhook Payload Types
 
@@ -453,7 +453,7 @@ The `status.message.parts[].data` field in A2A webhooks uses status-specific sch
 | `input-required` | `[task]-async-response-input-required.json` | Requirements, approval data |
 | `submitted` | `[task]-async-response-submitted.json` | Acknowledgment (usually minimal) |
 
-Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json)
+Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json)
 
 ### Webhook Handler Example
 

--- a/docs/building/integration/authentication.mdx
+++ b/docs/building/integration/authentication.mdx
@@ -96,7 +96,7 @@ AdCP distinguishes between the **agent** (who is making requests) and the **acco
 
 An agent may have access to multiple accounts (e.g., an agency managing several clients). See [Accounts and Agents](/docs/building/integration/accounts-and-agents) for details on account selection and billing attribution.
 
-For schema definitions, see [`account.json`](https://adcontextprotocol.org/schemas/v3/core/account.json).
+For schema definitions, see [`account.json`](https://adcontextprotocol.org/schemas/latest/core/account.json).
 
 ## Tenant resolution
 

--- a/docs/building/integration/mcp-guide.mdx
+++ b/docs/building/integration/mcp-guide.mdx
@@ -440,7 +440,7 @@ The `result` field contains the AdCP data payload. For `completed`/`failed` stat
 
 #### MCP Webhook Envelope Fields
 
-The [`mcp-webhook-payload.json`](https://adcontextprotocol.org/schemas/v3/core/mcp-webhook-payload.json) envelope includes:
+The [`mcp-webhook-payload.json`](https://adcontextprotocol.org/schemas/latest/core/mcp-webhook-payload.json) envelope includes:
 
 **Required fields:**
 - `task_id` — Unique task identifier for correlation
@@ -487,7 +487,7 @@ The `result` field in MCP webhooks uses status-specific schemas:
 | `input-required` | `[task]-async-response-input-required.json` | Requirements, approval data |
 | `submitted` | `[task]-async-response-submitted.json` | Acknowledgment (usually minimal) |
 
-Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json)
+Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json)
 
 #### Webhook Handler Example
 

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -12,7 +12,7 @@ AdCP schemas are available from two sources:
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Website | `https://adcontextprotocol.org/schemas/v3/` | Runtime fetching, version aliases |
+| Website | `https://adcontextprotocol.org/schemas/latest/` | Runtime fetching, version aliases |
 | GitHub | `https://github.com/adcontextprotocol/adcp/tree/main/dist/schemas` | Offline access, CI/CD pipelines |
 
 Both sources contain identical schemas. The GitHub repository includes all released versions with bundled schemas committed directly to the codebase.
@@ -97,10 +97,10 @@ Declare `supported_protocols` (for protocol baselines) and `specialisms` (for na
 
 | Schema | URL |
 |--------|-----|
-| Product | `https://adcontextprotocol.org/schemas/v3/core/product.json` |
-| Media Buy | `https://adcontextprotocol.org/schemas/v3/core/media-buy.json` |
-| Creative Format | `https://adcontextprotocol.org/schemas/v3/core/format.json` |
-| Schema Registry | `https://adcontextprotocol.org/schemas/v3/index.json` |
+| Product | `https://adcontextprotocol.org/schemas/latest/core/product.json` |
+| Media Buy | `https://adcontextprotocol.org/schemas/latest/core/media-buy.json` |
+| Creative Format | `https://adcontextprotocol.org/schemas/latest/core/format.json` |
+| Schema Registry | `https://adcontextprotocol.org/schemas/latest/index.json` |
 
 ### For AI Coding Agents
 
@@ -210,7 +210,7 @@ AdCP uses semantic versioning. Choose the right path for your use case:
 | Path | Example | Best For |
 |------|---------|----------|
 | Exact version | `/schemas/2.5.3/`, `/compliance/2.5.3/`, `/protocol/2.5.3.tgz` | Production, SDK generation |
-| Major version | `/schemas/v3/`, `/compliance/v3/` | Development, documentation |
+| Major version | `/schemas/latest/`, `/compliance/v3/` | Development, documentation |
 | Minor version | `/schemas/v2.5/`, `/compliance/v2.5/` | Stable development (patch updates only) |
 
 The same version semantics apply to `/schemas`, `/compliance`, and `/protocol/{version}.tgz` — one release cuts all three.
@@ -232,7 +232,7 @@ Use the major version alias to stay current with backward-compatible updates:
 
 ```javascript
 const schema = await fetch(
-  'https://adcontextprotocol.org/schemas/v3/core/product.json'
+  'https://adcontextprotocol.org/schemas/latest/core/product.json'
 );
 ```
 
@@ -306,13 +306,13 @@ All request/response task schemas are bundled:
 | `bundled/protocol/` | get-adcp-capabilities |
 | `bundled/core/` | tasks-get, tasks-list |
 
-See the [schema registry](https://adcontextprotocol.org/schemas/v3/index.json) for all available schemas.
+See the [schema registry](https://adcontextprotocol.org/schemas/latest/index.json) for all available schemas.
 
 ## Version Discovery
 
 ```bash
 # Get current version
-curl https://adcontextprotocol.org/schemas/v3/index.json | jq '.adcp_version'
+curl https://adcontextprotocol.org/schemas/latest/index.json | jq '.adcp_version'
 ```
 
 Check [Release Notes](/docs/reference/release-notes) for version history and migration guides.

--- a/docs/creative/asset-types.mdx
+++ b/docs/creative/asset-types.mdx
@@ -12,8 +12,8 @@ Standardizing asset types ensures consistency across formats and makes requireme
 ## Important: Payload vs Requirements
 
 For payload schemas (the structure of the actual asset data supplied in creative manifests), see:
-- [Asset Type Registry](https://adcontextprotocol.org/schemas/v3/creative/asset-types/index.json) - Links to all payload schemas
-- Core Asset Schemas at `/schemas/v3/core/assets/` - Individual asset payload definitions
+- [Asset Type Registry](https://adcontextprotocol.org/schemas/latest/creative/asset-types/index.json) - Links to all payload schemas
+- Core Asset Schemas at `/schemas/latest/core/assets/` - Individual asset payload definitions
 
 **Key distinction:**
 
@@ -232,7 +232,7 @@ VAST (Video Ad Serving Template) tags for third-party video ad serving.
 - `vpaid_enabled`: Whether VPAID (Video Player-Ad Interface Definition) is supported
 - `max_wrapper_depth`: Maximum allowed wrapper/redirect depth
 - `duration_ms`: Expected video duration in milliseconds (if known)
-- `tracking_events`: Array of supported tracking events. Valid values are defined by the [VAST Tracking Event](https://adcontextprotocol.org/schemas/v3/enums/vast-tracking-event.json) enum. Includes IAB VAST 4.2 TrackingEvents plus flattened representations of Impression, Error, VideoClicks, and ViewableImpression elements:
+- `tracking_events`: Array of supported tracking events. Valid values are defined by the [VAST Tracking Event](https://adcontextprotocol.org/schemas/latest/enums/vast-tracking-event.json) enum. Includes IAB VAST 4.2 TrackingEvents plus flattened representations of Impression, Error, VideoClicks, and ViewableImpression elements:
   - **Playback**: `impression` (billing event), `creativeView`, `loaded`, `start`, `firstQuartile`, `midpoint`, `thirdQuartile`, `complete`
   - **Interaction**: `mute`, `unmute`, `pause`, `resume`, `rewind`, `skip`, `playerExpand`, `playerCollapse`, `fullscreen` (pre-4.0 compat), `exitFullscreen` (pre-4.0 compat), `otherAdInteraction`, `interactiveStart` (SIMID)
   - **Progress**: `progress` (for custom progress points via VAST `offset` attribute), `notUsed` (prefetched but not played)
@@ -278,7 +278,7 @@ DAAST (Digital Audio Ad Serving Template) tags for third-party audio ad serving.
 - `content`: Inline DAAST XML content (required when delivery_type is "inline")
 - `daast_version`: DAAST specification version (1.0, 1.1)
 - `duration_ms`: Expected audio duration in milliseconds (if known)
-- `tracking_events`: Array of supported tracking events. Valid values are defined by the [DAAST Tracking Event](https://adcontextprotocol.org/schemas/v3/enums/daast-tracking-event.json) enum. Includes DAAST-applicable events plus flattened Impression, Error, and ViewableImpression elements:
+- `tracking_events`: Array of supported tracking events. Valid values are defined by the [DAAST Tracking Event](https://adcontextprotocol.org/schemas/latest/enums/daast-tracking-event.json) enum. Includes DAAST-applicable events plus flattened Impression, Error, and ViewableImpression elements:
   - **Playback**: `impression` (billing event), `creativeView` (companion ad display), `loaded`, `start`, `firstQuartile`, `midpoint`, `thirdQuartile`, `complete`
   - **Interaction**: `mute`, `unmute`, `pause`, `resume`, `skip`
   - **Progress**: `progress`

--- a/docs/creative/catalog-schemas.mdx
+++ b/docs/creative/catalog-schemas.mdx
@@ -29,7 +29,7 @@ In addition to the domain-specific fields listed in each vertical's table, all v
 
 Job postings for recruitment campaigns. Maps to LinkedIn Jobs XML, Google DynamicJobsAsset, and schema.org JobPosting.
 
-**Schema**: [`/schemas/core/job-item.json`](https://adcontextprotocol.org/schemas/v3/core/job-item.json)
+**Schema**: [`/schemas/core/job-item.json`](https://adcontextprotocol.org/schemas/latest/core/job-item.json)
 **Required**: `job_id`, `title`, `company_name`, `description`
 **Conversion events**: `submit_application`, `complete_registration`
 
@@ -56,7 +56,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/job-item.json",
   "job_id": "eng-sr-2025-042",
   "title": "Senior Software Engineer",
   "company_name": "Acme Corp",
@@ -68,7 +68,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/job-item.json",
   "job_id": "eng-sr-2025-042",
   "title": "Senior Software Engineer",
   "company_name": "Acme Corp",
@@ -90,7 +90,7 @@ Full example with optional fields:
 
 Hotel and lodging properties for travel ads and dynamic remarketing. Maps to Google Hotel Center feeds and Meta hotel catalogs.
 
-**Schema**: [`/schemas/core/hotel-item.json`](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json)
+**Schema**: [`/schemas/core/hotel-item.json`](https://adcontextprotocol.org/schemas/latest/core/hotel-item.json)
 **Required**: `hotel_id`, `name`, `location`
 **Conversion events**: `purchase` (booking)
 
@@ -119,7 +119,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/hotel-item.json",
   "hotel_id": "grand-amsterdam",
   "name": "Grand Hotel Amsterdam",
   "location": { "lat": 52.3676, "lng": 4.9041 }
@@ -130,7 +130,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/hotel-item.json",
   "hotel_id": "grand-amsterdam",
   "name": "Grand Hotel Amsterdam",
   "description": "Five-star canal-side hotel in the heart of Amsterdam with rooftop bar and spa.",
@@ -157,7 +157,7 @@ Full example with optional fields:
 
 Vehicle listings for automotive inventory ads. Maps to Meta Automotive Inventory Ads, Microsoft Auto Inventory feeds, and Google vehicle ads.
 
-**Schema**: [`/schemas/core/vehicle-item.json`](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json)
+**Schema**: [`/schemas/core/vehicle-item.json`](https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json)
 **Required**: `vehicle_id`, `title`, `make`, `model`, `year`
 **Conversion events**: `lead`, `schedule` (test drive)
 
@@ -187,7 +187,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json",
   "vehicle_id": "dlr-2024-horizon-001",
   "title": "2024 Apex Horizon EX Sedan",
   "make": "Apex",
@@ -200,7 +200,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json",
   "vehicle_id": "dlr-2024-horizon-001",
   "title": "2024 Apex Horizon EX Sedan",
   "make": "Apex",
@@ -223,7 +223,7 @@ Full example with optional fields:
 
 Flight routes for travel ads and dynamic remarketing. Maps to Google DynamicFlightsAsset and Meta flight catalogs.
 
-**Schema**: [`/schemas/core/flight-item.json`](https://adcontextprotocol.org/schemas/v3/core/flight-item.json)
+**Schema**: [`/schemas/core/flight-item.json`](https://adcontextprotocol.org/schemas/latest/core/flight-item.json)
 **Required**: `flight_id`, `origin`, `destination`
 **Conversion events**: `purchase` (booking)
 
@@ -247,7 +247,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/flight-item.json",
   "flight_id": "ams-jfk-summer",
   "origin": { "airport_code": "AMS" },
   "destination": { "airport_code": "JFK" }
@@ -258,7 +258,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/flight-item.json",
   "flight_id": "ams-jfk-summer",
   "origin": { "airport_code": "AMS", "city": "Amsterdam" },
   "destination": { "airport_code": "JFK", "city": "New York" },
@@ -275,7 +275,7 @@ Full example with optional fields:
 
 Property listings for real estate ads. Maps to Google DynamicRealEstateAsset and Meta home listing catalogs.
 
-**Schema**: [`/schemas/core/real-estate-item.json`](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json)
+**Schema**: [`/schemas/core/real-estate-item.json`](https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json)
 **Required**: `listing_id`, `title`, `address`
 **Conversion events**: `lead`, `schedule` (viewing)
 
@@ -302,7 +302,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json",
   "listing_id": "ams-jordaan-3br",
   "title": "Spacious 3BR Apartment in Jordaan",
   "address": { "city": "Amsterdam", "country": "NL" }
@@ -313,7 +313,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json",
   "listing_id": "ams-jordaan-3br",
   "title": "Spacious 3BR Apartment in Jordaan",
   "description": "Bright canal-view apartment with original features and modern kitchen, steps from Noordermarkt.",
@@ -341,7 +341,7 @@ Full example with optional fields:
 
 Educational programs and courses for student recruitment. Maps to Google DynamicEducationAsset and schema.org Course.
 
-**Schema**: [`/schemas/core/education-item.json`](https://adcontextprotocol.org/schemas/v3/core/education-item.json)
+**Schema**: [`/schemas/core/education-item.json`](https://adcontextprotocol.org/schemas/latest/core/education-item.json)
 **Required**: `program_id`, `name`, `school`
 **Conversion events**: `submit_application`, `complete_registration`
 
@@ -368,7 +368,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/education-item.json",
   "program_id": "pinnacle-msc-cs-2025",
   "name": "MSc Computer Science",
   "school": "Pinnacle University"
@@ -379,7 +379,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/education-item.json",
   "program_id": "pinnacle-msc-cs-2025",
   "name": "MSc Computer Science",
   "school": "Pinnacle University",
@@ -402,7 +402,7 @@ Full example with optional fields:
 
 Travel destinations for destination ads and travel remarketing. Maps to Meta destination catalogs and Google travel ads.
 
-**Schema**: [`/schemas/core/destination-item.json`](https://adcontextprotocol.org/schemas/v3/core/destination-item.json)
+**Schema**: [`/schemas/core/destination-item.json`](https://adcontextprotocol.org/schemas/latest/core/destination-item.json)
 **Required**: `destination_id`, `name`
 **Conversion events**: `purchase` (booking)
 
@@ -426,7 +426,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/destination-item.json",
   "destination_id": "barcelona",
   "name": "Barcelona"
 }
@@ -436,7 +436,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/destination-item.json",
   "destination_id": "barcelona",
   "name": "Barcelona",
   "description": "Mediterranean city blending Gaudí architecture, beaches, and world-class dining.",
@@ -457,7 +457,7 @@ Full example with optional fields:
 
 Mobile applications for app install and re-engagement campaigns. Maps to Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, and Snapchat App Install Ads. iOS and Android variants are separate items.
 
-**Schema**: [`/schemas/core/app-item.json`](https://adcontextprotocol.org/schemas/v3/core/app-item.json)
+**Schema**: [`/schemas/core/app-item.json`](https://adcontextprotocol.org/schemas/latest/core/app-item.json)
 **Required**: `app_id`, `name`, `platform`
 **Conversion events**: `app_install`, `app_launch`
 
@@ -488,7 +488,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/app-item.json",
   "app_id": "puzzlequest-ios",
   "name": "Puzzle Quest: Match 3",
   "platform": "ios"
@@ -499,7 +499,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/app-item.json",
   "app_id": "puzzlequest-ios",
   "name": "Puzzle Quest: Match 3",
   "platform": "ios",

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -108,10 +108,10 @@ Catalog types fall into two categories: **structural** types that describe the d
 
 | Type | Item Schema | Description |
 |------|-------------|-------------|
-| `offering` | [Offering](https://adcontextprotocol.org/schemas/v3/core/offering.json) | AdCP Offering objects — campaigns, vacancies, events, services |
+| `offering` | [Offering](https://adcontextprotocol.org/schemas/latest/core/offering.json) | AdCP Offering objects — campaigns, vacancies, events, services |
 | `product` | *(your existing feed format)* | Ecommerce product entries (Google Merchant Center, Shopify, etc.) |
 | `inventory` | *(your existing feed format)* | Stock and availability per product per location |
-| `store` | [StoreItem](https://adcontextprotocol.org/schemas/v3/core/store-item.json) | Physical locations with addresses and catchment areas |
+| `store` | [StoreItem](https://adcontextprotocol.org/schemas/latest/core/store-item.json) | Physical locations with addresses and catchment areas |
 | `promotion` | *(your existing feed format)* | Sales, deals, and promotional pricing |
 
 ### Vertical types
@@ -120,14 +120,14 @@ Each vertical type has a defined AdCP item schema, so formats can declare `catal
 
 | Type | Item Schema | Maps To |
 |------|-------------|---------|
-| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
-| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/v3/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
-| `job` | [JobItem](https://adcontextprotocol.org/schemas/v3/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
-| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
-| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
-| `education` | [EducationItem](https://adcontextprotocol.org/schemas/v3/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
-| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/v3/core/destination-item.json) | Meta destination catalogs, Google travel ads |
-| `app` | [AppItem](https://adcontextprotocol.org/schemas/v3/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
+| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/latest/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
+| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/latest/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
+| `job` | [JobItem](https://adcontextprotocol.org/schemas/latest/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
+| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
+| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
+| `education` | [EducationItem](https://adcontextprotocol.org/schemas/latest/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
+| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/latest/core/destination-item.json) | Meta destination catalogs, Google travel ads |
+| `app` | [AppItem](https://adcontextprotocol.org/schemas/latest/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
 
 ## Typed catalog assets
 
@@ -173,7 +173,7 @@ Formats use `field_bindings` (see [Format catalog requirements](#format-catalog-
 
 ## The Catalog object
 
-**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/v3/core/catalog.json)
+**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/latest/core/catalog.json)
 
 ```typescript test=false
 interface Catalog {
@@ -620,7 +620,7 @@ When a format declares catalog asset types, the buying agent syncs the required 
 
 ## Offerings
 
-**Schema URL**: [`/schemas/core/offering.json`](https://adcontextprotocol.org/schemas/v3/core/offering.json)
+**Schema URL**: [`/schemas/core/offering.json`](https://adcontextprotocol.org/schemas/latest/core/offering.json)
 
 An Offering is an individual promotable item within an `offering`-type catalog — a campaign, product, service, promotion, or vacancy. Each offering is a semantic unit with its own name, validity window, landing URL, creative assets, and geographic scope.
 
@@ -676,7 +676,7 @@ interface Offering {
 
 ### OfferingAssetGroup
 
-**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/v3/core/offering-asset-group.json)
+**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/latest/core/offering-asset-group.json)
 
 A typed pool of creative assets within an offering. Uses the same `asset_group_id` vocabulary as format-level asset definitions, enabling formats to declare per-group constraints on what each offering must provide.
 
@@ -696,7 +696,7 @@ interface OfferingAssetGroup {
 
 ### OfferingAssetConstraint
 
-**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/v3/core/requirements/offering-asset-constraint.json)
+**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/latest/core/requirements/offering-asset-constraint.json)
 
 Declared by a format to specify what asset groups each offering must provide. Used within a catalog asset's `requirements` to constrain what offerings in a catalog must provide.
 
@@ -776,7 +776,7 @@ Call `list_creative_formats` and check the format's `assets` array for `catalog`
 
 ## Stores
 
-**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/v3/core/store-item.json)
+**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/latest/core/store-item.json)
 
 A StoreItem represents a physical location within a `store`-type catalog. Each store carries coordinates, an optional address, and one or more catchment areas that define the geographic reach around that location.
 
@@ -816,7 +816,7 @@ interface StoreItem {
 
 ### Catchment areas
 
-**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/v3/core/catchment.json)
+**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/latest/core/catchment.json)
 
 A catchment defines the geographic area a store serves. Three methods are supported — provide exactly one per catchment:
 

--- a/docs/creative/creative-manifests.mdx
+++ b/docs/creative/creative-manifests.mdx
@@ -318,7 +318,7 @@ When a creative agent receives a manifest for validation:
    - Look up the `asset_id` in `format.assets`
    - If not found → **reject** with error "Unknown asset_id 'banner_imag' not defined in format"
    - If found → determine the expected `asset_type` from the format requirement
-   - Fetch the asset type schema (e.g., `/schemas/v3/core/assets/image-asset.json`)
+   - Fetch the asset type schema (e.g., `/schemas/latest/core/assets/image-asset.json`)
    - Validate the asset payload against that schema
    - Validate the asset meets any additional constraints in the format's `requirements` field
 4. **Check all required assets are present** (where `required: true` in format spec)
@@ -446,9 +446,9 @@ For carousel, slideshow, and multi-asset formats, see the [Carousel & Multi-Asse
 
 ## Schema Reference
 
-- [Creative Manifest Schema](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json)
-- [Preview Creative Request](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-request.json)
-- [Preview Creative Response](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-response.json)
+- [Creative Manifest Schema](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json)
+- [Preview Creative Request](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-request.json)
+- [Preview Creative Response](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-response.json)
 
 ## Related Documentation
 

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -61,7 +61,7 @@ Formats may be sourced from:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-response.json",
   "formats": [
     {
       "format_id": {
@@ -90,7 +90,7 @@ Each format includes an `agent_url` that identifies the authoritative creative a
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_30s_hosted"
@@ -127,7 +127,7 @@ This approach allows publishers to present complex formats without constraining 
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
   "format_id": {
     "agent_url": "https://publisher.com",
     "id": "homepage_takeover_premium"
@@ -149,7 +149,7 @@ AdCP uses structured format identifiers everywhere to avoid ambiguity and namesp
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format-id.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format-id.json",
   "agent_url": "https://creative.adcontextprotocol.org",
   "id": "display_300x250"
 }
@@ -220,7 +220,7 @@ Formats are JSON objects with the following key fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_30s_hosted"
@@ -448,7 +448,7 @@ Formats specify their rendered outputs via the `renders` array. Most formats pro
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "display_300x250"
@@ -474,7 +474,7 @@ Formats specify their rendered outputs via the `renders` array. Most formats pro
 **Multi-render example (companion ad):**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_with_companion_300x250"

--- a/docs/creative/multi-agent-orchestration.mdx
+++ b/docs/creative/multi-agent-orchestration.mdx
@@ -28,7 +28,7 @@ Before routing any requests, the orchestrator needs a map of what each agent sup
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/creative/sales-agent-creative-capabilities.mdx
+++ b/docs/creative/sales-agent-creative-capabilities.mdx
@@ -15,7 +15,7 @@ A sales agent declares Creative Protocol support in `get_adcp_capabilities`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/creative/specification.mdx
+++ b/docs/creative/specification.mdx
@@ -43,7 +43,7 @@ Creative agents MUST declare Creative Protocol support via `get_adcp_capabilitie
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -156,7 +156,7 @@ Sales agents MUST translate universal macros to their ad server's native syntax.
 
 ## Creative Status Lifecycle
 
-**Schema**: [`enums/creative-status.json`](https://adcontextprotocol.org/schemas/v3/enums/creative-status.json)
+**Schema**: [`enums/creative-status.json`](https://adcontextprotocol.org/schemas/latest/enums/creative-status.json)
 
 Creatives in a library progress through a defined set of states. `archived` is the only buyer-initiated state change; all others are seller-initiated (processing, review, approval/rejection).
 
@@ -466,11 +466,11 @@ Some creative protocol schemas (`build_creative`, `list_creative_formats`, `prev
 
 | Schema | Description |
 |--------|-------------|
-| [`core/format.json`](https://adcontextprotocol.org/schemas/v3/core/format.json) | Format definition |
-| [`core/creative-manifest.json`](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json) | Creative manifest |
-| [`core/creative-asset.json`](https://adcontextprotocol.org/schemas/v3/core/creative-asset.json) | Asset definition |
-| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) | list_creative_formats request |
-| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json) | list_creative_formats response |
+| [`core/format.json`](https://adcontextprotocol.org/schemas/latest/core/format.json) | Format definition |
+| [`core/creative-manifest.json`](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json) | Creative manifest |
+| [`core/creative-asset.json`](https://adcontextprotocol.org/schemas/latest/core/creative-asset.json) | Asset definition |
+| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) | list_creative_formats request |
+| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json) | list_creative_formats response |
 | [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json) | list_creatives request |
 | [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json) | list_creatives response |
 | [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json) | sync_creatives request |

--- a/docs/creative/task-reference/get_creative_delivery.mdx
+++ b/docs/creative/task-reference/get_creative_delivery.mdx
@@ -9,8 +9,8 @@ Retrieve creative delivery data including variant-level breakdowns with manifest
 
 This is a Creative Protocol task. Call it on any agent that declares `"creative"` in `supported_protocols` and `"delivery"` in its [creative agent capabilities](#capability-declaration) — whether that's a dedicated creative service or a [sales agent implementing the Creative Protocol](/docs/creative/sales-agent-creative-capabilities).
 
-**Request Schema**: [`/schemas/v3/creative/get-creative-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/creative/get-creative-delivery-request.json)
-**Response Schema**: [`/schemas/v3/creative/get-creative-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/creative/get-creative-delivery-response.json)
+**Request Schema**: [`/schemas/latest/creative/get-creative-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/creative/get-creative-delivery-request.json)
+**Response Schema**: [`/schemas/latest/creative/get-creative-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/creative/get-creative-delivery-response.json)
 
 ## Request Parameters
 

--- a/docs/creative/task-reference/list_creative_formats.mdx
+++ b/docs/creative/task-reference/list_creative_formats.mdx
@@ -12,8 +12,8 @@ Discover creative formats supported by a creative agent. Returns full format spe
 
 **Authentication**: None required (public endpoint for format discovery)
 
-**Request Schema**: [`/schemas/v3/creative/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-request.json)
-**Response Schema**: [`/schemas/v3/creative/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-response.json)
+**Request Schema**: [`/schemas/latest/creative/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-request.json)
+**Response Schema**: [`/schemas/latest/creative/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-response.json)
 
 ## Behavior by agent type
 
@@ -67,7 +67,7 @@ Formats may produce multiple rendered pieces (e.g., video + companion banner). D
 | `formats` | Array of full format definitions (format_id, name, assets, renders). The `type` field is deprecated and may be omitted. |
 | `creative_agents` | Optional array of other creative agents providing additional formats |
 
-See [Format schema](https://adcontextprotocol.org/schemas/v3/core/format.json) for complete format object structure.
+See [Format schema](https://adcontextprotocol.org/schemas/latest/core/format.json) for complete format object structure.
 
 ### Recursive Discovery
 
@@ -677,6 +677,6 @@ After discovering formats:
 
 ## Learn More
 
-- [Format Schema](https://adcontextprotocol.org/schemas/v3/core/format.json) - Complete format structure
+- [Format Schema](https://adcontextprotocol.org/schemas/latest/core/format.json) - Complete format structure
 - [Asset Types](/docs/creative/asset-types) - Asset specification details
 - [Standard Formats](/docs/media-buy/capability-discovery/implementing-standard-formats) - IAB-compatible reference formats

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -7,8 +7,8 @@ description: "preview_creative generates visual previews of ad creative manifest
 
 Generate preview renderings of creative manifests. Supports both single creative preview and batch preview (5-10x faster for multiple creatives).
 
-**Request Schema**: [`/schemas/v3/creative/preview-creative-request.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-request.json)
-**Response Schema**: [`/schemas/v3/creative/preview-creative-response.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-response.json)
+**Request Schema**: [`/schemas/latest/creative/preview-creative-request.json`](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-request.json)
+**Response Schema**: [`/schemas/latest/creative/preview-creative-response.json`](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-response.json)
 
 ## Quick Start
 

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -24,7 +24,7 @@ Artifacts are identified by `property_id` + `artifact_id` - the property defines
 
 ## Structure
 
-**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json)
+**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json)
 
 Web article:
 

--- a/docs/governance/content-standards/tasks/calibrate_content.mdx
+++ b/docs/governance/content-standards/tasks/calibrate_content.mdx
@@ -19,7 +19,7 @@ Unlike high-volume runtime evaluation, calibration is a **dialogue-based process
 
 ## Request
 
-**Schema**: [calibrate-content-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/calibrate-content-request.json)
+**Schema**: [calibrate-content-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/calibrate-content-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -28,7 +28,7 @@ Unlike high-volume runtime evaluation, calibration is a **dialogue-based process
 
 ### Artifact
 
-**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json)
+**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json)
 
 An artifact represents content context where ad placements occur - identified by `property_rid` + `artifact_id` and represented as a collection of assets:
 
@@ -48,7 +48,7 @@ An artifact represents content context where ad placements occur - identified by
 
 ## Response
 
-**Schema**: [calibrate-content-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/calibrate-content-response.json)
+**Schema**: [calibrate-content-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/calibrate-content-response.json)
 
 ### Passing Response
 

--- a/docs/governance/content-standards/tasks/create_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/create_content_standards.mdx
@@ -12,7 +12,7 @@ Create a new content standards configuration.
 
 ## Request
 
-**Schema**: [create-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/create-content-standards-request.json)
+**Schema**: [create-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/create-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -80,7 +80,7 @@ Implementors MUST apply a brand safety floor regardless of what policy is define
 
 ## Response
 
-**Schema**: [create-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/create-content-standards-response.json)
+**Schema**: [create-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/create-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/get_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/get_content_standards.mdx
@@ -10,7 +10,7 @@ Retrieve content safety policies for a specific standards configuration.
 
 ## Request
 
-**Schema**: [get-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-content-standards-request.json)
+**Schema**: [get-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -18,7 +18,7 @@ Retrieve content safety policies for a specific standards configuration.
 
 ## Response
 
-**Schema**: [get-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-content-standards-response.json)
+**Schema**: [get-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
+++ b/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
@@ -28,7 +28,7 @@ The buyer retrieves artifacts the seller has collected per the sampling configur
 
 ## Request
 
-**Schema**: [get-media-buy-artifacts-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-media-buy-artifacts-request.json)
+**Schema**: [get-media-buy-artifacts-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-media-buy-artifacts-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -54,7 +54,7 @@ Uses higher limits than standard pagination because artifact result sets can be 
 
 ## Response
 
-**Schema**: [get-media-buy-artifacts-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-media-buy-artifacts-response.json)
+**Schema**: [get-media-buy-artifacts-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-media-buy-artifacts-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/list_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/list_content_standards.mdx
@@ -12,7 +12,7 @@ List available content standards configurations.
 
 ## Request
 
-**Schema**: [list-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/list-content-standards-request.json)
+**Schema**: [list-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/list-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -23,7 +23,7 @@ List available content standards configurations.
 
 ## Response
 
-**Schema**: [list-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/list-content-standards-response.json)
+**Schema**: [list-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/list-content-standards-response.json)
 
 Returns an abbreviated list of standards configurations. Use [get_content_standards](./get_content_standards) to retrieve full details including policy text and calibration data.
 

--- a/docs/governance/content-standards/tasks/update_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/update_content_standards.mdx
@@ -12,7 +12,7 @@ Update an existing content standards configuration. Creates a new version.
 
 ## Request
 
-**Schema**: [update-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/update-content-standards-request.json)
+**Schema**: [update-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/update-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -70,7 +70,7 @@ Update an existing content standards configuration. Creates a new version.
 
 ## Response
 
-**Schema**: [update-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/update-content-standards-response.json)
+**Schema**: [update-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/update-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/validate_content_delivery.mdx
+++ b/docs/governance/content-standards/tasks/validate_content_delivery.mdx
@@ -37,7 +37,7 @@ This keeps responsibilities clear: sellers provide content samples via `get_medi
 
 ## Request
 
-**Schema**: [validate-content-delivery-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/validate-content-delivery-request.json)
+**Schema**: [validate-content-delivery-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/validate-content-delivery-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -81,7 +81,7 @@ This keeps responsibilities clear: sellers provide content samples via `get_medi
 
 ## Response
 
-**Schema**: [validate-content-delivery-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/validate-content-delivery-response.json)
+**Schema**: [validate-content-delivery-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/validate-content-delivery-response.json)
 
 ### Success Response
 

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -95,7 +95,7 @@ The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Example Publisher Ad Operations",
     "email": "adops@example.com",
@@ -199,7 +199,7 @@ For publishers with complex infrastructure or CDN distribution, `adagents.json` 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "authoritative_location": "https://cdn.example.com/adagents/v2/adagents.json",
   "last_updated": "2025-01-15T10:00:00Z"
 }
@@ -221,7 +221,7 @@ A publisher with multiple domains can maintain one authoritative file:
 **On each domain** (`https://domain1.com/.well-known/adagents.json`, `https://domain2.com/.well-known/adagents.json`, etc.):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "authoritative_location": "https://cdn.publisher.com/adagents/v2/adagents.json",
   "last_updated": "2025-01-15T10:00:00Z"
 }
@@ -230,7 +230,7 @@ A publisher with multiple domains can maintain one authoritative file:
 **Authoritative file** (`https://cdn.publisher.com/adagents/v2/adagents.json`):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Publisher Ad Operations",
     "email": "adops@publisher.com"
@@ -733,7 +733,7 @@ Publishers can declare which governance agents have data about their properties 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Premium News Publisher",
     "email": "adops@news.example.com",
@@ -1013,5 +1013,5 @@ After implementing adagents.json validation:
 
 - [AdCP Basics: Authorized Properties](https://bokonads.com/p/adcp-basics-authorized-properties) - Accessible introduction to AdCP authorization
 - [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities) - Discover agent capabilities and portfolio
-- [Property Schema](https://adcontextprotocol.org/schemas/v3/core/property.json) - Property definition structure
+- [Property Schema](https://adcontextprotocol.org/schemas/latest/core/property.json) - Property definition structure
 - [AdAgents.json Builder](https://agenticadvertising.org/adagents/builder) - Web-based validator and creator

--- a/docs/governance/property/authorized-properties.mdx
+++ b/docs/governance/property/authorized-properties.mdx
@@ -46,7 +46,7 @@ Publishers authorize sales agents by hosting an `adagents.json` file at `/.well-
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Sports Network Media",
     "email": "adops@sportsnetwork.com",
@@ -276,5 +276,5 @@ See the **[adagents.json Tech Spec](./adagents)** for complete implementation gu
 
 - **[`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities)** - Discover agent capabilities and portfolio information
 - **[Product Discovery](../../media-buy/product-discovery/)** - How authorization integrates with product discovery
-- **[Properties Schema](https://adcontextprotocol.org/schemas/v3/core/property.json)** - Technical property data model
+- **[Properties Schema](https://adcontextprotocol.org/schemas/latest/core/property.json)** - Technical property data model
 - **[adagents.json Tech Spec](./adagents)** - Complete `adagents.json` implementation guide

--- a/docs/governance/property/index.mdx
+++ b/docs/governance/property/index.mdx
@@ -36,7 +36,7 @@ Publishers declare their properties, authorize sales agents, and reference gover
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "properties": [
     {
       "property_id": "example_site",

--- a/docs/governance/property/managed-networks.mdx
+++ b/docs/governance/property/managed-networks.mdx
@@ -31,7 +31,7 @@ Each managed domain hosts a minimal pointer file at `/.well-known/adagents.json`
 **Pointer file** (on each domain):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
   "last_updated": "2025-06-01T00:00:00Z"
 }
@@ -42,7 +42,7 @@ The `last_updated` timestamp in the pointer file reflects when the pointer itsel
 **Authoritative file** (at the network):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Example Network Ad Operations",
     "email": "adops@network.example.com",
@@ -338,7 +338,7 @@ export default {
     const url = new URL(request.url);
     if (url.pathname === '/.well-known/adagents.json') {
       return new Response(JSON.stringify({
-        "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+        "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
         "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
         "last_updated": "2025-06-01T00:00:00Z"
       }), {
@@ -367,7 +367,7 @@ function handler(event) {
         'access-control-allow-origin': { value: '*' }
       },
       body: JSON.stringify({
-        "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+        "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
         "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
         "last_updated": "2025-06-01T00:00:00Z"
       })
@@ -389,7 +389,7 @@ add_action('init', function () {
         header('Content-Type: application/json');
         header('Cache-Control: public, max-age=86400');
         echo json_encode([
-            '$schema' => 'https://adcontextprotocol.org/schemas/v3/adagents.json',
+            '$schema' => 'https://adcontextprotocol.org/schemas/latest/adagents.json',
             'authoritative_location' => 'https://network.example.com/adagents/v2/adagents.json',
             'last_updated' => '2025-06-01T00:00:00Z',
         ]);
@@ -426,7 +426,7 @@ jobs:
             mkdir -p "dist/${domain}/.well-known"
             cat > "dist/${domain}/.well-known/adagents.json" <<EOF
           {
-            "\$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+            "\$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
             "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
             "last_updated": "${TIMESTAMP}"
           }

--- a/docs/governance/property/specification.mdx
+++ b/docs/governance/property/specification.mdx
@@ -206,7 +206,7 @@ Create a new property list with filters and optional brand reference.
 - **`identifiers`**: `{ "selection_type": "identifiers", "identifiers": [...] }` - no publisher context needed
 - **Omitted**: Query the agent's entire property database
 
-See the [base-property-source schema](https://adcontextprotocol.org/schemas/v3/property/base-property-source.json) for the full specification.
+See the [base-property-source schema](https://adcontextprotocol.org/schemas/latest/property/base-property-source.json) for the full specification.
 
 **Filter Logic** (explicit in field names):
 - `countries_all`: Property must have feature data for **ALL** listed countries

--- a/docs/governance/property/tasks/property_lists.mdx
+++ b/docs/governance/property/tasks/property_lists.mdx
@@ -116,7 +116,7 @@ The agent resolves the brand identity and applies rules based on its domain expe
 - A brand safety agent infers content categories from the brand's industry
 - A sustainability agent applies requirements from the brand's profile
 
-The brand reference uses the standard [core/brand-ref](https://adcontextprotocol.org/schemas/v3/core/brand-ref.json) schema. The governance agent resolves the domain to discover the brand's identity via its `brand.json` file.
+The brand reference uses the standard [core/brand-ref](https://adcontextprotocol.org/schemas/latest/core/brand-ref.json) schema. The governance agent resolves the domain to discover the brand's identity via its `brand.json` file.
 
 ## Webhooks
 
@@ -281,7 +281,7 @@ Each entry must include `selection_type`:
 
 If `base_properties` is omitted, the agent queries its entire property database for properties matching the filters.
 
-See the [base-property-source schema](https://adcontextprotocol.org/schemas/v3/property/base-property-source.json) for the full specification.
+See the [base-property-source schema](https://adcontextprotocol.org/schemas/latest/property/base-property-source.json) for the full specification.
 
 ---
 

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -96,7 +96,7 @@ AdCP standardizes this with the accounts protocol. Sam, Alex's media buyer, sets
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/account/sync-accounts-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/account/sync-accounts-request.json",
   "idempotency_key": "f6c0a3d4-2345-48b1-2345-6789012345ab",
   "accounts": [
     {
@@ -128,7 +128,7 @@ With AdCP, `get_products` sends the same brief to every connected seller. Sam de
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json",
   "buying_mode": "brief",
   "brief": "Premium sports video inventory, Q2 2026, targeting 25-45 males interested in outdoor recreation. Budget $50K across CTV and display.",
   "brand": { "domain": "acmeoutdoor.com" }
@@ -170,7 +170,7 @@ But Sam isn't done. He likes StreamHaus's sports package but wants to shift budg
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json",
   "buying_mode": "refine",
   "refine": [
     {
@@ -205,7 +205,7 @@ First, Maya discovers what each seller accepts:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-request.json",
   "type": "video"
 }
 ```
@@ -216,7 +216,7 @@ Then Maya briefs the creative agent. One brief produces all formats:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/build-creative-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/build-creative-request.json",
   "idempotency_key": "c1d2e3f4-a5b6-4789-c012-789012345678",
   "message": "Adventurous, aspirational summer campaign — gear for people who live outside",
   "brand": { "domain": "acmeoutdoor.com" },
@@ -235,7 +235,7 @@ Once approved, `sync_creatives` distributes the finished assets to every seller 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json",
   "idempotency_key": "d2e3f4a5-b6c7-4890-d123-890123456789",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "creatives": [
@@ -265,7 +265,7 @@ Sam has products, creatives, and accounts. Time to buy. One call to `create_medi
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json",
   "idempotency_key": "e3f4a5b6-c7d8-4901-e234-901234567890",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "brand": { "domain": "acmeoutdoor.com" },
@@ -307,7 +307,7 @@ Sam's campaign needs targeting beyond what the sellers provide. His client has C
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-request.json",
   "idempotency_key": "a7d1b4e5-3456-48c2-3456-789012345abc",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "audiences": [
@@ -324,7 +324,7 @@ Sam's campaign needs targeting beyond what the sellers provide. His client has C
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json",
   "signal_spec": "Outdoor recreation enthusiasts near sporting goods retailers, 25-45"
 }
 ```
@@ -333,7 +333,7 @@ Kai's Meridian Geo returns matching signal segments with pricing, coverage, and 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
   "idempotency_key": "f4a5b6c7-d8e9-4012-f345-012345678901",
   "signal_agent_segment_id": "meridian_outdoor_rec_25_45",
   "destinations": [
@@ -360,7 +360,7 @@ Before any of Sam's campaigns go live, they pass through governance. Jordan, Pin
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/governance/check-governance-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/governance/check-governance-request.json",
   "plan_id": "acme_outdoor_q2_plan",
   "caller": "https://buyer.pinnacle-agency.com/a2a",
   "tool": "create_media_buy",
@@ -438,7 +438,7 @@ For deeper performance tracking, AdCP provides two more tools:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json",
   "idempotency_key": "a5b6c7d8-e9f0-4123-a456-123456789012",
   "event_source_id": "acme_website_pixel",
   "events": [
@@ -457,7 +457,7 @@ For deeper performance tracking, AdCP provides two more tools:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json",
   "idempotency_key": "b6c7d8e9-f0a1-4234-b567-234567890123",
   "media_buy_id": "mb_acme_q2_001",
   "measurement_period": {
@@ -480,7 +480,7 @@ Acme Outdoor has a Shopify store with 200 products. They want their catalog avai
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-request.json",
   "idempotency_key": "b8e2c5f6-4567-48d3-4567-89012345abcd",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "catalogs": [
@@ -512,7 +512,7 @@ https://novamotors.com/.well-known/brand.json
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
   "house": {
     "domain": "novamotors.com",
     "name": "Nova Motors"

--- a/docs/media-buy/advanced-topics/pricing-models.mdx
+++ b/docs/media-buy/advanced-topics/pricing-models.mdx
@@ -163,7 +163,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_guaranteed",
   "pricing_model": "cpm",
   "fixed_price": 12.50,
@@ -188,7 +188,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/vcpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/vcpm-option.json",
   "pricing_option_id": "vcpm_usd_guaranteed",
   "pricing_model": "vcpm",
   "fixed_price": 18.50,
@@ -211,7 +211,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpcv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpcv-option.json",
   "pricing_option_id": "cpcv_usd_guaranteed",
   "pricing_model": "cpcv",
   "fixed_price": 0.15,
@@ -231,7 +231,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpv-option.json",
   "pricing_option_id": "cpv_usd_50pct",
   "pricing_model": "cpv",
   "fixed_price": 0.08,
@@ -257,7 +257,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpp-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpp-option.json",
   "pricing_option_id": "cpp_usd_a18-49",
   "pricing_model": "cpp",
   "fixed_price": 250.00,
@@ -337,7 +337,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpa-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpa-option.json",
   "pricing_option_id": "cpa_usd_purchase",
   "pricing_model": "cpa",
   "event_type": "purchase",
@@ -392,7 +392,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example** (sponsorship):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
   "pricing_option_id": "flat_rate_usd_sponsorship",
   "pricing_model": "flat_rate",
   "fixed_price": 50000.00,
@@ -403,7 +403,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example** (DOOH slot with parameters):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
   "pricing_option_id": "flat_rate_usd_dooh_morning",
   "pricing_model": "flat_rate",
   "fixed_price": 5000.00,
@@ -442,7 +442,7 @@ Sponsorship flat_rate options omit `parameters` — the fixed price covers the p
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/time-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/time-option.json",
   "pricing_option_id": "time_usd_daily",
   "pricing_model": "time",
   "fixed_price": 50000.00,

--- a/docs/media-buy/conversion-tracking/index.mdx
+++ b/docs/media-buy/conversion-tracking/index.mdx
@@ -65,7 +65,7 @@ To discover all sources on an account (including seller-managed), call `sync_eve
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json",
   "idempotency_key": "c9f3d6a7-5678-48e4-5678-9012345abcde",
   "account": { "account_id": "acct_12345" }
 }
@@ -79,7 +79,7 @@ Send events with [`log_event`](/docs/media-buy/task-reference/log_event):
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/event.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/event.json",
   "event_id": "evt_purchase_12345",
   "event_type": "purchase",
   "event_time": "2026-01-15T14:30:00Z",
@@ -118,7 +118,7 @@ User identifiers enable the seller to attribute conversions to ad impressions. P
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/user-match.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/user-match.json",
   "hashed_email": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
   "uids": [
     { "type": "uid2", "value": "AbC123XyZ..." }
@@ -150,7 +150,7 @@ Event-specific data for attribution and reporting. For purchase events, always i
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/event-custom-data.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/event-custom-data.json",
   "value": 149.99,
   "currency": "USD",
   "order_id": "order_98765",
@@ -341,7 +341,7 @@ The `issues[].message`, `measurement_readiness.notes`, and `detail.label` fields
 
 Optimization goals tell the seller what to optimize delivery toward. Set them on a package in [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy#campaign-with-conversion-optimization). A package accepts an array of goals — each with an optional `priority` (1 = highest). Products declare `max_optimization_goals` when they limit how many goals a package can carry (most social platforms accept only 1).
 
-**Schema**: [`/schemas/v3/core/optimization-goal.json`](https://adcontextprotocol.org/schemas/v3/core/optimization-goal.json)
+**Schema**: [`/schemas/latest/core/optimization-goal.json`](https://adcontextprotocol.org/schemas/latest/core/optimization-goal.json)
 
 There are two kinds of goals, discriminated by `kind`:
 

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -106,7 +106,7 @@ Publishers declare which pricing models they support for each product. Buyers se
 Each pricing option includes:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpcv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpcv-option.json",
   "pricing_option_id": "cpcv_usd_guaranteed",
   "pricing_model": "cpcv",
   "fixed_price": 0.15,
@@ -118,7 +118,7 @@ Each pricing option includes:
 For auction-based pricing (no `fixed_price`), use `floor_price` for minimum bid constraints and optional `price_guidance` for percentile hints. Bid-based auction models (`cpm`, `vcpm`, `cpc`, `cpcv`, `cpv`) may also include `max_bid` as a boolean signal that `bid_price` switches from exact honored price to buyer ceiling mode:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_auction",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -171,7 +171,7 @@ For products that include outcome measurement (common in retail media):
 Defines creative requirements and restrictions:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-policy.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-policy.json",
   "co_branding": "required",
   "landing_page": "retailer_site_only",
   "templates_available": true
@@ -193,7 +193,7 @@ Products can optionally declare specific ad placements within their inventory. W
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/placement.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/placement.json",
   "placement_id": "homepage_banner",
   "name": "Homepage Banner",
   "description": "Above-the-fold banner on the homepage",

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -43,7 +43,7 @@ Sales agents MUST declare Media Buy Protocol support via `get_adcp_capabilities`
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -141,7 +141,7 @@ Packages follow the same pause/cancel pattern as media buys. Additionally:
 
 ### Creative Approval on Packages
 
-**Schema**: [`enums/creative-approval-status.json`](https://adcontextprotocol.org/schemas/v3/enums/creative-approval-status.json)
+**Schema**: [`enums/creative-approval-status.json`](https://adcontextprotocol.org/schemas/latest/enums/creative-approval-status.json)
 
 Each package tracks per-creative approval status separately from the creative's library-level status. A creative may be `approved` in the library but `rejected` on a specific package (e.g., wrong format for the placement).
 
@@ -170,7 +170,7 @@ The Media Buy Protocol defines the following tasks. See task reference pages for
 
 ### get_products
 
-**Schema**: [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json) / [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
+**Schema**: [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json) / [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
 
 **Reference**: [`get_products` task](/docs/media-buy/task-reference/get_products)
 
@@ -204,7 +204,7 @@ Each `get_products` request with `buying_mode: "refine"` is self-contained — s
 
 ### list_creative_formats
 
-**Schema**: [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) / [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json)
+**Schema**: [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) / [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json)
 
 **Reference**: [`list_creative_formats` task](/docs/creative/task-reference/list_creative_formats)
 
@@ -217,7 +217,7 @@ Discover creative format requirements and specifications.
 
 ### create_media_buy
 
-**Schema**: [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json) / [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json)
+**Schema**: [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json) / [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json)
 
 **Reference**: [`create_media_buy` task](/docs/media-buy/task-reference/create_media_buy)
 
@@ -234,7 +234,7 @@ Create a media buy from selected packages or execute a proposal.
 
 ### update_media_buy
 
-**Schema**: [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json) / [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json)
+**Schema**: [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json) / [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json)
 
 **Reference**: [`update_media_buy` task](/docs/media-buy/task-reference/update_media_buy)
 
@@ -324,7 +324,7 @@ Sellers MAY omit actions based on business rules (e.g., omit `cancel` when contr
 
 ### get_media_buy_delivery
 
-**Schema**: [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json) / [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
+**Schema**: [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json) / [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json)
 
 **Reference**: [`get_media_buy_delivery` task](/docs/media-buy/task-reference/get_media_buy_delivery)
 
@@ -338,7 +338,7 @@ Track performance metrics and campaign delivery.
 
 ### provide_performance_feedback
 
-**Schema**: [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json) / [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json)
+**Schema**: [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json) / [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json)
 
 **Reference**: [`provide_performance_feedback` task](/docs/media-buy/task-reference/provide_performance_feedback)
 
@@ -351,7 +351,7 @@ Submit performance signals to enable publisher optimization.
 
 ### sync_event_sources
 
-**Schema**: [`media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json) / [`media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
+**Schema**: [`media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json) / [`media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
 
 **Reference**: [`sync_event_sources` task](/docs/media-buy/task-reference/sync_event_sources)
 
@@ -368,7 +368,7 @@ Configure event sources on a seller account for conversion tracking with upsert 
 
 ### log_event
 
-**Schema**: [`media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json) / [`media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-response.json)
+**Schema**: [`media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json) / [`media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-response.json)
 
 **Reference**: [`log_event` task](/docs/media-buy/task-reference/log_event)
 
@@ -504,19 +504,19 @@ Sales agents MAY require human approval for any operation. Approval is modelled 
 
 | Schema | Description |
 |--------|-------------|
-| [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json) | get_products request |
-| [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json) | get_products response |
-| [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json) | create_media_buy request |
-| [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json) | create_media_buy response |
-| [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json) | update_media_buy request |
-| [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json) | update_media_buy response |
-| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) | list_creative_formats request |
-| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json) | list_creative_formats response |
+| [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json) | get_products request |
+| [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json) | get_products response |
+| [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json) | create_media_buy request |
+| [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json) | create_media_buy response |
+| [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json) | update_media_buy request |
+| [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json) | update_media_buy response |
+| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) | list_creative_formats request |
+| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json) | list_creative_formats response |
 | [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json) | list_creatives request (Creative Protocol) |
 | [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json) | list_creatives response (Creative Protocol) |
 | [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json) | sync_creatives request (Creative Protocol) |
 | [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json) | sync_creatives response (Creative Protocol) |
-| [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json) | get_media_buy_delivery request |
-| [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) | get_media_buy_delivery response |
-| [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json) | provide_performance_feedback request |
-| [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json) | provide_performance_feedback response |
+| [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json) | get_media_buy_delivery request |
+| [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json) | get_media_buy_delivery response |
+| [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json) | provide_performance_feedback request |
+| [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json) | provide_performance_feedback response |

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -14,8 +14,8 @@ Supports two modes:
 
 **Response Time**: Instant to days (returns `completed`, `working` < 120s, or `submitted` for hours/days)
 
-**Request Schema**: [`/schemas/v3/media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -10,8 +10,8 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 **Response Time**: ~60 seconds (reporting query)
 
-**Request Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json)
 
 ## Request Parameters
 
@@ -59,7 +59,7 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 | `by_package` | Package-level breakdowns with delivery_status, paused state, and pacing_index |
 | `daily_breakdown` | Day-by-day delivery (date, impressions, spend, conversions, conversion_value, roas, new_to_brand_rate) |
 
-See [schema](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) for complete field list.
+See [schema](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json) for complete field list.
 
 ### Billing-grade vs best-effort numbers
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -11,8 +11,8 @@ Discover available advertising products based on campaign requirements using nat
 
 **Response Time**: ~60 seconds (AI inference with back-end systems)
 
-**Request Schema**: [`/schemas/v3/media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
 
 ## Quick Start
 
@@ -316,7 +316,7 @@ When the seller cannot complete all work within the `time_budget` (or due to its
 | `description` | string | Yes | Human-readable explanation of what is missing and why. |
 | `estimated_wait` | Duration | No | How much additional time would resolve this scope. |
 
-**See schema for complete field list**: [`get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
+**See schema for complete field list**: [`get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
 
 ## Common Scenarios
 

--- a/docs/media-buy/task-reference/index.mdx
+++ b/docs/media-buy/task-reference/index.mdx
@@ -106,8 +106,8 @@ Upload and manage first-party CRM audiences for targeting.
 
 All tasks include JSON schema definitions for requests and responses:
 
-- **Request Schemas**: `/schemas/v3/media-buy/[task-name]-request.json`
-- **Response Schemas**: `/schemas/v3/media-buy/[task-name]-response.json`
+- **Request Schemas**: `/schemas/latest/media-buy/[task-name]-request.json`
+- **Response Schemas**: `/schemas/latest/media-buy/[task-name]-response.json`
 
 **Task Management**: For tracking async operations across all AdCP domains, see [Task Lifecycle](/docs/building/implementation/task-lifecycle).
 

--- a/docs/media-buy/task-reference/log_event.mdx
+++ b/docs/media-buy/task-reference/log_event.mdx
@@ -10,8 +10,8 @@ Send conversion or marketing events for attribution and optimization. Supports b
 
 **Response Time**: ~1s (events are queued for processing)
 
-**Request Schema**: [`/schemas/v3/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/provide_performance_feedback.mdx
+++ b/docs/media-buy/task-reference/provide_performance_feedback.mdx
@@ -9,8 +9,8 @@ Share performance outcomes with publishers to enable data-driven optimization an
 
 **Response Time**: ~5 seconds (data ingestion)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json)
 
 ## Request Parameters
 

--- a/docs/media-buy/task-reference/sync_event_sources.mdx
+++ b/docs/media-buy/task-reference/sync_event_sources.mdx
@@ -10,8 +10,8 @@ Configure event sources on a seller account for conversion tracking. Supports up
 
 **Response Time**: ~1s (synchronous configuration)
 
-**Request Schema**: [`/schemas/v3/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
 
 ## Quick Start
 
@@ -126,7 +126,7 @@ asyncio.run(main())
 - `health` - Event source health assessment (when seller supports health scoring)
 - `errors` - Per-source errors (only when `action: "failed"`)
 
-**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
+**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
 
 ### Event Source Health
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -12,8 +12,8 @@ Modify an existing media buy using PATCH semantics. Supports campaign-level and 
 
 **PATCH Semantics**: Only specified fields are updated; omitted fields remain unchanged.
 
-**Request Schema**: [`/schemas/v3/media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json)
-**Response Schema**: [`/schemas/v3/media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json)
+**Request Schema**: [`/schemas/latest/media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json)
+**Response Schema**: [`/schemas/latest/media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json)
 
 ## Quick Start
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -15,8 +15,8 @@ Discover a seller's protocol support and capabilities across all AdCP protocols.
 - **Auth model** - Does this seller trust the agent directly, or must each operator authenticate independently?
 - **Detailed capabilities** - Features, execution integrations, geo targeting, portfolio
 
-**Request Schema**: [`/schemas/v3/protocol/get-adcp-capabilities-request.json`](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-request.json)
-**Response Schema**: [`/schemas/v3/protocol/get-adcp-capabilities-response.json`](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json)
+**Request Schema**: [`/schemas/latest/protocol/get-adcp-capabilities-request.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-request.json)
+**Response Schema**: [`/schemas/latest/protocol/get-adcp-capabilities-response.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json)
 
 ## Tool-Based Discovery
 
@@ -133,7 +133,7 @@ Optional specialization claims. Each entry corresponds to a narrow storyboard at
 }
 ```
 
-See the full [Compliance Catalog](/docs/building/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/v3/enums/specialism.json) for the authoritative list.
+See the full [Compliance Catalog](/docs/building/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/latest/enums/specialism.json) for the authoritative list.
 
 ### account
 

--- a/docs/reference/media-channel-taxonomy.mdx
+++ b/docs/reference/media-channel-taxonomy.mdx
@@ -579,7 +579,7 @@ The following channels do not have corresponding property types because they lac
 Channels are defined in the AdCP schema at:
 
 ```
-/schemas/v3/enums/channels.json
+/schemas/latest/enums/channels.json
 ```
 
 ```json

--- a/docs/reference/migration/attribution.mdx
+++ b/docs/reference/migration/attribution.mdx
@@ -37,7 +37,7 @@ AdCP 3.0 renames attribution window fields and replaces integer day counts with 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/attribution-window.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/attribution-window.json",
   "post_click": {
     "interval": 7,
     "unit": "days"

--- a/docs/reference/migration/channels.mdx
+++ b/docs/reference/migration/channels.mdx
@@ -102,7 +102,7 @@ v3 products declare an array of channels, so a single product can span multiple 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/reference/migration/creatives.mdx
+++ b/docs/reference/migration/creatives.mdx
@@ -73,7 +73,7 @@ Replace `format_types` filters with `asset_types` (what the format needs) or `fo
 **v3 — omit `weight` for equal distribution:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-assignment.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-assignment.json",
   "creative_id": "creative_1"
 }
 ```
@@ -143,7 +143,7 @@ Each assignment object:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-assignment.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-assignment.json",
   "creative_id": "hero_video",
   "weight": 60,
   "placement_ids": ["homepage_hero"]

--- a/docs/reference/migration/geo-targeting.mdx
+++ b/docs/reference/migration/geo-targeting.mdx
@@ -32,7 +32,7 @@ Fields that didn't change: `geo_countries`, `geo_countries_exclude`, `geo_region
 **v3** — codes grouped by system:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
   "geo_metros": [
     { "system": "nielsen_dma", "values": ["501", "602"] }
   ]
@@ -43,7 +43,7 @@ Each entry specifies a system and the codes within that system. Multiple systems
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
   "geo_metros": [
     { "system": "nielsen_dma", "values": ["501", "602"] },
     { "system": "uk_itl2", "values": ["UKC1", "UKD3"] }
@@ -77,7 +77,7 @@ Supported systems are defined in the `metro-system.json` enum: `nielsen_dma`, `u
 **v3** — renamed to `geo_postal_areas`, codes grouped by system:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
   "geo_postal_areas": [
     { "system": "us_zip", "values": ["10001", "90210"] }
   ]
@@ -108,7 +108,7 @@ v3 adds `_exclude` variants for metro and postal targeting:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
   "geo_countries": ["US"],
   "geo_metros_exclude": [
     { "system": "nielsen_dma", "values": ["501"] }
@@ -124,7 +124,7 @@ Before sending geo targeting, buyers should verify the seller supports the reque
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -155,7 +155,7 @@ A v3 targeting overlay combining geo restrictions:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
   "geo_countries": ["US", "CA"],
   "geo_regions": ["US-NY", "US-CA"],
   "geo_metros": [

--- a/docs/reference/migration/pricing.mdx
+++ b/docs/reference/migration/pricing.mdx
@@ -62,7 +62,7 @@ PG and Preferred Deals both use `fixed_price`. The distinction between them is i
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_fixed",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -91,7 +91,7 @@ Rename `fixed_rate` to `fixed_price`. No structural changes.
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_auction",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -113,7 +113,7 @@ The v3 `price_guidance` object contains only statistical percentiles:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/price-guidance.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/price-guidance.json",
   "p25": 8.50,
   "p50": 15.00,
   "p75": 18.00,
@@ -143,7 +143,7 @@ All fields are optional. Publishers include whichever percentiles they can provi
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
   "pricing_option_id": "dooh_times_square",
   "pricing_model": "flat_rate",
   "currency": "USD",
@@ -169,7 +169,7 @@ v3 adds an optional `min_spend_per_package` field to all pricing options:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_premium",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -214,7 +214,7 @@ v3 writers should only emit the new field names. Old field names (`fixed_rate`, 
     Verify floor enforcement works with the new field location.
   </Step>
   <Step title="Validate against schemas">
-    Each pricing model has its own schema in `/schemas/v3/pricing-options/`.
+    Each pricing model has its own schema in `/schemas/latest/pricing-options/`.
   </Step>
 </Steps>
 

--- a/docs/signals/data-providers.mdx
+++ b/docs/signals/data-providers.mdx
@@ -66,7 +66,7 @@ Following [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) well-known U
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Pinnacle Auto Data",
     "email": "partnerships@pinnacle-auto-data.com",
@@ -339,7 +339,7 @@ A full signal catalog for an automotive data provider:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Pinnacle Auto Data",
     "email": "partnerships@pinnacle-auto-data.com",

--- a/docs/signals/ecosystem.mdx
+++ b/docs/signals/ecosystem.mdx
@@ -112,7 +112,7 @@ Every company that owns targetable data can publish a **signal catalog** via `/.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Meridian Geo",
     "email": "partnerships@meridiangeo.example",
@@ -223,7 +223,7 @@ Your first-party purchase data (category buyers, loyalty tiers, basket value, ne
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
   "contact": {
     "name": "Acme Marketplace",
     "email": "partnerships@acme-marketplace.example",

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -24,7 +24,7 @@ Sam's agency platform translates the brief into a `get_signals` call. No need to
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json",
   "signal_spec": "In-market EV buyers with high purchase propensity, near auto dealerships"
 }
 ```
@@ -129,7 +129,7 @@ Each activation call specifies the destination platform and account:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
   "idempotency_key": "c3d4e5f6-a7b8-4901-c234-901234567890",
   "signal_agent_segment_id": "shopgrid_new_to_brand",
   "pricing_option_id": "po_shopgrid_retail_cpm",
@@ -151,7 +151,7 @@ Sam also wants to run a sponsored article campaign through Wonderstruck, a premi
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
   "idempotency_key": "d4e5f6a7-b8c9-4012-d345-012345678901",
   "signal_agent_segment_id": "shopgrid_new_to_brand",
   "pricing_option_id": "po_shopgrid_retail_cpm",
@@ -183,7 +183,7 @@ The campaign runs. Two weeks in, display CPAs are running 40% above target while
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
   "idempotency_key": "e5f6a7b8-c9d0-4123-e456-123456789012",
   "signal_agent_segment_id": "meridian_competitor_visitors",
   "action": "deactivate",

--- a/docs/signals/specification.mdx
+++ b/docs/signals/specification.mdx
@@ -39,7 +39,7 @@ Signal agents MUST declare Signals Protocol support via `get_adcp_capabilities`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -88,7 +88,7 @@ The Signals Protocol defines two tasks. See task reference pages for complete re
 
 ### get_signals
 
-**Schema**: [`get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json) / [`get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json)
+**Schema**: [`get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json) / [`get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json)
 
 **Reference**: [`get_signals` task](/docs/signals/tasks/get_signals)
 
@@ -101,7 +101,7 @@ Discover signals matching campaign criteria.
 
 ### activate_signal
 
-**Schema**: [`activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json) / [`activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json)
+**Schema**: [`activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json) / [`activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json)
 
 **Reference**: [`activate_signal` task](/docs/signals/tasks/activate_signal)
 
@@ -189,9 +189,9 @@ The `activate_signal` request supports two destination types. The choice depends
 
 | Schema | Description |
 |--------|-------------|
-| [`signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json) | get_signals request |
-| [`signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json) | get_signals response |
-| [`signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json) | activate_signal request |
-| [`signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json) | activate_signal response |
-| [`core/deployment.json`](https://adcontextprotocol.org/schemas/v3/core/deployment.json) | Deployment target |
-| [`core/activation-key.json`](https://adcontextprotocol.org/schemas/v3/core/activation-key.json) | Activation key |
+| [`signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json) | get_signals request |
+| [`signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json) | get_signals response |
+| [`signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json) | activate_signal request |
+| [`signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json) | activate_signal response |
+| [`core/deployment.json`](https://adcontextprotocol.org/schemas/latest/core/deployment.json) | Deployment target |
+| [`core/activation-key.json`](https://adcontextprotocol.org/schemas/latest/core/activation-key.json) | Activation key |

--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -9,8 +9,8 @@ description: "activate_signal is the AdCP task for pushing audience segments to 
 
 **Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json)
 
 The `activate_signal` task handles the entire activation lifecycle, including:
 - Initiating the activation request

--- a/docs/signals/tasks/get_signals.mdx
+++ b/docs/signals/tasks/get_signals.mdx
@@ -9,8 +9,8 @@ description: "get_signals is the AdCP task for discovering audience and contextu
 
 **Response Time**: ~60 seconds (inference/RAG with back-end systems)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json)
 
 The `get_signals` task returns both signal metadata and real-time deployment status across platforms, allowing agents to understand availability and guide the activation process.
 

--- a/docs/sponsored-intelligence/specification.mdx
+++ b/docs/sponsored-intelligence/specification.mdx
@@ -136,7 +136,7 @@ This enables hosts to show rich previews before session initiation.
 
 ### Session States
 
-**Schema**: [`enums/si-session-status.json`](https://adcontextprotocol.org/schemas/v3/enums/si-session-status.json)
+**Schema**: [`enums/si-session-status.json`](https://adcontextprotocol.org/schemas/latest/enums/si-session-status.json)
 
 SI sessions progress through the following states. Terminal states (`complete`, `terminated`) allow no further messages.
 
@@ -456,7 +456,7 @@ Brand agents MUST return errors in the `errors` array using the standard error s
 
 SI uses both standard AdCP error codes and SI-specific codes:
 
-**Standard AdCP error codes** (from [`enums/error-code.json`](https://adcontextprotocol.org/schemas/v3/enums/error-code.json)):
+**Standard AdCP error codes** (from [`enums/error-code.json`](https://adcontextprotocol.org/schemas/latest/enums/error-code.json)):
 
 | Code | Description |
 |------|-------------|

--- a/scripts/rewrite-dist-links.sh
+++ b/scripts/rewrite-dist-links.sh
@@ -37,6 +37,9 @@ rewrite_file() {
     -e "s|](/docs/|](/dist/docs/$VERSION/|g" \
     -e "s|href=\"/docs/|href=\"/dist/docs/$VERSION/|g" \
     -e "s|\"\$schema\": \"/schemas/|\"\$schema\": \"/schemas/$VERSION/|g" \
+    -e "s|https://adcontextprotocol.org/schemas/latest/|https://adcontextprotocol.org/schemas/$VERSION/|g" \
+    -e "s|](/schemas/latest/|](/schemas/$VERSION/|g" \
+    -e "s|\`/schemas/latest/|\`/schemas/$VERSION/|g" \
     "$file" > "$tmp"
 
   if ! diff -q "$file" "$tmp" > /dev/null 2>&1; then


### PR DESCRIPTION
## The bug

Live docs (the `latest` channel in the Mintlify dropdown) linked readers to `/schemas/v3/...`. That alias resolves to the highest released 3.x version — currently `3.0.0-rc.3` — which is **frozen** relative to that cut. But `/schemas/latest/` is a rolling snapshot that gets rebuilt on every merge to `main`.

The result: `get_adcp_capabilities.mdx` (and 63 other docs pages) describe fields like `reporting_delivery_methods` in the prose, but the schema URL embedded in the page (`/schemas/v3/...`) points to a schema that doesn't contain those fields. So readers who click through to validate types against the schema hit a 404-by-absence.

## The mental model this PR enforces

| Docs channel | Docs source | Linked schema URL | Substitution |
|---|---|---|---|
| `latest` dropdown (live) | `docs/**/*.mdx` | `/schemas/latest/` | none — live channel, always fresh |
| `3.0-rc` dropdown (frozen snapshot) | `dist/docs/3.0.0-rc.X/` | `/schemas/3.0.0-rc.X/` | `scripts/rewrite-dist-links.sh` rewrites `/schemas/latest/` → `/schemas/$VERSION/` at snapshot build time |
| `2.5` dropdown (frozen snapshot) | `dist/docs/2.5.3/` | `/schemas/2.5.3/` | same rewrite (already working) |

So **`/schemas/latest/` in the live MDX IS the macro** — resolved at snapshot build time by sed. Docs authors write `/schemas/latest/` once and the right version gets substituted per snapshot.

### Why a true per-version Mintlify macro isn't feasible here

Mintlify supports global `{{var}}` substitution but not per-dropdown-selection substitution. The version dropdown only filters the sidebar — the URL and page HTML are the same regardless of which version you pick. So a "select latest → see `/schemas/latest/`; select v3 → see `/schemas/v3/`" UX on the *same URL* can't work via runtime variables.

The workaround — which this repo already uses for `2.5` — is to make non-`latest` dropdown entries serve **different URLs** (frozen copies under `dist/docs/$VERSION/` with pre-rewritten links). That's the only way Mintlify versioning produces actually-different content.

## What this PR changes

1. **Replaced `/schemas/v3/` → `/schemas/latest/` in 64 `docs/**/*.mdx` files (264 occurrences).**
   - Skipped `docs/spec-guidelines.md` — its `/schemas/v3/` references describe the schema *directory layout itself* (example `$id`/`$ref` values for schema authors), not reader-facing navigation.
2. **Extended `scripts/rewrite-dist-links.sh`** so when docs snapshots are cut to `dist/docs/$VERSION/`, `/schemas/latest/` links rewrite to `/schemas/$VERSION/`. Added three sed expressions covering:
   - full URLs (`https://adcontextprotocol.org/schemas/latest/`)
   - markdown link hrefs (`](/schemas/latest/`)
   - inline code refs (`` `/schemas/latest/ ``)
3. **Changeset** describing the behavior change.

## What this PR does *not* fix (followups required)

- **The `3.0-rc` dropdown still references live `docs/` paths, not a snapshot.** `release-docs.yml` fires on GitHub Release publish events — but rc.3 was never actually published as a GitHub Release (only tagged/version-bumped), so the workflow never ran for it. `dist/docs/` only contains snapshots through `3.0.0-rc.2`. To fix: run `release-docs.yml` via `workflow_dispatch` with input `3.0.0-rc.3`.
- **The rc.2 `release-docs.yml` run failed** (`fatal: couldn't find remote ref auto/docs-v3.0.0-rc.2`) in the PR-creation step. Snapshot files did get committed somehow, but `docs.json` never got the update PR. Worth diagnosing before rc.4 cuts.
- **`release-docs.yml` opens a PR, doesn't commit directly.** Even when the workflow succeeds, someone has to merge the resulting PR. If it sits unreviewed, the `3.0-rc` dropdown doesn't repoint.

## Verification done locally

- `npm run test:docs-nav` ✅ (all 15 tests pass)
- `npm run test:unit` ✅ (627 tests pass)
- `tsc --noEmit` ✅
- **Simulated snapshot rewrite**: copied `docs/protocol/get_adcp_capabilities.mdx` into a fake `dist/docs/3.0.0-rc.4/` dir and ran `bash scripts/rewrite-dist-links.sh 3.0.0-rc.4`. Verified link hrefs rewrote correctly from `/schemas/latest/` → `/schemas/3.0.0-rc.4/`.

## Test plan

- [ ] CI green
- [ ] After merge, visually confirm the live `latest` docs page for `get_adcp_capabilities` links to `https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json` (which contains `reporting_delivery_methods`)
- [ ] Followup PR: backfill rc.3 snapshot via `gh workflow run release-docs.yml -f version=3.0.0-rc.3`