### PR TITLE
fix(http): respond 400 for malformed JSON bodies instead of 500

### DIFF
--- a/.changeset/fix-http-malformed-json-400.md
+++ b/.changeset/fix-http-malformed-json-400.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix http-server logging malformed JSON request bodies as unhandled server errors. body-parser `entity.parse.failed`, `entity.verify.failed`, `encoding.unsupported`, and 413/4xx errors now respond with their proper status and log at `warn` instead of paging as `error`-level "Unhandled error". This stops noisy Slack alerts (`System error: http-server [web]`) from bad client input.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -8284,13 +8284,29 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     });
 
     // Global error handler - logger.error() automatically captures to PostHog via error hook
-    this.app.use((err: Error & { status?: number; statusCode?: number }, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    this.app.use((err: Error & { status?: number; statusCode?: number; type?: string }, req: express.Request, res: express.Response, _next: express.NextFunction) => {
       const status = err.status || err.statusCode || 500;
 
       // Range Not Satisfiable (416) from static file serving is a client error, not a server issue
       if (status === 416) {
         logger.debug({ path: req.path }, 'Range not satisfiable');
         return res.status(416).end();
+      }
+
+      // body-parser malformed JSON / payload errors are client errors, not server issues
+      if (status === 400 && (err.type === 'entity.parse.failed' || err.type === 'entity.verify.failed' || err.type === 'encoding.unsupported')) {
+        logger.warn({ path: req.path, method: req.method, type: err.type, msg: err.message }, 'Malformed request body');
+        return res.status(400).json({ error: 'Malformed request body', type: err.type });
+      }
+      if (status === 413) {
+        logger.warn({ path: req.path, method: req.method }, 'Request body too large');
+        return res.status(413).json({ error: 'Request body too large' });
+      }
+
+      // Any other 4xx thrown by middleware is a client error, not an unhandled server error
+      if (status >= 400 && status < 500) {
+        logger.warn({ err, path: req.path, method: req.method, status }, 'Client error');
+        return res.status(status).json({ error: err.message || 'Bad request' });
       }
 
       logger.error({ err, path: req.path, method: req.method }, 'Unhandled error');


### PR DESCRIPTION
## Summary

- `body-parser` throws `SyntaxError` with `status: 400` and `type: 'entity.parse.failed'` when clients send malformed JSON.
- The global Express error handler at `server/src/http.ts:8287` logged every non-416 error at `logger.error()` level as `"Unhandled error"` — which fires the `http-server [web]` Slack system-error notifier — and responded with a generic 500.
- Now the handler routes known client errors to a `warn` log and the correct status:
  - `400` + `entity.parse.failed` / `entity.verify.failed` / `encoding.unsupported` → `400 {"error":"Malformed request body","type":...}`
  - `413` → `413 {"error":"Request body too large"}`
  - Any other `4xx` → mirror the status with the error message
  - `5xx` still logs at `error` level and responds `500` (unchanged)

## Why

Ordinary bad client input (e.g. a truncated/invalid JSON POST body) was paging us as if it were a server failure. The symptom in the original alert was:

```
System error: http-server [web]
Unhandled error: Expected property name or '}' in JSON at position 2 (line 2 column 1)
```

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] pre-commit `test:unit` (627 tests passed)
- [ ] Verify in staging: POST malformed JSON to a non-webhook endpoint → expect `400` response, `warn`-level log, no Slack alert
- [ ] Verify a genuine server error still logs as `error` and returns `500`