### PR TITLE
compliance(storyboards): resolved-auth fingerprint shape (#2708 + #2711)

### DIFF
--- a/.changeset/env-fingerprint-resolved-auth.md
+++ b/.changeset/env-fingerprint-resolved-auth.md
@@ -1,0 +1,16 @@
+---
+---
+
+compliance(storyboards): resolved-auth fingerprint shape (#2708 + #2711).
+
+Replaces the inline auth-emission in `fingerprintEnv` with a `describeStepAuth` helper that always returns a stable token — closing two structural gaps the sb= removal (#2670 part 2) exposed:
+
+**#2711** — `if (step.auth)` meant inheriting steps emitted nothing, so 336 of the 340 steps in the current suite contributed no `auth=` component and could collide with explicit steps authored against divergent transport defaults. Fixed by emitting `auth=kit_default` for absent `step.auth`, keeping inheritance as a distinct, legible fingerprint position.
+
+**#2708** — `auth.from_test_kit` was read as a boolean regardless of whether it was `true` or a string path, and `auth.value` literals were fingerprinted as `literal` with no identity hash. Both collapsed distinct principals into one group. Fixed by:
+- `from_test_kit: "<path>"` → `auth=<type>:from_test_kit:<path>` (forward-compatible with multi-principal kits; today no kit exposes multiple principals so this is latent shape work)
+- `value: "<literal>"` → `auth=<type>:literal:<sha1(literal, 8)>` (literal keys are a code smell but the hash guards against silent discrimination loss)
+
+No kit in the current suite declares multiple principals; no storyboard uses string-form `from_test_kit` or literal `value` — zero grouping change on the current 56-storyboard suite, confirmed by running the full contradiction lint before and after.
+
+Adds three tests: a shape-matrix unit test for `describeStepAuth` covering every branch (absent, none, `from_test_kit: true`, `from_test_kit: "<path>"`, `value_strategy`, literal, defensive fallbacks); an inherited-default cross-storyboard test pinning the `auth=kit_default` emission; and a multi-principal forward-guard test pinning that named-principal selection discriminates correctly.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -277,6 +277,81 @@ function normalizeFixturesForHashing(fixtures) {
 }
 
 /**
+ * Reduce a step's `auth` field to a stable fingerprint token. Always returns
+ * a string so the `auth=` component is ALWAYS present in the env fingerprint
+ * — required by #2711: steps that inherit the transport default used to emit
+ * no `auth=` component and could collide with explicit steps authored
+ * against divergent transport defaults once `sb=<doc.id>` was removed.
+ *
+ * Emission shape (what goes in `auth=...`):
+ *
+ *   kit_default              — step.auth absent. Step inherits whatever
+ *                              credential the transport is configured with
+ *                              (today: the test kit's `auth.api_key`, which
+ *                              is already covered by `test_kit=<path>` in
+ *                              the outer fingerprint; the explicit token
+ *                              keeps the shape legible and pins inheritance
+ *                              as a distinct semantic from a declared
+ *                              override).
+ *
+ *   none                     — step.auth === "none". Credentials stripped.
+ *
+ *   <type>:<strategy>        — step.auth is an object. Strategy encodes:
+ *     value_strategy          → the declared strategy verbatim
+ *                              (e.g., api_key:random_invalid). Per-run
+ *                              values are random; identity is the strategy.
+ *     from_test_kit: true     → `from_test_kit` — the kit's default
+ *                              principal handle. Equivalent in resolution
+ *                              to `kit_default` today, distinguished here
+ *                              because the explicit declaration carries
+ *                              type info the default case can't.
+ *     from_test_kit: "<path>" → `from_test_kit:<path>` — selects a named
+ *                              principal within a multi-principal kit
+ *                              (#2708). Today no kit declares multiple
+ *                              principals; emission shape is forward-
+ *                              compatible so the first multi-principal
+ *                              kit's storyboards are discriminated without
+ *                              further changes to the lint.
+ *     value: "<literal>"      → `literal:<sha1-8hex>` — hash the resolved
+ *                              identity (#2708) so two steps declaring
+ *                              different literal keys against the same
+ *                              kit don't collide. 32-bit truncation is
+ *                              deliberate: at storyboard-authoring scale
+ *                              (~thousands) the birthday bound is ~65K
+ *                              before even-odds collision, and a miss
+ *                              here degrades to a lint false-negative,
+ *                              not a correctness hazard. Literal keys in
+ *                              storyboards are already a code smell; the
+ *                              hash is defense-in-depth, not a load-
+ *                              bearing discriminator.
+ *
+ *   unknown                  — step.auth is some other shape. Defensive
+ *                              catch-all so the lint surfaces rather than
+ *                              silently drops.
+ *
+ * Precedence (first match wins): `value_strategy` > `from_test_kit` >
+ * `value`. Intentional: if a step declares both `value_strategy:
+ * random_invalid` and `from_test_kit: true`, the random value wins on the
+ * wire — the strategy is what the agent actually sees — so encoding the
+ * strategy is faithful to runtime behavior. Reordering would silently
+ * change which tests discriminate.
+ */
+function describeStepAuth(auth) {
+  if (auth === undefined) return 'kit_default';
+  if (auth === 'none') return 'none';
+  if (typeof auth !== 'object' || auth === null) return 'unknown';
+  const type = typeof auth.type === 'string' ? auth.type : '?';
+  if (typeof auth.value_strategy === 'string') return `${type}:${auth.value_strategy}`;
+  if (typeof auth.from_test_kit === 'string') return `${type}:from_test_kit:${auth.from_test_kit}`;
+  if (auth.from_test_kit === true) return `${type}:from_test_kit`;
+  if (typeof auth.value === 'string') {
+    const hash = crypto.createHash('sha1').update(auth.value).digest('hex').slice(0, 8);
+    return `${type}:literal:${hash}`;
+  }
+  return `${type}:?`;
+}
+
+/**
  * Env fingerprint: the external knobs that select which fixture a conformant
  * agent serves. Two steps with same request but different env can
  * legitimately disagree on outcome (e.g., api-key vs oauth_bearer auth
@@ -303,7 +378,13 @@ function normalizeFixturesForHashing(fixtures) {
  *                legitimately produce different outcomes for the same
  *                request.
  *   scenario   — step's `comply_scenario`.
- *   auth       — step's auth override shape (type + strategy).
+ *   auth       — step's effective credential shape, produced by
+ *                `describeStepAuth`. Always emitted (even for steps that
+ *                inherit the transport default) so inheritance itself
+ *                participates in the fingerprint rather than silently
+ *                collapsing with arbitrary other states — see #2711.
+ *                Forward-compatible with multi-principal kits via
+ *                `from_test_kit:<path>` selectors — see #2708.
  *   seed       — phase's `prerequisites.controller_seeding` (distinct from
  *                top-level fixtures; applies phase-scoped seeding).
  *
@@ -336,15 +417,7 @@ function fingerprintEnv(step, phase, doc) {
     parts.push(`fixtures=${fixturesHash}`);
   }
   if (typeof step.comply_scenario === 'string') parts.push(`scenario=${step.comply_scenario}`);
-  if (step.auth) {
-    const auth = step.auth;
-    if (auth === 'none') parts.push('auth=none');
-    else if (typeof auth === 'object') {
-      const type = auth.type || '?';
-      const strat = auth.value_strategy || (auth.from_test_kit ? 'from_test_kit' : auth.value ? 'literal' : '?');
-      parts.push(`auth=${type}:${strat}`);
-    }
-  }
+  parts.push(`auth=${describeStepAuth(step.auth)}`);
   const seeding = phase?.prerequisites?.controller_seeding;
   if (Array.isArray(seeding) && seeding.length > 0) {
     parts.push(`seed=${seeding.map((s) => s?.scenario || s).sort().join(',')}`);
@@ -580,6 +653,7 @@ module.exports = {
   canonicalizeRequest,
   fingerprintRequest,
   fingerprintEnv,
+  describeStepAuth,
   normalizeFixturesForHashing,
   classifyOutcome,
   outcomesAgree,

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -26,6 +26,7 @@ const {
   MUTATING_TASKS,
   loadMutatingTasksFromSchemas,
   normalizeFixturesForHashing,
+  describeStepAuth,
 } = require('../scripts/lint-storyboard-contradictions.cjs');
 
 const path = require('node:path');
@@ -678,4 +679,180 @@ phases:
             allowed_values: [401, 403]
 `);
   assert.deepEqual(contradictionsAcrossDocs({ 'a.yaml': doc }), []);
+});
+
+test('describeStepAuth covers the declared shape matrix (#2708, #2711)', () => {
+  // Unit-level coverage of the effective-credential reduction so each
+  // branch of the fingerprint shape matrix is pinned independently of
+  // the cross-storyboard contradiction path.
+
+  // #2711: absent step.auth must emit a distinct, stable token rather
+  // than vanishing from the fingerprint. `kit_default` is the sentinel.
+  assert.equal(describeStepAuth(undefined), 'kit_default');
+
+  // `auth: none` strips credentials entirely.
+  assert.equal(describeStepAuth('none'), 'none');
+
+  // Declared `from_test_kit: true` resolves to the kit's default principal
+  // but carries type info the default case can't express.
+  assert.equal(describeStepAuth({ type: 'api_key', from_test_kit: true }), 'api_key:from_test_kit');
+  assert.equal(describeStepAuth({ type: 'oauth_bearer', from_test_kit: true }), 'oauth_bearer:from_test_kit');
+
+  // #2708: `from_test_kit: "<path>"` selects a named principal within a
+  // multi-principal kit. The path must be in the fingerprint so two
+  // steps against the same kit but different principals discriminate.
+  assert.equal(
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.low_spend.api_key' }),
+    'api_key:from_test_kit:auth.principals.low_spend.api_key',
+  );
+  assert.notEqual(
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.low_spend.api_key' }),
+    describeStepAuth({ type: 'api_key', from_test_kit: 'auth.principals.full_auth.api_key' }),
+  );
+
+  // `value_strategy` — per-run random values; the strategy name IS the
+  // identity (no stable value to hash).
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value_strategy: 'random_invalid' }),
+    'api_key:random_invalid',
+  );
+
+  // #2708: literal values hash to 8 hex chars. Two different literals do
+  // not collide. Hashes are pinned to precomputed sha1(literal).slice(0,8)
+  // values so an accidental switch to a non-deterministic hash or a
+  // truncation-width change surfaces here rather than silently shifting
+  // fingerprint buckets.
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value: 'key-a' }),
+    'api_key:literal:70efd783',
+  );
+  assert.equal(
+    describeStepAuth({ type: 'api_key', value: 'key-b' }),
+    'api_key:literal:77daed1d',
+  );
+
+  // Defensive fallbacks — unknown shapes must not crash.
+  assert.equal(describeStepAuth(null), 'unknown');
+  assert.equal(describeStepAuth(42), 'unknown');
+  assert.equal(describeStepAuth({ type: 'api_key' }), 'api_key:?');
+  assert.equal(describeStepAuth({}), '?:?');
+});
+
+test('env fingerprint emits auth= for inherited-default steps (#2711)', () => {
+  // Two storyboards sharing every env component AND both inheriting the
+  // transport default (no step.auth). After this change, both still land
+  // in the same group (they semantically share credentials), so any
+  // outcome disagreement MUST surface as a contradiction rather than
+  // getting silently masked by asymmetric fingerprint emission.
+  const docs = {
+    'a.yaml': yaml.load(`
+id: sb_a
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: succeed
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+    'b.yaml': yaml.load(`
+id: sb_b
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/acme-outdoor.yaml"
+phases:
+  - id: p
+    steps:
+      - id: fail
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+  };
+  const contradictions = contradictionsAcrossDocs(docs);
+  assert.equal(contradictions.length, 1, 'inherited-default steps must participate in the group');
+
+  // Direct fingerprint assertion: an inheriting step emits `auth=kit_default`
+  // — the fix's defining property. Without this token the auth= component
+  // would be absent and two inheriting storyboards with divergent transport
+  // defaults could collide silently.
+  const fpInherit = fingerprintEnv({}, {}, { id: 'x', caller: { role: 'buyer_agent' } });
+  assert.ok(fpInherit.includes('auth=kit_default'), `expected auth=kit_default in ${fpInherit}`);
+});
+
+test('env fingerprint discriminates named principals within a kit (#2708)', () => {
+  // Forward guard: when a multi-principal kit declares
+  // `auth: { type: api_key, from_test_kit: "<path>" }` to select among
+  // principals, two steps selecting different principals MUST land in
+  // different fingerprint buckets even though all other env components
+  // (test_kit, role, fixtures, scenario) match. Today no kit exposes
+  // multiple principals — this test pins the shape so the first kit that
+  // does is handled without further lint changes.
+  const docs = {
+    'low_spend.yaml': yaml.load(`
+id: sb_principals
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/multi-principal.yaml"
+phases:
+  - id: p
+    steps:
+      - id: denied
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        auth: { type: api_key, from_test_kit: "auth.principals.low_spend.api_key" }
+        expect_error: true
+        validations:
+          - check: error_code
+            value: GOVERNANCE_DENIED
+`),
+    'full_auth.yaml': yaml.load(`
+id: sb_principals
+caller:
+  role: buyer_agent
+prerequisites:
+  test_kit: "test-kits/multi-principal.yaml"
+phases:
+  - id: p
+    steps:
+      - id: approved
+        task: create_media_buy
+        sample_request: { brand: { domain: x } }
+        auth: { type: api_key, from_test_kit: "auth.principals.full_auth.api_key" }
+        validations:
+          - check: field_present
+            path: media_buy_id
+`),
+  };
+  assert.deepEqual(contradictionsAcrossDocs(docs), []);
+
+  // Direct fingerprint-level assertion: pin the discrimination to the
+  // `from_test_kit:<path>` token specifically, not to whatever other
+  // coincidental env difference might fire. Mirrors the pattern used by
+  // the `caller.role discriminates env` test upstream — deepEqual([], [])
+  // can go green for unrelated classification failures.
+  const lowStep = docs['low_spend.yaml'].phases[0].steps[0];
+  const fullStep = docs['full_auth.yaml'].phases[0].steps[0];
+  const fpLow = fingerprintEnv(lowStep, {}, docs['low_spend.yaml']);
+  const fpFull = fingerprintEnv(fullStep, {}, docs['full_auth.yaml']);
+  assert.notEqual(fpLow, fpFull);
+  assert.ok(
+    fpLow.includes('auth=api_key:from_test_kit:auth.principals.low_spend.api_key'),
+    `expected low-spend path token in ${fpLow}`,
+  );
+  assert.ok(
+    fpFull.includes('auth=api_key:from_test_kit:auth.principals.full_auth.api_key'),
+    `expected full-auth path token in ${fpFull}`,
+  );
 });


### PR DESCRIPTION
## Summary

Combined fix for [#2708](https://github.com/adcontextprotocol/adcp/issues/2708) (auth= hashes strategy not identity) and [#2711](https://github.com/adcontextprotocol/adcp/issues/2711) (absent step.auth emits nothing). **Stacked on [#2714](https://github.com/adcontextprotocol/adcp/pull/2714)** (the `sb=<doc.id>` removal) — both issues are structural gaps the `sb=` removal exposes, so landing them together closes the contradiction-lint's env-fingerprint cycle.

## The audit behind the fix

- 340 total storyboard steps across 56 files
- 336 (98.8%) inherit transport-default auth → emit no `auth=` component under the pre-fix code
- Only 4 declare step-level overrides, all in `universal/security.yaml`
- No test kit declares multiple principals
- No storyboard uses `from_test_kit: "<path>"` string form or literal `value:`

So neither issue is a current bug — but once `sb=` is gone (PR #2714), both shapes are the remaining load-bearing discriminators and both were structurally incomplete.

## The shape

Replaces the inline auth emission in `fingerprintEnv` with a `describeStepAuth(auth)` helper that ALWAYS returns a stable token:

| `step.auth`                                      | Emitted token                                    | Rationale                                                                 |
|--------------------------------------------------|--------------------------------------------------|---------------------------------------------------------------------------|
| `undefined`                                      | `kit_default`                                    | **#2711** — inheritance is now a distinct fingerprint position           |
| `"none"`                                         | `none`                                           | Unchanged                                                                 |
| `{type, value_strategy: X}`                      | `<type>:<X>`                                     | Random-value strategies; identity IS the strategy                         |
| `{type, from_test_kit: true}`                    | `<type>:from_test_kit`                           | Default principal, explicit form                                          |
| `{type, from_test_kit: "<path>"}`                | `<type>:from_test_kit:<path>`                    | **#2708** — named-principal selection in multi-principal kits            |
| `{type, value: "<literal>"}`                     | `<type>:literal:<sha1-8hex>`                     | **#2708** — literal identity hash (defense-in-depth; see #2720)          |
| malformed / unknown                              | `unknown` / `<type>:?`                           | Defensive fallback; surfaces rather than silently drops                   |

Precedence when multiple fields coexist: `value_strategy > from_test_kit > value`. Encoded in the JSDoc because it's faithful to runtime behavior (random value wins on the wire).

## Zero grouping change on today's suite

Verified by running the contradiction lint before and after: no storyboard uses string-form `from_test_kit` or literal `value:`; all 336 inheriting steps get the new `kit_default` token uniformly.

## Tests

Three new tests in `tests/lint-storyboard-contradictions.test.cjs`:

1. **`describeStepAuth covers the declared shape matrix (#2708, #2711)`** — unit-level, every branch. Literal hashes pinned to precomputed sha1 values (`key-a` → `70efd783`, `key-b` → `77daed1d`) so an accidental hash-algorithm or truncation-width change surfaces here.
2. **`env fingerprint emits auth= for inherited-default steps (#2711)`** — two inheriting storyboards with disagreeing outcomes now collide as intended (contradiction fires). Direct `fingerprintEnv` call asserts `auth=kit_default` appears.
3. **`env fingerprint discriminates named principals within a kit (#2708)`** — forward guard: `deepEqual([], [])` + direct `fingerprintEnv` comparison + string-level assertions that both path tokens appear verbatim in their respective fingerprints.

## Expert review

Three rounds pre-push:

- **Code reviewer** — ship it. Flagged a vestigial line in test #2 (deleted). Nits applied: precedence-order and 8-hex-collision-scale notes added to `describeStepAuth` JSDoc.
- **Ad-tech protocol expert** — ship it. Confirmed the `kit_default` ↔ `from_test_kit:true` asymmetry is correct (authorial intent, not just resolved identity). Confirmed hashing the declarative path is the right shape for a static-analysis lint (don't resolve to identity values — would leak secrets and break under credential rotation). Flagged two structural observations as follow-ups:
  - **[#2720](https://github.com/adcontextprotocol/adcp/issues/2720)** — literal `auth.value:` is a code smell; add a separate per-storyboard lint rule that flags it
  - **[#2721](https://github.com/adcontextprotocol/adcp/issues/2721)** — runner test kits (webhook-receiver, substitution-observer, signed-requests) have no `auth:` block; if a storyboard ever composes runner + primary kit, `kit_default` becomes ambiguous — decide the composition model before that storyboard lands
- **Testing expert** — tightened three spots: deleted vestigial ternary-and-assignment line in #2; added direct `fingerprintEnv` comparison + path-token substring assertions to #3; pinned literal hashes to precomputed values in #1.

## Test plan

- [x] `npm run test:storyboard-contradictions` — 30/30 pass (3 new)
- [x] `npm run build:compliance` — all four storyboard lints green, 56 storyboards build
- [x] `npm run test:unit` — 631/631 pass (precommit)
- [x] `npm run typecheck` — clean (precommit)

## Related

- PR [#2714](https://github.com/adcontextprotocol/adcp/pull/2714) — prerequisite (`sb=` removal). Merge that first.
- PR [#2710](https://github.com/adcontextprotocol/adcp/pull/2710) — merged, added `role=` forward guard
- Issue #2720 — deferred (literal `auth.value:` lint rule)
- Issue #2721 — deferred (runner-kit composition model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)