### PR TITLE
fix(storyboards): resolve 16-fixture actionable drift bundle (adcp#2763)

### DIFF
--- a/.changeset/fix-actionable-drift-bundle.md
+++ b/.changeset/fix-actionable-drift-bundle.md
@@ -1,0 +1,13 @@
+---
+---
+
+Bundle resolution of all remaining actionable storyboard sample_request drift (adcp#2763 cluster follow-ups to #2768, #2781, #2788). 16 fixtures patched; allowlist shrinks 29 → 13.
+
+Changes by theme:
+- **Negative-test detection** broadens to treat `expect_error: true` as a negative-step marker alongside the existing `error_code` / `http_status_in` heuristics. This is the canonical marker throughout the suite and closes two entries (`reversed_dates`, `missing_fields`) without requiring per-fixture opt-ins.
+- **Shape completion** for fixtures missing fields the schema requires: `account`, `reason`, `query`/`uses`, `external_id`, `event_time`, `event_source_id`, `package_id`, `total_budget: {amount, currency}` (2 fixtures), `request_type`/`creative_manifest`/`assets`/`format_id`, `creatives[]` padding for reference-only sync_creatives.
+- **Additional-property removal** on `accounts[].brand.name` where the schema rejects it.
+- **Capture-site updates** for `sales-non-guaranteed` to expose `first_package_id`/`second_package_id` from create_media_buy so the update_media_buy step can reference them by package_id per schema.
+- **Negative-test opt-in** on `universal/error-compliance.yaml#missing_fields` via `sample_request_skip_schema: true` — the step intentionally tests the "missing buying_mode" path and doesn't carry an `expect_error` marker (the step accepts either a response or an error as valid).
+
+The remaining 13 allowlist entries are blocked on WG decisions in upstream issues adcp#2774-#2776 (refine[] naming, SI `context` field collision, governance `account` rejection) plus the dedicated `sales-social/sync_dpa_creative` cluster being handled in a separate PR.

--- a/scripts/lint-storyboard-sample-request-schema.cjs
+++ b/scripts/lint-storyboard-sample-request-schema.cjs
@@ -324,13 +324,14 @@ async function validateStep({ schemaRef, payload }) {
  * send malformed payloads to verify the agent's error response, so their
  * sample_request is not expected to validate.
  *
- * Detection is structural: a step is negative if any validation asserts an
- * error code or a 4xx/5xx HTTP status. Authors can also opt out explicitly
- * with `sample_request_skip_schema: true` for cases the heuristic misses
- * (e.g., shape-agnostic transport tests).
+ * Detection is structural, in priority order:
+ *   1. Explicit opt-out: `sample_request_skip_schema: true`
+ *   2. Canonical negative-path marker: `expect_error: true`
+ *   3. Validations that assert error codes or 4xx/5xx HTTP statuses
  */
 function isNegativeStep(step) {
   if (step?.sample_request_skip_schema === true) return true;
+  if (step?.expect_error === true) return true;
   const validations = Array.isArray(step?.validations) ? step.validations : [];
   for (const v of validations) {
     if (v?.check === 'error_code') return true;

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -340,7 +340,21 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          creative_id: "display_trail_pro_300x250"
+          request_type: "single"
+          creative_manifest:
+            creative_id: "display_trail_pro_300x250"
+            format_id:
+              agent_url: "https://your-platform.example.com"
+              id: "display_300x250"
+            assets:
+              image:
+                asset_type: "image"
+                url: "https://test-assets.adcontextprotocol.org/acme-outdoor/banner_300x250.jpg"
+                width: 300
+                height: 250
+              click_url:
+                asset_type: "url"
+                url: "https://acmeoutdoor.example/trail-pro"
 
           context:
             correlation_id: "creative_lifecycle--preview_display"

--- a/static/compliance/source/protocols/media-buy/creative-reception.yaml
+++ b/static/compliance/source/protocols/media-buy/creative-reception.yaml
@@ -211,6 +211,21 @@ phases:
             format_id:
               agent_url: "https://your-platform.example.com"
               id: "native_post"
+            assets:
+              headline:
+                asset_type: "text"
+                content: "Summer Sale — 40% Off"
+              body:
+                asset_type: "text"
+                content: "Top-rated outdoor gear. This weekend only."
+              image:
+                asset_type: "image"
+                url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero.jpg"
+                width: 1200
+                height: 628
+              click_url:
+                asset_type: "url"
+                url: "https://acmeoutdoor.example/summer-sale"
           output_format: "url"
           quality: "draft"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -384,6 +384,18 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+          creatives:
+            - creative_id: "$context.creative_id"
+              name: "Reassigned creative"
+              format_id:
+                agent_url: "https://your-platform.example.com"
+                id: "display_300x250"
+              assets:
+                image:
+                  asset_type: "image"
+                  url: "https://test-assets.adcontextprotocol.org/acme-outdoor/banner_300x250.jpg"
+                  width: 300
+                  height: 250
           assignments:
             - creative_id: "$context.creative_id"
               package_id: "$context.second_package_id"

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -230,7 +230,9 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           proposal_id: "balanced_reach_q2"
-          total_budget: 50000
+          total_budget:
+            amount: 50000
+            currency: "USD"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
 

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -151,6 +151,10 @@ phases:
           - status: active
 
         sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
           start_time: "2026-05-01T00:00:00Z"

--- a/static/compliance/source/protocols/sponsored-intelligence/index.yaml
+++ b/static/compliance/source/protocols/sponsored-intelligence/index.yaml
@@ -235,6 +235,7 @@ phases:
 
         sample_request:
           session_id: "$context.session_id"
+          reason: "handoff_complete"
 
           context:
             correlation_id: "si_session--si_terminate_session"

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -199,8 +199,10 @@ phases:
             - audience_id: "adcp-test-audience-001"
               name: "AdCP test audience"
               add:
-                - hashed_email: "a000000000000000000000000000000000000000000000000000000000000000"
-                - hashed_phone: "b000000000000000000000000000000000000000000000000000000000000000"
+                - external_id: "adcp-user-0001"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000000"
+                - external_id: "adcp-user-0002"
+                  hashed_phone: "b000000000000000000000000000000000000000000000000000000000000000"
 
           idempotency_key: "$generate:uuid_v4#audience_sync_audience_sync_create_audience"
           context:

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -142,6 +142,10 @@ phases:
         sample_request:
           buyer:
             domain: "pinnacle-agency.example"
+          query: "licensed commercial rights for a regional outdoor retail campaign"
+          uses:
+            - "commercial"
+            - "endorsement"
         context_outputs:
           - path: "rights[0].rights_id"
             key: "rights_id"

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -114,7 +114,6 @@ phases:
           accounts:
             - brand:
                 domain: "amsterdam-steakhouse.example"
-                name: "Amsterdam Steakhouse"
               operator: "pinnacle-agency.example"
               billing: "operator"
               sandbox: true
@@ -640,19 +639,19 @@ phases:
           events:
             - event_id: "evt_001"
               event_type: "purchase"
-              timestamp: "2026-04-15T19:30:00Z"
+              event_time: "2026-04-15T19:30:00Z"
               content_ids: ["ribeye_36oz"]
               value: 89.00
               currency: "USD"
             - event_id: "evt_002"
               event_type: "lead"
-              timestamp: "2026-04-15T20:15:00Z"
+              event_time: "2026-04-15T20:15:00Z"
               content_ids: ["wagyu_flight"]
               value: 195.00
               currency: "USD"
             - event_id: "evt_003"
               event_type: "page_view"
-              timestamp: "2026-04-15T20:45:00Z"
+              event_time: "2026-04-15T20:45:00Z"
               content_ids: ["seafood_tower"]
 
           idempotency_key: "$generate:uuid_v4#sales_catalog_driven_conversion_tracking_log_events"

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -244,6 +244,10 @@ phases:
         context_outputs:
           - name: media_buy_id
             path: "media_buy_id"
+          - name: first_package_id
+            path: "packages[0].package_id"
+          - name: second_package_id
+            path: "packages[1].package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -343,10 +347,10 @@ phases:
             operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           packages:
-            - product_id: "sports_display_auction"
+            - package_id: "$context.first_package_id"
               bid_price: 10.00
               budget: 12000
-            - product_id: "outdoor_video_auction"
+            - package_id: "$context.second_package_id"
               bid_price: 20.00
               budget: 13000
 

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -320,7 +320,9 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           proposal_id: "balanced_reach_q2"
-          total_budget: 50000
+          total_budget:
+            amount: 50000
+            currency: "USD"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
 

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -447,10 +447,11 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+          event_source_id: "acmeoutdoor_website"
           events:
             - event_type: "purchase"
               event_id: "evt_trail_pro_001"
-              timestamp: "2026-04-05T14:30:00Z"
+              event_time: "2026-04-05T14:30:00Z"
               value: 149.99
               currency: "USD"
 

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -276,10 +276,12 @@ phases:
         stateful: true
 
         sample_request:
-          brand:
-            domain: 'test.example'
-          operator: 'test.example'
-          sandbox: true
+          accounts:
+            - brand:
+                domain: 'test.example'
+              operator: 'test.example'
+              billing: 'operator'
+              sandbox: true
 
           idempotency_key: "$generate:uuid_v4#deterministic_testing_deterministic_account_sync_accounts_for_state"
           context:

--- a/static/compliance/source/universal/error-compliance.yaml
+++ b/static/compliance/source/universal/error-compliance.yaml
@@ -197,6 +197,10 @@ phases:
         doc_ref: "/media-buy/task-reference/get_products"
         comply_scenario: error_handling
         stateful: false
+        # The test value of this step is that buying_mode is missing — do not
+        # schema-validate the sample_request, or the lint would reject the
+        # very shape the step exists to exercise.
+        sample_request_skip_schema: true
         expected: |
           Either return products (treating empty request as browse) or return a
           structured error requesting the missing brief. Both are valid.

--- a/tests/storyboard-sample-request-schema-allowlist.json
+++ b/tests/storyboard-sample-request-schema-allowlist.json
@@ -1,18 +1,6 @@
 {
   "$comment": "Known storyboard sample_request schema drift, grandfathered before the lint was turned on. Each entry fingerprints the violation; new drift in a listed step fails the lint, and fixed drift that leaves an entry stale also fails (so follow-up PRs must remove entries as they fix fixtures). Regenerate with `node scripts/lint-storyboard-sample-request-schema.cjs --write-allowlist` after a real fix — defaults to shrink-only. Pass `--allow-grow` only when adding a deliberate, newly-identified drift is the explicit intent; never hand-edit to silence a new violation.",
   "entries": {
-    "protocols/creative/index.yaml#build_and_preview/preview_display": {
-      "schema": "creative/preview-creative-request.json",
-      "errors": [
-        "required@/:creative_manifest",
-        "if@/",
-        "required@/:requests",
-        "if@/",
-        "required@/:variant_id",
-        "if@/",
-        "required@/:request_type"
-      ]
-    },
     "protocols/governance/index.yaml#audit_trail/get_plan_audit_logs": {
       "schema": "governance/get-plan-audit-logs-request.json",
       "errors": [
@@ -30,24 +18,6 @@
         "additionalProperties@/:account",
         "type@/outcome:string",
         "enum@/outcome"
-      ]
-    },
-    "protocols/media-buy/creative-reception.yaml#preview/preview_synced": {
-      "schema": "creative/preview-creative-request.json",
-      "errors": [
-        "required@/creative_manifest:assets"
-      ]
-    },
-    "protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml#reuse_creative_on_new_buy/reassign_creative": {
-      "schema": "creative/sync-creatives-request.json",
-      "errors": [
-        "required@/:creatives"
-      ]
-    },
-    "protocols/media-buy/scenarios/proposal_finalize.yaml#accept_proposal/create_media_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "type@/total_budget:object"
       ]
     },
     "protocols/media-buy/scenarios/proposal_finalize.yaml#finalize_proposal/get_products_finalize": {
@@ -96,12 +66,6 @@
         "oneOf@/refine/1"
       ]
     },
-    "protocols/media-buy/state-machine.yaml#setup/create_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "required@/:account"
-      ]
-    },
     "protocols/sponsored-intelligence/index.yaml#offering_discovery/si_get_offering": {
       "schema": "sponsored-intelligence/si-get-offering-request.json",
       "errors": [
@@ -114,26 +78,6 @@
       "errors": [
         "required@/:identity",
         "type@/context:string"
-      ]
-    },
-    "protocols/sponsored-intelligence/index.yaml#session_lifecycle/si_terminate_session": {
-      "schema": "sponsored-intelligence/si-terminate-session-request.json",
-      "errors": [
-        "required@/:reason"
-      ]
-    },
-    "specialisms/audience-sync/index.yaml#audience_sync/create_audience": {
-      "schema": "media-buy/sync-audiences-request.json",
-      "errors": [
-        "required@/audiences/0/add/0:external_id",
-        "required@/audiences/0/add/1:external_id"
-      ]
-    },
-    "specialisms/brand-rights/scenarios/governance_denied.yaml#rights_denied/get_rights_catalog": {
-      "schema": "brand/get-rights-request.json",
-      "errors": [
-        "required@/:query",
-        "required@/:uses"
       ]
     },
     "specialisms/governance-delivery-monitor/index.yaml#drift_recheck/check_governance_drift": {
@@ -153,33 +97,6 @@
       "schema": "governance/check-governance-request.json",
       "errors": [
         "additionalProperties@/:account"
-      ]
-    },
-    "specialisms/sales-catalog-driven/index.yaml#account_setup/sync_accounts": {
-      "schema": "account/sync-accounts-request.json",
-      "errors": [
-        "additionalProperties@/accounts/0/brand:name"
-      ]
-    },
-    "specialisms/sales-catalog-driven/index.yaml#conversion_tracking/log_events": {
-      "schema": "media-buy/log-event-request.json",
-      "errors": [
-        "required@/events/0:event_time",
-        "required@/events/1:event_time",
-        "required@/events/2:event_time"
-      ]
-    },
-    "specialisms/sales-non-guaranteed/index.yaml#adjust_bids/update_media_buy": {
-      "schema": "media-buy/update-media-buy-request.json",
-      "errors": [
-        "required@/packages/0:package_id",
-        "required@/packages/1:package_id"
-      ]
-    },
-    "specialisms/sales-proposal-mode/index.yaml#accept_proposal/create_media_buy": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "type@/total_budget:object"
       ]
     },
     "specialisms/sales-proposal-mode/index.yaml#review_refine/get_products_refine": {
@@ -262,36 +179,11 @@
         "anyOf@/creatives/0/assets/click_url"
       ]
     },
-    "specialisms/sales-social/index.yaml#event_logging/log_event": {
-      "schema": "media-buy/log-event-request.json",
-      "errors": [
-        "required@/:event_source_id",
-        "required@/events/0:event_time"
-      ]
-    },
-    "universal/deterministic-testing.yaml#deterministic_account/sync_accounts_for_state": {
-      "schema": "account/sync-accounts-request.json",
-      "errors": [
-        "required@/:accounts"
-      ]
-    },
     "universal/deterministic-testing.yaml#deterministic_session/initiate_session": {
       "schema": "sponsored-intelligence/si-initiate-session-request.json",
       "errors": [
         "type@/context:string",
         "required@/identity:consent_granted"
-      ]
-    },
-    "universal/error-compliance.yaml#error_responses/missing_fields": {
-      "schema": "media-buy/get-products-request.json",
-      "errors": [
-        "required@/:buying_mode"
-      ]
-    },
-    "universal/schema-validation.yaml#temporal_validation/reversed_dates": {
-      "schema": "media-buy/create-media-buy-request.json",
-      "errors": [
-        "required@/:idempotency_key"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Third cluster-bundle follow-up to the storyboard schema lint from #2768, #2781, #2788. Bundles all remaining actionable drift into one reviewable PR. Allowlist shrinks **29 → 13**.

## Lint change

`isNegativeStep` now treats `expect_error: true` as a canonical negative-step marker alongside the existing `error_code` / `http_status_in` heuristics. `expect_error` is the widely-used convention throughout the compliance suite (20+ sites) and resolves deliberate-error fixtures (`reversed_dates`, etc.) without needing per-fixture opt-ins.

## Fixture changes (14 files, 16 allowlist entries resolved)

**Shape completion — missing required fields:**
- `protocols/media-buy/state-machine.yaml#setup/create_buy` — missing `account`
- `protocols/sponsored-intelligence/index.yaml#session_lifecycle/si_terminate_session` — missing `reason`
- `specialisms/brand-rights/scenarios/governance_denied.yaml#rights_denied/get_rights_catalog` — missing `query`/`uses`
- `specialisms/audience-sync/index.yaml#audience_sync/create_audience` — missing `external_id` on `add[]`
- `specialisms/sales-catalog-driven/index.yaml#conversion_tracking/log_events` — events used `timestamp` where schema wants `event_time`
- `specialisms/sales-social/index.yaml#event_logging/log_event` — missing `event_source_id` at root + `event_time` on event
- `protocols/creative/index.yaml#build_and_preview/preview_display` — missing `request_type`/`creative_manifest`/`assets`/`format_id`; populated the full single-request shape
- `protocols/media-buy/creative-reception.yaml#preview/preview_synced` — missing `creative_manifest.assets`
- `protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml#reuse_creative_on_new_buy/reassign_creative` — `creatives: []` required by schema minItems: 1 even for assignment-only calls; added minimal `creatives[]` padding
- `specialisms/sales-non-guaranteed/index.yaml#adjust_bids/update_media_buy` — packages used `product_id` but schema requires `package_id`; exposed `first_package_id`/`second_package_id` via `context_outputs` on the create step so update can reference them

**Shape corrections:**
- `protocols/media-buy/scenarios/proposal_finalize.yaml#accept_proposal/create_media_buy` — `total_budget: 50000` → `{ amount: 50000, currency: "USD" }`
- `specialisms/sales-proposal-mode/index.yaml#accept_proposal/create_media_buy` — same `total_budget` fix
- `universal/deterministic-testing.yaml#deterministic_account/sync_accounts_for_state` — flat `brand`/`operator` → `accounts: [{...}]` wrapper

**additionalProperty removal:**
- `specialisms/sales-catalog-driven/index.yaml#account_setup/sync_accounts` — removed `brand.name` (schema rejects)

**Explicit negative-test opt-in:**
- `universal/error-compliance.yaml#error_responses/missing_fields` — `sample_request_skip_schema: true` (step intentionally tests empty-brief path; accepts either response or error so no `expect_error` marker).

## Ratchet

Allowlist: **29 → 13**. Regenerated in shrink-only mode.

Remaining 13 entries — all blocked:
- 5 blocked on #2776 (governance `account` additionalProperty)
- 4 blocked on #2775 (`refine[]` naming)
- 3 blocked on #2774 (SI `context:string` collision; one of these is in deterministic-testing)
- 1 is `sales-social/sync_dpa_creative` — creative-manifest assets anyOf cluster (separate PR)

## Test plan

- [x] `npm run test:storyboard-sample-request-schema` — passes (13 grandfathered, 0 new drift, 0 stale)
- [x] All 6 other storyboard lints pass
- [x] 8 lint unit tests pass
- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean
- [x] Each fixture cross-checked against its schema's `required` / `additionalProperties` / type constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)