### PR TITLE
compliance: substitution-observer-runner contract for catalog-item macro safety (#2638)

### DIFF
--- a/.changeset/substitution-observer-runner-2638.md
+++ b/.changeset/substitution-observer-runner-2638.md
@@ -1,0 +1,37 @@
+---
+---
+
+compliance: substitution-observer-runner test-kit contract + first consumer phase (#2638)
+
+Closes #2638 (contract drafted; consumer phases beyond sales-catalog-driven tracked as follow-ups once #2640 merges).
+
+The #2620 rule — sales agents MUST percent-encode catalog-item macro values (unreserved-whitelist, RFC 3986 §2.5 for non-ASCII) before substitution into URL contexts — has a library-level conformance artifact (the 6-vector unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`). It had no runtime conformance test.
+
+This PR lands the runtime side:
+
+**`static/compliance/source/test-kits/substitution-observer-runner.yaml`** — new test-kit contract specifying how a black-box runner observes substituted tracker URLs in creative previews and asserts encoding safety. Mirrors the shape of `webhook-receiver-runner.yaml`:
+
+- Two observation modes: `preview_html_inline` (default for lint/fast) parses `preview_html` from the response; `preview_url_fetch` (default for AdCP Verified) fetches `preview_url` over HTTPS with SSRF allowlist enforcement.
+- `attacker_value_catalog` cross-references the 6 canonical vectors from the unit-test fixture so library-level and runtime-level conformance exercise the same payloads.
+- `step_task: expect_substitution_safe` documented with full argument shape and 6 error modes (`substitution_encoding_violation`, `nested_macro_re_expansion`, `substitution_binding_missing`, `preview_source_unavailable`, `preview_url_fetch_failed`, `preview_body_not_html`).
+- `client_primitives.substitution_observer` reserves the proposed `@adcp/client` surface (`parse_html`, `fetch_and_parse`, `assert_rfc3986_safe`, `assert_no_nested_expansion`) so conformance and production code paths share one implementation.
+- Out-of-scope v1: non-catalog macros, HTML-attribute contexts, VAST XML, post-impression log introspection. All explicitly called out with rationale.
+
+**`static/compliance/source/universal/storyboard-schema.yaml`** — registered `task: expect_substitution_safe` alongside the webhook task types so runners and storyboards share a single schema.
+
+**`static/compliance/source/specialisms/sales-catalog-driven/index.yaml`** — new `substitution_safety` phase inserted between `catalog_sync` and `create_buy`. Three steps:
+
+1. `sync_attacker_shaped_catalog` — pushes three of the canonical attacker-shaped values (reserved-char breakout, nested-expansion preservation, non-ASCII UTF-8) as catalog items.
+2. `build_catalog_aware_creative` — builds a creative with `{SKU}` in impression/click trackers and `include_preview: true`.
+3. `expect_substitution_safe` — gated on `substitution_observer_runner`. Runners that do not advertise the contract grade this step `not_applicable`; the earlier two steps still run and exercise the catalog-acceptance and build paths unconditionally.
+
+Extending the `expect_substitution_safe` pattern to `sales-social` and `creative-generative` (both of which add their catalog phases in #2640) is tracked as a follow-up — not bundled here to keep this PR off a pre-#2640 main and avoid merge conflicts.
+
+## Out of scope (follow-ups)
+
+- Reference runner implementation (adcp-client `SubstitutionObserver`) — tracked separately in the adcp-client repo once the contract YAML is reviewed.
+- Extension to `sales-social` / `creative-generative` once #2640 merges.
+- `sales-retail-media` wiring — waits for the retail-media epic per #2640's scoping.
+- Spec-level expansion of the #2620 rule to HTML-attribute contexts — explicitly deferred per #2620.
+
+No schema change. No spec change. New phase grades not_applicable for existing runners, so no conformance regression.

--- a/.changeset/substitution-observer-runner-2638.md
+++ b/.changeset/substitution-observer-runner-2638.md
@@ -3,35 +3,38 @@
 
 compliance: substitution-observer-runner test-kit contract + first consumer phase (#2638)
 
-Closes #2638 (contract drafted; consumer phases beyond sales-catalog-driven tracked as follow-ups once #2640 merges).
+Closes #2638 (contract drafted with v2 fixes from expert review; consumer phases beyond sales-catalog-driven tracked as follow-ups once #2640 merges).
 
-The #2620 rule — sales agents MUST percent-encode catalog-item macro values (unreserved-whitelist, RFC 3986 §2.5 for non-ASCII) before substitution into URL contexts — has a library-level conformance artifact (the 6-vector unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`). It had no runtime conformance test.
+The #2620 rule — sales agents MUST percent-encode catalog-item macro values (unreserved-whitelist, RFC 3986 §2.5 for non-ASCII) before substitution into URL contexts — has a library-level conformance artifact (the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`). It had no runtime conformance test.
 
-This PR lands the runtime side:
+**`static/compliance/source/test-kits/substitution-observer-runner.yaml`** — test-kit contract, shape mirrors `webhook-receiver-runner.yaml`:
 
-**`static/compliance/source/test-kits/substitution-observer-runner.yaml`** — new test-kit contract specifying how a black-box runner observes substituted tracker URLs in creative previews and asserts encoding safety. Mirrors the shape of `webhook-receiver-runner.yaml`:
+- **Normative SSRF policy** in contract body (not deferred to library): explicit IPv4/IPv6 CIDR deny lists (loopback, RFC 1918, link-local incl. 169.254.169.254 IMDS, CGNAT, IPv6 ULA, multicast), cloud metadata hostnames, HTTPS-only scheme allowlist, DNS revalidation, strict `follow_redirects: false`, `host_literal_policy_verified: reject` in AdCP Verified mode.
+- **Normative HTML attribute extraction set** — enumerated `tag_attribute_pairs`; `srcset` parsed per-descriptor; script text and comments explicitly out of scope.
+- **Normative macro-position alignment algorithm** — parse template + observed URL with same WHATWG URL parser, align query pairs by key, align path segments positionally, compare byte-for-byte.
+- **Normative hex case policy** — producers emit uppercase per RFC 3986 §2.1; verifiers use case-insensitive comparison on hex digits inside triplets only.
+- **Single-source-of-truth vectors** — contract references fixture by name; `expected_encoded` strings dropped from contract. Vector names aligned to fixture's hyphen convention. No drift risk.
+- **Simplified `catalog_bindings`** — `{macro, catalog_item_id, vector_name}`; runner looks up raw_value/expected_encoded from fixture. Custom vectors opt-in via optional override fields.
+- **Error-report payload policy** — canonical vectors echo verbatim; custom vectors auto-redact to SHA-256 unless `--include-raw-payloads` flag (default off, disabled in Verified).
+- **Split library surface** — `observer/` for runners; sibling `encoder/` for sellers. One library, disjoint APIs.
+- **`require_all_bindings_observed` → `require_every_binding_observed`** with default `true`. Closes silent-strip bypass.
+- **Collapsed error codes** — `preview_url_fetch_failed` + `preview_body_not_html` merged into `preview_url_unusable` with six sub-reasons including `ssrf_blocked`.
+- **`substitution_scheme_injection`** error code added for `javascript:`-scheme injection at href-whole-value positions.
+- **Preview/serve divergence** added to out-of-scope v1.
+- **Structured `scope:` and `references:` blocks** — machine-readable.
+- Fetch tuning: `max_body_bytes` 1 MiB → 256 KiB; `max_connect_seconds: 3`.
+- Observation modes renamed: `preview_html_inline` / `preview_url_fetch` → `html_inline` / `url_fetch`.
 
-- Two observation modes: `preview_html_inline` (default for lint/fast) parses `preview_html` from the response; `preview_url_fetch` (default for AdCP Verified) fetches `preview_url` over HTTPS with SSRF allowlist enforcement.
-- `attacker_value_catalog` cross-references the 6 canonical vectors from the unit-test fixture so library-level and runtime-level conformance exercise the same payloads.
-- `step_task: expect_substitution_safe` documented with full argument shape and 6 error modes (`substitution_encoding_violation`, `nested_macro_re_expansion`, `substitution_binding_missing`, `preview_source_unavailable`, `preview_url_fetch_failed`, `preview_body_not_html`).
-- `client_primitives.substitution_observer` reserves the proposed `@adcp/client` surface (`parse_html`, `fetch_and_parse`, `assert_rfc3986_safe`, `assert_no_nested_expansion`) so conformance and production code paths share one implementation.
-- Out-of-scope v1: non-catalog macros, HTML-attribute contexts, VAST XML, post-impression log introspection. All explicitly called out with rationale.
+**`static/test-vectors/catalog-macro-substitution.json`** — added `url-scheme-injection-neutralized` vector. Value `javascript:alert(0)` encodes to `javascript%3Aalert%280%29` per strict RFC 3986 (parens are NOT unreserved — encoders using `encodeURIComponent`-equivalent that leave parens unescaped fail this vector). All 7 vectors verified.
 
-**`static/compliance/source/universal/storyboard-schema.yaml`** — registered `task: expect_substitution_safe` alongside the webhook task types so runners and storyboards share a single schema.
+**`static/compliance/source/universal/storyboard-schema.yaml`** — `task: expect_substitution_safe` docs updated to match contract v2 shape.
 
-**`static/compliance/source/specialisms/sales-catalog-driven/index.yaml`** — new `substitution_safety` phase inserted between `catalog_sync` and `create_buy`. Three steps:
-
-1. `sync_attacker_shaped_catalog` — pushes three of the canonical attacker-shaped values (reserved-char breakout, nested-expansion preservation, non-ASCII UTF-8) as catalog items.
-2. `build_catalog_aware_creative` — builds a creative with `{SKU}` in impression/click trackers and `include_preview: true`.
-3. `expect_substitution_safe` — gated on `substitution_observer_runner`. Runners that do not advertise the contract grade this step `not_applicable`; the earlier two steps still run and exercise the catalog-acceptance and build paths unconditionally.
-
-Extending the `expect_substitution_safe` pattern to `sales-social` and `creative-generative` (both of which add their catalog phases in #2640) is tracked as a follow-up — not bundled here to keep this PR off a pre-#2640 main and avoid merge conflicts.
+**`static/compliance/source/specialisms/sales-catalog-driven/index.yaml`** — consumer phase updated to match contract v2: `require_every_binding_observed: true`, simplified bindings (vector_name lookup), `source: html_inline`, `content_id_type: "sku"` declared on probe catalog.
 
 ## Out of scope (follow-ups)
 
-- Reference runner implementation (adcp-client `SubstitutionObserver`) — tracked separately in the adcp-client repo once the contract YAML is reviewed.
+- Reference runner implementation (`@adcp/client` `SubstitutionObserver` + `SubstitutionEncoder` split) — adcp-client repo.
+- Unicode normalization round-trip (NFC vs NFD) — spec gap, surface in #2620 first.
+- Zero-width / invisible-char vectors — additive after NFC resolves.
 - Extension to `sales-social` / `creative-generative` once #2640 merges.
-- `sales-retail-media` wiring — waits for the retail-media epic per #2640's scoping.
-- Spec-level expansion of the #2620 rule to HTML-attribute contexts — explicitly deferred per #2620.
-
-No schema change. No spec change. New phase grades not_applicable for existing runners, so no conformance regression.
+- `sales-retail-media` wiring — retail-media epic per #2640.

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -321,8 +321,11 @@ phases:
           catalogs:
             - catalog_id: "substitution_safety_probe_v1"
               type: "product"
+              content_id_type: "sku"
               name: "Substitution safety probe"
               items:
+                # item_id is the vector name; the `sku` field carries the
+                # attacker-shaped value that substitution must encode.
                 - item_id: "reserved_char_breakout"
                   sku: "00013&cmd=drop"
                   title: "Reserved-char breakout probe"
@@ -396,29 +399,30 @@ phases:
           The runner inspects the preview artifact from the previous step,
           extracts tracker URLs that bind `{SKU}` to a catalog item from the
           attacker-shaped catalog, and asserts each value is percent-encoded
-          per RFC 3986 (unreserved-whitelist). Raw-byte leakage fails.
+          per RFC 3986 (unreserved-whitelist). Raw-byte leakage fails. Every
+          declared binding MUST be observed — a seller that silently strips
+          `{SKU}` rather than substituting it fails with
+          `substitution_binding_missing`.
         task: expect_substitution_safe
         requires_contract: substitution_observer_runner
-        source: preview_html
+        source: html_inline
         source_path: "/creative_manifest/preview_html"
         macro_template: "https://track.example/imp?sku={SKU}"
-        require_all_bindings_observed: false
+        require_every_binding_observed: true
         catalog_bindings:
+          # Each binding: `catalog_item_id` is the item_id in the synced
+          # catalog; `vector_name` is the fixture entry whose raw_value and
+          # expected_encoded the runner loads from
+          # static/test-vectors/catalog-macro-substitution.json.
           - macro: "{SKU}"
-            catalog_field: "items[0].sku"
-            item_id: "reserved_char_breakout"
-            raw_value: "00013&cmd=drop"
-            expected_encoded: "00013%26cmd%3Ddrop"
+            catalog_item_id: "reserved_char_breakout"
+            vector_name: "reserved-character-breakout"
           - macro: "{SKU}"
-            catalog_field: "items[1].sku"
-            item_id: "nested_expansion"
-            raw_value: "vacancy-{DEVICE_ID}-42"
-            expected_encoded: "vacancy-%7BDEVICE_ID%7D-42"
+            catalog_item_id: "nested_expansion"
+            vector_name: "nested-expansion-preserved-as-literal"
           - macro: "{SKU}"
-            catalog_field: "items[2].sku"
-            item_id: "non_ascii"
-            raw_value: "café-amsterdam"
-            expected_encoded: "caf%C3%A9-amsterdam"
+            catalog_item_id: "non_ascii"
+            vector_name: "non-ascii-utf8-percent-encoding"
   - id: create_buy
     title: "Create catalog-driven media buy"
     narrative: |

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -274,6 +274,151 @@ phases:
             path: "context.correlation_id"
             value: "sales_catalog_driven--sync_catalogs"
             description: "Context correlation_id returned unchanged"
+  - id: substitution_safety
+    title: "Catalog-item macro substitution safety"
+    narrative: |
+      Per docs/creative/universal-macros#substitution-safety-catalog-item-macros,
+      sales agents MUST percent-encode catalog-item macro values such that only
+      RFC 3986 `unreserved` characters remain unescaped before substituting them
+      into a URL context. Nested macro expansion is prohibited.
+
+      This phase exercises the rule with attacker-shaped catalog values drawn
+      from the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`:
+      reserved-char breakout, nested-expansion preservation, CRLF injection,
+      non-ASCII UTF-8, mixed path/query, and bidi-override neutralization.
+
+      The `expect_substitution_safe` step is gated on the
+      `substitution_observer_runner` test-kit contract (see
+      `test-kits/substitution-observer-runner.yaml`). Runners that do not
+      advertise the contract grade the step as `not_applicable` — the earlier
+      `sync_attacker_shaped_catalog` and `build_catalog_aware_creative` steps
+      still run (they exercise the catalog-acceptance and build paths), but
+      the substituted-URL assertion is skipped.
+
+    steps:
+      - id: sync_attacker_shaped_catalog
+        title: "Push a catalog with attacker-shaped values"
+        narrative: |
+          Push a small catalog whose fields contain the six canonical
+          attacker-shaped values from the substitution-safety fixture. The
+          seller MUST accept the payload at sync_catalogs (the rule applies at
+          substitution time, not at ingest — the seller is free to pass values
+          through, then encode them at serve time).
+        task: sync_catalogs
+        schema_ref: "media-buy/sync-catalogs-request.json"
+        response_schema_ref: "media-buy/sync-catalogs-response.json"
+        doc_ref: "/media-buy/task-reference/sync_catalogs"
+        stateful: true
+        expected: |
+          Catalog accepted with per-item counts. Runner captures the item_ids
+          for downstream assertion binding.
+
+        sample_request:
+          account:
+            brand:
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
+          catalogs:
+            - catalog_id: "substitution_safety_probe_v1"
+              type: "product"
+              name: "Substitution safety probe"
+              items:
+                - item_id: "reserved_char_breakout"
+                  sku: "00013&cmd=drop"
+                  title: "Reserved-char breakout probe"
+                  url: "https://amsterdam-steakhouse.example/probe/reserved"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/probe/reserved.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+                - item_id: "nested_expansion"
+                  sku: "vacancy-{DEVICE_ID}-42"
+                  title: "Nested-expansion probe"
+                  url: "https://amsterdam-steakhouse.example/probe/nested"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/probe/nested.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+                - item_id: "non_ascii"
+                  sku: "café-amsterdam"
+                  title: "Non-ASCII UTF-8 probe"
+                  url: "https://amsterdam-steakhouse.example/probe/non-ascii"
+                  image_url: "https://cdn.amsterdam-steakhouse.example/probe/non-ascii.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_substitution_safety_sync_attacker_shaped_catalog"
+          context:
+            correlation_id: "sales_catalog_driven--sync_attacker_shaped_catalog"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-catalogs-response.json schema"
+          - check: field_present
+            path: "catalogs[0].catalog_id"
+            description: "Catalog accepted"
+
+      - id: build_catalog_aware_creative
+        title: "Build a creative with catalog-item macros in tracker URLs"
+        narrative: |
+          Build a creative whose impression and click trackers include
+          catalog-item macros bound to the `sku` field of the attacker-shaped
+          catalog items above. Request `include_preview: true` so the
+          substitution-observer runner has a preview surface to inspect.
+        task: build_creative
+        schema_ref: "media-buy/build-creative-request.json"
+        response_schema_ref: "media-buy/build-creative-response.json"
+        doc_ref: "/creative/task-reference/build_creative"
+        comply_scenario: creative_flow
+        stateful: true
+        expected: |
+          Creative manifest returned with preview_html or preview_url populated.
+
+        sample_request:
+          message: "Build a catalog-driven display ad for the substitution_safety_probe_v1 catalog. Use {SKU} in impression and click tracker URLs."
+          target_format_id:
+            agent_url: "https://your-agent.example.com"
+            id: "display_300x250_catalog"
+          account:
+            brand:
+              domain: "amsterdam-steakhouse.example"
+            operator: "pinnacle-agency.example"
+          quality: "draft"
+          include_preview: true
+
+          idempotency_key: "$generate:uuid_v4#sales_catalog_driven_substitution_safety_build_catalog_aware_creative"
+          context:
+            correlation_id: "sales_catalog_driven--build_catalog_aware_creative"
+        validations:
+          - check: response_schema
+            description: "Response matches build-creative-response.json schema"
+          - check: field_present
+            path: "creative_manifest.format_id"
+            description: "Creative manifest returned"
+
+      - id: expect_substitution_safe
+        title: "Assert substituted tracker URLs percent-encode attacker shapes"
+        narrative: |
+          The runner inspects the preview artifact from the previous step,
+          extracts tracker URLs that bind `{SKU}` to a catalog item from the
+          attacker-shaped catalog, and asserts each value is percent-encoded
+          per RFC 3986 (unreserved-whitelist). Raw-byte leakage fails.
+        task: expect_substitution_safe
+        requires_contract: substitution_observer_runner
+        source: preview_html
+        source_path: "/creative_manifest/preview_html"
+        macro_template: "https://track.example/imp?sku={SKU}"
+        require_all_bindings_observed: false
+        catalog_bindings:
+          - macro: "{SKU}"
+            catalog_field: "items[0].sku"
+            item_id: "reserved_char_breakout"
+            raw_value: "00013&cmd=drop"
+            expected_encoded: "00013%26cmd%3Ddrop"
+          - macro: "{SKU}"
+            catalog_field: "items[1].sku"
+            item_id: "nested_expansion"
+            raw_value: "vacancy-{DEVICE_ID}-42"
+            expected_encoded: "vacancy-%7BDEVICE_ID%7D-42"
+          - macro: "{SKU}"
+            catalog_field: "items[2].sku"
+            item_id: "non_ascii"
+            raw_value: "café-amsterdam"
+            expected_encoded: "caf%C3%A9-amsterdam"
   - id: create_buy
     title: "Create catalog-driven media buy"
     narrative: |

--- a/static/compliance/source/test-kits/substitution-observer-runner.yaml
+++ b/static/compliance/source/test-kits/substitution-observer-runner.yaml
@@ -1,0 +1,296 @@
+# Substitution Observer Runner — Harness Contract Test Kit
+#
+# Applies to:
+#   - Any storyboard that exercises catalog-item macro substitution and needs
+#     to assert the RFC 3986 percent-encoding rule from
+#     docs/creative/universal-macros.mdx#substitution-safety-catalog-item-macros.
+#   - Current consumers (when phases are gated on this contract):
+#     - specialisms/sales-catalog-driven/index.yaml
+#     - specialisms/creative-generative/index.yaml
+#     - specialisms/sales-social/index.yaml (catalog_driven_dynamic_ads phase)
+#   - Future consumers: sales-retail-media (post-retail-media-epic),
+#     sales-broadcast-tv dynamic-creative phases, and anywhere else catalog
+#     values expand into URL contexts.
+#
+# The #2620 rule: sales agents MUST percent-encode catalog-item macro values
+# such that only RFC 3986 `unreserved` characters remain unescaped before
+# substitution into URL contexts. Nested macro expansion is prohibited.
+#
+# The ATTACK SURFACE is impression-time URL emission. AdCP's API surface does
+# not normally expose substituted output — it happens at serve time outside
+# the protocol. Two observable AdCP-layer hooks exist:
+#
+#   preview_creative responses (preview_html / preview_url)
+#   build_creative responses with include_preview: true
+#
+# This contract defines how a runner consumes those preview artifacts,
+# extracts tracker URLs with substituted catalog-item values, and asserts
+# the values are encoded per the #2620 rule.
+#
+# Clean seam: the runner does NOT reimplement URL parsing, HTML extraction,
+# or the encoding check. It delegates to @adcp/client primitives (proposed:
+# `SubstitutionObserver` with `extract_tracker_urls` and `assert_rfc3986_safe`
+# helpers) so the same library production receivers would use is what the
+# conformance runner exercises. Library fixes cover both.
+
+id: substitution_observer_runner
+applies_to:
+  specialisms:
+    - sales_catalog_driven
+    - creative_generative
+    - sales_social
+  universals: []
+
+description: |
+  Coordination contract between a runner that observes substituted tracker
+  URLs in preview artifacts and an agent under test that emits catalog-driven
+  creatives. The runner ingests preview_html or follows preview_url, extracts
+  tracker URLs bound to catalog-item macros, and asserts RFC 3986 percent-
+  encoding of catalog-item values per docs/creative/universal-macros#substitution-safety-catalog-item-macros.
+
+endpoint_scope: sandbox
+# Storyboards consuming this contract synthesize attacker-shaped catalog
+# values (e.g., title containing `abc&cmd=drop` or `\r\nHost: evil`) and
+# push them via sync_catalogs. Running those against production would
+# pollute live catalogs. Graders MUST target a sandbox/staging endpoint.
+
+harness_mode: black_box
+
+# --- Observation mechanism ---
+#
+# The runner captures preview output from two response shapes (either is
+# sufficient — the storyboard author names which to observe):
+#
+#   preview_html (inline HTML string in the response)
+#     The runner parses the HTML and extracts href / src / and known tracker
+#     attribute values. Zero network dependency.
+#
+#   preview_url (HTTPS URL the runner fetches)
+#     The runner performs a single GET against the URL, expects 200 + HTML,
+#     and extracts identically. Must respect the standard SSRF allowlist
+#     (no RFC 1918, no loopback, no link-local) — the runner applies the
+#     same validation @adcp/client uses for JWKS fetches.
+#
+# Both paths land at the same @adcp/client.SubstitutionObserver.extract_tracker_urls
+# primitive, which returns a deterministic list of `{ url, source_attr, line_hint }`
+# records that storyboards match against.
+
+observation_modes:
+  - mode: preview_html_inline
+    default_for: [lint, fast, full_conformance]
+    description: |
+      Runner reads preview_html from the response and parses it. No network
+      fetch. Appropriate for CI lint gates and SDK self-tests.
+    runner_config:
+      source_path: preview_html
+      html_parser: "@adcp/client.SubstitutionObserver.parse_html"
+
+  - mode: preview_url_fetch
+    default_for: [adcp_verified]
+    description: |
+      Runner fetches preview_url over HTTPS, expects 200 + text/html, and
+      parses the body. Required for AdCP Verified grading where the preview
+      is a live asset.
+    runner_config:
+      source_path: preview_url
+      fetch:
+        method: GET
+        follow_redirects: false
+        max_body_bytes: 1048576
+        timeout_seconds: 10
+        required_content_types: ["text/html", "application/xhtml+xml"]
+        ssrf_allowlist: "@adcp/client.SubstitutionObserver.fetch_ssrf_allowlist"
+
+# --- Attacker-shaped catalog values ---
+#
+# Storyboards consuming this contract push a small catalog with pre-defined
+# attacker-shaped values. The runner knows the mapping between catalog field
+# and target macro, so it can assert the emitted tracker URL contains the
+# encoded form of the original value (not the raw form).
+#
+# The six canonical attacker shapes match the unit-test fixture at
+# static/test-vectors/catalog-macro-substitution.json — storyboards SHOULD
+# reuse that fixture's payloads so library-level and runtime-level conformance
+# exercise the same vectors.
+
+attacker_value_catalog:
+  source_fixture: static/test-vectors/catalog-macro-substitution.json
+  canonical_vectors:
+    - vector: reserved_character_breakout
+      raw_value: "00013&cmd=drop"
+      expected_encoded: "00013%26cmd%3Ddrop"
+    - vector: nested_expansion_preserved
+      raw_value: "vacancy-{DEVICE_ID}-42"
+      expected_encoded: "vacancy-%7BDEVICE_ID%7D-42"
+    - vector: crlf_injection_neutralized
+      raw_value: "abc\r\nHost: evil.example"
+      expected_encoded: "abc%0D%0AHost%3A%20evil.example"
+    - vector: non_ascii_utf8
+      raw_value: "café-amsterdam"
+      expected_encoded: "caf%C3%A9-amsterdam"
+    - vector: path_and_query_mixed
+      raw_value: "gmc/primary feed"
+      expected_encoded: "gmc%2Fprimary%20feed"
+    - vector: bidi_override_neutralized
+      raw_value: "VIN-\u202E1234"
+      expected_encoded: "VIN-%E2%80%AE1234"
+
+# --- Storyboard-layer step task ---
+#
+# The contract exposes one primary step task:
+#
+#   task: expect_substitution_safe
+#
+# Arguments:
+#   source:
+#     preview_html  | preview_url  | response_body
+#     Which response field the runner observes. Default: preview_html.
+#   source_path:
+#     JSON-pointer into the previous step's response where `source` lives.
+#     Example: "/creative_manifest/preview_html"
+#   macro_template:
+#     The URL template containing AdCP macros (the value submitted via
+#     sync_creatives). Example: "https://track.example/imp?sku={SKU}"
+#   catalog_bindings:
+#     Array of { macro, catalog_field, item_id, expected_encoded }
+#     describing which catalog item's field feeds which macro, and what
+#     the encoded form MUST be.
+#   require_all_bindings_observed:
+#     Default true. If true, the step fails when the extracted tracker URLs
+#     do not include EVERY binding — catches a seller that silently strips
+#     macros rather than substituting. If false, only observed bindings are
+#     checked (permissive; useful when preview shows one item from a larger
+#     catalog).
+#
+# Validations (runner-internal; storyboards reference them by name):
+#
+#   substitution_encoded:
+#     For each binding, the extracted URL at the macro position MUST equal
+#     expected_encoded byte-for-byte. Raw-value leakage (any byte of the raw
+#     attacker shape appearing literally at the macro position) fails the
+#     step with `substitution_encoding_violation` plus the offending byte
+#     offset and the library-expected encoding.
+#
+#   nested_expansion_not_re_scanned:
+#     For the nested_expansion_preserved vector specifically: the extracted
+#     URL MUST contain `%7BDEVICE_ID%7D` (encoded braces) and MUST NOT contain
+#     any resolved value for {DEVICE_ID}. A second-round expansion fails
+#     with `nested_macro_re_expansion`.
+#
+#   rfc3986_unreserved_only_at_macro_position:
+#     A stricter check than substitution_encoded — verifies that every byte
+#     emitted at the macro position is either unreserved (ALPHA / DIGIT /
+#     "-" / "." / "_" / "~") or a percent-encoded triplet. A conformant
+#     encoder passes this trivially; an encoder that uses a reserved-char
+#     allowlist (rather than unreserved-whitelist) fails specifically on
+#     the CRLF and bidi vectors.
+
+step_task:
+  name: expect_substitution_safe
+  schema_ref: static/compliance/source/universal/storyboard-schema.yaml
+  error_modes:
+    - substitution_encoding_violation
+    - nested_macro_re_expansion
+    - substitution_binding_missing
+    - preview_source_unavailable
+    - preview_url_fetch_failed
+    - preview_body_not_html
+
+# --- @adcp/client primitives the runner consumes ---
+#
+# The runner does NOT reimplement HTML parsing, URL extraction, or the RFC
+# 3986 encoding check. It consumes library primitives so production code
+# paths match conformance paths.
+
+client_primitives:
+  substitution_observer:
+    reference: SubstitutionObserver
+    methods:
+      - parse_html(html: string) -> TrackerUrlRecord[]
+      - fetch_and_parse(url: URL) -> TrackerUrlRecord[]
+      - assert_rfc3986_safe(url: URL, binding: CatalogBinding) -> AssertionResult
+      - assert_no_nested_expansion(url: URL, prohibited_pattern: RegExp) -> AssertionResult
+    proposed_location: "@adcp/client/src/substitution-observer/"
+    doc: "To be filed as an adcp-client PR when #2638 lands."
+
+  tracker_url_record:
+    reference: TrackerUrlRecord
+    shape: |
+      {
+        url: URL;                    // parsed URL object
+        source_attr: string;         // 'href' | 'src' | 'data-impression-url' | …
+        line_hint: number | null;    // best-effort line number in preview HTML
+      }
+
+  catalog_binding:
+    reference: CatalogBinding
+    shape: |
+      {
+        macro: string;                // e.g., "{GTIN}"
+        catalog_field: string;        // e.g., "items[0].sku"
+        item_id: string;              // e.g., "trail_pro_3000"
+        raw_value: string;            // attacker-shaped input
+        expected_encoded: string;     // rfc3986_unreserved-encoded form
+      }
+
+# --- Grading decision tree ---
+#
+# A step gated on this contract grades as follows:
+#
+#   not_applicable:
+#     Runner does not advertise substitution_observer_runner in its
+#     capabilities, OR the specialism under test does not expose a preview
+#     surface (preview_html, preview_url, or equivalent). Recorded as
+#     not_applicable with a reason; does NOT contribute to the pass rate.
+#
+#   pass:
+#     All bindings in `catalog_bindings` appear at their macro positions in
+#     extracted tracker URLs, each byte-equal to `expected_encoded`.
+#
+#   fail with `substitution_encoding_violation`:
+#     At least one binding's extracted value differs from expected_encoded
+#     in any byte. Runner MUST include the binding, the observed URL, the
+#     offending byte offset, and the expected encoding in the error report.
+#
+#   fail with `nested_macro_re_expansion`:
+#     The nested_expansion_preserved vector's macro position contains any
+#     byte sequence that resolves as a second-round AdCP macro. Includes
+#     the resolved macro name and its unexpected value.
+#
+#   fail with `substitution_binding_missing`:
+#     `require_all_bindings_observed: true` (default) and one or more
+#     bindings are not present in any extracted URL. Catches a seller that
+#     silently drops the macro.
+#
+#   fail with `preview_source_unavailable`:
+#     The configured `source_path` resolves to null or an empty string in
+#     the observed response. The seller's preview shape does not satisfy
+#     the contract; specialism MAY grade not_applicable if the agent does
+#     not advertise preview support.
+#
+#   fail with `preview_url_fetch_failed` / `preview_body_not_html`:
+#     preview_url fetch path specific. The runner includes the HTTP status
+#     or the offending content-type in the error report.
+
+# --- Out of scope v1 ---
+#
+# The following are deliberate non-goals for the initial contract:
+#
+#   - Macros outside the catalog-item class. Trusted macros (MEDIA_BUY_ID,
+#     DEVICE_ID, GEO) are not observed by this contract. Extension to a
+#     universal URL-encoding check across all macros is tracked as a
+#     potential 3.2+ scope, not v1.
+#
+#   - HTML-attribute context assertions. The #2620 rule explicitly scopes
+#     to URL contexts; HTML-attribute escaping is the publisher's
+#     responsibility. A runner that detects a catalog value rendered
+#     unencoded into an HTML attribute SHOULD warn but MUST NOT fail.
+#
+#   - VAST XML bodies. VAST macros use [SQUARE_BRACKETS] and resolve in
+#     the player, not in AdCP. Runners MAY extract tracker URLs from VAST
+#     CDATA blocks for the AdCP-macro check but MUST NOT assert on VAST
+#     macro substitution.
+#
+#   - Non-preview surfaces (post-impression log introspection, direct
+#     ad-server querying). Those require a different contract — not this
+#     one — and are a separate 3.2+ RFC.

--- a/static/compliance/source/test-kits/substitution-observer-runner.yaml
+++ b/static/compliance/source/test-kits/substitution-observer-runner.yaml
@@ -34,6 +34,11 @@
 # conformance runner exercises. Library fixes cover both.
 
 id: substitution_observer_runner
+# Shape extension vs webhook-receiver-runner: this contract applies to
+# specialisms rather than universals, because catalog-macro substitution is a
+# specialism-scoped behavior (only catalog-accepting sellers emit it). The
+# `applies_to.specialisms` key is a deliberate structural addition for this
+# class of contract.
 applies_to:
   specialisms:
     - sales_catalog_driven
@@ -62,21 +67,20 @@ harness_mode: black_box
 # sufficient — the storyboard author names which to observe):
 #
 #   preview_html (inline HTML string in the response)
-#     The runner parses the HTML and extracts href / src / and known tracker
-#     attribute values. Zero network dependency.
+#     The runner parses the HTML and extracts tracker URLs from the
+#     attribute set enumerated below. Zero network dependency.
 #
-#   preview_url (HTTPS URL the runner fetches)
-#     The runner performs a single GET against the URL, expects 200 + HTML,
-#     and extracts identically. Must respect the standard SSRF allowlist
-#     (no RFC 1918, no loopback, no link-local) — the runner applies the
-#     same validation @adcp/client uses for JWKS fetches.
+#   preview_url (HTTPS URL the runner fetches subject to the SSRF policy
+#     enumerated below)
+#     The runner performs a single GET against the URL and extracts
+#     identically.
 #
 # Both paths land at the same @adcp/client.SubstitutionObserver.extract_tracker_urls
 # primitive, which returns a deterministic list of `{ url, source_attr, line_hint }`
 # records that storyboards match against.
 
 observation_modes:
-  - mode: preview_html_inline
+  - mode: html_inline
     default_for: [lint, fast, full_conformance]
     description: |
       Runner reads preview_html from the response and parses it. No network
@@ -85,7 +89,7 @@ observation_modes:
       source_path: preview_html
       html_parser: "@adcp/client.SubstitutionObserver.parse_html"
 
-  - mode: preview_url_fetch
+  - mode: url_fetch
     default_for: [adcp_verified]
     description: |
       Runner fetches preview_url over HTTPS, expects 200 + text/html, and
@@ -96,44 +100,161 @@ observation_modes:
       fetch:
         method: GET
         follow_redirects: false
-        max_body_bytes: 1048576
+        max_body_bytes: 262144  # 256 KiB — matches typical creative preview sizes
+        max_connect_seconds: 3
         timeout_seconds: 10
         required_content_types: ["text/html", "application/xhtml+xml"]
-        ssrf_allowlist: "@adcp/client.SubstitutionObserver.fetch_ssrf_allowlist"
+      # SSRF policy is NORMATIVE IN THIS CONTRACT (not deferred to a library).
+      # Verified graders MUST enforce every rule below. The runner MAY delegate
+      # the implementation to @adcp/client.SubstitutionObserver.enforce_ssrf_policy
+      # (or equivalent) provided the delegate implements this exact deny list.
+      ssrf_policy:
+        schemes_allowed: ["https"]
+        schemes_denied: ["http", "file", "gopher", "ftp", "ftps", "data", "javascript", "about", "ws", "wss"]
+        hosts_denied_ipv4_cidrs:
+          - "0.0.0.0/8"           # "this network"
+          - "10.0.0.0/8"          # RFC 1918 private
+          - "100.64.0.0/10"       # CGNAT
+          - "127.0.0.0/8"         # loopback
+          - "169.254.0.0/16"      # link-local (incl. 169.254.169.254 IMDS v1/v2)
+          - "172.16.0.0/12"       # RFC 1918 private
+          - "192.0.0.0/24"        # IETF protocol assignments
+          - "192.168.0.0/16"      # RFC 1918 private
+          - "224.0.0.0/4"         # multicast
+          - "240.0.0.0/4"         # reserved
+        hosts_denied_ipv6_cidrs:
+          - "::1/128"             # loopback
+          - "::/128"              # unspecified
+          - "::ffff:0:0/96"       # IPv4-mapped (re-check as IPv4)
+          - "64:ff9b::/96"        # IPv4/IPv6 translation
+          - "fc00::/7"            # unique local
+          - "fe80::/10"           # link-local
+          - "ff00::/8"            # multicast
+        hosts_denied_metadata:
+          # Cloud metadata hosts by name — the IP CIDRs above catch the standard
+          # 169.254.169.254 cases, but some providers expose hostname aliases.
+          - "metadata.google.internal"
+          - "metadata"
+          - "metadata.packet.net"
+          - "fd00:ec2::254"       # IMDS IPv6
+        host_literal_policy_verified: reject
+        # In AdCP Verified grading, reject ANY bare IP literal in preview_url
+        # (both IPv4 and IPv6) regardless of range — forces resolution through
+        # a public DNS name the grader can audit. Local-dev flags MAY relax this.
+        dns_revalidation: required
+        # After DNS resolution, EVERY resolved address MUST be re-checked against
+        # hosts_denied_*. Resolve once, bind to the resolved address for the
+        # request — do NOT pass the hostname to the HTTP client (closes DNS
+        # rebinding between resolve and connect).
+        redirects: follow_false_strict
+        # follow_redirects: false is already set above; this field documents
+        # the companion: if the origin returns 3xx, treat it as a failure
+        # (`preview_url_unusable` + sub-reason `redirect_returned`), do NOT
+        # chase — redirect chasing would require re-running the full SSRF
+        # policy at each hop and is out of scope for v1.
+
+# --- HTML attribute extraction set (normative) ---
+#
+# The runner extracts tracker URLs from the following attributes only. This
+# set is normative — runner MUST NOT under-extract (missing one of these
+# attributes lets a seller hide an unencoded value); runner MUST NOT over-
+# extract (e.g., arbitrary `data-*` attributes whose values happen to parse
+# as URLs but are not trackers). Extension to additional attributes MAY
+# happen in a future contract revision; today's set is closed.
+
+html_attribute_extraction_set:
+  tag_attribute_pairs:
+    - { tag: "a", attr: "href" }
+    - { tag: "img", attr: "src" }
+    - { tag: "img", attr: "srcset" }           # may contain multiple URLs
+    - { tag: "iframe", attr: "src" }
+    - { tag: "source", attr: "src" }
+    - { tag: "source", attr: "srcset" }
+    - { tag: "link", attr: "href" }
+    - { tag: "meta", attr: "content" }         # refresh redirects, og:image, etc.
+    - { tag: "*", attr: "data-impression-url" }
+    - { tag: "*", attr: "data-click-url" }
+    - { tag: "*", attr: "data-tracker-url" }
+    - { tag: "*", attr: "data-vast-url" }
+  srcset_handling: parse_per_descriptor
+  # srcset values are space-separated URL+descriptor pairs (e.g.,
+  # "a.jpg 1x, b.jpg 2x"). The runner MUST extract every URL component.
+  comment_nodes: ignored
+  script_text_content: ignored
+  # Tracker URLs in `<script>`-emitted document.write or similar are out
+  # of scope v1 — if a seller hides substitution inside script text, the
+  # runner does not see it (covered under "preview/serve code-path
+  # divergence" in out-of-scope, below).
+
+# --- Macro-position alignment algorithm (normative) ---
+#
+# The runner needs to map each extracted URL back to a position in the
+# submitted macro_template so it can compare the substituted bytes against
+# the expected_encoded form of the bound catalog-item value. The algorithm:
+#
+#   1. Parse `macro_template` with a WHATWG URL parser (absolute URLs only).
+#      Extract: scheme, host, port, path_segments[], query_pairs[{k,v}],
+#      fragment.
+#   2. Parse each extracted observed URL with the SAME parser. If an
+#      extracted URL is relative in the preview HTML, resolve against a
+#      synthetic base (`https://observer.test/`) so relative-resolution
+#      does not introduce cross-runner variance.
+#   3. Align query_pairs by key. A template pair {k: "sku", v: "{SKU}"}
+#      aligns to the observed pair whose key parses to the same sequence
+#      after percent-decoding `k`. If multiple observed pairs share a key,
+#      align positionally (template pair index N → observed pair index N
+#      among matching-key pairs).
+#   4. Align path_segments positionally. A template segment "{JOB_ID}"
+#      aligns to the observed segment at the same index.
+#   5. For each alignment, the observed value is the substituted output
+#      for that binding. Compare bytes against `expected_encoded` per the
+#      hex-case policy below.
+#
+# This algorithm is deterministic and does NOT depend on substring search
+# or regex — substring alignment fails on attacker values that happen to
+# equal other parts of the URL.
+
+# --- Hex case policy (normative) ---
+#
+# RFC 3986 §2.1 states producers SHOULD use uppercase hex digits in
+# percent-encoded triplets. This contract REQUIRES producers (sellers) to
+# emit uppercase hex (`%C3%A9`, not `%c3%a9`) to match the fixture's
+# expected_encoded values byte-for-byte.
+#
+# However, VERIFIERS (runners performing the byte comparison) MUST apply
+# case-insensitive comparison on the hex digits only — the two hex digits
+# inside a `%NN` triplet compare case-insensitively, every byte outside a
+# triplet compares case-sensitively. This accommodates legitimate producer
+# variation without silently accepting a non-conformant triplet encoding
+# (e.g., `%g7` is invalid regardless of case).
+#
+# Implementation note: @adcp/client.SubstitutionObserver.assert_rfc3986_safe
+# MUST implement the case-insensitive triplet comparison; runners MUST NOT
+# do naive byte-equal comparison.
+
+hex_case_policy:
+  producer_requirement: uppercase
+  verifier_comparison: case_insensitive_hex_digits_only
 
 # --- Attacker-shaped catalog values ---
 #
-# Storyboards consuming this contract push a small catalog with pre-defined
-# attacker-shaped values. The runner knows the mapping between catalog field
-# and target macro, so it can assert the emitted tracker URL contains the
-# encoded form of the original value (not the raw form).
-#
-# The six canonical attacker shapes match the unit-test fixture at
-# static/test-vectors/catalog-macro-substitution.json — storyboards SHOULD
-# reuse that fixture's payloads so library-level and runtime-level conformance
-# exercise the same vectors.
+# The canonical vectors live in the unit-test fixture at
+# static/test-vectors/catalog-macro-substitution.json. The fixture is the
+# SINGLE SOURCE OF TRUTH for `raw_value` and `expected_encoded` — the
+# runner MUST load the fixture at run time and look up each vector by name.
+# This contract NAMES the vectors a consuming storyboard can reference;
+# it does NOT duplicate the encoded values (they would drift).
 
 attacker_value_catalog:
   source_fixture: static/test-vectors/catalog-macro-substitution.json
-  canonical_vectors:
-    - vector: reserved_character_breakout
-      raw_value: "00013&cmd=drop"
-      expected_encoded: "00013%26cmd%3Ddrop"
-    - vector: nested_expansion_preserved
-      raw_value: "vacancy-{DEVICE_ID}-42"
-      expected_encoded: "vacancy-%7BDEVICE_ID%7D-42"
-    - vector: crlf_injection_neutralized
-      raw_value: "abc\r\nHost: evil.example"
-      expected_encoded: "abc%0D%0AHost%3A%20evil.example"
-    - vector: non_ascii_utf8
-      raw_value: "café-amsterdam"
-      expected_encoded: "caf%C3%A9-amsterdam"
-    - vector: path_and_query_mixed
-      raw_value: "gmc/primary feed"
-      expected_encoded: "gmc%2Fprimary%20feed"
-    - vector: bidi_override_neutralized
-      raw_value: "VIN-\u202E1234"
-      expected_encoded: "VIN-%E2%80%AE1234"
+  canonical_vector_names:
+    - reserved-character-breakout
+    - nested-expansion-preserved-as-literal
+    - crlf-injection-neutralized
+    - non-ascii-utf8-percent-encoding
+    - mixed-path-and-query-contexts
+    - bidi-override-neutralized
+    - url-scheme-injection-neutralized
 
 # --- Storyboard-layer step task ---
 #
@@ -143,47 +264,70 @@ attacker_value_catalog:
 #
 # Arguments:
 #   source:
-#     preview_html  | preview_url  | response_body
-#     Which response field the runner observes. Default: preview_html.
+#     html_inline  | url_fetch
+#     Which observation mode the runner uses. Default: html_inline.
 #   source_path:
-#     JSON-pointer into the previous step's response where `source` lives.
-#     Example: "/creative_manifest/preview_html"
+#     JSON-pointer into the previous step's response where the preview
+#     artifact lives. Example: "/creative_manifest/preview_html".
 #   macro_template:
 #     The URL template containing AdCP macros (the value submitted via
 #     sync_creatives). Example: "https://track.example/imp?sku={SKU}"
 #   catalog_bindings:
-#     Array of { macro, catalog_field, item_id, expected_encoded }
-#     describing which catalog item's field feeds which macro, and what
-#     the encoded form MUST be.
-#   require_all_bindings_observed:
-#     Default true. If true, the step fails when the extracted tracker URLs
-#     do not include EVERY binding — catches a seller that silently strips
-#     macros rather than substituting. If false, only observed bindings are
-#     checked (permissive; useful when preview shows one item from a larger
-#     catalog).
+#     Array of { macro, catalog_item_id, vector_name } entries. The runner
+#     loads the fixture (by source_fixture path above), looks up each
+#     vector_name, and binds `{macro}` to the vector's raw_value →
+#     expected_encoded pair. Storyboard authors DO NOT duplicate
+#     raw_value/expected_encoded inline; the fixture is authoritative.
+#
+#     Optional override fields for non-canonical vectors (e.g., seller-
+#     specific payloads not in the fixture): `raw_value` and
+#     `expected_encoded` MAY be inlined, and when inlined the runner skips
+#     the fixture lookup. Runners MUST redact `raw_value` from error
+#     reports for inlined custom vectors (treat as potentially sensitive);
+#     canonical fixture values MAY be echoed verbatim because the fixture
+#     is public.
+#   require_every_binding_observed:
+#     Default `true`. When true, the step fails if any declared binding is
+#     not observed in the extracted URLs — catches a seller that silently
+#     strips a macro rather than substituting it. Storyboard authors MUST
+#     explicitly set `false` and document why (e.g., preview shows one
+#     item from a larger catalog) when partial observation is legitimate.
+#     The previous name `require_all_bindings_observed` is deprecated; the
+#     new name disambiguates "every declared binding" from "every URL
+#     matches some binding."
 #
 # Validations (runner-internal; storyboards reference them by name):
 #
 #   substitution_encoded:
-#     For each binding, the extracted URL at the macro position MUST equal
-#     expected_encoded byte-for-byte. Raw-value leakage (any byte of the raw
-#     attacker shape appearing literally at the macro position) fails the
-#     step with `substitution_encoding_violation` plus the offending byte
-#     offset and the library-expected encoding.
+#     For each binding, the observed value at the aligned macro position
+#     MUST equal the fixture's `expected_encoded` under the hex_case_policy
+#     comparison. Raw-value leakage (any byte of `raw_value` appearing
+#     literally at the macro position) fails with
+#     `substitution_encoding_violation` plus the binding, observed URL,
+#     byte offset of divergence, and expected form.
 #
 #   nested_expansion_not_re_scanned:
-#     For the nested_expansion_preserved vector specifically: the extracted
-#     URL MUST contain `%7BDEVICE_ID%7D` (encoded braces) and MUST NOT contain
-#     any resolved value for {DEVICE_ID}. A second-round expansion fails
-#     with `nested_macro_re_expansion`.
+#     For the `nested-expansion-preserved-as-literal` vector specifically:
+#     the observed URL MUST contain `%7BDEVICE_ID%7D` (encoded braces) and
+#     MUST NOT contain any resolved value for {DEVICE_ID}. A second-round
+#     expansion fails with `nested_macro_re_expansion`.
+#
+#   url_scheme_preserved:
+#     For the `url-scheme-injection-neutralized` vector at an
+#     href-whole-value macro binding (i.e., the macro occupies the entire
+#     attribute value, like `<a href="{CLICK}">`): the scheme of the
+#     parsed observed URL MUST equal the scheme of the template. A
+#     substituted value that changes the scheme (e.g., `javascript:`
+#     appearing as the scheme of the observed URL) fails with
+#     `substitution_scheme_injection`.
 #
 #   rfc3986_unreserved_only_at_macro_position:
-#     A stricter check than substitution_encoded — verifies that every byte
-#     emitted at the macro position is either unreserved (ALPHA / DIGIT /
-#     "-" / "." / "_" / "~") or a percent-encoded triplet. A conformant
-#     encoder passes this trivially; an encoder that uses a reserved-char
-#     allowlist (rather than unreserved-whitelist) fails specifically on
-#     the CRLF and bidi vectors.
+#     A stricter check than substitution_encoded — verifies that every
+#     byte emitted at the macro position is either unreserved
+#     (ALPHA / DIGIT / "-" / "." / "_" / "~") or a percent-encoded triplet.
+#     Producers using a reserved-char allowlist (rather than
+#     unreserved-whitelist) fail specifically on the CRLF and bidi
+#     vectors.
 
 step_task:
   name: expect_substitution_safe
@@ -191,34 +335,60 @@ step_task:
   error_modes:
     - substitution_encoding_violation
     - nested_macro_re_expansion
+    - substitution_scheme_injection
     - substitution_binding_missing
     - preview_source_unavailable
-    - preview_url_fetch_failed
-    - preview_body_not_html
+    - preview_url_unusable       # collapses fetch-failed + body-not-html + ssrf-blocked into one code with sub-reasons
+  preview_url_unusable_sub_reasons:
+    - http_status                # non-200 response
+    - content_type               # not text/html or application/xhtml+xml
+    - size_exceeded              # body > max_body_bytes
+    - redirect_returned          # 3xx without follow
+    - ssrf_blocked               # ssrf_policy deny-hit, with specific rule id in the detail
+    - fetch_timeout              # exceeded max_connect_seconds or timeout_seconds
 
 # --- @adcp/client primitives the runner consumes ---
 #
 # The runner does NOT reimplement HTML parsing, URL extraction, or the RFC
 # 3986 encoding check. It consumes library primitives so production code
 # paths match conformance paths.
+#
+# The library surface is deliberately split into `observer/` (runner-side)
+# and `encoder/` (seller-side) modules sharing RFC 3986 primitives
+# underneath. Runners import only observer/; sellers implementing the
+# #2620 rule import only encoder/. Premature coupling is avoided.
 
 client_primitives:
   substitution_observer:
     reference: SubstitutionObserver
     methods:
-      - parse_html(html: string) -> TrackerUrlRecord[]
-      - fetch_and_parse(url: URL) -> TrackerUrlRecord[]
-      - assert_rfc3986_safe(url: URL, binding: CatalogBinding) -> AssertionResult
-      - assert_no_nested_expansion(url: URL, prohibited_pattern: RegExp) -> AssertionResult
-    proposed_location: "@adcp/client/src/substitution-observer/"
+      - "parse_html(html: string) -> TrackerUrlRecord[]"
+      - "fetch_and_parse(url: URL) -> Promise<TrackerUrlRecord[]>"
+      - "match_bindings(records: TrackerUrlRecord[], template: URL, bindings: CatalogBinding[]) -> BindingMatch[]"
+      - "assert_rfc3986_safe(match: BindingMatch) -> AssertionResult"
+      - "assert_no_nested_expansion(match: BindingMatch, prohibited_pattern: RegExp) -> AssertionResult"
+      - "assert_scheme_preserved(match: BindingMatch, template_scheme: string) -> AssertionResult"
+      - "enforce_ssrf_policy(url: URL, policy: SsrfPolicy) -> PolicyResult"
+    proposed_location: "@adcp/client/src/substitution/observer/"
     doc: "To be filed as an adcp-client PR when #2638 lands."
+
+  encoder_companion:
+    # Sibling module for seller-side production use. Shares RFC 3986
+    # primitives with observer/ so a single bug fix covers both.
+    reference: SubstitutionEncoder
+    methods:
+      - "encode_for_url_context(raw_value: string) -> string"
+      - "reject_if_contains_macro(raw_value: string) -> void | throw"
+    proposed_location: "@adcp/client/src/substitution/encoder/"
+    doc: "Seller-facing counterpart to observer/. Same library, disjoint API."
 
   tracker_url_record:
     reference: TrackerUrlRecord
     shape: |
       {
         url: URL;                    // parsed URL object
-        source_attr: string;         // 'href' | 'src' | 'data-impression-url' | …
+        source_attr: string;         // 'href' | 'src' | 'srcset' | 'data-impression-url' | …
+        source_tag: string;          // 'a' | 'img' | 'iframe' | 'meta' | …
         line_hint: number | null;    // best-effort line number in preview HTML
       }
 
@@ -227,10 +397,11 @@ client_primitives:
     shape: |
       {
         macro: string;                // e.g., "{GTIN}"
-        catalog_field: string;        // e.g., "items[0].sku"
-        item_id: string;              // e.g., "trail_pro_3000"
-        raw_value: string;            // attacker-shaped input
-        expected_encoded: string;     // rfc3986_unreserved-encoded form
+        catalog_item_id: string;      // looks up raw_value from preceding
+                                      // sync_catalogs response + fixture
+        vector_name: string;          // e.g., "reserved-character-breakout"
+        raw_value?: string;           // optional override (custom vectors)
+        expected_encoded?: string;    // optional override (custom vectors)
       }
 
 # --- Grading decision tree ---
@@ -244,23 +415,31 @@ client_primitives:
 #     not_applicable with a reason; does NOT contribute to the pass rate.
 #
 #   pass:
-#     All bindings in `catalog_bindings` appear at their macro positions in
-#     extracted tracker URLs, each byte-equal to `expected_encoded`.
+#     Every declared binding in `catalog_bindings` (when
+#     require_every_binding_observed is true — the default) is observed at
+#     an aligned macro position, each byte-equal (under hex_case_policy) to
+#     the fixture's `expected_encoded` for that vector. The nested-expansion
+#     vector additionally passes `nested_expansion_not_re_scanned`.
 #
 #   fail with `substitution_encoding_violation`:
-#     At least one binding's extracted value differs from expected_encoded
-#     in any byte. Runner MUST include the binding, the observed URL, the
-#     offending byte offset, and the expected encoding in the error report.
+#     At least one binding's observed value differs from expected_encoded.
+#     Runner MUST include the binding, the observed URL, the offending byte
+#     offset, and the expected encoding in the error report.
 #
 #   fail with `nested_macro_re_expansion`:
-#     The nested_expansion_preserved vector's macro position contains any
-#     byte sequence that resolves as a second-round AdCP macro. Includes
-#     the resolved macro name and its unexpected value.
+#     The nested-expansion-preserved-as-literal vector's macro position
+#     contains any byte sequence that resolves as a second-round AdCP
+#     macro. Includes the resolved macro name and its unexpected value.
+#
+#   fail with `substitution_scheme_injection`:
+#     A binding at an href-whole-value position produced an observed URL
+#     whose scheme differs from the template's scheme. Includes the
+#     template scheme, observed scheme, and binding.
 #
 #   fail with `substitution_binding_missing`:
-#     `require_all_bindings_observed: true` (default) and one or more
-#     bindings are not present in any extracted URL. Catches a seller that
-#     silently drops the macro.
+#     `require_every_binding_observed: true` (default) and one or more
+#     bindings are not present in the extracted URLs. Catches a seller
+#     that silently drops the macro.
 #
 #   fail with `preview_source_unavailable`:
 #     The configured `source_path` resolves to null or an empty string in
@@ -268,9 +447,33 @@ client_primitives:
 #     the contract; specialism MAY grade not_applicable if the agent does
 #     not advertise preview support.
 #
-#   fail with `preview_url_fetch_failed` / `preview_body_not_html`:
-#     preview_url fetch path specific. The runner includes the HTTP status
-#     or the offending content-type in the error report.
+#   fail with `preview_url_unusable`:
+#     The url_fetch path failed. Sub-reason set to one of http_status,
+#     content_type, size_exceeded, redirect_returned, ssrf_blocked, or
+#     fetch_timeout. `ssrf_blocked` includes the specific policy rule id
+#     (e.g., `hosts_denied_ipv4_cidrs:169.254.0.0/16`) so runner operators
+#     can distinguish grader-policy failures from seller bugs.
+
+# --- Error-report payload handling ---
+#
+# Canonical fixture vectors in attacker_value_catalog.canonical_vector_names
+# are public — runners MAY echo raw_value and expected_encoded verbatim in
+# error reports, logs, and grader telemetry.
+#
+# CUSTOM vectors (a storyboard author inlining their own raw_value /
+# expected_encoded for a seller-specific payload) MUST be redacted in error
+# reports: runners MUST replace the raw_value with a SHA-256 hex digest
+# prefixed `sha256:` UNLESS the grader was started with an explicit
+# --include-raw-payloads flag (default-off, disabled in AdCP Verified).
+# This prevents CI logs from becoming a searchable repository of seller-
+# reported attack payloads.
+
+error_report_payload_policy:
+  canonical_vectors: echo_verbatim
+  custom_vectors: redact_to_sha256_unless_flag
+  grader_flag_name: "--include-raw-payloads"
+  grader_flag_default: false
+  verified_mode: flag_disabled
 
 # --- Out of scope v1 ---
 #
@@ -281,10 +484,15 @@ client_primitives:
 #     universal URL-encoding check across all macros is tracked as a
 #     potential 3.2+ scope, not v1.
 #
-#   - HTML-attribute context assertions. The #2620 rule explicitly scopes
-#     to URL contexts; HTML-attribute escaping is the publisher's
-#     responsibility. A runner that detects a catalog value rendered
-#     unencoded into an HTML attribute SHOULD warn but MUST NOT fail.
+#   - HTML-attribute context assertions for non-URL-bearing attributes.
+#     This contract DOES extract from URL-bearing attributes (the
+#     `html_attribute_extraction_set` above) because those are the
+#     substitution surfaces #2620 governs. Non-URL attribute contexts —
+#     e.g., `<div data-title="{PRODUCT_TITLE}">` where the value goes into
+#     a text context, not a URL context — are the publisher's
+#     HTML-attribute-escaping responsibility and out of AdCP's scope per
+#     the #2620 rule text. A runner that detects a catalog value in a
+#     non-URL attribute SHOULD warn but MUST NOT fail.
 #
 #   - VAST XML bodies. VAST macros use [SQUARE_BRACKETS] and resolve in
 #     the player, not in AdCP. Runners MAY extract tracker URLs from VAST
@@ -294,3 +502,51 @@ client_primitives:
 #   - Non-preview surfaces (post-impression log introspection, direct
 #     ad-server querying). Those require a different contract — not this
 #     one — and are a separate 3.2+ RFC.
+#
+#   - Preview/serve code-path equivalence. This contract assumes the
+#     preview renderer shares substitution implementation with the
+#     impression-time renderer. Sellers with divergent paths (a separate
+#     serving tier, a compiled-ahead-of-time preview cache, etc.) MAY
+#     pass preview conformance while failing at serve time. Post-impression
+#     log introspection (above) is the complementary check. AdCP Verified
+#     grading SHOULD require sellers to attest to shared-path
+#     implementation; until that attestation exists, this contract's
+#     coverage claim is scoped to the preview surface only.
+#
+#   - Script-emitted substitution. Tracker URLs written to the document
+#     via <script> content (document.write, innerHTML, attachShadow) are
+#     not extracted by `html_inline` or `url_fetch`. A seller hiding
+#     substitution inside script text is not caught by v1; the runner
+#     treats script text as opaque (see `html_attribute_extraction_set`
+#     above).
+
+# --- Scope summary (machine-readable) ---
+
+scope:
+  in_scope:
+    - catalog_item_macro_substitution
+    - url_contexts_impression_click_vast_landing
+    - preview_html_observation
+    - preview_url_fetch_observation_with_ssrf_policy
+    - html_attribute_extraction_bounded_set
+    - rfc3986_unreserved_only_byte_comparison
+    - nested_macro_expansion_prohibition
+    - url_scheme_preservation_at_whole_value_position
+  out_of_scope:
+    - non_catalog_macros
+    - non_url_html_attribute_contexts
+    - vast_xml_macro_substitution
+    - post_impression_log_introspection
+    - preview_serve_code_path_equivalence
+    - script_emitted_substitution
+
+# --- References ---
+
+references:
+  spec: docs/creative/universal-macros.mdx#substitution-safety-catalog-item-macros
+  upstream_rule_pr: "#2620"
+  contract_rfc: "#2638"
+  consumer_coverage_rfc: "#2640"
+  unit_test_fixture: static/test-vectors/catalog-macro-substitution.json
+  sibling_contract_webhook: static/compliance/source/test-kits/webhook-receiver-runner.yaml
+  sibling_contract_signed_requests: static/compliance/source/test-kits/signed-requests-runner.yaml

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -437,6 +437,33 @@
 #   signature_key_purpose_invalid, signature_digest_mismatch, signature_tag_invalid,
 #   signature_replayed.
 #
+# task: expect_substitution_safe
+#   Assert that a creative preview (preview_html or preview_url) contains
+#   substituted catalog-item macro values that are percent-encoded per RFC 3986
+#   (unreserved-whitelist), per docs/creative/universal-macros#substitution-safety-catalog-item-macros.
+#   Runner delegates HTML parsing, URL extraction, and the encoding check to
+#   the `@adcp/client` SubstitutionObserver primitive (see test-kit
+#   substitution-observer-runner.yaml). Catches implementations that pass raw
+#   attacker bytes through substitution, including CRLF injection, bidi-override
+#   spoofing, and reserved-character URL breakout.
+#
+#   Fields:
+#     source: preview_html | preview_url  # default preview_html
+#     source_path: "<JSON pointer into previous step's response>"
+#     macro_template: "<URL template with {MACRO} placeholders>"
+#     catalog_bindings:
+#       - macro: "{SKU}"
+#         catalog_field: "items[0].sku"
+#         item_id: "<catalog item_id>"
+#         raw_value: "<attacker-shaped input>"
+#         expected_encoded: "<RFC 3986 unreserved-encoded form>"
+#     require_all_bindings_observed: true  # default true
+#     requires_contract: substitution_observer_runner
+#
+#   Error modes: substitution_encoding_violation, nested_macro_re_expansion,
+#   substitution_binding_missing, preview_source_unavailable,
+#   preview_url_fetch_failed, preview_body_not_html.
+#
 # --- shared_receiver (deferred / out of scope v1) ---
 #
 # Storyboards with multiple webhook-triggering steps MUST use per-step receiver

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -445,24 +445,33 @@
 #   the `@adcp/client` SubstitutionObserver primitive (see test-kit
 #   substitution-observer-runner.yaml). Catches implementations that pass raw
 #   attacker bytes through substitution, including CRLF injection, bidi-override
-#   spoofing, and reserved-character URL breakout.
+#   spoofing, reserved-character URL breakout, and javascript:-scheme injection.
 #
 #   Fields:
-#     source: preview_html | preview_url  # default preview_html
+#     source: html_inline | url_fetch  # default html_inline
 #     source_path: "<JSON pointer into previous step's response>"
 #     macro_template: "<URL template with {MACRO} placeholders>"
 #     catalog_bindings:
 #       - macro: "{SKU}"
-#         catalog_field: "items[0].sku"
-#         item_id: "<catalog item_id>"
-#         raw_value: "<attacker-shaped input>"
-#         expected_encoded: "<RFC 3986 unreserved-encoded form>"
-#     require_all_bindings_observed: true  # default true
+#         catalog_item_id: "<item_id in the synced catalog>"
+#         vector_name: "<fixture entry name, e.g. reserved-character-breakout>"
+#         # Optional overrides for custom (non-canonical-fixture) vectors:
+#         # raw_value: "<attacker-shaped input>"
+#         # expected_encoded: "<RFC 3986 unreserved-encoded form>"
+#     require_every_binding_observed: true  # default true. Opt to false only
+#                                           # when preview shows a partial
+#                                           # catalog and partial observation
+#                                           # is legitimate (document why in
+#                                           # the narrative). The old field
+#                                           # name require_all_bindings_observed
+#                                           # is deprecated.
 #     requires_contract: substitution_observer_runner
 #
 #   Error modes: substitution_encoding_violation, nested_macro_re_expansion,
-#   substitution_binding_missing, preview_source_unavailable,
-#   preview_url_fetch_failed, preview_body_not_html.
+#   substitution_scheme_injection, substitution_binding_missing,
+#   preview_source_unavailable, preview_url_unusable (with sub-reason:
+#   http_status | content_type | size_exceeded | redirect_returned |
+#   ssrf_blocked | fetch_timeout).
 #
 # --- shared_receiver (deferred / out of scope v1) ---
 #

--- a/static/test-vectors/catalog-macro-substitution.json
+++ b/static/test-vectors/catalog-macro-substitution.json
@@ -51,6 +51,14 @@
       "value": "VIN-\u202E1234",
       "template": "https://track.example/imp?v={VEHICLE_ID}",
       "expected": "https://track.example/imp?v=VIN-%E2%80%AE1234"
+    },
+    {
+      "name": "url-scheme-injection-neutralized",
+      "description": "A catalog value containing `javascript:alert(0)` substituted into an href-whole-value position (e.g., `<a href=\"{CLICK}\">`) would otherwise execute as a javascript: scheme URL. The strict unreserved-whitelist rule percent-encodes the colon and parens so the browser parses the result as a relative URL against the base, neutralizing the injection. Parentheses `(` and `)` are NOT in RFC 3986 `unreserved` (they are sub-delims), so the strict rule encodes them — encodeURIComponent-based encoders that leave parens alone FAIL this vector, which is how the runtime observer (#2638) distinguishes strict-RFC-3986 encoders from permissive ones.",
+      "macro": "{CLICK}",
+      "value": "javascript:alert(0)",
+      "template": "https://track.example/go?c={CLICK}",
+      "expected": "https://track.example/go?c=javascript%3Aalert%280%29"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes [#2638](https://github.com/adcontextprotocol/adcp/issues/2638) — drafts the `substitution_observer_runner` test-kit contract and wires up the first consumer phase.

The #2620 spec rule (sales agents MUST percent-encode catalog-item macro values per RFC 3986 unreserved-whitelist before substitution into URL contexts) shipped with a library-level conformance artifact — the 6-vector fixture at `static/test-vectors/catalog-macro-substitution.json`. It had no runtime conformance test. A non-conformant seller whose library code is broken could still pass every storyboard in the suite.

This PR lands the runtime side.

## What's in the box

**`static/compliance/source/test-kits/substitution-observer-runner.yaml`** — new test-kit contract. Mirrors the black-box shape of `webhook-receiver-runner.yaml`:

- **Two observation modes**: `preview_html_inline` (default for lint/fast) parses `preview_html` from the response; `preview_url_fetch` (default for AdCP Verified) fetches `preview_url` over HTTPS with SSRF allowlist enforcement.
- **`attacker_value_catalog`** cross-references the six canonical vectors from the unit-test fixture so library-level and runtime-level conformance exercise the same payloads.
- **`step_task: expect_substitution_safe`** documented with full argument shape and six error modes (`substitution_encoding_violation`, `nested_macro_re_expansion`, `substitution_binding_missing`, `preview_source_unavailable`, `preview_url_fetch_failed`, `preview_body_not_html`).
- **`client_primitives.substitution_observer`** reserves the proposed `@adcp/client` surface (`parse_html`, `fetch_and_parse`, `assert_rfc3986_safe`, `assert_no_nested_expansion`) so conformance and production code paths share one implementation.
- **Out-of-scope v1** explicitly called out: non-catalog macros, HTML-attribute contexts, VAST XML, post-impression log introspection.

**`static/compliance/source/universal/storyboard-schema.yaml`** — registered `task: expect_substitution_safe` alongside the webhook task types so runners and storyboards share one schema.

**`static/compliance/source/specialisms/sales-catalog-driven/index.yaml`** — new `substitution_safety` phase inserted between `catalog_sync` and `create_buy`. Three steps:

1. `sync_attacker_shaped_catalog` — pushes three canonical attacker-shaped values (reserved-char breakout, nested-expansion preservation, non-ASCII UTF-8) as catalog items.
2. `build_catalog_aware_creative` — builds a creative with `{SKU}` in impression/click trackers and `include_preview: true`.
3. `expect_substitution_safe` — gated on `substitution_observer_runner`. Runners without the contract grade `not_applicable`; the earlier two steps still run.

## Why `sales-catalog-driven` only

`sales-social`, `creative-generative`, and `sales-retail-media` all get their catalog phases in #2640 ([PR #2645](https://github.com/adcontextprotocol/adcp/pull/2645)). Adding `expect_substitution_safe` to those specialisms in this PR would require branching off a main that has #2640 merged, which it doesn't yet. The extension pattern is obvious (add the step to each specialism's catalog phase) — tracked as a follow-up on #2638 after both PRs land.

## Test plan

- [x] `npm run test:storyboard-scoping` passes (3/3)
- [x] `npm run test:error-codes` passes (pre-existing YAML warnings unrelated)
- [x] `npm run test:unit` passes (631 tests)
- [x] `npm run typecheck` passes
- [ ] Spec review — confirm the `@adcp/client.SubstitutionObserver` primitive surface is the right shape before it gets implemented in the client repo
- [ ] Reference-runner implementation — file a tracking issue in adcontextprotocol/adcp-client for the `SubstitutionObserver` implementation

Depends on: **#2640 / [#2645](https://github.com/adcontextprotocol/adcp/pull/2645)** (for extending the pattern to sales-social and creative-generative — not blocking this PR's merge, just a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)