### PR TITLE
fix(compliance): webhook-signing vec016 nonce meets 16-byte minimum

### DIFF
--- a/.changeset/fix-webhook-vec016-nonce-length.md
+++ b/.changeset/fix-webhook-vec016-nonce-length.md
@@ -1,0 +1,4 @@
+---
+---
+
+Regenerate webhook-signing negative vector 016-replayed-nonce with a 16-byte nonce so it survives the step-2 params check and reaches the step-12 replay assertion on spec-compliant verifiers. Prior nonce `REPLAYED_________A` decoded to ~13 bytes, below the AdCP RFC 9421 profile's 16-byte minimum, causing conformant verifiers to reject with `webhook_signature_params_incomplete` before the replay check could fire. Closes #2750.

--- a/static/compliance/source/test-vectors/webhook-signing/negative/016-replayed-nonce.json
+++ b/static/compliance/source/test-vectors/webhook-signing/negative/016-replayed-nonce.json
@@ -8,15 +8,15 @@
     "headers": {
       "Content-Type": "application/json",
       "Content-Digest": "sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:",
-      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"REPLAYED_________A\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
-      "Signature": "sig1=:ZFiyheNSnAVO2C0opTXRABtZaQhLq1MGzUdqBleEaiF3mCFRKXLHwHNXgZk-Xb6MzLKuLtbxFKZVvTkSwS4UCA:"
+      "Signature-Input": "sig1=(\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"REPLAYEDwebhook16byteA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
+      "Signature": "sig1=:ZVRllejdoOlcnH1VkRrzv901IucAouTrwja2a0fv5F08f2Q2ahbpSxRrmnTLtXVEMgRfBZ_n1X8SGurLifJ_BQ:"
     },
     "body": "{\"idempotency_key\":\"whk_01HW9D3H8FZP2N6R8T0V4X6Z9B\",\"task_id\":\"task_456\",\"operation_id\":\"op_abc\",\"status\":\"completed\",\"result\":{\"media_buy_id\":\"mb_001\"}}"
   },
   "jwks_ref": [
     "test-ed25519-webhook-2026"
   ],
-  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op_abc\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"REPLAYED_________A\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
+  "expected_signature_base": "\"@method\": POST\n\"@target-uri\": https://buyer.example.com/adcp/webhook/create_media_buy/agent_123/op_abc\n\"@authority\": buyer.example.com\n\"content-type\": application/json\n\"content-digest\": sha-256=:dJ2koiIMZIhdGE7tidErCHV13FFvOIowCcXDiwyG54I=:\n\"@signature-params\": (\"@method\" \"@target-uri\" \"@authority\" \"content-type\" \"content-digest\");created=1776520800;expires=1776521100;nonce=\"REPLAYEDwebhook16byteA\";keyid=\"test-ed25519-webhook-2026\";alg=\"ed25519\";tag=\"adcp/webhook-signing/v1\"",
   "expected_outcome": {
     "success": false,
     "error_code": "webhook_signature_replayed",
@@ -28,7 +28,7 @@
     "replay_cache_entries": [
       {
         "keyid": "test-ed25519-webhook-2026",
-        "nonce": "REPLAYED_________A"
+        "nonce": "REPLAYEDwebhook16byteA"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Closes #2750.

The negative vector at `static/compliance/source/test-vectors/webhook-signing/negative/016-replayed-nonce.json` used nonce `REPLAYED_________A` (18 base64url chars → ~13 decoded bytes), below the AdCP RFC 9421 profile's **16-byte floor** documented in `docs/building/implementation/security.mdx`. Spec-compliant verifiers therefore rejected at step 2 with `webhook_signature_params_incomplete` before the step-12 replay assertion could fire — so the vector's declared outcome `webhook_signature_replayed` was unreachable.

## Change

- New nonce `REPLAYEDwebhook16byteA` (22 base64url chars → exactly 16 decoded bytes). Recognizable-plaintext on purpose, matching the fixture's `deliver_twice` intent; the profile requires length + no-padding, not randomness.
- Updated all three in-vector occurrences: `Signature-Input` header, `expected_signature_base`, and `test_harness_state.replay_cache_entries[0].nonce`.
- Re-signed with the committed `test-ed25519-webhook-2026` Ed25519 key from `keys.json`.

## Validation

- Regeneration script round-trips `positive/001-basic-post.json`: re-signing its committed base produces byte-for-byte the committed `Signature` header. Proves the signing path is identical to whatever generated the suite.
- New signature on vector 016 verified against the public key half of the same keypair.
- `npm run test:unit` + `npm run typecheck` pass (pre-commit hook).
- Reviewed by ad-tech-protocol, security, and code-review subagents — no blocking concerns.

Sibling `test-vectors/request-signing/negative/016-replayed-nonce.json` was already correct (uses `KXYnfEfJ0PBRZXQyVXfVQA`, 16 bytes); no change needed there.

## Test plan

- [ ] `adcp-go` conformance runner stops skipping vector 016 (tracked at adcontextprotocol/adcp-go#71)
- [ ] Any other SDK wiring these vectors into CI sees vector 016 reach step 12 and reject with `webhook_signature_replayed`
- [ ] Positive vectors unaffected (not touched in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)