### PR TITLE
fix(c2pa): re-encode Gemini output to PNG before signing

### DIFF
--- a/.changeset/fix-illustration-c2pa-webp.md
+++ b/.changeset/fix-illustration-c2pa-webp.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix C2PA signing failures when Gemini's image model returns a non-PNG variant (webp/jpeg), which c2pa-node rejects with "type is unsupported". Both the illustration generator (`attachC2PAIfEnabled`) and the docs-storyboard build script (`scripts/generate-images.ts`) now re-encode the buffer through sharp with `failOn: 'error'` + `.rotate()` before signing, so the bytes match the `image/png` mimeType declared to the signer and any upstream EXIF/XMP metadata is stripped (the C2PA manifest is the sole provenance source of truth). The portrait path already normalized via sharp as part of the AI-badge composite, so this brings the three generator paths into alignment.

--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -20,6 +20,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import * as fs from "fs";
 import * as path from "path";
 import { createHash } from "crypto";
+import sharp from "sharp";
 import { signC2PA, isC2PASigningEnabled } from "../server/src/services/c2pa.js";
 
 const STYLES: Record<string, string> = {
@@ -123,7 +124,7 @@ async function generateAndSaveImage(
         fs.mkdirSync(dir, { recursive: true });
       }
       const rawBuffer = Buffer.from(part.inlineData.data, "base64");
-      const finalBuffer = signStoryboardIfEnabled(rawBuffer, outputPath, prompt, style);
+      const finalBuffer = await signStoryboardIfEnabled(rawBuffer, outputPath, prompt, style);
       fs.writeFileSync(outputPath, finalBuffer);
       console.log(`  Saved: ${outputPath} (${(finalBuffer.length / 1024).toFixed(0)} KB)`);
       return finalBuffer;
@@ -141,15 +142,24 @@ async function generateAndSaveImage(
  * and warns if signing fails — docs storyboards are a build-time artifact
  * and a single failure should not break a batch run.
  */
-function signStoryboardIfEnabled(
+async function signStoryboardIfEnabled(
   buffer: Buffer,
   outputPath: string,
   prompt: string,
   style: string,
-): Buffer {
+): Promise<Buffer> {
   if (!isC2PASigningEnabled()) return buffer;
   try {
-    const signed = signC2PA(buffer, {
+    // Re-encode to PNG before signing. Gemini occasionally returns webp/jpeg
+    // variants that c2pa-node rejects with "type is unsupported"; normalizing
+    // through sharp guarantees the bytes match the image/png mimeType the
+    // signer declares. failOn:'error' + .rotate() apply EXIF orientation and
+    // drop upstream metadata so the C2PA manifest is the sole provenance.
+    const pngBuffer = await sharp(buffer, { failOn: "error" })
+      .rotate()
+      .png()
+      .toBuffer();
+    const signed = signC2PA(pngBuffer, {
       claimGenerator: "AAO Docs Storyboard Generator",
       title: path.basename(outputPath),
       softwareAgent: { name: "gemini-3.1-flash-image-preview", version: "preview" },

--- a/server/src/services/illustration-generator.ts
+++ b/server/src/services/illustration-generator.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash } from 'crypto';
+import sharp from 'sharp';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { createLogger } from '../logger.js';
 import { withGeminiRetry } from '../utils/gemini-retry.js';
@@ -173,7 +174,7 @@ export async function generateIllustration(options: GenerateIllustrationOptions)
         throw new Error(`Gemini returned non-image content: ${mimeType}`);
       }
       logger.info({ sizeKB: (imageBuffer.length / 1024).toFixed(0), mimeType }, 'Illustration generated');
-      return attachC2PAIfEnabled({ imageBuffer, promptUsed: prompt }, { title, category, editionDate });
+      return await attachC2PAIfEnabled({ imageBuffer, promptUsed: prompt }, { title, category, editionDate });
     }
   }
 
@@ -194,13 +195,23 @@ export async function generateIllustration(options: GenerateIllustrationOptions)
  * Every failure fires a throttled system-error alert (one per 5 min per source,
  * via notifySystemError) so sustained failures surface rather than hiding in logs.
  */
-export function attachC2PAIfEnabled(
+export async function attachC2PAIfEnabled(
   result: { imageBuffer: Buffer; promptUsed: string },
   manifest: { title: string; category?: string; editionDate?: string },
-): GenerateIllustrationResult {
+): Promise<GenerateIllustrationResult> {
   if (!isC2PASigningEnabled()) return result;
   try {
-    const signed = signC2PA(result.imageBuffer, {
+    // Re-encode to PNG before signing. Gemini's image model sometimes returns
+    // WebP/JPEG variants that c2pa-node rejects with "type is unsupported";
+    // normalizing through sharp guarantees the bytes match the image/png
+    // mimeType declared to the signer and matches what the portrait path does.
+    // failOn:'error' + .rotate() apply EXIF orientation and drop any upstream
+    // metadata so the C2PA manifest is the sole provenance source of truth.
+    const pngBuffer = await sharp(result.imageBuffer, { failOn: 'error' })
+      .rotate()
+      .png()
+      .toBuffer();
+    const signed = signC2PA(pngBuffer, {
       claimGenerator: 'AAO Illustration Generator',
       title: manifest.title,
       softwareAgent: { name: GEMINI_IMAGE_MODEL, version: GEMINI_IMAGE_VERSION },

--- a/server/tests/unit/illustration-c2pa-wiring.test.ts
+++ b/server/tests/unit/illustration-c2pa-wiring.test.ts
@@ -7,6 +7,7 @@ import sharp from 'sharp';
 import { Reader } from '@contentauth/c2pa-node';
 import { attachC2PAIfEnabled } from '../../src/services/illustration-generator.js';
 import { resetC2PASignerCache } from '../../src/services/c2pa.js';
+import * as c2pa from '../../src/services/c2pa.js';
 import * as errorNotifier from '../../src/addie/error-notifier.js';
 
 const FIXTURE_DIR = join(__dirname, '..', 'fixtures', 'c2pa');
@@ -55,10 +56,10 @@ afterEach(() => {
 });
 
 describe('attachC2PAIfEnabled', () => {
-  it('returns the input unchanged when signing is disabled', () => {
+  it('returns the input unchanged when signing is disabled', async () => {
     delete process.env.C2PA_SIGNING_ENABLED;
     const input = { imageBuffer: testPng, promptUsed: 'test prompt' };
-    const result = attachC2PAIfEnabled(input, { title: 'Test hero' });
+    const result = await attachC2PAIfEnabled(input, { title: 'Test hero' });
     expect(result.imageBuffer).toBe(testPng);
     expect(result.c2pa).toBeUndefined();
   });
@@ -68,7 +69,7 @@ describe('attachC2PAIfEnabled', () => {
     process.env.C2PA_CERT_PEM_B64 = CERT_B64;
     process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
 
-    const result = attachC2PAIfEnabled(
+    const result = await attachC2PAIfEnabled(
       { imageBuffer: testPng, promptUsed: 'test prompt with private bits' },
       { title: 'Test hero', category: 'The Prompt', editionDate: '2026-04-20' },
     );
@@ -94,7 +95,7 @@ describe('attachC2PAIfEnabled', () => {
     process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
 
     const secretPrompt = 'author-private visual-description-that-should-not-leak';
-    const result = attachC2PAIfEnabled(
+    const result = await attachC2PAIfEnabled(
       { imageBuffer: testPng, promptUsed: secretPrompt },
       { title: 'Hero' },
     );
@@ -105,46 +106,98 @@ describe('attachC2PAIfEnabled', () => {
     expect(serialized).toContain('prompt_sha256');
   });
 
-  it('returns the unsigned result and alerts when signing throws on malformed input', () => {
+  it('signs a WebP buffer by normalizing through sharp before handing to c2pa', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+
+    // Gemini's image model occasionally returns non-PNG formats (webp, jpeg).
+    // c2pa-node throws "type is unsupported" when handed those bytes under
+    // an image/png declaration; the sharp re-encode is the guardrail.
+    const webpBuffer = await sharp({
+      create: { width: 64, height: 64, channels: 4, background: { r: 10, g: 10, b: 200, alpha: 1 } },
+    })
+      .webp()
+      .toBuffer();
+
+    const result = await attachC2PAIfEnabled(
+      { imageBuffer: webpBuffer, promptUsed: 'ok' },
+      { title: 'WebP hero' },
+    );
+
+    expect(result.c2pa).toBeDefined();
+    const reader = await Reader.fromAsset({ buffer: result.imageBuffer, mimeType: 'image/png' });
+    expect(reader.getActive()?.title).toBe('WebP hero');
+  });
+
+  it('returns the unsigned result and alerts when sharp rejects the input', async () => {
     process.env.C2PA_SIGNING_ENABLED = 'true';
     process.env.C2PA_CERT_PEM_B64 = CERT_B64;
     process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
     delete process.env.C2PA_STRICT;
 
-    // Valid cert/key but the buffer is not a PNG — Builder.sign throws when
-    // trying to parse the PNG ancillary-chunk structure. This exercises the
-    // real sign-failure fallback, not a startup-config error.
-    const notAPng = Buffer.from('this is plain text, definitely not PNG bytes');
-    const input = { imageBuffer: notAPng, promptUsed: 'test' };
-    const result = attachC2PAIfEnabled(input, { title: 'Hero' });
+    // Exercises the catch-block fallback via the sharp-reencode phase: if
+    // Gemini ever returns bytes sharp cannot decode, we still return unsigned
+    // and fire the alert instead of blocking the caller.
+    const notAnImage = Buffer.from('this is plain text, definitely not image bytes');
+    const input = { imageBuffer: notAnImage, promptUsed: 'test' };
+    const result = await attachC2PAIfEnabled(input, { title: 'Hero' });
 
-    expect(result.imageBuffer).toBe(notAPng);
+    expect(result.imageBuffer).toBe(notAnImage);
     expect(result.c2pa).toBeUndefined();
     expect(errorNotifier.notifySystemError).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'c2pa-illustration-signing' }),
     );
   });
 
-  it('rethrows the signing error in strict mode', () => {
-    process.env.C2PA_SIGNING_ENABLED = 'true';
-    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
-    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
-    process.env.C2PA_STRICT = 'true';
-
-    const notAPng = Buffer.from('not PNG');
-    const input = { imageBuffer: notAPng, promptUsed: 'test' };
-
-    expect(() => attachC2PAIfEnabled(input, { title: 'Hero' })).toThrow();
-    expect(errorNotifier.notifySystemError).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not fire the error alert on the happy path', () => {
+  it('returns the unsigned result and alerts when signC2PA itself throws post-sharp', async () => {
     process.env.C2PA_SIGNING_ENABLED = 'true';
     process.env.C2PA_CERT_PEM_B64 = CERT_B64;
     process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
     delete process.env.C2PA_STRICT;
 
-    const result = attachC2PAIfEnabled(
+    // Regression coverage for the original "type is unsupported" production
+    // bug: a buffer sharp accepts but the sign layer rejects must still fall
+    // back cleanly. Spy on signC2PA so the sharp step succeeds and the throw
+    // originates from the sign layer.
+    vi.spyOn(c2pa, 'signC2PA').mockImplementation(() => {
+      throw new Error('simulated c2pa-node sign failure');
+    });
+
+    const result = await attachC2PAIfEnabled(
+      { imageBuffer: testPng, promptUsed: 'test' },
+      { title: 'Hero' },
+    );
+
+    // Fallback returns the original (unsigned) input result — not the
+    // re-encoded buffer — so callers never ship something we half-processed.
+    expect(result.imageBuffer).toBe(testPng);
+    expect(result.c2pa).toBeUndefined();
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'c2pa-illustration-signing' }),
+    );
+  });
+
+  it('rethrows the signing error in strict mode', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    process.env.C2PA_STRICT = 'true';
+
+    const notAnImage = Buffer.from('not an image');
+    const input = { imageBuffer: notAnImage, promptUsed: 'test' };
+
+    await expect(attachC2PAIfEnabled(input, { title: 'Hero' })).rejects.toThrow();
+    expect(errorNotifier.notifySystemError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire the error alert on the happy path', async () => {
+    process.env.C2PA_SIGNING_ENABLED = 'true';
+    process.env.C2PA_CERT_PEM_B64 = CERT_B64;
+    process.env.C2PA_PRIVATE_KEY_PEM_B64 = KEY_B64;
+    delete process.env.C2PA_STRICT;
+
+    const result = await attachC2PAIfEnabled(
       { imageBuffer: testPng, promptUsed: 'ok' },
       { title: 'Hero' },
     );


### PR DESCRIPTION
## Summary
- Production was throwing `C2PA signing failed: type is unsupported` on the illustration path. Root cause: `signC2PA` hardcodes `mimeType: 'image/png'` (`server/src/services/c2pa.ts:132`) but Gemini's image model occasionally returns webp/jpeg. c2pa-node rejects the mismatch. The portrait path already normalized via sharp in `compositeAIBadge` — which is why it never hit this — while the illustration and docs-storyboard paths passed the raw Gemini buffer straight through.
- Fix: re-encode through `sharp(buffer, { failOn: 'error' }).rotate().png().toBuffer()` before signing in both `attachC2PAIfEnabled` (`server/src/services/illustration-generator.ts`) and `signStoryboardIfEnabled` (`scripts/generate-images.ts`). `failOn:'error'` hardens libvips against malformed input; `.rotate()` applies-and-drops EXIF orientation so upstream metadata can't leak past the C2PA manifest, which is meant to be the sole provenance source of truth.
- Regression coverage: real WebP buffer fed through the full path + spied-`signC2PA` test that exercises the post-sharp sign-layer fallback (matching the portrait test pattern). 17 tests in `illustration-c2pa-wiring.test.ts`, all passing alongside the broader 631-test unit suite.

## Test plan
- [x] New WebP test signs successfully end-to-end (would fail without the fix)
- [x] Sign-layer failure test exercises the exact production bug's fallback path
- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean
- [ ] Verify in prod after deploy: illustration generation for a perspective article succeeds with `C2PA_SIGNING_ENABLED=true` and no `type is unsupported` alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)