### PR TITLE
compliance(storyboards): fixture-hash normalization + requires_scenarios spec

### DIFF
--- a/.changeset/fixtures-sort-requires-scenarios-spec.md
+++ b/.changeset/fixtures-sort-requires-scenarios-spec.md
@@ -1,0 +1,40 @@
+---
+---
+
+compliance(storyboards): normalize fixture hash + formalize requires_scenarios flag flow
+
+Two hygiene follow-ups from #2679's expert review.
+
+**Fixture hash normalization (#2682).** `fingerprintEnv` in the
+contradiction lint now sorts arrays within each documented fixture
+category by its primary id before hashing. Two storyboards with
+semantically equivalent fixtures in different array order —
+`products: [A, B]` vs `products: [B, A]` — now land in the same env
+bucket, closing a false-negative envelope before `#2670 part 2`
+removes `sb=<doc.id>` and makes env-fingerprint precision
+load-bearing. Sort keys per category: `products → product_id`,
+`pricing_options → pricing_option_id`, `creatives → creative_id`,
+`plans → plan_id`, `media_buys → media_buy_id`.
+
+Unknown fixture categories throw immediately, forcing schema-doc and
+lint updates to land together whenever new seed categories ship.
+
+**Spec: flag flow across `requires_scenarios` (#2683).**
+`storyboard-schema.yaml` now normatively specifies how `branch_set`
+contribution flags flow between a parent storyboard and its linked
+scenarios:
+
+- A flag contributed in parent X is considered asserted if either X's
+  own phases assert it or a scenario Y in `X.requires_scenarios`
+  asserts it.
+- Reverse flow is prohibited — scenarios MUST be internally
+  self-grading to preserve standalone lintability.
+- Scenario IDs must match referenced files' top-level `id:` exactly,
+  and those files MUST exist at build time.
+
+Matches the `orphan_contribution` lint behavior that landed in #2679;
+the lint is now the de facto reference, and the spec prose is aligned.
+
+Follow-up filed at #2687 for `unresolved_scenario_reference` grading
+(runner + lint hard error on missing scenario files — symmetrizes
+with the duplicate-id throw in `buildScenarioFlagIndex`).

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -253,6 +253,56 @@ function fingerprintRequest(req) {
 }
 
 /**
+ * Primary-id field per documented fixture category (see the `fixtures:`
+ * block documentation in storyboard-schema.yaml). Used to sort arrays
+ * within a category so two storyboards with semantically equivalent
+ * fixtures in different array order hash the same.
+ *
+ * The seeding DAG is keyed on foreign-key dependencies across categories,
+ * not on intra-array order within one — sorting by primary id is safe and
+ * eliminates a false-negative envelope in the env fingerprint.
+ */
+const FIXTURE_CATEGORY_PRIMARY_ID = {
+  products: 'product_id',
+  pricing_options: 'pricing_option_id',
+  creatives: 'creative_id',
+  plans: 'plan_id',
+  media_buys: 'media_buy_id',
+};
+
+function normalizeFixturesForHashing(fixtures) {
+  if (!fixtures || typeof fixtures !== 'object') return fixtures;
+  const out = {};
+  for (const [category, entries] of Object.entries(fixtures)) {
+    if (!Array.isArray(entries)) {
+      out[category] = entries;
+      continue;
+    }
+    const idField = FIXTURE_CATEGORY_PRIMARY_ID[category];
+    if (!idField) {
+      // Unknown category: fail loudly rather than preserve order silently.
+      // A new fixture category added to the schema without updating this
+      // table would otherwise create a false-negative bucket in the env
+      // fingerprint (two authors listing entries in different orders
+      // produce different hashes for the same seeded state). Force the
+      // schema update and the lint update to land together.
+      throw new Error(
+        `lint-storyboard-contradictions: unknown fixture category "${category}". ` +
+          `Add it to FIXTURE_CATEGORY_PRIMARY_ID in scripts/lint-storyboard-contradictions.cjs ` +
+          'alongside the schema documentation in static/compliance/source/universal/storyboard-schema.yaml.',
+      );
+    }
+    out[category] = [...entries].sort((a, b) => {
+      const aid = a && typeof a === 'object' ? a[idField] : undefined;
+      const bid = b && typeof b === 'object' ? b[idField] : undefined;
+      if (typeof aid !== 'string' || typeof bid !== 'string') return 0;
+      return aid < bid ? -1 : aid > bid ? 1 : 0;
+    });
+  }
+  return out;
+}
+
+/**
  * Env fingerprint: the external knobs that select which fixture a conformant
  * agent serves. Two steps with same request but different env can
  * legitimately disagree on outcome (e.g., api-key vs oauth_bearer auth
@@ -285,7 +335,7 @@ function fingerprintEnv(step, phase, doc) {
   if (doc?.fixtures && typeof doc.fixtures === 'object' && Object.keys(doc.fixtures).length > 0) {
     const fixturesHash = crypto
       .createHash('sha1')
-      .update(stableStringify(doc.fixtures))
+      .update(stableStringify(normalizeFixturesForHashing(doc.fixtures)))
       .digest('hex')
       .slice(0, 8);
     parts.push(`fixtures=${fixturesHash}`);
@@ -530,11 +580,13 @@ module.exports = {
   MUTATING_TASKS,
   MUTATING_EXCEPTIONS,
   SKIP_TASKS,
+  FIXTURE_CATEGORY_PRIMARY_ID,
   loadMutatingTasksFromSchemas,
   normalizeRequestValue,
   canonicalizeRequest,
   fingerprintRequest,
   fingerprintEnv,
+  normalizeFixturesForHashing,
   classifyOutcome,
   outcomesAgree,
   describeOutcome,

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -31,7 +31,27 @@
 #
 # requires_scenarios: string[] (optional — scenario IDs from storyboards/scenarios/ that must pass alongside this storyboard.
 #   Scenarios are small, focused behavior tests (e.g., "media_buy_seller/accepts_governance").
-#   The compliance engine resolves and runs them alongside the main storyboard.)
+#   The compliance engine resolves and runs them alongside the main storyboard.
+#
+#   Flag flow across `requires_scenarios`:
+#     A `branch_set` flag contributed in a step of storyboard X is
+#     considered asserted if EITHER (a) a step in X's own phases asserts
+#     it via `assert_contribution` with `check: any_of, allowed_values:
+#     [<flag>]`, OR (b) a scenario Y listed in `X.requires_scenarios`
+#     asserts it via the same check. The `orphan_contribution` lint
+#     honors this flow.
+#
+#     Reverse flow (a contribution in scenario Y asserted in parent X)
+#     is NOT supported — scenarios MUST be internally self-grading.
+#     The restriction preserves standalone lintability of scenarios
+#     and prevents cycles in the composition graph. Scenarios that
+#     contribute a flag without asserting it in their own phases will
+#     surface as `orphan_contribution` when linted standalone.
+#
+#     Scenario IDs in `requires_scenarios` MUST match the referenced
+#     file's top-level `id:` exactly, and the referenced scenario file
+#     MUST exist in the source tree at build time. Duplicate IDs
+#     across files are a build-time error.)
 #
 # agent:
 #   interaction_model: enum (stateless_transform | stateful_preloaded | stateful_push | stateless_generate | media_buy_seller | marketplace_catalog | owned_signals | si_platform | brand_rights_holder | governance_agent)

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -20,11 +20,13 @@ const {
   findContradictions,
   canonicalizeRequest,
   fingerprintRequest,
+  fingerprintEnv,
   classifyOutcome,
   outcomesAgree,
   MUTATING_TASKS,
   MUTATING_EXCEPTIONS,
   loadMutatingTasksFromSchemas,
+  normalizeFixturesForHashing,
 } = require('../scripts/lint-storyboard-contradictions.cjs');
 
 const path = require('node:path');
@@ -427,6 +429,89 @@ phases:
 `),
   };
   assert.deepEqual(contradictionsAcrossDocs(docs), []);
+});
+
+test('fixtures hash is stable across array-order permutations within a category', () => {
+  // Regression guard: `products: [A, B]` and `products: [B, A]` seed the
+  // same runner state (the seeding DAG keys on foreign-key dependencies,
+  // not intra-array order). Their env fingerprints must match.
+  const docA = {
+    id: 'sb_fx',
+    fixtures: {
+      products: [
+        { product_id: 'p1', delivery_type: 'guaranteed' },
+        { product_id: 'p2', delivery_type: 'non_guaranteed' },
+      ],
+      creatives: [
+        { creative_id: 'c1', status: 'approved' },
+        { creative_id: 'c2', status: 'pending' },
+      ],
+    },
+  };
+  const docB = {
+    id: 'sb_fx',
+    fixtures: {
+      products: [
+        { product_id: 'p2', delivery_type: 'non_guaranteed' },
+        { product_id: 'p1', delivery_type: 'guaranteed' },
+      ],
+      creatives: [
+        { creative_id: 'c2', status: 'pending' },
+        { creative_id: 'c1', status: 'approved' },
+      ],
+    },
+  };
+  const step = { comply_scenario: 'test' };
+  assert.equal(fingerprintEnv(step, {}, docA), fingerprintEnv(step, {}, docB));
+});
+
+test('fixtures hash still discriminates genuinely different entries', () => {
+  // Complement to the stability guard: different fixture CONTENTS must
+  // still produce different env fingerprints, even if the array order
+  // looks similar.
+  const docA = {
+    id: 'sb_fx',
+    fixtures: {
+      plans: [{ plan_id: 'pre_approved', status: 'approved' }],
+    },
+  };
+  const docB = {
+    id: 'sb_fx',
+    fixtures: {
+      plans: [{ plan_id: 'pre_approved', status: 'denied' }],
+    },
+  };
+  const step = { comply_scenario: 'test' };
+  assert.notEqual(fingerprintEnv(step, {}, docA), fingerprintEnv(step, {}, docB));
+});
+
+test('normalizeFixturesForHashing throws on unknown fixture category', () => {
+  // Schema-lint coupling: a new category added to storyboard-schema.yaml
+  // without updating FIXTURE_CATEGORY_PRIMARY_ID would silently create a
+  // false-negative bucket in the env fingerprint. Force the schema doc
+  // update and the lint update to land together.
+  const input = {
+    custom_entities: [{ some_field: 'z' }, { some_field: 'a' }],
+  };
+  assert.throws(
+    () => normalizeFixturesForHashing(input),
+    /unknown fixture category "custom_entities"/,
+  );
+});
+
+test('normalizeFixturesForHashing accepts every documented category', () => {
+  // Complement to the throw: the five categories the schema documents
+  // today must round-trip cleanly. Guards against a rename or typo in
+  // FIXTURE_CATEGORY_PRIMARY_ID that would break all storyboards
+  // declaring fixtures.
+  const input = {
+    products: [{ product_id: 'p1' }],
+    pricing_options: [{ pricing_option_id: 'po1' }],
+    creatives: [{ creative_id: 'c1' }],
+    plans: [{ plan_id: 'pl1' }],
+    media_buys: [{ media_buy_id: 'mb1' }],
+  };
+  assert.doesNotThrow(() => normalizeFixturesForHashing(input));
 });
 
 test('auth override discriminates env: valid key vs random-invalid key', () => {


### PR DESCRIPTION
## Summary

Two hygiene follow-ups from [#2679](https://github.com/adcontextprotocol/adcp/pull/2679)'s expert review:

- **[#2682](https://github.com/adcontextprotocol/adcp/issues/2682)** — sort fixture arrays by primary id before hashing, closing a false-negative env-fingerprint envelope.
- **[#2683](https://github.com/adcontextprotocol/adcp/issues/2683)** — normative spec language for how \`branch_set\` contribution flags flow across \`requires_scenarios:\` boundaries, aligning the schema with the \`orphan_contribution\` lint shipped in #2679.

## Fixture hash normalization (#2682)

\`fingerprintEnv\` now sorts arrays within each documented fixture category by its primary id before \`stableStringify\`. Two storyboards with semantically equivalent fixtures — \`products: [A, B]\` vs \`products: [B, A]\` — land in the same env bucket. Closes the false-negative envelope before \`#2670 part 2\` removes \`sb=<doc.id>\` and makes env-fingerprint precision load-bearing.

**Sort keys** (mirrors the schema's \`fixtures:\` block):
- \`products → product_id\`
- \`pricing_options → pricing_option_id\`
- \`creatives → creative_id\`
- \`plans → plan_id\`
- \`media_buys → media_buy_id\`

**Unknown fixture categories throw** — a new seed category added to the schema without updating \`FIXTURE_CATEGORY_PRIMARY_ID\` is a hard error. Forces schema-doc and lint updates to land together so a silent false-negative bucket can't emerge.

## requires_scenarios spec (#2683)

\`storyboard-schema.yaml\` now normatively describes the flow of \`branch_set\` contribution flags between a parent storyboard and its linked scenarios:

- A flag contributed in parent X is considered asserted if either X's own phases assert it OR a scenario Y in \`X.requires_scenarios\` asserts it via \`assert_contribution any_of\`.
- **Reverse flow is prohibited** — scenarios MUST be internally self-grading to preserve standalone lintability and prevent cycles in the composition graph.
- Scenario IDs must match the referenced file's top-level \`id:\` exactly, and the file MUST exist at build time.

Matches the \`orphan_contribution\` lint behavior shipped in #2679. The lint was the de facto spec; this PR closes the gap.

## Test plan

- [x] \`npm run test:storyboard-contradictions\` — 25 tests (3 new: array-order stability, content-difference still discriminated, unknown-category throws + documented categories round-trip)
- [x] \`npm run test:storyboard-branch-sets\` — unchanged, 19 tests pass
- [x] \`npm run build:compliance\` — all four storyboard lints green
- [x] Precommit (\`npm run test:unit\` + \`typecheck\`) — 631 tests pass
- [x] Expert review (code + protocol) applied: throw on unknown fixture category, strengthened reverse-flow restriction, scenario file existence in spec

## Follow-up filed

- **[#2687](https://github.com/adcontextprotocol/adcp/issues/2687)** — \`unresolved_scenario_reference\` grading reason + lint hard error on missing scenario files. Symmetrizes with the duplicate-\`doc.id\` throw already in \`buildScenarioFlagIndex\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)