### PR TITLE
spec(compliance): add seed_* values to ListScenariosSuccess.scenarios enum

### DIFF
--- a/.changeset/list-scenarios-seed-enum.md
+++ b/.changeset/list-scenarios-seed-enum.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(compliance): add `seed_*` values to `ListScenariosSuccess.scenarios` enum
+
+The `comply_test_controller` request schema enumerates five `seed_*` scenarios (`seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`), but the `ListScenariosSuccess` response enum in `comply-test-controller-response.json` did not — so sellers advertising seed-scenario support had no schema-conformant way to report it. Adds the five seed values to the response enum (additive) and updates the `compliance_testing.scenarios` capability reference in `get_adcp_capabilities` to match. Runners and sellers MUST still accept unknown scenario strings for forward-compat.

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -437,7 +437,7 @@ Compliance testing capabilities. The presence of this block declares that the ag
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values: `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`. |
+| `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values: `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`, `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`. Runners MUST accept unknown scenario strings — new scenarios may be added in additive minor bumps. |
 
 Storyboard runners check for the `compliance_testing` block before running deterministic testing steps. If the agent does not include the block, controller-dependent storyboard steps cannot be validated.
 

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -21,10 +21,15 @@
               "force_media_buy_status",
               "force_session_status",
               "simulate_delivery",
-              "simulate_budget_spend"
+              "simulate_budget_spend",
+              "seed_product",
+              "seed_pricing_option",
+              "seed_creative",
+              "seed_plan",
+              "seed_media_buy"
             ]
           },
-          "description": "Scenarios this seller has implemented"
+          "description": "Scenarios this seller has implemented. Runners and sellers MUST accept unknown scenario strings (open-for-extension) — new scenarios may be added in additive minor bumps."
         },
         "context": { "$ref": "/schemas/core/context.json" },
         "ext": { "$ref": "/schemas/core/ext.json" }


### PR DESCRIPTION
## Summary

- Adds the five `seed_*` scenarios (`seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`) to the `ListScenariosSuccess.scenarios` enum in `comply-test-controller-response.json`. These values already exist in the request schema and the spec doc; the response enum was the only place they were missing, which meant a seller with seed support had no schema-conformant way to advertise it via `list_scenarios`.
- Updates the `compliance_testing.scenarios` row in `get_adcp_capabilities` to list all eleven scenarios and restates the open-for-extension rule (runners and sellers MUST accept unknown scenario strings so future additive additions don't break validation).
- Minor changeset — additive protocol change, no existing responses invalidated.

Fixes #2657.

## Test plan

- [x] `npm run test:schemas` — 483 schemas, 7 checks, all green
- [x] `npm run test:examples` — 31 example payloads still validate
- [x] `npm run test:composed` — 15 composed-schema checks pass
- [x] `npm run build:schemas` — `dist/schemas/latest/compliance/comply-test-controller-response.json` reflects the new enum
- [x] pre-commit: 631 unit tests + typecheck

## Downstream follow-ups (not in this PR)

- `@adcp/client` and the Python SDK will pick up the new enum values on their next schema-regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)