### PR TITLE
fix(oauth): return to originating page after agent OAuth completes

### DIFF
--- a/.changeset/fix-oauth-return-to-dashboard.md
+++ b/.changeset/fix-oauth-return-to-dashboard.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(oauth): redirect back to originating page after agent OAuth completes
+
+The agent OAuth callback previously landed on a terminal `oauth-complete.html`
+page asking the user to close the tab. When the flow was initiated from the
+dashboard, the user was stranded instead of returning to their work.
+
+`/api/oauth/agent/start` now accepts a same-origin `return_to` path, persists
+it with the pending flow, and forwards it to the success page. The dashboard
+passes its current path so the success page auto-redirects back after a brief
+confirmation. The Slack / MCP entry points omit `return_to`, preserving the
+existing "close this tab" behavior for those contexts.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1000,8 +1000,11 @@
           });
         }
 
-        // Redirect to OAuth flow
-        window.location.href = '/api/oauth/agent/start?agent_context_id=' + encodeURIComponent(agentContextId);
+        // Redirect to OAuth flow, asking it to return us here after completion
+        const returnTo = window.location.pathname + window.location.search + window.location.hash;
+        window.location.href = '/api/oauth/agent/start'
+          + '?agent_context_id=' + encodeURIComponent(agentContextId)
+          + '&return_to=' + encodeURIComponent(returnTo);
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Authorize';

--- a/server/public/oauth-complete.html
+++ b/server/public/oauth-complete.html
@@ -129,21 +129,32 @@
     const agent = params.get('agent');
     const error = params.get('error');
 
-    // Only accept same-origin path redirects (defense-in-depth;
-    // server validates before storing, but we revalidate here).
+    // Resolve return_to to a same-origin URL. Returns null for anything
+    // that isn't a plain path on the current origin. Server validates
+    // before storing; this is defense-in-depth.
     function safeReturnTo(raw) {
       if (!raw || typeof raw !== 'string') return null;
       if (raw.length > 512) return null;
       if (!raw.startsWith('/')) return null;
       if (raw.startsWith('//') || raw.startsWith('/\\')) return null;
-      return raw;
+      try {
+        const url = new URL(raw, window.location.origin);
+        if (url.origin !== window.location.origin) return null;
+        return url.pathname + url.search + url.hash;
+      } catch (_) {
+        return null;
+      }
     }
-    const returnTo = success ? safeReturnTo(params.get('return_to')) : null;
+    const returnToPath = success ? safeReturnTo(params.get('return_to')) : null;
+    // Build an absolute, provably same-origin URL for navigation.
+    const returnToUrl = returnToPath
+      ? window.location.origin + returnToPath
+      : null;
 
     const content = document.getElementById('content');
 
     if (success) {
-      const returningInstruction = returnTo
+      const returningInstruction = returnToUrl
         ? `Returning to your dashboard…`
         : `You can close this tab and return to your conversation.`;
       content.innerHTML = `
@@ -158,12 +169,15 @@
         <div class="oauth-complete__footer">
           <p class="oauth-complete__instruction">
             ${returningInstruction}
-            ${returnTo ? ` <a href="${escapeHtml(returnTo)}">Go now</a>.` : ''}
+            ${returnToUrl ? ` <a href="${escapeHtml(returnToUrl)}">Go now</a>.` : ''}
           </p>
         </div>
       `;
-      if (returnTo) {
-        setTimeout(() => { window.location.replace(returnTo); }, 1200);
+      if (returnToUrl) {
+        // codeql[js/client-side-unvalidated-url-redirection] -- returnToUrl
+        // is built from window.location.origin plus a path that was parsed
+        // via URL() and confirmed to resolve to the same origin.
+        setTimeout(() => { window.location.replace(returnToUrl); }, 1200);
       }
     } else {
       content.innerHTML = `

--- a/server/public/oauth-complete.html
+++ b/server/public/oauth-complete.html
@@ -129,9 +129,23 @@
     const agent = params.get('agent');
     const error = params.get('error');
 
+    // Only accept same-origin path redirects (defense-in-depth;
+    // server validates before storing, but we revalidate here).
+    function safeReturnTo(raw) {
+      if (!raw || typeof raw !== 'string') return null;
+      if (raw.length > 512) return null;
+      if (!raw.startsWith('/')) return null;
+      if (raw.startsWith('//') || raw.startsWith('/\\')) return null;
+      return raw;
+    }
+    const returnTo = success ? safeReturnTo(params.get('return_to')) : null;
+
     const content = document.getElementById('content');
 
     if (success) {
+      const returningInstruction = returnTo
+        ? `Returning to your dashboard…`
+        : `You can close this tab and return to your conversation.`;
       content.innerHTML = `
         <div class="oauth-complete__header">
           <div class="oauth-complete__icon oauth-complete__icon--success">&#10003;</div>
@@ -143,10 +157,14 @@
         </div>
         <div class="oauth-complete__footer">
           <p class="oauth-complete__instruction">
-            You can close this tab and return to your conversation.
+            ${returningInstruction}
+            ${returnTo ? ` <a href="${escapeHtml(returnTo)}">Go now</a>.` : ''}
           </p>
         </div>
       `;
+      if (returnTo) {
+        setTimeout(() => { window.location.replace(returnTo); }, 1200);
+      }
     } else {
       content.innerHTML = `
         <div class="oauth-complete__header">

--- a/server/src/db/agent-oauth-flows-db.ts
+++ b/server/src/db/agent-oauth-flows-db.ts
@@ -23,6 +23,7 @@ export interface PendingOAuthFlow {
     task: string;
     params: Record<string, unknown>;
   };
+  returnTo?: string;
 }
 
 // Internal stored representation (codeVerifier encrypted)
@@ -38,6 +39,7 @@ interface StoredPendingOAuthFlow {
     task: string;
     params: Record<string, unknown>;
   };
+  returnTo?: string;
 }
 
 function encryptFlowData(data: PendingOAuthFlow): StoredPendingOAuthFlow {

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -39,6 +39,18 @@ function sanitizeErrorMessage(error: unknown): string {
     .replace(/[<>]/g, '');
 }
 
+/**
+ * Validate that a return_to value is a safe same-origin path,
+ * preventing open redirects and javascript:/data: URIs.
+ */
+function sanitizeReturnTo(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 512) return undefined;
+  if (!value.startsWith('/')) return undefined;
+  if (value.startsWith('//') || value.startsWith('/\\')) return undefined;
+  if (/[\x00-\x1f]/.test(value)) return undefined;
+  return value;
+}
+
 // Type for token response
 interface TokenResponse {
   access_token: string;
@@ -188,7 +200,8 @@ export function createAgentOAuthRouter(): Router {
    */
   router.get('/start', requireAuth, async (req: Request, res: Response) => {
     try {
-      const { agent_context_id, pending_task, pending_params } = req.query;
+      const { agent_context_id, pending_task, pending_params, return_to } = req.query;
+      const returnTo = sanitizeReturnTo(return_to);
 
       // codeql[js/user-controlled-bypass] - agent context ID from query is validated and used as a lookup key
       if (!agent_context_id || typeof agent_context_id !== 'string') {
@@ -294,6 +307,7 @@ export function createAgentOAuthRouter(): Router {
         redirectUri,
         agentUrl: agentContext.agent_url,
         pendingRequest,
+        returnTo,
       });
 
       // Build authorization URL
@@ -378,7 +392,14 @@ export function createAgentOAuthRouter(): Router {
       logger.info({ agentUrl: flow.agentUrl, hasPendingRequest: !!flow.pendingRequest }, 'OAuth tokens saved successfully');
 
       // Redirect to success page - user can return to their conversation (Slack or web)
-      res.redirect(`/oauth-complete.html?success=true&agent=${encodeURIComponent(agentHost)}`);
+      const successParams = new URLSearchParams({
+        success: 'true',
+        agent: agentHost,
+      });
+      if (flow.returnTo) {
+        successParams.set('return_to', flow.returnTo);
+      }
+      res.redirect(`/oauth-complete.html?${successParams.toString()}`);
     } catch (error) {
       logger.error({ error }, 'OAuth callback failed');
       const message = sanitizeErrorMessage(error instanceof Error ? error.message : 'Unknown error');

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -42,13 +42,26 @@ function sanitizeErrorMessage(error: unknown): string {
 /**
  * Validate that a return_to value is a safe same-origin path,
  * preventing open redirects and javascript:/data: URIs.
+ *
+ * Expresses the same-origin invariant via URL parsing against a
+ * placeholder origin rather than inferring it from prefix checks,
+ * so the guarantee holds even if the value is later consumed in a
+ * context that concatenates or redirects without re-prepending an
+ * origin.
  */
 function sanitizeReturnTo(value: unknown): string | undefined {
   if (typeof value !== 'string' || value.length === 0 || value.length > 512) return undefined;
   if (!value.startsWith('/')) return undefined;
   if (value.startsWith('//') || value.startsWith('/\\')) return undefined;
   if (/[\x00-\x1f]/.test(value)) return undefined;
-  return value;
+  const placeholderOrigin = 'https://placeholder.invalid';
+  try {
+    const url = new URL(value, placeholderOrigin);
+    if (url.origin !== placeholderOrigin) return undefined;
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return undefined;
+  }
 }
 
 // Type for token response


### PR DESCRIPTION
## Summary

- Fixes Issue E: after agent OAuth completed, `oauth-complete.html` was a terminal "close this tab" page, stranding users who started the flow from the dashboard.
- `/api/oauth/agent/start` now accepts a same-origin `return_to` path (validated to block protocol-relative URLs, control chars, and >512-char values), persists it on the pending flow, and forwards it to the success page.
- `oauth-complete.html` re-validates client-side (defense in depth), shows a brief confirmation, then `location.replace`s to the return path after ~1.2s.
- Dashboard sends its current path as `return_to`. Slack/MCP entry points are unchanged and still show the existing "close this tab" copy.

## Test plan

- [ ] From `/dashboard-agents.html`, click Authorize on an OAuth-gated agent — verify browser returns to the dashboard after authorization.
- [ ] From Slack/Addie-initiated OAuth link, verify the success page still says "close this tab" (no auto-redirect).
- [ ] Attempt `return_to=//evil.com` and `return_to=javascript:...` — confirm they are rejected (no redirect).
- [ ] Failure path: force an OAuth error — verify error page renders and does not auto-redirect.