### PR TITLE
spec: extend x-entity annotation to account and governance (#2660 phase 3)

### DIFF
--- a/.changeset/x-entity-control-plane.md
+++ b/.changeset/x-entity-control-plane.md
@@ -4,19 +4,26 @@
 
 spec: extend `x-entity` annotation to account and governance domains (#2660 phase 3)
 
-Continues the rollout from phase 2 (#2672). Annotates the "control plane" cluster: 10 account schemas + 13 governance schemas. Registry grows by one entity type.
+Continues the rollout from phase 2 (#2672). Annotates the "control plane" cluster: 10 account schemas + 13 governance schemas + 4 cross-domain `policy_id` sites. Registry grows by two entity types.
 
-Registry addition:
-- `policy` — governance policy identifier (registry-published like `uk_hfss` or bespoke inline). Distinct from `governance_plan` (plans contain policies).
+Registry additions:
+- `governance_policy` — governance policy identifier (registry-published like `uk_hfss` or plan-scoped inline). Named for parallelism with `governance_plan`. Known caveat: registry vs. inline policy namespaces share this entity type today; splitting them requires schema-shape discrimination and is tracked in #2685.
+- `governance_check` — governance check result identifier, round-trips between `check_governance` response and `report_plan_outcome` request.
+
+Registry edits:
+- `media_plan` definition no longer cites `governance/sync-plans-request` (stale — those are all `governance_plan`). Marked as reserved for future media-plan schemas.
 
 Shared types:
-- `governance/policy-entry.json::policy_id` → `policy`
-- `governance/policy-ref.json::policy_id` → `policy`
+- `governance/policy-entry.json::policy_id` → `governance_policy`
+- `governance/policy-ref.json::policy_id` → `governance_policy`
 
 Domain leaves:
 - **account/**: `report-usage-request` (media_buy_id, vendor_pricing_option_id, signal_activation_id, content_standards_id, rights_grant_id, creative_id, property_list_id); `sync-accounts-response` (account_id).
-- **governance/**: every `plan_id` → `governance_plan` (phase-2 taxonomy decision applied); every `policy_id` → `policy`; array-items on `plan_ids[]`, `portfolio_plan_ids[]`, `member_plan_ids[]`, `policy_ids[]`, `shared_policy_ids[]`.
+- **governance/**: every `plan_id` → `governance_plan` (phase-2 taxonomy decision applied); every `policy_id` → `governance_policy`; `check_id` → `governance_check` on `check-governance-response`, `report-plan-outcome-request`, `get-plan-audit-logs-response` escalations; array-items on `plan_ids[]`, `portfolio_plan_ids[]`, `member_plan_ids[]`, `policy_ids[]`, `shared_policy_ids[]`.
+- **Cross-domain `policy_id` sites**: `property/validation-result`, `error-details/policy-violation`, `content-standards/validate-content-delivery-response`, `content-standards/calibrate-content-response` → `governance_policy`.
 
-No new shared-type conflicts uncovered by the lint. Walker, registry disagreement guard, and existing tests unchanged.
+Deliberate skips (documented): `outcome_id` (forensic), audit-log entry `id` (forensic), `governance_context` tokens (opaque signed state), `business-entity` (pure descriptor), `invoice_id` (transient billing record), `report-plan-outcome-request.seller_response.seller_reference` (polymorphic — could be media_buy_id, rights_grant_id, or deployment_id depending on purchase_type; no single entity fits).
+
+Doc updates: plan-vs-policy-vs-check disambiguation added under the registry category table; editorial-grouping comment added to clarify the table isn't authoritative.
 
 Deferred to phase 4 / capstone: `property/`, `collection/`, `sponsored-intelligence/`, plus a coverage counter in CI output and a schema-side nudge for new `*_id` fields without `x-entity`.

--- a/.changeset/x-entity-control-plane.md
+++ b/.changeset/x-entity-control-plane.md
@@ -1,0 +1,22 @@
+---
+"adcontextprotocol": patch
+---
+
+spec: extend `x-entity` annotation to account and governance domains (#2660 phase 3)
+
+Continues the rollout from phase 2 (#2672). Annotates the "control plane" cluster: 10 account schemas + 13 governance schemas. Registry grows by one entity type.
+
+Registry addition:
+- `policy` — governance policy identifier (registry-published like `uk_hfss` or bespoke inline). Distinct from `governance_plan` (plans contain policies).
+
+Shared types:
+- `governance/policy-entry.json::policy_id` → `policy`
+- `governance/policy-ref.json::policy_id` → `policy`
+
+Domain leaves:
+- **account/**: `report-usage-request` (media_buy_id, vendor_pricing_option_id, signal_activation_id, content_standards_id, rights_grant_id, creative_id, property_list_id); `sync-accounts-response` (account_id).
+- **governance/**: every `plan_id` → `governance_plan` (phase-2 taxonomy decision applied); every `policy_id` → `policy`; array-items on `plan_ids[]`, `portfolio_plan_ids[]`, `member_plan_ids[]`, `policy_ids[]`, `shared_policy_ids[]`.
+
+No new shared-type conflicts uncovered by the lint. Walker, registry disagreement guard, and existing tests unchanged.
+
+Deferred to phase 4 / capstone: `property/`, `collection/`, `sponsored-intelligence/`, plus a coverage counter in CI output and a schema-side nudge for new `*_id` fields without `x-entity`.

--- a/docs/contributing/x-entity-annotation.md
+++ b/docs/contributing/x-entity-annotation.md
@@ -109,7 +109,7 @@ High-level groupings (see the registry for full descriptions):
 | Creative | `creative`, `creative_format` |
 | Data & targeting | `audience`, `signal`, `signal_activation_id`, `event_source` |
 | Lists & catalogs | `collection_list`, `property_list`, `catalog`, `property` |
-| Plans & governance | `media_plan`, `governance_plan`, `content_standards`, `task` |
+| Plans & governance | `media_plan`, `governance_plan`, `policy`, `content_standards`, `task` |
 | Vendor services | `vendor_pricing_option` |
 | SI | `si_session` |
 

--- a/docs/contributing/x-entity-annotation.md
+++ b/docs/contributing/x-entity-annotation.md
@@ -99,7 +99,7 @@ If variants resolve to *different* entities, **split the type**. The registry li
 
 The authoritative list lives at `static/schemas/source/core/x-entity-types.json`. The lint rejects unknown values — extending the registry is intentional and requires a PR.
 
-High-level groupings (see the registry for full descriptions):
+High-level groupings (see the registry for full descriptions). *Categories below are editorial grouping for orientation only; the registry at `static/schemas/source/core/x-entity-types.json` is the authoritative list.*
 
 | Category | Values |
 |---|---|
@@ -109,9 +109,11 @@ High-level groupings (see the registry for full descriptions):
 | Creative | `creative`, `creative_format` |
 | Data & targeting | `audience`, `signal`, `signal_activation_id`, `event_source` |
 | Lists & catalogs | `collection_list`, `property_list`, `catalog`, `property` |
-| Plans & governance | `media_plan`, `governance_plan`, `policy`, `content_standards`, `task` |
+| Plans & governance | `media_plan`, `governance_plan`, `governance_policy`, `governance_check`, `content_standards`, `task` |
 | Vendor services | `vendor_pricing_option` |
 | SI | `si_session` |
+
+**Plan vs. policy vs. check:** `governance_plan` identifies the plan container (answers *"which plan?"*); `governance_policy` identifies a rule inside or referenced by a plan (*"which rule?"* — e.g., `uk_hfss`); `governance_check` identifies a specific evaluation of a plan against its policies (*"which check?"* — round-trips between `check_governance` and `report_plan_outcome`). Pick by the question the captured value answers.
 
 The registry file is the source of truth. To see every annotated field across the repo: `git grep -l x-entity static/schemas/source`.
 

--- a/static/schemas/source/account/report-usage-request.json
+++ b/static/schemas/source/account/report-usage-request.json
@@ -32,7 +32,8 @@
           },
           "media_buy_id": {
             "type": "string",
-            "description": "Seller-assigned media buy identifier. Links this usage record to a specific media buy."
+            "description": "Seller-assigned media buy identifier. Links this usage record to a specific media buy.",
+            "x-entity": "media_buy"
           },
           "vendor_cost": {
             "type": "number",
@@ -46,7 +47,8 @@
           },
           "pricing_option_id": {
             "type": "string",
-            "description": "Pricing option identifier from the vendor's discovery response (e.g., get_signals, list_content_standards). The vendor uses this to verify the correct rate was applied."
+            "description": "Pricing option identifier from the vendor's discovery response (e.g., get_signals, list_content_standards). The vendor uses this to verify the correct rate was applied.",
+            "x-entity": "vendor_pricing_option"
           },
           "impressions": {
             "type": "integer",
@@ -60,23 +62,28 @@
           },
           "signal_agent_segment_id": {
             "type": "string",
-            "description": "Signal identifier from get_signals. Required for signals agents."
+            "description": "Signal identifier from get_signals. Required for signals agents.",
+            "x-entity": "signal_activation_id"
           },
           "standards_id": {
             "type": "string",
-            "description": "Content standards configuration identifier. Required for governance agents."
+            "description": "Content standards configuration identifier. Required for governance agents.",
+            "x-entity": "content_standards"
           },
           "rights_id": {
             "type": "string",
-            "description": "Rights grant identifier from acquire_rights. Required for brand/rights agents. Links usage records to specific rights grants for cap tracking, billing verification, and overage calculation."
+            "description": "Rights grant identifier from acquire_rights. Required for brand/rights agents. Links usage records to specific rights grants for cap tracking, billing verification, and overage calculation.",
+            "x-entity": "rights_grant"
           },
           "creative_id": {
             "type": "string",
-            "description": "Creative identifier from build_creative or list_creatives. Required for creative agents. Links usage records to specific creatives for billing verification."
+            "description": "Creative identifier from build_creative or list_creatives. Required for creative agents. Links usage records to specific creatives for billing verification.",
+            "x-entity": "creative"
           },
           "property_list_id": {
             "type": "string",
-            "description": "Property list identifier from list_property_lists. Required for property list agents. Links usage records to specific property lists for billing verification."
+            "description": "Property list identifier from list_property_lists. Required for property list agents. Links usage records to specific property lists for billing verification.",
+            "x-entity": "property_list"
           }
         },
         "required": [

--- a/static/schemas/source/account/sync-accounts-response.json
+++ b/static/schemas/source/account/sync-accounts-response.json
@@ -22,7 +22,8 @@
             "properties": {
               "account_id": {
                 "type": "string",
-                "description": "Seller-assigned account identifier. Use this in subsequent create_media_buy and other account-scoped operations."
+                "description": "Seller-assigned account identifier. Use this in subsequent create_media_buy and other account-scoped operations.",
+                "x-entity": "account"
               },
               "brand": {
                 "$ref": "/schemas/core/brand-ref.json",

--- a/static/schemas/source/content-standards/calibrate-content-response.json
+++ b/static/schemas/source/content-standards/calibrate-content-response.json
@@ -41,7 +41,8 @@
               },
               "policy_id": {
                 "type": "string",
-                "description": "Policy ID that triggered this result. Enables the calibration loop to iterate on specific policies by correlating sample outcomes to policy ids."
+                "description": "Policy ID that triggered this result. Enables the calibration loop to iterate on specific policies by correlating sample outcomes to policy ids.",
+                "x-entity": "governance_policy"
               },
               "explanation": {
                 "type": "string",

--- a/static/schemas/source/content-standards/validate-content-delivery-response.json
+++ b/static/schemas/source/content-standards/validate-content-delivery-response.json
@@ -50,7 +50,8 @@
                     },
                     "policy_id": {
                       "type": "string",
-                      "description": "Registry policy ID that triggered this result. Present when the result originates from a specific registry policy (e.g., GARM category, CSBS standard). Enables programmatic routing by looking up the policy in the registry."
+                      "description": "Registry policy ID that triggered this result. Present when the result originates from a specific registry policy (e.g., GARM category, CSBS standard). Enables programmatic routing by looking up the policy in the registry.",
+                      "x-entity": "governance_policy"
                     },
                     "explanation": {
                       "type": "string",

--- a/static/schemas/source/core/x-entity-types.json
+++ b/static/schemas/source/core/x-entity-types.json
@@ -27,7 +27,8 @@
     "property",
     "media_plan",
     "governance_plan",
-    "policy",
+    "governance_policy",
+    "governance_check",
     "content_standards",
     "task",
     "si_session"
@@ -53,9 +54,10 @@
     "property_list": "A buyer-managed property list. `list_id` on property/* schemas. Same field name as collection_list — annotation distinguishes them.",
     "catalog": "A buyer catalog feed (product, inventory, promotion, offering). `catalog_id` in media-buy/sync-catalogs-request and core/catalog.json.",
     "property": "A publisher property in the seller's view. Appears in property/* and referenced by core/property.json.",
-    "media_plan": "A media plan (distinct from media_buy — a plan can have multiple buys or precede a buy). `plan_id` in governance/sync-plans-request and related schemas when the scope is media planning.",
-    "governance_plan": "A governance plan (AI Act, consent, suitability). `plan_id` in governance/* schemas when the scope is governance, not media planning.",
-    "policy": "A governance policy identifier (e.g., 'uk_hfss', 'us_coppa') from the policy registry or a bespoke inline policy scoped to a plan. `policy_id` in governance/policy-entry.json, governance/policy-ref.json, governance/sync-plans-request (policies and portfolio.shared_policy_ids), governance/check-governance-response (findings), and governance/get-plan-audit-logs-response (audit entries).",
+    "media_plan": "A media plan — distinct from media_buy (a plan can have multiple buys or precede a buy). Reserved for future media-plan schemas; no currently-shipped schemas use this value. Do not confuse with `governance_plan`, which owns every `plan_id` in governance/* schemas today.",
+    "governance_plan": "A governance plan (AI Act, consent, suitability). `plan_id` in governance/* schemas, plus media-buy/create-media-buy-request.plan_id (which flows into check_governance).",
+    "governance_policy": "A governance policy identifier (e.g., 'uk_hfss', 'us_coppa'). `policy_id` in governance/policy-entry.json, governance/policy-ref.json, governance/sync-plans-request, governance/check-governance-response findings, governance/get-plan-audit-logs-response audit entries, plus cross-domain sites: property/validation-result, error-details/policy-violation, and content-standards/*. Known caveat: registry-scoped ids (`uk_hfss`) and plan-scoped inline bespoke ids share this entity type today; splitting them requires schema-shape discrimination — tracked in issue #2685.",
+    "governance_check": "A governance check result identifier. `check_id` in governance/check-governance-response and governance/report-plan-outcome-request — it round-trips between the two, so entity-identity tracking is required.",
     "content_standards": "A content-standards document. `standards_id` in content-standards/* schemas.",
     "task": "An async task handle (governance check, validation result). `task_id` across core/tasks-* schemas.",
     "si_session": "A sponsored-intelligence conversation session. `session_id` in sponsored-intelligence/* schemas."

--- a/static/schemas/source/core/x-entity-types.json
+++ b/static/schemas/source/core/x-entity-types.json
@@ -27,6 +27,7 @@
     "property",
     "media_plan",
     "governance_plan",
+    "policy",
     "content_standards",
     "task",
     "si_session"
@@ -54,6 +55,7 @@
     "property": "A publisher property in the seller's view. Appears in property/* and referenced by core/property.json.",
     "media_plan": "A media plan (distinct from media_buy — a plan can have multiple buys or precede a buy). `plan_id` in governance/sync-plans-request and related schemas when the scope is media planning.",
     "governance_plan": "A governance plan (AI Act, consent, suitability). `plan_id` in governance/* schemas when the scope is governance, not media planning.",
+    "policy": "A governance policy identifier (e.g., 'uk_hfss', 'us_coppa') from the policy registry or a bespoke inline policy scoped to a plan. `policy_id` in governance/policy-entry.json, governance/policy-ref.json, governance/sync-plans-request (policies and portfolio.shared_policy_ids), governance/check-governance-response (findings), and governance/get-plan-audit-logs-response (audit entries).",
     "content_standards": "A content-standards document. `standards_id` in content-standards/* schemas.",
     "task": "An async task handle (governance check, validation result). `task_id` across core/tasks-* schemas.",
     "si_session": "A sponsored-intelligence conversation session. `session_id` in sponsored-intelligence/* schemas."

--- a/static/schemas/source/error-details/policy-violation.json
+++ b/static/schemas/source/error-details/policy-violation.json
@@ -7,7 +7,8 @@
   "properties": {
     "policy_id": {
       "type": "string",
-      "description": "Identifier for the violated policy"
+      "description": "Identifier for the violated policy",
+      "x-entity": "governance_policy"
     },
     "policy_url": {
       "type": "string",

--- a/static/schemas/source/governance/check-governance-request.json
+++ b/static/schemas/source/governance/check-governance-request.json
@@ -14,7 +14,8 @@
     },
     "plan_id": {
       "type": "string",
-      "description": "Campaign governance plan identifier."
+      "description": "Campaign governance plan identifier.",
+      "x-entity": "governance_plan"
     },
     "caller": {
       "type": "string",

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -8,7 +8,8 @@
   "properties": {
     "check_id": {
       "type": "string",
-      "description": "Unique identifier for this governance check record. Use in report_plan_outcome to link outcomes to the check that authorized them."
+      "description": "Unique identifier for this governance check record. Use in report_plan_outcome to link outcomes to the check that authorized them.",
+      "x-entity": "governance_check"
     },
     "status": {
       "type": "string",
@@ -41,7 +42,7 @@
           "policy_id": {
             "type": "string",
             "description": "ID of the policy that triggered this finding. May reference a registry policy (with source: registry) or a bespoke inline policy (with source: inline). Bespoke policy_ids are unique within their authoring container; use source_plan_id when findings aggregate across multiple plans (e.g., portfolio evaluations).",
-            "x-entity": "policy"
+            "x-entity": "governance_policy"
           },
           "source_plan_id": {
             "type": "string",

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -21,7 +21,8 @@
     },
     "plan_id": {
       "type": "string",
-      "description": "Echoed from request."
+      "description": "Echoed from request.",
+      "x-entity": "governance_plan"
     },
     "explanation": {
       "type": "string",
@@ -39,11 +40,13 @@
           },
           "policy_id": {
             "type": "string",
-            "description": "ID of the policy that triggered this finding. May reference a registry policy (with source: registry) or a bespoke inline policy (with source: inline). Bespoke policy_ids are unique within their authoring container; use source_plan_id when findings aggregate across multiple plans (e.g., portfolio evaluations)."
+            "description": "ID of the policy that triggered this finding. May reference a registry policy (with source: registry) or a bespoke inline policy (with source: inline). Bespoke policy_ids are unique within their authoring container; use source_plan_id when findings aggregate across multiple plans (e.g., portfolio evaluations).",
+            "x-entity": "policy"
           },
           "source_plan_id": {
             "type": "string",
-            "description": "For portfolio or aggregated evaluations where findings draw on bespoke policies from multiple member plans: identifies the plan whose policy triggered this finding. Omit when the finding's policy_id is unambiguous within the response context (e.g., single-plan check_governance)."
+            "description": "For portfolio or aggregated evaluations where findings draw on bespoke policies from multiple member plans: identifies the plan whose policy triggered this finding. Omit when the finding's policy_id is unambiguous within the response context (e.g., single-plan check_governance).",
+            "x-entity": "governance_plan"
           },
           "severity": {
             "$ref": "/schemas/enums/escalation-severity.json"

--- a/static/schemas/source/governance/get-plan-audit-logs-request.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-request.json
@@ -15,7 +15,8 @@
     "plan_ids": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "x-entity": "governance_plan"
       },
       "minItems": 1,
       "description": "Plan IDs to retrieve. For a single plan, pass a one-element array."
@@ -23,7 +24,8 @@
     "portfolio_plan_ids": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "x-entity": "governance_plan"
       },
       "minItems": 1,
       "description": "Portfolio plan IDs. The governance agent expands each to its member_plan_ids and returns combined audit data."

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -115,7 +115,8 @@
                   "properties": {
                     "check_id": {
                       "type": "string",
-                      "description": "The escalated governance check."
+                      "description": "The escalated governance check.",
+                      "x-entity": "governance_check"
                     },
                     "reason": {
                       "type": "string",
@@ -295,7 +296,7 @@
                       },
                       "policy_id": {
                         "type": "string",
-                        "x-entity": "policy"
+                        "x-entity": "governance_policy"
                       },
                       "severity": {
                         "$ref": "/schemas/enums/escalation-severity.json"

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -14,7 +14,8 @@
         "properties": {
           "plan_id": {
             "type": "string",
-            "description": "Plan identifier."
+            "description": "Plan identifier.",
+            "x-entity": "governance_plan"
           },
           "plan_version": {
             "type": "integer",
@@ -236,7 +237,8 @@
                 },
                 "plan_id": {
                   "type": "string",
-                  "description": "Plan this entry belongs to. Present when querying multiple plans or a portfolio."
+                  "description": "Plan this entry belongs to. Present when querying multiple plans or a portfolio.",
+                  "x-entity": "governance_plan"
                 },
                 "caller": {
                   "type": "string",
@@ -292,7 +294,8 @@
                         "type": "string"
                       },
                       "policy_id": {
-                        "type": "string"
+                        "type": "string",
+                        "x-entity": "policy"
                       },
                       "severity": {
                         "$ref": "/schemas/enums/escalation-severity.json"

--- a/static/schemas/source/governance/policy-category-definition.json
+++ b/static/schemas/source/governance/policy-category-definition.json
@@ -39,7 +39,7 @@
           },
           "policy_ids": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": { "type": "string", "x-entity": "policy" },
             "description": "Registry policy IDs that implement this framework."
           }
         },

--- a/static/schemas/source/governance/policy-category-definition.json
+++ b/static/schemas/source/governance/policy-category-definition.json
@@ -39,7 +39,7 @@
           },
           "policy_ids": {
             "type": "array",
-            "items": { "type": "string", "x-entity": "policy" },
+            "items": { "type": "string", "x-entity": "governance_policy" },
             "description": "Registry policy IDs that implement this framework."
           }
         },

--- a/static/schemas/source/governance/policy-entry.json
+++ b/static/schemas/source/governance/policy-entry.json
@@ -7,7 +7,8 @@
   "properties": {
     "policy_id": {
       "type": "string",
-      "description": "Unique identifier for this policy. Registry-published ids are canonical (e.g., \"uk_hfss\", \"garm:brand_safety:violence\"); buyer-authored bespoke ids should be flat (no colons or slashes) and unique within the authoring container (standards configuration, plan, or portfolio)."
+      "description": "Unique identifier for this policy. Registry-published ids are canonical (e.g., \"uk_hfss\", \"garm:brand_safety:violence\"); buyer-authored bespoke ids should be flat (no colons or slashes) and unique within the authoring container (standards configuration, plan, or portfolio).",
+      "x-entity": "policy"
     },
     "source": {
       "type": "string",

--- a/static/schemas/source/governance/policy-entry.json
+++ b/static/schemas/source/governance/policy-entry.json
@@ -8,7 +8,7 @@
     "policy_id": {
       "type": "string",
       "description": "Unique identifier for this policy. Registry-published ids are canonical (e.g., \"uk_hfss\", \"garm:brand_safety:violence\"); buyer-authored bespoke ids should be flat (no colons or slashes) and unique within the authoring container (standards configuration, plan, or portfolio).",
-      "x-entity": "policy"
+      "x-entity": "governance_policy"
     },
     "source": {
       "type": "string",

--- a/static/schemas/source/governance/policy-ref.json
+++ b/static/schemas/source/governance/policy-ref.json
@@ -8,7 +8,7 @@
     "policy_id": {
       "type": "string",
       "description": "The unique identifier of the policy in the registry (e.g., \"uk_hfss\", \"us_coppa\").",
-      "x-entity": "policy"
+      "x-entity": "governance_policy"
     },
     "version": {
       "type": "string",

--- a/static/schemas/source/governance/policy-ref.json
+++ b/static/schemas/source/governance/policy-ref.json
@@ -7,7 +7,8 @@
   "properties": {
     "policy_id": {
       "type": "string",
-      "description": "The unique identifier of the policy in the registry (e.g., \"uk_hfss\", \"us_coppa\")."
+      "description": "The unique identifier of the policy in the registry (e.g., \"uk_hfss\", \"us_coppa\").",
+      "x-entity": "policy"
     },
     "version": {
       "type": "string",

--- a/static/schemas/source/governance/report-plan-outcome-request.json
+++ b/static/schemas/source/governance/report-plan-outcome-request.json
@@ -19,7 +19,8 @@
     },
     "check_id": {
       "type": "string",
-      "description": "The check_id from check_governance. Links the outcome to the governance check that authorized it. Required for 'completed' and 'failed' outcomes."
+      "description": "The check_id from check_governance. Links the outcome to the governance check that authorized it. Required for 'completed' and 'failed' outcomes.",
+      "x-entity": "governance_check"
     },
     "idempotency_key": {
       "type": "string",

--- a/static/schemas/source/governance/report-plan-outcome-request.json
+++ b/static/schemas/source/governance/report-plan-outcome-request.json
@@ -14,7 +14,8 @@
     },
     "plan_id": {
       "type": "string",
-      "description": "The plan this outcome is for."
+      "description": "The plan this outcome is for.",
+      "x-entity": "governance_plan"
     },
     "check_id": {
       "type": "string",

--- a/static/schemas/source/governance/sync-plans-request.json
+++ b/static/schemas/source/governance/sync-plans-request.json
@@ -27,7 +27,8 @@
         "properties": {
           "plan_id": {
             "type": "string",
-            "description": "Unique identifier for this plan."
+            "description": "Unique identifier for this plan.",
+            "x-entity": "governance_plan"
           },
           "brand": {
             "$ref": "/schemas/core/brand-ref.json",
@@ -182,7 +183,8 @@
           "policy_ids": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "x-entity": "policy"
             },
             "description": "Registry policy IDs to enforce for this plan. The governance agent resolves full policy definitions from the registry and evaluates actions against them. Intersected with the plan's countries/regions to activate only geographically relevant policies."
           },
@@ -301,7 +303,8 @@
               "member_plan_ids": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "x-entity": "governance_plan"
                 },
                 "description": "Plan IDs governed by this portfolio plan. The governance agent validates member plan actions against portfolio constraints."
               },
@@ -325,7 +328,8 @@
               "shared_policy_ids": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "x-entity": "policy"
                 },
                 "description": "Registry policy IDs enforced across all member plans, regardless of individual brand configuration."
               },

--- a/static/schemas/source/governance/sync-plans-request.json
+++ b/static/schemas/source/governance/sync-plans-request.json
@@ -184,7 +184,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "x-entity": "policy"
+              "x-entity": "governance_policy"
             },
             "description": "Registry policy IDs to enforce for this plan. The governance agent resolves full policy definitions from the registry and evaluates actions against them. Intersected with the plan's countries/regions to activate only geographically relevant policies."
           },
@@ -329,7 +329,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "x-entity": "policy"
+                  "x-entity": "governance_policy"
                 },
                 "description": "Registry policy IDs enforced across all member plans, regardless of individual brand configuration."
               },

--- a/static/schemas/source/governance/sync-plans-response.json
+++ b/static/schemas/source/governance/sync-plans-response.json
@@ -64,7 +64,7 @@
                 "policy_id": {
                   "type": "string",
                   "description": "Registry policy ID.",
-                  "x-entity": "policy"
+                  "x-entity": "governance_policy"
                 },
                 "source": {
                   "type": "string",

--- a/static/schemas/source/governance/sync-plans-response.json
+++ b/static/schemas/source/governance/sync-plans-response.json
@@ -14,7 +14,8 @@
         "properties": {
           "plan_id": {
             "type": "string",
-            "description": "Plan identifier."
+            "description": "Plan identifier.",
+            "x-entity": "governance_plan"
           },
           "status": {
             "type": "string",
@@ -62,7 +63,8 @@
               "properties": {
                 "policy_id": {
                   "type": "string",
-                  "description": "Registry policy ID."
+                  "description": "Registry policy ID.",
+                  "x-entity": "policy"
                 },
                 "source": {
                   "type": "string",

--- a/static/schemas/source/property/validation-result.json
+++ b/static/schemas/source/property/validation-result.json
@@ -39,7 +39,8 @@
           },
           "policy_id": {
             "type": "string",
-            "description": "Registry policy ID that triggered this result. Enables programmatic routing by looking up the policy in the registry."
+            "description": "Registry policy ID that triggered this result. Enables programmatic routing by looking up the policy in the registry.",
+            "x-entity": "governance_policy"
           },
           "explanation": {
             "type": "string",


### PR DESCRIPTION
## Summary

Phase 3 of the [#2660](https://github.com/adcontextprotocol/adcp/issues/2660) rollout. Phases 1 (#2668) and 2 (#2672) merged; this PR sweeps the control-plane cluster — **account/** (10 schemas) and **governance/** (13 schemas).

Registry grows by **one** entity type: `policy`.

## Reviewer skim guide (15 files → 3 load-bearing)

**Mechanical** (~12 files): scalar annotations via the patch pattern from phase 2; every diff is a single `"x-entity": "…"` line on a known id-shaped field.

**Load-bearing, please review:**

1. `static/schemas/source/core/x-entity-types.json` — new `policy` value added
2. `static/schemas/source/governance/policy-entry.json` + `policy-ref.json` — shared-type annotations that propagate via `$ref`
3. `static/schemas/source/account/report-usage-request.json` — seven inherited annotations on a usage-rollup endpoint. Notable: `report-usage` is the one place where most of the cross-entity graph surfaces in a single payload (media_buy + vendor_pricing_option + signal_activation + content_standards + rights_grant + creative + property_list). If the taxonomy is wrong here, the lint will surface it on every storyboard that ends in a billing-reconciliation step.

## New entity type: `policy`

Governance plans **contain** policies. They're different entities: a plan references many policies, and a policy can be referenced by many plans. Registry definition:

> A governance policy identifier (e.g., `uk_hfss`, `us_coppa`) from the policy registry or a bespoke inline policy scoped to a plan. `policy_id` in `governance/policy-entry.json`, `governance/policy-ref.json`, `governance/sync-plans-request` (policies and portfolio.shared_policy_ids), `governance/check-governance-response` (findings), and `governance/get-plan-audit-logs-response` (audit entries).

## plan_id disambiguation (carried from phase 2)

Every `plan_id` in `governance/` is tagged `governance_plan` (not `media_plan`). Verified: governance schemas never reference a media plan; media-buy schemas' `plan_id` was hand-tagged `governance_plan` in phase 2 where it refers to a governance plan flowing into `check_governance`.

## Deliberate non-annotations

Documented in the phase-3 inventory:

- `check_id` on governance check responses — forensic handle, not cross-storyboard; lint is silent
- `outcome_id` on `report-plan-outcome-response` — forensic
- Audit log entry `id` — forensic
- `governance_context` tokens — opaque signed state, not entity identity
- `business-entity.json` — pure descriptor (legal name, tax IDs); no cross-entity identifier
- `invoice_id` on `get-account-financials-response` — transient billing record; revisit if a storyboard ever captures it

## Not closing #2660

Remaining: `property/`, `collection/`, `sponsored-intelligence/`. Plus the capstone deferred from earlier reviews:

- **Coverage counter** in CI output ("x-entity coverage: N/M domains, K id-fields annotated")
- **Schema-side nudge** — warn-only lint for new `*_id` fields added without `x-entity`

## Test plan

- [x] `npm run test:storyboard-context-entity` — 13 tests still pass
- [x] `npm run test:schemas` — all schemas validate with new annotations
- [x] `npm run test:storyboard-branch-sets`, `test:storyboard-scoping`, `test:storyboard-contradictions` still pass
- [x] `npm run build:compliance` — lint runs clean against source tree
- [x] `npm run test:unit` (pre-commit) — passes, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)