### PR TITLE
chore(deps): bump @adcp/client 5.9.0 -> 5.9.1

### DIFF
--- a/.changeset/adcp-client-5.9.1.md
+++ b/.changeset/adcp-client-5.9.1.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore(deps): bump `@adcp/client` 5.9.0 → 5.9.1
+
+Picks up [adcp-client#752](https://github.com/adcontextprotocol/adcp-client/pull/752), which fixes the default `context.no_secret_echo` assertion's auth extraction so it actually catches leaks when callers pass structured `TestOptions.auth` objects (bearer / basic / oauth / oauth_client_credentials). Pre-5.9.1 the assertion did `secrets.add(options.auth)` on the raw object — `String.includes(obj)` coerced to `[object Object]` and matched nothing, making the check a silent no-op for every consumer using structured auth.
+
+5.9.1 also adds `registerAssertion(spec, { override: true })` for consumers that want to replace SDK defaults with stricter local versions — we don't need it here since #2771 already dropped our local assertions in favor of the SDK defaults, but the patch bump is worth picking up for the bug fix alone.
+
+Scoped bump — only `@adcp/client` resolution + integrity change in `package-lock.json`, no peer cascade, no code changes required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-rc.3",
       "dependencies": {
-        "@adcp/client": "^5.9.0",
+        "@adcp/client": "^5.9.1",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.9.0.tgz",
-      "integrity": "sha512-Sri+HfNMNAMjaXdjXXjUqmAirauAqnplJlYjC5KFC6E6D3Qsr543WMRQcCOBhgxI6BQz/pFx9OtjxWS/hoq8Fg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.9.1.tgz",
+      "integrity": "sha512-ZxhavK9s3gGs1G8B9BHUt1QLoi6ZsnABoqAT28tyQu3DfOXlKwMFanHCwXF2tNDpu/xvE88LQM3eNTifZLImJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "^5.9.0",
+    "@adcp/client": "^5.9.1",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",


### PR DESCRIPTION
Scoped patch bump to pick up [adcp-client#752](https://github.com/adcontextprotocol/adcp-client/pull/752).

## Why

5.9.0's default `context.no_secret_echo` assertion in `@adcp/client/testing` silently no-ops for every consumer passing structured `TestOptions.auth`. The relevant code in `default-invariants.ts`:

```ts
const optAny = ctx.options as unknown as { auth?: string };
if (optAny.auth) secrets.add(optAny.auth);  // 'auth' is really an object
// later:
if (dumped.includes(secret)) { ... }         // String.includes(obj) → matches [object Object]
```

Since [#2771](https://github.com/adcontextprotocol/adcp/pull/2771) adopted 5.9.0 and dropped our stricter local assertions in favor of the SDK defaults, we were implicitly depending on the default to work — but it doesn't, for any auth type other than a loose `options.auth_token` string. A compliance run that should have flagged a leaked access token, basic password, or client secret was passing cleanly.

## What 5.9.1 fixes

- `extractAuthSecrets` walks every variant of the `TestOptions.auth` union and pulls leaf strings: `token` (bearer), `password` (basic) plus the `base64(user:pass)` Authorization header blob, `tokens.access_token` / `tokens.refresh_token` (oauth and oauth_client_credentials), `client.client_secret` (oauth confidential), `credentials.client_secret` with `$ENV:VAR` reference resolution (oauth_client_credentials).
- `SECRET_MIN_LENGTH = 16` guards against short fixture values driving false positives.
- Not extracted: `client_id` (RFC 6749 §2.2 — public identifier) or basic-auth `username` alone (not a secret; the base64 header blob catches real leaks of the credential).

Also adds `registerAssertion(spec, { override: true })` for consumers who want to swap a default for a stricter local version — not needed here post-#2771, but doesn't hurt to have in scope.

## Scope

- `package.json`: `"@adcp/client": "^5.9.0"` → `"^5.9.1"`
- `package-lock.json`: 5 lines (just `@adcp/client`'s `resolved` + `integrity`)
- No code changes, no peer cascade, no API surface changes

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run test:server-unit` — 1699 passed / 34 skipped / 0 failed
- [x] `collection-lists-storyboard.test.ts` (the one test whose fixture loading had flaked in earlier sessions) — passes cleanly on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)