### PR TITLE
fix(compliance): return refreshable OAuth creds for Test-your-agent flow

### DIFF
--- a/.changeset/fix-oauth-test-your-agent-401.md
+++ b/.changeset/fix-oauth-test-your-agent-401.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(compliance): resolve OAuth creds for Test-your-agent instead of 401ing
+
+`resolveOwnerAuth` collapsed OAuth entries into a bare bearer and dropped them entirely within 5 minutes of `expires_at`, so the dashboard's Test-your-agent flow hit "Missing Authorization header" right after a successful authorize. It now returns the full `{ type: 'oauth', tokens, client }` shape so the `@adcp/client` SDK can refresh via the stored refresh token + client credentials.
+
+Also adds `resolveUserAgentAuth` on the registry route so Test-your-agent prefers the authenticated user's own org context (matching the "Auth configured via OAuth" the UI displays), then falls back to the owning-org lookup. Static bearer/basic credentials saved via the connect form are honored first; only OAuth entries with a refresh token are returned as the refreshable `oauth` shape.

--- a/.changeset/fix-test-your-agent-oauth-auth.md
+++ b/.changeset/fix-test-your-agent-oauth-auth.md
@@ -1,0 +1,37 @@
+---
+---
+
+fix(dashboard-agents): send saved OAuth auth when running "Test your agent" from the dashboard
+
+The storyboard step/run/compare/applicable-storyboards endpoints all called
+`complianceDb.resolveOwnerAuth` to pull saved credentials for the agent.
+That helper was happy to drop auth on the floor in two cases:
+
+- The user's org context (`organization_memberships`) pointed at an
+  `agent_context` whose owning-org `member_profile.agents` list didn't list
+  the agent — the JOIN returned empty and `auth` came back `undefined`.
+- The OAuth access token was within 5 minutes of expiry — the helper
+  returned `undefined` with no attempt to refresh, even when a
+  `refresh_token` was sitting next to it.
+
+Either path produced the same symptom: the UI showed "Auth configured via
+OAuth" after authorization, but the very next click on **Test your agent**
+hit `get_adcp_capabilities` with no `Authorization` header and came back
+with `@adcp/client`'s "Missing Authorization header — provide an
+OAuthFlowHandler or run an interactive flow" error.
+
+Two fixes in this change:
+
+1. The four storyboard endpoints in `registry-api` now resolve auth through
+   a new `resolveUserAgentAuth(userId, agentUrl)` helper that mirrors the
+   lookup the `auth-status` endpoint already uses (the same one that drives
+   the "Auth configured via OAuth" label). The agent_context consulted for
+   auth is now guaranteed to be the one the UI told the user was connected.
+2. `complianceDb.resolveOwnerAuth` (still used by the compliance heartbeat
+   cron) now returns the full `{ type: 'oauth', tokens, client }` shape
+   when a refresh token is available, so the `@adcp/client` SDK can
+   silently mint a fresh access token instead of falling off the cliff at
+   the 5-minute expiry buffer.
+
+Log levels bumped from `debug` to `info`/`warn` on the auth-resolution
+failure paths so future regressions surface in production logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -860,6 +860,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -906,6 +907,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2940,7 +2942,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -3627,7 +3628,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/prebuild/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4735,7 +4737,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/scraping/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4958,7 +4961,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -5261,7 +5263,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -5281,6 +5282,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5637,6 +5639,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5950,8 +5953,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
       "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6697,6 +6699,7 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -8585,7 +8588,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
       "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8798,6 +8800,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -8925,6 +8928,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9288,6 +9292,7 @@
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9356,6 +9361,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10549,8 +10555,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "4.2.0",
@@ -11193,8 +11198,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "6.2.1",
@@ -11572,7 +11576,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12505,6 +12510,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14519,6 +14525,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14819,6 +14826,7 @@
       "integrity": "sha512-2CbJAa7XeziZYe6pDS5RVLirRY28iSGMQuEV8jRU5NQsONQNfcR/BZHHc9vkMg2lGYTHTM2pskxC1YmY28p6bQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.0",
         "ansi-escapes": "^7.0.0",
@@ -15882,6 +15890,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -16523,7 +16532,6 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -19200,6 +19208,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19464,6 +19473,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21197,6 +21207,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -21335,8 +21346,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -22856,6 +22866,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23049,6 +23060,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -23222,6 +23234,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23305,6 +23318,7 @@
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -23781,6 +23795,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -24521,6 +24536,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -546,16 +546,34 @@ export class ComplianceDatabase {
    * Resolve auth credentials for an agent from the owning organization's
    * saved tokens in agent_contexts. Only uses credentials from the org
    * that owns the agent (via member_profiles.agents), not arbitrary orgs.
+   *
+   * For OAuth: returns the full `oauth` shape (tokens + client) so the
+   * @adcp/client SDK can auto-refresh on 401. Returning a raw bearer would
+   * drop auth entirely once the access token drifted near expiry, which is
+   * exactly when the UI surfaces "Missing Authorization header" on the
+   * dashboard's Test-your-agent flow right after an authorize.
    */
   async resolveOwnerAuth(
     agentUrl: string,
-  ): Promise<{ type: 'bearer'; token: string } | { type: 'basic'; username: string; password: string } | undefined> {
+  ): Promise<
+    | { type: 'bearer'; token: string }
+    | { type: 'basic'; username: string; password: string }
+    | {
+        type: 'oauth';
+        tokens: { access_token: string; refresh_token?: string; expires_at?: string };
+        client?: { client_id: string; client_secret?: string };
+      }
+    | undefined
+  > {
     try {
       const result = await query(
         `SELECT ac.organization_id,
                 ac.auth_token_encrypted, ac.auth_token_iv, ac.auth_type,
                 ac.oauth_access_token_encrypted, ac.oauth_access_token_iv,
-                ac.oauth_token_expires_at
+                ac.oauth_refresh_token_encrypted, ac.oauth_refresh_token_iv,
+                ac.oauth_token_expires_at,
+                ac.oauth_client_id,
+                ac.oauth_client_secret_encrypted, ac.oauth_client_secret_iv
          FROM agent_contexts ac
          JOIN member_profiles mp
            ON mp.workos_organization_id = ac.organization_id
@@ -568,7 +586,10 @@ export class ComplianceDatabase {
       );
 
       const row = result.rows[0];
-      if (!row) return undefined;
+      if (!row) {
+        logger.info({ agentUrl }, 'resolveOwnerAuth: no owning-org credentials found');
+        return undefined;
+      }
 
       // Prefer static token when available
       if (row.auth_token_encrypted) {
@@ -585,26 +606,65 @@ export class ComplianceDatabase {
         return { type: 'bearer', token };
       }
 
-      // Fall back to OAuth access token
+      // Fall back to OAuth. Hand the SDK the full token+client pair so it
+      // can refresh via the saved refresh_token instead of silently failing.
       if (row.oauth_access_token_encrypted && row.oauth_access_token_iv) {
-        // Check expiration with 5-minute buffer
-        if (row.oauth_token_expires_at) {
-          const expiresAt = new Date(row.oauth_token_expires_at);
-          if (expiresAt.getTime() - Date.now() <= 5 * 60 * 1000) {
-            logger.debug({ agentUrl, expiresAt }, 'OAuth token expired or expiring soon for compliance auth');
-            return undefined;
-          }
-        } else {
-          logger.debug({ agentUrl }, 'OAuth token has no expiration recorded');
+        const accessToken = decryptToken(
+          row.oauth_access_token_encrypted,
+          row.oauth_access_token_iv,
+          row.organization_id,
+        );
+
+        const tokens: { access_token: string; refresh_token?: string; expires_at?: string } = {
+          access_token: accessToken,
+        };
+
+        if (row.oauth_refresh_token_encrypted && row.oauth_refresh_token_iv) {
+          tokens.refresh_token = decryptToken(
+            row.oauth_refresh_token_encrypted,
+            row.oauth_refresh_token_iv,
+            row.organization_id,
+          );
         }
 
-        const token = decryptToken(row.oauth_access_token_encrypted, row.oauth_access_token_iv, row.organization_id);
-        return { type: 'bearer', token };
+        if (row.oauth_token_expires_at) {
+          tokens.expires_at = new Date(row.oauth_token_expires_at).toISOString();
+        }
+
+        // No refresh token available — fall back to raw bearer. If the
+        // access token is already expired, a refresh can't save us; send it
+        // anyway so the agent returns a clear 401 rather than swallowing the
+        // request with no Authorization header at all.
+        if (!tokens.refresh_token) {
+          return { type: 'bearer', token: accessToken };
+        }
+
+        const oauth: {
+          type: 'oauth';
+          tokens: typeof tokens;
+          client?: { client_id: string; client_secret?: string };
+        } = { type: 'oauth', tokens };
+
+        if (row.oauth_client_id) {
+          const client: { client_id: string; client_secret?: string } = {
+            client_id: row.oauth_client_id,
+          };
+          if (row.oauth_client_secret_encrypted && row.oauth_client_secret_iv) {
+            client.client_secret = decryptToken(
+              row.oauth_client_secret_encrypted,
+              row.oauth_client_secret_iv,
+              row.organization_id,
+            );
+          }
+          oauth.client = client;
+        }
+
+        return oauth;
       }
 
       return undefined;
     } catch (error) {
-      logger.debug({ error, agentUrl }, 'Could not resolve owner auth for heartbeat');
+      logger.warn({ err: error, agentUrl }, 'Could not resolve owner auth');
       return undefined;
     }
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3527,13 +3527,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   const complianceWriteMiddleware = authMiddleware ? [authMiddleware] : [];
 
   /**
-   * Verify the authenticated user belongs to the organization that owns this agent.
-   * Returns true if ownership is confirmed, false otherwise.
+   * Resolve the organization id that owns this agent from the authenticated
+   * user's perspective. Returns the workos_organization_id when the user is
+   * a member of an org whose member_profile lists this agent, else null.
+   *
+   * Mirrors the query used by the auth-status endpoint (see `/registry/agents/:url/auth-status`),
+   * so the agent_context consulted for "Test your agent" auth is the same
+   * one the UI displayed as "Auth configured via OAuth".
    */
-  async function verifyAgentOwnership(userId: string, agentUrl: string): Promise<boolean> {
+  async function resolveAgentOwnerOrg(userId: string, agentUrl: string): Promise<string | null> {
     try {
-      const result = await query(
-        `SELECT 1 FROM member_profiles mp
+      const result = await query<{ workos_organization_id: string }>(
+        `SELECT mp.workos_organization_id
+         FROM member_profiles mp
          JOIN organization_memberships om
            ON om.workos_organization_id = mp.workos_organization_id
          WHERE mp.agents @> $1::jsonb
@@ -3541,10 +3547,83 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
          LIMIT 1`,
         [JSON.stringify([{ url: agentUrl }]), userId],
       );
-      return result.rows.length > 0;
+      return result.rows[0]?.workos_organization_id ?? null;
     } catch {
-      return false;
+      return null;
     }
+  }
+
+  async function verifyAgentOwnership(userId: string, agentUrl: string): Promise<boolean> {
+    return (await resolveAgentOwnerOrg(userId, agentUrl)) !== null;
+  }
+
+  type ResolvedAuth = Awaited<ReturnType<ComplianceDatabase['resolveOwnerAuth']>>;
+
+  /**
+   * Resolve test-time auth for an agent using the authenticated user's own
+   * org context. Falls back to `complianceDb.resolveOwnerAuth` when the
+   * user-scoped lookup misses (e.g., org membership exists but the member's
+   * profile.agents list is out of sync), so the Test-your-agent flow doesn't
+   * silently drop auth and 401 against OAuth-protected agents.
+   */
+  async function resolveUserAgentAuth(
+    userId: string,
+    agentUrl: string,
+  ): Promise<ResolvedAuth> {
+    const orgId = await resolveAgentOwnerOrg(userId, agentUrl);
+    if (orgId) {
+      try {
+        const staticAuth = await agentContextDb.getAuthInfoByOrgAndUrl(orgId, agentUrl);
+        if (staticAuth) {
+          if (staticAuth.authType === 'basic') {
+            const decoded = Buffer.from(staticAuth.token, 'base64').toString();
+            const colonIndex = decoded.indexOf(':');
+            if (colonIndex >= 0) {
+              return {
+                type: 'basic',
+                username: decoded.slice(0, colonIndex),
+                password: decoded.slice(colonIndex + 1),
+              };
+            }
+          }
+          return { type: 'bearer', token: staticAuth.token };
+        }
+      } catch (err) {
+        logger.warn({ err, agentUrl, orgId }, 'resolveUserAgentAuth: static token lookup failed');
+      }
+
+      try {
+        const context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+        if (context?.has_oauth_token) {
+          const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, agentUrl);
+          if (tokens?.access_token) {
+            if (!tokens.refresh_token) {
+              return { type: 'bearer', token: tokens.access_token };
+            }
+
+            const client = await agentContextDb.getOAuthClient(context.id);
+            return {
+              type: 'oauth',
+              tokens: {
+                access_token: tokens.access_token,
+                refresh_token: tokens.refresh_token,
+                ...(tokens.expires_at && { expires_at: tokens.expires_at.toISOString() }),
+              },
+              ...(client && {
+                client: {
+                  client_id: client.client_id,
+                  ...(client.client_secret && { client_secret: client.client_secret }),
+                },
+              }),
+            };
+          }
+        }
+      } catch (err) {
+        logger.warn({ err, agentUrl, orgId }, 'resolveUserAgentAuth: OAuth token lookup failed');
+      }
+    }
+
+    return complianceDb.resolveOwnerAuth(agentUrl);
   }
 
   function validateAgentUrlParam(raw: string): string | null {
@@ -3915,11 +3994,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
 
     try {
-      let auth;
+      let auth: ResolvedAuth;
       try {
-        auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        auth = await resolveUserAgentAuth(req.user.id, agentUrl);
       } catch (authErr) {
-        logger.debug({ err: authErr, agentUrl }, "Auth resolution failed — trying without auth");
+        logger.warn({ err: authErr, agentUrl }, "Auth resolution failed — trying without auth");
       }
 
       let profile;
@@ -4059,11 +4138,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        let auth;
+        let auth: ResolvedAuth;
         try {
-          auth = await complianceDb.resolveOwnerAuth(agentUrl);
+          auth = await resolveUserAgentAuth(req.user.id, agentUrl);
         } catch (authErr) {
-          logger.debug({ err: authErr, agentUrl }, "Auth resolution failed for step run");
+          logger.warn({ err: authErr, agentUrl }, "Auth resolution failed for step run");
         }
 
         const { context, dry_run } = req.body;
@@ -4136,7 +4215,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
 
         // Resolve agent auth
-        const auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        const auth = await resolveUserAgentAuth(req.user.id, agentUrl);
 
         const complyResult = await comply(agentUrl, {
           timeout_ms: 90_000,
@@ -4226,7 +4305,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        const auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        const auth = await resolveUserAgentAuth(req.user.id, agentUrl);
         const storyboardIds = [req.params.storyboardId];
 
         const [userResult, referenceResult] = await Promise.all([


### PR DESCRIPTION
## Summary

- `ComplianceDatabase.resolveOwnerAuth` was collapsing every OAuth entry into a raw bearer token and, worse, returning `undefined` within 5 minutes of `expires_at`. That left the dashboard's *Test your agent* flow with no `Authorization` header at all on OAuth-backed agents right after the user authorized — surfacing as `"Missing Authorization header"` on the very next click.
- It now returns the full `{ type: 'oauth', tokens: { access_token, refresh_token, expires_at }, client }` shape when a refresh token is saved, so the `@adcp/client` SDK can refresh transparently instead of 401ing. Entries without a refresh token still fall through to `{ type: 'bearer' }` so the agent returns a clear 401 rather than the server swallowing auth silently.
- Registry route gains `resolveUserAgentAuth`: Test-your-agent now prefers credentials saved on the authenticated user's own org (matching the "Auth configured via OAuth" the UI displays), then falls back to `resolveOwnerAuth` so stale `member_profile.agents` lists don't knock auth out.

## Test plan

- [ ] Authorize an OAuth-protected agent from the dashboard, then click *Test your agent* within 5 minutes — expect capability discovery to succeed (previously 401 with `Missing Authorization header`).
- [ ] Let the access token drift past its `expires_at` while a refresh_token is saved — expect the SDK to refresh and the test to still succeed.
- [ ] For an agent saved with a static bearer token via the connect form, confirm Test-your-agent still uses that bearer (not the OAuth path).
- [ ] Confirm a user with no org membership for the agent still gets `403 "You do not have permission to test this agent"`.