### PR TITLE
fix(storyboards): format_id / signal_ids entity-id drift cluster (adcp#2763)

### DIFF
--- a/.changeset/fix-format-id-cluster.md
+++ b/.changeset/fix-format-id-cluster.md
@@ -1,0 +1,12 @@
+---
+---
+
+Resolve the `format_id` / `signal_ids` entity-id drift cluster (adcp#2763 cluster follow-up to #2768).
+
+Two-part fix:
+
+1. **Lint improvement.** `placeholderFor` now synthesizes shape-valid object placeholders for substitutions that land at object-typed schema locations (including oneOf/anyOf discriminated unions). Previously, a substitution string like `"$context.first_signal_id"` landing at a `oneOf` of object variants produced `{}`, which ajv rejected against every `required`. The runtime resolves those substitutions to concrete objects captured from prior steps, so the lint should treat them as shape-valid. Five false positives across `format_ids`, `format_id`, and `signal_ids` now pass automatically.
+
+2. **Fixture fix.** `specialisms/creative-template/index.yaml#build/build_multi_format` was missing the required `format_id` on `creative_manifest`. Added `{ agent_url, id }` matching the canonical `core/format-id.json` shape.
+
+Allowlist shrinks 35 → 29.

--- a/scripts/lint-storyboard-sample-request-schema.cjs
+++ b/scripts/lint-storyboard-sample-request-schema.cjs
@@ -156,8 +156,16 @@ const STRING_PLACEHOLDER = '00000000-0000-4000-8000-000000000000';
  * Build a schema-typed placeholder for a substitution string. The placeholder
  * must satisfy the schema's type constraints without reproducing the business
  * semantics of the resolved value — ajv only checks shape, not meaning.
+ *
+ * For object-typed locations (including oneOf/anyOf variants whose first
+ * branch is an object), recursively synthesize a shape-valid placeholder by
+ * populating every `required` field with a type-valid placeholder. This
+ * matches the runtime behavior of substitutions like `$context.first_signal_id`
+ * that resolve to an object captured from a prior step's response.
+ *
+ * The `depth` guard prevents infinite recursion on self-referential schemas.
  */
-function placeholderFor(schema) {
+function placeholderFor(schema, depth = 0) {
   const resolved = resolveSchemaNode(schema);
   if (!resolved) return STRING_PLACEHOLDER;
   const types = Array.isArray(resolved.type) ? resolved.type : [resolved.type];
@@ -169,15 +177,46 @@ function placeholderFor(schema) {
     if (resolved.format === 'email') return 'placeholder@example.com';
     if (Array.isArray(resolved.enum) && resolved.enum.length > 0) return resolved.enum[0];
     if (typeof resolved.const !== 'undefined') return resolved.const;
+    // Object variant nested inside a oneOf/anyOf at a location where the
+    // author's substitution will resolve to that shape at runtime. Synthesize
+    // the concrete shape instead of returning a string that fails required.
+    if (!resolved.type) {
+      const objectBranch = firstObjectBranch(resolved);
+      if (objectBranch) return synthesizeObject(objectBranch, depth);
+    }
     return STRING_PLACEHOLDER;
   }
   if (types.includes('integer')) return resolved.minimum ?? 1;
   if (types.includes('number')) return resolved.minimum ?? 0;
   if (types.includes('boolean')) return true;
   if (types.includes('array')) return [];
-  if (types.includes('object')) return {};
+  if (types.includes('object')) return synthesizeObject(resolved, depth);
   if (types.includes('null')) return null;
   return STRING_PLACEHOLDER;
+}
+
+function firstObjectBranch(node) {
+  for (const key of ['oneOf', 'anyOf']) {
+    if (!Array.isArray(node[key])) continue;
+    for (const branch of node[key]) {
+      const r = resolveSchemaNode(branch);
+      if (!r) continue;
+      const t = Array.isArray(r.type) ? r.type : [r.type];
+      if (t.includes('object') || r.properties || r.required) return r;
+    }
+  }
+  return null;
+}
+
+function synthesizeObject(schema, depth) {
+  if (depth > 4) return {};
+  const required = Array.isArray(schema?.required) ? schema.required : [];
+  const properties = schema?.properties || {};
+  const out = {};
+  for (const field of required) {
+    out[field] = placeholderFor(properties[field] || {}, depth + 1);
+  }
+  return out;
 }
 
 /**

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -364,6 +364,9 @@ phases:
 
         sample_request:
           creative_manifest:
+            format_id:
+              agent_url: "https://your-agent.example.com"
+              id: "source_master"
             assets:
               image:
                 asset_type: "image"

--- a/tests/lint-storyboard-sample-request-schema.test.cjs
+++ b/tests/lint-storyboard-sample-request-schema.test.cjs
@@ -175,3 +175,56 @@ test('normalizeSubstitutions replaces every live substitution dialect', () => {
   // Non-substitution literals pass through
   assert.equal(normalizeSubstitutions('plain value', stringSchema), 'plain value');
 });
+
+// Object-typed substitution synthesis — the lint change landed in this PR.
+// A substitution that lands at an object location (plain or inside a
+// discriminated oneOf) must produce a shape-valid placeholder or ajv will
+// reject every branch. Regression guard against refactors of `placeholderFor`
+// / `synthesizeObject` / `firstObjectBranch`.
+test('normalizeSubstitutions synthesizes shape-valid placeholders at object-typed locations', () => {
+  const objectSchema = {
+    type: 'object',
+    required: ['agent_url', 'id'],
+    properties: {
+      agent_url: { type: 'string', format: 'uri' },
+      id: { type: 'string' },
+    },
+  };
+  const synthesized = normalizeSubstitutions('$context.product_format_id', objectSchema);
+  assert.equal(typeof synthesized, 'object');
+  assert.ok(synthesized !== null && !Array.isArray(synthesized));
+  assert.ok('agent_url' in synthesized, 'required agent_url is populated');
+  assert.ok('id' in synthesized, 'required id is populated');
+  assert.equal(typeof synthesized.agent_url, 'string');
+  assert.equal(typeof synthesized.id, 'string');
+
+  // Discriminated oneOf: pick the first object branch and synthesize its required set.
+  const oneOfSchema = {
+    oneOf: [
+      {
+        type: 'object',
+        required: ['source', 'data_provider_domain', 'id'],
+        properties: {
+          source: { type: 'string', const: 'catalog' },
+          data_provider_domain: { type: 'string' },
+          id: { type: 'string' },
+        },
+      },
+      {
+        type: 'object',
+        required: ['source', 'agent_url', 'id'],
+        properties: {
+          source: { type: 'string', const: 'agent' },
+          agent_url: { type: 'string', format: 'uri' },
+          id: { type: 'string' },
+        },
+      },
+    ],
+  };
+  const oneOfSynth = normalizeSubstitutions('$context.first_signal_id', oneOfSchema);
+  assert.equal(typeof oneOfSynth, 'object');
+  // First branch picked; const on discriminator is honored.
+  assert.equal(oneOfSynth.source, 'catalog');
+  assert.ok('data_provider_domain' in oneOfSynth);
+  assert.ok('id' in oneOfSynth);
+});

--- a/tests/storyboard-sample-request-schema-allowlist.json
+++ b/tests/storyboard-sample-request-schema-allowlist.json
@@ -38,31 +38,10 @@
         "required@/creative_manifest:assets"
       ]
     },
-    "protocols/media-buy/index.yaml#creative_sync/sync_creatives": {
-      "schema": "creative/sync-creatives-request.json",
-      "errors": [
-        "required@/creatives/0/format_id:agent_url",
-        "required@/creatives/0/format_id:id"
-      ]
-    },
-    "protocols/media-buy/index.yaml#product_discovery/list_formats_integrity": {
-      "schema": "creative/list-creative-formats-request.json",
-      "errors": [
-        "required@/format_ids/0:agent_url",
-        "required@/format_ids/0:id"
-      ]
-    },
     "protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml#reuse_creative_on_new_buy/reassign_creative": {
       "schema": "creative/sync-creatives-request.json",
       "errors": [
         "required@/:creatives"
-      ]
-    },
-    "protocols/media-buy/scenarios/pending_creatives_to_start.yaml#supply_creatives/sync_creative": {
-      "schema": "creative/sync-creatives-request.json",
-      "errors": [
-        "required@/creatives/0/format_id:agent_url",
-        "required@/creatives/0/format_id:id"
       ]
     },
     "protocols/media-buy/scenarios/proposal_finalize.yaml#accept_proposal/create_media_buy": {
@@ -155,12 +134,6 @@
       "errors": [
         "required@/:query",
         "required@/:uses"
-      ]
-    },
-    "specialisms/creative-template/index.yaml#build/build_multi_format": {
-      "schema": "media-buy/build-creative-request.json",
-      "errors": [
-        "required@/creative_manifest:format_id"
       ]
     },
     "specialisms/governance-delivery-monitor/index.yaml#drift_recheck/check_governance_drift": {
@@ -294,30 +267,6 @@
       "errors": [
         "required@/:event_source_id",
         "required@/events/0:event_time"
-      ]
-    },
-    "specialisms/signal-marketplace/index.yaml#discovery/search_by_ids": {
-      "schema": "signals/get-signals-request.json",
-      "errors": [
-        "required@/signal_ids/0:source",
-        "required@/signal_ids/0:data_provider_domain",
-        "required@/signal_ids/0:id",
-        "required@/signal_ids/0:source",
-        "required@/signal_ids/0:agent_url",
-        "required@/signal_ids/0:id",
-        "oneOf@/signal_ids/0"
-      ]
-    },
-    "specialisms/signal-marketplace/index.yaml#verification/verify_provenance_metadata": {
-      "schema": "signals/get-signals-request.json",
-      "errors": [
-        "required@/signal_ids/0:source",
-        "required@/signal_ids/0:data_provider_domain",
-        "required@/signal_ids/0:id",
-        "required@/signal_ids/0:source",
-        "required@/signal_ids/0:agent_url",
-        "required@/signal_ids/0:id",
-        "oneOf@/signal_ids/0"
       ]
     },
     "universal/deterministic-testing.yaml#deterministic_account/sync_accounts_for_state": {


### PR DESCRIPTION
## Summary

Second cluster follow-up to the schema lint from #2768. Two-part fix for the entity-id-as-object cluster.

### Lint improvement

`placeholderFor` now recursively synthesizes shape-valid object placeholders for substitutions that land at object-typed schema locations — including \`oneOf\`/\`anyOf\` discriminated unions. Before this, a substitution like \`\$context.first_signal_id\` landing at a oneOf of object variants produced \`{}\`, and ajv rejected it against every branch's \`required\`. At runtime the substitution resolves to a concrete object captured from a prior step's response, so the lint should treat it as shape-valid. This resolves 5 false positives across \`format_ids\`, \`format_id\`, and \`signal_ids\` automatically:

- \`protocols/media-buy/index.yaml#creative_sync/sync_creatives\`
- \`protocols/media-buy/index.yaml#product_discovery/list_formats_integrity\`
- \`protocols/media-buy/scenarios/pending_creatives_to_start.yaml#supply_creatives/sync_creative\`
- \`specialisms/signal-marketplace/index.yaml#discovery/search_by_ids\`
- \`specialisms/signal-marketplace/index.yaml#verification/verify_provenance_metadata\`

### Fixture fix

\`specialisms/creative-template/index.yaml#build/build_multi_format\` was missing the required \`format_id\` on \`creative_manifest\`. The schema at \`core/creative-manifest.json\` lists \`format_id\` and \`assets\` as required. Added \`{ agent_url, id }\` matching the canonical \`core/format-id.json\` shape.

## Ratchet

Allowlist shrinks 35 → 29. Six cluster entries drop deterministically.

## Test plan

- [x] `npm run test:storyboard-sample-request-schema` — passes (29 grandfathered, 0 new drift, 0 stale)
- [x] `node --test tests/lint-storyboard-sample-request-schema.test.cjs` — 7/7 pass (reducer + fingerprint + substitution + negative-step unit tests)
- [x] All 6 other storyboard lints pass
- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)