### PR TITLE
ci(links): timeout + parallelism for owned-link checker

### DIFF
--- a/.changeset/owned-link-checker-timeout-parallelism.md
+++ b/.changeset/owned-link-checker-timeout-parallelism.md
@@ -1,0 +1,10 @@
+---
+---
+
+ci(links): timeout + parallelism for owned-link checker
+
+`scripts/check-owned-links.js` had no per-fetch timeout and ran URLs serially.
+When agenticadvertising.org HEAD responses were slow, the job ballooned from
+~15s to 11–27 minutes (observed on bokelley/refs-resolve runs). Each fetch now
+runs with a 10s `AbortSignal.timeout`, URLs are checked with 8-way concurrency,
+and the workflow step has a 5-minute ceiling.

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: Check browser-facing Agentic Advertising links
       run: npm run check:owned-links
+      timeout-minutes: 5
 
     - name: Check README links
       run: npx markdown-link-check README.md --config .markdown-link-check.json

--- a/scripts/check-owned-links.js
+++ b/scripts/check-owned-links.js
@@ -5,6 +5,8 @@ import { globSync } from 'glob';
 const LINK_HOSTS = new Set(['agenticadvertising.org', 'docs.adcontextprotocol.org']);
 const SKIPPED_PATH_PREFIXES = ['/api/'];
 const ROOT = process.cwd();
+const FETCH_TIMEOUT_MS = 10_000;
+const CONCURRENCY = 8;
 
 function getCandidateFiles() {
   return globSync(
@@ -52,6 +54,7 @@ async function fetchStatus(url, method, retries = 3) {
         headers: {
           'User-Agent': 'adcp-owned-link-check/1.0',
         },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (response.status >= 500 && attempt < retries) {
         await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
@@ -66,6 +69,7 @@ async function fetchStatus(url, method, retries = 3) {
       throw err;
     }
   }
+  throw new Error(`fetchStatus exhausted retries without returning for ${url}`);
 }
 
 // 405 means the endpoint exists but rejects this HTTP method (e.g. MCP
@@ -106,16 +110,27 @@ async function main() {
     }
   }
 
-  const broken = [];
+  const urls = [...urlSources.keys()].sort();
+  const results = new Array(urls.length);
+  let cursor = 0;
 
-  for (const url of [...urlSources.keys()].sort()) {
-    const result = await checkUrl(url);
-    if (result.ok) {
-      continue;
+  async function worker() {
+    while (true) {
+      const index = cursor++;
+      if (index >= urls.length) return;
+      results[index] = await checkUrl(urls[index]);
     }
-
-    broken.push({ url, result, files: urlSources.get(url) ?? [] });
   }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+  const broken = [];
+  urls.forEach((url, index) => {
+    const result = results[index];
+    if (!result.ok) {
+      broken.push({ url, result, files: urlSources.get(url) ?? [] });
+    }
+  });
 
   if (broken.length === 0) {
     const hosts = [...LINK_HOSTS].join(', ');


### PR DESCRIPTION
## Summary

`scripts/check-owned-links.js` had no per-fetch timeout and ran 48 URLs serially. When `agenticadvertising.org` HEAD responses were slow, the "Check browser-facing Agentic Advertising links" step ballooned from ~15s to 11–27 minutes — observed twice on `bokelley/refs-resolve` at 11m 51s and 26m 47s while other runs completed normally. The links themselves were fine; the step just couldn't bound its worst case.

- Added `AbortSignal.timeout(10_000)` to each fetch
- Replaced the serial loop with an 8-way concurrent worker pool
- Added `timeout-minutes: 5` on the workflow step as a safety net
- Hardened `fetchStatus` with an explicit throw at loop exit so a future editor can't silently produce `undefined` (per code review)

Local wall time: ~15s serial → **3s parallel**, with a firm per-URL ceiling.

## Test plan

- [x] Ran `npm run check:owned-links` locally (3s, "All browser-facing links are reachable")
- [x] Verified all 48 URLs still extracted by the glob + hostname allowlist
- [x] code-reviewer: no Must/Should Fix remaining
- [x] security-reviewer: no findings (CI-only script, URLs from repo content, hostname-allowlisted)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)