### PR TITLE
fix(storyboards): check_governance & build_creative fixtures match 3.0 schemas

### DIFF
--- a/.changeset/fix-storyboard-fixtures-governance-creative.md
+++ b/.changeset/fix-storyboard-fixtures-governance-creative.md
@@ -1,0 +1,15 @@
+---
+---
+
+Fix storyboard fixtures that fail validation against the 3.0 GA JSON Schemas. Surfaced by the `@adcp/client` skill-matrix harness.
+
+**`check_governance` fixtures** — `check-governance-request.json` has `required: ["plan_id", "caller"]` and `additionalProperties: false` at the root, with intent checks using `tool` + `payload` (where `payload` is the full tool arguments). Fixtures had top-level `account`/`binding`/`human_approval`, were missing `caller`, and their `payload` did not validate as a `create_media_buy` request (scalar `total_budget` instead of proposal-mode money object, missing `idempotency_key`/`brand`/`start_time`/`end_time`, missing `packages[].pricing_option_id`). Fixed in:
+
+- `static/compliance/source/protocols/governance/index.yaml` — `check_governance_denied` and `check_governance_approved` steps. Approved-step `human_approval` removed; per schema, human approval is carried in the `governance_context` JWS. Closes #2740.
+- `static/compliance/source/specialisms/governance-spend-authority/denied.yaml` — `check_governance_denied` parallel fixture (same bug).
+
+**`build_creative` fixture** — `build-creative-request.json` has no `output_format` field and requires `idempotency_key`. `target_format_id` is the single-format field. Fixed in:
+
+- `static/compliance/source/protocols/creative/index.yaml` — `build_video_tag` step: renamed `output_format` → `target_format_id`, added `idempotency_key`. Closes #2741.
+
+Three other `check_governance` fixtures in `specialisms/governance-spend-authority/index.yaml`, `specialisms/governance-delivery-monitor/index.yaml` have the same drift and will be addressed in a follow-up issue.

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -378,9 +378,10 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           creative_id: "video_30s_trail_pro"
-          output_format:
+          target_format_id:
             agent_url: "https://your-platform.example.com"
             id: "vast_30s"
+          idempotency_key: "$generate:uuid_v4#creative_lifecycle_build_video_tag"
 
           context:
             correlation_id: "creative_lifecycle--build_video_tag"

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -338,23 +338,26 @@ phases:
           - plan_id: the governance plan that triggered the denial
 
         sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
-          binding:
-            type: "media_buy"
+          caller: "https://pinnacle-agency.example"
+          tool: "create_media_buy"
+          payload:
+            idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_check_governance_denied_payload"
             account:
               brand:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
-            total_budget: 50000
+            brand:
+              domain: "acmeoutdoor.example"
+            start_time: "2027-01-01T00:00:00Z"
+            end_time: "2027-03-31T23:59:59Z"
             packages:
               - product_id: "sports_ctv_q2"
                 budget: 30000
+                pricing_option_id: "cpm_standard"
               - product_id: "outdoor_video_q2"
                 budget: 20000
+                pricing_option_id: "cpm_standard"
 
           context:
             correlation_id: "media_buy_governance_escalation--check_governance_denied"
@@ -409,30 +412,27 @@ phases:
           - approved_at: timestamp of approval
 
         sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
+          caller: "https://pinnacle-agency.example"
           governance_context: "gov_ctx_acme_q2_escalated"
-          binding:
-            type: "media_buy"
+          tool: "create_media_buy"
+          payload:
+            idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_check_governance_approved_payload"
             account:
               brand:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
-            total_budget: 50000
+            brand:
+              domain: "acmeoutdoor.example"
+            start_time: "2027-01-01T00:00:00Z"
+            end_time: "2027-03-31T23:59:59Z"
             packages:
               - product_id: "sports_ctv_q2"
                 budget: 30000
+                pricing_option_id: "cpm_standard"
               - product_id: "outdoor_video_q2"
                 budget: 20000
-          human_approval:
-            approved_by: "jsmith@pinnacle-agency.example"
-            approved_at: "2026-04-03T14:22:00Z"
-            conditions:
-              - "Weekly delivery reporting required"
-              - "Human review required for any budget increase above 10%"
+                pricing_option_id: "cpm_standard"
 
           context:
             correlation_id: "media_buy_governance_escalation--check_governance_approved"

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -171,23 +171,26 @@ phases:
           - No escalation instructions (plan has no escalation path)
 
         sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
+          caller: "https://pinnacle-agency.example"
           tool: "create_media_buy"
           payload:
+            idempotency_key: "$generate:uuid_v4#governance_spend_authority_denied_check_governance_denied_payload"
             account:
               brand:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
-            total_budget: 50000
+            brand:
+              domain: "acmeoutdoor.example"
+            start_time: "2027-01-01T00:00:00Z"
+            end_time: "2027-03-31T23:59:59Z"
             packages:
               - product_id: "sports_ctv_q2"
                 budget: 30000
+                pricing_option_id: "cpm_standard"
               - product_id: "outdoor_video_q2"
                 budget: 20000
+                pricing_option_id: "cpm_standard"
 
           context:
             correlation_id: "governance_spend_authority--denied--check_governance_denied"


### PR DESCRIPTION
Closes #2740. Closes #2741.

## Summary

Storyboard `sample_request` fixtures for `check_governance` and `build_creative` did not validate against the 3.0 GA JSON Schemas — caught by the `@adcp/client` skill-matrix harness (`-32602 Invalid params` on every run).

- **`check_governance` fixtures** — `check-governance-request.json` has `required: ["plan_id", "caller"]` and `additionalProperties: false`. Intent checks use `tool` + `payload` (the full tool arguments the seller would receive). Fixtures had top-level `account`/`binding`/`human_approval`, omitted `caller`, and their `payload` was not a valid `create_media_buy` request (scalar `total_budget` where schema defines `{amount, currency}` proposal-mode only, missing `idempotency_key`/`brand`/`start_time`/`end_time`, missing `packages[].pricing_option_id`).
- **`build_creative` fixture** — used the undefined `output_format` field instead of `target_format_id`, and omitted the required `idempotency_key`.

The `check_governance_approved` step previously carried a top-level `human_approval` block; per schema, human approval state travels in the `governance_context` JWS returned from the prior denial, so the block was dropped.

## Files

- `static/compliance/source/protocols/governance/index.yaml` — `check_governance_denied` and `check_governance_approved` steps in `media_buy_governance_escalation`
- `static/compliance/source/protocols/creative/index.yaml` — `build_video_tag` step
- `static/compliance/source/specialisms/governance-spend-authority/denied.yaml` — parallel `check_governance_denied` fixture with the same bug

## Out of scope (follow-up)

Three other `check_governance` fixtures show the same drift and will be addressed separately:

- `specialisms/governance-spend-authority/index.yaml:185` (`check_governance_conditions`)
- `specialisms/governance-delivery-monitor/index.yaml:174` (`check_governance_approved`)
- `specialisms/governance-delivery-monitor/index.yaml:290` (`check_governance_drift`, delivery-phase)

Also: `scripts/build-compliance.cjs` lints for `idempotency_key` presence but does not validate `sample_request` payloads against their `schema_ref` — which is why this drift slipped through. Worth a CI addition in a follow-up.

## Test plan

- [x] `node scripts/build-compliance.cjs` — storyboard lints pass
- [x] `npm run test:unit` — 631 tests pass
- [x] `npm run typecheck` — clean
- [x] Ad-hoc Ajv validation of the four fixtures against their target schemas (including nested `payload` against `create-media-buy-request.json`) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)