### PR TITLE
compliance: extend expect_substitution_safe to creative-generative (#2638 follow-up)

### DIFF
--- a/.changeset/extend-expect-substitution-safe.md
+++ b/.changeset/extend-expect-substitution-safe.md
@@ -1,0 +1,21 @@
+---
+---
+
+compliance: extend expect_substitution_safe to creative-generative (#2638 follow-up)
+
+Second consumer of the `substitution_observer_runner` test-kit contract (#2647), now that both prerequisites have merged:
+
+- #2645 — `creative-generative` has a `catalog_augmented_generation` phase with `build_creative` returning `preview_html`
+- #2647 — the observer contract is live
+
+Adds a new `catalog_substitution_safety` phase to `creative-generative/index.yaml` mirroring the pattern already established in `sales-catalog-driven`:
+
+1. `sync_substitution_probe_catalog` — pushes three canonical attacker-shaped values (`reserved-character-breakout`, `nested-expansion-preserved-as-literal`, `non-ascii-utf8-percent-encoding`) as catalog-item `sku` fields.
+2. `build_substitution_probe_creative` — generates a creative whose impression tracker URL binds `{SKU}`, with `include_preview: true`.
+3. `expect_substitution_safe` — gated on `substitution_observer_runner`. Uses fixture-lookup shape (`catalog_item_id` + `vector_name`) with `require_every_binding_observed: true`.
+
+## sales-social deliberately deferred
+
+Tracked as a follow-up issue in this PR's description, not landed here. `sales-social` specialisms use `sync_creatives` to register DPA templates but have no AdCP-level preview hook — social platforms substitute at serve time in their own rendering pipeline. Adding `preview_creative` to sales-social's `required_tools` would force an API surface that doesn't match real social-platform implementations. The observer contract's `preview_html` observation path assumes substitution happens in the agent being tested; for specialisms without a preview surface, a different observation hook is needed (post-impression log introspection, or a dedicated dry-run substitution endpoint). Filed as a separate issue.
+
+No spec change. No schema change. `creative-generative` runners without the observer contract grade the new phase's `expect_substitution_safe` step `not_applicable`; the preceding two steps exercise the catalog-acceptance and build paths unconditionally.

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -541,3 +541,155 @@ phases:
             path: "context.correlation_id"
             value: "creative_generative--build_catalog_aware_creative"
             description: "Context correlation_id returned unchanged"
+
+  - id: catalog_substitution_safety
+    title: "Catalog-item macro substitution safety"
+    narrative: |
+      Per docs/creative/universal-macros#substitution-safety-catalog-item-macros,
+      sales and creative agents MUST percent-encode catalog-item macro values
+      such that only RFC 3986 `unreserved` characters remain unescaped before
+      substituting them into a URL context. Nested macro expansion is prohibited.
+
+      This phase exercises the rule with attacker-shaped catalog values drawn
+      from the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`:
+      reserved-char breakout, nested-expansion preservation, and non-ASCII
+      UTF-8. `preview_creative` / `build_creative`-with-`include_preview` is
+      the natural observation point on a generative specialism — the
+      substitution-observer runner (#2638) parses the returned `preview_html`
+      and asserts each macro position carries the fixture's `expected_encoded`
+      form, not the raw attacker bytes.
+
+      The `expect_substitution_safe` step is gated on the
+      `substitution_observer_runner` test-kit contract (see
+      `test-kits/substitution-observer-runner.yaml`). Runners that do not
+      advertise the contract grade the step as `not_applicable` — the earlier
+      `sync_substitution_probe_catalog` and `build_substitution_probe_creative`
+      steps still run (exercising the catalog-acceptance and build paths),
+      but the substituted-URL assertion is skipped.
+
+    steps:
+      - id: sync_substitution_probe_catalog
+        title: "Push a probe catalog with attacker-shaped values"
+        narrative: |
+          Push a small probe catalog whose `sku` fields contain three of the
+          canonical attacker-shaped values from the substitution-safety
+          fixture. The agent MUST accept the payload at sync_catalogs — the
+          encoding rule applies at substitution time, not at ingest — but
+          subsequent build_creative output must percent-encode each value.
+        task: sync_catalogs
+        schema_ref: "media-buy/sync-catalogs-request.json"
+        response_schema_ref: "media-buy/sync-catalogs-response.json"
+        doc_ref: "/media-buy/task-reference/sync_catalogs"
+        stateful: true
+        expected: |
+          Catalog accepted with per-item counts. Runner captures the
+          catalog_id + item_ids for the downstream assertion binding.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          catalogs:
+            - catalog_id: "creative_generative_substitution_probe_v1"
+              type: "product"
+              content_id_type: "sku"
+              name: "Substitution safety probe"
+              items:
+                # item_id names the vector; the `sku` field carries the
+                # attacker-shaped value that substitution must encode.
+                - item_id: "reserved_char_breakout"
+                  sku: "00013&cmd=drop"
+                  title: "Reserved-char breakout probe"
+                  url: "https://acmeoutdoor.example/probe/reserved"
+                  image_url: "https://cdn.acmeoutdoor.example/probe/reserved.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+                - item_id: "nested_expansion"
+                  sku: "vacancy-{DEVICE_ID}-42"
+                  title: "Nested-expansion probe"
+                  url: "https://acmeoutdoor.example/probe/nested"
+                  image_url: "https://cdn.acmeoutdoor.example/probe/nested.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+                - item_id: "non_ascii"
+                  sku: "café-amsterdam"
+                  title: "Non-ASCII UTF-8 probe"
+                  url: "https://acmeoutdoor.example/probe/non-ascii"
+                  image_url: "https://cdn.acmeoutdoor.example/probe/non-ascii.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+
+          idempotency_key: "$generate:uuid_v4#creative_generative_catalog_substitution_safety_sync_substitution_probe_catalog"
+          context:
+            correlation_id: "creative_generative--sync_substitution_probe_catalog"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-catalogs-response.json schema"
+          - check: field_present
+            path: "catalogs[0].catalog_id"
+            description: "Probe catalog accepted"
+
+      - id: build_substitution_probe_creative
+        title: "Generate a creative with catalog-item macros bound to the probe"
+        narrative: |
+          Generate a draft creative that uses `{SKU}` in its impression tracker
+          URL and request `include_preview: true` so the substitution-observer
+          runner has a preview surface to inspect.
+        task: build_creative
+        schema_ref: "media-buy/build-creative-request.json"
+        response_schema_ref: "media-buy/build-creative-response.json"
+        doc_ref: "/creative/task-reference/build_creative"
+        comply_scenario: creative_flow
+        stateful: true
+        expected: |
+          Creative manifest returned with preview_html populated. Impression
+          tracker asset includes {SKU} bound to the probe catalog's items.
+
+        sample_request:
+          message: "Generate a 300x250 display ad for the creative_generative_substitution_probe_v1 catalog. Use {SKU} in the impression tracker URL."
+          target_format_id:
+            agent_url: "https://your-agent.example.com"
+            id: "display_300x250_generative"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          quality: "draft"
+          include_preview: true
+
+          idempotency_key: "$generate:uuid_v4#creative_generative_catalog_substitution_safety_build_substitution_probe_creative"
+          context:
+            correlation_id: "creative_generative--build_substitution_probe_creative"
+        validations:
+          - check: response_schema
+            description: "Response matches build-creative-response.json schema"
+          - check: field_present
+            path: "creative_manifest.format_id"
+            description: "Creative manifest returned"
+
+      - id: expect_substitution_safe
+        title: "Assert substituted tracker URLs percent-encode attacker shapes"
+        narrative: |
+          The runner inspects the preview_html from the previous step, extracts
+          tracker URLs that bind `{SKU}` to a probe catalog item, and asserts
+          each value is percent-encoded per RFC 3986 (unreserved-whitelist).
+          Raw-byte leakage fails. Every declared binding MUST be observed — a
+          generative agent that silently strips `{SKU}` rather than
+          substituting it fails with `substitution_binding_missing`.
+        task: expect_substitution_safe
+        requires_contract: substitution_observer_runner
+        source: html_inline
+        source_path: "/creative_manifest/preview_html"
+        macro_template: "https://track.example/imp?sku={SKU}"
+        require_every_binding_observed: true
+        catalog_bindings:
+          # Each binding: `catalog_item_id` is the item_id in the probe
+          # catalog; `vector_name` is the fixture entry whose raw_value and
+          # expected_encoded the runner loads from the unit-test fixture.
+          - macro: "{SKU}"
+            catalog_item_id: "reserved_char_breakout"
+            vector_name: "reserved-character-breakout"
+          - macro: "{SKU}"
+            catalog_item_id: "nested_expansion"
+            vector_name: "nested-expansion-preserved-as-literal"
+          - macro: "{SKU}"
+            catalog_item_id: "non_ascii"
+            vector_name: "non-ascii-utf8-percent-encoding"

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -683,7 +683,7 @@ phases:
           resolved at impression time against catalog items).
 
         sample_request:
-          message: "Generate a 300x250 display ad for the creative_generative_substitution_probe_v1 catalog. Use the literal `{SKU}` macro (unsubstituted) in at least one impression tracker URL so the platform can resolve it per-impression against catalog items."
+          message: "Generate a 300x250 display ad for the creative_generative_substitution_probe_v1 catalog. Include the `{SKU}` macro as a literal token in the impression tracker URL — the platform resolves it per-impression against catalog items."
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250_generative"

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -550,14 +550,32 @@ phases:
       such that only RFC 3986 `unreserved` characters remain unescaped before
       substituting them into a URL context. Nested macro expansion is prohibited.
 
-      This phase exercises the rule with attacker-shaped catalog values drawn
-      from the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`:
-      reserved-char breakout, nested-expansion preservation, and non-ASCII
-      UTF-8. `preview_creative` / `build_creative`-with-`include_preview` is
-      the natural observation point on a generative specialism — the
-      substitution-observer runner (#2638) parses the returned `preview_html`
-      and asserts each macro position carries the fixture's `expected_encoded`
-      form, not the raw attacker bytes.
+      This phase exercises the rule with five canonical attacker-shaped
+      catalog values drawn from the fixture at
+      `static/test-vectors/catalog-macro-substitution.json`:
+      reserved-char breakout, nested-expansion preservation, non-ASCII UTF-8,
+      CRLF injection, and bidi-override neutralization. Generative pipelines
+      have a higher risk profile on bidi-override than template pipelines
+      (LLM-generated copy with embedded user text can round-trip bidi
+      controls into attribute contexts), so this phase exercises bidi
+      alongside the baseline vectors. The two remaining fixture vectors —
+      `mixed-path-and-query-contexts` (requires the same macro in two URL
+      positions) and `url-scheme-injection-neutralized` (requires an
+      href-whole-value macro binding) — are unit-test-layer conformance only;
+      runtime observation in a storyboard requires specialism-specific
+      template shapes tracked as follow-ups.
+
+      `build_creative`-with-`include_preview: true` is the natural observation
+      point on a generative specialism — the substitution-observer runner
+      (#2638) parses the returned `preview_html` and asserts each macro
+      position carries the fixture's `expected_encoded` form, not the raw
+      attacker bytes.
+
+      Scope note: this phase validates substitution on the PREVIEW surface
+      only. Sellers with divergent preview vs impression-time substitution
+      paths MAY pass here while failing at serve time; serve-time attestation
+      or log-introspection observability is deferred (#2651, out-of-scope v1
+      per the observer contract).
 
       The `expect_substitution_safe` step is gated on the
       `substitution_observer_runner` test-kit contract (see
@@ -616,6 +634,18 @@ phases:
                   url: "https://acmeoutdoor.example/probe/non-ascii"
                   image_url: "https://cdn.acmeoutdoor.example/probe/non-ascii.jpg"
                   price: { amount: 1.00, currency: "USD" }
+                - item_id: "crlf_injection"
+                  sku: "abc\r\nHost: evil.example"
+                  title: "CRLF injection probe"
+                  url: "https://acmeoutdoor.example/probe/crlf"
+                  image_url: "https://cdn.acmeoutdoor.example/probe/crlf.jpg"
+                  price: { amount: 1.00, currency: "USD" }
+                - item_id: "bidi_override"
+                  sku: "VIN-\u202E1234"
+                  title: "Bidi-override probe"
+                  url: "https://acmeoutdoor.example/probe/bidi"
+                  image_url: "https://cdn.acmeoutdoor.example/probe/bidi.jpg"
+                  price: { amount: 1.00, currency: "USD" }
 
           idempotency_key: "$generate:uuid_v4#creative_generative_catalog_substitution_safety_sync_substitution_probe_catalog"
           context:
@@ -633,6 +663,14 @@ phases:
           Generate a draft creative that uses `{SKU}` in its impression tracker
           URL and request `include_preview: true` so the substitution-observer
           runner has a preview surface to inspect.
+
+          The `message` is a natural-language brief; a generative agent that
+          ignores the `{SKU}` directive (generates its own macro, inlines an
+          encoded value, omits the tracker) fails the downstream
+          `expect_substitution_safe` step with `substitution_binding_missing`.
+          To keep that failure mode diagnostically clear, this step validates
+          the creative_manifest contains `{SKU}` unsubstituted in at least
+          one tracker asset before the observer runs.
         task: build_creative
         schema_ref: "media-buy/build-creative-request.json"
         response_schema_ref: "media-buy/build-creative-response.json"
@@ -641,10 +679,11 @@ phases:
         stateful: true
         expected: |
           Creative manifest returned with preview_html populated. Impression
-          tracker asset includes {SKU} bound to the probe catalog's items.
+          tracker asset includes {SKU} unsubstituted in its template (to be
+          resolved at impression time against catalog items).
 
         sample_request:
-          message: "Generate a 300x250 display ad for the creative_generative_substitution_probe_v1 catalog. Use {SKU} in the impression tracker URL."
+          message: "Generate a 300x250 display ad for the creative_generative_substitution_probe_v1 catalog. Use the literal `{SKU}` macro (unsubstituted) in at least one impression tracker URL so the platform can resolve it per-impression against catalog items."
           target_format_id:
             agent_url: "https://your-agent.example.com"
             id: "display_300x250_generative"
@@ -693,3 +732,9 @@ phases:
           - macro: "{SKU}"
             catalog_item_id: "non_ascii"
             vector_name: "non-ascii-utf8-percent-encoding"
+          - macro: "{SKU}"
+            catalog_item_id: "crlf_injection"
+            vector_name: "crlf-injection-neutralized"
+          - macro: "{SKU}"
+            catalog_item_id: "bidi_override"
+            vector_name: "bidi-override-neutralized"

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -282,10 +282,14 @@ phases:
       RFC 3986 `unreserved` characters remain unescaped before substituting them
       into a URL context. Nested macro expansion is prohibited.
 
-      This phase exercises the rule with attacker-shaped catalog values drawn
-      from the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`:
-      reserved-char breakout, nested-expansion preservation, CRLF injection,
-      non-ASCII UTF-8, mixed path/query, and bidi-override neutralization.
+      This phase exercises the rule with three attacker-shaped catalog values
+      drawn from the unit-test fixture at `static/test-vectors/catalog-macro-substitution.json`:
+      reserved-char breakout, nested-expansion preservation, and non-ASCII
+      UTF-8. The remaining canonical vectors (CRLF injection, bidi-override,
+      mixed path/query, url-scheme injection) are exercised at the unit-test
+      layer and, where a specialism's template shape supports them, in
+      specialism-specific substitution-safety phases (see
+      `creative-generative/index.yaml` for CRLF + bidi coverage).
 
       The `expect_substitution_safe` step is gated on the
       `substitution_observer_runner` test-kit contract (see

--- a/static/compliance/source/test-kits/substitution-observer-runner.yaml
+++ b/static/compliance/source/test-kits/substitution-observer-runner.yaml
@@ -5,12 +5,14 @@
 #     to assert the RFC 3986 percent-encoding rule from
 #     docs/creative/universal-macros.mdx#substitution-safety-catalog-item-macros.
 #   - Current consumers (when phases are gated on this contract):
-#     - specialisms/sales-catalog-driven/index.yaml
-#     - specialisms/creative-generative/index.yaml
-#     - specialisms/sales-social/index.yaml (catalog_driven_dynamic_ads phase)
+#     - specialisms/sales-catalog-driven/index.yaml (substitution_safety phase)
+#     - specialisms/creative-generative/index.yaml (catalog_substitution_safety phase)
+#   - Deferred pending observation-hook design (#2651):
+#     - specialisms/sales-social/index.yaml — social platforms substitute at
+#       serve time in proprietary renderers; no AdCP-level preview hook.
 #   - Future consumers: sales-retail-media (post-retail-media-epic),
 #     sales-broadcast-tv dynamic-creative phases, and anywhere else catalog
-#     values expand into URL contexts.
+#     values expand into URL contexts through a previewable surface.
 #
 # The #2620 rule: sales agents MUST percent-encode catalog-item macro values
 # such that only RFC 3986 `unreserved` characters remain unescaped before
@@ -43,7 +45,7 @@ applies_to:
   specialisms:
     - sales_catalog_driven
     - creative_generative
-    - sales_social
+    # sales_social deferred — no AdCP-level preview hook (see #2651).
   universals: []
 
 description: |


### PR DESCRIPTION
## Summary

Second consumer of the `substitution_observer_runner` contract, now that both prerequisites have merged:

- [#2645](https://github.com/adcontextprotocol/adcp/pull/2645) — `creative-generative` got a `catalog_augmented_generation` phase with `build_creative` returning `preview_html`
- [#2647](https://github.com/adcontextprotocol/adcp/pull/2647) — the observer contract is live

This PR extends the runtime substitution-safety check from `sales-catalog-driven` to `creative-generative`, following the same pattern established by #2647.

## What changed

**`static/compliance/source/specialisms/creative-generative/index.yaml`** — new `catalog_substitution_safety` phase appended after `catalog_augmented_generation`. Three steps:

1. `sync_substitution_probe_catalog` — pushes three canonical attacker-shaped values (`reserved-character-breakout`, `nested-expansion-preserved-as-literal`, `non-ascii-utf8-percent-encoding`) as catalog-item `sku` fields.
2. `build_substitution_probe_creative` — generates a creative whose impression tracker URL binds `{SKU}`, with `include_preview: true`.
3. `expect_substitution_safe` — gated on `substitution_observer_runner`. Fixture-lookup shape (`catalog_item_id` + `vector_name`) with `require_every_binding_observed: true`.

## Why `sales-social` is NOT included

`sales-social` uses `sync_creatives` to register a DPA template but has no AdCP-level preview hook. Social platforms substitute macros at serve time in their own rendering pipeline; they don't expose `preview_creative` or equivalent. Forcing `preview_creative` onto `required_tools` would misalign with real social-platform implementations (Snap, Meta, TikTok DPA all render server-side, not via AdCP).

The `substitution_observer_runner` contract's observation modes (`html_inline`, `url_fetch`) assume substitution happens in an AdCP-visible preview surface. For specialisms without one, a different hook is needed — post-impression log introspection, a dedicated `dry_run_substitution` endpoint, or an out-of-band conformance-test endpoint. Tracked as a follow-up.

## Out of scope / follow-ups

- **`sales-social` substitution observation** — separate issue. Needs new observation mechanism, not just extension of existing phases.
- **`sales-retail-media`** — still a 3.1 placeholder per its specialism file; lands with the retail-media epic.
- **Reference runner implementation** of `SubstitutionObserver` / `SubstitutionEncoder` — tracked in adcp-client repo.
- **Unicode normalization spec gap** (NFC vs NFD) — separate issue against #2620.

## Test plan

- [x] `npm run test:storyboard-scoping` passes (3/3)
- [x] `npm run test:error-codes` passes (pre-existing YAML warning unrelated)
- [x] `npm run test:unit` passes (631 tests)
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)