### PR TITLE
ci: path-filter broken-links, trim codeql + changeset-check

### DIFF
--- a/.changeset/ci-quick-wins.md
+++ b/.changeset/ci-quick-wins.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci: path-filter broken-links, drop codeql single-language matrix, skip `npm ci` in changeset-check
+
+- `broken-links.yml` now only runs when docs, README, addie rules, or the owned-links script actually change. Previously it ran on every PR (including schema- and training-agent-only PRs), pulling in a full workspace install plus Mintlify + Puppeteer.
+- `codeql.yml` drops a single-entry `matrix:` that added noise without parallelism.
+- `changeset-check.yml` stops running a full `npm ci` just to invoke one CLI; it now uses `npx --yes @changesets/cli@^2.31.0` so the check starts in seconds instead of ~1 min.

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -3,8 +3,30 @@ name: Check for Broken Links
 on:
   push:
     branches: [ main, develop, '2.6.x' ]
+    paths:
+      - 'docs/**'
+      - 'dist/docs/**'
+      - 'mintlify-docs/**'
+      - 'mint.json'
+      - 'README.md'
+      - 'server/src/addie/rules/**'
+      - 'server/src/addie/**/*.ts'
+      - 'scripts/check-owned-links.js'
+      - '.markdown-link-check.json'
+      - '.github/workflows/broken-links.yml'
   pull_request:
     branches: [ main, develop, '2.6.x' ]
+    paths:
+      - 'docs/**'
+      - 'dist/docs/**'
+      - 'mintlify-docs/**'
+      - 'mint.json'
+      - 'README.md'
+      - 'server/src/addie/rules/**'
+      - 'server/src/addie/**/*.ts'
+      - 'scripts/check-owned-links.js'
+      - '.markdown-link-check.json'
+      - '.github/workflows/broken-links.yml'
   workflow_run:
     workflows: ["Sync Versioned Docs"]
     types:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -19,12 +19,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
 
       - name: Check for changeset
-        run: npx changeset status --since=origin/main
+        run: npx --yes @changesets/cli@^2.31.0 status --since=origin/main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,16 +16,13 @@ jobs:
       security-events: write
       actions: read
       contents: read
-    strategy:
-      matrix:
-        language: [javascript-typescript]
     steps:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
+          languages: javascript-typescript
           build-mode: none
           config-file: .github/codeql-config.yml
       - uses: github/codeql-action/analyze@v4
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:javascript-typescript


### PR DESCRIPTION
## Summary
Three quick wins from a CI audit — no coverage change, just less redundant work per PR.

- **`broken-links.yml`**: add path filters so it no longer runs on schema-only, training-agent, or other PRs that can't affect docs. Previously ran on every PR, pulling in a full `npm ci` + Mintlify + Puppeteer. Filters mirror what `scripts/check-owned-links.js` actually scans (`docs/`, `dist/docs/`, `README.md`, `server/src/addie/rules/`, `server/src/addie/**/*.ts`) plus the script + workflow itself.
- **`codeql.yml`**: drop a single-entry `matrix: language: [javascript-typescript]` — noise without parallelism.
- **`changeset-check.yml`**: drop `npm ci` (was installing the full workspace — puppeteer, sharp, `@adcp/client`, the lot — just to invoke one CLI). Now uses `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`. Pinned to the version in `package.json`.

Expected PR-time wins: broken-links skipped on most non-docs PRs; changeset-check starts in seconds instead of ~1 min.

There's more to consolidate (7 workflows currently run `npm ci` on every PR — build-check + schema-validation could share an install, migration-smoke-test shouldn't run the full protocol build just to build `migrate.js`, etc.) — leaving those for a follow-up.

## Test plan
- [ ] This PR itself should skip `broken-links` (no files in the filtered paths are touched)
- [ ] `changeset-check` runs and passes without `npm ci`
- [ ] `codeql` still uploads results to the security tab
- [ ] A docs-only PR opened on top of this branch should still trigger `broken-links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)