### PR TITLE
storyboards(idempotency): lock in error-claim-release semantics (closes #2760)

### DIFF
--- a/.changeset/idempotency-error-claim-release-narrative.md
+++ b/.changeset/idempotency-error-claim-release-narrative.md
@@ -1,0 +1,6 @@
+---
+---
+
+Lock in the error-claim-release invariant in `universal/idempotency.yaml` so the storyboard is no longer silent on what happens when a mutating request errors. Adds a fifth narrative bullet documenting that error responses (returned envelopes, thrown envelopes, uncaught exceptions) MUST NOT cache — the next request carrying the same key re-executes the handler — and calls out the handler-author mutate-last contract. Adds a reviewer check on `key_reuse_conflict` so reviewers verify the behavior via documentation or manual probe.
+
+Closes the conformance gap flagged in adcontextprotocol/adcp#2760: a seller that silently cached error responses could pass conformance today, locking buyers into stale errors across out-of-band remediation (e.g., a buyer paying their invoice to clear `ACCOUNT_PAYMENT_REQUIRED`). An end-to-end programmatic phase is deferred until a generic force-error controller verb exists across specialisms.

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -42,6 +42,18 @@ narrative: |
      IDEMPOTENCY_CONFLICT. The buyer has clearly reused a key by mistake.
   4. A request with a different key is treated as a new request, even if the payload
      is identical — the key is what makes retries safe, not payload equivalence.
+  5. Error responses (returned envelopes, thrown envelopes, and uncaught exceptions)
+     do not cache. The next request carrying the same key re-executes the handler.
+     This applies to every recovery class, including terminal — terminal states in
+     AdCP are mostly state-dependent (e.g., ACCOUNT_SUSPENDED flips after buyer
+     remediation) and cached error replay would mask legitimate recovery. Handler
+     authors must mutate state last: a handler that writes state then returns or
+     throws an error envelope will double-write on retry. See
+     security.mdx#idempotency rule 3 ("Only successful responses are cached"),
+     which this storyboard validates structurally via the reviewer check on
+     key_reuse_conflict. An end-to-end phase that drives a deterministic terminal
+     error and replays the key is deferred pending a generic force-error controller
+     verb (see adcontextprotocol/adcp#2760).
 
   Missing idempotency_key on any mutating request MUST be rejected with INVALID_REQUEST.
   Sellers MUST declare adcp.idempotency on get_adcp_capabilities — either
@@ -429,6 +441,7 @@ phases:
         reviewer_checks:
           - "Error body MUST NOT include the cached payload, the original request, or any fingerprint (hash, digest, field diff). Leaking cached state turns key-reuse into a read oracle for attackers who stole a key."
           - "Error body MAY include code + message only. No `field` json-pointer — even a pointer like `/packages/0/budget` reveals schema shape."
+          - "Reviewer MUST confirm the seller's documentation states that errored requests release the idempotency claim, or manually probe the behavior (force a deterministic terminal error, then retry with the same key and a valid payload — the seller MUST return a fresh success, not IDEMPOTENCY_CONFLICT and not the cached error). See security.mdx#idempotency rule 3."
 
   - id: fresh_key_new_resource
     title: "Different key creates a new resource"


### PR DESCRIPTION
## Summary

- Adds a fifth narrative bullet to `universal/idempotency.yaml` documenting that error responses (returned envelopes, thrown envelopes, uncaught exceptions) MUST NOT cache — the next request carrying the same key re-executes the handler. Covers every recovery class, including `terminal` (most terminal codes are state-dependent: `ACCOUNT_SUSPENDED` flips after remediation, `ACCOUNT_PAYMENT_REQUIRED` flips after payment). Calls out the handler-author mutate-last contract.
- Adds a reviewer check on `key_reuse_conflict` requiring the reviewer to confirm — via seller docs or a manual probe — that errored requests release the idempotency claim (retry with same key + valid payload must return fresh success, not `IDEMPOTENCY_CONFLICT` and not the cached error).

Closes https://github.com/adcontextprotocol/adcp/issues/2760.

## Why this over an end-to-end phase

The issue proposes an `error_claim_release` phase that forces a deterministic terminal error and retries the key. The author explicitly labels the narrative-bullet + reviewer-check path as the minimum viable alternative: "If adding an end-to-end phase is too heavy (the 'force a terminal error' step needs a controller hook that not every specialism has), the minimum viable change is the narrative bullet above, plus a reviewer checklist item on `key_reuse_conflict`."

No generic force-terminal-error controller verb exists yet. Using the existing `force_account_status → suspended` scenario would bloat the universal storyboard with account-lifecycle setup already tested by `deterministic_testing`, and would miss non-account-bound terminal codes. The narrative bullet flags this follow-up inline: "An end-to-end phase that drives a deterministic terminal error and replays the key is deferred pending a generic force-error controller verb (see adcontextprotocol/adcp#2760)."

The spec is already normative on this (security.mdx#idempotency rule 3: "Only successful responses are cached"). The storyboard change makes the invariant visible to storyboard readers and reviewable at conformance time.

## Test plan
- [x] `npm run test:storyboard-scoping` — passes
- [x] `npm run test:storyboard-branch-sets` — passes
- [x] `npm run test:storyboard-contradictions` — passes
- [x] `npm run test:storyboard-context-entity` — passes
- [x] `npm run test:storyboard-auth-shape` — passes
- [x] `npm run test:storyboard-test-kits` — passes
- [x] `npm run build:compliance` — succeeds (10 universal, 6 protocols, 24 specialisms)
- [x] precommit (`test:unit` + `typecheck`) — 631 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)