### PR TITLE
spec + tooling: x-mutates-state annotation on request schemas (#2675)

### DIFF
--- a/.changeset/x-mutates-state-annotation.md
+++ b/.changeset/x-mutates-state-annotation.md
@@ -1,0 +1,44 @@
+---
+---
+
+spec + tooling: x-mutates-state annotation on request schemas (#2675)
+
+Replaces the contradiction lint's idempotency-key inference +
+hardcoded-exception model with an explicit `x-mutates-state: true`
+annotation on each mutating request schema. Decouples two concerns
+that happen to correlate ~95% of the time:
+
+- **Mutation semantics** (`x-mutates-state: true`) — "this task changes
+  observable server state a later conformant call may assert against."
+- **Idempotency mechanism** (`required: [idempotency_key]`) — "replay
+  dedup requires a key on the request."
+
+The two sets legitimately diverge for naturally-idempotent mutations:
+`comply_test_controller` (scenario enum is the dedup boundary) and
+`si_terminate_session` (session_id is the dedup boundary). Before this
+PR both were carved out via a `MUTATING_EXCEPTIONS` set in
+`scripts/lint-storyboard-contradictions.cjs` — a drift hazard that
+required documented rationale for each entry. Now both declare
+`x-mutates-state: true` directly in their schemas, the exception set
+is gone, and the lint reads one source of truth.
+
+**Changes:**
+- 31 `*-request.json` schemas under `static/schemas/source/` gain
+  `"x-mutates-state": true` (29 previously detected via
+  `idempotency_key` + 2 previously exceptions).
+- `loadMutatingTasksFromSchemas` reads `schema['x-mutates-state'] === true`.
+- `MUTATING_EXCEPTIONS` removed from `lint-storyboard-contradictions.cjs`.
+- `storyboard-schema.yaml` gains a normative paragraph describing
+  `x-mutates-state` semantics and enumerating included task classes.
+- `build-compliance.cjs` retains its idempotency-key read (separate
+  concern) with an inline comment explaining the divergence.
+
+**Tests updated:**
+- Drift guard: `MUTATING_TASKS` equals the schema-derived set exactly
+  (no exception side channel).
+- Positive anchors expanded to include `comply_test_controller` and
+  `si_terminate_session`.
+- Negative anchors unchanged (`get_products`, `get_signals`,
+  `list_creative_formats`, `get_adcp_capabilities` must not appear).
+- Total: 24 contradiction tests pass (was 25 — dropped the now-
+  vestigial "every exception absent from derived" test).

--- a/.changeset/x-mutates-state-annotation.md
+++ b/.changeset/x-mutates-state-annotation.md
@@ -24,8 +24,8 @@ is gone, and the lint reads one source of truth.
 
 **Changes:**
 - 31 `*-request.json` schemas under `static/schemas/source/` gain
-  `"x-mutates-state": true` (29 previously detected via
-  `idempotency_key` + 2 previously exceptions).
+  `"x-mutates-state": true` (29 previously inferred via
+  `idempotency_key`, 2 previously carved out as exceptions).
 - `loadMutatingTasksFromSchemas` reads `schema['x-mutates-state'] === true`.
 - `MUTATING_EXCEPTIONS` removed from `lint-storyboard-contradictions.cjs`.
 - `storyboard-schema.yaml` gains a normative paragraph describing

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -175,6 +175,15 @@ function discoverProtocols(sourceDir, specialisms) {
 // arrival. The one documented exception (si-terminate-session: naturally
 // idempotent by session_id) carries a `$comment` on its request schema
 // and is correctly absent from the required-key set.
+//
+// Divergence with `x-mutates-state`: the contradiction lint's cousin at
+// `scripts/lint-storyboard-contradictions.cjs:loadMutatingTasksFromSchemas`
+// reads `x-mutates-state: true` instead — that's the mutation-semantics
+// declaration ("this task changes observable state"), which is a different
+// concern from the idempotency mechanism enforced here. The two sets
+// overlap on ~95% of tasks but legitimately diverge on naturally-idempotent
+// mutations (comply_test_controller, si_terminate_session). Do not
+// unify — they answer different questions.
 
 function loadMutatingSchemaRefs(schemasDir) {
   const refs = new Set();

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -61,40 +61,20 @@ const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'compliance', 'source
 const SCHEMAS_DIR = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
 
 /**
- * Tasks whose state mutations are invisible to the idempotency-key heuristic
- * below — they don't require `idempotency_key` in their request schema
- * (typically because they are naturally idempotent or session-scoped) but
- * still change observable agent state that a later step's outcome depends on.
- *
- * Each entry must be justified. Adding to this set without a schema-level
- * reason is a drift hazard; prefer declaring `idempotency_key` required on
- * the request schema instead.
- */
-const MUTATING_EXCEPTIONS = new Set([
-  // Schema description: "Naturally idempotent: the `scenario` enum is either
-  // a lookup (`list_scenarios`) or a state-forcing operation whose target
-  // state is carried in the payload (`force_*_status`, `simulate_*`), so
-  // replays converge to the same observable state." The controller scenarios
-  // do mutate controller state the next step observes, so the contradiction
-  // lint must treat them as mutations.
-  'comply_test_controller',
-  // Schema description: "Naturally idempotent — `session_id` is the dedup
-  // boundary, and terminating an already-terminated session is a no-op that
-  // returns the same terminal state." The termination still transitions
-  // active → terminated, and a later si_send_message on the same session_id
-  // asserts against that terminal state; the contradiction lint must
-  // discriminate pre- vs post-termination state paths.
-  'si_terminate_session',
-]);
-
-/**
  * Read every `*-request.json` under `SCHEMAS_DIR` and return the set of
- * task names that require `idempotency_key`. Task name is derived from the
- * filename: `create-media-buy-request.json` → `create_media_buy`.
+ * task names whose schema declares `"x-mutates-state": true`. Task name
+ * is derived from the filename: `create-media-buy-request.json` →
+ * `create_media_buy`.
  *
- * Mirrors the pattern in `scripts/build-compliance.cjs:loadMutatingSchemaRefs`;
- * kept local rather than shared because the two lints have slightly
- * different output needs (tool-only here, refs+tools there).
+ * `x-mutates-state` is the explicit schema-level declaration that this
+ * task changes observable server state a later step's assertion may
+ * depend on. It decouples "mutation semantics" (what the contradiction
+ * lint needs) from "idempotency mechanism" (what
+ * `build-compliance.cjs:loadMutatingSchemaRefs` enforces) — the two
+ * correlate ~95% of the time but legitimately diverge for naturally-
+ * idempotent mutations like `comply_test_controller` (scenario enum is
+ * the dedup boundary) and `si_terminate_session` (session_id is the
+ * dedup boundary).
  */
 function loadMutatingTasksFromSchemas(schemasDir) {
   // Map<task, srcPath> so same-task-name across subdirs surfaces as an
@@ -117,8 +97,7 @@ function loadMutatingTasksFromSchemas(schemasDir) {
       } catch {
         continue;
       }
-      const required = Array.isArray(schema.required) ? schema.required : [];
-      if (!required.includes('idempotency_key')) continue;
+      if (schema['x-mutates-state'] !== true) continue;
       const task = entry.name.replace(/-request\.json$/, '').replace(/-/g, '_');
       const prior = origins.get(task);
       if (prior && prior !== p) {
@@ -137,18 +116,13 @@ function loadMutatingTasksFromSchemas(schemasDir) {
 
 /**
  * AdCP task names that MUTATE server state. Derived at module load by
- * reading request schemas' `required: [idempotency_key]` declarations
- * (source of truth for "this task is a mutation"), plus documented
- * exceptions for naturally-idempotent tasks that still change state.
+ * reading every request schema's `x-mutates-state: true` declaration.
  *
  * Prior-state discrimination in the contradiction lint depends on this
  * set — a step whose prior phase contains only read tasks is at the same
  * "state" as a step with no prior phases.
  */
-const MUTATING_TASKS = new Set([
-  ...loadMutatingTasksFromSchemas(SCHEMAS_DIR),
-  ...MUTATING_EXCEPTIONS,
-]);
+const MUTATING_TASKS = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
 
 /**
  * Step tasks that we skip entirely — they're synthetic assertions or
@@ -578,7 +552,6 @@ if (require.main === module) main();
 
 module.exports = {
   MUTATING_TASKS,
-  MUTATING_EXCEPTIONS,
   SKIP_TASKS,
   FIXTURE_CATEGORY_PRIMARY_ID,
   loadMutatingTasksFromSchemas,

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -362,6 +362,20 @@
 #   a `branch_set.id`) are exempt from contradiction flagging by design:
 #   any_of semantics intentionally asserts mutually exclusive outcomes.
 #
+#   Mutating-task detection: the lint's prior-state fingerprint partitions
+#   steps by the ordered list of prior MUTATING tasks. A task is mutating
+#   iff its request schema declares `"x-mutates-state": true` at the top
+#   level. The annotation is an explicit contract — decoupled from the
+#   separate `idempotency_key` mechanism — meaning "this task changes
+#   observable server state a later conformant call may assert against."
+#   Mutating tasks include writes (create/update/delete/sync/build), state
+#   transitions (cancel, approve, reject), session-scoped primitives
+#   (si_initiate_session, si_send_message, si_terminate_session), and
+#   reporting/audit writes (log_event, report_usage, report_plan_outcome,
+#   provide_performance_feedback — their outputs surface in later
+#   get_plan_audit_logs / billing reads). Read-only tasks (get_*, list_*,
+#   check_*, validate_*, preview_*) do not declare `x-mutates-state`.
+#
 # --- Validation ---
 #
 # check: string (what to validate: "response_schema", "field_present", "field_value",

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -365,16 +365,50 @@
 #   Mutating-task detection: the lint's prior-state fingerprint partitions
 #   steps by the ordered list of prior MUTATING tasks. A task is mutating
 #   iff its request schema declares `"x-mutates-state": true` at the top
-#   level. The annotation is an explicit contract — decoupled from the
-#   separate `idempotency_key` mechanism — meaning "this task changes
-#   observable server state a later conformant call may assert against."
-#   Mutating tasks include writes (create/update/delete/sync/build), state
-#   transitions (cancel, approve, reject), session-scoped primitives
-#   (si_initiate_session, si_send_message, si_terminate_session), and
-#   reporting/audit writes (log_event, report_usage, report_plan_outcome,
-#   provide_performance_feedback — their outputs surface in later
-#   get_plan_audit_logs / billing reads). Read-only tasks (get_*, list_*,
-#   check_*, validate_*, preview_*) do not declare `x-mutates-state`.
+#   level. The annotation is consumed by
+#   `scripts/lint-storyboard-contradictions.cjs` (which builds the
+#   mutating-task set at lint time) and is the single source of truth for
+#   this concern.
+#
+#   Decidability rule (apply to any new task):
+#     A task declares `"x-mutates-state": true` iff a conformant compliance
+#     suite could write an assertion — on any later `get_*`, `list_*`, or
+#     follow-up call — whose outcome depends on this request having run.
+#     Equivalently: "this task changes observable server state a later
+#     conformant call may assert against."
+#
+#   Mutating task classes (illustrative; the decidability rule above is
+#   the actual test):
+#     - Writes (create/update/delete/sync/build) — resource lifecycle.
+#     - State transitions (cancel, approve, reject) — status moves.
+#     - Session-scoped primitives (si_initiate_session, si_send_message,
+#       si_terminate_session) — session lifecycle.
+#     - Reporting/audit writes (log_event, report_usage,
+#       report_plan_outcome, provide_performance_feedback) — mutating
+#       because `get_plan_audit_logs` and billing-summary tasks can assert
+#       against their recorded outputs.
+#
+#   Non-mutating task classes:
+#     - Read-only tasks (get_*, list_*, check_*, validate_*, preview_*) do
+#       not declare `x-mutates-state` UNLESS the read itself produces
+#       observable state a later task can assert against (e.g., a view
+#       counter that `get_analytics` can read) — those are mutating
+#       regardless of prefix.
+#     - Pure-compute tasks (no state read or write — estimates,
+#       calculations) MUST NOT declare `x-mutates-state`.
+#
+#   Relationship to idempotency_key (decoupled, do not unify):
+#     `x-mutates-state` declares mutation semantics. `required:
+#     [idempotency_key]` declares the idempotency mechanism. The sets
+#     overlap ~95% but legitimately diverge for naturally-idempotent
+#     mutations. Example: `comply_test_controller` declares
+#     `x-mutates-state: true` but omits `idempotency_key` from `required`
+#     because the `scenario` enum is the dedup boundary — replaying
+#     `force_media_buy_status=active` converges to the same observable
+#     state without a key. `si_terminate_session` is the same shape
+#     (session_id is the dedup boundary). `scripts/build-compliance.cjs`
+#     reads `idempotency_key` for its own enforcement; do not try to share
+#     the two reads.
 #
 # --- Validation ---
 #

--- a/static/schemas/source/account/report-usage-request.json
+++ b/static/schemas/source/account/report-usage-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/account/report-usage-request.json",
   "title": "Report Usage Request",
   "description": "Reports how a vendor's service was consumed after campaign delivery. Used by orchestrators (DSPs, storefronts) to inform vendor agents (signals, governance, creative) what was used so the vendor can track earned revenue and verify billing. Records can span multiple accounts and campaigns in a single request.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/account/sync-accounts-request.json
+++ b/static/schemas/source/account/sync-accounts-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/account/sync-accounts-request.json",
   "title": "Sync Accounts Request",
   "description": "Sync advertiser accounts with a seller using upsert semantics. The agent declares which brands it represents, who operates on each brand's behalf, and the billing model. The seller provisions or links accounts accordingly, returning per-account status.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/account/sync-governance-request.json
+++ b/static/schemas/source/account/sync-governance-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/account/sync-governance-request.json",
   "title": "Sync Governance Request",
   "description": "Sync governance agent endpoints against specific accounts. The seller persists these governance agents and calls them for approval during media buy lifecycle events via check_governance. Uses replace semantics: each call replaces any previously synced agents on the specified accounts. The seller MUST verify that the authenticated agent has authority over each referenced account before persisting governance agents.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/brand/acquire-rights-request.json
+++ b/static/schemas/source/brand/acquire-rights-request.json
@@ -4,6 +4,7 @@
   "title": "Acquire Rights Request",
   "description": "Binding contractual request to acquire rights from a brand agent. Parallels create_media_buy — the buyer selects a pricing_option_id from a get_rights response and provides campaign details. The agent clears against existing contracts and returns terms, generation credentials, and disclosure requirements.",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/brand/creative-approval-request.json
+++ b/static/schemas/source/brand/creative-approval-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/brand/creative-approval-request.json",
   "title": "Creative Approval Request",
   "description": "Payload submitted by the buyer to the approval_webhook URL from acquire_rights. Contains the creative for rights holder review before distribution.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/brand/update-rights-request.json
+++ b/static/schemas/source/brand/update-rights-request.json
@@ -4,6 +4,7 @@
   "title": "Update Rights Request",
   "description": "Modify an existing rights grant — extend dates, adjust impression caps, change pricing, or pause/resume. Parallels update_media_buy. Only the fields provided are updated; omitted fields remain unchanged.",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/collection/create-collection-list-request.json
+++ b/static/schemas/source/collection/create-collection-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/collection/create-collection-list-request.json",
   "title": "Create Collection List Request",
   "description": "Request parameters for creating a new collection list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/collection/delete-collection-list-request.json
+++ b/static/schemas/source/collection/delete-collection-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/collection/delete-collection-list-request.json",
   "title": "Delete Collection List Request",
   "description": "Request parameters for deleting a collection list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/collection/update-collection-list-request.json
+++ b/static/schemas/source/collection/update-collection-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/collection/update-collection-list-request.json",
   "title": "Update Collection List Request",
   "description": "Request parameters for updating an existing collection list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/compliance/comply-test-controller-request.json",
   "title": "Comply Test Controller Request",
   "description": "Request payload for the comply_test_controller tool. Triggers seller-side state transitions for compliance testing. Sandbox only — sellers MUST NOT expose this tool in production. Naturally idempotent: the `scenario` enum is either a lookup (`list_scenarios`) or a state-forcing operation whose target state is carried in the payload (`force_*_status`, `simulate_*`), so replays converge to the same observable state without needing an idempotency_key. The compliance harness drives this tool deterministically and does not rely on the seller's at-most-once replay cache.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "scenario": {

--- a/static/schemas/source/content-standards/calibrate-content-request.json
+++ b/static/schemas/source/content-standards/calibrate-content-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/content-standards/calibrate-content-request.json",
   "title": "Calibrate Content Request",
   "description": "Request parameters for evaluating content during calibration. Multi-turn dialogue is handled at the protocol layer via contextId.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/content-standards/create-content-standards-request.json
+++ b/static/schemas/source/content-standards/create-content-standards-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/content-standards/create-content-standards-request.json",
   "title": "Create Content Standards Request",
   "description": "Request parameters for creating a new content standards configuration",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/content-standards/update-content-standards-request.json
+++ b/static/schemas/source/content-standards/update-content-standards-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/content-standards/update-content-standards-request.json",
   "title": "Update Content Standards Request",
   "description": "Request parameters for updating an existing content standards configuration. Creates a new version.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/creative/sync-creatives-request.json
+++ b/static/schemas/source/creative/sync-creatives-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/creative/sync-creatives-request.json",
   "title": "Sync Creatives Request",
   "description": "Request parameters for syncing creative assets with upsert semantics - supports bulk operations, scoped updates, and assignment management",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/governance/report-plan-outcome-request.json
+++ b/static/schemas/source/governance/report-plan-outcome-request.json
@@ -4,6 +4,7 @@
   "title": "Report Plan Outcome Request",
   "description": "Report the outcome of an action to the governance agent. Called by the orchestrator (buyer-side agent) after a seller responds. This is the 'after' half of the governance loop. Sellers do not call this task -- they report delivery data via check_governance with phase 'delivery'.",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/governance/sync-plans-request.json
+++ b/static/schemas/source/governance/sync-plans-request.json
@@ -4,6 +4,7 @@
   "title": "Sync Plans Request",
   "description": "Push campaign plans to the governance agent. A plan defines the authorized parameters for a campaign -- budget limits, channels, flight dates, and authorized markets.",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/build-creative-request.json
+++ b/static/schemas/source/media-buy/build-creative-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/build-creative-request.json",
   "title": "Build Creative Request",
   "description": "Request to transform, generate, or retrieve a creative manifest. Supports three modes: (1) generation from a brief or seed assets, (2) transformation of an existing manifest, (3) retrieval from a creative library by creative_id. Produces target manifest(s) in the specified format(s). Provide either target_format_id for a single format or target_format_ids for multiple formats.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/create-media-buy-request.json",
   "title": "Create Media Buy Request",
   "description": "Request parameters for creating a media buy. Supports two modes: (1) Manual mode - provide packages array with explicit line item configurations, or (2) Proposal mode - provide proposal_id and total_budget to execute a proposal from get_products. One of packages or proposal_id must be provided.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/log-event-request.json
+++ b/static/schemas/source/media-buy/log-event-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/log-event-request.json",
   "title": "Log Event Request",
   "description": "Request parameters for logging marketing events",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/provide-performance-feedback-request.json
+++ b/static/schemas/source/media-buy/provide-performance-feedback-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/provide-performance-feedback-request.json",
   "title": "Provide Performance Feedback Request",
   "description": "Request payload for provide_performance_feedback task",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/sync-audiences-request.json
+++ b/static/schemas/source/media-buy/sync-audiences-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/sync-audiences-request.json",
   "title": "Sync Audiences Request",
   "description": "Request parameters for managing CRM-based audiences on an account with upsert semantics. Existing audiences matched by audience_id are updated, new ones are created. Members are specified as delta operations: add appends new members, remove drops existing ones. Recommend no more than 100,000 members per call; for larger lists, chunk and call incrementally using add/remove deltas. When delete_missing is true, buyer-managed audiences on the account not in this request are removed — do not combine with omitted audiences or all buyer-managed audiences will be deleted. When audiences is omitted, the call is discovery-only: it returns all audiences on the account without modification.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/sync-catalogs-request.json
+++ b/static/schemas/source/media-buy/sync-catalogs-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/sync-catalogs-request.json",
   "title": "Sync Catalogs Request",
   "description": "Request parameters for syncing catalog feeds with upsert semantics. Supports bulk operations across multiple catalog types (products, inventory, stores, promotions, offerings). Existing catalogs matched by catalog_id are updated, new ones are created. When catalogs is omitted, the call is discovery-only: returns all catalogs on the account without modification.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/sync-event-sources-request.json
+++ b/static/schemas/source/media-buy/sync-event-sources-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/sync-event-sources-request.json",
   "title": "Sync Event Sources Request",
   "description": "Request parameters for configuring event sources on an account with upsert semantics. Existing event sources matched by event_source_id are updated, new ones are created. When delete_missing is true, buyer-managed event sources on the account not in this request are removed. When event_sources is omitted, the call is discovery-only: it returns all event sources on the account without modification. The response always includes both synced and seller-managed event sources for full visibility.",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/media-buy/update-media-buy-request.json",
   "title": "Update Media Buy Request",
   "description": "Request parameters for updating campaign and package settings",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/property/create-property-list-request.json
+++ b/static/schemas/source/property/create-property-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/property/create-property-list-request.json",
   "title": "Create Property List Request",
   "description": "Request parameters for creating a new property list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/property/delete-property-list-request.json
+++ b/static/schemas/source/property/delete-property-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/property/delete-property-list-request.json",
   "title": "Delete Property List Request",
   "description": "Request parameters for deleting a property list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/property/update-property-list-request.json
+++ b/static/schemas/source/property/update-property-list-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/property/update-property-list-request.json",
   "title": "Update Property List Request",
   "description": "Request parameters for updating an existing property list",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/signals/activate-signal-request.json
+++ b/static/schemas/source/signals/activate-signal-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/signals/activate-signal-request.json",
   "title": "Activate Signal Request",
   "description": "Request parameters for activating or deactivating a signal on deployment targets",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
@@ -4,6 +4,7 @@
   "title": "SI Initiate Session Request",
   "description": "Host initiates a session with a brand agent",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/sponsored-intelligence/si-send-message-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-send-message-request.json
@@ -4,6 +4,7 @@
   "title": "SI Send Message Request",
   "description": "Send a message to the brand agent within an active session",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/sponsored-intelligence/si-terminate-session-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-terminate-session-request.json
@@ -4,6 +4,7 @@
   "title": "SI Terminate Session Request",
   "description": "Request to terminate an SI session. Naturally idempotent — `session_id` is the dedup boundary, and terminating an already-terminated session is a no-op that returns the same terminal state. No `idempotency_key` is needed on this request.",
   "x-status": "experimental",
+  "x-mutates-state": true,
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -24,7 +24,6 @@ const {
   classifyOutcome,
   outcomesAgree,
   MUTATING_TASKS,
-  MUTATING_EXCEPTIONS,
   loadMutatingTasksFromSchemas,
   normalizeFixturesForHashing,
 } = require('../scripts/lint-storyboard-contradictions.cjs');
@@ -40,46 +39,45 @@ function contradictionsAcrossDocs(docs) {
   return findContradictions(events);
 }
 
-test('MUTATING_TASKS is derived from idempotency_key-required schemas + exceptions', () => {
-  // Drift guard: the union of (schemas requiring idempotency_key) and
-  // MUTATING_EXCEPTIONS must equal MUTATING_TASKS exactly. If this test
-  // breaks, a new mutating task was added without either (a) adding
-  // idempotency_key to its request schema, or (b) documenting it in
-  // MUTATING_EXCEPTIONS with a schema-level rationale.
+test('MUTATING_TASKS is derived entirely from x-mutates-state schemas', () => {
+  // Drift guard: the schema-derived set (via `x-mutates-state: true`)
+  // must equal MUTATING_TASKS exactly. If this test breaks, a new
+  // mutating task shipped without its request schema declaring
+  // `x-mutates-state: true`, or vice versa.
   const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
-  const expected = new Set([...derived, ...MUTATING_EXCEPTIONS]);
   assert.deepEqual(
     [...MUTATING_TASKS].sort(),
-    [...expected].sort(),
-    'MUTATING_TASKS drifted from (schema-derived + MUTATING_EXCEPTIONS)',
+    [...derived].sort(),
+    'MUTATING_TASKS drifted from schemas — add or remove x-mutates-state: true',
   );
-});
-
-test('every MUTATING_EXCEPTION is absent from the schema-derived set', () => {
-  // If a task exists in both, the exception is redundant and should be
-  // removed. This keeps MUTATING_EXCEPTIONS as a disciplined list of
-  // genuine gaps the schema heuristic doesn't cover.
-  const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
-  const redundant = [...MUTATING_EXCEPTIONS].filter((t) => derived.has(t));
-  assert.deepEqual(redundant, [], 'MUTATING_EXCEPTIONS entries redundant with schema');
 });
 
 test('schema-derived set covers known mutating tasks', () => {
   // Sanity check: these are anchored task names that MUST be present
   // regardless of schema refactors. If the schema filename convention
-  // changes or a file moves, this test localizes the break.
+  // changes or a file moves, this test localizes the break. Includes
+  // the two tasks that were exceptions under the old idempotency-key
+  // heuristic (comply_test_controller, si_terminate_session) — both
+  // now declare x-mutates-state: true explicitly.
   const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
-  for (const task of ['create_media_buy', 'update_media_buy', 'sync_creatives', 'sync_audiences']) {
+  for (const task of [
+    'create_media_buy',
+    'update_media_buy',
+    'sync_creatives',
+    'sync_audiences',
+    'comply_test_controller',
+    'si_terminate_session',
+  ]) {
     assert.ok(derived.has(task), `expected ${task} in schema-derived mutating set`);
   }
 });
 
 test('schema-derived set does not over-match read-only tasks', () => {
-  // Negative anchor: if a read-only request schema ever starts listing
-  // idempotency_key in required (spec drift, accidental copy-paste), the
-  // contradiction lint would silently over-discriminate state paths. Lock
-  // in a handful of anchor reads so the bug surfaces here, not in a
-  // false-positive at build time.
+  // Negative anchor: if a read-only request schema ever declares
+  // `x-mutates-state: true` (spec drift, accidental copy-paste), the
+  // contradiction lint would silently over-discriminate state paths.
+  // Lock in a handful of anchor reads so the bug surfaces here, not
+  // in a false-positive at build time.
   const derived = loadMutatingTasksFromSchemas(SCHEMAS_DIR);
   for (const task of [
     'get_products',


### PR DESCRIPTION
## Summary

Closes [#2675](https://github.com/adcontextprotocol/adcp/issues/2675).

Replaces the contradiction lint's idempotency-key inference + hardcoded-exception model with an explicit \`x-mutates-state: true\` annotation on each mutating request schema. Decouples two concerns that correlate ~95% of the time:

- **Mutation semantics** (\`x-mutates-state: true\`) — \"this task changes observable server state a later conformant call may assert against.\"
- **Idempotency mechanism** (\`required: [idempotency_key]\`) — \"replay dedup requires a key on the request.\"

The two sets legitimately diverge for naturally-idempotent mutations: \`comply_test_controller\` (scenario enum is the dedup boundary) and \`si_terminate_session\` (session_id is the dedup boundary). Before this PR both were carved out via a \`MUTATING_EXCEPTIONS\` Set in \`scripts/lint-storyboard-contradictions.cjs\` — a drift hazard with documented rationale per entry. Now both declare \`x-mutates-state: true\` directly in their schemas, the exception Set is gone, and the lint reads one source of truth.

## Changes

- **31 schemas** under \`static/schemas/source/\` gained \`\"x-mutates-state\": true\` (29 previously detected via \`idempotency_key\` + 2 previously \`MUTATING_EXCEPTIONS\`). Insertion position: right after \`description\` / \`x-status\`, before \`\"type\": \"object\",\` — matches the \`x-status\` / \`x-entity\` convention.
- **\`loadMutatingTasksFromSchemas\`** now reads \`schema['x-mutates-state'] === true\` directly. Strict boolean check (non-boolean values silently treated as absent — documented in the JSDoc).
- **\`MUTATING_EXCEPTIONS\`** Set removed.
- **\`storyboard-schema.yaml\`** gains a normative paragraph describing \`x-mutates-state\` semantics, enumerating the task classes that carry it (writes, state transitions, session primitives, reporting/audit writes), and calling out the separate-concern relationship with \`idempotency_key\`.
- **\`build-compliance.cjs\`** retains its idempotency-key read unchanged (separate concern) with an inline comment pointing at the \`x-mutates-state\` cousin so the next reader doesn't try to unify them.

## Tests

- **24 contradiction tests pass.**
- Drift guard: \`MUTATING_TASKS\` equals the schema-derived set exactly (no exception side channel).
- Positive-anchor test expanded to cover \`comply_test_controller\` and \`si_terminate_session\` — both now schema-driven.
- Negative anchors unchanged: \`get_products\`, \`get_signals\`, \`list_creative_formats\`, \`get_adcp_capabilities\` must not appear.
- Dropped the now-vestigial \"every MUTATING_EXCEPTION is absent from derived\" test.
- \`npm run build:compliance\` and \`npm run build:schemas\` both clean; 631 unit tests + typecheck green.

## Expert review

Both protocol and code review cleared the PR. Fixes applied pre-push:
- Normative paragraph added to \`storyboard-schema.yaml\` (protocol expert).
- Divergence comment added to \`build-compliance.cjs\` (protocol expert).
- One-shot migration script deleted from \`.context/\` (code reviewer — stale re-run hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)