### PR TITLE
feat(dashboard): add Update auth button on agent cards

### DIFF
--- a/.changeset/agent-update-auth-button.md
+++ b/.changeset/agent-update-auth-button.md
@@ -1,0 +1,4 @@
+---
+---
+
+Dashboard: always show the connect toggle on agent cards, relabeled to "Update auth" when auth is already configured. Lets users re-run the OAuth flow (or swap tokens) on agents whose credentials have expired or broken, without deleting and re-registering the agent.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -942,15 +942,15 @@
             <div class="agent-meta-row">
               <span>Last checked: ${escapeHtml(lastChecked)}</span>
               <div style="display: flex; gap: var(--space-3); align-items: center;">
-                ${!hasAuth ? '<button class="agent-connect-toggle agent-action-link" data-card-id="' + cardId + '" data-agent-url="' + escapeHtml(agent.url) + '">Connect agent</button>' : ''}
+                <button class="agent-connect-toggle agent-action-link" data-card-id="${cardId}" data-agent-url="${escapeHtml(agent.url)}">${hasAuth ? 'Update auth' : 'Connect agent'}</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" data-agent-tracks="${escapeHtml(JSON.stringify(tracks))}">Test your agent</button>
                 <button class="agent-history-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">View history</button>
                 <button class="agent-requests-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">View requests</button>
               </div>
             </div>
-            ${!hasAuth ? '<div id="' + cardId + '-connect" style="display:none;border-top:1px solid var(--color-border);margin-top:var(--space-3);padding-top:var(--space-3);">' +
-              buildConnectForm(escapeHtml(agent.url), platformTypeOptions, authInfo?.agent_context_id) +
-              '</div>' : ''}
+            <div id="${cardId}-connect" style="display:none;border-top:1px solid var(--color-border);margin-top:var(--space-3);padding-top:var(--space-3);">
+              ${buildConnectForm(escapeHtml(agent.url), platformTypeOptions, authInfo?.agent_context_id)}
+            </div>
             <div class="agent-storyboard-panel" id="${cardId}-storyboard" style="display:none;"></div>
             <div class="agent-history-panel" id="${cardId}-history" style="display:none;"></div>
             <div class="agent-requests-panel" id="${cardId}-requests" style="display:none;"></div>


### PR DESCRIPTION
## Summary
- Always render the connect toggle on agent compliance cards, relabeled to **Update auth** when auth is already configured (was only shown for agents with no auth).
- Fixes the dead-end when an agent's OAuth token expires or the authorization server changes — users can now re-run the OAuth flow or swap in a new token without deleting and re-registering the agent.
- Backend is unchanged: `PUT /api/registry/agents/:url/connect` already overwrites tokens, and `saveOAuthTokens()` already upserts, so the existing `agent_context_id` is reused automatically.

## Test plan
- [ ] Open the agents dashboard with an agent that already has auth configured → card shows an **Update auth** button next to Test your agent / View history / View requests.
- [ ] Click **Update auth** → connect panel expands with the OAuth / Bearer / Basic form.
- [ ] Run the OAuth flow for an agent whose token has expired (e.g. the `agents.scope3.com/spotify` unreachable case) → after the callback, the agent card reloads and subsequent compliance checks succeed.
- [ ] Swap a bearer token via the form for an agent that previously used bearer auth → `has_auth_token` remains true and the new token is used on the next check.
- [ ] An agent with no auth still shows **Connect agent** (unchanged behavior).