### PR TITLE
fix(schemas)!: rename SI context→intent, adopt core context echo (#2774)

### DIFF
--- a/.changeset/si-rename-context-to-intent.md
+++ b/.changeset/si-rename-context-to-intent.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+**Breaking (SI, experimental):** On `si_get_offering` and `si_initiate_session` requests, the natural-language user-intent field is renamed from `context` to `intent`. `context` on these requests now refers to the universal opaque-echo object (`/schemas/core/context.json`), matching every other AdCP subprotocol. `si_terminate_session` already conformed and is unchanged. Treated as `minor` under the experimental-surface carve-out (`x-status: experimental` + 6-week notice policy from `docs/reference/experimental-status`). SI consumers must rename the field and stop relying on `context` being typed as a string. Closes #2774.

--- a/docs/sponsored-intelligence/implementing-si-agents.mdx
+++ b/docs/sponsored-intelligence/implementing-si-agents.mdx
@@ -71,12 +71,12 @@ server.tool(
   "si_initiate_session",
   "Start a conversational session with this brand agent",
   {
-    context: { type: "string", description: "Natural language user intent" },
+    intent: { type: "string", description: "Natural language user intent" },
     identity: { type: "object", description: "User identity with consent" },
     media_buy_id: { type: "string", description: "AdCP media buy ID (optional)" },
     offering_id: { type: "string", description: "Brand-specific offering reference (optional)" },
   },
-  async ({ context, identity, media_buy_id, offering_id }) => {
+  async ({ intent, identity, media_buy_id, offering_id }) => {
     // Your implementation here
     return {
       content: [{
@@ -96,17 +96,17 @@ server.tool(
 
 ### 1. The Conversation Handoff
 
-The `context` field in `si_initiate_session` is the host's handoff message - what the host AI tells your brand agent about the user's intent. This is visible to the user as part of the conversation flow.
+The `intent` field in `si_initiate_session` is the host's handoff message — what the host AI tells your brand agent about what the user is trying to do. This is visible to the user as part of the conversation flow.
 
 For example, when a user says "I need to fly to Boston next week" in ChatGPT, and the host decides to connect them to Delta's SI agent, the handoff might look like:
 
 > "I'm connecting you with Delta to help with your Boston flight. They can check availability and offerings for you."
 
-Your brand agent receives the context and should respond naturally - as if continuing the conversation:
+Your brand agent receives the intent and should respond naturally — as if continuing the conversation:
 
 ```typescript
 // Your agent is an AI that responds conversationally
-// The context tells you what the user needs - just help them
+// The intent tells you what the user needs — just help them
 
 // Good response:
 "Hi! I'd be happy to help you find a flight to Boston.

--- a/docs/sponsored-intelligence/networks.mdx
+++ b/docs/sponsored-intelligence/networks.mdx
@@ -184,7 +184,7 @@ The key fields at each leg:
 |---|---|---|
 | `media_buy_id` | Network's media buy ID | May differ or be omitted |
 | `offering_id` | Not set (platform doesn't know) | Brand-specific offering |
-| `context` | User intent from the conversation | Forwarded as-is |
+| `intent` | User intent from the conversation | Forwarded as-is |
 | `identity` | User identity (if consented) | Forwarded as-is |
 
 The network handles attribution correlation across the two legs. It knows which platform triggered the session (`placement`), which media buy funded it (`media_buy_id`), and which brand responded (`offering_id`). This lets the network provide unified delivery reporting to buyers via `get_media_buy_delivery` while each brand agent only sees its own sessions.

--- a/docs/sponsored-intelligence/si-chat-protocol.mdx
+++ b/docs/sponsored-intelligence/si-chat-protocol.mdx
@@ -361,11 +361,11 @@ SI sessions have explicit lifecycle management.
 
 ### Initiate Session
 
-Host → Brand, including context, capabilities, identity (if consented), and any active offer from the media buy:
+Host → Brand, including the user intent, capabilities, identity (if consented), and any active offer from the media buy:
 
 ```json
 {
-  "context": "User wants to fly to Boston next Tuesday morning on flight 632 at 6 AM.",
+  "intent": "User wants to fly to Boston next Tuesday morning on flight 632 at 6 AM.",
   "identity": {
     "consent_granted": true,
     "user": {
@@ -381,7 +381,7 @@ Host → Brand, including context, capabilities, identity (if consented), and an
 }
 ```
 
-The `context` is a conversation handoff - the host tells the brand agent what the user needs, and the brand agent responds naturally. The `offering_id` references a campaign promotion (like free upgrades on eligible flights) that the brand knows how to apply.
+The `intent` is the conversation handoff — the host tells the brand agent what the user needs in natural language, and the brand agent responds naturally. The `offering_id` references a campaign promotion (like free upgrades on eligible flights) that the brand knows how to apply.
 
 **Frequent flyer and loyalty data**: The brand looks this up from the user's email - hosts don't store loyalty numbers. Delta recognizes `jane@example.com` and retrieves her SkyMiles status automatically.
 

--- a/docs/sponsored-intelligence/specification.mdx
+++ b/docs/sponsored-intelligence/specification.mdx
@@ -86,7 +86,7 @@ If a host calls `si_get_offering`:
 
 1. The request MUST NOT include user PII
 2. The request MUST include `offering_id`
-3. The request MAY include `context` for personalized results (e.g., "mens size 14 near Cincinnati")
+3. The request MAY include `intent` for personalized results (e.g., "mens size 14 near Cincinnati")
 4. The request MAY set `include_products: true` to get matching products
 5. Brand agents MUST return an `offering_token` if available
 6. Brand agents SHOULD return a `ttl_seconds` indicating validity duration
@@ -107,7 +107,7 @@ If a host receives an `offering_token`:
 
 ### Matching Products
 
-When `include_products` is true and `context` is provided, the response MAY include matching products:
+When `include_products` is true and `intent` is provided, the response MAY include matching products:
 
 ```json
 {
@@ -197,7 +197,7 @@ The `si_initiate_session` task establishes a new SI session.
 
 Hosts MUST include:
 
-- `context` - Natural language description of user intent
+- `intent` - Natural language description of user intent — the conversation handoff from host to brand agent
 - `identity` - User identity with consent status
 
 Hosts SHOULD include:

--- a/docs/sponsored-intelligence/tasks/index.mdx
+++ b/docs/sponsored-intelligence/tasks/index.mdx
@@ -51,7 +51,7 @@ SI tasks work over both MCP and A2A protocols:
   "params": {
     "name": "si_initiate_session",
     "arguments": {
-      "context": "User wants to fly to Boston next Tuesday morning",
+      "intent": "User wants to fly to Boston next Tuesday morning",
       "identity": { /* ... */ }
     }
   }
@@ -64,7 +64,7 @@ SI tasks work over both MCP and A2A protocols:
 {
   "task": "si_initiate_session",
   "payload": {
-    "context": "User wants to fly to Boston next Tuesday morning",
+    "intent": "User wants to fly to Boston next Tuesday morning",
     "identity": { /* ... */ }
   }
 }
@@ -78,7 +78,7 @@ For anonymous browsing without personalization:
 
 ```json
 {
-  "context": "User interested in product information",
+  "intent": "User interested in product information",
   "identity": {
     "consent_granted": false,
     "anonymous_session_id": "anon_xyz789"
@@ -92,7 +92,7 @@ For personalized experiences with consented PII:
 
 ```json
 {
-  "context": "User wants to book a flight",
+  "intent": "User wants to book a flight",
   "identity": {
     "consent_granted": true,
     "consent_timestamp": "2026-01-18T10:30:00Z",
@@ -111,7 +111,7 @@ When SI is invoked as part of a media buy:
 
 ```json
 {
-  "context": "User searching for flights to Boston",
+  "intent": "User searching for flights to Boston",
   "media_buy_id": "media_buy_q1_promo",
   "placement": "chatgpt_search",
   "offering_id": "premium_upgrade_offer",

--- a/docs/sponsored-intelligence/tasks/si_get_offering.mdx
+++ b/docs/sponsored-intelligence/tasks/si_get_offering.mdx
@@ -20,7 +20,7 @@ There are two valid flows for starting an SI session:
 si_get_offering → Host shows products → User consents → si_initiate_session with offering_token
 ```
 
-Use this when you want to show the user products **before** asking for consent. The `offering_token` bridges pre-session context into the session, so references like "the second one" work.
+Use this when you want to show the user products **before** asking for consent. The `offering_token` bridges what was shown into the session, so references like "the second one" work.
 
 **Example**: Search results page shows "Nike has 3 running shoes in your size from \$89" before the user decides to engage.
 
@@ -41,21 +41,22 @@ The key difference: `si_get_offering` is for **anonymous pre-consent previews**.
 The offering lookup serves three purposes:
 
 1. **Show offering details** - Display pricing, availability, and descriptions to users before consent
-2. **Surface matching products** - When given context, return relevant products from the offering
-3. **Session continuity** - The returned token preserves what was shown, so the brand agent knows the context when the session starts
+2. **Surface matching products** - When given an `intent`, return relevant products from the offering
+3. **Session continuity** - The returned token preserves what was shown, so the brand agent knows what the user already saw when the session starts
 
 ## Request
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `offering_id` | string | Yes | Offering identifier from the catalog |
-| `context` | string | No | Natural language context for personalized results (no PII) |
+| `intent` | string | No | Natural language description of user intent for personalized results (no PII) |
 | `include_products` | boolean | No | Whether to include matching products (default: false) |
 | `product_limit` | integer | No | Max products to return (default: 5, max: 50) |
+| `context` | object | No | Opaque correlation data echoed unchanged in the response |
 
 ### Privacy
 
-This request must not include any personally identifiable information. The `context` field may include intent description but must be anonymous (e.g., "mens size 14 near Cincinnati" is OK, but email addresses are not).
+This request must not include any personally identifiable information. The `intent` field describes what the user is looking for but must be anonymous (e.g., "mens size 14 near Cincinnati" is OK, but email addresses are not).
 
 ## Response
 
@@ -66,7 +67,7 @@ This request must not include any personally identifiable information. The `cont
 | `ttl_seconds` | integer | How long this information is valid |
 | `checked_at` | string | ISO 8601 timestamp of the lookup |
 | `offering` | object | Offering details |
-| `matching_products` | array | Products matching the context (if requested) |
+| `matching_products` | array | Products matching the intent (if requested) |
 | `total_matching` | integer | Total products matching (may exceed returned count) |
 | `unavailable_reason` | string | Why offering is unavailable (if not available) |
 | `alternative_offering_ids` | array | Alternative offerings to check |
@@ -141,7 +142,7 @@ This request must not include any personally identifiable information. The `cont
 {
   "$schema": "/schemas/sponsored-intelligence/si-get-offering-request.json",
   "offering_id": "nike-summer-sale",
-  "context": "mens size 14 running shoes near Cincinnati",
+  "intent": "mens size 14 running shoes near Cincinnati",
   "include_products": true,
   "product_limit": 3
 }
@@ -213,7 +214,7 @@ Without the token, this conversation breaks:
 ```
 Host: "Nike has 3 running shoes in size 14: Pegasus 41 ($89), Air Max 90 ($129), Vomero 18 ($139)"
 User: "Tell me more about the second one"
-Host → si_initiate_session: { context: "User wants more info about the second shoe" }
+Host → si_initiate_session: { intent: "User wants more info about the second shoe" }
 Brand Agent: ??? (Which shoes were shown? In what order?)
 ```
 
@@ -221,7 +222,7 @@ With the token, the brand agent can reconstruct the full context:
 
 ```
 Host → si_initiate_session: {
-  context: "User wants more info about the second shoe",
+  intent: "User wants more info about the second shoe",
   offering_token: "offering_abc123xyz"
 }
 Brand Agent: (Looks up token → sees Pegasus, Air Max, Vomero were shown in that order)
@@ -237,7 +238,7 @@ When generating an `offering_token`, store the full query state server-side:
 const token = generateToken();
 await store.save(token, {
   offering_id: request.offering_id,
-  context: request.context,
+  intent: request.intent,
   products_shown: matchingProducts,  // In exact order returned
   product_ids: matchingProducts.map(p => p.product_id),
   queried_at: new Date().toISOString(),
@@ -269,7 +270,7 @@ When initiating a session after getting offering details, include the token:
 
 ```json
 {
-  "context": "User wants running shoes, mens size 14",
+  "intent": "User wants running shoes, mens size 14",
   "offering_id": "nike-summer-sale",
   "offering_token": "offering_abc123xyz",
   "identity": {
@@ -285,7 +286,7 @@ When initiating a session after getting offering details, include the token:
 
 2. **Session continuity** - The offering token is the brand's memory of what was shown. When users reference "the first option" or "that blue one", the token lets the brand agent resolve those references.
 
-3. **Product matching** - When `include_products` is true and `context` is provided, brands can return relevant products. This powers pre-session previews like "12 shoes in your size from \$89."
+3. **Product matching** - When `include_products` is true and `intent` is provided, brands can return relevant products. This powers pre-session previews like "12 shoes in your size from \$89."
 
 4. **Caching** - Hosts may cache responses for up to `ttl_seconds`. This reduces load on brand agents for frequently checked offerings.
 
@@ -298,7 +299,7 @@ When initiating a session after getting offering details, include the token:
 ### For Hosts
 
 - Get offering details before showing sponsored results to users
-- Use `include_products` with context for richer previews
+- Use `include_products` with an `intent` for richer previews
 - Respect TTL for caching to avoid stale data
 - Handle unavailable gracefully - don't show expired offerings
 - Include offering token in session initiation when available

--- a/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
+++ b/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
@@ -21,7 +21,7 @@ Start a conversational session with a brand agent. The host platform invokes thi
 | `offering_id` | string | No | Brand-specific offering reference to apply |
 | `supported_capabilities` | object | No | What the host platform supports |
 | `offering_token` | string | No | Token from `si_get_offering` for correlation |
-| `context` | object | No | Opaque correlation data echoed unchanged in the response (see [context sessions](/docs/building/integration/context-sessions)) |
+| `context` | object | No | Opaque correlation data echoed unchanged in the response (see [application context](/docs/building/integration/context-sessions#application-context-context)) |
 
 ### Offering Token
 

--- a/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
+++ b/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
@@ -14,13 +14,14 @@ Start a conversational session with a brand agent. The host platform invokes thi
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `context` | string | Yes | Natural language description of user intent |
+| `intent` | string | Yes | Natural language description of user intent — the conversation handoff from the host |
 | `identity` | object | Yes | User identity with consent status |
 | `media_buy_id` | string | No | AdCP media buy ID if triggered by advertising |
 | `placement` | string | No | Where the session was triggered (e.g., "chatgpt_search") |
 | `offering_id` | string | No | Brand-specific offering reference to apply |
 | `supported_capabilities` | object | No | What the host platform supports |
 | `offering_token` | string | No | Token from `si_get_offering` for correlation |
+| `context` | object | No | Opaque correlation data echoed unchanged in the response (see [context sessions](/docs/building/integration/context-sessions)) |
 
 ### Offering Token
 
@@ -104,7 +105,7 @@ Declares what the host platform can render:
 {
   "$schema": "/schemas/sponsored-intelligence/si-initiate-session-request.json",
   "idempotency_key": "f6a7b8c9-d0e1-4234-f567-234567890123",
-  "context": "User wants to fly to Boston next Tuesday morning on flight 632 at 6 AM.",
+  "intent": "User wants to fly to Boston next Tuesday morning on flight 632 at 6 AM.",
   "media_buy_id": "delta_q1_premium_upgrade",
   "placement": "chatgpt_search",
   "offering_id": "delta_chatgpt_3313",
@@ -177,7 +178,7 @@ Declares what the host platform can render:
 
 ## Key Points
 
-1. **Context is a conversation handoff** - The host tells the brand agent what the user needs. The brand agent responds naturally, continuing the conversation.
+1. **`intent` is the conversation handoff** - The host tells the brand agent what the user needs in natural language. The brand agent responds naturally, continuing the conversation. `context` is a separate, optional field: an opaque object (e.g., `{"trace_id": "abc-123"}`) that the brand agent echoes back unchanged — used by the buyer for correlation, never parsed by the brand agent.
 
 2. **Brand looks up loyalty data** - If Jane's email is recognized, Delta retrieves her SkyMiles status automatically. Hosts don't store loyalty numbers.
 

--- a/skills/adcp-si/SKILL.md
+++ b/skills/adcp-si/SKILL.md
@@ -64,6 +64,7 @@ Start a conversational session with a brand agent.
 - `offering_id` (string, optional): Brand-specific offering reference
 - `offering_token` (string, optional): Token from `si_get_offering` for session continuity
 - `supported_capabilities` (object, optional): Host platform capabilities (modalities, components, commerce)
+- `context` (object, optional): Opaque correlation data (e.g., `{"trace_id": "abc-123"}`) echoed unchanged in the response — never parsed by the brand agent
 
 **Response contains:**
 - `session_id`: Use in subsequent `si_send_message` and `si_terminate_session` calls
@@ -130,6 +131,7 @@ Get offering details and availability before initiating a session. Allows showin
 - `intent` (string, optional): Natural language description of user intent for personalized results (no PII)
 - `include_products` (boolean, optional): Include matching products
 - `product_limit` (number, optional): Max products to return (default 5, max 50)
+- `context` (object, optional): Opaque correlation data echoed unchanged in the response — never parsed by the brand agent
 
 **Response contains:**
 - `offering`: Offering details (name, description, availability)
@@ -153,7 +155,8 @@ End an SI session.
 **Key fields:**
 - `session_id` (string, required): Session ID to terminate
 - `reason` (string, required): Why the session is ending — `handoff_transaction`, `handoff_complete`, `user_exit`, `session_timeout`, `host_terminated`
-- `termination_context` (object, optional): Additional context
+- `termination_context` (object, optional): Conversation summary, transaction intent, and cause for the termination
+- `context` (object, optional): Opaque correlation data echoed unchanged in the response — never parsed by the brand agent
 
 **Reason values:**
 - `handoff_transaction`: User is being redirected to complete a transaction

--- a/skills/adcp-si/SKILL.md
+++ b/skills/adcp-si/SKILL.md
@@ -21,7 +21,7 @@ The SI Protocol provides 4 standardized tasks for managing conversational sessio
 ## Typical Workflow
 
 1. **Preview** (optional): `si_get_offering` to see what the brand offers before consent
-2. **Start session**: `si_initiate_session` with user context and consent
+2. **Start session**: `si_initiate_session` with the user's `intent` and consent
 3. **Converse**: `si_send_message` to relay user messages and action responses
 4. **End**: `si_terminate_session` when done
 
@@ -36,7 +36,7 @@ Start a conversational session with a brand agent.
 **Request:**
 ```json
 {
-  "context": "I'm interested in your winter jacket collection",
+  "intent": "I'm interested in your winter jacket collection",
   "identity": {
     "consent_granted": true,
     "consent_timestamp": "2025-01-15T10:30:00Z",
@@ -52,7 +52,7 @@ Start a conversational session with a brand agent.
 ```
 
 **Key fields:**
-- `context` (string, required): Natural language description of user intent
+- `intent` (string, required): Natural language description of user intent — the conversation handoff from host to brand agent
 - `identity` (object, required): User identity with consent status
   - `consent_granted` (boolean, required): Whether user consented to share identity
   - `consent_timestamp` (string, optional): ISO 8601 timestamp of consent
@@ -119,7 +119,7 @@ Get offering details and availability before initiating a session. Allows showin
 ```json
 {
   "offering_id": "winter-collection-2025",
-  "context": "Looking for warm jackets under $200",
+  "intent": "Looking for warm jackets under $200",
   "include_products": true,
   "product_limit": 5
 }
@@ -127,7 +127,7 @@ Get offering details and availability before initiating a session. Allows showin
 
 **Key fields:**
 - `offering_id` (string, required): Offering identifier from the catalog
-- `context` (string, optional): Natural language context for personalized results (no PII)
+- `intent` (string, optional): Natural language description of user intent for personalized results (no PII)
 - `include_products` (boolean, optional): Include matching products
 - `product_limit` (number, optional): Max products to return (default 5, max 50)
 

--- a/static/compliance/source/protocols/sponsored-intelligence/index.yaml
+++ b/static/compliance/source/protocols/sponsored-intelligence/index.yaml
@@ -154,9 +154,7 @@ phases:
           - Available interaction modes
 
         sample_request:
-          brand:
-            domain: "novamotors.example"
-          campaign_context: "Nova EV launch — targeting environmentally conscious drivers interested in electric vehicles"
+          intent: "User is researching electric vehicles for long road trips and wants to talk to Nova Motors"
 
           idempotency_key: "$generate:uuid_v4#si_baseline_session_lifecycle_si_initiate_session"
           context:

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -919,6 +919,7 @@ phases:
           Return a session with a session_id.
 
         sample_request:
+          intent: "comply test — initiate deterministic SI session"
           identity:
             user_type: 'consumer'
           supported_capabilities:

--- a/static/schemas/source/sponsored-intelligence/si-get-offering-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-get-offering-request.json
@@ -17,9 +17,12 @@
       "description": "Offering identifier from the catalog to get details for",
       "x-entity": "offering"
     },
-    "context": {
+    "intent": {
       "type": "string",
-      "description": "Optional natural language context about user intent for personalized results (e.g., 'mens size 14 near Cincinnati'). Must be anonymous - no PII."
+      "description": "Optional natural language description of user intent for personalized results (e.g., 'mens size 14 near Cincinnati'). Must be anonymous - no PII."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
     },
     "include_products": {
       "type": "boolean",

--- a/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
@@ -13,9 +13,12 @@
       "minimum": 1,
       "maximum": 99
     },
-    "context": {
+    "intent": {
       "type": "string",
-      "description": "Conversation handoff from the host describing what the user needs"
+      "description": "Natural language description of user intent — the conversation handoff from the host describing what the user needs from the brand agent"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
     },
     "identity": {
       "$ref": "/schemas/sponsored-intelligence/si-identity.json"
@@ -55,7 +58,7 @@
   },
   "required": [
     "idempotency_key",
-    "context",
+    "intent",
     "identity"
   ],
   "additionalProperties": true

--- a/tests/storyboard-sample-request-schema-allowlist.json
+++ b/tests/storyboard-sample-request-schema-allowlist.json
@@ -150,15 +150,13 @@
     "protocols/sponsored-intelligence/index.yaml#offering_discovery/si_get_offering": {
       "schema": "sponsored-intelligence/si-get-offering-request.json",
       "errors": [
-        "required@/:offering_id",
-        "type@/context:string"
+        "required@/:offering_id"
       ]
     },
     "protocols/sponsored-intelligence/index.yaml#session_lifecycle/si_initiate_session": {
       "schema": "sponsored-intelligence/si-initiate-session-request.json",
       "errors": [
-        "required@/:identity",
-        "type@/context:string"
+        "required@/:identity"
       ]
     },
     "protocols/sponsored-intelligence/index.yaml#session_lifecycle/si_terminate_session": {
@@ -365,7 +363,6 @@
     "universal/deterministic-testing.yaml#deterministic_session/initiate_session": {
       "schema": "sponsored-intelligence/si-initiate-session-request.json",
       "errors": [
-        "type@/context:string",
         "required@/identity:consent_granted"
       ]
     },


### PR DESCRIPTION
## Summary

- **Breaking (SI, experimental):** On `si_get_offering` and `si_initiate_session` requests, the natural-language user-intent field is renamed from `context` (string) to `intent` (string).
- `context` on these requests now refers to the universal opaque-echo object (`/schemas/core/context.json`), matching every other AdCP subprotocol.
- `si_terminate_session` already conformed (used `context: $ref /schemas/core/context.json`) and is unchanged.

## Why

`context` was redefined locally on three SI request schemas as a typed `string` with protocol-parsed semantic meaning. That collided with the universal `context` object — the "opaque correlation data echoed unchanged" contract that every other subprotocol relies on. Buyers and SDK generators who trusted the universal contract were mis-typing SI payloads. Surfaced by the sample_request schema lint in #2768.

Field name chosen after expert protocol review: `intent` over `handoff` because `si_get_offering` is pre-session and anonymous — there's no session to "hand off" yet. `intent` is endpoint-neutral and already matches the descriptions the docs used three times.

Closes #2774.

## Cascade

- 2 schema source files (the rename + adding `context: $ref`)
- 2 storyboard YAMLs (sample_requests; also replaced the misleading "Nova EV launch — targeting environmentally conscious drivers" campaign-brief string with an actual host-side user-intent description)
- 1 regenerated allowlist (only stale `type@/context:string` entries removed)
- 8 docs: `specification.mdx` (normative requirements list), `implementing-si-agents.mdx` (MCP tool example + prose), `networks.mdx` (leg-mapping table), `si-chat-protocol.mdx`, `tasks/{index,si_get_offering,si_initiate_session}.mdx`, `skills/adcp-si/SKILL.md`
- 1 changeset: `"adcontextprotocol": minor` (experimental-surface carve-out per `docs/reference/experimental-status`)

## What's NOT in this PR (intentional)

- Internal Addie `siAgentService.initiateSession({context})` still uses `context` as its internal param name. It's a local service (not an AdCP wire call) that writes to DB column `initial_context`, so the rename doesn't cascade. Follow-up refactor if we want full Addie-internal consistency.

## Test plan

- [x] `test:schemas` — 7 passing
- [x] `test:examples` — 31 passing
- [x] `test:composed` — 21 passing
- [x] `test:storyboard-sample-request-schema` — 7 passing (allowlist shrunk, no new drift)
- [x] `test:storyboard-{scoping,branch-sets,contradictions,context-entity,auth-shape,test-kits}` — all passing
- [x] `test:docs-nav` — 15 passing
- [x] `test:server-unit` — 1699 passing (34 skipped, unrelated)
- [x] `test:unit` (precommit) — 631 passing
- [x] `typecheck` (precommit) — clean
- [x] Mintlify link-check (pre-push) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)