### PR TITLE
fix(storyboards): push_notification_config uses schemes array (#2770)

### DIFF
--- a/.changeset/fix-storyboards-push-notification-schemes.md
+++ b/.changeset/fix-storyboards-push-notification-schemes.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(storyboards): use `schemes` (array) + `credentials` in push_notification_config.authentication
+
+The `sales-guaranteed` and `creative-generative/seller` storyboards declared the deprecated singular `scheme` field inside `push_notification_config.authentication`. The spec schema (`/schemas/core/push-notification-config.json`) requires `schemes` (array) and `credentials`, and conformant agents using `@adcp/client` 5.9.0+ reject the malformed shape at client-side validation.
+
+Align both storyboards with `sales-broadcast-tv` (already correct) and drop the two grandfathered entries from the sample-request schema allowlist now that the drift is fixed.
+
+Closes #2770.

--- a/.changeset/fix-storyboards-push-notification-schemes.md
+++ b/.changeset/fix-storyboards-push-notification-schemes.md
@@ -3,8 +3,8 @@
 
 fix(storyboards): use `schemes` (array) + `credentials` in push_notification_config.authentication
 
-The `sales-guaranteed` and `creative-generative/seller` storyboards declared the deprecated singular `scheme` field inside `push_notification_config.authentication`. The spec schema (`/schemas/core/push-notification-config.json`) requires `schemes` (array) and `credentials`, and conformant agents using `@adcp/client` 5.9.0+ reject the malformed shape at client-side validation.
+The base `media_buy_seller` storyboard and two specialisms (`sales-guaranteed`, `creative-generative/seller`) declared the deprecated singular `scheme` field inside `push_notification_config.authentication`. The spec schema (`/schemas/core/push-notification-config.json`) requires `schemes` (array) and `credentials`, and conformant agents using `@adcp/client` 5.9.0+ reject the malformed shape at client-side validation.
 
-Align both storyboards with `sales-broadcast-tv` (already correct) and drop the two grandfathered entries from the sample-request schema allowlist now that the drift is fixed.
+Align all three with `sales-broadcast-tv` (already correct) and drop the three grandfathered entries from the sample-request schema allowlist now that the drift is fixed.
 
 Closes #2770.

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -441,7 +441,9 @@ phases:
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
-              scheme: "HMAC-SHA256"
+              schemes:
+                - "HMAC-SHA256"
+              credentials: "media-buy-seller-webhook-secret-token"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_create_buy_create_media_buy"
           context:
             correlation_id: "media_buy_seller--create_media_buy"

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -337,7 +337,9 @@ phases:
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
-              scheme: "HMAC-SHA256"
+              schemes:
+                - "HMAC-SHA256"
+              credentials: "placeholder-webhook-secret-token"
 
           idempotency_key: "$generate:uuid_v4#creative_generative_seller_create_buy_create_media_buy"
           context:

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -339,7 +339,7 @@ phases:
             authentication:
               schemes:
                 - "HMAC-SHA256"
-              credentials: "placeholder-webhook-secret-token"
+              credentials: "creative-generative-seller-webhook-secret-token"
 
           idempotency_key: "$generate:uuid_v4#creative_generative_seller_create_buy_create_media_buy"
           context:

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -277,7 +277,9 @@ phases:
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
-              scheme: "HMAC-SHA256"
+              schemes:
+                - "HMAC-SHA256"
+              credentials: "placeholder-webhook-secret-token"
 
           idempotency_key: "$generate:uuid_v4#sales_guaranteed_create_buy_submitted_create_media_buy"
           context:

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -279,7 +279,7 @@ phases:
             authentication:
               schemes:
                 - "HMAC-SHA256"
-              credentials: "placeholder-webhook-secret-token"
+              credentials: "sales-guaranteed-webhook-secret-token"
 
           idempotency_key: "$generate:uuid_v4#sales_guaranteed_create_buy_submitted_create_media_buy"
           context:

--- a/tests/storyboard-sample-request-schema-allowlist.json
+++ b/tests/storyboard-sample-request-schema-allowlist.json
@@ -195,14 +195,6 @@
         "required@/:uses"
       ]
     },
-    "specialisms/creative-generative/generative-seller.yaml#create_buy/create_media_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "required@/push_notification_config/authentication:schemes",
-        "required@/push_notification_config/authentication:credentials",
-        "additionalProperties@/push_notification_config/authentication:scheme"
-      ]
-    },
     "specialisms/creative-template/index.yaml#build/build_multi_format": {
       "schema": "media-buy/build-creative-request.json",
       "errors": [
@@ -240,14 +232,6 @@
         "required@/events/0:event_time",
         "required@/events/1:event_time",
         "required@/events/2:event_time"
-      ]
-    },
-    "specialisms/sales-guaranteed/index.yaml#create_buy_submitted/create_media_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "required@/push_notification_config/authentication:schemes",
-        "required@/push_notification_config/authentication:credentials",
-        "additionalProperties@/push_notification_config/authentication:scheme"
       ]
     },
     "specialisms/sales-non-guaranteed/index.yaml#adjust_bids/update_media_buy": {

--- a/tests/storyboard-sample-request-schema-allowlist.json
+++ b/tests/storyboard-sample-request-schema-allowlist.json
@@ -38,14 +38,6 @@
         "required@/creative_manifest:assets"
       ]
     },
-    "protocols/media-buy/index.yaml#create_buy/create_media_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "required@/push_notification_config/authentication:schemes",
-        "required@/push_notification_config/authentication:credentials",
-        "additionalProperties@/push_notification_config/authentication:scheme"
-      ]
-    },
     "protocols/media-buy/index.yaml#creative_sync/sync_creatives": {
       "schema": "creative/sync-creatives-request.json",
       "errors": [


### PR DESCRIPTION
## Summary
- Fix `push_notification_config.authentication` shape in three storyboards (one base + two specialisms) to use `schemes` (array) + `credentials` per `PushNotificationConfigSchema`. The fixtures had the deprecated singular `scheme` field, which `@adcp/client` 5.9.0+ rejects at client-side zod validation.
  - `static/compliance/source/protocols/media-buy/index.yaml` (base `media_buy_seller`)
  - `static/compliance/source/specialisms/sales-guaranteed/index.yaml`
  - `static/compliance/source/specialisms/creative-generative/generative-seller.yaml`
- Drop the three grandfathered entries from `tests/storyboard-sample-request-schema-allowlist.json` now that the drift is fixed (surfaces via the lint added in #2768).
- Use storyboard-scoped placeholder credentials (per the `sales-broadcast-tv` pattern) instead of a generic string.

`sales-broadcast-tv/index.yaml` was already correct and served as the reference shape.

Closes #2770.

## Follow-ups (out of scope)
- Storyboards currently teach the deprecated legacy HMAC path; baseline should be the RFC 9421 profile (schema comment: `authentication` is a "switch, not a fallback"). Worth a narrative pass or adding a no-`authentication` example variant.
- No runtime test exercises storyboard `sample_request` payloads through `@adcp/client` zod schemas — only static AJV lint. Closing that gap would catch AJV↔zod drift.
- Other allowlist entries look like analogous field-name drift (e.g. `additionalProperties@/:account` across five fixtures); triage suggested.

## Test plan
- [x] `npm run test:storyboard-sample-request-schema` passes (previously failed on stale allowlist entries)
- [x] `npm run test:unit` + `npm run typecheck` (precommit) green on both commits
- [x] CI green on first commit (build, changeset, CodeQL, schema validation, storyboards legacy+framework, semgrep, GitGuardian)
- [ ] Downstream compliance audit re-run against `media_buy_seller`, `sales_guaranteed`, and `creative_generative/seller` with `@adcp/client` 5.9.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)