### PR TITLE
fix(schemas): hoist nested $defs to root when bundling (#2648)

### DIFF
--- a/.changeset/bundle-hoist-nested-defs.md
+++ b/.changeset/bundle-hoist-nested-defs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bundler: hoist nested `$defs` / `definitions` blocks to the document root when generating `bundled/*` schemas. Previously, local `#/$defs/...` pointers authored inside referenced schemas (e.g. `format.json`, `policy-entry.json`, `artifact.json`) landed deep inside the bundled output while their refs still pointed at the document root, making the bundled schemas unresolvable for draft-07 validators like Ajv. Affected consumers: any client compiling `list_creative_formats` or `list_content_standards` bundled responses. Fixes #2648.

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -567,6 +567,109 @@ function resolveRefs(schema, sourceDir, ancestorRefs = new Set()) {
 }
 
 /**
+ * Hoist nested `$defs` and `definitions` blocks to the document root.
+ *
+ * After `resolveRefs` inlines a referenced schema, any local pointers it
+ * carried (e.g. `#/$defs/baseIndividualAsset` authored inside `format.json`)
+ * land wherever the inlining landed — typically deep inside an array item.
+ * The pointer is still `#/$defs/...` but the `$defs` block is no longer at
+ * the document root, so draft-07 validators (Ajv) can't resolve it.
+ *
+ * This function moves every nested `$defs` / `definitions` block up to the
+ * root, deleting it from its nested location. Identical entries across
+ * copies are deduped; conflicting entries throw.
+ *
+ * Note: `$defs` is the draft 2019-09+ name and `definitions` is the
+ * draft-07 name. Both conventions appear in our source schemas, and a
+ * local `#/...` pointer targets whichever spelling the author used, so we
+ * hoist each into its own root-level block (rather than merging them).
+ */
+function hoistNestedDefsToRoot(schema) {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return schema;
+  }
+
+  const rootDefs = { ...(schema.$defs || {}) };
+  const rootDefinitions = { ...(schema.definitions || {}) };
+
+  // Key-order-insensitive deep equality. Used to distinguish "same shape
+  // authored twice" (safe to dedupe) from "two different shapes under the
+  // same name" (a real conflict). A plain `JSON.stringify` comparison
+  // would false-positive on identical objects authored with different
+  // key order.
+  function canonicalize(value) {
+    if (value === null || typeof value !== 'object') return value;
+    if (Array.isArray(value)) return value.map(canonicalize);
+    return Object.keys(value)
+      .sort()
+      .reduce((acc, k) => { acc[k] = canonicalize(value[k]); return acc; }, {});
+  }
+  function sameDef(a, b) {
+    return JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b));
+  }
+
+  // Reject reserved property names. Source schemas are trusted today, but
+  // `JSON.parse` surfaces a literal `"__proto__"` key as an own enumerable
+  // property, so a plain `target[key] = value` assignment would mutate the
+  // resulting object's prototype. Defensive, not reactive.
+  const RESERVED_DEF_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+  function mergeInto(target, key, value, originPath, blockName) {
+    if (RESERVED_DEF_KEYS.has(key)) {
+      throw new Error(
+        `Refusing to hoist reserved key \`${blockName}.${key}\` (at ${originPath}). ` +
+        `Source schemas may not use "__proto__", "constructor", or "prototype" as \`${blockName}\` entry names.`
+      );
+    }
+    if (Object.prototype.hasOwnProperty.call(target, key) && !sameDef(target[key], value)) {
+      throw new Error(
+        `Conflicting \`${blockName}.${key}\` definitions encountered while hoisting nested defs (at ${originPath}). ` +
+        `Two inlined schemas define different shapes under the same key.`
+      );
+    }
+    target[key] = value;
+  }
+
+  // Assumes every `$defs` / `definitions` block encountered during the walk
+  // is a JSON Schema keyword, not a property name in some schema-about-
+  // schemas. True for every source schema in this repo — AdCP does not
+  // author meta-schemas. Revisit if that changes: a correct disambiguation
+  // would exempt the immediate child of `properties`, `patternProperties`,
+  // and `dependentSchemas` from keyword treatment.
+  function walk(node, path) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => walk(item, `${path}[${i}]`));
+      return;
+    }
+
+    if (path !== '' && node.$defs && typeof node.$defs === 'object' && !Array.isArray(node.$defs)) {
+      for (const [k, v] of Object.entries(node.$defs)) {
+        mergeInto(rootDefs, k, v, `${path}.$defs.${k}`, '$defs');
+      }
+      delete node.$defs;
+    }
+    if (path !== '' && node.definitions && typeof node.definitions === 'object' && !Array.isArray(node.definitions)) {
+      for (const [k, v] of Object.entries(node.definitions)) {
+        mergeInto(rootDefinitions, k, v, `${path}.definitions.${k}`, 'definitions');
+      }
+      delete node.definitions;
+    }
+
+    for (const [k, v] of Object.entries(node)) {
+      walk(v, `${path}.${k}`);
+    }
+  }
+
+  walk(schema, '');
+
+  if (Object.keys(rootDefs).length > 0) schema.$defs = rootDefs;
+  if (Object.keys(rootDefinitions).length > 0) schema.definitions = rootDefinitions;
+
+  return schema;
+}
+
+/**
  * Generate bundled (dereferenced) schemas
  * These have all $ref resolved inline for tools that can't handle references
  */
@@ -612,6 +715,13 @@ async function generateBundledSchemas(sourceDir, bundledDir, version) {
 
       // Resolve all $refs
       const dereferenced = resolveRefs(schema, sourceDir, new Set([schemaPath]));
+
+      // After inlining, referenced schemas that carried local `#/$defs/...`
+      // pointers leave their `$defs` nested wherever they were inlined —
+      // which breaks draft-07 validators that expect root-level `$defs`.
+      // Hoist every nested `$defs` / `definitions` block to the root so
+      // those pointers resolve. See #2648.
+      hoistNestedDefsToRoot(dereferenced);
 
       // Update $id to indicate this is a bundled schema
       if (dereferenced.$id) {

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -376,6 +376,26 @@ async function runTests() {
         'Bundled create-media-buy-request (no ref resolution)'
       );
 
+      // Regression for #2648: bundled schemas that carry local `#/$defs/...`
+      // pointers (format.json, policy-entry.json, artifact.json) must compile
+      // with a vanilla Ajv — i.e. the bundler must hoist nested `$defs` to
+      // the document root.
+      await testBundledSchemaCompile(
+        path.join(bundledPath, 'media-buy/list-creative-formats-response.json'),
+        'Bundled list-creative-formats-response (media-buy) compiles — #2648'
+      );
+      await testBundledSchemaCompile(
+        path.join(bundledPath, 'creative/list-creative-formats-response.json'),
+        'Bundled list-creative-formats-response (creative) compiles — #2648'
+      );
+      await testBundledSchemaCompile(
+        path.join(bundledPath, 'content-standards/list-content-standards-response.json'),
+        'Bundled list-content-standards-response compiles — #2648'
+      );
+
+      // Every bundled schema must be self-contained and compile standalone.
+      await testAllBundledSchemasCompile(bundledPath);
+
       // Test a response schema to verify nested refs are resolved
       await testBundledSchemaValidation(
         path.join(bundledPath, 'media-buy/get-products-response.json'),
@@ -485,6 +505,63 @@ async function testBundledSchemaValidation(schemaPath, testData, description) {
     failedTests++;
     return false;
   }
+}
+
+/**
+ * Compile a bundled schema with a vanilla Ajv (no loadSchema). Does not
+ * validate data — just asserts the schema itself is resolvable.
+ */
+async function testBundledSchemaCompile(schemaPath, description) {
+  totalTests++;
+  try {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+    ajv.compile(schema);
+    log(`  \u2713 ${description}`, 'success');
+    passedTests++;
+    return true;
+  } catch (error) {
+    log(`  \u2717 ${description}: ${error.message}`, 'error');
+    failedTests++;
+    return false;
+  }
+}
+
+/**
+ * Walk the entire bundled/ tree and assert every schema compiles standalone.
+ * This is the real guarantee bundled/ is supposed to provide: a consumer can
+ * `new Ajv().compile(require('bundled/.../foo.json'))` without any loader.
+ */
+async function testAllBundledSchemasCompile(bundledPath) {
+  totalTests++;
+  const failures = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.json')) {
+        try {
+          const ajv = new Ajv({ allErrors: true, strict: false });
+          addFormats(ajv);
+          ajv.compile(JSON.parse(fs.readFileSync(p, 'utf8')));
+        } catch (error) {
+          failures.push(`${path.relative(bundledPath, p)}: ${error.message}`);
+        }
+      }
+    }
+  };
+  walk(bundledPath);
+
+  if (failures.length === 0) {
+    log(`  \u2713 All bundled schemas compile standalone (no loadSchema)`, 'success');
+    passedTests++;
+    return true;
+  }
+  log(`  \u2717 ${failures.length} bundled schema(s) failed to compile:`, 'error');
+  for (const f of failures) log(`      ${f}`, 'error');
+  failedTests++;
+  return false;
 }
 
 runTests().catch(error => {


### PR DESCRIPTION
## Summary

- Fixes #2648 — bundled response schemas carried `$ref: "#/$defs/..."` pointers that Ajv (draft-07) couldn't resolve because the bundler inlined referenced schemas (`format.json`, `policy-entry.json`, `artifact.json`) but left their `$defs` blocks nested wherever they landed, while the refs still pointed at the document root.
- `scripts/build-schemas.cjs`: after `resolveRefs`, walk the bundled output, hoist every nested `$defs` / `definitions` block to the document root, dedupe identical entries (order-insensitive deep-equal), throw on conflicting shapes. Reserved keys (`__proto__`/`constructor`/`prototype`) rejected defensively.
- Regression coverage in `tests/composed-schema-validation.test.cjs`: named tests for the three schemas called out in the issue plus a bulk assertion that **all 81 bundled schemas compile with a vanilla Ajv (no custom `loadSchema`)** — the actual guarantee `bundled/` is supposed to offer.

Versioned snapshots already committed under `dist/schemas/3.0.0-rc.3/bundled/` are not retroactively regenerated — next release picks up the fix.

## Test plan

- [x] `npm run build:schemas` succeeds; 81 bundled schemas produced.
- [x] `node tests/composed-schema-validation.test.cjs` → 21/21 pass, including the new #2648 regressions.
- [x] Precommit: `npm run test:unit` (631 tests) + `npm run typecheck` both clean.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)