### PR TITLE
compliance(storyboards): drop sb=<doc.id> from contradiction lint env fingerprint (#2670 pt2)

### DIFF
--- a/.changeset/env-fingerprint-drop-sb-doc-id.md
+++ b/.changeset/env-fingerprint-drop-sb-doc-id.md
@@ -1,0 +1,14 @@
+---
+---
+
+compliance(storyboards): drop `sb=<doc.id>` from the contradiction lint's env fingerprint (#2670 part 2).
+
+Including the storyboard id in the fingerprint was the conservative shape during the lint's initial rollout in #2661, but it suppressed the exact class of bug the lint was built to catch — cross-storyboard contradictions (#2627, #2628, #2629 all shared the shape "two locally-valid storyboards encoding disagreeing required responses for the same request").
+
+Prerequisites now in place: #2679 added `test_kit` and top-level `fixtures` precision; #2684 audited principal identity and added `role=<doc.caller.role>` as the forward guard; #2708 tracks the remaining structural gap in `auth=`.
+
+Experiment result on the current suite: removing `sb=` surfaces 10 multi-member groups (7 spanning ≥2 storyboard files) — all agreeing, zero new contradictions. The two largest cross-file groups are a cross-brand consistency win the lint could not previously reach: `get_adcp_capabilities → success` agreed by 25 files on `acme-outdoor.yaml` and by 6 files on `nova-motors.yaml`. Sync-accounts and get-products groups land smaller but the same way. The lint now exercises cross-storyboard consistency as originally intended.
+
+Inverts one test (`no contradiction when storyboard IDs differ (independent test suites)` → `cross-storyboard contradictions surface when ids differ but env matches`) to pin the new behavior instead of the old false-negative, and adds a complementary negative test (`different test_kit + different ids → no contradiction`) that pins `test_kit=` as a cross-file separator now that `sb=` is gone.
+
+Protocol review surfaced a residual hole that `sb=` removal exposes: when a step inherits the transport's default auth instead of overriding it, `fingerprintEnv` emits no `auth=` component at all, so two storyboards with different transport defaults collide. Out of scope for this change and tracked separately in #2711.

--- a/.changeset/env-fingerprint-resolved-auth.md
+++ b/.changeset/env-fingerprint-resolved-auth.md
@@ -1,0 +1,16 @@
+---
+---
+
+compliance(storyboards): resolved-auth fingerprint shape (#2708 + #2711).
+
+Replaces the inline auth-emission in `fingerprintEnv` with a `describeStepAuth` helper that always returns a stable token — closing two structural gaps the sb= removal (#2670 part 2) exposed:
+
+**#2711** — `if (step.auth)` meant inheriting steps emitted nothing, so 336 of the 340 steps in the current suite contributed no `auth=` component and could collide with explicit steps authored against divergent transport defaults. Fixed by emitting `auth=kit_default` for absent `step.auth`, keeping inheritance as a distinct, legible fingerprint position.
+
+**#2708** — `auth.from_test_kit` was read as a boolean regardless of whether it was `true` or a string path, and `auth.value` literals were fingerprinted as `literal` with no identity hash. Both collapsed distinct principals into one group. Fixed by:
+- `from_test_kit: "<path>"` → `auth=<type>:from_test_kit:<path>` (forward-compatible with multi-principal kits; today no kit exposes multiple principals so this is latent shape work)
+- `value: "<literal>"` → `auth=<type>:literal:<sha1(literal, 8)>` (literal keys are a code smell but the hash guards against silent discrimination loss)
+
+No kit in the current suite declares multiple principals; no storyboard uses string-form `from_test_kit` or literal `value` — zero grouping change on the current 56-storyboard suite, confirmed by running the full contradiction lint before and after.
+
+Adds three tests: a shape-matrix unit test for `describeStepAuth` covering every branch (absent, none, `from_test_kit: true`, `from_test_kit: "<path>"`, `value_strategy`, literal, defensive fallbacks); an inherited-default cross-storyboard test pinning the `auth=kit_default` emission; and a multi-principal forward-guard test pinning that named-principal selection discriminates correctly.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -284,10 +284,6 @@ function normalizeFixturesForHashing(fixtures) {
  * governance states).
  *
  * Components:
- *   sb         — storyboard's top-level `id:`. Ensures distinct storyboard
- *                files aren't treated as running against the same in-memory
- *                agent. Conservative: means cross-storyboard contradictions
- *                are unreachable today. See #2670 for the planned removal.
  *   test_kit   — `doc.prerequisites.test_kit`. Two storyboards sharing id +
  *                scenario but loading different test kits target different
  *                agent fixtures. Also the de-facto principal-identity
@@ -299,12 +295,9 @@ function normalizeFixturesForHashing(fixtures) {
  *                governance-approved path. See #2684 for the audit.
  *   role       — `doc.caller.role`. Forward-compatible guard for the
  *                "shared test_kit, distinct principal role" case identified
- *                in #2684. No-op on the current suite (all buyer_agent) but
- *                automatically discriminates the first storyboard that
- *                authors a different caller role against a shared kit —
- *                load-bearing once #2670 part 2 removes `sb=` and the
- *                fingerprint stops getting a free discriminator from the
- *                storyboard id.
+ *                in #2684. No-op on the current suite (all buyer_agent)
+ *                but automatically discriminates the first storyboard that
+ *                authors a different caller role against a shared kit.
  *   fixtures   — hash of `doc.fixtures` (top-level). Storyboards that seed
  *                different prerequisite state via `comply_test_controller`
  *                legitimately produce different outcomes for the same
@@ -313,10 +306,21 @@ function normalizeFixturesForHashing(fixtures) {
  *   auth       — step's auth override shape (type + strategy).
  *   seed       — phase's `prerequisites.controller_seeding` (distinct from
  *                top-level fixtures; applies phase-scoped seeding).
+ *
+ * Note on `sb=<doc.id>`: the env fingerprint deliberately does NOT include
+ * the storyboard id. That was the conservative shape during the lint's
+ * initial rollout (#2661) but suppressed the exact class of bug the lint
+ * was built to catch — cross-storyboard contradictions (#2627, #2628,
+ * #2629). #2670 documented the planned removal; #2684 audited principal
+ * identity as the prerequisite discriminator (→ added `role=`); and
+ * #2708 tracks the deeper gap that `auth=` encodes strategy, not resolved
+ * principal identity. With those precisions in place, two steps that
+ * share (task, request, state, env) are now treated as the same test
+ * vector regardless of which storyboard file they live in — which is the
+ * whole point of this lint.
  */
 function fingerprintEnv(step, phase, doc) {
   const parts = [];
-  if (typeof doc?.id === 'string') parts.push(`sb=${doc.id}`);
   if (typeof doc?.prerequisites?.test_kit === 'string') {
     parts.push(`test_kit=${doc.prerequisites.test_kit}`);
   }

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -277,6 +277,81 @@ function normalizeFixturesForHashing(fixtures) {
 }
 
 /**
+ * Reduce a step's `auth` field to a stable fingerprint token. Always returns
+ * a string so the `auth=` component is ALWAYS present in the env fingerprint
+ * — required by #2711: steps that inherit the transport default used to emit
+ * no `auth=` component and could collide with explicit steps authored
+ * against divergent transport defaults once `sb=<doc.id>` was removed.
+ *
+ * Emission shape (what goes in `auth=...`):
+ *
+ *   kit_default              — step.auth absent. Step inherits whatever
+ *                              credential the transport is configured with
+ *                              (today: the test kit's `auth.api_key`, which
+ *                              is already covered by `test_kit=<path>` in
+ *                              the outer fingerprint; the explicit token
+ *                              keeps the shape legible and pins inheritance
+ *                              as a distinct semantic from a declared
+ *                              override).
+ *
+ *   none                     — step.auth === "none". Credentials stripped.
+ *
+ *   <type>:<strategy>        — step.auth is an object. Strategy encodes:
+ *     value_strategy          → the declared strategy verbatim
+ *                              (e.g., api_key:random_invalid). Per-run
+ *                              values are random; identity is the strategy.
+ *     from_test_kit: true     → `from_test_kit` — the kit's default
+ *                              principal handle. Equivalent in resolution
+ *                              to `kit_default` today, distinguished here
+ *                              because the explicit declaration carries
+ *                              type info the default case can't.
+ *     from_test_kit: "<path>" → `from_test_kit:<path>` — selects a named
+ *                              principal within a multi-principal kit
+ *                              (#2708). Today no kit declares multiple
+ *                              principals; emission shape is forward-
+ *                              compatible so the first multi-principal
+ *                              kit's storyboards are discriminated without
+ *                              further changes to the lint.
+ *     value: "<literal>"      → `literal:<sha1-8hex>` — hash the resolved
+ *                              identity (#2708) so two steps declaring
+ *                              different literal keys against the same
+ *                              kit don't collide. 32-bit truncation is
+ *                              deliberate: at storyboard-authoring scale
+ *                              (~thousands) the birthday bound is ~65K
+ *                              before even-odds collision, and a miss
+ *                              here degrades to a lint false-negative,
+ *                              not a correctness hazard. Literal keys in
+ *                              storyboards are already a code smell; the
+ *                              hash is defense-in-depth, not a load-
+ *                              bearing discriminator.
+ *
+ *   unknown                  — step.auth is some other shape. Defensive
+ *                              catch-all so the lint surfaces rather than
+ *                              silently drops.
+ *
+ * Precedence (first match wins): `value_strategy` > `from_test_kit` >
+ * `value`. Intentional: if a step declares both `value_strategy:
+ * random_invalid` and `from_test_kit: true`, the random value wins on the
+ * wire — the strategy is what the agent actually sees — so encoding the
+ * strategy is faithful to runtime behavior. Reordering would silently
+ * change which tests discriminate.
+ */
+function describeStepAuth(auth) {
+  if (auth === undefined) return 'kit_default';
+  if (auth === 'none') return 'none';
+  if (typeof auth !== 'object' || auth === null) return 'unknown';
+  const type = typeof auth.type === 'string' ? auth.type : '?';
+  if (typeof auth.value_strategy === 'string') return `${type}:${auth.value_strategy}`;
+  if (typeof auth.from_test_kit === 'string') return `${type}:from_test_kit:${auth.from_test_kit}`;
+  if (auth.from_test_kit === true) return `${type}:from_test_kit`;
+  if (typeof auth.value === 'string') {
+    const hash = crypto.createHash('sha1').update(auth.value).digest('hex').slice(0, 8);
+    return `${type}:literal:${hash}`;
+  }
+  return `${type}:?`;
+}
+
+/**
  * Env fingerprint: the external knobs that select which fixture a conformant
  * agent serves. Two steps with same request but different env can
  * legitimately disagree on outcome (e.g., api-key vs oauth_bearer auth
@@ -303,7 +378,13 @@ function normalizeFixturesForHashing(fixtures) {
  *                legitimately produce different outcomes for the same
  *                request.
  *   scenario   — step's `comply_scenario`.
- *   auth       — step's auth override shape (type + strategy).
+ *   auth       — step's effective credential shape, produced by
+ *                `describeStepAuth`. Always emitted (even for steps that
+ *                inherit the transport default) so inheritance itself
+ *                participates in the fingerprint rather than silently
+ *                collapsing with arbitrary other states — see #2711.
+ *                Forward-compatible with multi-principal kits via
+ *                `from_test_kit:<path>` selectors — see #2708.
  *   seed       — phase's `prerequisites.controller_seeding` (distinct from
  *                top-level fixtures; applies phase-scoped seeding).
  *
@@ -336,15 +417,7 @@ function fingerprintEnv(step, phase, doc) {
     parts.push(`fixtures=${fixturesHash}`);
   }
   if (typeof step.comply_scenario === 'string') parts.push(`scenario=${step.comply_scenario}`);
-  if (step.auth) {
-    const auth = step.auth;
-    if (auth === 'none') parts.push('auth=none');
-    else if (typeof auth === 'object') {
-      const type = auth.type || '?';
-      const strat = auth.value_strategy || (auth.from_test_kit ? 'from_test_kit' : auth.value ? 'literal' : '?');
-      parts.push(`auth=${type}:${strat}`);
-    }
-  }
+  parts.push(`auth=${describeStepAuth(step.auth)}`);
   const seeding = phase?.prerequisites?.controller_seeding;
   if (Array.isArray(seeding) && seeding.length > 0) {
     parts.push(`seed=${seeding.map((s) => s?.scenario || s).sort().join(',')}`);
@@ -580,6 +653,7 @@ module.exports = {
   canonicalizeRequest,
   fingerprintRequest,
   fingerprintEnv,
+  describeStepAuth,
   normalizeFixturesForHashing,
   classifyOutcome,
   outcomesAgree,

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -214,13 +214,20 @@ phases:
   assert.deepEqual(outcomes, ['error', 'success']);
 });
 
-test('no contradiction when storyboard IDs differ (independent test suites)', () => {
-  // Same task, same request, same outcome-disagreement — but two distinct
-  // storyboards. The env fingerprint includes doc.id so cross-suite
-  // differences in controller-seeded state are not flagged as contradictions.
+test('cross-storyboard contradictions surface when ids differ but env matches', () => {
+  // #2670 part 2: the env fingerprint no longer includes `sb=<doc.id>`, so
+  // two storyboards declaring disagreeing outcomes for the same
+  // (task, request, state, env) triple land in the same group and fire
+  // as a contradiction — which is the exact bug class (#2627, #2628,
+  // #2629) this lint exists to catch. Prior to this change the sb=
+  // component suppressed the cross-storyboard case entirely.
   const docs = {
     'a.yaml': yaml.load(`
 id: sb_a
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
 phases:
   - id: p
     steps:
@@ -233,6 +240,69 @@ phases:
 `),
     'b.yaml': yaml.load(`
 id: sb_b
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: fail
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+  };
+  const contradictions = contradictionsAcrossDocs(docs);
+  assert.equal(contradictions.length, 1, 'expected one cross-storyboard contradiction');
+  const [c] = contradictions;
+  // Assert files via `members` (full group) not `mismatch` (one picked pair) —
+  // `findContradictions` only records the first disagreeing pair per group,
+  // so `mismatch` is brittle under group-size changes. `members` is stable.
+  const memberFiles = new Set(c.members.map((m) => m.file));
+  assert.deepEqual([...memberFiles].sort(), ['a.yaml', 'b.yaml']);
+  // Pin the kind of disagreement, not just its existence: one success, one
+  // error. Guards against a future regression where grouping still fires but
+  // the outcome classification flipped for an unrelated reason.
+  const outcomes = c.members.map((m) => m.outcome.kind).sort();
+  assert.deepEqual(outcomes, ['error', 'success']);
+});
+
+test('cross-storyboard env differences still protect: different test_kit + different ids → no contradiction', () => {
+  // Complementary to the cross-storyboard-surface test above. After dropping
+  // `sb=` from the env fingerprint, the burden of separating legitimately-
+  // different test vectors falls entirely on the remaining env components
+  // (test_kit / role / fixtures / scenario / auth / seed). This test pins
+  // that two storyboards running against *different* test kits can still
+  // assert disagreeing outcomes for the same request without being flagged
+  // — i.e., `test_kit=` still discriminates correctly across storyboard
+  // files, not just within-file.
+  const docs = {
+    'acme.yaml': yaml.load(`
+id: sb_acme
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: succeed
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'nova.yaml': yaml.load(`
+id: sb_nova
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/nova-motors.yaml"
 phases:
   - id: p
     steps:
@@ -353,6 +423,10 @@ test('test_kit discriminates env: two storyboards sharing id+scenario but differ
   // running against different agent fixtures via different test_kit paths.
   // They legitimately produce different outcomes for the same request
   // shape. Env fingerprint must discriminate.
+  //
+  // With `sb=<doc.id>` removed from the env fingerprint (#2670 part 2),
+  // `test_kit=` is the sole discriminator here — both docs deliberately
+  // share `id:` so no implicit fallback separates them.
   const docs = {
     'acme.yaml': yaml.load(`
 id: sb_parallel

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -26,6 +26,7 @@ const {
   MUTATING_TASKS,
   loadMutatingTasksFromSchemas,
   normalizeFixturesForHashing,
+  describeStepAuth,
 } = require('../scripts/lint-storyboard-contradictions.cjs');
 
 const path = require('node:path');
@@ -678,4 +679,180 @@ phases:
             allowed_values: [401, 403]
 `);
   assert.deepEqual(contradictionsAcrossDocs({ 'a.yaml': doc }), []);
+});
+
+test('describeStepAuth covers the declared shape matrix (#2708, #2711)', () => {
+  // Unit-level coverage of the effective-credential reduction so each
+  // branch of the fingerprint shape matrix is pinned independently of
+  // the cross-storyboard contradiction path.
+
+  // #2711: absent step.auth must emit a distinct, stable token rather
+  // than vanishing from the fingerprint. `kit_default` is the sentinel.
+  assert.equal(describeStepAuth(undefined), 'kit_default');
+
+  // `auth: none` strips credentials entirely.
+  assert.equal(describeStepAuth('none'), 'none');
+
+  // Declared `from_test_kit: true` resolves to the kit's default principal
+  // but carries type info the default case can't express.
+  assert.equal(describeStepAuth({ type: 'api_key', from_test_kit: true }), 'api_key:from_test_kit');
+  assert.equal(describeStepAuth({ type: 'oauth_bearer', from_test_kit: true }), 'oauth_bearer:from_test_kit');
+
+  // #2708: `from_test_kit: "<path>"` selects a named principal within a
+  // multi-principal kit. The path must be in the fingerprint so two
+  // steps against the same kit but different principals discriminate.
+  assert.equal(
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.low_spend.api_key' }),
+    'api_key:from_test_kit:auth.principals.low_spend.api_key',
+  );
+  assert.notEqual(
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.low_spend.api_key' }),
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.full_auth.api_key' }),
+  );
+
+  // `value_strategy` — per-run random values; the strategy name IS the
+  // identity (no stable value to hash).
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value_strategy: 'random_invalid' }),
+    'api_key:random_invalid',
+  );
+
+  // #2708: literal values hash to 8 hex chars. Two different literals do
+  // not collide. Hashes are pinned to precomputed sha1(literal).slice(0,8)
+  // values so an accidental switch to a non-deterministic hash or a
+  // truncation-width change surfaces here rather than silently shifting
+  // fingerprint buckets.
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value: 'key-a' }),
+    'api_key:literal:70efd783',
+  );
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value: 'key-b' }),
+    'api_key:literal:77daed1d',
+  );
+
+  // Defensive fallbacks — unknown shapes must not crash.
+  assert.equal(describeStepAuth(null), 'unknown');
+  assert.equal(describeStepAuth(42), 'unknown');
+  assert.equal(describeStepAuth({ type: 'api_key' }), 'api_key:?');
+  assert.equal(describeStepAuth({}), '?:?');
+});
+
+test('env fingerprint emits auth= for inherited-default steps (#2711)', () => {
+  // Two storyboards sharing every env component AND both inheriting the
+  // transport default (no step.auth). After this change, both still land
+  // in the same group (they semantically share credentials), so any
+  // outcome disagreement MUST surface as a contradiction rather than
+  // getting silently masked by asymmetric fingerprint emission.
+  const docs = {
+    'a.yaml': yaml.load(`
+id: sb_a
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: succeed
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'b.yaml': yaml.load(`
+id: sb_b
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: fail
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+  };
+  const contradictions = contradictionsAcrossDocs(docs);
+  assert.equal(contradictions.length, 1, 'inherited-default steps must participate in the group');
+
+  // Direct fingerprint assertion: an inheriting step emits `auth=kit_default`
+  // — the fix's defining property. Without this token the auth= component
+  // would be absent and two inheriting storyboards with divergent transport
+  // defaults could collide silently.
+  const fpInherit = fingerprintEnv({}, {}, { id: 'x', caller: { role: 'buyer_agent' } });
+  assert.ok(fpInherit.includes('auth=kit_default'), `expected auth=kit_default in ${fpInherit}`);
+});
+
+test('env fingerprint discriminates named principals within a kit (#2708)', () => {
+  // Forward guard: when a multi-principal kit declares
+  // `auth: { type: api_key, from_test_kit: "<path>" }` to select among
+  // principals, two steps selecting different principals MUST land in
+  // different fingerprint buckets even though all other env components
+  // (test_kit, role, fixtures, scenario) match. Today no kit exposes
+  // multiple principals — this test pins the shape so the first kit that
+  // does is handled without further lint changes.
+  const docs = {
+    'low_spend.yaml': yaml.load(`
+id: sb_principals
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/multi-principal.yaml"
+phases:
+  - id: p
+    steps:
+      - id: denied
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        auth: { type: api_key, from_test_kit: "auth.principals.low_spend.api_key" }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+    'full_auth.yaml': yaml.load(`
+id: sb_principals
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/multi-principal.yaml"
+phases:
+  - id: p
+    steps:
+      - id: approved
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        auth: { type: api_key, from_test_kit: "auth.principals.full_auth.api_key" }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+  };
+  assert.deepEqual(contradictionsAcrossDocs(docs), []);
+
+  // Direct fingerprint-level assertion: pin the discrimination to the
+  // `from_test_kit:<path>` token specifically, not to whatever other
+  // coincidental env difference might fire. Mirrors the pattern used by
+  // the `caller.role discriminates env` test upstream — deepEqual([], [])
+  // can go green for unrelated classification failures.
+  const lowStep = docs['low_spend.yaml'].phases[0].steps[0];
+  const fullStep = docs['full_auth.yaml'].phases[0].steps[0];
+  const fpLow = fingerprintEnv(lowStep, {}, docs['low_spend.yaml']);
+  const fpFull = fingerprintEnv(fullStep, {}, docs['full_auth.yaml']);
+  assert.notEqual(fpLow, fpFull);
+  assert.ok(
+    fpLow.includes('auth=api_key:from_test_kit:auth.principals.low_spend.api_key'),
+    `expected low-spend path token in ${fpLow}`,
+  );
+  assert.ok(
+    fpFull.includes('auth=api_key:from_test_kit:auth.principals.full_auth.api_key'),
+    `expected full-auth path token in ${fpFull}`,
+  );
 });


### PR DESCRIPTION
## Summary

Closes the #2670 planned evolution (part 2): removes `sb=<doc.id>` from the contradiction lint's env fingerprint so cross-storyboard contradictions actually surface. Builds on PR #2710 (#2684, `role=` forward guard) which was the prerequisite audit.

## Why now

Including the storyboard id in the fingerprint was conservative-by-design during the lint's initial rollout (#2661) but suppressed the exact class of bug the lint was built to catch — [#2627](https://github.com/adcontextprotocol/adcp/issues/2627), [#2628](https://github.com/adcontextprotocol/adcp/issues/2628), [#2629](https://github.com/adcontextprotocol/adcp/issues/2629) all shared the shape "two locally-valid storyboards encoding disagreeing required responses for the same request." The richer env fingerprint is now sufficient:

- [#2679](https://github.com/adcontextprotocol/adcp/pull/2679) — `test_kit` + top-level `fixtures`
- PR [#2710](https://github.com/adcontextprotocol/adcp/pull/2710) (from [#2684](https://github.com/adcontextprotocol/adcp/issues/2684)) — `role=<doc.caller.role>`
- [#2708](https://github.com/adcontextprotocol/adcp/issues/2708) — tracks the `auth=` identity-vs-strategy gap (out of scope here)
- [#2711](https://github.com/adcontextprotocol/adcp/issues/2711) — filed from protocol review on this PR; covers the transport-default auth inheritance hole that `sb=` removal exposes (out of scope, deferred)

## Experiment result

On the current 56-storyboard suite, after removing `sb=`:

- 10 multi-member groups form; 7 span ≥2 storyboard files
- Biggest cross-file groups:
  - `get_adcp_capabilities → success` agreed across **25 files** on `acme-outdoor.yaml`
  - `get_adcp_capabilities → success` agreed across **6 files** on `nova-motors.yaml`
  - `sync_accounts → success` across 8 files; `get_products` pairs across scenarios; `list_creative_formats` across creative-generative + creative-template
- **Zero contradictions** — suite is genuinely consistent, lint gains real cross-storyboard coverage

## Changes

- **`scripts/lint-storyboard-contradictions.cjs`** — removed the `sb=<doc.id>` push from `fingerprintEnv`; removed the `sb` entry from the Components JSDoc; added a trailing "Note on `sb=<doc.id>`" paragraph explaining the removal and cross-referencing #2670 / #2684 / #2708 so future readers aren't surprised by the absence.
- **`tests/lint-storyboard-contradictions.test.cjs`** — inverted one existing test to pin the new surfaceable behavior (`length === 1`, both files in `members`, outcome pair = `['error', 'success']`); added a complementary negative test (`different test_kit + different ids → no contradiction`); updated the `test_kit discriminates env` comment to note it's the sole discriminator post-removal.
- **`.changeset/env-fingerprint-drop-sb-doc-id.md`** — descriptive changeset with the audit numbers and the #2711 deferred-scope pointer.

## Expert review

Three rounds pre-push:

- **Code reviewer** — ship it. Removal clean, inverted test triangulated well. Nit applied: changeset now notes the 6-file nova-motors group as a second cross-brand consistency win alongside the 25-file acme-outdoor one.
- **Testing expert** — tightened the inverted test on three axes: assert via `c.members` (full group, stable) instead of `c.mismatch` (picked pair, brittle under group-size changes); added an outcome-pair sort assertion to pin the *kind* of disagreement not just its existence; added the complementary negative test they recommended; updated the `test_kit discriminates env` comment so a future reader doesn't delete it as redundant.
- **Ad-tech protocol expert** — removal structurally sound. Time-dependent state, controller session affinity, branch-set peers, locale/currency all adequately covered by existing components. Flagged **one real residual hole**: `fingerprintEnv` gates its auth emission on `if (step.auth)` — steps inheriting the transport's default auth contribute nothing, so two storyboards with different transport defaults can collide. Filed as [#2711](https://github.com/adcontextprotocol/adcp/issues/2711) with a concrete resolve-then-emit proposal; out of scope for this PR since no storyboard in the current suite exercises the case.

## Test plan

- [x] `npm run test:storyboard-contradictions` — 27/27 pass (1 inverted, 1 new)
- [x] `npm run build:compliance` — all four storyboard lints green, 56 storyboards build
- [x] `npm run test:unit` — 631/631 pass (precommit)
- [x] `npm run typecheck` — clean (precommit)
- [x] Manual experiment harness (`.context/try-sb-removal.cjs`) confirmed zero new contradictions + 7 cross-file groups before the source edit landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)