### PR TITLE
storyboards: align recancel_buy with #2619 NOT_CANCELLABLE rule

### DIFF
--- a/.changeset/storyboard-recancel-alignment.md
+++ b/.changeset/storyboard-recancel-alignment.md
@@ -1,0 +1,16 @@
+---
+---
+
+storyboards: align state-machine recancel_buy phase with the normative NOT_CANCELLABLE rule landed in #2619
+
+Follow-up to #2619 which merged before this storyboard fix could be bundled in. PR #2619 tightened the spec so that re-cancel of a `canceled` buy MUST return `NOT_CANCELLABLE` (previously the spec allowed either `INVALID_STATE` or `NOT_CANCELLABLE` under conflicting rules). The `media_buy_state_machine/terminal_state_enforcement > recancel_buy` storyboard still reflected the pre-#2619 ambiguity ("Either reject with INVALID_STATE or accept idempotently — both are valid") and would have let non-conformant sellers pass.
+
+Aligns the storyboard to the spec:
+
+- `expect_error: true` (was unset — allowed idempotent-accept as a valid pass)
+- Expected code: `NOT_CANCELLABLE` (was INVALID_STATE-or-accept either/or)
+- Added validations: `error_code` check + context echo (mirrors the `invalid_transitions.yaml > second_cancel` pattern that was already correct)
+
+Narrative updated to reflect the carve-out: cancellation-specific code takes precedence over the generic terminal-state rule; idempotent acceptance is not conformant for this case.
+
+No spec change. No other storyboards needed updates — `invalid_transitions.yaml > second_cancel` was already correct.

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -383,21 +383,25 @@ phases:
             value: "media_buy_state_machine--resume_canceled_buy"
             description: "Context correlation_id returned unchanged"
       - id: recancel_buy
-        title: "Handle re-cancel of canceled buy"
+        title: "Reject re-cancel of canceled buy with NOT_CANCELLABLE"
         narrative: |
-          Attempt to cancel an already-canceled media buy. The agent should either
-          return an error or accept it idempotently. Both are valid, so no context
-          echo validation — the error path loses structured data without expect_error,
-          and we cannot set expect_error when success is also valid.
+          Attempt to cancel an already-canceled media buy. Per the media-buy
+          specification, the agent MUST reject with NOT_CANCELLABLE — the
+          cancellation-specific code takes precedence over the generic
+          terminal-state INVALID_STATE rule. Idempotent acceptance is NOT
+          conformant for this case.
         task: update_media_buy
         schema_ref: "media-buy/update-media-buy-request.json"
         response_schema_ref: "media-buy/update-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/update_media_buy"
         comply_scenario: terminal_state_enforcement
+        expect_error: true
         stateful: true
         expected: |
-          Either reject with INVALID_STATE or accept idempotently.
-          Both behaviors are valid.
+          Reject with:
+          - code: NOT_CANCELLABLE
+          - recovery: correctable
+          - context echoed unchanged
 
         sample_request:
           account:
@@ -410,3 +414,14 @@ phases:
           idempotency_key: "$generate:uuid_v4#media_buy_state_machine_terminal_enforcement_recancel_buy"
           context:
             correlation_id: "media_buy_state_machine--recancel_buy"
+        validations:
+          - check: error_code
+            value: "NOT_CANCELLABLE"
+            description: "Error code is NOT_CANCELLABLE on re-cancel of canceled buy"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--recancel_buy"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
## Summary

Follow-up fixup to [#2619](https://github.com/adcontextprotocol/adcp/pull/2619), which merged before this storyboard alignment could land in the same PR.

#2619 tightened the media-buy spec so that re-cancel of a `canceled` buy MUST return `NOT_CANCELLABLE` (previously the spec had two conflicting rules — §128 MAY `NOT_CANCELLABLE` and §129 MUST `INVALID_STATE` — both applying to re-cancel). The `state-machine.yaml > terminal_state_enforcement > recancel_buy` phase still reflected the pre-#2619 ambiguity with **"Either reject with `INVALID_STATE` or accept idempotently — both are valid"**, which would let non-conformant sellers pass the conformance suite.

## Change

Aligns `recancel_buy` to the post-#2619 spec:

- `expect_error: true` (was unset — allowed idempotent-accept as a valid pass)
- Expected code: `NOT_CANCELLABLE` (was `INVALID_STATE`-or-accept either/or)
- Added validations: `error_code` check + context echo (mirrors the `invalid_transitions.yaml > second_cancel` pattern that was already correct)
- Narrative updated to reflect the carve-out: cancellation-specific code takes precedence over the generic terminal-state rule; idempotent acceptance is not conformant

## Why this wasn't in #2619

Storyboard audit happened after the spec PR was already merged. Pushing the fixup to the already-merged branch would have been a no-op.

## Test plan

- [x] `npm run test:storyboard-scoping` passes
- [x] `npm run test:error-codes` passes (pre-existing YAML warning unrelated)
- [x] Verified `invalid_transitions.yaml > second_cancel` already expects `NOT_CANCELLABLE` — no other storyboards needed alignment
- [ ] Spec review — confirm the reshuffled validations match the house style in `invalid_transitions.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)