### PR TITLE
spec(storyboards): audit follow-ups — known-ambiguities + second_cancel idempotency (#2635, #2637)

### DIFF
--- a/.changeset/audit-followups-known-ambiguities-second-cancel.md
+++ b/.changeset/audit-followups-known-ambiguities-second-cancel.md
@@ -1,0 +1,14 @@
+---
+---
+
+Bucket A follow-ups from the training-agent 5.7 storyboard audit (PR #2631):
+
+- **#2637 (second_cancel idempotency_key)**: added `idempotency_key` to `scenarios/invalid_transitions.yaml > double_cancel/second_cancel.sample_request`. Same pattern as the `recancel_buy` fix in PR #2631 — without the key, a conformant agent could reject for missing-key rather than `NOT_CANCELLABLE`, failing the step for the wrong reason.
+
+- **#2635 (known-ambiguities entries)**: added four entries to `docs/building/implementation/known-ambiguities.mdx` so implementers hitting pre-fix symptoms on older SDK versions can find the resolution:
+  - Rights-holder vs advertiser `brand_id` (#2627)
+  - Re-cancel error code `NOT_CANCELLABLE` vs `INVALID_STATE` (#2617/#2619/#2628)
+  - Branch-set step grading `peer_branch_taken` (#2629)
+  - SDK `request-builder` override masking spec-conformant `sample_request` (#2626 / adcp-client#689)
+
+#2636 (brand_rights compatibility-filtering assertion) was dropped from this bucket after discovering two missing primitives blocked the proposed negative-peer-phase approach. Filed as follow-ups: #2642 (cross-step comparison validation primitive) and #2643 (conflicting-brand test-kit fixture).

--- a/docs/building/implementation/known-ambiguities.mdx
+++ b/docs/building/implementation/known-ambiguities.mdx
@@ -6,11 +6,11 @@ description: "Open AdCP spec gaps that affect compliance testing — with workar
 
 This page enumerates spec gaps that currently affect storyboard conformance. Each entry covers one of three patterns: a spec `MAY` branch where vectors assert one outcome, a response field storyboards assert that the schema does not yet require, or a testing-infrastructure quirk that prevents a vector from probing through the reference SDK.
 
-**Entries are removed as the underlying issue closes.** If an entry here doesn't match what you're seeing, check the GitHub issue for the latest state — the fix may have landed in a release you haven't pulled yet.
+**Entries persist until the fix ships in a tagged `@adcp/client` or spec release** — closing the GitHub issue is not the removal trigger, because an implementer on an SDK version that predates the fix still hits the symptom. Each entry's Workaround names the release gate when relevant. If an entry here doesn't match what you're seeing, check the GitHub issue for the latest state — the fix may have landed in a release you haven't pulled yet.
 
 ## How to use this page
 
-If a storyboard fails on a behavior you believe is spec-conformant, search this page for the storyboard name or the assertion text. Each entry describes the gap, the workaround that gets you past the blocker, and the issue that tracks the fix. When the issue closes the entry here is removed — so always pair this page with the linked issue for the authoritative state.
+If a storyboard fails on a behavior you believe is spec-conformant, search this page for the storyboard name or the assertion text. Each entry describes the gap, the workaround that gets you past the blocker, and the issue that tracks the fix. Entries are removed when the fix ships in a tagged release, not when the issue closes — pair this page with the linked issue and the SDK / spec release notes for the authoritative state.
 
 For the opposite direction — failures that are **not** in this list and do have clean fixes — see the [storyboard troubleshooting guide](/docs/building/implementation/storyboard-troubleshooting).
 
@@ -19,7 +19,7 @@ For the opposite direction — failures that are **not** in this list and do hav
 ### `check_governance` `conditions` field shape
 
 - **Schema**: `check-governance-response.json` defines `conditions[]` items as `{ field, required_value?, reason }` with `field` and `reason` required. The `status: conditions` status now requires `conditions` with `minItems: 1`.
-- **Gap closed by**: [#2603](https://github.com/adcontextprotocol/adcp/issues/2603). The schema tightening lands in the protocol patch release following this entry's removal.
+- **Resolution**: [#2603](https://github.com/adcontextprotocol/adcp/issues/2603). The schema tightening lands in the protocol patch release following this entry's removal.
 - **Workaround (until you pull the fix)**: emit `conditions[]` with the canonical `{ field, reason }` shape on every `status: conditions` response. Agents following the prose description already do this; the schema tightening just makes enforcement mechanical.
 
 ### PRM required for non-OAuth agents
@@ -50,7 +50,7 @@ For the opposite direction — failures that are **not** in this list and do hav
 ### Rights-holder vs advertiser `brand_id` in brand protocol
 
 - **Storyboard**: `specialisms/brand-rights/index.yaml` phases `identity_discovery` + `rights_search`.
-- **Gap**: `get_brand_identity.brand_id` identifies the advertiser (e.g., `acme_outdoor`); `get_rights.brand_id` filters by rights-holder brand (e.g., talent like `daan_janssen`). Same field name, different entities — pre-fix the storyboard threaded the advertiser id through to the rights-holder filter, and a conformant agent either returned empty rights (fail) or added a "return all when no match" fallback (masking bugs).
+- **Gap**: `get_brand_identity.brand_id` identifies the advertiser (e.g., `acme_outdoor`); `get_rights.brand_id` scopes the search to a specific rights-holder brand (e.g., talent like `daan_janssen`). Same field name, different entities — before the #2627 fix the storyboard threaded the advertiser id through to the rights-holder filter, and a conformant agent either returned empty rights (fail) or added a "return all when no match" fallback (masking bugs).
 - **Resolution**: [#2627](https://github.com/adcontextprotocol/adcp/issues/2627) — the storyboard now sends `buyer_brand` (advertiser for compatibility filtering) and omits the rights-holder `brand_id` filter so the agent returns its full catalog.
 - **Workaround**: treat `get_rights.brand_id` as a rights-holder filter only; populate `buyer_brand` for compatibility filtering against the buyer's `brand.json`.
 
@@ -63,8 +63,8 @@ For the opposite direction — failures that are **not** in this list and do hav
 
 ### Branch-set step grading (`peer_branch_taken`)
 
-- **Storyboards**: any with parallel `optional: true` phases sharing a `contributes_to:` flag — canonical example `universal/schema-validation.yaml > past_start_reject_path` + `past_start_adjust_path`.
-- **Gap**: a conformant agent picks one branch (e.g., rejects past `start_time`); the other branch's assertion (e.g., `field_present: media_buy_id`) fails because the agent took the opposite behavior. Pre-fix runners surfaced this as `× (unknown step)` in the summary even though the `any_of` aggregate passed — implementers debugged a branch they weren't on.
+- **Storyboards**: any with parallel `optional: true` phases sharing a `contributes_to:` flag — canonical example `universal/schema-validation.yaml > past_start_reject_path` + `past_start_adjust_path` (aggregation flag `past_start_handled`).
+- **Gap**: a conformant agent picks one branch (e.g., rejects past `start_time`); the other branch's assertion (e.g., `field_present: media_buy_id`) fails because the agent took the opposite behavior. Runners before the #2629 fix surfaced this as `× (unknown step)` in the summary even though the `any_of` aggregate passed — implementers debugged a branch they weren't on.
 - **Resolution**: [#2629](https://github.com/adcontextprotocol/adcp/issues/2629) — runners now grade non-chosen branch steps with skip reason `peer_branch_taken` (distinct from `not_applicable`, which is reserved for protocol/specialism coverage gaps). See `storyboard-schema.yaml` § "Per-step grading in any_of branch patterns" for the authoring rules and `runner-output-contract.yaml > skip_result.reasons.peer_branch_taken` for the canonical `detail` shape.
 - **Workaround**: if your runner reports an unexpected branch failure, check whether a peer optional phase contributed the same `contributes_to` flag. If so, you're conformant on the branch you chose — the runner needs the #2629 update.
 

--- a/docs/building/implementation/known-ambiguities.mdx
+++ b/docs/building/implementation/known-ambiguities.mdx
@@ -47,6 +47,34 @@ For the opposite direction — failures that are **not** in this list and do hav
   - `report-usage-request.json` `vendor_cost`: already required.
 - **Workaround**: emit `item_count` on every non-failed/non-deleted catalog entry. Conformant agents already do this; the schema tightening catches gaps at `response_schema` validation.
 
+### Rights-holder vs advertiser `brand_id` in brand protocol
+
+- **Storyboard**: `specialisms/brand-rights/index.yaml` phases `identity_discovery` + `rights_search`.
+- **Gap**: `get_brand_identity.brand_id` identifies the advertiser (e.g., `acme_outdoor`); `get_rights.brand_id` filters by rights-holder brand (e.g., talent like `daan_janssen`). Same field name, different entities — pre-fix the storyboard threaded the advertiser id through to the rights-holder filter, and a conformant agent either returned empty rights (fail) or added a "return all when no match" fallback (masking bugs).
+- **Resolution**: [#2627](https://github.com/adcontextprotocol/adcp/issues/2627) — the storyboard now sends `buyer_brand` (advertiser for compatibility filtering) and omits the rights-holder `brand_id` filter so the agent returns its full catalog.
+- **Workaround**: treat `get_rights.brand_id` as a rights-holder filter only; populate `buyer_brand` for compatibility filtering against the buyer's `brand.json`.
+
+### Re-cancel error code — `NOT_CANCELLABLE` vs `INVALID_STATE`
+
+- **Storyboards**: `protocols/media-buy/state-machine.yaml > recancel_buy` and `scenarios/invalid_transitions.yaml > double_cancel/second_cancel`.
+- **Gap**: `specification.mdx` §128 (MAY `NOT_CANCELLABLE`) and §129 (MUST `INVALID_STATE` on terminal-state updates) both applied to re-cancel of a `canceled` buy. State-machine-first implementations returned `INVALID_STATE` per §129; cancellation-first implementations returned `NOT_CANCELLABLE`. Vectors historically pinned one.
+- **Resolution**: [#2617](https://github.com/adcontextprotocol/adcp/issues/2617) / [#2619](https://github.com/adcontextprotocol/adcp/pull/2619) + [#2628](https://github.com/adcontextprotocol/adcp/issues/2628) — §129 now carves out the cancellation case: when the terminal-state update IS a cancellation attempt, agents MUST return `NOT_CANCELLABLE`. Other illegal transitions (pause/resume on canceled) still return `INVALID_STATE`. Both storyboards now assert `NOT_CANCELLABLE` on re-cancel.
+- **Workaround**: return `NOT_CANCELLABLE` on `canceled: true` updates to buys already in `canceled`. Return `INVALID_STATE` on pause/resume of terminal-state buys. The cancellation-specific code wins on re-cancel; the generic code wins on everything else.
+
+### Branch-set step grading (`peer_branch_taken`)
+
+- **Storyboards**: any with parallel `optional: true` phases sharing a `contributes_to:` flag — canonical example `universal/schema-validation.yaml > past_start_reject_path` + `past_start_adjust_path`.
+- **Gap**: a conformant agent picks one branch (e.g., rejects past `start_time`); the other branch's assertion (e.g., `field_present: media_buy_id`) fails because the agent took the opposite behavior. Pre-fix runners surfaced this as `× (unknown step)` in the summary even though the `any_of` aggregate passed — implementers debugged a branch they weren't on.
+- **Resolution**: [#2629](https://github.com/adcontextprotocol/adcp/issues/2629) — runners now grade non-chosen branch steps with skip reason `peer_branch_taken` (distinct from `not_applicable`, which is reserved for protocol/specialism coverage gaps). See `storyboard-schema.yaml` § "Per-step grading in any_of branch patterns" for the authoring rules and `runner-output-contract.yaml > skip_result.reasons.peer_branch_taken` for the canonical `detail` shape.
+- **Workaround**: if your runner reports an unexpected branch failure, check whether a peer optional phase contributed the same `contributes_to` flag. If so, you're conformant on the branch you chose — the runner needs the #2629 update.
+
+### SDK request-builder overriding spec-conformant `sample_request`
+
+- **Storyboard**: `sales_catalog_driven` `optimization_loop/provide_feedback`, exposed via the `@adcp/client` compliance runner.
+- **Gap**: the storyboard's `sample_request` correctly declares `performance_index`, `metric_type`, `feedback_source` per the `provide-performance-feedback-request.json` schema. But `@adcp/client`'s internal `request-builder.js` had a hardcoded override for `provide_performance_feedback` that replaced the payload with a non-spec `feedback: { satisfaction, notes }` shape, so conformant agents rejected with `INVALID_REQUEST` and failed the vector.
+- **Resolution**: upstream [adcontextprotocol/adcp-client#689](https://github.com/adcontextprotocol/adcp-client/issues/689) + [#2626](https://github.com/adcontextprotocol/adcp/issues/2626) — remove the override and let the storyboard's `sample_request` drive the payload.
+- **Workaround**: bump to an `@adcp/client` release that includes the adcp-client#689 fix. Until then, the `provide_performance_feedback` vector will fail on any agent that validates its requests against the spec schema.
+
 ## When an ambiguity isn't listed
 
 If you're blocked on a behavior you believe the spec leaves ambiguous but it's not on this list, open an issue at [adcontextprotocol/adcp](https://github.com/adcontextprotocol/adcp/issues/new). Include the storyboard, the vector's assertion text, the conformant branch you picked, and why you believe the spec allows it. The fastest resolutions come from issues that cite the specific spec paragraph and the specific vector assertion — that's enough for a maintainer to either point you at an existing fix or confirm the gap and schedule it.

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -263,6 +263,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Deliberate re-cancel to force NOT_CANCELLABLE"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_invalid_transitions_double_cancel_second_cancel"
           context:
             correlation_id: "invalid_transitions--second_cancel"
         validations:


### PR DESCRIPTION
## Summary

Bucket A follow-ups from the training-agent 5.7 storyboard audit in PR #2631. Two of three fixes from the planned bucket; the third hit an infrastructure blocker and was split out.

- **Closes #2637** — added `idempotency_key` to `scenarios/invalid_transitions.yaml > double_cancel/second_cancel.sample_request`. PR #2631 expert code review caught the same issue on the sibling `recancel_buy` step in `state-machine.yaml` and fixed it there; this propagates the fix. Without the key, a conformant agent could legitimately reject for missing-key (per `universal/idempotency.yaml`) rather than `NOT_CANCELLABLE`, failing the vector for the wrong reason.

- **Closes #2635** — added four entries to `docs/building/implementation/known-ambiguities.mdx` so implementers hitting pre-fix symptoms on older SDK versions can find the canonical resolution by searching the storyboard name / assertion text:
  - Rights-holder vs advertiser `brand_id` (#2627)
  - Re-cancel error code `NOT_CANCELLABLE` vs `INVALID_STATE` (#2617 / #2619 / #2628)
  - Branch-set step grading `peer_branch_taken` (#2629)
  - SDK `request-builder.js` override masking spec-conformant `sample_request` (#2626 → adcp-client#689)

### Why #2636 is not in this PR

The proposed negative-peer-phase approach for `brand_rights` compatibility filtering (send a conflicting `buyer_brand`, assert the returned rights set is smaller) hit two infrastructure blockers during implementation:

1. **No cross-step comparison validation primitive** — all existing `check:` options scope to a single step's response. Filed #2642 to add `check: field_less_than` + `field_equals_context` against the existing `context_outputs` accumulator.
2. **No conflicting-brand test-kit fixture** — none of the 5 sandbox test-kits declare compatibility exclusions that would deterministically filter rights-holders. Filed #2643.

#2636 stays open, blocked on both. Comment left on the issue with the analysis.

## Test plan

- [x] `npm run build:compliance` — clean
- [x] `npm run test:unit` (precommit) — 631 tests pass
- [x] `npm run typecheck` — clean
- [x] No changes to schema files — doc-only + single-line storyboard additive
- [ ] Spec review: confirm the known-ambiguities entries accurately describe the fixes landed in #2631

🤖 Generated with [Claude Code](https://claude.com/claude-code)