### PR TITLE
fix(compliance): add sample_request to webhook-emission trigger steps (#2758)

### DIFF
--- a/.changeset/fix-webhook-emission-missing-sample-request.md
+++ b/.changeset/fix-webhook-emission-missing-sample-request.md
@@ -1,0 +1,24 @@
+---
+---
+
+fix(compliance): add sample_request to webhook-emission trigger steps
+
+The `universal/webhook-emission.yaml` storyboard had three trigger steps
+(`trigger_webhook_operation`, `trigger_retry_scenario`, `trigger_signed_webhook`)
+with narratives that described passing `push_notification_config.url =
+{{runner.webhook_url:<step_id>}}`, but none of the three carried a
+`sample_request` block. The runner's mustache expander only substitutes
+placeholders that appear in a step's `sample_request`, so no webhook URL ever
+reached the agent under test — `expect_webhook_presence`,
+`expect_key_stable_across_retries`, and `expect_signature_valid` then all
+timed out with "webhook never arrived" across every webhook-emitting agent.
+
+Each trigger step now carries a minimal, operation-agnostic `sample_request`:
+`push_notification_config.url` (directs the webhook at the per-step receiver,
+no authentication block so the 9421 baseline is in effect), `idempotency_key`
+(keeps the trigger call itself retry-safe), and `context.correlation_id`.
+Operation-specific required fields (e.g., brand, packages, budget for
+`create_media_buy`) are supplied by whichever `test_kit` resolves
+`$test_kit.operations.primary_webhook_emitter`.
+
+Closes adcp#2758.

--- a/static/compliance/source/universal/webhook-emission.yaml
+++ b/static/compliance/source/universal/webhook-emission.yaml
@@ -146,10 +146,24 @@ phases:
         doc_ref: "/building/implementation/webhooks"
         comply_scenario: webhook_trigger
         stateful: false
+        sample_request:
+          push_notification_config:
+            url: "{{runner.webhook_url:trigger_webhook_operation}}"
+          idempotency_key: "$generate:uuid_v4#webhook_emission_trigger"
+          context:
+            correlation_id: "webhook_emission--trigger_webhook_operation"
         expected: |
           Agent accepts the request and begins async execution. Response either
           returns an immediate terminal status (no webhook needed) or an
           interim status indicating async processing (webhook will follow).
+
+          Operation-specific required fields (e.g., brand, packages, budget for
+          create_media_buy) are supplied by the resolved test_kit — this
+          universal only declares the two fields that apply to every
+          webhook-emitting operation: push_notification_config.url (directs the
+          emitted webhook at the runner's per-step receiver, no authentication
+          block so 9421 is in effect) and idempotency_key (so the trigger call
+          itself is safe to retry).
 
       - id: expect_webhook_presence
         title: "Assert inbound webhook carries a valid idempotency_key"
@@ -203,6 +217,12 @@ phases:
         doc_ref: "/building/implementation/webhooks"
         comply_scenario: webhook_retry_trigger
         stateful: false
+        sample_request:
+          push_notification_config:
+            url: "{{runner.webhook_url:trigger_retry_scenario}}"
+          idempotency_key: "$generate:uuid_v4#webhook_emission_retry_trigger"
+          context:
+            correlation_id: "webhook_emission--trigger_retry_scenario"
         expected: |
           Agent accepts the request and begins async execution. The webhook
           it emits will be rejected with 503 by the runner and retried.
@@ -273,6 +293,12 @@ phases:
         doc_ref: "/building/implementation/webhooks"
         comply_scenario: webhook_signed_trigger
         stateful: false
+        sample_request:
+          push_notification_config:
+            url: "{{runner.webhook_url:trigger_signed_webhook}}"
+          idempotency_key: "$generate:uuid_v4#webhook_emission_signed_trigger"
+          context:
+            correlation_id: "webhook_emission--trigger_signed_webhook"
         expected: |
           Agent accepts the request; the webhook it emits will carry
           Signature-Input, Signature, and Content-Digest headers per the

--- a/static/compliance/source/universal/webhook-emission.yaml
+++ b/static/compliance/source/universal/webhook-emission.yaml
@@ -157,14 +157,6 @@ phases:
           returns an immediate terminal status (no webhook needed) or an
           interim status indicating async processing (webhook will follow).
 
-          Operation-specific required fields (e.g., brand, packages, budget for
-          create_media_buy) are supplied by the resolved test_kit — this
-          universal only declares the two fields that apply to every
-          webhook-emitting operation: push_notification_config.url (directs the
-          emitted webhook at the runner's per-step receiver, no authentication
-          block so 9421 is in effect) and idempotency_key (so the trigger call
-          itself is safe to retry).
-
       - id: expect_webhook_presence
         title: "Assert inbound webhook carries a valid idempotency_key"
         narrative: |


### PR DESCRIPTION
## Summary

- Adds a minimal `sample_request` block to all three trigger steps in `universal/webhook-emission.yaml` (`trigger_webhook_operation`, `trigger_retry_scenario`, `trigger_signed_webhook`).
- Each block carries `push_notification_config.url = {{runner.webhook_url:<step_id>}}` (no `authentication`, so the 9421 baseline is in effect), a generated `idempotency_key` (keeps the trigger call itself retry-safe), and a `context.correlation_id`.
- Operation-specific required fields (brand, packages, budget for `create_media_buy` etc.) remain the responsibility of whichever test_kit resolves `$test_kit.operations.primary_webhook_emitter`.

## Why

The three steps described passing `push_notification_config.url = {{runner.webhook_url:<step_id>}}` in prose but had no `sample_request`. The runner's mustache expander only substitutes placeholders that appear in a step's `sample_request`, so no webhook URL ever reached the agent under test — `expect_webhook_presence`, `expect_key_stable_across_retries`, and `expect_signature_valid` all timed out with "webhook never arrived" across every webhook-emitting agent. All three phases failed vacuously for the same bug; fixing only `trigger_webhook_operation` (as the issue proposed) would leave the other two phases broken under the same pattern.

The lint from #2768 skips `$test_kit.*` schema_refs, so the new blocks don't need an allowlist entry.

Closes #2758.

## Test plan

- [x] `npm run test:storyboard-sample-request-schema` — passes (no new drift)
- [x] `npm run test:storyboard-scoping`, `branch-sets`, `contradictions`, `context-entity`, `auth-shape`, `test-kits` — pass
- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean
- [ ] Runner rerun against training agent: three webhook-emission phases advance past "webhook never arrived" (needs runner environment, not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)