### PR TITLE
compliance(storyboards): richer env fingerprint + requires_scenarios resolution

### DIFF
--- a/.changeset/env-fingerprint-scenario-resolution.md
+++ b/.changeset/env-fingerprint-scenario-resolution.md
@@ -1,0 +1,40 @@
+---
+---
+
+compliance(storyboards): richer env fingerprint + requires_scenarios orphan resolution
+
+Two follow-ups from #2676's expert review, landing as a small bundle.
+
+**Env fingerprint: test_kit + fixtures (#2670 part 1).** The contradiction
+lint now includes `doc.prerequisites.test_kit` and a hash of top-level
+`doc.fixtures` in `fingerprintEnv`. Two storyboards sharing `id` +
+`comply_scenario` but loading different test kits (or seeding different
+prerequisite state via the top-level `fixtures:` block) legitimately
+produce different outcomes for the same request — they now land in
+distinct env buckets rather than collapsing into one.
+
+Non-breaking: adds precision without changing outcomes on today's
+storyboards. Planned removal of the `sb=<doc.id>` component (so
+cross-storyboard contradictions surface) remains tracked at #2670.
+
+**Orphan-contribution: requires_scenarios resolution (#2671).** The
+branch-set lint's `orphan_contribution` rule flags any `contributes_to`
+flag that no `assert_contribution` step consumes. Before this change,
+the walk was local to the containing doc, which false-positived on the
+legitimate pattern where a parent storyboard declares
+`requires_scenarios:` and the linked scenario owns the assertion.
+
+Resolution now walks the full source tree once via
+`buildScenarioFlagIndex`, producing `Map<doc.id, Set<flag>>`. Parent
+docs with `requires_scenarios:` union the linked scenarios' asserted
+flags into their own before the orphan check runs. Unresolved scenario
+ids fall through silently — a separate scoping-lint concern.
+
+Duplicate `doc.id` across files throws immediately in
+`buildScenarioFlagIndex`: order-dependent resolution of a collision
+could mask a real orphan elsewhere, so the lint surfaces the duplicate
+rather than papering over it.
+
+Tests: 21 contradiction tests (2 new env-discrimination), 19 branch-set
+tests (4 new: requires_scenarios resolution, unresolved-scenario
+fallback, duplicate-id throw, non-string entry skip).

--- a/scripts/lint-storyboard-branch-sets.cjs
+++ b/scripts/lint-storyboard-branch-sets.cjs
@@ -129,6 +129,45 @@ function collectAssertedFlags(doc) {
 }
 
 /**
+ * Walk the source tree and build `Map<doc.id, Set<flag>>` of asserted flags
+ * per storyboard/scenario. `orphan_contribution` checks consume this to
+ * honor `requires_scenarios:` references — a flag asserted in a linked
+ * scenario is legitimately consumed.
+ *
+ * Duplicate `id:` across files is a source bug: which file "wins" becomes
+ * order-dependent on filesystem iteration, and the wrong file's asserted
+ * flags could mask a real orphan elsewhere. Throw immediately so the
+ * collision surfaces at lint time rather than as a silent false negative.
+ */
+function buildScenarioFlagIndex(sourceDir) {
+  const index = new Map();
+  const sources = new Map();
+  for (const file of walkYaml(sourceDir)) {
+    let doc;
+    try {
+      doc = yaml.load(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!doc || typeof doc !== 'object') continue;
+    const id = doc.id;
+    if (typeof id !== 'string' || id.length === 0) continue;
+    const prior = sources.get(id);
+    if (prior && prior !== file) {
+      throw new Error(
+        `lint-storyboard-branch-sets: duplicate storyboard id "${id}" in ` +
+          `${path.relative(sourceDir, prior)} and ` +
+          `${path.relative(sourceDir, file)}. IDs must be unique across the ` +
+          'source tree so requires_scenarios resolution is deterministic.',
+      );
+    }
+    sources.set(id, file);
+    index.set(id, collectAssertedFlags(doc));
+  }
+  return index;
+}
+
+/**
  * Lint a single parsed storyboard doc. Returns an array of violations shaped
  * as `{ rule, phaseId, stepId?, ...rule-specific payload }`. File paths are
  * threaded on at the caller.
@@ -136,14 +175,28 @@ function collectAssertedFlags(doc) {
  * Accepts an options object so tests can exercise future `semantics` values
  * without mutating module state.
  */
-function lintDoc(doc, { supportedSemantics = SUPPORTED_SEMANTICS } = {}) {
+function lintDoc(doc, { supportedSemantics = SUPPORTED_SEMANTICS, scenarioFlagIndex } = {}) {
   const violations = [];
   if (!doc || typeof doc !== 'object') return violations;
   const phases = Array.isArray(doc.phases) ? doc.phases : [];
 
   const semanticsById = new Map();
   const declaredBranchSetIds = new Set();
+  // A contribution is legitimately consumed if any of (a) this doc asserts
+  // it via assert_contribution any_of, or (b) a scenario the doc declares
+  // in `requires_scenarios:` asserts it. The two kinds are unioned so a
+  // parent storyboard that delegates its grading to a shared scenario
+  // doesn't trigger orphan_contribution.
   const assertedFlags = collectAssertedFlags(doc);
+  if (scenarioFlagIndex && Array.isArray(doc.requires_scenarios)) {
+    for (const scenarioId of doc.requires_scenarios) {
+      if (typeof scenarioId !== 'string') continue;
+      const scenarioFlags = scenarioFlagIndex.get(scenarioId);
+      if (scenarioFlags) {
+        for (const flag of scenarioFlags) assertedFlags.add(flag);
+      }
+    }
+  }
 
   // Pass 1: gather declared branch_set.ids so pass 2 can enforce peer
   // completeness against contributes_to on peer phases that haven't been
@@ -315,6 +368,7 @@ function lintDoc(doc, { supportedSemantics = SUPPORTED_SEMANTICS } = {}) {
 
 function lint() {
   const files = walkYaml(SOURCE_DIR);
+  const scenarioFlagIndex = buildScenarioFlagIndex(SOURCE_DIR);
   const allViolations = [];
   for (const file of files) {
     let doc;
@@ -326,7 +380,7 @@ function lint() {
       continue;
     }
     const relFile = path.relative(SOURCE_DIR, file);
-    for (const v of lintDoc(doc)) {
+    for (const v of lintDoc(doc, { scenarioFlagIndex })) {
       allViolations.push({ ...v, file: relFile });
     }
   }
@@ -359,5 +413,6 @@ module.exports = {
   lint,
   lintDoc,
   collectAssertedFlags,
+  buildScenarioFlagIndex,
   formatMessage,
 };

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -259,15 +259,37 @@ function fingerprintRequest(req) {
  * returning different error shapes, or two storyboards seeding different
  * governance states).
  *
- * The storyboard's top-level `id:` is included: distinct storyboard files
- * exercise distinct test-kit/controller configurations that a runner
- * resets between runs. Contradictions within a single storyboard are the
- * high-value signal; cross-storyboard contradictions require an explicit
- * shared env tag (comply_scenario + prerequisites) to surface.
+ * Components:
+ *   sb         — storyboard's top-level `id:`. Ensures distinct storyboard
+ *                files aren't treated as running against the same in-memory
+ *                agent. Conservative: means cross-storyboard contradictions
+ *                are unreachable today. See #2670 for the planned removal.
+ *   test_kit   — `doc.prerequisites.test_kit`. Two storyboards sharing id +
+ *                scenario but loading different test kits target different
+ *                agent fixtures.
+ *   fixtures   — hash of `doc.fixtures` (top-level). Storyboards that seed
+ *                different prerequisite state via `comply_test_controller`
+ *                legitimately produce different outcomes for the same
+ *                request.
+ *   scenario   — step's `comply_scenario`.
+ *   auth       — step's auth override shape (type + strategy).
+ *   seed       — phase's `prerequisites.controller_seeding` (distinct from
+ *                top-level fixtures; applies phase-scoped seeding).
  */
 function fingerprintEnv(step, phase, doc) {
   const parts = [];
   if (typeof doc?.id === 'string') parts.push(`sb=${doc.id}`);
+  if (typeof doc?.prerequisites?.test_kit === 'string') {
+    parts.push(`test_kit=${doc.prerequisites.test_kit}`);
+  }
+  if (doc?.fixtures && typeof doc.fixtures === 'object' && Object.keys(doc.fixtures).length > 0) {
+    const fixturesHash = crypto
+      .createHash('sha1')
+      .update(stableStringify(doc.fixtures))
+      .digest('hex')
+      .slice(0, 8);
+    parts.push(`fixtures=${fixturesHash}`);
+  }
   if (typeof step.comply_scenario === 'string') parts.push(`scenario=${step.comply_scenario}`);
   if (step.auth) {
     const auth = step.auth;

--- a/tests/lint-storyboard-branch-sets.test.cjs
+++ b/tests/lint-storyboard-branch-sets.test.cjs
@@ -16,7 +16,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const yaml = require('js-yaml');
 
-const { lint, lintDoc, collectAssertedFlags } = require('../scripts/lint-storyboard-branch-sets.cjs');
+const {
+  lint,
+  lintDoc,
+  collectAssertedFlags,
+  buildScenarioFlagIndex,
+} = require('../scripts/lint-storyboard-branch-sets.cjs');
 
 test('source tree passes the branch-set lint', () => {
   const violations = lint();
@@ -272,6 +277,107 @@ phases:
   const orphans = violations.filter((v) => v.rule === 'orphan_contribution');
   assert.equal(orphans.length, 1);
   assert.equal(orphans[0].flag, 'unasserted');
+});
+
+test('orphan_contribution: requires_scenarios resolves linked assertions', () => {
+  // A parent storyboard delegates grading to a linked scenario via
+  // `requires_scenarios`. Contributions in the parent that the scenario
+  // asserts must not fire orphan_contribution.
+  const parent = yaml.load(`
+id: parent_sb
+requires_scenarios: [linked_suite/governance_denied]
+phases:
+  - id: emit
+    steps:
+      - id: contribute
+        contributes_to: governance_denied_flag
+`);
+  const scenarioFlagIndex = new Map([
+    ['linked_suite/governance_denied', new Set(['governance_denied_flag'])],
+  ]);
+  const orphans = lintDoc(parent, { scenarioFlagIndex }).filter(
+    (v) => v.rule === 'orphan_contribution',
+  );
+  assert.deepEqual(orphans, []);
+});
+
+test('orphan_contribution: unresolved requires_scenarios still flags orphan', () => {
+  // Fail-open on unknown scenario ids (separate authoring bug the scoping
+  // lint catches) but don't pretend the flag is asserted. Missing scenarios
+  // produce the same orphan violation as storyboards with no
+  // requires_scenarios at all.
+  const parent = yaml.load(`
+id: parent_sb
+requires_scenarios: [nonexistent/foo]
+phases:
+  - id: emit
+    steps:
+      - id: contribute
+        contributes_to: dangling
+`);
+  const orphans = lintDoc(parent, { scenarioFlagIndex: new Map() }).filter(
+    (v) => v.rule === 'orphan_contribution',
+  );
+  assert.deepEqual(
+    orphans.map((v) => ({ stepId: v.stepId, flag: v.flag })),
+    [{ stepId: 'contribute', flag: 'dangling' }],
+  );
+});
+
+test('buildScenarioFlagIndex indexes source tree by doc.id', () => {
+  // Real source tree is indexed and non-empty. No current scenario file
+  // uses assert_contribution, so the in-memory round-trip below exercises
+  // the flag-collection path directly.
+  const index = buildScenarioFlagIndex(
+    require('node:path').resolve(__dirname, '..', 'static', 'compliance', 'source'),
+  );
+  assert.ok(index.size > 0, 'expected scenario flag index to be non-empty');
+  // Known anchor: a real scenario file that requires_scenarios points at.
+  assert.ok(
+    index.has('media_buy_seller/governance_denied'),
+    'expected media_buy_seller/governance_denied in index',
+  );
+});
+
+test('buildScenarioFlagIndex throws on duplicate doc.id across files', () => {
+  // Load-bearing for orphan resolution: a duplicate id would make "which
+  // file's asserted flags win" order-dependent on filesystem iteration,
+  // potentially masking a real orphan elsewhere. Surface the collision.
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const os = require('node:os');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'branch-set-lint-'));
+  try {
+    fs.writeFileSync(path.join(tmp, 'a.yaml'), 'id: collide\nphases: []\n');
+    fs.writeFileSync(path.join(tmp, 'b.yaml'), 'id: collide\nphases: []\n');
+    assert.throws(() => buildScenarioFlagIndex(tmp), /duplicate storyboard id "collide"/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('requires_scenarios: non-string entries are skipped, not thrown', () => {
+  // Defensive: authoring error (e.g., accidental map entry) shouldn't crash
+  // the lint. Strings resolve; non-strings are ignored.
+  const parent = yaml.load(`
+id: parent_mixed
+requires_scenarios:
+  - valid_scenario
+  - 42
+  - { not: a string }
+phases:
+  - id: emit
+    steps:
+      - id: contribute
+        contributes_to: a_flag
+`);
+  const scenarioFlagIndex = new Map([
+    ['valid_scenario', new Set(['a_flag'])],
+  ]);
+  const orphans = lintDoc(parent, { scenarioFlagIndex }).filter(
+    (v) => v.rule === 'orphan_contribution',
+  );
+  assert.deepEqual(orphans, []);
 });
 
 test('collectAssertedFlags pulls every any_of flag from every assert_contribution step', () => {

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -348,6 +348,87 @@ phases:
   assert.deepEqual(contradictionsAcrossDocs({ 'a.yaml': doc }), []);
 });
 
+test('test_kit discriminates env: two storyboards sharing id+scenario but different kits', () => {
+  // Authoring hazard: two parallel storyboards copied from one template,
+  // running against different agent fixtures via different test_kit paths.
+  // They legitimately produce different outcomes for the same request
+  // shape. Env fingerprint must discriminate.
+  const docs = {
+    'acme.yaml': yaml.load(`
+id: sb_parallel
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: succeed
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'osei.yaml': yaml.load(`
+id: sb_parallel
+prerequisites:
+  test_kit: "test-kits/osei-natural.yaml"
+phases:
+  - id: p
+    steps:
+      - id: fail
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+  };
+  assert.deepEqual(contradictionsAcrossDocs(docs), []);
+});
+
+test('top-level fixtures discriminates env: same id, different seeded state', () => {
+  // Two runs of the same storyboard id against different seeded prerequisite
+  // state (via top-level `fixtures:`) can legitimately assert different
+  // outcomes. Fingerprint must treat them as separate envs.
+  const docs = {
+    'approved.yaml': yaml.load(`
+id: sb_seeded
+fixtures:
+  plans:
+    - plan_id: pre_approved
+      status: approved
+phases:
+  - id: p
+    steps:
+      - id: go
+        task: create_media_buy
+        sample_request: { brand: { domain: x }, plan_id: pre_approved }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'denied.yaml': yaml.load(`
+id: sb_seeded
+fixtures:
+  plans:
+    - plan_id: pre_approved
+      status: denied
+phases:
+  - id: p
+    steps:
+      - id: nope
+        task: create_media_buy
+        sample_request: { brand: { domain: x }, plan_id: pre_approved }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+  };
+  assert.deepEqual(contradictionsAcrossDocs(docs), []);
+});
+
 test('auth override discriminates env: valid key vs random-invalid key', () => {
   const doc = yaml.load(`
 id: sb_auth


### PR DESCRIPTION
## Summary

Bundles two follow-ups filed after [#2676](https://github.com/adcontextprotocol/adcp/pull/2676):

- **[#2670](https://github.com/adcontextprotocol/adcp/issues/2670) part 1** — add \`doc.prerequisites.test_kit\` and top-level \`doc.fixtures\` to the contradiction lint's env fingerprint.
- **[#2671](https://github.com/adcontextprotocol/adcp/issues/2671)** — resolve \`requires_scenarios:\` before flagging \`orphan_contribution\`, so a parent storyboard that delegates grading to a linked scenario doesn't false-positive.

Both are precision-adding, non-breaking changes. Contradiction counts on the current source tree are unchanged (36/56 clean, 295 passed).

## Env fingerprint (#2670 part 1)

Before:
\`\`\`
sb=<doc.id>|scenario=<comply_scenario>|auth=<type:strat>|seed=<controller_seeding>
\`\`\`

After:
\`\`\`
sb=<doc.id>|test_kit=<prerequisites.test_kit>|fixtures=<hash>|scenario=<comply_scenario>|auth=<type:strat>|seed=<controller_seeding>
\`\`\`

Covers two legitimate "same id+scenario, different outcome" cases:
- Two storyboards copied from one template, running against different agent fixtures via different \`prerequisites.test_kit\` paths.
- Same storyboard seeded with different controller state via top-level \`fixtures:\` entries.

The \`sb=<doc.id>\` component stays in place — removing it (so cross-storyboard contradictions surface) remains tracked as part 2 of #2670 with triage time to match.

## Orphan contribution + requires_scenarios (#2671)

\`buildScenarioFlagIndex\` walks the source tree once and produces \`Map<doc.id, Set<flag>>\` keyed on every storyboard/scenario file's top-level \`id:\`. \`lintDoc\` accepts a \`scenarioFlagIndex\` option; when a parent doc declares \`requires_scenarios:\`, the linked scenarios' asserted flags union into the parent's own before the orphan check runs.

**Duplicate \`doc.id\` across files throws** — order-dependent resolution of a collision could silently mask a real orphan elsewhere, so we surface the duplicate at lint time rather than papering over it.

Unresolved scenario ids fall through silently (scoping-lint concern per the issue); non-string \`requires_scenarios\` entries are skipped defensively.

## Tests

- [x] \`npm run test:storyboard-contradictions\` — 21 tests (2 new: \`test_kit\` discrimination, \`fixtures\` discrimination)
- [x] \`npm run test:storyboard-branch-sets\` — 19 tests (4 new: \`requires_scenarios\` resolution, unresolved-scenario fallback, duplicate-id throw, non-string entry skip)
- [x] \`npm run build:compliance\` — all four storyboard lints pass
- [x] Precommit (\`npm run test:unit\` + \`typecheck\`) — 631 tests pass
- [x] Training Agent Storyboards locally — 36/56 clean, 295 passed (unchanged from main, above CI floors)

## Expert review

One round pre-merge:
- **Duplicate-id throw** added per code reviewer's load-bearing note (applied in commit).
- **Strengthened \`buildScenarioFlagIndex\` test** with an anchor scenario id check.
- **Non-string \`requires_scenarios\` entry test** pinning defensive skip behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)