### PR TITLE
storyboards: add fixtures + controller_seeding to 5 storyboards (closes #2743)

### DIFF
--- a/.changeset/storyboards-fixtures-controller-seeding.md
+++ b/.changeset/storyboards-fixtures-controller-seeding.md
@@ -1,0 +1,4 @@
+---
+---
+
+storyboards: add `fixtures:` blocks + `prerequisites.controller_seeding: true` to the five storyboards that reference fixture IDs no prior step creates (governance-spend-authority, media-buy/governance escalation, creative-ad-server, sales-non-guaranteed, governance-delivery-monitor). Agents that implement `comply_test_controller.seed_*` have the fixtures auto-seeded before phases run; agents without seed support grade these storyboards `not_applicable` rather than failed. Tracks #2743, companion to adcp#2742.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -41,6 +41,21 @@ prerequisites:
     URL. The test kit provides a sample brand (Acme Outdoor) with campaign parameters
     and a governance configuration with spending authority limits.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  plans:
+    - plan_id: "gov_acme_q2_2027"
+      brand:
+        domain: "acmeoutdoor.example"
+      objectives: "Q2 outdoor lifestyle campaign — display and video, Adults 25-54, US"
+      budget:
+        total: 50000
+        currency: "USD"
+        reallocation_threshold: 20000
+      flight:
+        start: "2027-04-01T00:00:00Z"
+        end: "2027-06-30T23:59:59Z"
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -44,6 +44,28 @@ prerequisites:
   controller_seeding: true
 
 fixtures:
+  products:
+    - product_id: "sports_ctv_q2"
+      delivery_type: "guaranteed"
+      channels: ["ctv"]
+      format_ids:
+        - id: "video_30s"
+    - product_id: "outdoor_video_q2"
+      delivery_type: "guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_15s"
+  pricing_options:
+    - product_id: "sports_ctv_q2"
+      pricing_option_id: "cpm_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 45.0
+    - product_id: "outdoor_video_q2"
+      pricing_option_id: "cpm_standard"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 12.0
   plans:
     - plan_id: "gov_acme_q2_2027"
       brand:
@@ -56,6 +78,14 @@ fixtures:
       flight:
         start: "2027-04-01T00:00:00Z"
         end: "2027-06-30T23:59:59Z"
+      countries: ["US"]
+      custom_policies:
+        - policy_id: "weekly_reporting_over_10k"
+          enforcement: "must"
+          policy: "Weekly reporting required for buys over $10K."
+        - policy_id: "seller_concentration_cap"
+          enforcement: "must"
+          policy: "No single-seller concentration above 60% of total budget."
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -52,6 +52,11 @@ fixtures:
       status: "approved"
       format_id:
         id: "vast_30s"
+      pricing_options:
+        - pricing_option_id: "po_vast_30s_cpm"
+          pricing_model: "cpm"
+          rate: 0.50
+          currency: "USD"
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -44,6 +44,14 @@ prerequisites:
 
     For pricing steps, the buyer must have an established account with the ad server.
     The account's rate card determines creative pricing.
+  controller_seeding: true
+
+fixtures:
+  creatives:
+    - creative_id: "campaign_hero_video"
+      status: "approved"
+      format_id:
+        id: "vast_30s"
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -44,6 +44,30 @@ prerequisites:
     and an active media buy with delivery data. The governance plan defines a
     reallocation threshold that triggers re-evaluation.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  plans:
+    - plan_id: "gov_acme_delivery_monitor"
+      brand:
+        domain: "acmeoutdoor.example"
+      objectives: "Delivery-phase governance with drift detection and rebalancing"
+      budget:
+        total: 40000
+        currency: "USD"
+        reallocation_threshold: 8000
+      flight:
+        start: "2027-01-01T00:00:00Z"
+        end: "2027-12-31T23:59:59Z"
+  media_buys:
+    - media_buy_id: "mb_acme_q2_2026"
+      status: "active"
+      budget:
+        total: 40000
+        currency: "USD"
+      flight:
+        start: "2026-04-01T00:00:00Z"
+        end: "2026-06-30T23:59:59Z"
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -59,6 +59,11 @@ fixtures:
       flight:
         start: "2027-01-01T00:00:00Z"
         end: "2027-12-31T23:59:59Z"
+      countries: ["US"]
+      custom_policies:
+        - policy_id: "drift_reevaluation"
+          enforcement: "must"
+          policy: "Re-evaluate governance if any line item drifts more than 20% from plan."
   media_buys:
     - media_buy_id: "mb_acme_q2_2026"
       status: "active"

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -46,6 +46,21 @@ prerequisites:
     The caller needs a brand identity, operator credentials, and a governance agent URL.
     The governance plan defines policy conditions that trigger on specific buy parameters.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  plans:
+    - plan_id: "gov_acme_q2_2027"
+      brand:
+        domain: "acmeoutdoor.example"
+      objectives: "Full spending authority with conditional policies on CTV reporting and UGC brand safety"
+      budget:
+        total: 100000
+        currency: "USD"
+        reallocation_unlimited: true
+      flight:
+        start: "2027-01-01T00:00:00Z"
+        end: "2027-12-31T23:59:59Z"
 
 phases:
   - id: capability_discovery
@@ -112,7 +127,7 @@ phases:
         sample_request:
           idempotency_key: "governance-spend-authority-sync-plans-v1"
           plans:
-            - plan_id: "gov_acme_conditional"
+            - plan_id: "gov_acme_q2_2027"
               brand:
                 domain: "acmeoutdoor.example"
               objectives: "Full spending authority with conditional policies on CTV reporting and UGC brand safety"

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -49,6 +49,28 @@ prerequisites:
   controller_seeding: true
 
 fixtures:
+  products:
+    - product_id: "sports_ctv_q2"
+      delivery_type: "guaranteed"
+      channels: ["ctv"]
+      format_ids:
+        - id: "video_30s"
+    - product_id: "lifestyle_display_q2"
+      delivery_type: "guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "sports_ctv_q2"
+      pricing_option_id: "cpm_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 45.0
+    - product_id: "lifestyle_display_q2"
+      pricing_option_id: "cpm_standard"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 8.0
   plans:
     - plan_id: "gov_acme_q2_2027"
       brand:
@@ -61,6 +83,14 @@ fixtures:
       flight:
         start: "2027-01-01T00:00:00Z"
         end: "2027-12-31T23:59:59Z"
+      countries: ["US"]
+      custom_policies:
+        - policy_id: "ctv_weekly_reporting"
+          enforcement: "must"
+          policy: "CTV buys require weekly delivery reporting."
+        - policy_id: "ugc_brand_safety"
+          enforcement: "must"
+          policy: "UGC placements require brand safety review before go-live."
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -74,15 +74,6 @@ fixtures:
       pricing_model: "cpm"
       currency: "USD"
       floor_price: 15.0
-  media_buys:
-    - media_buy_id: "mb_acme_q2_2026_auction"
-      status: "active"
-      budget:
-        total: 25000
-        currency: "USD"
-      flight:
-        start: "2026-04-01T00:00:00Z"
-        end: "2026-06-30T23:59:59Z"
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -49,6 +49,40 @@ prerequisites:
     provides a sample brand (Acme Outdoor) with bid parameters suitable for testing
     the auction-based flow.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "sports_display_auction"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+    - product_id: "outdoor_video_auction"
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_30s"
+  pricing_options:
+    - product_id: "sports_display_auction"
+      pricing_option_id: "cpm_auction"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5.0
+    - product_id: "outdoor_video_auction"
+      pricing_option_id: "cpm_auction"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 15.0
+  media_buys:
+    - media_buy_id: "mb_acme_q2_2026_auction"
+      status: "active"
+      budget:
+        total: 25000
+        currency: "USD"
+      flight:
+        start: "2026-04-01T00:00:00Z"
+        end: "2026-06-30T23:59:59Z"
 
 phases:
   - id: capability_discovery


### PR DESCRIPTION
## Summary

Adds the spec's existing `fixtures:` block + `prerequisites.controller_seeding: true` to the five storyboards whose `sample_request` payloads reference fixture IDs no prior step creates. When those are set, the runner auto-injects a fixtures phase that calls `comply_test_controller.seed_*` before phases run.

Agents missing `seed_*` support grade these storyboards as `not_applicable` rather than `failed`, so no implementer is penalized for a test-kit setup gap.

| Storyboard | Seeded fixtures |
|---|---|
| `specialisms/governance-spend-authority` | plan `gov_acme_q2_2027` (renamed sync_plans id from `gov_acme_conditional` to match) |
| `protocols/media-buy` governance escalation | plan `gov_acme_q2_2027` (already the sync_plans id) |
| `specialisms/creative-ad-server` | creative `campaign_hero_video` |
| `specialisms/sales-non-guaranteed` | products `sports_display_auction` / `outdoor_video_auction`, `cpm_auction` pricing options, plus auction-mode media buy |
| `specialisms/governance-delivery-monitor` | plan `gov_acme_delivery_monitor` + media buy `mb_acme_q2_2026` |

Companion to adcp#2742 (agent-side `seed_*` implementation in training-agent's `comply_test_controller`).

## Test plan

- [x] `build:compliance` passes (10 universal, 6 protocols, 24 specialisms)
- [x] `test:storyboard-scoping` / `-branch-sets` / `-contradictions` / `-context-entity` / `-auth-shape` all pass
- [x] precommit (`test:unit` + `typecheck`) passes
- [ ] Re-run the 5 affected storyboards against a seed-supporting agent (training-agent after adcp#2742 merges); confirm they close
- [ ] Confirm storyboards grade `not_applicable` (not failed) on agents without `seed_*`

Closes #2743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)