### PR TITLE
feat(billing): notify admins of listing auto-publish + checkout disclosure (#2583)

### DIFF
--- a/.changeset/listing-autopublish-notify-and-disclose.md
+++ b/.changeset/listing-autopublish-notify-and-disclose.md
@@ -1,0 +1,8 @@
+---
+---
+
+Notify admins when a membership activation auto-publishes their directory listing, and disclose the auto-publish at checkout. Follow-up to #2581 / #2583.
+
+- The Stripe `customer.subscription.created` webhook now calls `ensureMemberProfilePublished` after the `organizations` row is updated, then threads the resulting `{ slug, action }` into the thank-you Slack DM and welcome email. When a listing is created or flipped public, admins see a new "Your listing is live" section with view, edit, and make-private links — no separate notification send. Deferring autopublish until after the org row reflects activation avoids a transient state where the listing is public but the backend hasn't recorded membership.
+- `createCheckoutSession` adds `custom_text.submit.message` on membership prices (lookup keys starting with `aao_membership_` or `aao_invoice_`), disclosing that completing checkout publishes the org in the public member directory. Non-membership checkouts (event sponsorships, etc.) are unaffected.
+- `ensureMemberProfilePublished` now returns `slug` on `published` and `noop` results so callers can link to the listing without an extra DB round trip.

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -1308,6 +1308,23 @@ export async function createCheckoutSession(
     const price = await stripe.prices.retrieve(data.priceId);
     const mode = price.recurring ? 'subscription' : 'payment';
 
+    // Disclose auto-publish on membership checkouts. Membership prices use
+    // lookup keys prefixed `aao_membership_` or `aao_invoice_`; once the
+    // subscription or invoice activates, the Stripe webhook flips the org's
+    // directory listing to is_public=true. Surfacing that at purchase time
+    // closes the consent loop from issue #2583.
+    const isMembershipCheckout =
+      !!price.lookup_key &&
+      (price.lookup_key.startsWith('aao_membership_') || price.lookup_key.startsWith('aao_invoice_'));
+    const customText = isMembershipCheckout
+      ? {
+          submit: {
+            message:
+              'Completing checkout activates your membership and publishes your organization in the public member directory at agenticadvertising.org/members. You can edit or make the listing private anytime from your dashboard.',
+          },
+        }
+      : undefined;
+
     // Resolve discounts before building the params object
     let discounts: Array<{ coupon?: string; promotion_code?: string }> | undefined;
     let allow_promotion_codes: boolean | undefined;
@@ -1332,6 +1349,7 @@ export async function createCheckoutSession(
       success_url: data.successUrl,
       cancel_url: data.cancelUrl,
       billing_address_collection: 'required',
+      ...(customText ? { custom_text: customText } : {}),
       metadata: {
         ...(data.workosOrganizationId && { workos_organization_id: data.workosOrganizationId }),
         ...(data.workosUserId && { workos_user_id: data.workosUserId }),

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3436,6 +3436,17 @@ export class HTTPServer {
               subscription,
             });
 
+            // Captured inside the fresh-activation block for use in the
+            // post-UPDATE autopublish + notification dispatch below. Kept
+            // out of that later block so the listing isn't flipped public
+            // until the organizations row reflects the activated membership.
+            let activationAdminContext: {
+              userEmail: string;
+              workosUserId: string;
+              firstName?: string;
+              productName?: string;
+            } | undefined;
+
             // For subscription created, record agreement acceptance atomically
             if (event.type === 'customer.subscription.created') {
               if (org) {
@@ -3562,55 +3573,17 @@ export class HTTPServer {
                       interval,
                     }).catch(err => logger.error({ err }, 'Failed to send Slack notification'));
 
-                    // Send thank you to org admin group DM (fire-and-forget)
-                    (async () => {
-                      try {
-                        // Get org admins/owners
-                        const orgMemberships = await workos!.userManagement.listOrganizationMemberships({
-                          organizationId: org.workos_organization_id,
-                        });
-                        const adminEmails: string[] = [];
-                        for (const membership of orgMemberships.data) {
-                          if (membership.role?.slug === 'admin' || membership.role?.slug === 'owner') {
-                            try {
-                              const adminUser = await workos!.userManagement.getUser(membership.userId);
-                              if (adminUser.email) {
-                                adminEmails.push(adminUser.email);
-                              }
-                            } catch {
-                              // Skip if can't fetch user
-                            }
-                          }
-                        }
-
-                        if (adminEmails.length > 0) {
-                          // Compute seat limits for the welcome message
-                          const { getSeatLimits } = await import('./db/organization-db.js');
-                          const welcomeUpdate = buildSubscriptionUpdate(subscription as any, org.is_personal);
-                          const seatLimits = getSeatLimits(welcomeUpdate.membership_tier);
-
-                          await notifySubscriptionThankYou({
-                            orgId: org.workos_organization_id,
-                            orgName: org.name || 'Organization',
-                            adminEmails,
-                            seatLimits,
-                          });
-                        }
-                      } catch (err) {
-                        logger.warn({ err, orgId: org.workos_organization_id }, 'Failed to send thank you to admin group DM');
-                      }
-                    })();
-
-                    // Send welcome email to new member
-                    sendWelcomeEmail({
-                      to: userEmail,
-                      organizationName: org.name || 'Unknown Organization',
-                      productName,
+                    // Capture the admin-facing touch context so the post-UPDATE
+                    // block can auto-publish the listing and thread the result
+                    // into the thank-you DM + welcome email. Deferring the
+                    // notifications avoids publishing a directory listing
+                    // before the organizations row reflects activation.
+                    activationAdminContext = {
+                      userEmail,
                       workosUserId: workosUser.id,
-                      workosOrganizationId: org.workos_organization_id,
-                      isPersonal: org.is_personal || false,
                       firstName: workosUser.firstName || undefined,
-                    }).catch(err => logger.error({ err }, 'Failed to send welcome email'));
+                      productName,
+                    };
 
                     // Record to org_activities for prospect tracking
                     const amountStr = amount ? `$${(amount / 100).toFixed(2)}` : '';
@@ -3739,27 +3712,93 @@ export class HTTPServer {
                 invalidateMemberContextCache();
                 invalidateMembershipCache(org.workos_organization_id);
 
-                // Auto-publish directory listing on fresh activation only.
-                // Scoped to subscription.created to avoid clobbering a later
-                // manual unpublish on renewals / tier changes.
-                if (
-                  event.type === 'customer.subscription.created' &&
-                  (TIER_PRESERVING_STATUSES as readonly string[]).includes(subUpdate.subscription_status)
-                ) {
-                  try {
-                    await ensureMemberProfilePublished({
-                      orgId: org.workos_organization_id,
-                      orgName: org.name ?? '',
-                      source: `stripe:${event.type}`,
-                    });
-                  } catch (err) {
-                    // Don't fail the webhook — the backlog endpoint surfaces
-                    // orgs we missed so an operator can clean them up.
-                    logger.error(
-                      { err, orgId: org.workos_organization_id },
-                      'Failed to auto-publish member profile on activation',
-                    );
+                // Auto-publish the directory listing and fire the welcome
+                // touch — only after the organizations row reflects an active
+                // membership. Autopublish is gated on an active/trial/past_due
+                // status so renewals and tier changes don't clobber a later
+                // manual unpublish (#2583). Notifications fire even if the
+                // subscription was created in a non-active status (e.g.,
+                // incomplete), matching prior behavior — just without the
+                // listing section. Failures never throw: the unpublished-
+                // backlog admin endpoint surfaces orgs we missed.
+                if (event.type === 'customer.subscription.created' && activationAdminContext) {
+                  let listingNotice: { slug: string; action: 'created' | 'published' } | undefined;
+                  if ((TIER_PRESERVING_STATUSES as readonly string[]).includes(subUpdate.subscription_status)) {
+                    try {
+                      const autopublishResult = await ensureMemberProfilePublished({
+                        orgId: org.workos_organization_id,
+                        orgName: org.name ?? '',
+                        source: `stripe:${event.type}`,
+                      });
+                      if (
+                        (autopublishResult.action === 'created' || autopublishResult.action === 'published') &&
+                        autopublishResult.slug
+                      ) {
+                        listingNotice = {
+                          slug: autopublishResult.slug,
+                          action: autopublishResult.action,
+                        };
+                      }
+                    } catch (err) {
+                      logger.error(
+                        { err, orgId: org.workos_organization_id },
+                        'Failed to auto-publish member profile on activation',
+                      );
+                    }
                   }
+
+                  const { getSeatLimits } = await import('./db/organization-db.js');
+                  const seatLimits = getSeatLimits(subUpdate.membership_tier);
+                  const capturedAdmin = activationAdminContext;
+                  const orgIdForDispatch = org.workos_organization_id;
+                  const orgNameForDispatch = org.name;
+                  const isPersonalForDispatch = org.is_personal;
+
+                  // Thank-you DM (fire-and-forget)
+                  (async () => {
+                    try {
+                      const orgMemberships = await workos!.userManagement.listOrganizationMemberships({
+                        organizationId: orgIdForDispatch,
+                      });
+                      const adminEmails: string[] = [];
+                      for (const membership of orgMemberships.data) {
+                        if (membership.role?.slug === 'admin' || membership.role?.slug === 'owner') {
+                          try {
+                            const adminUser = await workos!.userManagement.getUser(membership.userId);
+                            if (adminUser.email) {
+                              adminEmails.push(adminUser.email);
+                            }
+                          } catch {
+                            // Skip if can't fetch user
+                          }
+                        }
+                      }
+
+                      if (adminEmails.length > 0) {
+                        await notifySubscriptionThankYou({
+                          orgId: orgIdForDispatch,
+                          orgName: orgNameForDispatch || 'Organization',
+                          adminEmails,
+                          seatLimits,
+                          listing: listingNotice,
+                        });
+                      }
+                    } catch (err) {
+                      logger.warn({ err, orgId: orgIdForDispatch }, 'Failed to send thank you to admin group DM');
+                    }
+                  })();
+
+                  // Welcome email (fire-and-forget)
+                  sendWelcomeEmail({
+                    to: capturedAdmin.userEmail,
+                    organizationName: orgNameForDispatch || 'Unknown Organization',
+                    productName: capturedAdmin.productName,
+                    workosUserId: capturedAdmin.workosUserId,
+                    workosOrganizationId: orgIdForDispatch,
+                    isPersonal: isPersonalForDispatch || false,
+                    firstName: capturedAdmin.firstName,
+                    listing: listingNotice,
+                  }).catch(err => logger.error({ err }, 'Failed to send welcome email'));
                 }
 
                 // Send Slack notification for subscription cancellation

--- a/server/src/notifications/email.ts
+++ b/server/src/notifications/email.ts
@@ -114,6 +114,12 @@ export type EmailType =
 /**
  * Send welcome email to new members after subscription is created
  * Now with tracking!
+ *
+ * If `listing` is provided, an "Your listing is live" section is included
+ * that links to the public listing and the edit / privacy controls. This is
+ * populated by the Stripe webhook when `ensureMemberProfilePublished` has
+ * just created or flipped a profile public — consistent with the activation
+ * touch, so admins know their listing went public without a separate email.
  */
 export async function sendWelcomeEmail(data: {
   to: string;
@@ -123,6 +129,10 @@ export async function sendWelcomeEmail(data: {
   workosOrganizationId?: string;
   isPersonal?: boolean;
   firstName?: string;
+  listing?: {
+    slug: string;
+    action: 'created' | 'published';
+  };
 }): Promise<boolean> {
   if (!resend) {
     logger.debug('Resend not configured, skipping welcome email');
@@ -171,6 +181,60 @@ export async function sendWelcomeEmail(data: {
     const footerHtml = generateFooterHtml(trackingId, null);
     const footerText = generateFooterText(null);
 
+    // Optional: auto-published listing section. Piggybacks on this email so
+    // admins see (and can correct) the listing without a separate send.
+    let listingSectionHtml = '';
+    let listingSectionText = '';
+    if (data.listing) {
+      const orgQuery = data.workosOrganizationId
+        ? `?org=${encodeURIComponent(data.workosOrganizationId)}`
+        : '';
+      // Defense-in-depth: slugs are validated at creation (slugify → [a-z0-9-]),
+      // but the URL path and display both encode/escape so a future policy
+      // change can't introduce injection here.
+      const encodedSlug = encodeURIComponent(data.listing.slug);
+      const safeSlug = escapeHtml(data.listing.slug);
+      const viewUrl = trackedUrl(
+        trackingId,
+        'cta_listing_view',
+        `https://agenticadvertising.org/members/${encodedSlug}`,
+      );
+      const editUrl = trackedUrl(
+        trackingId,
+        'cta_listing_edit',
+        `https://agenticadvertising.org/member-profile${orgQuery}`,
+      );
+      const privacyAnchor = orgQuery ? `${orgQuery}#field-is-public` : '#field-is-public';
+      const privacyUrl = trackedUrl(
+        trackingId,
+        'cta_listing_privacy',
+        `https://agenticadvertising.org/member-profile${privacyAnchor}`,
+      );
+      const intro = data.listing.action === 'created'
+        ? 'Your directory listing is now live. We created it when your membership activated so other members and visitors can find you.'
+        : 'Your directory listing is now live — we published it when your membership activated.';
+      listingSectionHtml = `
+  <div style="background: #f8fafc; border-left: 4px solid #2563eb; border-radius: 8px; padding: 16px 20px; margin: 24px 0;">
+    <p style="margin: 0 0 10px 0;"><strong>Your listing is live</strong></p>
+    <p style="margin: 0 0 12px 0; font-size: 14px;">${intro}</p>
+    <p style="margin: 0 0 4px 0; font-size: 14px;">
+      <a href="${viewUrl}" style="color: #2563eb;">View listing</a>
+      &nbsp;·&nbsp;
+      <a href="${editUrl}" style="color: #2563eb;">Edit</a>
+      &nbsp;·&nbsp;
+      <a href="${privacyUrl}" style="color: #2563eb;">Make private</a>
+    </p>
+    <p style="margin: 8px 0 0 0; font-size: 12px; color: #666;">/members/${safeSlug}</p>
+  </div>`;
+      listingSectionText = `
+Your listing is live
+${intro}
+- View: https://agenticadvertising.org/members/${encodedSlug}
+- Edit: https://agenticadvertising.org/member-profile${orgQuery}
+- Make private: https://agenticadvertising.org/member-profile${privacyAnchor}
+`;
+    }
+
     const { data: sendData, error } = await resend.emails.send({
       from: FROM_EMAIL,
       to: data.to,
@@ -204,7 +268,7 @@ export async function sendWelcomeEmail(data: {
   <p style="text-align: center; margin: 30px 0;">
     <a href="${dashboardUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 500;">Go to Dashboard</a>
   </p>
-
+  ${listingSectionHtml}
   <p>If you have any questions, just reply to this email - we're happy to help.</p>
 
   <p style="margin-top: 30px;">
@@ -229,7 +293,7 @@ As a member, you now have access to:
 
 To get started, visit your dashboard to set up your member profile:
 https://agenticadvertising.org/dashboard
-
+${listingSectionText}
 If you have any questions, just reply to this email - we're happy to help.
 
 Best,

--- a/server/src/services/member-profile-autopublish.ts
+++ b/server/src/services/member-profile-autopublish.ts
@@ -69,7 +69,7 @@ export async function ensureMemberProfilePublished(params: {
   const existing = await memberDb.getProfileByOrgId(orgId);
 
   if (existing?.is_public) {
-    return { action: 'noop', profileId: existing.id };
+    return { action: 'noop', profileId: existing.id, slug: existing.slug };
   }
 
   if (existing) {
@@ -79,7 +79,7 @@ export async function ensureMemberProfilePublished(params: {
       { orgId, profileId: existing.id, source },
       'Auto-published existing member profile on membership activation',
     );
-    return { action: 'published', profileId: existing.id };
+    return { action: 'published', profileId: existing.id, slug: existing.slug };
   }
 
   // No profile yet — create one with a unique slug. Retry on unique-violation
@@ -108,12 +108,12 @@ export async function ensureMemberProfilePublished(params: {
       if (concurrent) {
         if (concurrent.is_public) {
           logger.info({ orgId, profileId: concurrent.id, source }, 'Profile created concurrently by another webhook — noop');
-          return { action: 'noop', profileId: concurrent.id };
+          return { action: 'noop', profileId: concurrent.id, slug: concurrent.slug };
         }
         await memberDb.updateProfile(concurrent.id, { is_public: true });
         await recordProfilePublishedIfNeeded(orgId, concurrent.is_public, true, SYSTEM_ACTOR);
         logger.info({ orgId, profileId: concurrent.id, source }, 'Profile created concurrently by another webhook — published');
-        return { action: 'published', profileId: concurrent.id };
+        return { action: 'published', profileId: concurrent.id, slug: concurrent.slug };
       }
 
       // Slug collision with a different org — retry with a new suffix.

--- a/server/src/slack/org-group-dm.ts
+++ b/server/src/slack/org-group-dm.ts
@@ -387,12 +387,20 @@ export async function notifyMemberAdded(data: {
 
 /**
  * Send thank you message when org subscribes, including seat entitlement info.
+ *
+ * When `listing` is provided, a note and action buttons are added so admins
+ * see the auto-published directory listing alongside the welcome — avoids a
+ * separate send while still closing the consent loop from issue #2583.
  */
 export async function notifySubscriptionThankYou(data: {
   orgId: string;
   orgName: string;
   adminEmails: string[];
   seatLimits?: SeatLimits;
+  listing?: {
+    slug: string;
+    action: 'created' | 'published';
+  };
 }): Promise<boolean> {
   const safeOrgName = escapeSlackMrkdwn(data.orgName);
 
@@ -404,50 +412,75 @@ export async function notifySubscriptionThankYou(data: {
     welcomeText += `\n\nYour plan includes *${contribLabel} contributor seats* and *${communityLabel} community seats*. When teammates join, you'll get a prompt to assign access.`;
   }
 
-  const message: SlackBlockMessage = {
-    text: `Thank you for joining AgenticAdvertising.org!`,
-    blocks: [
+  const blocks: SlackBlock[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'Welcome to AgenticAdvertising.org!',
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: welcomeText,
+      },
+    },
+  ];
+
+  if (data.listing) {
+    // Defense-in-depth: slugs and orgIds are validated at their source
+    // (slugify → [a-z0-9-]; WorkOS orgIds are opaque `org_...`). Encode
+    // both before interpolating into the Slack `<URL|label>` link syntax
+    // so a future policy shift can't break the link or inject into it.
+    const safeSlug = escapeSlackMrkdwn(data.listing.slug);
+    const encodedOrgId = encodeURIComponent(data.orgId);
+    const listingUrl = `${APP_URL}/members/${encodeURIComponent(data.listing.slug)}`;
+    const editUrl = `${APP_URL}/member-profile?org=${encodedOrgId}`;
+    const privacyUrl = `${APP_URL}/member-profile?org=${encodedOrgId}#field-is-public`;
+    const intro = data.listing.action === 'created'
+      ? `Your directory listing went live at <${listingUrl}|/members/${safeSlug}>. We created it when your membership activated so others can find you.`
+      : `Your directory listing is now live at <${listingUrl}|/members/${safeSlug}> — we published it when your membership activated.`;
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `${intro}\n<${editUrl}|Edit the listing> or <${privacyUrl}|make it private>.`,
+      },
+    });
+  }
+
+  blocks.push({
+    type: 'actions',
+    elements: [
       {
-        type: 'header',
+        type: 'button',
         text: {
           type: 'plain_text',
-          text: 'Welcome to AgenticAdvertising.org!',
+          text: 'Manage Team',
           emoji: true,
         },
+        url: `${APP_URL}/team?org=${data.orgId}`,
+        action_id: 'go_to_team',
       },
       {
-        type: 'section',
+        type: 'button',
         text: {
-          type: 'mrkdwn',
-          text: welcomeText,
+          type: 'plain_text',
+          text: 'Go to Dashboard',
+          emoji: true,
         },
-      },
-      {
-        type: 'actions',
-        elements: [
-          {
-            type: 'button',
-            text: {
-              type: 'plain_text',
-              text: 'Manage Team',
-              emoji: true,
-            },
-            url: `${APP_URL}/team?org=${data.orgId}`,
-            action_id: 'go_to_team',
-          },
-          {
-            type: 'button',
-            text: {
-              type: 'plain_text',
-              text: 'Go to Dashboard',
-              emoji: true,
-            },
-            url: `${APP_URL}/dashboard`,
-            action_id: 'go_to_dashboard',
-          },
-        ],
+        url: `${APP_URL}/dashboard`,
+        action_id: 'go_to_dashboard',
       },
     ],
+  });
+
+  const message: SlackBlockMessage = {
+    text: `Thank you for joining AgenticAdvertising.org!`,
+    blocks,
   };
 
   return sendToOrgAdmins(data.orgId, data.adminEmails, message);

--- a/server/tests/unit/email-notification.test.ts
+++ b/server/tests/unit/email-notification.test.ts
@@ -244,6 +244,101 @@ describe('Email Notifications', () => {
         })
       );
     });
+
+    it('omits the listing section when no listing is provided', async () => {
+      const { sendWelcomeEmail } = await import('../../src/notifications/email.js');
+
+      await sendWelcomeEmail({
+        to: 'test@example.com',
+        organizationName: 'Acme Corp',
+        workosOrganizationId: 'org_acme',
+      });
+
+      const sendCall = mockSend.mock.calls[0]?.[0];
+      expect(sendCall?.html).not.toContain('Your listing is live');
+      expect(sendCall?.text).not.toContain('Your listing is live');
+    });
+
+    it('includes a listing section with view/edit/privacy links when a profile was created', async () => {
+      const { sendWelcomeEmail } = await import('../../src/notifications/email.js');
+
+      await sendWelcomeEmail({
+        to: 'test@example.com',
+        organizationName: 'Acme Corp',
+        workosOrganizationId: 'org_acme',
+        listing: { slug: 'acme-corp', action: 'created' },
+      });
+
+      const sendCall = mockSend.mock.calls[0]?.[0];
+      // Section header in both HTML and text
+      expect(sendCall?.html).toContain('Your listing is live');
+      expect(sendCall?.text).toContain('Your listing is live');
+      // "created" wording communicates the auto-creation
+      expect(sendCall?.html).toContain('We created it when your membership activated');
+      // Slug display line in HTML
+      expect(sendCall?.html).toContain('/members/acme-corp');
+      // Text fallback has plain URLs (not routed through tracker)
+      expect(sendCall?.text).toContain('https://agenticadvertising.org/members/acme-corp');
+      expect(sendCall?.text).toContain('https://agenticadvertising.org/member-profile?org=org_acme');
+      expect(sendCall?.text).toContain('#field-is-public');
+      // HTML link tracker names identify each CTA
+      expect(sendCall?.html).toContain('cta_listing_view');
+      expect(sendCall?.html).toContain('cta_listing_edit');
+      expect(sendCall?.html).toContain('cta_listing_privacy');
+    });
+
+    it('uses "published" wording when an existing draft is flipped public', async () => {
+      const { sendWelcomeEmail } = await import('../../src/notifications/email.js');
+
+      await sendWelcomeEmail({
+        to: 'test@example.com',
+        organizationName: 'Acme Corp',
+        workosOrganizationId: 'org_acme',
+        listing: { slug: 'acme-corp', action: 'published' },
+      });
+
+      const sendCall = mockSend.mock.calls[0]?.[0];
+      expect(sendCall?.html).toContain('we published it when your membership activated');
+      // Should NOT say "created" — that would be misleading for pre-existing drafts
+      expect(sendCall?.html).not.toContain('We created it when your membership activated');
+    });
+
+    it('omits the listing section for a noop (profile already public)', async () => {
+      // Contract with the webhook handler: when ensureMemberProfilePublished
+      // returns action === 'noop', the handler does NOT pass `listing`.
+      // This test pins the rendered-output invariant that matters:
+      // a member who already had a public listing should never be told it
+      // "just went live".
+      const { sendWelcomeEmail } = await import('../../src/notifications/email.js');
+
+      await sendWelcomeEmail({
+        to: 'test@example.com',
+        organizationName: 'Acme Corp',
+        workosOrganizationId: 'org_acme',
+        // no listing — matching the webhook behavior for action === 'noop'
+      });
+
+      const sendCall = mockSend.mock.calls[0]?.[0];
+      expect(sendCall?.html).not.toContain('Your listing is live');
+      expect(sendCall?.text).not.toContain('Your listing is live');
+      expect(sendCall?.html).not.toContain('cta_listing_view');
+    });
+
+    it('escapes slugs with HTML-sensitive characters in the display line', async () => {
+      const { sendWelcomeEmail } = await import('../../src/notifications/email.js');
+
+      await sendWelcomeEmail({
+        to: 'test@example.com',
+        organizationName: 'Weird Corp',
+        workosOrganizationId: 'org_weird',
+        listing: { slug: 'a&b<c>"d', action: 'created' },
+      });
+
+      const sendCall = mockSend.mock.calls[0]?.[0];
+      // Raw slug must not appear unescaped in HTML display
+      expect(sendCall?.html).not.toContain('<c>');
+      expect(sendCall?.html).toContain('&amp;');
+    });
   });
 
   describe('sendUserSignupEmail', () => {

--- a/server/tests/unit/subscription-thank-you.test.ts
+++ b/server/tests/unit/subscription-thank-you.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture what the Slack client is asked to send.
+const sendChannelMessage = vi.fn();
+const sendDirectMessage = vi.fn();
+const openGroupDM = vi.fn();
+
+vi.mock("../../src/slack/client.js", () => ({
+  sendChannelMessage,
+  sendDirectMessage,
+  openGroupDM,
+}));
+
+// Two admins with Slack mappings — takes us down the group-DM path.
+const query = vi.fn();
+vi.mock("../../src/db/client.js", () => ({
+  query,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sendChannelMessage.mockResolvedValue({ ok: true });
+  sendDirectMessage.mockResolvedValue({ ok: true });
+  openGroupDM.mockResolvedValue({ channelId: "G_TEST" });
+
+  // Mock query() responses for sendToOrgAdmins → getOrCreateOrgAdminGroupDM
+  query.mockImplementation(async (sql: string) => {
+    if (sql.includes("FROM slack_user_mappings")) {
+      return { rows: [{ slack_user_id: "U1" }, { slack_user_id: "U2" }] };
+    }
+    if (sql.includes("FROM org_admin_group_dms")) {
+      return { rows: [] };
+    }
+    if (sql.includes("INSERT INTO org_admin_group_dms")) {
+      return {
+        rows: [
+          {
+            id: "rec",
+            workos_organization_id: "org_acme",
+            slack_channel_id: "G_TEST",
+            admin_slack_user_ids: ["U1", "U2"],
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      };
+    }
+    return { rows: [] };
+  });
+});
+
+describe("notifySubscriptionThankYou — listing disclosure", () => {
+  it("omits the listing block when no listing is provided", async () => {
+    const { notifySubscriptionThankYou } = await import("../../src/slack/org-group-dm.js");
+
+    await notifySubscriptionThankYou({
+      orgId: "org_acme",
+      orgName: "Acme Corp",
+      adminEmails: ["a@acme.com", "b@acme.com"],
+    });
+
+    expect(sendChannelMessage).toHaveBeenCalledTimes(1);
+    const message = sendChannelMessage.mock.calls[0][1];
+    const rendered = JSON.stringify(message);
+    expect(rendered).not.toContain("listing went live");
+    expect(rendered).not.toContain("make it private");
+    // Still has the welcome header and team CTA
+    expect(rendered).toContain("Welcome to AgenticAdvertising.org!");
+    expect(rendered).toContain("Manage Team");
+  });
+
+  it("adds a listing block with view / edit / make-private links when created", async () => {
+    const { notifySubscriptionThankYou } = await import("../../src/slack/org-group-dm.js");
+
+    await notifySubscriptionThankYou({
+      orgId: "org_acme",
+      orgName: "Acme Corp",
+      adminEmails: ["a@acme.com", "b@acme.com"],
+      listing: { slug: "acme-corp", action: "created" },
+    });
+
+    const message = sendChannelMessage.mock.calls[0][1];
+    const rendered = JSON.stringify(message);
+    expect(rendered).toContain("listing went live");
+    // Discloses *why* it went live — closes the consent loop the issue asked for
+    expect(rendered).toContain("We created it when your membership activated");
+    // All three links present
+    expect(rendered).toContain("/members/acme-corp");
+    expect(rendered).toContain("/member-profile?org=org_acme");
+    expect(rendered).toContain("#field-is-public");
+  });
+
+  it("omits the listing block for a noop (profile already public)", async () => {
+    // Contract with the webhook handler: on action === 'noop' the handler
+    // passes no `listing` arg. This pins the rendered-message invariant.
+    const { notifySubscriptionThankYou } = await import("../../src/slack/org-group-dm.js");
+
+    await notifySubscriptionThankYou({
+      orgId: "org_acme",
+      orgName: "Acme Corp",
+      adminEmails: ["a@acme.com", "b@acme.com"],
+      // no listing
+    });
+
+    const rendered = JSON.stringify(sendChannelMessage.mock.calls[0][1]);
+    expect(rendered).not.toContain("listing went live");
+    expect(rendered).not.toContain("make it private");
+  });
+
+  it("uses 'published' wording for an existing draft that was flipped public", async () => {
+    const { notifySubscriptionThankYou } = await import("../../src/slack/org-group-dm.js");
+
+    await notifySubscriptionThankYou({
+      orgId: "org_acme",
+      orgName: "Acme Corp",
+      adminEmails: ["a@acme.com", "b@acme.com"],
+      listing: { slug: "acme-corp", action: "published" },
+    });
+
+    const rendered = JSON.stringify(sendChannelMessage.mock.calls[0][1]);
+    expect(rendered).toContain("we published it when your membership activated");
+    // Should NOT lie about having "created" the listing
+    expect(rendered).not.toContain("We created it when your membership activated");
+  });
+
+  it("escapes slugs with Slack-sensitive characters in the display text", async () => {
+    const { notifySubscriptionThankYou } = await import("../../src/slack/org-group-dm.js");
+
+    await notifySubscriptionThankYou({
+      orgId: "org_x",
+      orgName: "Evil & Co",
+      adminEmails: ["a@x.com", "b@x.com"],
+      listing: { slug: "a<b>c", action: "created" },
+    });
+
+    const rendered = JSON.stringify(sendChannelMessage.mock.calls[0][1]);
+    // The display label must not contain raw < or > (link-injection risk in mrkdwn)
+    expect(rendered).toContain("a&lt;b&gt;c");
+  });
+});

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -803,6 +803,141 @@ describe('stripe-client', () => {
       const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0] as any;
       expect(createCall.subscription_data).toBeUndefined();
     });
+
+    test('adds autopublish disclosure for membership-tier prices', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+
+      const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
+      const mockStripeInstance = {
+        prices: {
+          retrieve: vi.fn<any>().mockResolvedValue({
+            id: 'price_membership',
+            recurring: { interval: 'year' },
+            lookup_key: 'aao_membership_professional_250',
+          }),
+        },
+        checkout: {
+          sessions: {
+            create: vi.fn<any>().mockResolvedValue({ id: 'cs_mem', url: 'https://checkout.stripe.com/mem' }),
+          },
+        },
+      };
+      StripeMock.mockImplementation(function () { return mockStripeInstance as any; });
+
+      const { createCheckoutSession } = await import('../../server/src/billing/stripe-client.js');
+
+      await createCheckoutSession({
+        priceId: 'price_membership',
+        customerEmail: 'test@example.com',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+        workosOrganizationId: 'org_test_123',
+      });
+
+      const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0] as any;
+      expect(createCall.custom_text?.submit?.message).toBeDefined();
+      expect(createCall.custom_text.submit.message).toMatch(/publishes your organization/i);
+      expect(createCall.custom_text.submit.message).toMatch(/member directory/i);
+    });
+
+    test('adds disclosure for invoice-based membership prices', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+
+      const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
+      const mockStripeInstance = {
+        prices: {
+          retrieve: vi.fn<any>().mockResolvedValue({
+            id: 'price_invoice_mem',
+            recurring: null,
+            lookup_key: 'aao_invoice_corporate_5m',
+          }),
+        },
+        checkout: {
+          sessions: {
+            create: vi.fn<any>().mockResolvedValue({ id: 'cs_inv', url: 'https://checkout.stripe.com/inv' }),
+          },
+        },
+      };
+      StripeMock.mockImplementation(function () { return mockStripeInstance as any; });
+
+      const { createCheckoutSession } = await import('../../server/src/billing/stripe-client.js');
+
+      await createCheckoutSession({
+        priceId: 'price_invoice_mem',
+        customerEmail: 'test@example.com',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+      });
+
+      const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0] as any;
+      expect(createCall.custom_text?.submit?.message).toMatch(/directory/i);
+    });
+
+    test('omits disclosure for non-membership prices (e.g. event sponsorships)', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+
+      const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
+      const mockStripeInstance = {
+        prices: {
+          retrieve: vi.fn<any>().mockResolvedValue({
+            id: 'price_sponsorship',
+            recurring: null,
+            lookup_key: 'event_sponsorship_gold',
+          }),
+        },
+        checkout: {
+          sessions: {
+            create: vi.fn<any>().mockResolvedValue({ id: 'cs_spons', url: 'https://checkout.stripe.com/spons' }),
+          },
+        },
+      };
+      StripeMock.mockImplementation(function () { return mockStripeInstance as any; });
+
+      const { createCheckoutSession } = await import('../../server/src/billing/stripe-client.js');
+
+      await createCheckoutSession({
+        priceId: 'price_sponsorship',
+        customerEmail: 'test@example.com',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+      });
+
+      const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0] as any;
+      expect(createCall.custom_text).toBeUndefined();
+    });
+
+    test('omits disclosure when price has no lookup_key', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+
+      const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
+      const mockStripeInstance = {
+        prices: {
+          retrieve: vi.fn<any>().mockResolvedValue({
+            id: 'price_unlabeled',
+            recurring: { interval: 'year' },
+            lookup_key: null,
+          }),
+        },
+        checkout: {
+          sessions: {
+            create: vi.fn<any>().mockResolvedValue({ id: 'cs_ul', url: 'https://checkout.stripe.com/ul' }),
+          },
+        },
+      };
+      StripeMock.mockImplementation(function () { return mockStripeInstance as any; });
+
+      const { createCheckoutSession } = await import('../../server/src/billing/stripe-client.js');
+
+      await createCheckoutSession({
+        priceId: 'price_unlabeled',
+        customerEmail: 'test@example.com',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+      });
+
+      const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0] as any;
+      expect(createCall.custom_text).toBeUndefined();
+    });
   });
 
   describe('resolveLookupKeyAlias', () => {


### PR DESCRIPTION
## Summary

Follow-up to #2581 closing #2583. Two tactical fixes that close the consent loop opened by the auto-publish behavior added in #2581.

- **Post-UPDATE autopublish + deferred notifications.** The `customer.subscription.created` webhook now runs `ensureMemberProfilePublished` *after* the `organizations` row is updated, then threads the result into the thank-you Slack DM and welcome email. When a listing is created or flipped public, admins see a "Your listing is live" section with view, edit, and make-private links — no separate send. Deferring autopublish until the org row reflects activation eliminates a transient state where the listing was public before the backend recorded membership.
- **Checkout-time disclosure.** `createCheckoutSession` adds `custom_text.submit.message` on membership prices (lookup keys starting with `aao_membership_` or `aao_invoice_`) so buyers see the auto-publish behavior before clicking pay. Non-membership checkouts (event sponsorships, etc.) are unaffected.
- `ensureMemberProfilePublished` now returns `slug` on `published`/`noop` results so callers can link without an extra DB round trip.

Closes #2583. Optional slug-review grace period (issue part 3) intentionally skipped; worth a follow-up issue if wanted.

## Review-driven hardening

Code + security review surfaced several Should Fix items, all addressed in this PR:

- Moved autopublish to after `UPDATE organizations` (was running before in the first cut) — closes the "listing public before org row updated" window.
- `encodeURIComponent` on slug in the plain-text email and on `orgId` in Slack URLs — defense-in-depth even though both are validated at source.
- Eliminated duplicate `buildSubscriptionUpdate` calls (was 3x on identical input; now 1x).
- Added test coverage for `noop` action (profile already public) in both email and Slack suites.

## Test plan

- [x] `npx vitest run tests/billing/ server/tests/unit/email-notification.test.ts server/tests/unit/subscription-thank-you.test.ts server/tests/unit/seat-lifecycle-notifications.test.ts` — 178 passing
- [x] `npx tsc --noEmit --project server/tsconfig.json` — clean
- [x] Pre-commit full-suite: 631 tests passing
- [ ] Post-deploy: verify one real membership activation fires the welcome email with the listing section and the Slack DM contains the view/edit/make-private links

🤖 Generated with [Claude Code](https://claude.com/claude-code)