### PR TITLE
fix(compliance): return refreshable OAuth creds for Test-your-agent flow

### DIFF
--- a/.changeset/fix-test-your-agent-oauth-auth.md
+++ b/.changeset/fix-test-your-agent-oauth-auth.md
@@ -1,0 +1,18 @@
+---
+---
+
+fix(compliance): send refreshable OAuth creds when Test-your-agent runs from the dashboard
+
+The four storyboard endpoints that back the dashboard's *Test your agent* flow (`applicable-storyboards`, `storyboard/:id/step/:id`, `storyboard/:id/run`, `storyboard/:id/compare`) were pulling saved credentials through `complianceDb.resolveOwnerAuth`, which dropped auth on the floor in two cases:
+
+- The access token was within 5 minutes of `expires_at` — the helper returned `undefined` with no attempt to refresh, even when a `refresh_token` was saved alongside it.
+- The chosen `agent_context` was picked by "whichever org lists this agent", not "the org the authenticated user belongs to" — so stale `member_profile.agents` lists could land on an org without credentials.
+
+Either path surfaced as *"Missing Authorization header"* right after a user authorized an OAuth-protected agent.
+
+Fixes:
+
+1. `resolveOwnerAuth` (still called by the compliance heartbeat cron) now returns the full `{ type: 'oauth', tokens, client }` shape when a refresh token is available, so the `@adcp/client` SDK can refresh silently instead of failing at the 5-minute expiry buffer. When no refresh token is saved, it returns the raw access token as a bearer rather than `undefined`, so the agent surfaces a clear 401 instead of the server sending a request with no Authorization header at all.
+2. The four storyboard endpoints now resolve auth through a new `resolveUserAgentAuth(orgId, agentUrl)` that uses the authenticated user's own org context — the same org the `auth-status` endpoint (and the UI's "Auth configured via OAuth" label) points at. Ownership resolution and auth lookup share a single query via `resolveAgentOwnerOrg`.
+
+Log levels on the auth-resolution failure paths bumped from `debug` to `warn` so future regressions surface in production logs.

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -14,6 +14,40 @@ export type OverallRunStatus = 'passing' | 'failing' | 'partial';
 export type TriggeredBy = 'heartbeat' | 'manual' | 'webhook';
 export type TrackStatus = 'pass' | 'fail' | 'partial' | 'skip';
 
+/**
+ * Auth shape resolved from an agent_context for outbound compliance/test
+ * requests. Matches the SDK's `TestOptions.auth` union in `@adcp/client/testing`.
+ * Resolvers return `ResolvedOwnerAuth | undefined`; `undefined` is not part
+ * of the domain type so post-null-check call sites don't carry the
+ * possibility forward.
+ */
+export type ResolvedOwnerAuth =
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | {
+      type: 'oauth';
+      tokens: { access_token: string; refresh_token: string; expires_at?: string };
+      client?: { client_id: string; client_secret?: string };
+    };
+
+/**
+ * Decode an HTTP Basic Authorization credential (base64(`username:password`))
+ * into a typed shape. Returns null when the payload has no `:` separator —
+ * callers should fall back to treating the raw token as bearer.
+ */
+export function decodeBasicCredentials(
+  token: string,
+): { type: 'basic'; username: string; password: string } | null {
+  const decoded = Buffer.from(token, 'base64').toString();
+  const colonIndex = decoded.indexOf(':');
+  if (colonIndex < 0) return null;
+  return {
+    type: 'basic',
+    username: decoded.slice(0, colonIndex),
+    password: decoded.slice(colonIndex + 1),
+  };
+}
+
 export interface AgentRegistryMetadata {
   agent_url: string;
   lifecycle_stage: LifecycleStage;
@@ -546,16 +580,23 @@ export class ComplianceDatabase {
    * Resolve auth credentials for an agent from the owning organization's
    * saved tokens in agent_contexts. Only uses credentials from the org
    * that owns the agent (via member_profiles.agents), not arbitrary orgs.
+   *
+   * Returns the full `oauth` shape when a refresh token is saved so the
+   * @adcp/client SDK can refresh on 401 instead of failing once the access
+   * token drifts near expiry. Without a refresh token, returns the raw
+   * access token as a bearer so callers surface a clear 401 from the agent
+   * rather than sending no Authorization header at all.
    */
-  async resolveOwnerAuth(
-    agentUrl: string,
-  ): Promise<{ type: 'bearer'; token: string } | { type: 'basic'; username: string; password: string } | undefined> {
+  async resolveOwnerAuth(agentUrl: string): Promise<ResolvedOwnerAuth | undefined> {
     try {
       const result = await query(
         `SELECT ac.organization_id,
                 ac.auth_token_encrypted, ac.auth_token_iv, ac.auth_type,
                 ac.oauth_access_token_encrypted, ac.oauth_access_token_iv,
-                ac.oauth_token_expires_at
+                ac.oauth_refresh_token_encrypted, ac.oauth_refresh_token_iv,
+                ac.oauth_token_expires_at,
+                ac.oauth_client_id,
+                ac.oauth_client_secret_encrypted, ac.oauth_client_secret_iv
          FROM agent_contexts ac
          JOIN member_profiles mp
            ON mp.workos_organization_id = ac.organization_id
@@ -575,36 +616,54 @@ export class ComplianceDatabase {
         const token = decryptToken(row.auth_token_encrypted, row.auth_token_iv, row.organization_id);
 
         if (row.auth_type === 'basic') {
-          const decoded = Buffer.from(token, 'base64').toString();
-          const colonIndex = decoded.indexOf(':');
-          if (colonIndex >= 0) {
-            return { type: 'basic', username: decoded.slice(0, colonIndex), password: decoded.slice(colonIndex + 1) };
-          }
+          const basic = decodeBasicCredentials(token);
+          if (basic) return basic;
         }
 
         return { type: 'bearer', token };
       }
 
-      // Fall back to OAuth access token
       if (row.oauth_access_token_encrypted && row.oauth_access_token_iv) {
-        // Check expiration with 5-minute buffer
-        if (row.oauth_token_expires_at) {
-          const expiresAt = new Date(row.oauth_token_expires_at);
-          if (expiresAt.getTime() - Date.now() <= 5 * 60 * 1000) {
-            logger.debug({ agentUrl, expiresAt }, 'OAuth token expired or expiring soon for compliance auth');
-            return undefined;
-          }
-        } else {
-          logger.debug({ agentUrl }, 'OAuth token has no expiration recorded');
+        const accessToken = decryptToken(
+          row.oauth_access_token_encrypted,
+          row.oauth_access_token_iv,
+          row.organization_id,
+        );
+
+        const refreshToken = row.oauth_refresh_token_encrypted && row.oauth_refresh_token_iv
+          ? decryptToken(row.oauth_refresh_token_encrypted, row.oauth_refresh_token_iv, row.organization_id)
+          : undefined;
+
+        if (!refreshToken) {
+          return { type: 'bearer', token: accessToken };
         }
 
-        const token = decryptToken(row.oauth_access_token_encrypted, row.oauth_access_token_iv, row.organization_id);
-        return { type: 'bearer', token };
+        const tokens: { access_token: string; refresh_token: string; expires_at?: string } = {
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        };
+        if (row.oauth_token_expires_at) {
+          tokens.expires_at = new Date(row.oauth_token_expires_at).toISOString();
+        }
+
+        const oauth: Extract<ResolvedOwnerAuth, { type: 'oauth' }> = { type: 'oauth', tokens };
+        if (row.oauth_client_id) {
+          const client: { client_id: string; client_secret?: string } = { client_id: row.oauth_client_id };
+          if (row.oauth_client_secret_encrypted && row.oauth_client_secret_iv) {
+            client.client_secret = decryptToken(
+              row.oauth_client_secret_encrypted,
+              row.oauth_client_secret_iv,
+              row.organization_id,
+            );
+          }
+          oauth.client = client;
+        }
+        return oauth;
       }
 
       return undefined;
     } catch (error) {
-      logger.debug({ error, agentUrl }, 'Could not resolve owner auth for heartbeat');
+      logger.warn({ err: error, agentUrl }, 'Could not resolve owner auth');
       return undefined;
     }
   }

--- a/server/src/routes/helpers/resolve-user-agent-auth.ts
+++ b/server/src/routes/helpers/resolve-user-agent-auth.ts
@@ -1,0 +1,74 @@
+/**
+ * Resolve Test-your-agent auth for a storyboard endpoint.
+ *
+ * Uses the authenticated user's org context (matching the "Auth configured
+ * via OAuth" label the UI shows), returns the full `{tokens, client}` shape
+ * for OAuth when a refresh token is saved so the SDK can refresh transparently,
+ * and falls back to the raw access token as a bearer otherwise so the agent
+ * returns a clear 401 rather than the server dropping the Authorization header.
+ *
+ * Callers must have confirmed the user belongs to `orgId` and that `orgId`
+ * owns the agent; by construction no further fallback is needed.
+ */
+
+import type { AgentContextDatabase } from '../../db/agent-context-db.js';
+import { decodeBasicCredentials, type ResolvedOwnerAuth } from '../../db/compliance-db.js';
+
+interface WarnLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+export async function resolveUserAgentAuth(
+  agentContextDb: AgentContextDatabase,
+  orgId: string,
+  agentUrl: string,
+  logger: WarnLogger,
+): Promise<ResolvedOwnerAuth | undefined> {
+  // Static token lookup throwing falls through to the OAuth branch below —
+  // the connect-form token and the OAuth token are independent paths.
+  try {
+    const staticAuth = await agentContextDb.getAuthInfoByOrgAndUrl(orgId, agentUrl);
+    if (staticAuth) {
+      if (staticAuth.authType === 'basic') {
+        const basic = decodeBasicCredentials(staticAuth.token);
+        if (basic) return basic;
+      }
+      return { type: 'bearer', token: staticAuth.token };
+    }
+  } catch (err) {
+    logger.warn({ err, agentUrl, orgId }, 'resolveUserAgentAuth: static token lookup failed');
+  }
+
+  try {
+    const context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+    if (!context?.has_oauth_token) return undefined;
+
+    const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, agentUrl);
+    if (!tokens?.access_token) return undefined;
+
+    if (!tokens.refresh_token) {
+      return { type: 'bearer', token: tokens.access_token };
+    }
+
+    const oauth: Extract<ResolvedOwnerAuth, { type: 'oauth' }> = {
+      type: 'oauth',
+      tokens: {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        ...(tokens.expires_at && { expires_at: tokens.expires_at.toISOString() }),
+      },
+    };
+
+    const client = await agentContextDb.getOAuthClient(context.id);
+    if (client) {
+      oauth.client = {
+        client_id: client.client_id,
+        ...(client.client_secret && { client_secret: client.client_secret }),
+      };
+    }
+    return oauth;
+  } catch (err) {
+    logger.warn({ err, agentUrl, orgId }, 'resolveUserAgentAuth: OAuth token lookup failed');
+    return undefined;
+  }
+}

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -73,6 +73,7 @@ import { PropertyCheckService } from "../services/property-check.js";
 import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
+import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
@@ -3527,13 +3528,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   const complianceWriteMiddleware = authMiddleware ? [authMiddleware] : [];
 
   /**
-   * Verify the authenticated user belongs to the organization that owns this agent.
-   * Returns true if ownership is confirmed, false otherwise.
+   * Resolve the workos_organization_id of the org that owns this agent,
+   * for the authenticated user. Returns null if the user is not a member
+   * of any org whose member_profile lists the agent (403 case).
+   *
+   * Mirrors the query driving the `auth-status` endpoint so the org id the
+   * UI surfaces ("Auth configured via OAuth") is the one we consult for
+   * Test-your-agent credentials.
    */
-  async function verifyAgentOwnership(userId: string, agentUrl: string): Promise<boolean> {
+  async function resolveAgentOwnerOrg(userId: string, agentUrl: string): Promise<string | null> {
     try {
-      const result = await query(
-        `SELECT 1 FROM member_profiles mp
+      const result = await query<{ workos_organization_id: string }>(
+        `SELECT mp.workos_organization_id
+         FROM member_profiles mp
          JOIN organization_memberships om
            ON om.workos_organization_id = mp.workos_organization_id
          WHERE mp.agents @> $1::jsonb
@@ -3541,10 +3548,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
          LIMIT 1`,
         [JSON.stringify([{ url: agentUrl }]), userId],
       );
-      return result.rows.length > 0;
+      return result.rows[0]?.workos_organization_id ?? null;
     } catch {
-      return false;
+      return null;
     }
+  }
+
+  async function verifyAgentOwnership(userId: string, agentUrl: string): Promise<boolean> {
+    return (await resolveAgentOwnerOrg(userId, agentUrl)) !== null;
   }
 
   function validateAgentUrlParam(raw: string): string | null {
@@ -3909,18 +3920,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       return res.status(401).json({ error: "Authentication required" });
     }
 
-    const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-    if (!isOwner) {
+    const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+    if (!orgId) {
       return res.status(403).json({ error: "You do not have permission to test this agent" });
     }
 
     try {
-      let auth;
-      try {
-        auth = await complianceDb.resolveOwnerAuth(agentUrl);
-      } catch (authErr) {
-        logger.debug({ err: authErr, agentUrl }, "Auth resolution failed — trying without auth");
-      }
+      const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
 
       let profile;
       try {
@@ -4049,8 +4055,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-        if (!isOwner) {
+        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
@@ -4059,12 +4065,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        let auth;
-        try {
-          auth = await complianceDb.resolveOwnerAuth(agentUrl);
-        } catch (authErr) {
-          logger.debug({ err: authErr, agentUrl }, "Auth resolution failed for step run");
-        }
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
 
         const { context, dry_run } = req.body;
         if (context && (typeof context !== "object" || Array.isArray(context))) {
@@ -4125,8 +4126,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-        if (!isOwner) {
+        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
@@ -4135,8 +4136,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        // Resolve agent auth
-        const auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
 
         const complyResult = await comply(agentUrl, {
           timeout_ms: 90_000,
@@ -4216,8 +4216,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-        if (!isOwner) {
+        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
@@ -4226,7 +4226,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        const auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
         const storyboardIds = [req.params.storyboardId];
 
         const [userResult, referenceResult] = await Promise.all([

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/encryption.js', () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+  deriveKey: vi.fn(),
+}));
+
+import { ComplianceDatabase, type ResolvedOwnerAuth } from '../../src/db/compliance-db.js';
+import { query } from '../../src/db/client.js';
+import { decrypt } from '../../src/db/encryption.js';
+
+const mockedQuery = vi.mocked(query);
+const mockedDecrypt = vi.mocked(decrypt);
+
+function mockRow(overrides: Record<string, unknown>) {
+  const base = {
+    organization_id: 'org_123',
+    auth_token_encrypted: null,
+    auth_token_iv: null,
+    auth_type: 'bearer',
+    oauth_access_token_encrypted: null,
+    oauth_access_token_iv: null,
+    oauth_refresh_token_encrypted: null,
+    oauth_refresh_token_iv: null,
+    oauth_token_expires_at: null,
+    oauth_client_id: null,
+    oauth_client_secret_encrypted: null,
+    oauth_client_secret_iv: null,
+    ...overrides,
+  };
+  mockedQuery.mockResolvedValueOnce({ rows: [base], rowCount: 1, command: '', oid: 0, fields: [] });
+}
+
+describe('ComplianceDatabase.resolveOwnerAuth', () => {
+  let db: ComplianceDatabase;
+
+  beforeEach(() => {
+    db = new ComplianceDatabase();
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined when no row matches', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 0, command: '', oid: 0, fields: [] });
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toBeUndefined();
+  });
+
+  it('returns static bearer when auth_token_encrypted is present', async () => {
+    mockRow({ auth_token_encrypted: 'enc_bearer', auth_token_iv: 'iv_bearer', auth_type: 'bearer' });
+    mockedDecrypt.mockReturnValueOnce('bearer-token-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({ type: 'bearer', token: 'bearer-token-plaintext' });
+  });
+
+  it('decodes static basic auth into username/password', async () => {
+    const username = 'test-user';
+    const password = 'test-pass';
+    const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+    mockRow({ auth_token_encrypted: 'enc_basic', auth_token_iv: 'iv_basic', auth_type: 'basic' });
+    mockedDecrypt.mockReturnValueOnce(credentials);
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({ type: 'basic', username, password });
+  });
+
+  it('falls back to bearer when basic-typed token has no colon separator', async () => {
+    const malformed = Buffer.from('no_separator_here').toString('base64');
+    mockRow({ auth_token_encrypted: 'enc_mal', auth_token_iv: 'iv_mal', auth_type: 'basic' });
+    mockedDecrypt.mockReturnValueOnce(malformed);
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({ type: 'bearer', token: malformed });
+  });
+
+  it('returns the full oauth shape when a refresh token is saved', async () => {
+    const expiresAt = new Date('2030-01-01T00:00:00.000Z');
+    mockRow({
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_refresh_token_encrypted: 'enc_refresh',
+      oauth_refresh_token_iv: 'iv_refresh',
+      oauth_token_expires_at: expiresAt,
+      oauth_client_id: 'client_abc',
+      oauth_client_secret_encrypted: 'enc_secret',
+      oauth_client_secret_iv: 'iv_secret',
+    });
+    // Distinct plaintexts per ciphertext — swapping access/refresh in the code
+    // under test would produce different assertion values.
+    mockedDecrypt.mockImplementation((encrypted: string) => {
+      if (encrypted === 'enc_access') return 'access-plaintext';
+      if (encrypted === 'enc_refresh') return 'refresh-plaintext';
+      if (encrypted === 'enc_secret') return 'secret-plaintext';
+      throw new Error(`unexpected decrypt call: ${encrypted}`);
+    });
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: {
+        access_token: 'access-plaintext',
+        refresh_token: 'refresh-plaintext',
+        expires_at: expiresAt.toISOString(),
+      },
+      client: { client_id: 'client_abc', client_secret: 'secret-plaintext' },
+    });
+
+    // Type-assignability guard: the returned value fits the SDK-compatible union.
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('returns oauth without client when no oauth_client_id is saved', async () => {
+    mockRow({
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_refresh_token_encrypted: 'enc_refresh',
+      oauth_refresh_token_iv: 'iv_refresh',
+    });
+    mockedDecrypt.mockImplementation((encrypted: string) =>
+      encrypted === 'enc_access' ? 'access-plaintext' : 'refresh-plaintext',
+    );
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access-plaintext', refresh_token: 'refresh-plaintext' },
+    });
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('returns oauth with public client (no secret) when secret is not saved', async () => {
+    mockRow({
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_refresh_token_encrypted: 'enc_refresh',
+      oauth_refresh_token_iv: 'iv_refresh',
+      oauth_client_id: 'public_client',
+    });
+    mockedDecrypt.mockImplementation((encrypted: string) =>
+      encrypted === 'enc_access' ? 'access-plaintext' : 'refresh-plaintext',
+    );
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access-plaintext', refresh_token: 'refresh-plaintext' },
+      client: { client_id: 'public_client' },
+    });
+  });
+
+  it('falls back to raw bearer when no refresh token is saved, even if token is near expiry', async () => {
+    // Previously the 5-minute buffer returned undefined here, which dropped
+    // the Authorization header entirely. Sending the access token lets the
+    // agent return a clear 401 rather than "Missing Authorization header".
+    const expiresInTwoMinutes = new Date(Date.now() + 2 * 60 * 1000);
+    mockRow({
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_token_expires_at: expiresInTwoMinutes,
+    });
+    mockedDecrypt.mockReturnValueOnce('access-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({ type: 'bearer', token: 'access-plaintext' });
+  });
+
+  it('prefers static token over OAuth when both are present', async () => {
+    mockRow({
+      auth_token_encrypted: 'enc_bearer',
+      auth_token_iv: 'iv_bearer',
+      auth_type: 'bearer',
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_refresh_token_encrypted: 'enc_refresh',
+      oauth_refresh_token_iv: 'iv_refresh',
+    });
+    mockedDecrypt.mockReturnValueOnce('static-bearer-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({ type: 'bearer', token: 'static-bearer-plaintext' });
+    // Exactly one decrypt call: the OAuth path must not execute.
+    expect(mockedDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when the query throws', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('db down'));
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toBeUndefined();
+  });
+});

--- a/server/tests/unit/resolve-user-agent-auth.test.ts
+++ b/server/tests/unit/resolve-user-agent-auth.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveUserAgentAuth } from '../../src/routes/helpers/resolve-user-agent-auth.js';
+import type { AgentContextDatabase } from '../../src/db/agent-context-db.js';
+import type { ResolvedOwnerAuth } from '../../src/db/compliance-db.js';
+
+type StubbedAgentContextDb = Pick<
+  AgentContextDatabase,
+  'getAuthInfoByOrgAndUrl' | 'getByOrgAndUrl' | 'getOAuthTokensByOrgAndUrl' | 'getOAuthClient'
+>;
+
+function makeDb(): {
+  [K in keyof StubbedAgentContextDb]: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getAuthInfoByOrgAndUrl: vi.fn(),
+    getByOrgAndUrl: vi.fn(),
+    getOAuthTokensByOrgAndUrl: vi.fn(),
+    getOAuthClient: vi.fn(),
+  };
+}
+
+function makeLogger() {
+  return { warn: vi.fn() };
+}
+
+const ORG = 'org_xyz';
+const URL = 'https://agent.example.com';
+
+describe('resolveUserAgentAuth', () => {
+  let db: ReturnType<typeof makeDb>;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    db = makeDb();
+    logger = makeLogger();
+  });
+
+  const call = () =>
+    resolveUserAgentAuth(db as unknown as AgentContextDatabase, ORG, URL, logger);
+
+  it('returns static bearer when the connect form saved one', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: 'static_bearer', authType: 'bearer' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({ type: 'bearer', token: 'static_bearer' });
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
+  });
+
+  it('decodes static basic auth into username/password', async () => {
+    const username = 'test-user';
+    const password = 'test-pass';
+    const encoded = Buffer.from(`${username}:${password}`).toString('base64');
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: encoded, authType: 'basic' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({ type: 'basic', username, password });
+  });
+
+  it('falls back to bearer when basic auth has no colon separator', async () => {
+    // Documents the malformed-basic behavior: we don't silently fail or pass
+    // through to OAuth — we hand the raw token to the agent as a bearer and
+    // let it return a clear 401 if the format is wrong.
+    const malformed = Buffer.from('no_separator_here').toString('base64');
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: malformed, authType: 'basic' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({ type: 'bearer', token: malformed });
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns full oauth shape when refresh token and client are saved', async () => {
+    const expiresAt = new Date('2030-01-01T00:00:00Z');
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({
+      access_token: 'access',
+      refresh_token: 'refresh',
+      expires_at: expiresAt,
+    });
+    db.getOAuthClient.mockResolvedValueOnce({ client_id: 'client_abc', client_secret: 'secret' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access', refresh_token: 'refresh', expires_at: expiresAt.toISOString() },
+      client: { client_id: 'client_abc', client_secret: 'secret' },
+    });
+    // Arg-ordering guard: getOAuthClient is called with the context id, not the agent URL.
+    expect(db.getOAuthClient).toHaveBeenCalledWith('ctx_1');
+    expect(db.getOAuthTokensByOrgAndUrl).toHaveBeenCalledWith(ORG, URL);
+
+    // Type-assignability guard: the returned value is a valid ResolvedOwnerAuth.
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('omits client_secret when the OAuth client is public', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({
+      access_token: 'access',
+      refresh_token: 'refresh',
+    });
+    db.getOAuthClient.mockResolvedValueOnce({ client_id: 'client_abc' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access', refresh_token: 'refresh' },
+      client: { client_id: 'client_abc' },
+    });
+  });
+
+  it('returns oauth without client when none is registered', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({
+      access_token: 'access',
+      refresh_token: 'refresh',
+    });
+    db.getOAuthClient.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access', refresh_token: 'refresh' },
+    });
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('falls back to raw bearer when OAuth has no refresh token (clear 401 instead of silent drop)', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({ access_token: 'access' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({ type: 'bearer', token: 'access' });
+    // No client lookup needed when there's no refresh token.
+    expect(db.getOAuthClient).not.toHaveBeenCalled();
+  });
+
+  it('prefers static token over OAuth when both are present', async () => {
+    // Symmetry with resolveOwnerAuth: a connect-form static token shortcircuits
+    // the OAuth path entirely.
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: 'static_bearer', authType: 'bearer' });
+
+    const auth = await call();
+
+    expect(auth).toEqual({ type: 'bearer', token: 'static_bearer' });
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
+    expect(db.getOAuthTokensByOrgAndUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the org has no stored credentials', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: false });
+
+    const auth = await call();
+
+    expect(auth).toBeUndefined();
+    expect(db.getOAuthTokensByOrgAndUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when agent_context is missing entirely', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toBeUndefined();
+  });
+
+  it('logs and falls through to OAuth when the static token lookup throws', async () => {
+    db.getAuthInfoByOrgAndUrl.mockRejectedValueOnce(new Error('boom'));
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({
+      access_token: 'access',
+      refresh_token: 'refresh',
+    });
+    db.getOAuthClient.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access', refresh_token: 'refresh' },
+    });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentUrl: URL, orgId: ORG }),
+      expect.stringContaining('static token lookup failed'),
+    );
+  });
+
+  it('returns undefined and logs when the OAuth lookup throws', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockRejectedValueOnce(new Error('db down'));
+
+    const auth = await call();
+
+    expect(auth).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentUrl: URL, orgId: ORG }),
+      expect.stringContaining('OAuth token lookup failed'),
+    );
+  });
+});


### PR DESCRIPTION
Re-applies #2738 (merged, then reverted via #2748) with review feedback addressed.

## Summary

The dashboard's *Test your agent* flow was dropping the `Authorization` header on OAuth-protected agents right after a user authorized, surfacing as *"Missing Authorization header"* on the very next click. Two root causes:

- `complianceDb.resolveOwnerAuth` returned `undefined` when the access token was within 5 minutes of `expires_at` — even when a `refresh_token` was saved alongside it, so the `@adcp/client` SDK never got a chance to refresh.
- The same helper picked its `agent_context` by "any org whose `member_profile.agents` lists this agent", not "the authenticated user's org" — so stale profile lists could land on an org without credentials saved, while the UI still showed *"Auth configured via OAuth"* against a different org.

## What changed

**`server/src/db/compliance-db.ts`** — `resolveOwnerAuth` now:
- Returns `{ type: 'oauth', tokens, client }` when a `refresh_token` is saved, so the SDK can refresh on 401 instead of failing at the 5-minute buffer.
- Returns the raw access token as `{ type: 'bearer', token }` when no refresh token is saved, so the agent surfaces a clear 401 rather than the server sending a request with no `Authorization` header at all.
- Exports a shared `ResolvedOwnerAuth` type matching the SDK's `TestOptions.auth` union, plus a `decodeBasicCredentials` util used by both resolvers.

**`server/src/routes/registry-api.ts`** — the four Test-your-agent endpoints (`applicable-storyboards`, `storyboard/:id/step/:id`, `storyboard/:id/run`, `storyboard/:id/compare`) now:
- Resolve the owning org with `resolveAgentOwnerOrg(userId, agentUrl)` (mirrors the `auth-status` endpoint's query) and 403 if there's no match.
- Look up credentials via `resolveUserAgentAuth(orgId, agentUrl)` — the `agent_context` consulted is the one the UI labeled *"Auth configured via OAuth"*. Single query for ownership; no unscoped fallback.

**`server/src/routes/helpers/resolve-user-agent-auth.ts`** — extracted helper so the auth-resolution branches are unit-testable. Static bearer/basic first, then OAuth with refresh token → full shape, OAuth without refresh → bearer fallback, nothing saved → `undefined`.

**Logging** — auth-resolution failures log at `warn`, not `debug`, so future regressions surface in production.

## What's different from #2738

The original, reverted via #2748:
- **Single changeset** (`fix-test-your-agent-oauth-auth.md`) instead of two.
- **Zero `package-lock.json` churn** — no unrelated `peer: true` flips.
- **Ownership query deduped** — `resolveAgentOwnerOrg` + `resolveUserAgentAuth` replaces `verifyAgentOwnership` + `complianceDb.resolveOwnerAuth`; one SQL query instead of two.
- **Dead-code fallback removed** — the old `resolveUserAgentAuth` called `complianceDb.resolveOwnerAuth` as a safety net when its own lookup missed, but by construction the user is already gated into the owning org, so the fallback was unreachable.
- **Tests added** — 22 unit tests across two files covering every branch of both helpers, with type-assignability guards so SDK compatibility is compiler-enforced.

## Related

- **#2761** — tracks the `oauth_client_credentials` extension (RFC 6749 §4.4). Same resolver surface, different shape. Blocked on SDK PR [`adcp-client#746`](https://github.com/adcontextprotocol/adcp-client/pull/746). The extraction done here (`decodeBasicCredentials` util + clean `ResolvedOwnerAuth` union + helper seam) is exactly where #2761 plugs in.
- **[`adcp-client#746`](https://github.com/adcontextprotocol/adcp-client/pull/746)** — adds `oauth_client_credentials` to `TestOptions.auth`, and also fixes a latent `is401Error` bug affecting every MCP OAuth flow including the auth-code path this PR plumbs. The server-side fix in this PR resolves the primary reported bug standalone; the SDK PR closes the mid-session token-rotation edge case.

## Test plan

Server-side, covered by this PR:
- [x] Typecheck clean (`npm run typecheck`).
- [x] Server unit suite: 1717 passed / 34 skipped / 0 failed.
- [x] Pre-commit repo-wide unit suite: 631 passed / 0 failed.
- [x] `test:storyboard-auth-shape` lint: 6/6 passed.

End-to-end (requires running server + an OAuth-protected agent):
- [ ] Authorize an OAuth-protected agent from the dashboard, then click **Test your agent** within 5 minutes — expect capability discovery to succeed. *(Primary bug — resolved by this PR alone.)*
- [ ] Let the access token drift past `expires_at` while a `refresh_token` is saved — expect the SDK to refresh silently via pre-flight refresh. *(Resolved by this PR; SDK pre-flight path doesn't depend on `adcp-client#746`.)*
- [ ] Token rotated server-side mid-session → expect SDK to retry on 401 and refresh. *(Depends on `adcp-client#746` being released — see "Related" above.)*
- [ ] For an agent saved with a static bearer token via the connect form, confirm Test-your-agent still uses that bearer and doesn't fall back to OAuth.
- [ ] Confirm a user with no org membership still gets `403 "You do not have permission to test this agent"`.

Co-authored with Emma Mulitz (original PR #2738).

🤖 Generated with [Claude Code](https://claude.com/claude-code)