### PR TITLE
fix(storyboards): inject caller into specialism check_governance fixtures

### DIFF
--- a/.changeset/fix-specialism-check-governance-caller.md
+++ b/.changeset/fix-specialism-check-governance-caller.md
@@ -1,0 +1,6 @@
+---
+---
+
+Inject `caller` into every `check_governance` sample_request in the `specialisms/governance-spend-authority` and `specialisms/governance-delivery-monitor` storyboards, matching the shape already landed in `protocols/governance/index.yaml`.
+
+Surfaced by a Matrix v9 wire-tap showing the request payload omitted `caller` even though adcp#2740 had added it to the protocol fixture — the specialisms are authored separately and were missed. Closes the gap referenced in adcp#2763.

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -206,6 +206,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
+          caller: "https://pinnacle-agency.example"
           tool: "create_media_buy"
           payload:
             account:
@@ -322,6 +323,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
+          caller: "https://pinnacle-agency.example"
           phase: "delivery"
           governance_context: "gov_ctx_acme_delivery_approved"
           media_buy_id: "mb_acme_q2_2026"

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -233,6 +233,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           plan_id: "$context.plan_id"
+          caller: "https://pinnacle-agency.example"
           tool: "create_media_buy"
           payload:
             account:


### PR DESCRIPTION
## Summary

- Injects `caller: "https://pinnacle-agency.example"` into every `check_governance` `sample_request` in the two affected specialism storyboards, matching the shape already landed in `protocols/governance/index.yaml` via adcp#2740.
- Fixes three gaps: one in `specialisms/governance-spend-authority/index.yaml`, two in `specialisms/governance-delivery-monitor/index.yaml`. (`denied.yaml` already had it.)
- Closes the concrete wire-level divergence documented in #2763.

## Context

Matrix v9 was failing `check_governance` runs. A logging proxy (4499 → 4500) captured the actual request payload and confirmed `caller` was missing on the wire. adcp#2740 had added it to `protocols/governance/index.yaml`, but the specialisms are authored separately and were never updated — the runs that fail are hitting specialism fixtures.

This is the narrower, verified half of the #2763 audit. Hypotheses for `build_creative` (creative-template), `sync_catalogs`, and `report_usage` (creative-ad-server) are not included here — those need their own wire-taps before committing to a specific shape.

## Test plan

- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean
- [x] `npm run test:storyboard-scoping` — pass
- [x] `npm run test:storyboard-context-entity` — pass
- [x] `npm run test:storyboard-auth-shape` — pass
- [ ] Rerun Matrix v9 against republished tarball to confirm the wire payload now includes `caller`

Note: `@adcp/client` consumers won't see the fix until the compliance tarball is republished — the same republish-lag pattern as adcp#2335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)