### PR TITLE
fix(dashboard-agents): cap Retry-After wait so page never hangs on loading

### DIFF
--- a/.changeset/fix-dashboard-agents-retry-after-hang.md
+++ b/.changeset/fix-dashboard-agents-retry-after-hang.md
@@ -1,0 +1,17 @@
+---
+---
+
+fix(dashboard-agents): cap Retry-After wait so the page never hangs on "Loading agents..."
+
+`fetchWithRetry` blindly honored the server's `Retry-After` header on 429
+responses. `bulkResolveRateLimiter` (used by every per-agent compliance
+endpoint) sits on a 60s window via `standardHeaders`, so under load the
+header could tell the browser to sleep for nearly a minute. That sleep
+blocked `Promise.allSettled` inside `loadAgents()`, which meant
+`renderPage()` never ran and `#hub-loading` stayed visible indefinitely.
+
+Cap the Retry-After wait at 3s; past that, return the 429 to the caller so
+the per-agent "Rate-limited — Retry" card renders (that branch already
+exists). Also wrap the fan-out in a 15s timeout race so any future fetch
+hang still falls through to per-card states instead of pinning the page on
+the loading spinner.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -569,6 +569,11 @@
     // network failures, honoring Retry-After when present. Rate-limit hits
     // are common when the dashboard fans out 3 requests per agent on reload
     // — without retry, agents silently collapse to "not yet checked".
+    // Retry-After is capped: bulkResolveRateLimiter's 60s window can ask us
+    // to wait nearly a minute, which hangs the whole page behind one agent.
+    // If the server wants longer than MAX_RETRY_WAIT_MS, surface the 429 to
+    // the caller so the per-agent "Rate-limited — Retry" card renders.
+    const MAX_RETRY_WAIT_MS = 3000;
     async function fetchWithRetry(url, opts, { retries = 1, baseDelayMs = 800 } = {}) {
       let lastErr;
       for (let attempt = 0; attempt <= retries; attempt++) {
@@ -576,6 +581,9 @@
           const res = await fetch(url, opts);
           if (res.status === 429 && attempt < retries) {
             const retryAfter = parseInt(res.headers.get('retry-after') || '', 10);
+            if (Number.isFinite(retryAfter) && retryAfter * 1000 > MAX_RETRY_WAIT_MS) {
+              return res;
+            }
             const wait = Number.isFinite(retryAfter) ? retryAfter * 1000 : baseDelayMs;
             await new Promise(r => setTimeout(r, wait));
             continue;
@@ -692,17 +700,26 @@
           });
         }
 
-        // Fetch compliance data for org's agents
+        // Fetch compliance data for org's agents. A hard 15s ceiling guards
+        // against any single fetch hanging the entire page — unresolved agents
+        // fall through to the per-card "not yet checked" / error state, and
+        // the user can still interact with the page.
         const agentCompliance = new Map();
         const agents = profileData?.profile?.agents || [];
         if (agents.length > 0) {
-          const results = await Promise.allSettled(agents.map(fetchAgentState));
-          for (const r of results) {
-            if (r.status === 'fulfilled') {
-              agentCompliance.set(r.value.url, r.value);
-            } else {
-              console.error('Agent compliance fetch rejected:', r.reason);
+          const allSettled = Promise.allSettled(agents.map(fetchAgentState));
+          const timeout = new Promise(resolve => setTimeout(() => resolve(null), 15000));
+          const results = await Promise.race([allSettled, timeout]);
+          if (Array.isArray(results)) {
+            for (const r of results) {
+              if (r.status === 'fulfilled') {
+                agentCompliance.set(r.value.url, r.value);
+              } else {
+                console.error('Agent compliance fetch rejected:', r.reason);
+              }
             }
+          } else {
+            console.warn('Agent compliance fetch timed out after 15s; rendering with partial data');
           }
         }
 


### PR DESCRIPTION
## Summary
- `fetchWithRetry` in `dashboard-agents.html` blindly honored the server's `Retry-After` header on 429 responses. `bulkResolveRateLimiter` (used by every per-agent compliance endpoint) runs on a 60s window with `standardHeaders: true`, so under load the header asked the browser to sleep nearly a minute per retry. That sleep blocked `Promise.allSettled` inside `loadAgents()`, so `renderPage()` never ran and `#hub-loading` stayed visible indefinitely — the exact symptom shown by the user on `/dashboard/agents`.
- Cap the Retry-After wait at 3s; when the server asks for longer, surface the 429 to the caller so the per-agent "Rate-limited — Retry" card renders (that branch already exists in `renderAgentsSection` at lines 814-835).
- Wrap the `Promise.allSettled(agents.map(fetchAgentState))` fan-out in a 15s timeout race so any future fetch hang still falls through to per-card states instead of pinning the page on the loading spinner.

Regression introduced by #2717 (commit `0a07631ae`), which added the retry helper.

## Test plan
- [ ] Load `/dashboard/agents` with a user that has multiple agents — page renders within 15s even if some fetches get rate-limited.
- [ ] Force 429s by reloading rapidly — per-agent "Rate-limited — Retry" cards render; clicking Retry re-fetches.
- [ ] Normal path: single agent, no rate limiting — compliance/history/auth fetches still succeed and cards render.
- [ ] Confirm no TypeScript regressions (`npm run typecheck`).