### PR TITLE
docs: two-tenant testing prep for uniform not-found MUST (#2727)

### DIFF
--- a/.changeset/uniform-error-testing-prep-guide.md
+++ b/.changeset/uniform-error-testing-prep-guide.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs: add "Preparing to test uniform error responses" to validate-your-agent.mdx, covering two-tenant setup, `adcp fuzz` baseline vs cross-tenant modes, and the `--auth-token-cross-tenant` CLI flag. Cross-link from error-handling.mdx § uniform-response so implementors land on the setup guidance from the MUST. Closes #2727.

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -161,6 +161,8 @@ Non-normative implementation note: a single-query pattern like `SELECT ... WHERE
 
 **Cache warmth** is a distinct oracle: a warm cache on tenant B's id indicates someone accessed it recently. Sellers MUST NOT gate cache population on authorization — true-miss ids MUST be cached-as-miss with the same TTL as resolve-then-deny, or cache reads MUST be bypassed for not-found responses.
 
+**Verifying this yourself.** The paired-probe `adcp fuzz` invariant checks uniform-response compliance by comparing two responses per tool. See [Validate Your Agent — Preparing to test uniform error responses](/docs/building/validate-your-agent#preparing-to-test-uniform-error-responses) for tenant-setup requirements and CLI invocation. Full-strength testing requires two isolated tenants; single-tenant runs cover only the "does not exist" leg.
+
 ### Authentication and Access
 
 | Code | Recovery | Description | Resolution |

--- a/docs/building/validate-your-agent.mdx
+++ b/docs/building/validate-your-agent.mdx
@@ -184,6 +184,43 @@ A typical failure looks like:
 
 Insertion-order approval records, governance tokens, signal activations, and sponsored-intelligence sessions all fall under the same rule. Any state you write that a later call can read back must live in a shared store — not a per-process `Map` or module-level variable.
 
+## Preparing to test uniform error responses
+
+The [uniform-response MUST](/docs/building/implementation/error-handling#standard-error-codes) requires byte-equivalent responses for "the id exists but the caller lacks access" and "the id does not exist" across every observable channel — error body, transport status, headers, side effects, and telemetry. Verifying this needs a paired-probe runner (`adcp fuzz`) that compares two responses per tool. The runner has two modes, and you need to plan tenant setup before you can exercise the strong one.
+
+**Baseline mode — single tenant.** One auth token, two fresh UUIDs probed per tool. Catches id-echo in error bodies, header divergence outside the allowlist, MCP `isError` / A2A `task.status.state` divergence, and gross latency deltas. Cannot catch cross-tenant existence leaks, because neither probe resolves to a real resource.
+
+**Cross-tenant mode — two tenants.** Tenant A seeds a resource (e.g., a property list, content standard, media buy, creative); tenant B probes against the seeded id plus a fresh UUID. Catches the full MUST, because it exercises the `(exists, unauthorized)` vs `(does not exist)` pair that baseline cannot construct.
+
+Both modes exercise spec MUSTs. Only the cross-tenant path verifies the whole invariant.
+
+### Minimum tenant setup
+
+Provision two isolated test accounts against your agent:
+
+- **Tenant A** — can create resources the invariant seeds (property lists, content standards, media buys, creatives). Sandbox-mode accounts are fine.
+- **Tenant B** — read-only against shared discovery surfaces. MUST NOT share any per-tenant state with A beyond what your platform makes globally visible (e.g., published product catalogs).
+
+Anything else the two tenants share — audit shards, rate-limit buckets keyed by resource type, cache tags — is a potential side channel the invariant is designed to catch. Share only what you'd share in production.
+
+### Runner invocation
+
+```bash
+# Cross-tenant (full MUST)
+npx @adcp/client fuzz my-agent \
+  --auth-token $TENANT_A_TOKEN \
+  --auth-token-cross-tenant $TENANT_B_TOKEN
+
+# Baseline (partial coverage)
+npx @adcp/client fuzz my-agent --auth-token $TOKEN
+```
+
+Tokens may also be supplied via `ADCP_AUTH_TOKEN` and `ADCP_AUTH_TOKEN_CROSS_TENANT`. See the [`@adcp/client` uniform-error-response invariant guide](https://github.com/adcontextprotocol/adcp-client/blob/main/docs/guides/VALIDATE-YOUR-AGENT.md#uniform-error-response-invariant-paired-probe) for the full flag list, the header allowlist, and the list of tools currently probed.
+
+### Testing with only one tenant
+
+If you haven't provisioned a second tenant yet, run baseline anyway — it still catches a meaningful class of leaks, and the CLI flags the run as baseline-only so operators can see coverage is partial. Treat single-tenant fuzz as a pre-check, not a conformance signal: a clean baseline run does not prove the MUST holds. Add the cross-tenant leg before you claim uniform-response conformance.
+
 ## The build-validate-fix loop
 
 The typical development workflow:


### PR DESCRIPTION
## Summary

- Adds **Preparing to test uniform error responses** to `validate-your-agent.mdx` covering why two test tenants matter, minimum tenant setup (A creates, B reads), the `adcp fuzz` invocation with `--auth-token` / `--auth-token-cross-tenant`, and what single-tenant baseline does and doesn't verify.
- Cross-links from `error-handling.mdx § uniform-response` so a reader of the MUST lands on the setup guidance instead of bouncing into the `@adcp/client` SDK to find it.

The MUST itself was hardened in #2691; the conformance tooling lands in [adcp-client#737](https://github.com/adcontextprotocol/adcp-client/pull/737). What was missing — and what #2727 asked for — is implementor-facing guidance in the spec repo so a seller standing up AdCP for the first time doesn't quietly ship with baseline-only coverage.

Closes #2727.

## Test plan

- [x] `npm run test:docs-nav` — 15/15
- [x] `npm run test:error-handling` — clean
- [x] `npm run test:platform-agnostic` — clean
- [x] `npm run test:unit` (precommit) — 631/631
- [x] `npm run typecheck` — clean
- [x] Mintlify validation green on push
- [ ] Visual review of the rendered subsection on the docs preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)