### PR TITLE
spec(training-agent): recover storyboard CI floors after 5.8.1 bump (#2667)

### DIFF
--- a/.changeset/recover-storyboard-floors.md
+++ b/.changeset/recover-storyboard-floors.md
@@ -1,0 +1,12 @@
+---
+---
+
+Rebaseline storyboard CI non-regression floors after #2666 recovered the training-agent responses (#2667).
+
+#2666 restored the fixture/handler shapes the `@adcp/client` 5.6→5.8.1 bump had broken, but left the CI floors at the post-regression values of 27/271 legacy and 19/226 framework. The non-regression gate should track the recovered baseline so future regressions actually fail CI.
+
+- `.github/workflows/training-agent-storyboards.yml`: floors raised to legacy **36 clean / 295 passing** and framework **21 clean / 241 passing**, matching the post-recovery counts reported in #2666.
+- `.gitignore`: exclude `/dist/compliance/assertions/` from the tracked `/dist/compliance/` tree so `tsc` output from `server/src/compliance/**` (the assertion modules landed in #2663) doesn't collide with the published spec tarball.
+- `server/src/training-agent/property-handlers.ts`: comment clarifying why `violations[]` was moved into the closed-shape `features[]` channel, for readers landing in the handler after #2666.
+
+No behavior change — the floor move is the operational gate.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -45,24 +45,23 @@ jobs:
             #  - schema_validation past-start rejection reverted to keep
             #    6 status-derivation unit tests passing; closes as
             #    accept-and-derive per spec's any_of.)
-            # 35→27 after bumping @adcp/client 5.6.0 → 5.8.1 in adcp#2663: the
-            # SDK brought stricter schema-driven validation (#694), strict
-            # sync_creatives validation (#661), refs_resolve cross-step
-            # checks (#670), branch_set grading (#693). These are legitimate
-            # tightening of the runner; the drop represents training-agent
-            # follow-ups, not invariant-assertion failures (the #2639 YAML
-            # additions are inert against the SDK-bundled cache until
-            # @adcp/client republishes the compliance tarball).
-            min_clean_storyboards: 27
-            min_passing_steps: 271
+            # 35→27 temporarily after @adcp/client 5.6→5.8.1 bump (adcp#2663)
+            # surfaced stricter schema checks; recovered to 36 in adcp#2666 by
+            # fixing training-agent fixtures (creative format asset_type/
+            # catalog_type/dimensions.unit), adding required total_budget on
+            # get_media_buys, and tightening validate_property_delivery
+            # response shape.
+            min_clean_storyboards: 36
+            min_passing_steps: 295
           - mode: framework
             flag_value: '1'
             # Framework path is opt-in and trails legacy until zod parity
             # lands. Gate keeps it from going backwards while we close the gap.
-            # 21→19, 237→226 from the same @adcp/client 5.8.1 tightening
-            # described above.
-            min_clean_storyboards: 19
-            min_passing_steps: 226
+            # Rebaselined alongside the legacy recovery in adcp#2666: the
+            # training-agent fixture fixes bought back the same 237→241
+            # passing-step delta for the framework path.
+            min_clean_storyboards: 21
+            min_passing_steps: 241
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ server/node_modules
 /dist/schemas/registry.*
 /dist/compliance/latest
 /dist/compliance/v*
+# TS compile output from server/src/compliance/** lands here; the spec
+# tarball only publishes YAML / JSON so the compiled JS never belongs in
+# git even though /dist/compliance is otherwise tracked for release artifacts.
+/dist/compliance/assertions
 /dist/protocol/latest.tgz
 /dist/protocol/latest.tgz.sha256
 /dist/protocol/latest.tgz.sig

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -369,6 +369,11 @@ export async function handleValidatePropertyDelivery(
       nonCompliantImpressions += impressions;
     }
 
+    // Per validation-result.json (additionalProperties: false), allowed
+    // keys are identifier, record_id, status, impressions, features,
+    // authorization, ext. Violations belong in `features[]` as the spec's
+    // machine-readable channel — a "record:list_membership" feature with
+    // status: failed carries the same signal.
     return {
       identifier: { type: 'domain', value: domain },
       ...(record.record_id ? { record_id: record.record_id } : {}),


### PR DESCRIPTION
## Summary

Closes the regression from #2663 where the `@adcp/client` 5.6→5.8.1 bump dropped legacy storyboard CI from 35 → 27 clean and framework from 21/237 → 19/226. Fixing four training-agent fixture / handler issues recovers both paths past the pre-bump baseline:

- **legacy**: 27 → **36 clean** / 271 → **295 passing** (pre-bump was 35 / 279)
- **framework**: 19 → **21 clean** / 226 → **241 passing** (pre-bump was 21 / 237)

CI floors rebased to the recovery values.

## Fixes

### `server/src/shared/formats.ts` — creative format fixtures

Ripple-fixed about a dozen storyboards that call `list_creative_formats` (most of the creative, sales, and catalog-driven specialisms).

- `catalog_types: ['product']` → `catalog_type: 'product'` on `sponsored_product` and `search_shopping`. The current `catalog-requirements.json` schema uses the singular field — plural bypasses the `catalog` oneOf branch and fails the whole format.
- `dimensions.unit: 'in'` → `'inches'` on `print_full_page`. The `dimension-unit` enum is `{px, dp, inches, cm, mm, pt}`.
- `asset_type: 'file'` → `'url'` / `'audio'` on `print_full_page` / `radio_spot`. The `format.assets` `oneOf` has no `file` branch. URL (with `mime_types: ['application/pdf']`) is the nearest spec-valid match for a PDF artwork reference; audio fits a radio spot directly.

### `server/src/training-agent/task-handlers.ts` — `handleGetMediaBuys`

`get-media-buys-response.json` now requires `total_budget` on every `media_buys[]` entry. Compute as `sum(pkg.budget)` across packages (all denominated in the media buy's `currency` per the core schema).

### `server/src/training-agent/property-handlers.ts` — `handleValidatePropertyDelivery`

`validate-property-delivery-response.json` is strict (`additionalProperties: false`) and `validation-result.json` is too.

- Drop top-level `compliant` (not in allowlist; derivable from summary counts).
- Move per-record `violations[]` into `features[]` using the closed enum: `feature_id`, `status: 'failed'`, `explanation`.

### `.gitignore`

Exclude `/dist/compliance/assertions/` from the tracked `/dist/compliance/` tree so tsc output from `server/src/compliance/**` doesn't leak into the published spec-tarball path.

## CI evidence

```
legacy     → storyboards: 36/56 clean  |  steps: 295 passed | 35 failed | 52 skipped
framework  → storyboards: 21/56 clean  |  steps: 241 passed | 80 failed | 61 skipped
```

Both exceed the pre-5.8.1 floors without relying on lowered thresholds.

## Remaining follow-ups (tracked in #2667)

Not fixed here — each is a discrete training-agent or storyboard issue rather than a schema-shape bug:

- `deterministic_testing` — `UNKNOWN_SCENARIO` / `INVALID_PARAMS` / `NOT_FOUND` / `INVALID_TRANSITION` error codes don't match what the test-controller expects under 5.8+ scenario vocabulary.
- `webhook_emission` — payload shape, retry-replay, and 9421 signature verification all fail.
- `media_buy_governance_escalation` — plan lookup misses and condition-in-approval mismatch.
- `governance_spend_authority` — `cpm_guaranteed` pricing alias missing (seller returns a different pricing_option_id).
- `creative_ad_server` — pricing_options in creative response, campaign_hero_video resolution, vendor_cost validation.
- `brand_rights/governance_denied`, `sales_broadcast_tv` webhooks, `media_buy_seller/creative_fate_after_cancellation` sync_creatives shape, `signed_requests` verifier-order regression for vectors 015/017/020.
- `sales_retail_media`, `sales_social`, `sales_catalog_driven` — catalog item count reporting.
- `media_buy_seller/measurement_terms_rejected` — expected TERMS_REJECTED not emitted.
- `sales_non_guaranteed` — package lookup miss on empty id.

Each of these is a 1-2 line handler fix; attacking one per follow-up PR is safer than batching.

## Test plan

- [x] `tsc --project server/tsconfig.json --noEmit` — clean
- [x] `npx vitest run server/tests/unit/training-agent.test.ts server/tests/unit/compliance-assertions.test.ts` — 375 passing
- [x] Local `server/tests/manual/run-storyboards.ts` legacy + framework both exceed pre-bump baselines (captured above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)