### PR TITLE
spec(compliance): non-OAuth auth path + branchable-behavior pattern (#2605, #2606)

### DIFF
--- a/.changeset/ambiguity-resolution-2605-2606.md
+++ b/.changeset/ambiguity-resolution-2605-2606.md
@@ -1,0 +1,10 @@
+---
+---
+
+spec(compliance): clarify non-OAuth auth path and document branchable-behavior pattern (#2605, #2606)
+
+`universal/security.yaml` narrative now spells out the API-key-only path: declare `auth.api_key` in the test-kit and do not serve RFC 9728 protected-resource metadata. Failures inside the `oauth_discovery` phase are already non-fatal (optional-phase semantics), but the narrative did not make that explicit, leading implementers to stand up fake issuer URLs + stub RFC 8414 metadata documents just to "pass" discovery. The new narrative and the `oauth_discovery` phase header now cross-reference the API-key path so non-OAuth agents know to skip PRM entirely.
+
+`docs/contributing/storyboard-authoring.md` adds an "Asserting on branchable behaviors" section documenting the parallel-optional-phases + `assert_contribution` pattern used by `past_start_reject_path` / `past_start_adjust_path` / `past_start_enforcement` in `universal/schema-validation.yaml`. This is the canonical shape for spec `MAY` branches where conformant agents pick one observable outcome; the single-code `check: error_code` pattern remains correct when the spec mandates one canonical code per scenario.
+
+Audit finding for #2605: no additional storyboards carry single-branch `error_code:` assertions that mask spec `any_of` behaviors. The `past_start` split landed in #2389; remaining single-value asserts (`GOVERNANCE_DENIED`, `TERMS_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `NOT_CANCELLABLE`, etc.) are scenario-specific and spec-mandated.

--- a/docs/contributing/storyboard-authoring.md
+++ b/docs/contributing/storyboard-authoring.md
@@ -260,6 +260,17 @@ Canonical example: `past_start_reject_path` / `past_start_adjust_path` / `past_s
 
 Single-code `check: error_code` is still correct when the spec mandates a canonical code for a scenario (e.g. `GOVERNANCE_DENIED` on a governance-denied outcome, `NOT_CANCELLABLE` on re-cancel). The split-phase pattern applies only when the spec itself leaves the outcome branchable.
 
+### When NOT to use this pattern
+
+The parallel-optional-phases + `assert_contribution` shape is only appropriate when the **spec text itself** permits multiple observable outcomes (look for explicit `MAY`/`OR` in the normative prose, or an enum of acceptable statuses). It is **not** a tool for softening a vector because an agent's behavior drifted from the spec. Do not apply this pattern to:
+
+- **Idempotency semantics.** `idempotency_key` must be rejected when missing on mutating tasks; replay must return the cached response; conflict must surface `IDEMPOTENCY_CONFLICT`. The spec mandates single behaviors — any other outcome is non-conformant, not a valid branch.
+- **Context echo.** Responses MUST echo `context:` verbatim when the caller sent it. There is no conformant branch that omits the echo.
+- **Error-code vocabulary.** Canonical codes enumerated in `static/schemas/source/enums/error-code.json` are single-value per scenario. If a storyboard asserts `GOVERNANCE_DENIED` on a governance-denied outcome, that is the code — not one option among several.
+- **Webhook signing correctness.** RFC 9421 signing with AdCP's covered-components profile is a single verification shape; there is no alternate branch.
+
+If you find yourself reaching for the split-phase pattern to get past a failing vector, first verify the spec actually permits the branch you want to accept. If it doesn't, the fix is in the agent (or in the spec), not in the vector.
+
 ## Running the lint locally
 
 ```bash

--- a/docs/contributing/storyboard-authoring.md
+++ b/docs/contributing/storyboard-authoring.md
@@ -216,6 +216,50 @@ When a rename is required, register the old code in `scripts/error-code-aliases.
 
 Aliased codes pass the lint as **warnings** during the deprecation window, giving authors time to migrate storyboards. Once the alias is removed from the file, references to the old code become lint errors. This is how renames land without breaking storyboard authorship across versions.
 
+## Asserting on branchable behaviors
+
+Some spec requirements allow multiple conformant agent behaviors — e.g. a past `start_time` on `create_media_buy` MAY be rejected with `INVALID_REQUEST` OR accepted-and-adjusted forward. A single-assertion validator that asserts only one branch forces a conformant agent that picked the other branch to silently fail.
+
+When the spec allows a branchable outcome, split the storyboard into parallel optional phases and resolve via `assert_contribution`:
+
+```yaml
+phases:
+  - id: reject_path
+    optional: true
+    steps:
+      - id: probe_reject
+        expect_error: true
+        contributes_to: behavior_handled
+        validations:
+          - check: error_code
+            value: "INVALID_REQUEST"
+
+  - id: adjust_path
+    optional: true
+    steps:
+      - id: probe_adjust
+        contributes_to: behavior_handled
+        validations:
+          - check: response_schema
+          - check: field_present
+            path: "media_buy_id"
+
+  - id: enforcement
+    steps:
+      - id: require_either
+        task: assert_contribution
+        validations:
+          - check: any_of
+            allowed_values: ["behavior_handled"]
+            description: "Agent must exhibit one of the conformant branches."
+```
+
+Failures inside an `optional: true` phase do NOT fail the storyboard — only the synthetic `assert_contribution` in the final phase does, and only when no branch contributed. Conformant agents pass exactly one branch and fail the other by design.
+
+Canonical example: `past_start_reject_path` / `past_start_adjust_path` / `past_start_enforcement` in `universal/schema-validation.yaml`. Use the same shape for any spec `MAY` / `any_of` where observable outcomes differ across branches.
+
+Single-code `check: error_code` is still correct when the spec mandates a canonical code for a scenario (e.g. `GOVERNANCE_DENIED` on a governance-denied outcome, `NOT_CANCELLABLE` on re-cancel). The split-phase pattern applies only when the spec itself leaves the outcome branchable.
+
 ## Running the lint locally
 
 ```bash

--- a/static/compliance/source/universal/security.yaml
+++ b/static/compliance/source/universal/security.yaml
@@ -34,6 +34,18 @@ narrative: |
   `auth_mechanism_verified`. Agents that fail any required phase, or advertise no
   working auth mechanism, are non-conformant.
 
+  **API-key-only agents (no OAuth).** An agent with no OAuth issuer — sandbox,
+  staging, or any production deployment that chose Bearer-only auth — does NOT
+  need to advertise RFC 9728 protected-resource metadata. Declare
+  `auth.api_key` in the test-kit and do not serve
+  `/.well-known/oauth-protected-resource/...`. The `api_key_path` phase
+  contributes `auth_mechanism_verified` and `oauth_discovery` is allowed to fail
+  silently as an optional phase — no fake issuer URL or stub RFC 8414 metadata
+  document is required. Agents that DO advertise `authorization_servers` in
+  their PRM MUST stand up the RFC 8414 auth-server metadata document to match;
+  advertising an issuer without serving its metadata is the failure mode this
+  storyboard was written to catch.
+
   For local debugging before re-running compliance, use `adcp diagnose-auth <alias>`
   (see adcp-client#563) to trace the full OAuth handshake and surface ranked
   hypotheses about what's wrong.
@@ -217,6 +229,14 @@ phases:
     title: "OAuth discovery and audience binding"
     narrative: |
       **This phase OR `api_key_path` MUST pass — see `mechanism_required`.**
+
+      **Skip for API-key-only agents.** If your agent has no OAuth issuer,
+      declare `auth.api_key` in the test-kit and do not serve PRM. This phase
+      will fail its probes (404 on the well-known path), but failures inside
+      an `optional: true` phase do not fail the storyboard — the api_key path
+      carries `auth_mechanism_verified` on its own. Do NOT serve PRM pointing
+      at a fake issuer to "pass" this phase; that triggers the
+      advertised-but-unserved failure mode below.
 
       OAuth-enabled agents advertise their auth server at the well-known path defined
       by RFC 9728 §3. For an agent at `https://agent.example.com/mcp`, metadata lives


### PR DESCRIPTION
## Summary

- **security.yaml**: add explicit API-key-only guidance to the narrative and the \`oauth_discovery\` phase header. Non-OAuth agents declare \`auth.api_key\` in the test-kit and do NOT serve RFC 9728 protected-resource metadata. Optional-phase semantics already made \`oauth_discovery\` failures non-fatal; the narrative did not make that explicit, so implementers were standing up fake issuer URLs + stub RFC 8414 metadata documents just to "pass" discovery.
- **storyboard-authoring.md**: new "Asserting on branchable behaviors" section documenting the parallel-optional-phases + \`assert_contribution\` + \`any_of\` pattern. Canonical example: \`past_start_reject_path\` / \`past_start_adjust_path\` / \`past_start_enforcement\` in \`schema-validation.yaml\`.

Closes #2605, closes #2606.

## Audit findings (#2605)

Grepped every \`check: error_code\` in \`static/compliance/source/\` for single-branch asserts that might mask spec \`any_of\` behaviors. Findings:

- \`past_start_date_reject\`: already split into optional reject/adjust paths + enforcement via \`any_of\` in #2389. No further work.
- All other single-value \`error_code\` asserts (\`GOVERNANCE_DENIED\`, \`TERMS_REJECTED\`, \`MEDIA_BUY_NOT_FOUND\`, \`PACKAGE_NOT_FOUND\`, \`NOT_CANCELLABLE\`, \`VERSION_UNSUPPORTED\`): scenario-specific, spec-mandated canonical codes. Splitting would violate the spec.

The storyboard-authoring.md addition codifies the split pattern so future branchable-behavior requirements get the right shape the first time.

## Scope notes

- **#2606 does not add a \`skip_if\` opt-out** on \`oauth_discovery\`. The current \`optional: true\` + \`any_of\` composition already handles API-key-only agents cleanly — the gap was authoring awareness, not runner behavior. Adding a new test-kit field just for explicit opt-out would be churn without a matching problem.
- **No runner-side changes required.** The \`@adcp/client\` runner already implements optional-phase semantics per \`storyboard-schema.yaml\` (lines 171–179).

## Test plan

- [x] \`npm run build:compliance\` — storyboard scoping lint passes
- [x] \`npm run test:storyboard-scoping\` — 3/3 pass
- [x] Pre-commit hooks — \`test:unit\` (631/631) + \`typecheck\` pass
- [ ] Reviewer sanity-check the added \`security.yaml\` narrative reads correctly alongside the existing \`api_key_path\` / \`oauth_discovery\` / \`mechanism_required\` phase headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)