### PR TITLE
feat(editorial): reviewer notifications on pending_review (#2701)

### DIFF
--- a/.changeset/feat-editorial-review-notifications.md
+++ b/.changeset/feat-editorial-review-notifications.md
@@ -1,0 +1,24 @@
+---
+---
+
+feat(editorial): reviewer notifications for content entering pending_review (#2701).
+
+When a member submits content via the dashboard or Addie, reviewers now get a Slack notification they can action. Two notification paths run concurrently:
+
+1. **Committee channel** (existing behavior, enriched): posts to the working group's configured `slack_channel_id` when set.
+2. **Global editorial channel** (new): admins can configure a central `editorial_slack_channel` via `PUT /api/admin/settings/editorial-channel`, and pending-review content posts there too. Gives a reliable queue regardless of which committee the draft belongs to — previously, if the WG had no Slack channel, nobody was notified.
+
+Notification content now includes:
+- Excerpt (if supplied)
+- Committee lead names (so reviewers know who owns the queue)
+- Direct review link with the item id
+- "Review" button
+
+Security: user-supplied title/excerpt/author are run through a new `escapeSlackText` helper that escapes `<`, `>`, and `&` so a malicious submitter can't embed `<!here>`/`<!channel>`/`<@userid>` pings in a pending notification. Covered by `server/tests/unit/slack-escape.test.ts`.
+
+Follow-ups still open on epic #2693:
+- #2703 Google Docs reader
+- #2700 auto cover image
+- #2702 escalation linking
+- #2699 rich-text paste
+- Plus: stale-queue nudges (no issue yet — will file if it comes up)

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -699,6 +699,38 @@
         if (isAdmin) {
           switchTab('all');
         }
+
+        // Deep link support: /dashboard/content?status=pending_review&id=<uuid>
+        // lands the reviewer on the pending-review tab and focuses the named
+        // item. The Slack notification "Review draft" button uses this URL;
+        // without the focus, the reviewer lands on the queue and has to
+        // re-find the item by title. The id= param is a best-effort hint —
+        // if the item isn't in the current queue (e.g. already reviewed),
+        // we fall through to the unfocused tab view.
+        try {
+          const params = new URLSearchParams(window.location.search);
+          const statusParam = params.get('status');
+          const idParam = params.get('id');
+          if (statusParam === 'pending_review' && canReview) {
+            switchTab('review');
+            if (idParam) {
+              // Retry a couple of times — renderPendingContent is async via
+              // loadPendingContent and the DOM may not be populated yet.
+              const tryFocus = (attempt = 0) => {
+                const card = document.querySelector(`[data-id="${CSS.escape(idParam)}"]`);
+                if (card) {
+                  card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                  card.style.transition = 'box-shadow 0.3s ease';
+                  card.style.boxShadow = '0 0 0 3px var(--color-warning-500, #fbbf24)';
+                  setTimeout(() => { card.style.boxShadow = ''; }, 2500);
+                } else if (attempt < 5) {
+                  setTimeout(() => tryFocus(attempt + 1), 300);
+                }
+              };
+              tryFocus();
+            }
+          }
+        } catch (e) { /* best-effort; never block the dashboard on a deep link */ }
       } catch (err) {
         console.error('Init error:', err);
         document.getElementById('loading').innerHTML =

--- a/server/src/db/system-settings-db.ts
+++ b/server/src/db/system-settings-db.ts
@@ -40,6 +40,11 @@ export interface ErrorChannelSetting {
   channel_name: string | null;
 }
 
+export interface EditorialChannelSetting {
+  channel_id: string | null;
+  channel_name: string | null;
+}
+
 // ============== Setting Keys ==============
 
 export const SETTING_KEYS = {
@@ -49,6 +54,7 @@ export const SETTING_KEYS = {
   PROSPECT_SLACK_CHANNEL: 'prospect_slack_channel',
   PROSPECT_TRIAGE_ENABLED: 'prospect_triage_enabled',
   ERROR_SLACK_CHANNEL: 'error_slack_channel',
+  EDITORIAL_SLACK_CHANNEL: 'editorial_slack_channel',
 } as const;
 
 // ============== Generic Operations ==============
@@ -235,6 +241,33 @@ export async function setErrorChannel(
 ): Promise<void> {
   await setSetting<ErrorChannelSetting>(
     SETTING_KEYS.ERROR_SLACK_CHANNEL,
+    { channel_id: channelId, channel_name: channelName },
+    updatedBy
+  );
+}
+
+// ============== Editorial Channel Operations ==============
+
+/**
+ * Get the configured editorial review notification Slack channel.
+ * Posts land here when content enters pending_review, giving reviewers
+ * a central queue regardless of which committee the draft belongs to.
+ */
+export async function getEditorialChannel(): Promise<EditorialChannelSetting> {
+  const result = await getSetting<EditorialChannelSetting>(SETTING_KEYS.EDITORIAL_SLACK_CHANNEL);
+  return result ?? { channel_id: null, channel_name: null };
+}
+
+/**
+ * Set the editorial review notification Slack channel
+ */
+export async function setEditorialChannel(
+  channelId: string | null,
+  channelName: string | null,
+  updatedBy?: string
+): Promise<void> {
+  await setSetting<EditorialChannelSetting>(
+    SETTING_KEYS.EDITORIAL_SLACK_CHANNEL,
     { channel_id: channelId, channel_name: channelName },
     updatedBy
   );

--- a/server/src/routes/admin/settings.ts
+++ b/server/src/routes/admin/settings.ts
@@ -23,6 +23,8 @@ import {
   setProspectTriageEnabled,
   getErrorChannel,
   setErrorChannel,
+  getEditorialChannel,
+  setEditorialChannel,
 } from '../../db/system-settings-db.js';
 import { getSlackChannels, getChannelInfo, isSlackConfigured } from '../../slack/client.js';
 
@@ -42,6 +44,8 @@ export function createAdminSettingsRouter(): Router {
       const prospectTriageEnabled = await getProspectTriageEnabled();
       const errorChannel = await getErrorChannel();
 
+      const editorialChannel = await getEditorialChannel();
+
       res.json({
         settings,
         billing_channel: billingChannel,
@@ -50,6 +54,7 @@ export function createAdminSettingsRouter(): Router {
         prospect_channel: prospectChannel,
         prospect_triage_enabled: prospectTriageEnabled,
         error_channel: errorChannel,
+        editorial_channel: editorialChannel,
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to get system settings');
@@ -360,6 +365,57 @@ export function createAdminSettingsRouter(): Router {
       logger.error({ err: error }, 'Failed to update error channel');
       res.status(500).json({
         error: 'Failed to update error channel',
+      });
+    }
+  });
+
+  // PUT /api/admin/settings/editorial-channel - Update editorial review notification channel
+  router.put('/editorial-channel', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+    try {
+      const { channel_id, channel_name } = req.body;
+
+      if (channel_id !== null && channel_id !== undefined) {
+        if (typeof channel_id !== 'string' || !/^[CG][A-Z0-9]+$/.test(channel_id)) {
+          res.status(400).json({
+            error: 'Invalid channel ID format',
+            message: 'Channel ID should start with C or G followed by alphanumeric characters',
+          });
+          return;
+        }
+
+        if (isSlackConfigured()) {
+          const channelInfo = await getChannelInfo(channel_id);
+          if (channelInfo && !channelInfo.is_private) {
+            res.status(400).json({
+              error: 'Invalid channel',
+              message: 'Only private channels are allowed for editorial notifications',
+            });
+            return;
+          }
+        }
+      }
+
+      if (channel_name !== null && channel_name !== undefined) {
+        if (typeof channel_name !== 'string' || channel_name.length > 200) {
+          res.status(400).json({
+            error: 'Invalid channel name',
+            message: 'Channel name must be a string under 200 characters',
+          });
+          return;
+        }
+      }
+
+      const userId = req.user?.id;
+      await setEditorialChannel(channel_id ?? null, channel_name ?? null, userId);
+
+      logger.info({ channel_id, channel_name, userId }, 'Editorial channel updated');
+
+      const updated = await getEditorialChannel();
+      res.json({ success: true, editorial_channel: updated });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to update editorial channel');
+      res.status(500).json({
+        error: 'Failed to update editorial channel',
       });
     }
   });

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -73,13 +73,20 @@ async function notifyPendingReview(
     slug: string;
     excerpt: string | null;
     content_type: string;
+    content: string | null;
+    proposed_at: string;
   },
-  authorName: string
+  authorName: string,
+  proposerUserId: string
 ): Promise<void> {
   const pool = getPool();
 
-  // Fetch the working group and committee leads in one trip so we can include
-  // lead names in the message (helps reviewers know who to tag or assign).
+  // Fetch the working group, committee leads, and channel config in one
+  // round-trip so we can enrich the message with lead names. The leads
+  // query only surfaces WorkOS-linked users — slack-only leads (leaders
+  // added by Slack ID before mapping) won't appear in the `*Leads:*` line.
+  // That matches the current data-integrity requirement; a reviewer seeing
+  // a missing leads line just means the committee has unmapped leads.
   const [wgResult, leadersResult, editorialChannel] = await Promise.all([
     pool.query(
       `SELECT name, slack_channel_id FROM working_groups WHERE id = $1`,
@@ -120,11 +127,36 @@ async function notifyPendingReview(
   const safeWg = escapeSlackText(wgName, 80);
   const safeExcerpt = perspective.excerpt ? escapeSlackText(perspective.excerpt, 240) : null;
   const leadLine = leadNames.length > 0
-    ? `\n*Leads:* ${leadNames.map(n => escapeSlackText(n, 60)).join(', ')}`
+    ? `*Leads:* ${leadNames.map(n => escapeSlackText(n, 60)).join(', ')}`
     : '';
   const excerptLine = safeExcerpt ? `\n\n> ${safeExcerpt}` : '';
   const reviewUrl = `https://agenticadvertising.org/dashboard/content?status=pending_review&id=${encodeURIComponent(perspective.id)}`;
   const typeLabel = perspective.content_type === 'link' ? 'Link' : 'Article';
+
+  // Reviewer triage fields: word count, reading time, submission age,
+  // source (Addie vs direct). Gives reviewers enough to decide whether
+  // to open the draft without clicking through.
+  const wordCount = perspective.content
+    ? perspective.content.split(/\s+/).filter(Boolean).length
+    : 0;
+  const readingMin = Math.max(1, Math.round(wordCount / 200));
+  const proposedAtUnix = Math.floor(new Date(perspective.proposed_at).getTime() / 1000);
+  const submittedLine = `Submitted <!date^${proposedAtUnix}^{date_short_pretty} at {time}|${perspective.proposed_at}>`;
+  const source = proposerUserId === 'system:addie' || proposerUserId?.startsWith('system:')
+    ? 'drafted with Addie'
+    : 'direct submission';
+  const triageLine = perspective.content_type === 'article' && wordCount > 0
+    ? `${wordCount.toLocaleString()} words • ~${readingMin} min read • ${submittedLine} • ${source}`
+    : `${submittedLine} • ${source}`;
+
+  const headerLine = `📝 *New ${typeLabel.toLowerCase()} for review — ${safeWg}*`;
+  const titleLine = `*${safeTitle}* by ${safeAuthor}`;
+
+  const messageBlocks = [
+    `${headerLine}\n${titleLine}\n${triageLine}`,
+    leadLine,
+    excerptLine.trimStart(),
+  ].filter(Boolean).join('\n');
 
   const message: SlackBlockMessage = {
     text: `${typeLabel} pending review: "${safeTitle}" by ${safeAuthor}`,
@@ -133,7 +165,7 @@ async function notifyPendingReview(
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `📝 *New ${typeLabel.toLowerCase()} submitted for review*\n\n*Title:* ${safeTitle}\n*Author:* ${safeAuthor}\n*Committee:* ${safeWg}${leadLine}${excerptLine}`,
+          text: messageBlocks,
         },
       },
       {
@@ -141,7 +173,7 @@ async function notifyPendingReview(
         elements: [
           {
             type: 'button',
-            text: { type: 'plain_text', text: 'Review', emoji: true },
+            text: { type: 'plain_text', text: 'Review draft', emoji: true },
             url: reviewUrl,
             action_id: 'review_content',
             style: 'primary',
@@ -158,20 +190,33 @@ async function notifyPendingReview(
     targets.push({ channelId: editorialChannelId, label: 'editorial' });
   }
 
-  await Promise.all(targets.map(async ({ channelId, label }) => {
+  const results = await Promise.all(targets.map(async ({ channelId, label }) => {
     try {
       await sendChannelMessage(channelId, message);
       logger.info(
         { workingGroupId, perspectiveId: perspective.id, channelId, target: label },
         'Sent pending content notification'
       );
+      return true;
     } catch (error) {
       logger.error(
         { error, workingGroupId, perspectiveId: perspective.id, channelId, target: label },
         'Failed to send pending content notification'
       );
+      return false;
     }
   }));
+
+  // Surface the case where every configured target failed. A single
+  // failure is already logged per-target; the additional log fires only
+  // when the queue is effectively silent despite a channel being
+  // configured — ops can alert on this.
+  if (results.length > 0 && results.every(r => !r)) {
+    logger.error(
+      { workingGroupId, perspectiveId: perspective.id, targetCount: targets.length },
+      'All pending-review notification targets failed — reviewers will not be paged'
+    );
+  }
 }
 
 /**
@@ -412,8 +457,11 @@ export async function proposeContentForUser(
         slug: perspective.slug,
         excerpt: perspective.excerpt ?? null,
         content_type: perspective.content_type,
+        content: perspective.content ?? null,
+        proposed_at: perspective.proposed_at,
       },
-      authorName
+      authorName,
+      user.id
     ).catch(err => {
       logger.error({ err, perspectiveId: perspective.id, committeeId, authorName }, 'Failed to send content notification');
     });

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -15,7 +15,10 @@ import { requireAuth } from '../middleware/auth.js';
 import { getPool } from '../db/client.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
 import { sendChannelMessage } from '../slack/client.js';
+import type { SlackBlockMessage } from '../slack/types.js';
 import { notifyPublishedPost, sendSocialAmplificationDM } from '../notifications/slack.js';
+import { getEditorialChannel } from '../db/system-settings-db.js';
+import { escapeSlackText } from '../utils/slack-escape.js';
 import { computeJourneyStage } from '../addie/services/journey-computation.js';
 import { CommunityDatabase } from '../db/community-db.js';
 import { createAsset } from '../db/perspective-asset-db.js';
@@ -54,61 +57,121 @@ interface ProposeContentRequest {
 }
 
 /**
- * Notify a working group's Slack channel about pending content
+ * Notify reviewers that content has entered pending_review.
+ *
+ * Posts to both (a) the working group's Slack channel if one is configured
+ * (keeps WG-specific review flows working) and (b) the system-wide editorial
+ * review channel if one is configured (central queue for admins and
+ * committee leads regardless of WG). Either, both, or neither may exist —
+ * that's fine, we just skip what's missing.
  */
-async function notifyWorkingGroupOfPendingContent(
+async function notifyPendingReview(
   workingGroupId: string,
-  perspective: { id: string; title: string; slug: string },
+  perspective: {
+    id: string;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    content_type: string;
+  },
   authorName: string
 ): Promise<void> {
   const pool = getPool();
 
-  // Get the working group's Slack channel
-  const wgResult = await pool.query(
-    `SELECT name, slack_channel_id FROM working_groups WHERE id = $1`,
-    [workingGroupId]
-  );
+  // Fetch the working group and committee leads in one trip so we can include
+  // lead names in the message (helps reviewers know who to tag or assign).
+  const [wgResult, leadersResult, editorialChannel] = await Promise.all([
+    pool.query(
+      `SELECT name, slack_channel_id FROM working_groups WHERE id = $1`,
+      [workingGroupId]
+    ),
+    pool.query(
+      `SELECT u.first_name, u.last_name, u.email
+         FROM working_group_leaders wgl
+         LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
+         LEFT JOIN users u ON u.workos_user_id = COALESCE(sm.workos_user_id, wgl.user_id)
+         WHERE wgl.working_group_id = $1
+           AND u.workos_user_id IS NOT NULL
+         LIMIT 10`,
+      [workingGroupId]
+    ),
+    getEditorialChannel(),
+  ]);
 
-  if (wgResult.rows.length === 0 || !wgResult.rows[0].slack_channel_id) {
-    logger.debug({ workingGroupId }, 'Working group has no Slack channel, skipping notification');
+  if (wgResult.rows.length === 0) {
+    logger.warn({ workingGroupId }, 'Working group not found for pending-review notification');
     return;
   }
 
-  const { name: wgName, slack_channel_id: slackChannelId } = wgResult.rows[0];
+  const { name: wgName, slack_channel_id: wgChannelId } = wgResult.rows[0];
+  const editorialChannelId = editorialChannel.channel_id;
 
-  try {
-    await sendChannelMessage(slackChannelId, {
-      text: `New content pending review: "${perspective.title}" by ${authorName}`,
-      blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `📝 *New content submitted for review*\n\n*Title:* ${perspective.title}\n*Author:* ${authorName}\n*Collection:* ${wgName}`,
-          },
-        },
-        {
-          type: 'actions',
-          elements: [
-            {
-              type: 'button',
-              text: {
-                type: 'plain_text',
-                text: 'Review Content',
-                emoji: true,
-              },
-              url: `https://agenticadvertising.org/dashboard/content?status=pending_review`,
-              action_id: 'review_content',
-            },
-          ],
-        },
-      ],
-    });
-
-    logger.info({ workingGroupId, perspectiveId: perspective.id, slackChannelId }, 'Sent pending content notification to working group');
-  } catch (error) {
-    logger.error({ error, workingGroupId, perspectiveId: perspective.id }, 'Failed to send pending content notification');
+  if (!wgChannelId && !editorialChannelId) {
+    logger.debug({ workingGroupId }, 'No Slack channels configured for pending-review notification');
+    return;
   }
+
+  const leadNames: string[] = leadersResult.rows
+    .map(r => (r.first_name && r.last_name ? `${r.first_name} ${r.last_name}` : r.email?.split('@')[0] || null))
+    .filter((n): n is string => !!n);
+
+  const safeTitle = escapeSlackText(perspective.title, 180);
+  const safeAuthor = escapeSlackText(authorName, 80);
+  const safeWg = escapeSlackText(wgName, 80);
+  const safeExcerpt = perspective.excerpt ? escapeSlackText(perspective.excerpt, 240) : null;
+  const leadLine = leadNames.length > 0
+    ? `\n*Leads:* ${leadNames.map(n => escapeSlackText(n, 60)).join(', ')}`
+    : '';
+  const excerptLine = safeExcerpt ? `\n\n> ${safeExcerpt}` : '';
+  const reviewUrl = `https://agenticadvertising.org/dashboard/content?status=pending_review&id=${encodeURIComponent(perspective.id)}`;
+  const typeLabel = perspective.content_type === 'link' ? 'Link' : 'Article';
+
+  const message: SlackBlockMessage = {
+    text: `${typeLabel} pending review: "${safeTitle}" by ${safeAuthor}`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `📝 *New ${typeLabel.toLowerCase()} submitted for review*\n\n*Title:* ${safeTitle}\n*Author:* ${safeAuthor}\n*Committee:* ${safeWg}${leadLine}${excerptLine}`,
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Review', emoji: true },
+            url: reviewUrl,
+            action_id: 'review_content',
+            style: 'primary',
+          },
+        ],
+      },
+    ],
+  };
+
+  const targets: Array<{ channelId: string; label: string }> = [];
+  if (wgChannelId) targets.push({ channelId: wgChannelId, label: 'working group' });
+  // Avoid double-posting if WG and editorial channels are the same
+  if (editorialChannelId && editorialChannelId !== wgChannelId) {
+    targets.push({ channelId: editorialChannelId, label: 'editorial' });
+  }
+
+  await Promise.all(targets.map(async ({ channelId, label }) => {
+    try {
+      await sendChannelMessage(channelId, message);
+      logger.info(
+        { workingGroupId, perspectiveId: perspective.id, channelId, target: label },
+        'Sent pending content notification'
+      );
+    } catch (error) {
+      logger.error(
+        { error, workingGroupId, perspectiveId: perspective.id, channelId, target: label },
+        'Failed to send pending content notification'
+      );
+    }
+  }));
 }
 
 /**
@@ -339,9 +402,19 @@ export async function proposeContentForUser(
     committeeSlug,
   }, 'Content proposed via direct function call');
 
-  // Notify working group if content needs review
+  // Notify working group and editorial reviewers if content needs review
   if (status === 'pending_review') {
-    notifyWorkingGroupOfPendingContent(committeeId, perspective, authorName).catch(err => {
+    notifyPendingReview(
+      committeeId,
+      {
+        id: perspective.id,
+        title: perspective.title,
+        slug: perspective.slug,
+        excerpt: perspective.excerpt ?? null,
+        content_type: perspective.content_type,
+      },
+      authorName
+    ).catch(err => {
       logger.error({ err, perspectiveId: perspective.id, committeeId, authorName }, 'Failed to send content notification');
     });
   } else if (status === 'published') {

--- a/server/src/utils/slack-escape.ts
+++ b/server/src/utils/slack-escape.ts
@@ -5,13 +5,16 @@
  * embedding those strings in a title, excerpt, or member name could ping
  * the reviewer channel at submission time.
  *
- * Escapes `<`, `>`, and `&` (the three characters Slack uses to delimit
- * formatting commands), then truncates with an ellipsis if over `maxLength`.
+ * Truncates the raw input to `maxLength` *first*, then escapes `&`, `<`,
+ * `>`. Truncating first ensures `maxLength` caps the meaningful content —
+ * not the expanded escape output — so an attacker can't flood the Slack
+ * block by stuffing characters that balloon in size after escaping
+ * (e.g. `<` → `&lt;` is a 4x expansion).
  */
 export function escapeSlackText(raw: string, maxLength = 240): string {
-  const escaped = raw
+  const truncated = raw.length > maxLength ? `${raw.slice(0, maxLength)}…` : raw;
+  return truncated
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
-  return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}…` : escaped;
 }

--- a/server/src/utils/slack-escape.ts
+++ b/server/src/utils/slack-escape.ts
@@ -1,0 +1,17 @@
+/**
+ * Escape user-controlled text before interpolating it into a Slack mrkdwn
+ * block. Slack mrkdwn can't execute code, but it interprets `<!here>`,
+ * `<!channel>`, and `<@USERID>` as pings — so a malicious submitter
+ * embedding those strings in a title, excerpt, or member name could ping
+ * the reviewer channel at submission time.
+ *
+ * Escapes `<`, `>`, and `&` (the three characters Slack uses to delimit
+ * formatting commands), then truncates with an ellipsis if over `maxLength`.
+ */
+export function escapeSlackText(raw: string, maxLength = 240): string {
+  const escaped = raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}…` : escaped;
+}

--- a/server/tests/unit/slack-escape.test.ts
+++ b/server/tests/unit/slack-escape.test.ts
@@ -32,10 +32,22 @@ describe('escapeSlackText', () => {
     expect(escapeSlackText(short, 240).endsWith('…')).toBe(false);
   });
 
-  it('truncation counts escaped characters toward the limit', () => {
-    // "<!here>" → "&lt;!here&gt;" (13 chars). If maxLength is 10, truncate.
-    const result = escapeSlackText('<!here> please', 10);
-    expect(result.length).toBe(11); // 10 + '…'
-    expect(result.endsWith('…')).toBe(true);
+  it('truncation caps raw input — escape expansion does not eat budget', () => {
+    // Attacker stuffs 1000 `<` characters. Raw length is 1000, so we
+    // truncate to 240 `<` before escaping. Escaped output is
+    // 240 * len('&lt;') + '…' = 240*4 + 1 = 961. Without
+    // truncate-first, a 240-char output cap would leave only ~60
+    // attacker characters visible; an attacker could pad content with
+    // cheap chars to push real content past the cutoff.
+    const evil = '<'.repeat(1000);
+    const result = escapeSlackText(evil, 240);
+    expect(result).toBe('&lt;'.repeat(240) + '…');
+    expect(result.length).toBe(240 * 4 + 1);
+  });
+
+  it('escape is applied after truncation, so short inputs are not mangled', () => {
+    // "<!here>" is 7 chars, well under 240 — should escape cleanly
+    // without losing characters to truncation.
+    expect(escapeSlackText('<!here>', 240)).toBe('&lt;!here&gt;');
   });
 });

--- a/server/tests/unit/slack-escape.test.ts
+++ b/server/tests/unit/slack-escape.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { escapeSlackText } from '../../src/utils/slack-escape.js';
+
+describe('escapeSlackText', () => {
+  it('leaves plain text unchanged', () => {
+    expect(escapeSlackText('Hello world')).toBe('Hello world');
+  });
+
+  it('escapes angle brackets so Slack does not parse formatting commands', () => {
+    // Without escaping, <!here> pings the channel. With escaping, it renders literally.
+    expect(escapeSlackText('<!here> please review')).toBe('&lt;!here&gt; please review');
+    expect(escapeSlackText('<!channel>')).toBe('&lt;!channel&gt;');
+    expect(escapeSlackText('<@U12345>')).toBe('&lt;@U12345&gt;');
+  });
+
+  it('escapes ampersands to prevent double-unescaping', () => {
+    expect(escapeSlackText('A & B')).toBe('A &amp; B');
+    // Ampersand encoded first, so already-encoded entities become literals
+    expect(escapeSlackText('&lt;')).toBe('&amp;lt;');
+  });
+
+  it('truncates over-long strings with an ellipsis', () => {
+    const long = 'a'.repeat(300);
+    const result = escapeSlackText(long, 240);
+    expect(result.length).toBe(241); // 240 chars + '…'
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('does not truncate strings within the limit', () => {
+    const short = 'short title';
+    expect(escapeSlackText(short, 240)).toBe('short title');
+    expect(escapeSlackText(short, 240).endsWith('…')).toBe(false);
+  });
+
+  it('truncation counts escaped characters toward the limit', () => {
+    // "<!here>" → "&lt;!here&gt;" (13 chars). If maxLength is 10, truncate.
+    const result = escapeSlackText('<!here> please', 10);
+    expect(result.length).toBe(11); // 10 + '…'
+    expect(result.endsWith('…')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2701. Part of epic #2693.

Makes the editorial review queue actually move. After PR #2709 closed the auto-publish bypass, content correctly lands in `pending_review` — but Mary Mason's post sat for a day before anyone noticed, because only the working group's own Slack channel got pinged (and most WGs don't have one set).

## Summary

- **Global editorial channel (new):** admin-configurable via `editorial_slack_channel` system setting. Posts go here in addition to the WG channel, so there's always a reliable queue regardless of which committee the draft belongs to.
- **Enriched notification content:** excerpt, committee lead names, direct review link with item id, primary-style "Review" button.
- **Security:** new `escapeSlackText` helper escapes `<`, `>`, `&` so a malicious submitter can't embed `<!here>` / `<!channel>` / `<@user>` pings in a pending notification. Covered by 6 unit tests.
- **Rename:** `notifyWorkingGroupOfPendingContent` → `notifyPendingReview` (scope is no longer limited to one WG).

Follows the existing billing/escalation/admin channel settings pattern:
- Schema + get/set in `system-settings-db.ts`
- `PUT /api/admin/settings/editorial-channel` route with the same admin + private-channel validation as siblings

## E2E validation (Playwright against Docker)

| Test | Result |
|---|---|
| `GET /api/admin/settings` includes `editorial_channel` | ✅ |
| `PUT /api/admin/settings/editorial-channel` sets channel | ✅ |
| Invalid `channel_id` format rejected with 400 | ✅ |
| Null clears the channel | ✅ |
| Non-admin (member) blocked with 403 | ✅ |
| Content submission fires notification path without crashing | ✅ |
| Title containing `<!here>` submits cleanly (escape protects Slack) | ✅ |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run server/tests/unit/` — 1673 passed, 34 skipped
- [x] New unit test `slack-escape.test.ts` — 6/6 passed
- [x] E2E Playwright against Docker — 7/7 assertions
- [ ] Smoke in production once deployed: admin configures editorial channel at `/admin/settings`, submits a test perspective, confirms message appears in channel with Review button

## Out of scope (follow-ups still open)

- **Admin-settings.html UI picker** for the new channel — configurable via API in the meantime. Will add in a small follow-up PR once a channel is chosen.
- **Stale-queue nudges** — 24h re-notification mentioned in the issue. Defer; file separate issue if Mary's queue fills up again.
- **Interactive Slack buttons** (approve/reject from Slack) — button in this PR deep-links to dashboard. One-click-in-Slack is a larger Bolt action handler change.

## Remaining epic (#2693) issues

Per the UX expert ship order:
1. ✅ #2701 — reviewer notifications (this PR)
2. #2703 — Google Docs reader (next)
3. #2700 — auto cover image
4. #2702 — escalation linking
5. #2699 — rich-text paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)