### PR TITLE
compliance: catalog→creative coverage for sales-social, creative-generative, sales-retail-media (#2640)

### DIFF
--- a/.changeset/catalog-creative-coverage-2640.md
+++ b/.changeset/catalog-creative-coverage-2640.md
@@ -1,0 +1,30 @@
+---
+---
+
+compliance: add catalog→creative coverage to sales-social, creative-generative, sales-retail-media (#2640)
+
+Closes #2640 (partial — retail-media full flow deferred to its 3.1 epic per the specialism's placeholder).
+
+The audit in #2638 / #2640 surfaced that only `sales-catalog-driven` exercised catalog→creative flow in its storyboard. Three other catalog-relevant specialisms had no catalog-sync phase despite their production equivalents routinely handling catalogs:
+
+- `sales-social` — Snap Dynamic Ads, Meta DPA, TikTok Dynamic Showcase are all catalog-driven
+- `creative-generative` — generative DSPs routinely hydrate catalog items into the generation context
+- `sales-retail-media` — Amazon Ads, Walmart Connect, Target Roundel, Kroger Precision are almost entirely catalog/SKU-driven
+
+This PR adds phases that establish the catalog-acceptance plumbing on each.
+
+**Mixed scope** — depth calibrated per specialism:
+
+- `sales-social/index.yaml`: new `catalog_driven_dynamic_ads` phase inserted between `creative_push` and `event_logging`. Two steps: `sync_catalogs` with an inline product catalog, then `sync_creatives` pushing a DPA template whose tracker URLs include `{SKU}` and `{GTIN}` catalog-item macros. Acme-outdoor test-kit.
+- `creative-generative/index.yaml`: new `catalog_augmented_generation` phase at the end. Two steps: `sync_catalogs` with a small inline feed, then `build_creative` generating a catalog-bound creative with `include_preview: true` (natural observation point for the substitution-safety runtime check in #2638).
+- `sales-retail-media/index.yaml`: was `phases: []` (3.1 placeholder). Now has one `catalog_acceptance` phase using the summit-foods test-kit (the retail-media-specific fixture). Narrative explicitly flags that the full retail-media flow lands with the retail-media epic.
+
+`required_tools` updated on each specialism to include `sync_catalogs` (and `sync_creatives` on sales-social).
+
+**Out of scope (follow-ups):**
+
+- Runtime substitution-safety check (#2638) — requires the `substitution_observer_runner` test-kit contract that doesn't exist yet. Phases in this PR establish the catalog→creative flow that #2638's runtime check will hang on.
+- Full retail-media buy-to-attribution flow — deferred to the retail-media epic (tracked via #2640's retail-media section).
+- DPA-specific format schemas, per-platform DPA behaviors (Meta, Snap, TikTok) — this PR uses a platform-agnostic `dynamic_product_feed` format_id as placeholder; specialism-specific refinement can come with implementer input.
+
+No schema change. No spec change. Existing phases on each specialism unchanged.

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -6,7 +6,10 @@ category: creative_generative
 summary: "Agent that takes a brief and generates finished creatives from scratch — no input assets required."
 required_tools:
   - build_creative
-  - sync_catalogs
+# Note: sync_catalogs is NOT in required_tools. The catalog_augmented_generation
+# phase below is additive — brief-only generative agents (pure-prompt DSPs) pass
+# the other phases without claiming catalog support. Agents that do not implement
+# sync_catalogs grade that phase not_applicable rather than fail the specialism.
 
 narrative: |
   You run a generative creative platform — an AI ad network, a generative DSP, or any system
@@ -459,6 +462,7 @@ phases:
           catalogs:
             - catalog_id: "acme_generative_source"
               type: "product"
+              content_id_type: "sku"
               name: "Acme Outdoor — Generative source feed"
               items:
                 - item_id: "peak_jacket_x"

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -6,6 +6,7 @@ category: creative_generative
 summary: "Agent that takes a brief and generates finished creatives from scratch — no input assets required."
 required_tools:
   - build_creative
+  - sync_catalogs
 
 narrative: |
   You run a generative creative platform — an AI ad network, a generative DSP, or any system
@@ -417,4 +418,122 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "creative_generative--build_production"
+            description: "Context correlation_id returned unchanged"
+
+  - id: catalog_augmented_generation
+    title: "Catalog-augmented generation"
+    narrative: |
+      Generative platforms routinely hydrate catalog items into the generation context:
+      the buyer pushes a product catalog, and each generated creative references a specific
+      catalog item (via `{SKU}`, `{GTIN}`, or the catalog-item family) in its impression
+      trackers and click trackers. This is how generative DSPs produce per-SKU dynamic
+      creative at scale.
+
+      This phase exercises the catalog-acceptance leg and emits a generative build that
+      includes catalog-item macros in its tracker URL assets. `preview_creative` is the
+      natural observation point for the runtime substitution-safety check tracked in
+      #2638 — when the substitution-observer contract lands, a runner can assert that
+      the previewed HTML contains percent-encoded catalog-item values per
+      `docs/creative/universal-macros#substitution-safety-catalog-item-macros`.
+
+    steps:
+      - id: sync_generation_catalog
+        title: "Push a product catalog for generation"
+        narrative: |
+          The buyer pushes a small inline catalog. Your agent will use these items as the
+          hydration targets for subsequent generated creatives.
+        task: sync_catalogs
+        schema_ref: "media-buy/sync-catalogs-request.json"
+        response_schema_ref: "media-buy/sync-catalogs-response.json"
+        doc_ref: "/media-buy/task-reference/sync_catalogs"
+        stateful: true
+        expected: |
+          Return per-catalog results with catalog_id, action, item_count, and
+          items_approved counts.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          catalogs:
+            - catalog_id: "acme_generative_source"
+              type: "product"
+              name: "Acme Outdoor — Generative source feed"
+              items:
+                - item_id: "peak_jacket_x"
+                  title: "Peak Jacket X"
+                  description: "Goretex 3L shell, seam-taped, 280g."
+                  url: "https://acmeoutdoor.example/gear/peak-jacket-x"
+                  image_url: "https://cdn.acmeoutdoor.example/gear/peak-jacket-x.jpg"
+                  price:
+                    amount: 449.00
+                    currency: "USD"
+
+          idempotency_key: "$generate:uuid_v4#creative_generative_catalog_augmented_generation_sync_generation_catalog"
+          context:
+            correlation_id: "creative_generative--sync_generation_catalog"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-catalogs-response.json schema"
+          - check: field_present
+            path: "catalogs[0].catalog_id"
+            description: "Catalog has an ID"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--sync_generation_catalog"
+            description: "Context correlation_id returned unchanged"
+
+      - id: build_catalog_aware_creative
+        title: "Generate a creative bound to a catalog item"
+        narrative: |
+          The buyer asks your agent to build a creative for a specific catalog item.
+          The generated manifest MUST include tracker URLs with catalog-item macros
+          (`{SKU}`, `{GTIN}`) so impression-time substitution renders per-SKU output.
+
+          Per #2620, the substitution step MUST percent-encode catalog-item values
+          against the RFC 3986 unreserved set — but the substitution itself happens at
+          serve time, not in the build_creative response. Runtime observability is
+          tracked in #2638.
+        task: build_creative
+        schema_ref: "media-buy/build-creative-request.json"
+        response_schema_ref: "media-buy/build-creative-response.json"
+        doc_ref: "/creative/task-reference/build_creative"
+        comply_scenario: creative_flow
+        stateful: true
+        expected: |
+          Return a creative manifest whose tracker assets include catalog-item
+          macros ({SKU} or {GTIN}) and whose format references a catalog-capable
+          format declared by the agent.
+
+        sample_request:
+          message: "Generate a 300x250 display ad for the Peak Jacket X, using our catalog feed for product fields and tracker URLs."
+          target_format_id:
+            agent_url: "https://your-agent.example.com"
+            id: "display_300x250_generative"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          quality: "draft"
+          include_preview: true
+
+          idempotency_key: "$generate:uuid_v4#creative_generative_catalog_augmented_generation_build_catalog_aware_creative"
+          context:
+            correlation_id: "creative_generative--build_catalog_aware_creative"
+        validations:
+          - check: response_schema
+            description: "Response matches build-creative-response.json schema"
+          - check: field_present
+            path: "creative_manifest.format_id"
+            description: "Generated manifest includes format_id"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--build_catalog_aware_creative"
             description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/specialisms/sales-retail-media/index.yaml
+++ b/static/compliance/source/specialisms/sales-retail-media/index.yaml
@@ -5,6 +5,8 @@ protocol: media-buy
 status: preview
 summary: "Retail media network seller — onsite, offsite, and in-store inventory tied to commerce signals and SKU-level reporting."
 track: media-buy
+required_tools:
+  - sync_catalogs
 
 narrative: |
   You run a retail media network. Inventory spans owned-and-operated digital
@@ -14,7 +16,15 @@ narrative: |
   3.1 placeholder: retail-media-specific phases (SKU targeting, closed-loop
   attribution, ROAS reporting, commerce-media signal activation) will be
   populated as the retail-media additions to media-buy and signals stabilize.
-  Agents claiming this specialism today pass the media-buy baseline storyboard.
+  Agents claiming this specialism today pass the media-buy baseline storyboard
+  plus the single catalog-acceptance phase below.
+
+  The catalog-acceptance phase is the minimum viable retail-media test: retail
+  media is almost entirely catalog/SKU-driven, so any agent claiming this
+  specialism MUST accept a product catalog via `sync_catalogs`. The full
+  retail-media flow (create catalog-backed media buy, SKU-level measurement,
+  closed-loop attribution) is tracked in the retail-media epic referenced from
+  #2640.
 
 agent:
   interaction_model: media_buy_agent
@@ -29,4 +39,87 @@ agent:
 caller:
   role: buyer_agent
 
-phases: []
+prerequisites:
+  description: |
+    Seller supports sync_catalogs and accepts retail product feeds. Minimal
+    catalog-acceptance testing — full retail-media flow populated with the
+    retail-media epic.
+  test_kit: "test-kits/summit-foods.yaml"
+
+phases:
+  - id: catalog_acceptance
+    title: "Retail product catalog acceptance"
+    narrative: |
+      The buyer pushes a small retail product feed. Retail media networks are
+      fundamentally catalog-driven: onsite sponsored-product ads, offsite DPAs,
+      and closed-loop measurement all resolve back to SKU-level catalog items.
+      This phase establishes the catalog-acceptance contract; the full buy-to-
+      attribution flow lands with the retail-media epic (see #2640).
+
+    steps:
+      - id: sync_retail_catalog
+        title: "Push a retail product catalog"
+        narrative: |
+          The buyer pushes a small inline retail catalog with SKU-level items.
+          Your platform validates each item and returns per-item approval status.
+          Items that fail validation MUST return specific `item_issues`.
+        task: sync_catalogs
+        schema_ref: "media-buy/sync-catalogs-request.json"
+        response_schema_ref: "media-buy/sync-catalogs-response.json"
+        doc_ref: "/media-buy/task-reference/sync_catalogs"
+        stateful: true
+        expected: |
+          Return per-catalog results with catalog_id, action, item_count,
+          items_approved, and item_issues for any rejected items.
+
+        sample_request:
+          account:
+            brand:
+              domain: "summitfoods.example"
+            operator: "pinnacle-agency.example"
+          catalogs:
+            - catalog_id: "summit_foods_pantry_2026"
+              type: "product"
+              name: "Summit Foods — Pantry Staples 2026"
+              items:
+                - item_id: "organic_oats_1kg"
+                  sku: "SF-OAT-1000"
+                  title: "Organic Rolled Oats, 1kg"
+                  description: "Whole-grain rolled oats, single-origin, no additives."
+                  url: "https://summitfoods.example/shop/organic-oats-1kg"
+                  image_url: "https://cdn.summitfoods.example/products/organic-oats-1kg.jpg"
+                  price:
+                    amount: 8.99
+                    currency: "USD"
+                - item_id: "wild_honey_500g"
+                  sku: "SF-HNY-500"
+                  title: "Wild Wildflower Honey, 500g"
+                  description: "Raw unfiltered honey from regional wildflower meadows."
+                  url: "https://summitfoods.example/shop/wild-honey-500g"
+                  image_url: "https://cdn.summitfoods.example/products/wild-honey-500g.jpg"
+                  price:
+                    amount: 14.50
+                    currency: "USD"
+
+          idempotency_key: "$generate:uuid_v4#sales_retail_media_catalog_acceptance_sync_retail_catalog"
+          context:
+            correlation_id: "sales_retail_media--sync_retail_catalog"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-catalogs-response.json schema"
+          - check: field_present
+            path: "catalogs[0].catalog_id"
+            description: "Catalog has an ID"
+          - check: field_present
+            path: "catalogs[0].item_count"
+            description: "Catalog reports item count"
+          - check: field_present
+            path: "catalogs[0].items_approved"
+            description: "Catalog reports approved item count"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sales_retail_media--sync_retail_catalog"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/specialisms/sales-retail-media/index.yaml
+++ b/static/compliance/source/specialisms/sales-retail-media/index.yaml
@@ -80,10 +80,11 @@ phases:
           catalogs:
             - catalog_id: "summit_foods_pantry_2026"
               type: "product"
+              content_id_type: "sku"
               name: "Summit Foods — Pantry Staples 2026"
               items:
-                - item_id: "organic_oats_1kg"
-                  sku: "SF-OAT-1000"
+                # item_id IS the SKU per content_id_type: "sku" above.
+                - item_id: "SF-OAT-1000"
                   title: "Organic Rolled Oats, 1kg"
                   description: "Whole-grain rolled oats, single-origin, no additives."
                   url: "https://summitfoods.example/shop/organic-oats-1kg"
@@ -91,8 +92,7 @@ phases:
                   price:
                     amount: 8.99
                     currency: "USD"
-                - item_id: "wild_honey_500g"
-                  sku: "SF-HNY-500"
+                - item_id: "SF-HNY-500"
                   title: "Wild Wildflower Honey, 500g"
                   description: "Raw unfiltered honey from regional wildflower meadows."
                   url: "https://summitfoods.example/shop/wild-honey-500g"

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -283,13 +283,19 @@ phases:
       TikTok Dynamic Showcase): the buyer pushes a product catalog and the platform
       renders per-impression creative pulling product images, titles, and tracker URLs
       from catalog items. The creative template references catalog-item macros
-      (`{SKU}`, `{GTIN}`, `{JOB_ID}`, etc.) whose values resolve to the specific item
-      shown at impression time.
+      (`{SKU}`, `{GTIN}`) whose values resolve to the specific item shown at
+      impression time.
 
       This phase exercises the catalog-acceptance leg of that flow: push a small inline
-      catalog, then push a DPA creative whose tracker URL includes catalog-item
-      macros. Runtime substitution-safety checks (that the emitted tracker URLs
-      percent-encode the macro values per `docs/creative/universal-macros#substitution-safety-catalog-item-macros`)
+      product catalog (with `content_id_type: "sku"` declared so macro resolution binds
+      to the right field), then push a DPA creative template using the AdCP-native
+      `product_carousel_3_to_10` format on `creative.adcontextprotocol.org`. Real
+      social-platform formats (Meta `native_carousel`, Snap dynamic ad set, TikTok
+      dynamic showcase) are platform-specific refinements tracked as follow-ups on
+      #2640; the AdCP-native format is the interop baseline.
+
+      Runtime substitution-safety checks (that the emitted tracker URLs percent-encode
+      the macro values per `docs/creative/universal-macros#substitution-safety-catalog-item-macros`)
       require the substitution-observer contract tracked in #2638; phases gated on
       that contract activate when runners advertise it.
 
@@ -317,6 +323,7 @@ phases:
           catalogs:
             - catalog_id: "acme_gear_spring_2026"
               type: "product"
+              content_id_type: "sku"
               name: "Acme Outdoor — Spring 2026 Gear"
               items:
                 - item_id: "trail_pro_3000"
@@ -359,15 +366,17 @@ phases:
       - id: sync_dpa_creative
         title: "Push a dynamic product ad creative with catalog-item macros"
         narrative: |
-          The buyer pushes a creative template whose tracker URL references catalog-item
-          macros (`{SKU}`, `{GTIN}`). At impression time, your platform substitutes
-          each catalog item's values into the template to render the per-impression ad.
+          The buyer pushes a creative template whose tracker URLs reference
+          catalog-item macros (`{SKU}`, `{GTIN}`). At impression time, your platform
+          substitutes each catalog item's values into the template to render the
+          per-impression ad.
 
-          Per #2620, values substituted into URL contexts MUST be percent-encoded
-          such that only RFC 3986 unreserved characters remain unescaped; nested
-          macro expansion is prohibited. This step validates that the template is
-          accepted into the library; runtime substitution validation is tracked
-          under #2638.
+          The template uses the AdCP-native `product_carousel_3_to_10` format
+          (see `docs/creative/channels/carousels.mdx`). Per #2620, values substituted
+          into URL contexts MUST be percent-encoded such that only RFC 3986 unreserved
+          characters remain unescaped; nested macro expansion is prohibited. This step
+          validates that the template is accepted into the library; runtime
+          substitution validation is tracked under #2638.
         task: sync_creatives
         schema_ref: "creative/sync-creatives-request.json"
         response_schema_ref: "creative/sync-creatives-response.json"
@@ -386,13 +395,13 @@ phases:
             - creative_id: "acme_dpa_spring_2026"
               name: "Acme Outdoor — Spring DPA template"
               format_id:
-                agent_url: "https://social-platform.example.com"
-                id: "dynamic_product_feed"
+                agent_url: "https://creative.adcontextprotocol.org"
+                id: "product_carousel_3_to_10"
               assets:
-                impression_tracker:
+                impression_pixel:
                   asset_type: "url"
                   url: "https://track.acmeoutdoor.example/imp?sku={SKU}&gtin={GTIN}&mb={MEDIA_BUY_ID}"
-                click_tracker:
+                click_url:
                   asset_type: "url"
                   url: "https://track.acmeoutdoor.example/click?sku={SKU}"
 

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -7,6 +7,8 @@ summary: "Social media platform that accepts audience segments, native creatives
 track: audiences
 required_tools:
   - sync_audiences
+  - sync_catalogs
+  - sync_creatives
 
 narrative: |
   You run a social media platform — Snap, Meta, TikTok, Pinterest, or any walled garden that
@@ -273,6 +275,139 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "sales_social--sync_creatives"
+            description: "Context correlation_id returned unchanged"
+  - id: catalog_driven_dynamic_ads
+    title: "Catalog-driven dynamic product ads"
+    narrative: |
+      Social platforms routinely ship dynamic product ads (Snap Dynamic Ads, Meta DPA,
+      TikTok Dynamic Showcase): the buyer pushes a product catalog and the platform
+      renders per-impression creative pulling product images, titles, and tracker URLs
+      from catalog items. The creative template references catalog-item macros
+      (`{SKU}`, `{GTIN}`, `{JOB_ID}`, etc.) whose values resolve to the specific item
+      shown at impression time.
+
+      This phase exercises the catalog-acceptance leg of that flow: push a small inline
+      catalog, then push a DPA creative whose tracker URL includes catalog-item
+      macros. Runtime substitution-safety checks (that the emitted tracker URLs
+      percent-encode the macro values per `docs/creative/universal-macros#substitution-safety-catalog-item-macros`)
+      require the substitution-observer contract tracked in #2638; phases gated on
+      that contract activate when runners advertise it.
+
+    steps:
+      - id: sync_product_catalog
+        title: "Push a product catalog"
+        narrative: |
+          The buyer pushes a small inline product catalog — the shape social platforms
+          accept for dynamic product ads. Your platform validates each item and
+          returns per-item approval status.
+        task: sync_catalogs
+        schema_ref: "media-buy/sync-catalogs-request.json"
+        response_schema_ref: "media-buy/sync-catalogs-response.json"
+        doc_ref: "/media-buy/task-reference/sync_catalogs"
+        stateful: true
+        expected: |
+          Return per-catalog results with catalog_id, action, item_count, and
+          items_approved counts.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          catalogs:
+            - catalog_id: "acme_gear_spring_2026"
+              type: "product"
+              name: "Acme Outdoor — Spring 2026 Gear"
+              items:
+                - item_id: "trail_pro_3000"
+                  title: "Trail Pro 3000 Backpack"
+                  description: "65L expedition pack with torso-length adjustment."
+                  url: "https://acmeoutdoor.example/gear/trail-pro-3000"
+                  image_url: "https://cdn.acmeoutdoor.example/gear/trail-pro-3000.jpg"
+                  price:
+                    amount: 289.00
+                    currency: "USD"
+                - item_id: "summit_tent_2p"
+                  title: "Summit 2P Ultralight Tent"
+                  description: "2-person four-season tent, 1.8kg packed."
+                  url: "https://acmeoutdoor.example/gear/summit-tent-2p"
+                  image_url: "https://cdn.acmeoutdoor.example/gear/summit-tent-2p.jpg"
+                  price:
+                    amount: 549.00
+                    currency: "USD"
+
+          idempotency_key: "$generate:uuid_v4#sales_social_catalog_driven_dynamic_ads_sync_product_catalog"
+          context:
+            correlation_id: "sales_social--sync_product_catalog"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-catalogs-response.json schema"
+          - check: field_present
+            path: "catalogs[0].catalog_id"
+            description: "Catalog has an ID"
+          - check: field_present
+            path: "catalogs[0].item_count"
+            description: "Catalog reports item count"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sales_social--sync_product_catalog"
+            description: "Context correlation_id returned unchanged"
+
+      - id: sync_dpa_creative
+        title: "Push a dynamic product ad creative with catalog-item macros"
+        narrative: |
+          The buyer pushes a creative template whose tracker URL references catalog-item
+          macros (`{SKU}`, `{GTIN}`). At impression time, your platform substitutes
+          each catalog item's values into the template to render the per-impression ad.
+
+          Per #2620, values substituted into URL contexts MUST be percent-encoded
+          such that only RFC 3986 unreserved characters remain unescaped; nested
+          macro expansion is prohibited. This step validates that the template is
+          accepted into the library; runtime substitution validation is tracked
+          under #2638.
+        task: sync_creatives
+        schema_ref: "creative/sync-creatives-request.json"
+        response_schema_ref: "creative/sync-creatives-response.json"
+        doc_ref: "/creative/task-reference/sync_creatives"
+        comply_scenario: creative_sync
+        stateful: true
+        expected: |
+          Accept the DPA creative template. Per-creative action: created or updated.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          creatives:
+            - creative_id: "acme_dpa_spring_2026"
+              name: "Acme Outdoor — Spring DPA template"
+              format_id:
+                agent_url: "https://social-platform.example.com"
+                id: "dynamic_product_feed"
+              assets:
+                impression_tracker:
+                  asset_type: "url"
+                  url: "https://track.acmeoutdoor.example/imp?sku={SKU}&gtin={GTIN}&mb={MEDIA_BUY_ID}"
+                click_tracker:
+                  asset_type: "url"
+                  url: "https://track.acmeoutdoor.example/click?sku={SKU}"
+
+          idempotency_key: "$generate:uuid_v4#sales_social_catalog_driven_dynamic_ads_sync_dpa_creative"
+          context:
+            correlation_id: "sales_social--sync_dpa_creative"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-creatives-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sales_social--sync_dpa_creative"
             description: "Context correlation_id returned unchanged"
   - id: event_logging
     title: "Conversion event tracking"


### PR DESCRIPTION
## Summary

Closes [#2640](https://github.com/adcontextprotocol/adcp/issues/2640) (partial — full retail-media flow deferred to its 3.1 epic per the specialism's placeholder status).

The audit from #2638 / #2640 showed that only `sales-catalog-driven` exercised catalog→creative flow in its storyboard. Three other catalog-relevant specialisms had no catalog-sync phase at all despite their production equivalents routinely handling catalogs:

| Specialism | Prod reality | Storyboard today |
|---|---|---|
| `sales-social` | Snap Dynamic Ads, Meta DPA, TikTok Dynamic Showcase are catalog-driven | Single native creatives, no catalog |
| `creative-generative` | Generative DSPs hydrate catalog items into generation context | Brief-to-creative only |
| `sales-retail-media` | Amazon / Walmart / Target / Kroger are catalog/SKU-driven | `phases: []` (3.1 placeholder) |

This PR adds phases that establish the catalog-acceptance plumbing. Depth is calibrated per specialism ("Mixed" scope).

## What landed

**`sales-social/index.yaml`** — new `catalog_driven_dynamic_ads` phase inserted between `creative_push` and `event_logging`. Two steps:

1. `sync_catalogs` with an inline Acme Outdoor product catalog (Trail Pro 3000 + Summit Tent 2P).
2. `sync_creatives` pushing a DPA template whose impression and click trackers include `{SKU}` and `{GTIN}` catalog-item macros — the exact substitution surface #2620 is meant to protect.

**`creative-generative/index.yaml`** — new `catalog_augmented_generation` phase appended at the end. Two steps:

1. `sync_catalogs` with a small inline feed (Peak Jacket X).
2. `build_creative` generating a catalog-bound creative with `include_preview: true`.

`preview_creative` / `include_preview` is the natural observation point for the substitution-safety runtime check that #2638's `substitution_observer_runner` contract will enforce — when that contract lands, this phase becomes the seat for the runtime assertion.

**`sales-retail-media/index.yaml`** — was a 32-line stub with `phases: []`. Now has one `catalog_acceptance` phase using the `summit-foods` test-kit. Narrative explicitly calls out that the full retail-media flow (create buy with catalog-backed packages, SKU-level measurement, closed-loop attribution) lands with the retail-media epic referenced from #2640 — this PR just establishes the minimum viable catalog-acceptance contract.

## Why mixed scope

`sales-retail-media` is explicitly deferred to a retail-media epic. Writing a full catalog→buy→measurement flow speculatively in this PR would be rework when the epic lands — so it gets the minimum viable phase only. `sales-social` and `creative-generative` are active specialisms and can absorb proper multi-step phases now.

## Out of scope (tracked separately)

- **Runtime substitution-safety check (#2638)** — requires the `substitution_observer_runner` test-kit contract. This PR establishes the catalog→creative flow that #2638's runtime check will hang on.
- **Full retail-media buy-to-attribution flow** — deferred to the retail-media epic.
- **DPA-specific format schemas, per-platform behaviors (Meta, Snap, TikTok)** — this PR uses a platform-agnostic `dynamic_product_feed` format_id as placeholder; specialism-specific refinement can come with implementer input.

## Test plan

- [x] `npm run test:storyboard-scoping` passes (3/3)
- [x] `npm run test:error-codes` passes (pre-existing YAML warning unrelated)
- [x] `npm run test:unit` passes (631 tests)
- [x] `npm run typecheck` passes
- [ ] Spec review on the DPA template shape — currently uses `format_id: dynamic_product_feed` as a platform-agnostic placeholder; a social-platform implementer may want this mapped to a specific format id
- [ ] Confirm `summit-foods` test-kit is the right fixture for retail-media (CPG brand, ShopGrid retail-media-buyer positioning)

Depends on / unblocks: **#2638** (substitution-safety runtime check) — next up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)