### PR TITLE
fix(dashboard-agents): preserve URL path in agent card header

### DIFF
--- a/.changeset/fix-agent-url-header-display.md
+++ b/.changeset/fix-agent-url-header-display.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix: agent compliance card header now preserves the full URL path (e.g. `agents.scope3.com/snap/`) instead of collapsing to just the hostname. Display-only change; storage and queries were already path-aware.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -728,7 +728,14 @@
         const data = complianceMap?.get(agent.url);
         const cs = data?.status;
         const history = data?.history;
-        const hostname = (() => { try { return new URL(agent.url).hostname; } catch { return agent.url; } })();
+        const hostname = (() => {
+          try {
+            const u = new URL(agent.url);
+            return u.hostname + u.pathname + u.search + u.hash;
+          } catch {
+            return agent.url;
+          }
+        })();
         const authInfo = data?.authStatus;
         const hasData = cs && cs.status && cs.status !== 'unknown';
         const hasAuth = authInfo?.has_auth;


### PR DESCRIPTION
## Summary
- Agent compliance card header was calling `new URL(agent.url).hostname`, which stripped paths — so `agents.scope3.com/` and `agents.scope3.com/snap/` both rendered as just `agents.scope3.com`, even though the backend stores and queries them as distinct URLs.
- Switched the header display extraction to `hostname + pathname + search + hash` so distinct agent URLs render distinctly. Display-only change; no storage or query behavior touched.

## Test plan
- [ ] Register two agents on the same host with different paths (e.g. `https://agents.scope3.com/` and `https://agents.scope3.com/snap/`) and verify both cards show their full path in the header.
- [ ] Verify an agent registered with no path still renders cleanly (e.g. `agents.scope3.com/`).
- [ ] Confirm toggles, track pills, and action buttons (Connect, Test, History, Requests) still resolve to the correct agent (they key off `agent.url`, not the header text).