### PR TITLE
fix(training-agent): uniform not-found on property-list handlers (#2739)

### DIFF
--- a/.changeset/training-agent-property-list-uniform-errors.md
+++ b/.changeset/training-agent-property-list-uniform-errors.md
@@ -1,0 +1,6 @@
+---
+---
+
+Training agent: `get_property_list`, `update_property_list`, `delete_property_list`, and `validate_property_delivery` now return a uniform error on unresolved `list_id` — `error.code` is `REFERENCE_NOT_FOUND` (was lowercase `not_found`), `error.message` is the generic `"Property list not found"` (was `"No property list with id '<id>'"`), and `error.field` is `list_id`. Closes #2739.
+
+The probed id is no longer echoed back on the error path, so paired-probe uniform-response invariants (e.g. `@adcp/client` fuzz) now pass against the public test agent. This matters because the training agent is the reference implementors point conformance runs at; an echoing message there invalidates the signal for every downstream seller running the same invariant.

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -257,7 +257,7 @@ export async function handleGetPropertyList(
 
   const state = session.propertyLists.get(req.list_id);
   if (!state) {
-    return { errors: [{ code: 'not_found', message: `No property list with id '${req.list_id}'` }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }] };
   }
 
   const domains = extractDomains(state.baseProperties);
@@ -280,7 +280,7 @@ export async function handleUpdatePropertyList(
 
   const state = session.propertyLists.get(req.list_id);
   if (!state) {
-    return { errors: [{ code: 'not_found', message: `No property list with id '${req.list_id}'` }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }] };
   }
 
   if (req.name) {
@@ -324,7 +324,7 @@ export async function handleDeletePropertyList(
 
   const existed = session.propertyLists.delete(req.list_id);
   if (!existed) {
-    return { errors: [{ code: 'not_found', message: `No property list with id '${req.list_id}'` }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }] };
   }
 
   return { list_id: req.list_id, deleted: true };
@@ -343,7 +343,7 @@ export async function handleValidatePropertyDelivery(
 
   const state = session.propertyLists.get(req.list_id);
   if (!state) {
-    return { errors: [{ code: 'not_found', message: `No property list with id '${req.list_id}'` }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }] };
   }
 
   const records = req.records || [];

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -6860,6 +6860,50 @@ describe('get_brand_identity handler', () => {
   });
 });
 
+describe('property-list uniform not-found response (issue #2739)', () => {
+  beforeEach(async () => {
+    await clearSessions();
+  });
+  afterEach(async () => {
+    await clearSessions();
+    stopSessionCleanup();
+  });
+
+  // Paired-probe: two distinct unresolvable list_ids must produce byte-identical
+  // error bodies, otherwise the probed id is a cross-tenant enumeration oracle.
+  const PROBE_TOOLS = ['get_property_list', 'update_property_list', 'delete_property_list'] as const;
+  for (const toolName of PROBE_TOOLS) {
+    it(`${toolName} returns byte-identical errors for two distinct unresolvable list_ids`, async () => {
+      const server = createTrainingAgentServer(DEFAULT_CTX);
+      const account = { brand: { domain: 'uniform-probe.example' }, operator: 'pinnacle-agency.com' };
+
+      const probeA = await simulateCallTool(server, toolName, { account, list_id: 'd7aff8ea-136c-498f-b70f-a69582ad3bec' });
+      const probeB = await simulateCallTool(server, toolName, { account, list_id: '221acd34-cd2c-4763-ae0a-321c1e85fb2b' });
+
+      expect(probeA.isError).toBe(probeB.isError);
+      expect(probeA.result).toEqual(probeB.result);
+      expect(probeA.result.code).toBe('REFERENCE_NOT_FOUND');
+      expect(probeA.result.message).toBe('Property list not found');
+      expect(probeA.result.field).toBe('list_id');
+    });
+  }
+
+  it('validate_property_delivery returns byte-identical errors for two distinct unresolvable list_ids', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'uniform-probe.example' }, operator: 'pinnacle-agency.com' };
+    const records = [{ identifier: { type: 'domain', value: 'x.example' }, impressions: 1 }];
+
+    const probeA = await simulateCallTool(server, 'validate_property_delivery', { account, list_id: 'd7aff8ea-136c-498f-b70f-a69582ad3bec', records });
+    const probeB = await simulateCallTool(server, 'validate_property_delivery', { account, list_id: '221acd34-cd2c-4763-ae0a-321c1e85fb2b', records });
+
+    expect(probeA.isError).toBe(probeB.isError);
+    expect(probeA.result).toEqual(probeB.result);
+    expect(probeA.result.code).toBe('REFERENCE_NOT_FOUND');
+    expect(probeA.result.message).toBe('Property list not found');
+    expect(probeA.result.field).toBe('list_id');
+  });
+});
+
 describe('cross-machine session persistence', () => {
   beforeEach(async () => {
     await clearSessions();


### PR DESCRIPTION
## Summary

- `get_property_list`, `update_property_list`, `delete_property_list`, and `validate_property_delivery` in the training agent were returning `{ code: 'not_found', message: "No property list with id '<id>'" }` on unresolved `list_id` — echoing the probed id into the error body made "exists but inaccessible" and "does not exist" distinguishable via two paired probes, a direct violation of the AdCP 3.0 uniform-error-response MUST (closes #2739).
- Now returns `{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }` — byte-identical across probes. `REFERENCE_NOT_FOUND` is the spec's canonical fallback for property lists per [`error-code.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/enums/error-code.json). `error.field` names the caller-supplied parameter (not a resolved type), which is allowed for type-neutral parameter names per `error-handling.mdx`.
- Adds four paired-probe tests (one per tool) that call with two distinct unresolvable UUIDs and assert the error bodies are deep-equal. This locks the invariant so the `@adcp/client` fuzz check (adcontextprotocol/adcp-client#731, #737) stays green against the public test agent.

## Scope

Limited to `property-handlers.ts`. Security review inventoried the same bug pattern in adjacent files — `content-standards-handlers.ts` (4 sites), `governance-handlers.ts:1135`, `brand-handlers.ts` (4 sites), `inventory-governance-handlers.ts` (2 sites), `catalog-event-handlers.ts:496`, and `task-handlers.ts` — each needs a per-resource judgement (REFERENCE_NOT_FOUND vs resource-specific codes like PLAN_NOT_FOUND that were retained in the collapse). Filing a follow-up issue rather than bundling, per code-reviewer guidance.

`brand-handlers.ts:1222` in particular leaks a state-transition hint via the recovery message ("Acquire rights first using acquire_rights") that distinguishes "never existed" from "expired/consumed" even if the id is stripped — call out in the follow-up.

## Test plan

- [x] `npx vitest run tests/unit/training-agent.test.ts` — 338/338 passing (334 existing + 4 new paired-probe)
- [x] `tsc --noEmit` clean
- [x] Full pre-commit suite (631 tests + typecheck) green
- [ ] After merge: re-run `npx @adcp/client fuzz https://test-agent.adcontextprotocol.org/mcp/ --tools get_property_list --turn-budget 1` against the deployed training agent and confirm the uniform-error invariant flips from FAIL to PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)