### PR TITLE
fix(member-agents): surface OAuth challenge instead of raw SDK error

### DIFF
--- a/.changeset/fix-member-agents-oauth-challenge.md
+++ b/.changeset/fix-member-agents-oauth-challenge.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(member-agents): surface OAuth challenge instead of raw SDK error
+
+When a member-agent requires OAuth authorization, the storyboard runner on
+`/dashboard/agents` rendered the SDK's `NeedsAuthorizationError` message
+verbatim ("Provide an OAuthFlowHandler or run an interactive flow to complete
+authorization.") with no way to act on it. The `/applicable-storyboards`,
+`/storyboard/:id/step/:stepId`, `/storyboard/:id/run`, and
+`/storyboard/:id/compare` endpoints now detect the SDK's OAuth-required
+signal (either `NeedsAuthorizationError` message text or
+`ComplianceResult.overall_status === 'auth_required'`), lazily ensure an
+`agent_context` exists, and return `{ needs_oauth: true, agent_context_id }`.
+The dashboard renders a "Connect via OAuth" panel whose authorize button
+reuses the existing `/api/oauth/agent/start` flow.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1163,6 +1163,49 @@
       }
     });
 
+    // OAuth "Authorize with agent" button surfaced inline in storyboard panels
+    // when the server returns needs_oauth. Mirrors the connect-form flow:
+    // ensure agent_context, then redirect to /api/oauth/agent/start.
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('.agent-oauth-challenge-btn');
+      if (!btn) return;
+
+      const agentUrl = btn.dataset.agentUrl;
+      let agentContextId = btn.dataset.agentContextId;
+
+      btn.disabled = true;
+      const originalLabel = btn.textContent;
+      btn.textContent = 'Starting OAuth...';
+
+      try {
+        if (!agentContextId) {
+          const connectRes = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/connect', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({}),
+          });
+          if (!connectRes.ok) {
+            const data = await connectRes.json().catch(() => ({}));
+            throw new Error(data.error || 'Failed to create agent context');
+          }
+          const connectData = await connectRes.json();
+          agentContextId = connectData.agent_context_id;
+          if (!agentContextId) throw new Error('Failed to create agent context');
+        }
+
+        const returnTo = window.location.pathname + window.location.search + window.location.hash;
+        window.location.href = '/api/oauth/agent/start'
+          + '?agent_context_id=' + encodeURIComponent(agentContextId)
+          + '&return_to=' + encodeURIComponent(returnTo);
+      } catch (err) {
+        btn.disabled = false;
+        btn.textContent = originalLabel;
+        console.error('OAuth challenge failed:', err);
+        alert(err.message || 'Failed to start OAuth flow');
+      }
+    });
+
     // Monitoring pause toggle
     document.addEventListener('change', async function(e) {
       const toggle = e.target.closest('.monitoring-pause-toggle');
@@ -1422,6 +1465,22 @@
         }
       }
 
+      // Shared: render a "Connect via OAuth" prompt when an agent 401s with
+      // a WWW-Authenticate: Bearer challenge and no refreshable token is stored.
+      function renderOAuthChallenge(agentUrl, agentContextId, reason) {
+        const safeReason = reason
+          ? '<div style="margin-bottom:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary);">' + escapeHtml(String(reason)) + '</div>'
+          : '<div style="margin-bottom:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary);">This agent requires OAuth authorization before storyboards can run.</div>';
+        const ctxAttr = agentContextId ? ' data-agent-context-id="' + escapeHtml(agentContextId) + '"' : '';
+        return (
+          '<div style="padding:var(--space-3);background:var(--color-warning-50);border:1px solid var(--color-warning-200);border-radius:var(--radius-md);">'
+          + '<div style="font-weight:var(--font-semibold);margin-bottom:var(--space-2);">Connect via OAuth</div>'
+          + safeReason
+          + '<button class="agent-oauth-challenge-btn" data-agent-url="' + escapeHtml(agentUrl) + '"' + ctxAttr + '>Authorize with agent</button>'
+          + '</div>'
+        );
+      }
+
       // Shared: render the storyboard map into a panel
       async function renderStoryboardPicker(panel, agentUrl, cardId, agentTracks) {
         panel.style.display = 'block';
@@ -1500,6 +1559,11 @@
 
           // Non-2xx — surface specific reason before falling back
           const errBody = await res.json().catch(() => ({}));
+
+          if (errBody.needs_oauth) {
+            panel.innerHTML = renderOAuthChallenge(agentUrl, errBody.agent_context_id, errBody.error);
+            return;
+          }
 
           if (errBody.needs_auth) {
             panel.innerHTML = '<div style="padding:var(--space-4) 0;color:var(--color-text-secondary);font-size:var(--text-sm);">Your agent requires authentication to discover tools. Authorize or save an auth token using the connect form above, then try again.</div>';
@@ -1709,6 +1773,11 @@
             return;
           }
 
+          if (result.needs_oauth) {
+            panel.innerHTML = renderOAuthChallenge(agentUrl, result.agent_context_id, result.error);
+            return;
+          }
+
           // Render result and next step
           const resultEl = panel.querySelector('.step-runner-result');
           const cls = result.skipped ? 'skip' : result.passed ? 'pass' : 'fail';
@@ -1798,6 +1867,11 @@
 
           const data = await res.json();
           progressEl.remove();
+
+          if (res.status === 422 && data.needs_oauth) {
+            panel.innerHTML = renderOAuthChallenge(agentUrl, data.agent_context_id, data.error);
+            return;
+          }
 
           let html = '<button class="storyboard-back-btn" data-agent-url="' + escapeHtml(agentUrl) + '" data-card-id="' + escapeHtml(cardId) + '">&larr; Back to storyboards</button>';
           html += '<div style="margin-bottom:var(--space-3);"><strong>' + escapeHtml(data.storyboard.title) + '</strong> — Results</div>';
@@ -1973,9 +2047,15 @@
 
     function escapeHtml(str) {
       if (!str) return '';
-      const d = document.createElement('div');
-      d.textContent = str;
-      return d.innerHTML;
+      // textContent → innerHTML escapes &, <, > but leaves " and ' intact,
+      // which is unsafe in double-quoted attribute contexts — this file uses
+      // escapeHtml both for text and for data-* attributes.
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
     }
   </script>
 </body>

--- a/server/src/routes/helpers/oauth-error-detection.ts
+++ b/server/src/routes/helpers/oauth-error-detection.ts
@@ -1,0 +1,19 @@
+/**
+ * Detect when a storyboard step's error string signals that the user must
+ * (re)authorize via OAuth. The @adcp/client SDK catches its own
+ * `NeedsAuthorizationError` inside `runStep` and preserves only `err.message`
+ * on the step result, so by the time runStoryboardStep / comply return we
+ * only have a string. Two shapes map to "user must (re)authorize":
+ *
+ * - Transport 401 with WWW-Authenticate: Bearer → SDK's
+ *   `NeedsAuthorizationError` message begins with
+ *   "Agent <url> requires OAuth authorization."
+ * - Agent returns an AdCP `AUTH_REQUIRED` error payload (200 body) when it
+ *   accepted the token at the transport layer but rejected it at the
+ *   application layer — common when a saved token has gone stale.
+ */
+export function isOAuthRequiredErrorMessage(error: string | null | undefined): boolean {
+  if (!error) return false;
+  return /requires OAuth authorization/i.test(error)
+    || /(^|[^A-Z0-9_])AUTH_REQUIRED($|[^A-Z0-9_])/.test(error);
+}

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -74,6 +74,7 @@ import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
+import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
@@ -3584,6 +3585,28 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   }
 
+  /**
+   * Ensure an agent_context exists so the UI can hand the user a working
+   * `/api/oauth/agent/start?agent_context_id=...` link even if they never
+   * opened the connect form. Idempotent.
+   */
+  async function ensureAgentContextId(orgId: string, agentUrl: string, userId: string): Promise<string | null> {
+    try {
+      let context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+      if (!context) {
+        context = await agentContextDb.create({
+          organization_id: orgId,
+          agent_url: agentUrl,
+          created_by: userId,
+        });
+      }
+      return context.id;
+    } catch (err) {
+      logger.warn({ err, orgId, agentUrl }, "Failed to ensure agent context for OAuth challenge");
+      return null;
+    }
+  }
+
   router.put("/registry/agents/:encodedUrl/lifecycle", ...complianceWriteMiddleware, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
@@ -3932,6 +3955,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       try {
         const caps = await testCapabilityDiscovery(agentUrl, { ...(auth && { auth }) });
         profile = caps.profile;
+
+        // The SDK swallows the agent's 401 into steps[0].error; surface it as
+        // a structured challenge so the UI can route the user to the OAuth
+        // flow instead of rendering a storyboard list they can't run.
+        const probeStep = caps.steps?.[0];
+        if (probeStep && !probeStep.passed && isOAuthRequiredErrorMessage(probeStep.error)) {
+          const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
+          return res.status(422).json({
+            error: "This agent requires OAuth authorization. Connect via OAuth to run storyboards.",
+            needs_oauth: true,
+            ...(agentContextId && { agent_context_id: agentContextId }),
+          });
+        }
       } catch (connectErr) {
         if (!auth) {
           return res.status(422).json({
@@ -4080,6 +4116,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           ...(context && { context }),
         });
 
+        if (!result.passed && isOAuthRequiredErrorMessage(result.error)) {
+          const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
+          return res.json({
+            ...result,
+            needs_oauth: true,
+            ...(agentContextId && { agent_context_id: agentContextId }),
+          });
+        }
+
         res.json(result);
       } catch (error) {
         logger.error({ err: error, path: req.path }, "Failed to run storyboard step");
@@ -4143,6 +4188,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           storyboards: [req.params.storyboardId],
           ...(auth && { auth }),
         });
+
+        if (complyResult.overall_status === 'auth_required') {
+          const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
+          return res.status(422).json({
+            error: "Agent requires OAuth authorization. Connect via OAuth to run this storyboard.",
+            needs_oauth: true,
+            ...(agentContextId && { agent_context_id: agentContextId }),
+          });
+        }
 
         // Record the run (pass storyboard ID for per-storyboard status materialization)
         const metadata = await complianceDb.getRegistryMetadata(agentUrl);
@@ -4241,6 +4295,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
             auth: { type: "bearer", token: PUBLIC_TEST_AGENT.token },
           }),
         ]);
+
+        if (userResult.overall_status === 'auth_required') {
+          const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
+          return res.status(422).json({
+            error: "Agent requires OAuth authorization. Connect via OAuth to compare against the reference agent.",
+            needs_oauth: true,
+            ...(agentContextId && { agent_context_id: agentContextId }),
+          });
+        }
 
         // Annotate storyboard steps with both results
         const comparisonPhases = storyboard.phases.map((phase) => ({

--- a/server/tests/unit/oauth-error-detection.test.ts
+++ b/server/tests/unit/oauth-error-detection.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { isOAuthRequiredErrorMessage } from '../../src/routes/helpers/oauth-error-detection.js';
+
+describe('isOAuthRequiredErrorMessage', () => {
+  it('matches the SDK NeedsAuthorizationError message', () => {
+    const msg = 'Agent https://agents.scope3.com/spotify requires OAuth authorization. '
+      + 'Authorization server: https://agents.scope3.com/spotify. '
+      + 'Server said: Missing Authorization header. '
+      + 'Provide an OAuthFlowHandler or run an interactive flow to complete authorization.';
+    expect(isOAuthRequiredErrorMessage(msg)).toBe(true);
+  });
+
+  it('matches an AdCP AUTH_REQUIRED protocol error payload', () => {
+    expect(isOAuthRequiredErrorMessage('AUTH_REQUIRED: Unauthorized')).toBe(true);
+    expect(isOAuthRequiredErrorMessage('task failed with AUTH_REQUIRED')).toBe(true);
+    // Embedded in a sentence with trailing punctuation
+    expect(isOAuthRequiredErrorMessage('Request failed: AUTH_REQUIRED.')).toBe(true);
+    expect(isOAuthRequiredErrorMessage('AUTH_REQUIRED, please reauthorize')).toBe(true);
+  });
+
+  it('does not match a transport-level connection failure', () => {
+    expect(isOAuthRequiredErrorMessage(
+      'Failed to discover MCP endpoint. Tried: https://example.com None responded to MCP protocol.',
+    )).toBe(false);
+  });
+
+  it('does not match a generic 5xx / timeout error', () => {
+    expect(isOAuthRequiredErrorMessage('Request timed out after 90000ms')).toBe(false);
+    expect(isOAuthRequiredErrorMessage('Agent returned 503 Service Unavailable')).toBe(false);
+  });
+
+  it('does not match a schema validation failure that happens to mention authorization', () => {
+    // Looks similar but isn't a NeedsAuthorization signal — the SDK never
+    // emits this phrase in other error paths.
+    expect(isOAuthRequiredErrorMessage(
+      'Schema validation failed: field `authorization` must be a string',
+    )).toBe(false);
+  });
+
+  it('does not false-positive on field names or identifiers containing the substring', () => {
+    expect(isOAuthRequiredErrorMessage('response.context.AUTH_REQUIREDMENTS invalid')).toBe(false);
+    expect(isOAuthRequiredErrorMessage('MY_AUTH_REQUIRED_OTHER error')).toBe(false);
+  });
+
+  it('handles null and undefined without throwing', () => {
+    expect(isOAuthRequiredErrorMessage(null)).toBe(false);
+    expect(isOAuthRequiredErrorMessage(undefined)).toBe(false);
+    expect(isOAuthRequiredErrorMessage('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Detect OAuth-required failures (both SDK `NeedsAuthorizationError` text and AdCP `AUTH_REQUIRED` protocol error) on `/applicable-storyboards`, `/storyboard/:id/step/:stepId`, `/storyboard/:id/run`, `/storyboard/:id/compare` and return `{ needs_oauth: true, agent_context_id }` instead of the raw string.
- `/dashboard/agents` now renders a Connect via OAuth panel whose button reuses the existing `/api/oauth/agent/start` flow, so users never see "Provide an OAuthFlowHandler or run an interactive flow to complete authorization." again.
- Tightens `escapeHtml` in `dashboard-agents.html` to escape `"` and `'` — the file used `escapeHtml` for both text and attribute contexts, and the old `textContent→innerHTML` trick only covered text.

## Reproductions (both verified in Docker)

1. **No saved token.** Agent 401s with `WWW-Authenticate: Bearer` → SDK error "Agent ... requires OAuth authorization ...". Step endpoint now returns `needs_oauth: true`; applicable-storyboards returns 422 with the same payload.
2. **Stale saved token.** Agent accepts the bearer at transport but returns AdCP `AUTH_REQUIRED: Unauthorized` at the app layer. Same UX.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:server-unit` (1742 tests)
- [x] `npm run test:unit` (631 tests)
- [x] `npm run build`
- [x] New unit tests for `isOAuthRequiredErrorMessage` (7 cases covering both signal shapes, negative cases, null/undefined)
- [x] Manual UI verification via Playwright in docker-compose stack — storyboard panel renders "Connect via OAuth" with correct `data-agent-context-id`
- [x] Reviewed by `code-reviewer` and `security-reviewer` subagents

🤖 Generated with [Claude Code](https://claude.com/claude-code)