### PR TITLE
compliance(storyboards): unresolved_scenario_reference lint + runner grading (#2687)

### DIFF
--- a/.changeset/unresolved-scenario-reference.md
+++ b/.changeset/unresolved-scenario-reference.md
@@ -1,0 +1,44 @@
+---
+---
+
+compliance(storyboards): unresolved_scenario_reference lint + runner grading (#2687)
+
+Closes #2687. Two coordinated changes symmetric with the duplicate-
+`doc.id` throw already shipped in `buildScenarioFlagIndex`.
+
+**Lint**: `scripts/lint-storyboard-branch-sets.cjs` gains a new
+`unresolved_scenario_reference` rule. When `lintDoc` is called with a
+`scenarioFlagIndex` and a `requires_scenarios:` entry in the doc isn't
+a key in the index, emit a violation — once per occurrence. The rule
+fires independently of `orphan_contribution`; a missing scenario
+reference does not pretend the flag was asserted. Only active when
+`scenarioFlagIndex` is provided (the production `lint()` driver always
+passes it; unit tests without an index are unaffected).
+
+**Spec**: `static/compliance/source/universal/storyboard-schema.yaml`
+documents the runner-side grading. Per the `detailed_reason_mapping`
+convention in `runner-output-contract.yaml`, runners MUST populate the
+canonical `reason: not_applicable` and encode
+`unresolved_scenario_reference` in `detail`. The detail shape is pinned
+(`'requires_scenarios reference "<scenario_id>" did not resolve
+against the source tree'`) and enumerates every unresolved id when
+multiple references are broken.
+
+An explicit anti-conflation paragraph distinguishes this reason from
+`fixture_seed_unsupported`: the latter is an agent-coverage gap,
+`unresolved_scenario_reference` is a source-tree authoring bug.
+Dashboards and aggregators SHOULD NOT combine them.
+
+**Audit**: verified 0 unresolved `requires_scenarios` entries in the
+current source tree — safe to add the hard lint error without breaking
+the build.
+
+**Tests**: 23 branch-set tests pass (4 new: fires on unresolved,
+silent without index, quiet when all resolve, fires-per-occurrence on
+duplicate unresolved ids). Existing `orphan_contribution` test
+unchanged.
+
+**Follow-up**: `@adcp/client` runner will need to honor the new reason
+when consuming AdCP storyboards from outside this repo (lint catches
+in-repo cases pre-merge; runner behavior is defensive). Tracked
+separately.

--- a/scripts/lint-storyboard-branch-sets.cjs
+++ b/scripts/lint-storyboard-branch-sets.cjs
@@ -24,11 +24,22 @@
  *   contributes_bad_type — `contributes` is present but not a boolean
  *   orphan_contribution  — contributes_to flag is never consumed by any
  *                          assert_contribution any_of in the same storyboard
+ *   unresolved_scenario_reference — requires_scenarios entry names an id
+ *                          that doesn't exist in the source tree (no file
+ *                          declares that `id:`). Symmetric with the
+ *                          duplicate-doc.id throw in buildScenarioFlagIndex:
+ *                          if collisions are a build-time error, missing
+ *                          references must be too.
  *
  * `contributes_both` / `contributes_outside_branch_set` / `contributes_bad_type`
  * mirror adcp-client's loader (node_modules/@adcp/client/dist/lib/testing/
  * storyboard/loader.js `resolveContributesShorthand`) so authors see the
  * violation at build time instead of storyboard-load time.
+ *
+ * Doc-level rules (those that apply to the storyboard as a whole, not a
+ * specific phase) use `phaseId: '<doc>'` as a sentinel so the main()
+ * formatter can render `file.yaml:<doc>` consistently. Current doc-level
+ * rules: unresolved_scenario_reference.
  */
 
 'use strict';
@@ -83,6 +94,12 @@ const RULE_MESSAGES = {
     `step in this storyboard references it via \`check: any_of, ` +
     `allowed_values: [${flag}]\`. Either add the assertion or remove the ` +
     'dead contribution — nothing is grading what this step produces.',
+  unresolved_scenario_reference: ({ scenarioId }) =>
+    `requires_scenarios references "${scenarioId}" but no file in the source ` +
+    `tree declares that \`id:\`. Either fix the reference, add the missing ` +
+    'scenario file, or remove the entry — the runner will grade this ' +
+    'storyboard `not_applicable` with `unresolved_scenario_reference` rather ' +
+    'than silently pass.',
 };
 
 function formatMessage(violation) {
@@ -187,6 +204,10 @@ function lintDoc(doc, { supportedSemantics = SUPPORTED_SEMANTICS, scenarioFlagIn
   // in `requires_scenarios:` asserts it. The two kinds are unioned so a
   // parent storyboard that delegates its grading to a shared scenario
   // doesn't trigger orphan_contribution.
+  //
+  // An unresolved entry in `requires_scenarios` is a separate, stronger
+  // violation: it means the runner will grade this storyboard
+  // not_applicable at execution time. Surface it at lint time instead.
   const assertedFlags = collectAssertedFlags(doc);
   if (scenarioFlagIndex && Array.isArray(doc.requires_scenarios)) {
     for (const scenarioId of doc.requires_scenarios) {
@@ -194,6 +215,12 @@ function lintDoc(doc, { supportedSemantics = SUPPORTED_SEMANTICS, scenarioFlagIn
       const scenarioFlags = scenarioFlagIndex.get(scenarioId);
       if (scenarioFlags) {
         for (const flag of scenarioFlags) assertedFlags.add(flag);
+      } else {
+        violations.push({
+          rule: 'unresolved_scenario_reference',
+          phaseId: '<doc>',
+          scenarioId,
+        });
       }
     }
   }

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -546,6 +546,36 @@
 #       UNKNOWN_SCENARIO). The storyboard grades not_applicable (coverage gap),
 #       not failed.
 #
+#   unresolved_scenario_reference
+#       A detailed sub-reason under the canonical skip `reason:
+#       not_applicable`. Emitted when a parent storyboard's
+#       `requires_scenarios:` entry cannot be resolved against the source
+#       tree (no file declares that `id:`). Per the
+#       `detailed_reason_mapping` convention in runner-output-contract.yaml,
+#       runners MUST populate the canonical `reason: not_applicable` and
+#       encode `unresolved_scenario_reference` in `detail`. detail MUST
+#       follow the shape
+#       'requires_scenarios reference "<scenario_id>" did not resolve
+#       against the source tree' — and when multiple references are
+#       unresolved, detail MUST enumerate every unresolved id with the
+#       same shape (comma-separated or newline-delimited) so downstream
+#       tooling can parse each. Runners MUST NOT silently pass the parent
+#       as if the missing scenario had contributed.
+#
+#       Distinct from `fixture_seed_unsupported`: that reason indicates an
+#       agent-coverage gap (seller doesn't implement a seed scenario);
+#       `unresolved_scenario_reference` indicates a source-tree authoring
+#       bug that the build-time lint SHOULD have caught. Dashboards and
+#       summary reports SHOULD NOT conflate the two when aggregating
+#       `not_applicable` counts — they are categorically different
+#       signals.
+#
+#       The `lint:storyboard-branch-sets` script surfaces this as a
+#       build-time error via the `unresolved_scenario_reference` rule so
+#       unresolved references in a well-linted corpus never reach a
+#       runner. The runner-side grading is defensive for corpora that
+#       bypass the lint or come from pre-lint CI states.
+#
 # --- Webhook receiver (optional, for outbound-webhook conformance) ---
 #
 # Storyboards that verify outbound webhook conformance (signing, idempotency_key

--- a/tests/lint-storyboard-branch-sets.test.cjs
+++ b/tests/lint-storyboard-branch-sets.test.cjs
@@ -302,10 +302,8 @@ phases:
 });
 
 test('orphan_contribution: unresolved requires_scenarios still flags orphan', () => {
-  // Fail-open on unknown scenario ids (separate authoring bug the scoping
-  // lint catches) but don't pretend the flag is asserted. Missing scenarios
-  // produce the same orphan violation as storyboards with no
-  // requires_scenarios at all.
+  // Missing scenarios don't pretend the flag is asserted. Orphan violation
+  // fires independently of the new unresolved_scenario_reference rule.
   const parent = yaml.load(`
 id: parent_sb
 requires_scenarios: [nonexistent/foo]
@@ -322,6 +320,81 @@ phases:
     orphans.map((v) => ({ stepId: v.stepId, flag: v.flag })),
     [{ stepId: 'contribute', flag: 'dangling' }],
   );
+});
+
+test('unresolved_scenario_reference: fires on requires_scenarios id absent from index', () => {
+  // Symmetric with the duplicate-doc.id throw in buildScenarioFlagIndex:
+  // if collisions are a build-time error, missing references must be too.
+  // The runner will grade this storyboard not_applicable at execution
+  // time; surface it at lint time so authors catch the typo/rename.
+  const parent = yaml.load(`
+id: parent_unresolved
+requires_scenarios: [typo/misnamed_scenario, present/scenario]
+phases:
+  - id: p
+    steps: []
+`);
+  const scenarioFlagIndex = new Map([['present/scenario', new Set()]]);
+  const unresolved = lintDoc(parent, { scenarioFlagIndex }).filter(
+    (v) => v.rule === 'unresolved_scenario_reference',
+  );
+  assert.deepEqual(
+    unresolved.map((v) => v.scenarioId),
+    ['typo/misnamed_scenario'],
+  );
+});
+
+test('unresolved_scenario_reference: absent when scenarioFlagIndex is not provided', () => {
+  // Back-compat: callers that don't pass the index (pre-#2671 code paths,
+  // unit tests) don't trigger the new rule. Only kicks in when the lint
+  // has the source-tree context to verify resolution.
+  const parent = yaml.load(`
+id: parent_no_index
+requires_scenarios: [any/id]
+phases:
+  - id: p
+    steps: []
+`);
+  const unresolved = lintDoc(parent).filter(
+    (v) => v.rule === 'unresolved_scenario_reference',
+  );
+  assert.deepEqual(unresolved, []);
+});
+
+test('unresolved_scenario_reference: fires once per occurrence on duplicate unresolved ids', () => {
+  // Duplicate entries in the array produce one violation per occurrence.
+  // If a future refactor de-duplicates, this test forces the decision to
+  // be explicit rather than silent.
+  const parent = yaml.load(`
+id: parent_dup_unresolved
+requires_scenarios: [typo/x, typo/x]
+phases:
+  - id: p
+    steps: []
+`);
+  const unresolved = lintDoc(parent, { scenarioFlagIndex: new Map() }).filter(
+    (v) => v.rule === 'unresolved_scenario_reference',
+  );
+  assert.equal(unresolved.length, 2);
+  assert.ok(unresolved.every((v) => v.scenarioId === 'typo/x'));
+});
+
+test('unresolved_scenario_reference: no violation for resolved references', () => {
+  const parent = yaml.load(`
+id: parent_all_resolve
+requires_scenarios: [a/one, b/two]
+phases:
+  - id: p
+    steps: []
+`);
+  const scenarioFlagIndex = new Map([
+    ['a/one', new Set()],
+    ['b/two', new Set()],
+  ]);
+  const unresolved = lintDoc(parent, { scenarioFlagIndex }).filter(
+    (v) => v.rule === 'unresolved_scenario_reference',
+  );
+  assert.deepEqual(unresolved, []);
 });
 
 test('buildScenarioFlagIndex indexes source tree by doc.id', () => {


### PR DESCRIPTION
## Summary

Closes [#2687](https://github.com/adcontextprotocol/adcp/issues/2687). Symmetric with the duplicate-\`doc.id\` throw already shipped in \`buildScenarioFlagIndex\` — if collisions are a build-time error, missing references must be too.

## Lint

\`scripts/lint-storyboard-branch-sets.cjs\` gains \`unresolved_scenario_reference\`. When \`lintDoc\` is called with a \`scenarioFlagIndex\` and a \`requires_scenarios:\` entry isn't a key in the index, emit a violation — once per occurrence. Independent of \`orphan_contribution\`; a missing scenario reference doesn't pretend the flag was asserted. Back-compat: the rule only fires when \`scenarioFlagIndex\` is passed; unit tests without an index behave unchanged.

## Spec

\`storyboard-schema.yaml\` documents the runner-side grading per the \`detailed_reason_mapping\` convention in \`runner-output-contract.yaml\`. Key normative statements:

- Runner MUST populate canonical \`reason: not_applicable\` with \`unresolved_scenario_reference\` in \`detail\`.
- \`detail\` shape pinned: \`'requires_scenarios reference \"<scenario_id>\" did not resolve against the source tree'\`, enumerated when multiple refs are broken.
- Anti-conflation paragraph: \`fixture_seed_unsupported\` is an agent-coverage gap, \`unresolved_scenario_reference\` is a source-tree authoring bug. Dashboards SHOULD NOT combine them.

## Audit

Verified 0 unresolved \`requires_scenarios\` in the current source tree — safe to add the hard lint error without breaking the build.

## Test plan

- [x] \`npm run test:storyboard-branch-sets\` — 23 tests (4 new: fires on unresolved, silent without index, quiet when all resolve, fires-per-occurrence on duplicate unresolved ids)
- [x] \`npm run build:compliance\` — all four storyboard lints pass
- [x] Precommit (\`npm run test:unit\` + \`typecheck\`) — 631 tests pass
- [x] Expert review (code + protocol) applied pre-push: routed through \`detailed_reason_mapping\`, added anti-conflation paragraph, pinned \`detail\` shape, documented \`<doc>\` sentinel in rule-IDs comment.

## Follow-up

\`@adcp/client\` runner will need to honor the new reason when consuming AdCP storyboards from outside this repo. The lint catches in-repo cases pre-merge; runner behavior is defensive for corpora that bypass the lint or come from pre-lint CI states. To be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)