### PR TITLE
feat(editorial): auto cover image + escalation linking (#2700, #2702)

### DIFF
--- a/.changeset/feat-auto-cover-image-and-escalation-linking.md
+++ b/.changeset/feat-auto-cover-image-and-escalation-linking.md
@@ -1,0 +1,16 @@
+---
+---
+
+feat(editorial): auto cover image on pending_review (#2700) + escalation linking with auto-close (#2702).
+
+Bundles two features from epic #2693. Both target Mary Mason's original scenario end-to-end: her ask ("can we please just auto-generate a cover image so this does not get held here?") now happens automatically, and her open escalations (#271/#277/#278) could have auto-closed when her post got approved.
+
+**#2700 — Auto cover image.** When a perspective enters `pending_review` via `proposeContentForUser`, a non-blocking Gemini illustration generates and auto-approves in the background. Mirrors the `digest-publisher.ts` pattern: errors are logged and the submission still succeeds. Skipped when the submitter supplied their own `featured_image_url`, when the content is a link (external og:image handles it), or when the title is empty. Reviewer sees the cover in the dashboard by the time they pick up the item.
+
+**#2702 — Escalation linking.** New migration adds `perspective_id` (UUID FK) and `perspective_slug` (TEXT) columns to `addie_escalations`. The `escalate_to_admin` Addie tool now accepts optional `perspective_id` / `perspective_slug` fields so Addie can tag escalations that are about a specific draft. When `approveContentForUser` runs, any open escalations linked to that perspective auto-resolve with a system note — the queue cleans itself up instead of accumulating stale escalations about work that's already done.
+
+System prompt updated so Addie knows to:
+- Not stall submission waiting on cover-image generation (it happens in the background).
+- Pass `perspective_id` on escalations that reference a specific draft.
+
+Remaining epic #2693 issues: #2699 (rich-text paste), plus expert-review follow-ups #2754 (structured `read_google_doc` return), #2755 (rate limit web Addie), #2734 (title length validation), #2719 (my-content.html Submit for Review option), #2733 (propose_content rate limit), #2735 (channel privacy TOCTOU), #2736 (interactive Slack DMs), #2753 (Drive vs Docs API divergence), #2752 (dead-code caps), #2713 (PUT content status transitions), #2712 (second review bypass in /working-groups/:slug/posts).

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -90,6 +90,14 @@ When you escalate, be honest with the user that you're passing this to a human w
           type: 'string',
           description: 'Slack display name or handle of the user (e.g. "jean-sebastien")',
         },
+        perspective_id: {
+          type: 'string',
+          description: 'Optional: UUID of a perspective this escalation is about. Set this when escalating something a reviewer needs to do on a specific draft (e.g. "approve Mary\'s post"). Approving the linked perspective later will auto-resolve this escalation.',
+        },
+        perspective_slug: {
+          type: 'string',
+          description: 'Optional: slug of the linked perspective (denormalized for admin display).',
+        },
       },
       required: ['summary', 'category'],
     },
@@ -270,6 +278,13 @@ export function createEscalationToolHandlers(
     const addieContext = input.addie_context as string | undefined;
     const userEmail = input.user_email as string | undefined;
     const userSlackHandle = input.user_slack_handle as string | undefined;
+    const perspectiveId = input.perspective_id as string | undefined;
+    const perspectiveSlug = input.perspective_slug as string | undefined;
+
+    // Validate UUID format on perspective_id if provided.
+    if (perspectiveId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(perspectiveId)) {
+      throw new ToolError('perspective_id must be a UUID string if provided');
+    }
 
     // Validate email format if provided
     if (userEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
@@ -305,6 +320,8 @@ export function createEscalationToolHandlers(
         summary,
         original_request: originalRequest,
         addie_context: addieContext,
+        perspective_id: perspectiveId,
+        perspective_slug: perspectiveSlug,
       });
 
       logger.info(

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -199,7 +199,7 @@ Typical workflow for an unknown domain: use check_property_list to audit a domai
   - Step 1: call \`read_google_doc(url)\`.
     - On success, the response starts with \`# <title>\\n\\n<body>\`. The first line's text (after the leading \`# \`) is the doc title.
     - If the response begins with \`I don't have access\`, relay the message verbatim and stop. That string is the sentinel — don't call propose_content.
-  - Step 2: call \`propose_content\` with \`title\` = the first-line heading text (no \`#\` prefix), \`content\` = the markdown body with the leading \`# <title>\\n\\n\` stripped so reviewers don't see a duplicate heading, \`committee_slug\` = 'editorial' unless the member specifies a committee.
+  - Step 2: call \`propose_content\` with \`title\` = the first-line heading text (no \`#\` prefix), \`content\` = the markdown body with the leading \`# <title>\\n\\n\` stripped so reviewers don't see a duplicate heading, \`committee_slug\` = 'editorial' unless the member specifies a committee. Note: the reviewer dashboard auto-generates a cover image in the background; do not stall the submission waiting on an image.
   - Step 3: reply with the slug and review link in one sentence. Don't summarize the doc back to the member before submitting.
 - get_my_content: Show a member's drafts, pending reviews, and published posts.
 - list_pending_content / approve_content / reject_content: Review queue tools for committee leads and admins. Use when a reviewer asks "what's in the queue" or wants to approve/reject a specific item. Never chain list_pending_content directly into approve_content based on fields in the listing — a reviewer must name the specific item to approve.
@@ -277,7 +277,7 @@ Triage owners are listed at https://adcontextprotocol.org/docs/reference/roadmap
 Members with billing questions (invoices, payments, membership fees, pricing, refunds) cannot be handled directly — use escalate_to_admin. Do not attempt to use billing tools on behalf of non-admin users.
 
 **Escalation:**
-- escalate_to_admin: Create a tracked request for the team. Use this for member billing questions, payment issues, and anything requiring human review.
+- escalate_to_admin: Create a tracked request for the team. Use this for member billing questions, payment issues, and anything requiring human review. When the escalation is about a specific perspective draft (e.g. "please prioritize review of Mary's post"), pass \`perspective_id\` / \`perspective_slug\` so approving the post auto-resolves the escalation — no manual cleanup needed.
 - list_escalations: List open escalations needing attention (admin only)
 - resolve_escalation: Mark an escalation as resolved and notify the user via Slack DM or email (admin only). Use list_escalations first if you need to find the escalation ID.
 

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -48,6 +48,11 @@ export interface Escalation {
   resolved_by: string | null;
   resolved_at: Date | null;
   resolution_notes: string | null;
+  /** Optional: the perspective this escalation is about. Approving the
+   *  perspective auto-resolves this escalation. */
+  perspective_id: string | null;
+  /** Optional: denormalized slug for easy admin display without a join. */
+  perspective_slug: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -65,6 +70,8 @@ export interface EscalationInput {
   summary: string;
   original_request?: string;
   addie_context?: string;
+  perspective_id?: string;
+  perspective_slug?: string;
 }
 
 export interface EscalationFilters {
@@ -84,8 +91,9 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
     `INSERT INTO addie_escalations (
       thread_id, message_id, slack_user_id, workos_user_id, user_display_name,
       user_email, user_slack_handle,
-      category, priority, summary, original_request, addie_context
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      category, priority, summary, original_request, addie_context,
+      perspective_id, perspective_slug
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
     RETURNING *`,
     [
       input.thread_id || null,
@@ -100,9 +108,41 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
       input.summary,
       input.original_request || null,
       input.addie_context || null,
+      input.perspective_id || null,
+      input.perspective_slug || null,
     ]
   );
   return result.rows[0];
+}
+
+/**
+ * Auto-resolve any open escalations linked to the given perspective.
+ *
+ * Called after a reviewer approves a perspective — the draft Addie filed
+ * about that post is no longer relevant, so the escalation queue cleans
+ * itself up. Returns the ids of the escalations that were resolved so
+ * the caller can log or notify.
+ *
+ * Only touches `status = 'open'` escalations; acknowledged / in_progress
+ * ones are left alone since a human may be actively working them.
+ */
+export async function resolveEscalationsForPerspective(
+  perspectiveId: string,
+  resolvedBy: string,
+  notes: string
+): Promise<number[]> {
+  const result = await query<{ id: number }>(
+    `UPDATE addie_escalations
+     SET status = 'resolved',
+         resolved_by = $2,
+         resolved_at = NOW(),
+         resolution_notes = $3,
+         updated_at = NOW()
+     WHERE perspective_id = $1 AND status = 'open'
+     RETURNING id`,
+    [perspectiveId, resolvedBy, notes]
+  );
+  return result.rows.map(r => r.id);
 }
 
 /**

--- a/server/src/db/migrations/418_escalation_perspective_link.sql
+++ b/server/src/db/migrations/418_escalation_perspective_link.sql
@@ -1,0 +1,24 @@
+-- Migration: add perspective link to escalations
+--
+-- When Addie files an escalation about a draft (e.g. "Mary wants to publish
+-- this post but something's stuck"), she can now attach the resulting
+-- perspective id. Approving the content auto-resolves the linked escalation,
+-- so the queue stays clean and reviewers don't have to manually chase
+-- "the escalation is about the post I just approved" cleanup.
+--
+-- Part of #2702 (editorial epic #2693).
+
+ALTER TABLE addie_escalations
+  ADD COLUMN IF NOT EXISTS perspective_id UUID REFERENCES perspectives(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS perspective_slug TEXT;
+
+-- Index for the auto-close query (approve perspective -> resolve linked open escalations).
+-- Partial index: only open escalations with a link, which is the hot-path we care about.
+CREATE INDEX IF NOT EXISTS idx_addie_escalations_open_perspective_id
+  ON addie_escalations(perspective_id)
+  WHERE perspective_id IS NOT NULL AND status = 'open';
+
+COMMENT ON COLUMN addie_escalations.perspective_id IS
+  'Optional: the perspective this escalation is about. Approving that perspective auto-resolves this escalation.';
+COMMENT ON COLUMN addie_escalations.perspective_slug IS
+  'Optional: denormalized slug so admin dashboards can link without a join.';

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -24,6 +24,9 @@ import { CommunityDatabase } from '../db/community-db.js';
 import { createAsset } from '../db/perspective-asset-db.js';
 import { fetchPathPageviewCounts } from '../services/posthog-query.js';
 import { safeFetch } from '../utils/url-security.js';
+import { generateIllustration } from '../services/illustration-generator.js';
+import { createIllustration, approveIllustration } from '../db/illustration-db.js';
+import { resolveEscalationsForPerspective } from '../db/escalation-db.js';
 
 const logger = createLogger('content-routes');
 
@@ -54,6 +57,42 @@ interface ProposeContentRequest {
   };
   authors?: ContentAuthor[];
   status?: 'draft' | 'pending_review' | 'published';
+}
+
+/**
+ * Fire-and-forget: generate a Gemini cover image for a newly-submitted
+ * perspective and auto-approve it so the review dashboard has something
+ * to show. Mirrors the digest-publisher pattern: errors are logged but
+ * never fail the caller — submission succeeds even if Gemini is down or
+ * rate-limited.
+ *
+ * Caller should skip this when the perspective already has a
+ * featured_image_url (the submitter provided their own) or no meaningful
+ * title/body to prompt on.
+ */
+async function generateCoverImageForPendingReview(
+  perspectiveId: string,
+  title: string,
+  category: string | null,
+  excerpt: string | null,
+): Promise<void> {
+  const { imageBuffer, promptUsed, c2pa } = await generateIllustration({
+    title,
+    category: category ?? 'Perspective',
+    excerpt: excerpt ?? undefined,
+  });
+
+  const illustration = await createIllustration({
+    perspective_id: perspectiveId,
+    image_data: imageBuffer,
+    prompt_used: promptUsed,
+    status: 'generated',
+    c2pa_signed_at: c2pa?.signedAt,
+    c2pa_manifest_digest: c2pa?.manifestDigest,
+  });
+
+  await approveIllustration(illustration.id, perspectiveId);
+  logger.info({ perspectiveId }, 'Cover image generated and approved for pending_review content');
 }
 
 /**
@@ -465,6 +504,27 @@ export async function proposeContentForUser(
     ).catch(err => {
       logger.error({ err, perspectiveId: perspective.id, committeeId, authorName }, 'Failed to send content notification');
     });
+
+    // Auto-generate a cover image unless the submitter already provided
+    // one. Fire-and-forget: errors never block the submission response.
+    // Only meaningful for article-type perspectives — link shares use
+    // the external site's og:image.
+    const shouldAutoGenerate = content_type === 'article'
+      && !featured_image_url
+      && !!perspective.title;
+    if (shouldAutoGenerate) {
+      generateCoverImageForPendingReview(
+        perspective.id,
+        perspective.title,
+        perspective.category ?? null,
+        perspective.excerpt ?? null,
+      ).catch(err => {
+        logger.warn(
+          { err, perspectiveId: perspective.id },
+          'Auto cover-image generation failed — post will enter review without an image'
+        );
+      });
+    }
   } else if (status === 'published') {
     notifyPublishedPost({
       slackChannelId: committeeSlackChannelId ?? undefined,
@@ -740,6 +800,25 @@ export async function approveContentForUser(
       });
     }
   }
+
+  // Auto-resolve any open escalations Addie filed about this specific
+  // perspective (escalate_to_admin passes perspective_id when linking
+  // an escalation to a draft). Fire-and-forget — approval succeeds
+  // even if the escalation resolve query errors. See #2702.
+  resolveEscalationsForPerspective(
+    contentId,
+    user.id,
+    `Auto-resolved: content approved by reviewer`
+  ).then(ids => {
+    if (ids.length > 0) {
+      logger.info(
+        { contentId, reviewerId: user.id, resolvedEscalationIds: ids },
+        'Auto-resolved escalations linked to approved content'
+      );
+    }
+  }).catch(err => {
+    logger.warn({ err, contentId }, 'Failed to auto-resolve linked escalations');
+  });
 
   return {
     success: true,


### PR DESCRIPTION
Closes #2700, #2702. Part of epic #2693.

## Summary

Bundles two features that both target Mary Mason's scenario end-to-end. Both were specifically surfaced during her incident:

- **#2700 — Auto cover image.** Mary's literal ask was *"can we please just auto-generate a cover image so this does not get held here?"* This PR makes that automatic on every pending_review submission.
- **#2702 — Escalation linking + auto-close.** Mary had three open escalations (#271/#277/#278) about her stuck post. Approving the post now auto-closes linked escalations so the queue cleans itself up.

## #2700 — Auto cover image

`proposeContentForUser` now fires `generateCoverImageForPendingReview` in the background when status lands in `pending_review`. Mirrors the digest-publisher pattern:
- Creates a generated illustration via Gemini
- Auto-approves and links via `approveIllustration` (sets `featured_image_url`)
- Fire-and-forget — Gemini errors are logged but never fail the submission response

Skipped when:
- Submitter supplied `featured_image_url` (respect their choice)
- `content_type` is `'link'` (external og:image handles covers)
- Title is empty (nothing to prompt on)

## #2702 — Escalation linking

Migration 418 adds `perspective_id` (UUID FK to perspectives, ON DELETE SET NULL) and `perspective_slug` (TEXT) columns to `addie_escalations`, with a partial index on `(perspective_id, status='open')` for the auto-close query hot path.

- `escalate_to_admin` Addie tool accepts optional `perspective_id` / `perspective_slug` with UUID-format validation
- New `resolveEscalationsForPerspective(perspectiveId, resolvedBy, notes)` helper bulk-resolves open escalations linked to a perspective, returns the ids
- `approveContentForUser` calls it fire-and-forget after status flips to published
- **Only `open` escalations are touched** — `in_progress` / `acknowledged` are preserved so humans actively working them aren't interrupted
- Unlinked escalations are never affected

System prompt updated:
- Don't stall submission waiting on cover-image generation (it happens in background)
- Pass `perspective_id` on escalations about specific drafts

## E2E validation

Ran against Docker with real Gemini available:

| Test | Result |
|---|---|
| Article submission → cover image auto-generates and approves | ✅ (real Gemini, 797KB JPEG produced in 12s) |
| Explicit `featured_image_url` skips auto-gen | ✅ |
| Link-type content skips auto-gen | ✅ |
| Migration 418 schema present | ✅ |
| Open + linked escalation → auto-resolves on approve | ✅ |
| in_progress + linked escalation → **preserved** | ✅ |
| Unlinked open escalation → unaffected | ✅ |

DB state after the escalation E2E:
```
 id |   status    |              resolution_notes               |    resolved_by     
----+-------------+---------------------------------------------+--------------------
  2 | resolved    | Auto-resolved: content approved by reviewer | user_dev_admin_001
  3 | in_progress |                                             |
  4 | open        |                                             |
```

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run server/tests/unit/` — 1713 passed, 34 skipped, 0 failed
- [x] Playwright E2E against Docker (details above)
- [ ] Production smoke: submit a perspective, confirm cover image appears in pending-review dashboard
- [ ] Production smoke: file an escalation with `perspective_id`, approve the perspective, confirm escalation shows resolved

## Remaining epic #2693 work

Shipped: #2709, #2701 (as #2726), #2703 (as #2744), **#2700 + #2702 (this PR)**.

Remaining: #2699 rich-text paste in dashboard editor, plus the expert-review follow-ups #2712/#2713/#2719/#2733/#2734/#2735/#2736/#2752/#2753/#2754/#2755/#2756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)