### PR TITLE
fix(oauth): treat refreshable tokens as valid in auth-status

### DIFF
--- a/.changeset/fix-oauth-auth-status-refresh-token.md
+++ b/.changeset/fix-oauth-auth-status-refresh-token.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `hasValidOAuthTokens` treating near-expiry access tokens as invalid when a refresh token exists. The auth-status endpoint no longer flips `has_auth` from true → false as tokens age, keeping the UI on "Auth configured" instead of flashing back to the OAuth form for agents that can be silently refreshed.

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -23,6 +23,7 @@ export interface AgentContext {
   auth_type: AuthType;
   // OAuth info (never expose actual tokens!)
   has_oauth_token: boolean;
+  has_oauth_refresh_token: boolean;
   oauth_token_expires_at: Date | null;
   has_oauth_client: boolean;
   // Discovery cache
@@ -145,6 +146,7 @@ export class AgentContextDatabase {
         auth_token_hint,
         auth_type,
         oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
+        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         tools_discovered,
@@ -181,6 +183,7 @@ export class AgentContextDatabase {
         auth_token_hint,
         auth_type,
         oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
+        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         tools_discovered,
@@ -216,6 +219,7 @@ export class AgentContextDatabase {
         auth_token_hint,
         auth_type,
         oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
+        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         tools_discovered,
@@ -259,6 +263,7 @@ export class AgentContextDatabase {
         auth_token_hint,
         auth_type,
         FALSE as has_oauth_token,
+        FALSE as has_oauth_refresh_token,
         oauth_token_expires_at,
         FALSE as has_oauth_client,
         tools_discovered,
@@ -343,6 +348,7 @@ export class AgentContextDatabase {
          auth_token_hint,
          auth_type,
          oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
+         oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
          oauth_token_expires_at,
          oauth_client_id IS NOT NULL as has_oauth_client,
          tools_discovered,
@@ -580,10 +586,13 @@ export class AgentContextDatabase {
   }
 
   /**
-   * Check if OAuth tokens are valid (exist and not expired)
+   * Check if OAuth tokens are valid (exist and not expired, or refreshable)
    */
   hasValidOAuthTokens(context: AgentContext): boolean {
     if (!context.has_oauth_token) return false;
+    // A refresh token lets us mint a new access token on demand, so auth is
+    // still valid even if the access token is near/past expiry.
+    if (context.has_oauth_refresh_token) return true;
     if (!context.oauth_token_expires_at) return true;
 
     // Expired if within 5 minutes of expiration


### PR DESCRIPTION
## Summary
- `hasValidOAuthTokens` (`server/src/db/agent-context-db.ts:591`) returned `false` for any access token within 5 minutes of expiry, causing `/auth-status` to flip `has_auth` true → false as tokens aged and the UI to bounce between "Auth configured" and the OAuth form — even when a refresh token was present and could silently mint a new access token.
- Added `has_oauth_refresh_token: boolean` to `AgentContext`, hydrated from `oauth_refresh_token_encrypted IS NOT NULL` in all 5 SELECT/RETURNING sites (`getByOrganization`, `getById`, `getByOrgAndUrl`, `create`, `update`).
- Short-circuit `hasValidOAuthTokens` to return `true` when a refresh token exists; otherwise the existing 5-minute expiry window still applies.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Verify in UI: connect an agent via OAuth, advance past the 5-minute expiry window, confirm `/auth-status` keeps reporting `has_auth: true` and the "Auth configured" state persists.
- [ ] Verify an agent without a refresh token still correctly flips to "auth required" when the access token expires.