### PR TITLE
compliance(storyboards): caller.role in contradiction lint env fingerprint (#2684)

### DIFF
--- a/.changeset/env-fingerprint-caller-role.md
+++ b/.changeset/env-fingerprint-caller-role.md
@@ -1,0 +1,12 @@
+---
+---
+
+compliance(storyboards): add `role=<doc.caller.role>` to the contradiction lint's env fingerprint as a forward-compatible discriminator for the "shared `test_kit`, distinct principal roles" case flagged in #2684.
+
+Audit of the current 56-storyboard suite (#2684): every storyboard declares `caller.role: buyer_agent`, and no storyboard declares `prerequisites.principal`. The two shared `test_kit` paths (`acme-outdoor.yaml` ×42 and `nova-motors.yaml` ×6) are consumed uniformly by `buyer_agent` callers. So `test_kit` is a sufficient principal-identity proxy today and the fingerprint collision shape the issue describes does not exist.
+
+Including `role=` anyway is cheap (no-op on the current suite — every event gets the same `role=buyer_agent` component) and load-bearing the moment #2670 part 2 drops `sb=<doc.id>` from the fingerprint. At that point the first storyboard that pairs a non-`buyer_agent` caller with an already-shared test_kit would false-positive as a contradiction; `role=` keeps the two legitimately distinct test vectors separate without requiring the author to remember the convention.
+
+Documents the proxy reasoning and the forward guard in the `fingerprintEnv` comment, and adds two tests — one covering the shared-kit/distinct-role discrimination, one pinning the `role=` behavior with a direct `fingerprintEnv` comparison and covering the missing-caller / non-string-role guards.
+
+Protocol review surfaced a deeper structural gap that the `role=` addition does not cover: the `auth=` component today hashes `<type>:<value_strategy>`, not the resolved principal identity. Two kits with the same auth shape but different `auth.api_key` values collide on `auth=`, which becomes relevant once a single test kit exposes multiple principals and step-level auth overrides select among them. Out of scope for this change; tracked in #2708.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -290,7 +290,21 @@ function normalizeFixturesForHashing(fixtures) {
  *                are unreachable today. See #2670 for the planned removal.
  *   test_kit   — `doc.prerequisites.test_kit`. Two storyboards sharing id +
  *                scenario but loading different test kits target different
- *                agent fixtures.
+ *                agent fixtures. Also the de-facto principal-identity
+ *                discriminator today: every test kit binds a principal
+ *                profile (spend authority, brand rights, category scoping),
+ *                and the current storyboard suite declares `caller.role:
+ *                buyer_agent` uniformly — so `test_kit` alone separates the
+ *                governance-denied-by-spend-authority path from the
+ *                governance-approved path. See #2684 for the audit.
+ *   role       — `doc.caller.role`. Forward-compatible guard for the
+ *                "shared test_kit, distinct principal role" case identified
+ *                in #2684. No-op on the current suite (all buyer_agent) but
+ *                automatically discriminates the first storyboard that
+ *                authors a different caller role against a shared kit —
+ *                load-bearing once #2670 part 2 removes `sb=` and the
+ *                fingerprint stops getting a free discriminator from the
+ *                storyboard id.
  *   fixtures   — hash of `doc.fixtures` (top-level). Storyboards that seed
  *                different prerequisite state via `comply_test_controller`
  *                legitimately produce different outcomes for the same
@@ -305,6 +319,9 @@ function fingerprintEnv(step, phase, doc) {
   if (typeof doc?.id === 'string') parts.push(`sb=${doc.id}`);
   if (typeof doc?.prerequisites?.test_kit === 'string') {
     parts.push(`test_kit=${doc.prerequisites.test_kit}`);
+  }
+  if (typeof doc?.caller?.role === 'string') {
+    parts.push(`role=${doc.caller.role}`);
   }
   if (doc?.fixtures && typeof doc.fixtures === 'object' && Object.keys(doc.fixtures).length > 0) {
     const fixturesHash = crypto

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -387,6 +387,75 @@ phases:
   assert.deepEqual(contradictionsAcrossDocs(docs), []);
 });
 
+test('caller.role discriminates env: shared test_kit, distinct principal roles', () => {
+  // Forward guard (#2684): once #2670 part 2 removes `sb=` from the env
+  // fingerprint, two storyboards sharing a test_kit but exercising
+  // different principal roles (buyer_agent vs. orchestrator) would
+  // collapse into one fingerprint and false-positive as a contradiction.
+  // Note: both docs deliberately share id + test_kit; `role=<doc.caller.role>`
+  // is the sole discriminator under test.
+  const docs = {
+    'as_buyer.yaml': yaml.load(`
+id: sb_role_split
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/shared.yaml"
+phases:
+  - id: p
+    steps:
+      - id: approved
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'as_orchestrator.yaml': yaml.load(`
+id: sb_role_split
+caller:
+  role: orchestrator
+prerequisites:
+  test_kit: "test-kits/shared.yaml"
+phases:
+  - id: p
+    steps:
+      - id: denied
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: POLICY_VIOLATION
+`),
+  };
+  assert.deepEqual(contradictionsAcrossDocs(docs), []);
+
+  // Direct fingerprint-level assertion: pin the discrimination to the
+  // role component specifically, not just "no contradiction fired for
+  // some reason." A future refactor that stops classifying outcomes
+  // across docs would leave the deepEqual check green.
+  const step = { comply_scenario: 'create' };
+  assert.notEqual(
+    fingerprintEnv(step, {}, docs['as_buyer.yaml']),
+    fingerprintEnv(step, {}, docs['as_orchestrator.yaml']),
+  );
+});
+
+test('env fingerprint tolerates missing caller block', () => {
+  // Guard: storyboards without a `caller:` block (or with non-string
+  // `caller.role`) must not crash the fingerprint and must not emit a
+  // spurious `role=` component. Matches the `typeof === 'string'`
+  // guards on sb/test_kit.
+  const docNoCaller = { id: 'sb_x', prerequisites: { test_kit: 'tk' } };
+  const docShapeyRole = { id: 'sb_x', caller: { role: { name: 'buyer' } }, prerequisites: { test_kit: 'tk' } };
+  const step = { comply_scenario: 'create' };
+  const fpNone = fingerprintEnv(step, {}, docNoCaller);
+  const fpShapey = fingerprintEnv(step, {}, docShapeyRole);
+  assert.equal(fpNone, fpShapey, 'non-string caller.role should be ignored like a missing caller block');
+  assert.ok(!fpNone.includes('role='), 'missing caller block must not produce a role= component');
+});
+
 test('top-level fixtures discriminates env: same id, different seeded state', () => {
   // Two runs of the same storyboard id against different seeded prerequisite
   // state (via top-level `fixtures:`) can legitimately assert different


### PR DESCRIPTION
## Summary

Closes [#2684](https://github.com/adcontextprotocol/adcp/issues/2684) (protocol review follow-up from [#2679](https://github.com/adcontextprotocol/adcp/pull/2679)).

Audit of the 56-storyboard suite: every storyboard declares `caller.role: buyer_agent`; `prerequisites.principal` is never used. Two test_kits are shared (`acme-outdoor.yaml` ×42, `nova-motors.yaml` ×6), both consumed uniformly by `buyer_agent` callers. **No distinct-role case exists today** → `test_kit` is a sufficient principal-identity proxy on the current suite and the collision shape the issue describes does not exist.

Including `role=<doc.caller.role>` in `fingerprintEnv` anyway: cheap (no-op on today's suite — every event gets the same `role=buyer_agent` component), load-bearing the moment [#2670](https://github.com/adcontextprotocol/adcp/issues/2670) part 2 drops `sb=<doc.id>`. At that point the first storyboard that pairs a non-`buyer_agent` caller with an already-shared test_kit would false-positive as a contradiction; `role=` keeps the two test vectors separate without requiring the author to remember the convention.

## Changes

- **`scripts/lint-storyboard-contradictions.cjs`** — `fingerprintEnv` reads `doc.caller.role` and emits `role=<value>` when present. Updated the component-level JSDoc to document `test_kit` as the de-facto principal-identity proxy today and `role=` as the forward guard.
- **`tests/lint-storyboard-contradictions.test.cjs`** — two new tests:
  - `caller.role discriminates env: shared test_kit, distinct principal roles` — fixture with two docs sharing id + test_kit but differing only in `caller.role`; pins behavior to the `role=` field with a direct `fingerprintEnv` comparison (not just "no contradiction fired for some reason").
  - `env fingerprint tolerates missing caller block` — guards the `typeof === 'string'` check against missing `caller` block and non-string `caller.role`.
- **`.changeset/env-fingerprint-caller-role.md`** — empty changeset with rationale + forward-gap pointer.

## Expert review

Three rounds pre-push:

- **Code reviewer** — ship it. Ordering consistent with existing precedent; comment accurate; test isomorphic to the existing `test_kit discriminates env` shape. Nit applied: reader-orientation comment calling out that both docs share id + test_kit so `role=` is the sole discriminator under test.
- **Testing expert** — added the direct `fingerprintEnv` comparison pattern from `fixtures hash is stable across array-order permutations` to pin behavior specifically to `role=` rather than to "no contradiction fired." Added the missing-caller / non-string-role edge-case test. Fixed the error code (`AUTHORIZATION_DENIED` → `POLICY_VIOLATION`; the former isn't in `static/schemas/source/enums/error-code.json`).
- **Ad-tech protocol expert** — surfaced a deeper structural gap that's out of scope for this PR: the `auth=` component hashes `<type>:<value_strategy>`, not the resolved principal identity, so two kits with the same auth shape but different `auth.api_key` values collide on `auth=`. Becomes reachable once a single test kit exposes multiple principals and step-level auth overrides select among them. Filed as **[#2708](https://github.com/adcontextprotocol/adcp/issues/2708)** with a concrete proposal (hash the resolved identity handle, not just the strategy name).

## Test plan

- [x] `npm run test:storyboard-contradictions` — 26/26 tests pass (2 new)
- [x] `npm run build:compliance` — all four storyboard lints green, 56 storyboards build (unchanged from main)
- [x] `npm run test:unit` — 631/631 pass
- [x] `npm run typecheck` — clean
- [x] Precommit hook runs all of the above on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)