### PR TITLE
compliance(storyboards): schema-driven mutations + contributes migration

### DIFF
--- a/.changeset/schema-driven-mutations-contributes-migration.md
+++ b/.changeset/schema-driven-mutations-contributes-migration.md
@@ -1,0 +1,39 @@
+---
+---
+
+compliance(storyboards): schema-driven mutating tasks + contributes shorthand migration
+
+Closes #2669 and #2662.
+
+**Schema-driven MUTATING_TASKS (#2669).** The contradiction lint's
+prior-state discrimination previously read a hardcoded `MUTATING_TASKS`
+set in `scripts/lint-storyboard-contradictions.cjs`. The set had drifted
+from the spec (`sync_audiences` was missing) and required manual updates
+whenever new mutating tasks shipped.
+
+The set is now derived at lint-time by walking `static/schemas/source/`
+for every `*-request.json` that lists `idempotency_key` in its top-level
+`required` array. Mirrors the existing `loadMutatingSchemaRefs` pattern
+in `scripts/build-compliance.cjs`. A `MUTATING_EXCEPTIONS` set retains
+one documented carve-out: `comply_test_controller` mutates controller
+state but is naturally idempotent (its schema description explicitly
+justifies the absence of `idempotency_key`).
+
+Three new drift-guard tests protect the invariant:
+- `MUTATING_TASKS === (schema-derived ∪ MUTATING_EXCEPTIONS)`
+- no redundancy between `MUTATING_EXCEPTIONS` and the schema-derived set
+- anchor-task coverage (`create_media_buy`, `update_media_buy`,
+  `sync_creatives`, `sync_audiences`) so a schema rename localizes the
+  break.
+
+**contributes shorthand migration (#2662).** `@adcp/client` 5.8.1
+accepts `contributes: true` inside a `branch_set:` phase; the runner's
+loader resolves it to the enclosing phase's `branch_set.id`. This PR
+adopts the shorthand in the two universal branch-set storyboards:
+`schema-validation.yaml` (past_start_handled) and `security.yaml`
+(auth_mechanism_verified). Four call sites migrated.
+
+Dogfoods the spec + client + lint stack end-to-end. Verified locally:
+storyboards pass 36/56 clean, 295 steps (both above regression floors).
+The schema doc's guidance updated to name both forms as semantically
+equivalent, with the shorthand preferred inside branch_set phases.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -78,6 +78,13 @@ const MUTATING_EXCEPTIONS = new Set([
   // do mutate controller state the next step observes, so the contradiction
   // lint must treat them as mutations.
   'comply_test_controller',
+  // Schema description: "Naturally idempotent — `session_id` is the dedup
+  // boundary, and terminating an already-terminated session is a no-op that
+  // returns the same terminal state." The termination still transitions
+  // active → terminated, and a later si_send_message on the same session_id
+  // asserts against that terminal state; the contradiction lint must
+  // discriminate pre- vs post-termination state paths.
+  'si_terminate_session',
 ]);
 
 /**
@@ -90,14 +97,19 @@ const MUTATING_EXCEPTIONS = new Set([
  * different output needs (tool-only here, refs+tools there).
  */
 function loadMutatingTasksFromSchemas(schemasDir) {
-  const tools = new Set();
+  // Map<task, srcPath> so same-task-name across subdirs surfaces as an
+  // explicit collision rather than silently deduping through Set.add.
+  const origins = new Map();
   function walk(dir) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const p = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
+      // Real directories only. Skip symlinks to avoid unbounded recursion
+      // if a schemas subtree symlinks back to itself.
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
         walk(p);
         continue;
       }
+      if (!entry.isFile()) continue;
       if (!entry.name.endsWith('-request.json')) continue;
       let schema;
       try {
@@ -106,13 +118,21 @@ function loadMutatingTasksFromSchemas(schemasDir) {
         continue;
       }
       const required = Array.isArray(schema.required) ? schema.required : [];
-      if (required.includes('idempotency_key')) {
-        tools.add(entry.name.replace(/-request\.json$/, '').replace(/-/g, '_'));
+      if (!required.includes('idempotency_key')) continue;
+      const task = entry.name.replace(/-request\.json$/, '').replace(/-/g, '_');
+      const prior = origins.get(task);
+      if (prior && prior !== p) {
+        throw new Error(
+          `lint-storyboard-contradictions: task name "${task}" derives from two schema files: ` +
+            `${path.relative(schemasDir, prior)} and ${path.relative(schemasDir, p)}. ` +
+            'Rename one of the files (the hyphen-to-underscore conversion collides).',
+        );
       }
+      origins.set(task, p);
     }
   }
   walk(schemasDir);
-  return tools;
+  return new Set(origins.keys());
 }
 
 /**

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -58,49 +58,76 @@ const crypto = require('node:crypto');
 const yaml = require('js-yaml');
 
 const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'compliance', 'source');
+const SCHEMAS_DIR = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
 
 /**
- * AdCP task names that MUTATE server state. Prior-state discrimination
- * depends on this list — a step whose prior phase contains only read tasks
- * is at the same "state" as a step with no prior phases.
+ * Tasks whose state mutations are invisible to the idempotency-key heuristic
+ * below — they don't require `idempotency_key` in their request schema
+ * (typically because they are naturally idempotent or session-scoped) but
+ * still change observable agent state that a later step's outcome depends on.
  *
- * Keep in sync with TENANT_SCOPED_TASKS in lint-storyboard-scoping.cjs where
- * overlap exists; reads like list_creative_formats/get_products are
- * intentionally NOT here.
+ * Each entry must be justified. Adding to this set without a schema-level
+ * reason is a drift hazard; prefer declaring `idempotency_key` required on
+ * the request schema instead.
+ */
+const MUTATING_EXCEPTIONS = new Set([
+  // Schema description: "Naturally idempotent: the `scenario` enum is either
+  // a lookup (`list_scenarios`) or a state-forcing operation whose target
+  // state is carried in the payload (`force_*_status`, `simulate_*`), so
+  // replays converge to the same observable state." The controller scenarios
+  // do mutate controller state the next step observes, so the contradiction
+  // lint must treat them as mutations.
+  'comply_test_controller',
+]);
+
+/**
+ * Read every `*-request.json` under `SCHEMAS_DIR` and return the set of
+ * task names that require `idempotency_key`. Task name is derived from the
+ * filename: `create-media-buy-request.json` → `create_media_buy`.
+ *
+ * Mirrors the pattern in `scripts/build-compliance.cjs:loadMutatingSchemaRefs`;
+ * kept local rather than shared because the two lints have slightly
+ * different output needs (tool-only here, refs+tools there).
+ */
+function loadMutatingTasksFromSchemas(schemasDir) {
+  const tools = new Set();
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+        continue;
+      }
+      if (!entry.name.endsWith('-request.json')) continue;
+      let schema;
+      try {
+        schema = JSON.parse(fs.readFileSync(p, 'utf8'));
+      } catch {
+        continue;
+      }
+      const required = Array.isArray(schema.required) ? schema.required : [];
+      if (required.includes('idempotency_key')) {
+        tools.add(entry.name.replace(/-request\.json$/, '').replace(/-/g, '_'));
+      }
+    }
+  }
+  walk(schemasDir);
+  return tools;
+}
+
+/**
+ * AdCP task names that MUTATE server state. Derived at module load by
+ * reading request schemas' `required: [idempotency_key]` declarations
+ * (source of truth for "this task is a mutation"), plus documented
+ * exceptions for naturally-idempotent tasks that still change state.
+ *
+ * Prior-state discrimination in the contradiction lint depends on this
+ * set — a step whose prior phase contains only read tasks is at the same
+ * "state" as a step with no prior phases.
  */
 const MUTATING_TASKS = new Set([
-  'create_media_buy',
-  'update_media_buy',
-  'sync_creatives',
-  'creative_approval',
-  'sync_accounts',
-  'sync_governance',
-  'sync_plans',
-  'sync_catalogs',
-  'sync_event_sources',
-  'activate_signal',
-  'provide_performance_feedback',
-  'acquire_rights',
-  'update_rights',
-  'log_event',
-  'calibrate_content',
-  'create_property_list',
-  'update_property_list',
-  'delete_property_list',
-  'create_collection_list',
-  'update_collection_list',
-  'delete_collection_list',
-  'create_content_standards',
-  'update_content_standards',
-  'report_plan_outcome',
-  'report_usage',
-  'build_creative',
-  // Test-controller primitives mutate the runner's controller state; a
-  // later comply_test_controller assertion depends on what prior ones did.
-  'comply_test_controller',
-  // Sponsored-intelligence session primitives mutate session state.
-  'si_initiate_session',
-  'si_send_message',
+  ...loadMutatingTasksFromSchemas(SCHEMAS_DIR),
+  ...MUTATING_EXCEPTIONS,
 ]);
 
 /**
@@ -459,7 +486,9 @@ if (require.main === module) main();
 
 module.exports = {
   MUTATING_TASKS,
+  MUTATING_EXCEPTIONS,
   SKIP_TASKS,
+  loadMutatingTasksFromSchemas,
   normalizeRequestValue,
   canonicalizeRequest,
   fingerprintRequest,

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -375,7 +375,7 @@ phases:
         comply_scenario: temporal_validation
         expect_error: true
         stateful: false
-        contributes_to: past_start_handled
+        contributes: true
         expected: |
           Reject the request with:
           - Error code: INVALID_REQUEST
@@ -441,7 +441,7 @@ phases:
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: temporal_validation
         stateful: false
-        contributes_to: past_start_handled
+        contributes: true
         expected: |
           Accept the request with auto-adjusted dates:
           - Response matches create-media-buy-response.json schema

--- a/static/compliance/source/universal/security.yaml
+++ b/static/compliance/source/universal/security.yaml
@@ -207,7 +207,7 @@ phases:
         auth:
           type: api_key
           value_strategy: random_invalid
-        contributes_to: auth_mechanism_verified
+        contributes: true
         contributes_if: "prior_step.probe_api_key.passed"
         expect_error: true
         expected: |
@@ -378,7 +378,7 @@ phases:
         auth:
           type: oauth_bearer
           value_strategy: random_invalid_jwt
-        contributes_to: auth_mechanism_verified
+        contributes: true
         contributes_if: "prior_step.probe_protected_resource.passed"
         expect_error: true
         expected: |

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -236,11 +236,12 @@
 #
 #   `@adcp/client` 5.8.0+ also accepts the boolean shorthand
 #   `contributes: true` on a step inside a branch_set phase — the runner's
-#   loader resolves it to the enclosing phase's `branch_set.id`. Storyboards
-#   in this repository currently stay on the string form pending resolution
-#   of unrelated 5.8.0 schema-validation regressions; the defensive lint
-#   rules below cover both forms so the shorthand can be adopted
-#   per-storyboard once the runner upgrade lands.
+#   loader resolves it to the enclosing phase's `branch_set.id`. The two
+#   forms are semantically identical; `contributes: true` is preferred
+#   inside a branch_set phase because it eliminates the typo surface (the
+#   string form must equal `branch_set.id` exactly). Authors may use
+#   either. `universal/schema-validation.yaml` and `universal/security.yaml`
+#   use the shorthand as reference examples.
 #
 #   New storyboards MUST declare branch-set membership with a `branch_set:`
 #   object. The implicit-detection fallback below exists only so pre-#2633

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -240,8 +240,7 @@
 #   forms are semantically identical; `contributes: true` is preferred
 #   inside a branch_set phase because it eliminates the typo surface (the
 #   string form must equal `branch_set.id` exactly). Authors may use
-#   either. `universal/schema-validation.yaml` and `universal/security.yaml`
-#   use the shorthand as reference examples.
+#   either; the lint enforces both.
 #
 #   New storyboards MUST declare branch-set membership with a `branch_set:`
 #   object. The implicit-detection fallback below exists only so pre-#2633

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -72,6 +72,23 @@ test('schema-derived set covers known mutating tasks', () => {
   }
 });
 
+test('schema-derived set does not over-match read-only tasks', () => {
+  // Negative anchor: if a read-only request schema ever starts listing
+  // idempotency_key in required (spec drift, accidental copy-paste), the
+  // contradiction lint would silently over-discriminate state paths. Lock
+  // in a handful of anchor reads so the bug surfaces here, not in a
+  // false-positive at build time.
+  const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
+  for (const task of [
+    'get_products',
+    'get_signals',
+    'list_creative_formats',
+    'get_adcp_capabilities',
+  ]) {
+    assert.ok(!derived.has(task), `read-only ${task} must not be in mutating set`);
+  }
+});
+
 test('source tree has no contradictions', () => {
   const contradictions = lint();
   assert.deepEqual(

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -22,7 +22,13 @@ const {
   fingerprintRequest,
   classifyOutcome,
   outcomesAgree,
+  MUTATING_TASKS,
+  MUTATING_EXCEPTIONS,
+  loadMutatingTasksFromSchemas,
 } = require('../scripts/lint-storyboard-contradictions.cjs');
+
+const path = require('node:path');
+const SCHEMAS_DIR = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
 
 function contradictionsAcrossDocs(docs) {
   const events = [];
@@ -31,6 +37,40 @@ function contradictionsAcrossDocs(docs) {
   }
   return findContradictions(events);
 }
+
+test('MUTATING_TASKS is derived from idempotency_key-required schemas + exceptions', () => {
+  // Drift guard: the union of (schemas requiring idempotency_key) and
+  // MUTATING_EXCEPTIONS must equal MUTATING_TASKS exactly. If this test
+  // breaks, a new mutating task was added without either (a) adding
+  // idempotency_key to its request schema, or (b) documenting it in
+  // MUTATING_EXCEPTIONS with a schema-level rationale.
+  const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
+  const expected = new Set([...derived, ...MUTATING_EXCEPTIONS]);
+  assert.deepEqual(
+    [...MUTATING_TASKS].sort(),
+    [...expected].sort(),
+    'MUTATING_TASKS drifted from (schema-derived + MUTATING_EXCEPTIONS)',
+  );
+});
+
+test('every MUTATING_EXCEPTION is absent from the schema-derived set', () => {
+  // If a task exists in both, the exception is redundant and should be
+  // removed. This keeps MUTATING_EXCEPTIONS as a disciplined list of
+  // genuine gaps the schema heuristic doesn't cover.
+  const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
+  const redundant = [...MUTATING_EXCEPTIONS].filter((t) => derived.has(t));
+  assert.deepEqual(redundant, [], 'MUTATING_EXCEPTIONS entries redundant with schema');
+});
+
+test('schema-derived set covers known mutating tasks', () => {
+  // Sanity check: these are anchored task names that MUST be present
+  // regardless of schema refactors. If the schema filename convention
+  // changes or a file moves, this test localizes the break.
+  const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
+  for (const task of ['create_media_buy', 'update_media_buy', 'sync_creatives', 'sync_audiences']) {
+    assert.ok(derived.has(task), `expected ${task} in schema-derived mutating set`);
+  }
+});
 
 test('source tree has no contradictions', () => {
   const contradictions = lint();


### PR DESCRIPTION
## Summary

Bundles two follow-ups from [#2661](https://github.com/adcontextprotocol/adcp/pull/2661):

- **[#2669](https://github.com/adcontextprotocol/adcp/issues/2669)** — derive \`MUTATING_TASKS\` from request-schema \`required: [idempotency_key]\` declarations; replace the hardcoded list in \`scripts/lint-storyboard-contradictions.cjs\`.
- **[#2662](https://github.com/adcontextprotocol/adcp/issues/2662)** — adopt the \`contributes: true\` shorthand ([adcp-client#693](https://github.com/adcontextprotocol/adcp-client/issues/693), shipped in \`@adcp/client\` 5.8.1) on the two universal branch-set storyboards.

## Schema-driven mutations

\`loadMutatingTasksFromSchemas\` walks \`static/schemas/source/\` for \`*-request.json\` files whose top-level \`required\` array lists \`idempotency_key\`. Mirrors the existing \`loadMutatingSchemaRefs\` pattern in \`scripts/build-compliance.cjs\`.

\`MUTATING_EXCEPTIONS\` retains two carve-outs, each documented in the target schema's description:
- \`comply_test_controller\` — naturally idempotent (scenario enum is the dedup boundary).
- \`si_terminate_session\` — naturally idempotent (session_id is the dedup boundary). Added after protocol expert review flagged the omission.

Before this PR, the hardcoded set was missing \`sync_audiences\` entirely. Schema-driven derivation catches it automatically.

## Drift guards

Four new tests in \`tests/lint-storyboard-contradictions.test.cjs\`:

1. **Union invariant** — \`MUTATING_TASKS\` equals \`(schema-derived ∪ MUTATING_EXCEPTIONS)\`. Breaks if someone adds to one side without the other.
2. **No exception redundancy** — \`MUTATING_EXCEPTIONS\` ∩ schema-derived is empty. Prevents a task accidentally carrying both justifications.
3. **Positive anchor coverage** — \`create_media_buy\`, \`update_media_buy\`, \`sync_creatives\`, \`sync_audiences\` MUST be in the derived set.
4. **Negative anchor coverage** — \`get_products\`, \`get_signals\`, \`list_creative_formats\`, \`get_adcp_capabilities\` MUST NOT be in the derived set. Guards against a read-schema drifting to require idempotency_key.

Also hardened \`loadMutatingTasksFromSchemas\`: throws on hyphen-to-underscore collisions across subdirs (previously silent via Set dedup), and skips symlinked directories to prevent unbounded recursion.

## contributes migration

Four call sites migrated from \`contributes_to: <flag>\` to \`contributes: true\`:
- \`universal/schema-validation.yaml\` — \`past_start_reject_path\` / \`past_start_adjust_path\`
- \`universal/security.yaml\` — \`probe_invalid_api_key\` / \`probe_invalid_oauth_token\`

Storyboard doc (\`universal/storyboard-schema.yaml\`) updated: both forms are documented as semantically equivalent, with the shorthand preferred inside branch_set phases.

## Test plan

- [x] \`npm run test:storyboard-contradictions\` — 19 tests pass (3 new drift guards + 1 negative anchor)
- [x] \`npm run test:storyboard-branch-sets\` — 14 tests unchanged, all pass
- [x] \`npm run build:compliance\` — all four storyboard lints pass
- [x] Precommit (\`test:unit\` + \`typecheck\`) — 631 tests pass
- [x] Storyboards run against \`@adcp/client\` 5.8.1 — 36/56 clean, 295 steps (above 35/279 floors)

## Follow-ups

- **[#2675](https://github.com/adcontextprotocol/adcp/issues/2675)** — introduce \`x-mutates-state: true\` schema annotation to eliminate the \`MUTATING_EXCEPTIONS\` list entirely; decouples \"mutation semantics\" from \"idempotency mechanism.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)