### PR TITLE
feat(compliance): OAuth 2.0 client-credentials for Test-your-agent (closes #2761 server leg)

### DIFF
--- a/.changeset/oauth-client-credentials-server.md
+++ b/.changeset/oauth-client-credentials-server.md
@@ -1,0 +1,25 @@
+---
+---
+
+feat(compliance): persist OAuth 2.0 client-credentials auth for Test-your-agent flow (RFC 6749 §4.4)
+
+Closes the server leg of [#2761](https://github.com/adcontextprotocol/adcp/issues/2761) — storyboard endpoints now resolve machine-to-machine OAuth credentials from `agent_context` and hand the SDK the [`oauth_client_credentials`](https://github.com/adcontextprotocol/adcp-client/pull/746) shape it shipped in `@adcp/client` 5.9.0. Complements the authorization-code path landed by #2738.
+
+- **Migration** `419_oauth_client_credentials.sql` — new `oauth_cc_token_endpoint` / `oauth_cc_client_id` / `oauth_cc_client_secret_*` / `oauth_cc_scope` / `oauth_cc_resource` / `oauth_cc_audience` / `oauth_cc_auth_method` columns on `agent_contexts`. Client secret AES-256-GCM encrypted via the existing `encryption.ts` (same pattern as the auth-code path). `agent_context_summary` view surfaces a derived `has_oauth_client_credentials` flag.
+- **DB layer** — `AgentContextDatabase.saveOAuthClientCredentials` / `getOAuthClientCredentialsByOrgAndUrl` / `removeOAuthClientCredentials`. New `OAuthClientCredentials` interface mirrors the SDK's `AgentOAuthClientCredentials` exactly (`auth_method: 'basic' | 'body'`, optional `scope` / `resource` / `audience`). `AgentContext.has_oauth_client_credentials: boolean` on every read path.
+- **Resolvers** — `ResolvedOwnerAuth` union gains the `{ type: 'oauth_client_credentials', credentials, tokens? }` variant. Both `ComplianceDatabase.resolveOwnerAuth` (used by the compliance heartbeat cron) and the `resolveUserAgentAuth` helper behind the four Test-your-agent endpoints read the new columns and emit the shape the SDK consumes. Precedence: static bearer/basic > auth-code OAuth with refresh > client-credentials > raw bearer fallback. Only one of these will be set for any given agent in practice; the ordering is for the edge case.
+- **New endpoint** `PUT /api/registry/agents/{encodedUrl}/oauth-client-credentials` — validates `token_endpoint` via the same SSRF-resistant helper that gates agent URLs (HTTPS-only in production, cloud-metadata + private-IP blocked), persists via the new DB method. Same ownership check as `/connect`.
+- **Addie tool** — `save_agent` accepts an `oauth_client_credentials` object alongside `auth_token`. Handler validates the blob shape, short-circuits on bad URLs / missing fields with user-visible strings (the caller is an LLM — raw exceptions summarize poorly), then persists.
+- **OpenAPI** — full schema for the new endpoint registered; `AgentAuthStatusSchema` extended with `has_oauth_client_credentials` flag and the `oauth_client_credentials` auth-type value.
+
+`$ENV:VAR_NAME` references in `client_id` / `client_secret` are stored as-written — the SDK resolves at exchange time, so no on-disk plaintext for operators who wire secrets through environment variables.
+
+Dashboard UI form for configuring client-credentials is intentionally not in this PR — tracked as a separate follow-up. This change is end-to-end testable via the `save_agent` Addie tool or a direct PUT to the endpoint.
+
+## Test plan
+
+- [x] `npm run typecheck` clean
+- [x] 29 unit tests across `compliance-db-resolve-owner-auth.test.ts` + `resolve-user-agent-auth.test.ts` covering every branch of the extended resolvers: client-credentials with all optional fields, with only required fields, with an invalid `auth_method` value (defensive-ignore), precedence vs auth-code OAuth, flag-vs-row divergence
+- [x] Full server unit suite: 1728 passed / 34 skipped / 0 failed
+- [x] OpenAPI coverage test passes (new endpoint registered with full request/response schemas)
+- [ ] Integration smoke test against a real authorization server — follow-up, not blocking

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -1085,15 +1085,29 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'save_agent',
     description:
-      'Save an agent URL to the organization\'s context and add it to the dashboard for compliance monitoring. Optionally store an auth token securely (encrypted, never shown in conversations). Use this when users want to connect their agent, set up compliance monitoring, save their agent for testing, or provide an auth token.',
-    usage_hints: 'use for "connect my agent", "add agent for compliance monitoring", "save my agent", "remember this agent URL", "store my auth token"',
+      'Save an agent URL to the organization\'s context and add it to the dashboard for compliance monitoring. Optionally store credentials securely (encrypted, never shown in conversations). Three auth modes, any of which may be combined with a new or existing save: (1) static bearer/basic via `auth_token`, (2) OAuth 2.0 client credentials (RFC 6749 §4.4, machine-to-machine) via `oauth_client_credentials`. Use this when users want to connect their agent, set up compliance monitoring, save their agent for testing, or provide credentials.',
+    usage_hints: 'use for "connect my agent", "add agent for compliance monitoring", "save my agent", "remember this agent URL", "store my auth token", "configure client credentials", "save OAuth client credentials"',
     input_schema: {
       type: 'object',
       properties: {
         agent_url: { type: 'string', description: 'Agent URL' },
         agent_name: { type: 'string', description: 'Agent name' },
-        auth_token: { type: 'string', description: 'Auth token (stored encrypted)' },
-        auth_type: { type: 'string', enum: ['bearer', 'basic'], description: 'How the token is sent. "bearer" (default): sends Authorization: Bearer <token>. "basic": auth_token must be the base64-encoded "user:password" string, sent as Authorization: Basic <token>' },
+        auth_token: { type: 'string', description: 'Static auth token (stored encrypted). Mutually exclusive with oauth_client_credentials on any given save call.' },
+        auth_type: { type: 'string', enum: ['bearer', 'basic'], description: 'How the auth_token is sent. "bearer" (default): sends Authorization: Bearer <token>. "basic": auth_token must be the base64-encoded "user:password" string, sent as Authorization: Basic <token>' },
+        oauth_client_credentials: {
+          type: 'object',
+          description: 'OAuth 2.0 client-credentials configuration for machine-to-machine auth (RFC 6749 §4.4). The SDK exchanges at the token endpoint before every call and refreshes on 401. Use this when the agent requires a bearer token minted from a client_id/client_secret pair, not a human authorization flow.',
+          properties: {
+            token_endpoint: { type: 'string', description: 'Token endpoint URL (HTTPS required; localhost allowed in dev).' },
+            client_id: { type: 'string', description: 'OAuth client ID. May be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time.' },
+            client_secret: { type: 'string', description: 'OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest regardless.' },
+            scope: { type: 'string', description: 'Space-separated OAuth scope values (optional).' },
+            resource: { type: 'string', description: 'RFC 8707 resource indicator (optional).' },
+            audience: { type: 'string', description: 'Audience parameter for audience-validating authorization servers like Auth0, Okta, Azure AD (optional).' },
+            auth_method: { type: 'string', enum: ['basic', 'body'], description: 'Where to put client credentials on the token request. "basic" (default, RFC 6749 §2.3.1 preferred): HTTP Basic header. "body": form fields.' },
+          },
+          required: ['token_endpoint', 'client_id', 'client_secret'],
+        },
         protocol: { type: 'string', enum: ['mcp', 'a2a'], description: 'Protocol (default: mcp)' },
       },
       required: ['agent_url'],
@@ -4873,6 +4887,54 @@ export function createMemberToolHandlers(
     const authType: 'bearer' | 'basic' = rawAuthType === 'basic' ? 'basic' : 'bearer';
     const protocol = (input.protocol as 'mcp' | 'a2a') || 'mcp';
 
+    // Parse and validate OAuth client-credentials if provided. Fail fast with
+    // a user-visible string — the tool's caller is an LLM and raw exceptions
+    // tend to get summarized into unhelpful errors.
+    let clientCredentials: {
+      token_endpoint: string;
+      client_id: string;
+      client_secret: string;
+      scope?: string;
+      resource?: string;
+      audience?: string;
+      auth_method?: 'basic' | 'body';
+    } | null = null;
+    if (input.oauth_client_credentials !== undefined && input.oauth_client_credentials !== null) {
+      const cc = input.oauth_client_credentials as Record<string, unknown>;
+      if (typeof cc !== 'object' || Array.isArray(cc)) {
+        return 'oauth_client_credentials must be an object with token_endpoint, client_id, and client_secret.';
+      }
+      if (typeof cc.token_endpoint !== 'string' || !cc.token_endpoint) {
+        return 'oauth_client_credentials.token_endpoint is required and must be a string.';
+      }
+      try {
+        const tokenUrl = new URL(cc.token_endpoint);
+        if (tokenUrl.protocol !== 'https:' && tokenUrl.hostname !== 'localhost' && tokenUrl.hostname !== '127.0.0.1') {
+          return 'oauth_client_credentials.token_endpoint must use https:// (http://localhost is OK for development).';
+        }
+      } catch {
+        return 'oauth_client_credentials.token_endpoint is not a valid URL.';
+      }
+      if (typeof cc.client_id !== 'string' || !cc.client_id) {
+        return 'oauth_client_credentials.client_id is required and must be a string.';
+      }
+      if (typeof cc.client_secret !== 'string' || !cc.client_secret) {
+        return 'oauth_client_credentials.client_secret is required and must be a string. Use `$ENV:VAR_NAME` to reference an environment variable.';
+      }
+      if (cc.auth_method !== undefined && cc.auth_method !== 'basic' && cc.auth_method !== 'body') {
+        return 'oauth_client_credentials.auth_method must be "basic" or "body" when set.';
+      }
+      clientCredentials = {
+        token_endpoint: cc.token_endpoint,
+        client_id: cc.client_id,
+        client_secret: cc.client_secret,
+        ...(typeof cc.scope === 'string' && cc.scope && { scope: cc.scope }),
+        ...(typeof cc.resource === 'string' && cc.resource && { resource: cc.resource }),
+        ...(typeof cc.audience === 'string' && cc.audience && { audience: cc.audience }),
+        ...(cc.auth_method && { auth_method: cc.auth_method as 'basic' | 'body' }),
+      };
+    }
+
     async function ensureAgentInProfile(displayName: string): Promise<void> {
       if (!saveOrgId) return;
       try {
@@ -4901,6 +4963,9 @@ export function createMemberToolHandlers(
         if (authToken) {
           await agentContextDb.saveAuthToken(context.id, authToken, authType);
         }
+        if (clientCredentials) {
+          await agentContextDb.saveOAuthClientCredentials(context.id, clientCredentials);
+        }
         context = await agentContextDb.getById(context.id);
 
         await ensureAgentInProfile(agentName || context?.agent_name || new URL(agentUrl).hostname);
@@ -4910,6 +4975,10 @@ export function createMemberToolHandlers(
           const typeLabel = authType === 'basic' ? 'Basic' : 'Bearer';
           response += `🔐 ${typeLabel} auth token saved securely (hint: ${context?.auth_token_hint})\n`;
           response += `_The token is encrypted and will never be shown again._\n`;
+        }
+        if (clientCredentials) {
+          response += `🔐 OAuth client-credentials saved securely for token endpoint ${clientCredentials.token_endpoint}\n`;
+          response += `_The client secret is encrypted and will never be shown again. The SDK exchanges and refreshes at test time._\n`;
         }
         return response;
       }
@@ -4925,6 +4994,11 @@ export function createMemberToolHandlers(
 
       if (authToken) {
         await agentContextDb.saveAuthToken(context.id, authToken, authType);
+      }
+      if (clientCredentials) {
+        await agentContextDb.saveOAuthClientCredentials(context.id, clientCredentials);
+      }
+      if (authToken || clientCredentials) {
         context = await agentContextDb.getById(context.id);
       }
 
@@ -4937,6 +5011,10 @@ export function createMemberToolHandlers(
         const typeLabel = authType === 'basic' ? 'Basic' : 'Bearer';
         response += `\n🔐 ${typeLabel} auth token saved securely (hint: ${context?.auth_token_hint})\n`;
         response += `_The token is encrypted and will never be shown again._\n`;
+      }
+      if (clientCredentials) {
+        response += `\n🔐 OAuth client-credentials saved securely for token endpoint ${clientCredentials.token_endpoint}\n`;
+        response += `_The client secret is encrypted and will never be shown again. The SDK exchanges and refreshes at test time._\n`;
       }
       response += `\nThe agent has been added to your dashboard. When you test this agent, I'll automatically use the saved credentials.`;
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -13,6 +13,8 @@
 import { randomUUID } from 'node:crypto';
 import { logger } from '../../logger.js';
 import { classifyProbeError, probeReasonLabel } from '../../utils/probe-error.js';
+import { validateExternalUrl } from '../../utils/url-security.js';
+import { parseOAuthClientCredentialsInput } from '../../routes/helpers/oauth-client-credentials-input.js';
 import { PUBLIC_TEST_AGENT, INTERNAL_PATH_AGENT_URL } from '../../config/test-agent.js';
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
@@ -44,7 +46,7 @@ import {
   type StoryboardContext,
   type StoryboardStepResult,
 } from '@adcp/client/testing';
-import { AgentContextDatabase } from '../../db/agent-context-db.js';
+import { AgentContextDatabase, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import {
   findExistingProposalOrFeed,
   createFeedProposal,
@@ -4887,52 +4889,17 @@ export function createMemberToolHandlers(
     const authType: 'bearer' | 'basic' = rawAuthType === 'basic' ? 'basic' : 'bearer';
     const protocol = (input.protocol as 'mcp' | 'a2a') || 'mcp';
 
-    // Parse and validate OAuth client-credentials if provided. Fail fast with
-    // a user-visible string — the tool's caller is an LLM and raw exceptions
-    // tend to get summarized into unhelpful errors.
-    let clientCredentials: {
-      token_endpoint: string;
-      client_id: string;
-      client_secret: string;
-      scope?: string;
-      resource?: string;
-      audience?: string;
-      auth_method?: 'basic' | 'body';
-    } | null = null;
+    // Route oauth_client_credentials through the shared parser so the Addie
+    // tool applies identical SSRF + $ENV-prefix rules as the REST endpoint.
+    // Any divergence here reopens the cloud-metadata / env-var exfiltration
+    // surface the REST path closed.
+    let clientCredentials: OAuthClientCredentials | null = null;
     if (input.oauth_client_credentials !== undefined && input.oauth_client_credentials !== null) {
-      const cc = input.oauth_client_credentials as Record<string, unknown>;
-      if (typeof cc !== 'object' || Array.isArray(cc)) {
-        return 'oauth_client_credentials must be an object with token_endpoint, client_id, and client_secret.';
-      }
-      if (typeof cc.token_endpoint !== 'string' || !cc.token_endpoint) {
-        return 'oauth_client_credentials.token_endpoint is required and must be a string.';
-      }
-      try {
-        const tokenUrl = new URL(cc.token_endpoint);
-        if (tokenUrl.protocol !== 'https:' && tokenUrl.hostname !== 'localhost' && tokenUrl.hostname !== '127.0.0.1') {
-          return 'oauth_client_credentials.token_endpoint must use https:// (http://localhost is OK for development).';
-        }
-      } catch {
-        return 'oauth_client_credentials.token_endpoint is not a valid URL.';
-      }
-      if (typeof cc.client_id !== 'string' || !cc.client_id) {
-        return 'oauth_client_credentials.client_id is required and must be a string.';
-      }
-      if (typeof cc.client_secret !== 'string' || !cc.client_secret) {
-        return 'oauth_client_credentials.client_secret is required and must be a string. Use `$ENV:VAR_NAME` to reference an environment variable.';
-      }
-      if (cc.auth_method !== undefined && cc.auth_method !== 'basic' && cc.auth_method !== 'body') {
-        return 'oauth_client_credentials.auth_method must be "basic" or "body" when set.';
-      }
-      clientCredentials = {
-        token_endpoint: cc.token_endpoint,
-        client_id: cc.client_id,
-        client_secret: cc.client_secret,
-        ...(typeof cc.scope === 'string' && cc.scope && { scope: cc.scope }),
-        ...(typeof cc.resource === 'string' && cc.resource && { resource: cc.resource }),
-        ...(typeof cc.audience === 'string' && cc.audience && { audience: cc.audience }),
-        ...(cc.auth_method && { auth_method: cc.auth_method as 'basic' | 'body' }),
-      };
+      const parsed = parseOAuthClientCredentialsInput(input.oauth_client_credentials, {
+        validateTokenEndpoint: validateExternalUrl,
+      });
+      if (!parsed.ok) return parsed.error;
+      clientCredentials = parsed.creds;
     }
 
     async function ensureAgentInProfile(displayName: string): Promise<void> {

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -1,6 +1,9 @@
 import { query } from './client.js';
 import { encrypt as encryptToken, decrypt as decryptToken } from './encryption.js';
+import { createLogger } from '../logger.js';
 import crypto from 'crypto';
+
+const logger = createLogger('agent-context-db');
 
 // =====================================================
 // TYPES
@@ -67,12 +70,7 @@ export interface OAuthClientCredentials {
   client_id: string;
   client_secret: string;
   scope?: string;
-  /**
-   * RFC 8707 resource indicator. The SDK accepts `string | string[]`; this
-   * first cut stores a single resource. Multi-resource support is a
-   * straightforward follow-up (JSON-encode on write, decode on read) but
-   * is not wired up yet.
-   */
+  /** RFC 8707 resource indicator. Single-resource only; multi-resource tracked as #2805. */
   resource?: string;
   audience?: string;
   /**
@@ -848,6 +846,13 @@ export class AgentContextDatabase {
     if (row.oauth_cc_audience) creds.audience = row.oauth_cc_audience;
     if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
       creds.auth_method = row.oauth_cc_auth_method;
+    } else if (row.oauth_cc_auth_method !== null && row.oauth_cc_auth_method !== undefined) {
+      // Surface unexpected values rather than silently dropping — a write
+      // path bypassed validation if this fires.
+      logger.warn(
+        { agentUrl, organizationId, value: row.oauth_cc_auth_method },
+        'agent-context-db: dropped unrecognized oauth_cc_auth_method',
+      );
     }
     return creds;
   }

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -26,6 +26,9 @@ export interface AgentContext {
   has_oauth_refresh_token: boolean;
   oauth_token_expires_at: Date | null;
   has_oauth_client: boolean;
+  // OAuth 2.0 client-credentials (RFC 6749 §4.4). True when token_endpoint
+  // + client_id + client_secret are all saved; the SDK exchanges at call time.
+  has_oauth_client_credentials: boolean;
   // Discovery cache
   tools_discovered: string[] | null;
   last_discovered_at: Date | null;
@@ -51,6 +54,33 @@ export interface OAuthClient {
   client_id: string;
   client_secret?: string;
   registered_redirect_uri?: string;
+}
+
+/**
+ * OAuth 2.0 client-credentials configuration stored for machine-to-machine
+ * agent auth (RFC 6749 §4.4). Mirrors the SDK's `AgentOAuthClientCredentials`
+ * shape in `@adcp/client`. `client_secret` is either a literal value or a
+ * `$ENV:VAR_NAME` reference — the SDK resolves the reference at exchange time.
+ */
+export interface OAuthClientCredentials {
+  token_endpoint: string;
+  client_id: string;
+  client_secret: string;
+  scope?: string;
+  /**
+   * RFC 8707 resource indicator. The SDK accepts `string | string[]`; this
+   * first cut stores a single resource. Multi-resource support is a
+   * straightforward follow-up (JSON-encode on write, decode on read) but
+   * is not wired up yet.
+   */
+  resource?: string;
+  audience?: string;
+  /**
+   * Client-credentials auth placement. `basic` = HTTP Basic header
+   * (RFC 6749 §2.3.1 preferred); `body` = client_id/client_secret as form
+   * fields. Passed through to `@adcp/client`'s exchange helper.
+   */
+  auth_method?: 'basic' | 'body';
 }
 
 export interface AgentTestHistory {
@@ -149,6 +179,9 @@ export class AgentContextDatabase {
         oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
+        (oauth_cc_token_endpoint IS NOT NULL
+          AND oauth_cc_client_id IS NOT NULL
+          AND oauth_cc_client_secret_encrypted IS NOT NULL) as has_oauth_client_credentials,
         tools_discovered,
         last_discovered_at,
         last_test_scenario,
@@ -186,6 +219,9 @@ export class AgentContextDatabase {
         oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
+        (oauth_cc_token_endpoint IS NOT NULL
+          AND oauth_cc_client_id IS NOT NULL
+          AND oauth_cc_client_secret_encrypted IS NOT NULL) as has_oauth_client_credentials,
         tools_discovered,
         last_discovered_at,
         last_test_scenario,
@@ -222,6 +258,9 @@ export class AgentContextDatabase {
         oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
+        (oauth_cc_token_endpoint IS NOT NULL
+          AND oauth_cc_client_id IS NOT NULL
+          AND oauth_cc_client_secret_encrypted IS NOT NULL) as has_oauth_client_credentials,
         tools_discovered,
         last_discovered_at,
         last_test_scenario,
@@ -351,6 +390,9 @@ export class AgentContextDatabase {
          oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
          oauth_token_expires_at,
          oauth_client_id IS NOT NULL as has_oauth_client,
+         (oauth_cc_token_endpoint IS NOT NULL
+           AND oauth_cc_client_id IS NOT NULL
+           AND oauth_cc_client_secret_encrypted IS NOT NULL) as has_oauth_client_credentials,
          tools_discovered,
          last_discovered_at,
          last_test_scenario,
@@ -706,6 +748,125 @@ export class AgentContextDatabase {
          oauth_refresh_token_encrypted = NULL,
          oauth_refresh_token_iv = NULL,
          oauth_token_expires_at = NULL,
+         updated_at = NOW()
+       WHERE id = $1`,
+      [id]
+    );
+  }
+
+  // =====================================================
+  // OAUTH CLIENT-CREDENTIALS METHODS (RFC 6749 §4.4)
+  // =====================================================
+
+  /**
+   * Save OAuth 2.0 client-credentials configuration for an agent context.
+   * `client_secret` is encrypted at rest regardless of whether it's a literal
+   * value or a `$ENV:VAR_NAME` reference — the SDK resolves the reference at
+   * exchange time, the server just stores and returns.
+   */
+  async saveOAuthClientCredentials(id: string, creds: OAuthClientCredentials): Promise<void> {
+    const context = await this.getById(id);
+    if (!context) {
+      throw new Error(`Agent context ${id} not found`);
+    }
+
+    const secretEncrypted = encryptToken(creds.client_secret, context.organization_id);
+
+    await query(
+      `UPDATE agent_contexts
+       SET
+         oauth_cc_token_endpoint = $1,
+         oauth_cc_client_id = $2,
+         oauth_cc_client_secret_encrypted = $3,
+         oauth_cc_client_secret_iv = $4,
+         oauth_cc_scope = $5,
+         oauth_cc_resource = $6,
+         oauth_cc_audience = $7,
+         oauth_cc_auth_method = $8,
+         updated_at = NOW()
+       WHERE id = $9`,
+      [
+        creds.token_endpoint,
+        creds.client_id,
+        secretEncrypted.encrypted,
+        secretEncrypted.iv,
+        creds.scope || null,
+        creds.resource || null,
+        creds.audience || null,
+        creds.auth_method || null,
+        id,
+      ]
+    );
+  }
+
+  /**
+   * Get OAuth client-credentials configuration by org + URL. Returns null if
+   * no credentials are saved (or if any required field is missing, which
+   * shouldn't happen for a well-formed save but is defensive).
+   */
+  async getOAuthClientCredentialsByOrgAndUrl(
+    organizationId: string,
+    agentUrl: string,
+  ): Promise<OAuthClientCredentials | null> {
+    const result = await query(
+      `SELECT
+        oauth_cc_token_endpoint,
+        oauth_cc_client_id,
+        oauth_cc_client_secret_encrypted,
+        oauth_cc_client_secret_iv,
+        oauth_cc_scope,
+        oauth_cc_resource,
+        oauth_cc_audience,
+        oauth_cc_auth_method
+       FROM agent_contexts
+       WHERE organization_id = $1 AND agent_url = $2`,
+      [organizationId, agentUrl]
+    );
+
+    const row = result.rows[0];
+    if (
+      !row ||
+      !row.oauth_cc_token_endpoint ||
+      !row.oauth_cc_client_id ||
+      !row.oauth_cc_client_secret_encrypted ||
+      !row.oauth_cc_client_secret_iv
+    ) {
+      return null;
+    }
+
+    const creds: OAuthClientCredentials = {
+      token_endpoint: row.oauth_cc_token_endpoint,
+      client_id: row.oauth_cc_client_id,
+      client_secret: decryptToken(
+        row.oauth_cc_client_secret_encrypted,
+        row.oauth_cc_client_secret_iv,
+        organizationId
+      ),
+    };
+    if (row.oauth_cc_scope) creds.scope = row.oauth_cc_scope;
+    if (row.oauth_cc_resource) creds.resource = row.oauth_cc_resource;
+    if (row.oauth_cc_audience) creds.audience = row.oauth_cc_audience;
+    if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
+      creds.auth_method = row.oauth_cc_auth_method;
+    }
+    return creds;
+  }
+
+  /**
+   * Remove OAuth client-credentials configuration.
+   */
+  async removeOAuthClientCredentials(id: string): Promise<void> {
+    await query(
+      `UPDATE agent_contexts
+       SET
+         oauth_cc_token_endpoint = NULL,
+         oauth_cc_client_id = NULL,
+         oauth_cc_client_secret_encrypted = NULL,
+         oauth_cc_client_secret_iv = NULL,
+         oauth_cc_scope = NULL,
+         oauth_cc_resource = NULL,
+         oauth_cc_audience = NULL,
+         oauth_cc_auth_method = NULL,
          updated_at = NOW()
        WHERE id = $1`,
       [id]

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -33,10 +33,8 @@ export type ResolvedOwnerAuth =
       /**
        * OAuth 2.0 client credentials (RFC 6749 §4.4). The SDK exchanges at
        * `credentials.token_endpoint` before every call and refreshes on 401.
-       * `credentials.client_secret` may be a `$ENV:VAR_NAME` reference — the
-       * SDK resolves at exchange time. `tokens` is an optional cache hint
-       * from a prior exchange; omitted when none is cached (SDK will
-       * exchange on first call).
+       * `credentials.client_secret` may be a `$ENV:ADCP_OAUTH_<NAME>`
+       * reference — the SDK resolves at exchange time.
        */
       type: 'oauth_client_credentials';
       credentials: {
@@ -48,7 +46,6 @@ export type ResolvedOwnerAuth =
         audience?: string;
         auth_method?: 'basic' | 'body';
       };
-      tokens?: { access_token: string; refresh_token?: string; expires_at?: string };
     };
 
 /**
@@ -714,6 +711,15 @@ export class ComplianceDatabase {
         if (row.oauth_cc_audience) credentials.audience = row.oauth_cc_audience;
         if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
           credentials.auth_method = row.oauth_cc_auth_method;
+        } else if (row.oauth_cc_auth_method !== null && row.oauth_cc_auth_method !== undefined) {
+          // Drop values outside the SDK's accepted enum rather than poisoning
+          // the return type — but log it. An unexpected value here means a
+          // write path bypassed validation, which is a latent bug worth
+          // surfacing before it spreads.
+          logger.warn(
+            { agentUrl, orgId: row.organization_id, value: row.oauth_cc_auth_method },
+            'Dropped unrecognized oauth_cc_auth_method from agent_context',
+          );
         }
         return { type: 'oauth_client_credentials', credentials };
       }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -28,6 +28,27 @@ export type ResolvedOwnerAuth =
       type: 'oauth';
       tokens: { access_token: string; refresh_token: string; expires_at?: string };
       client?: { client_id: string; client_secret?: string };
+    }
+  | {
+      /**
+       * OAuth 2.0 client credentials (RFC 6749 §4.4). The SDK exchanges at
+       * `credentials.token_endpoint` before every call and refreshes on 401.
+       * `credentials.client_secret` may be a `$ENV:VAR_NAME` reference — the
+       * SDK resolves at exchange time. `tokens` is an optional cache hint
+       * from a prior exchange; omitted when none is cached (SDK will
+       * exchange on first call).
+       */
+      type: 'oauth_client_credentials';
+      credentials: {
+        token_endpoint: string;
+        client_id: string;
+        client_secret: string;
+        scope?: string;
+        resource?: string;
+        audience?: string;
+        auth_method?: 'basic' | 'body';
+      };
+      tokens?: { access_token: string; refresh_token?: string; expires_at?: string };
     };
 
 /**
@@ -596,13 +617,24 @@ export class ComplianceDatabase {
                 ac.oauth_refresh_token_encrypted, ac.oauth_refresh_token_iv,
                 ac.oauth_token_expires_at,
                 ac.oauth_client_id,
-                ac.oauth_client_secret_encrypted, ac.oauth_client_secret_iv
+                ac.oauth_client_secret_encrypted, ac.oauth_client_secret_iv,
+                ac.oauth_cc_token_endpoint, ac.oauth_cc_client_id,
+                ac.oauth_cc_client_secret_encrypted, ac.oauth_cc_client_secret_iv,
+                ac.oauth_cc_scope, ac.oauth_cc_resource, ac.oauth_cc_audience, ac.oauth_cc_auth_method
          FROM agent_contexts ac
          JOIN member_profiles mp
            ON mp.workos_organization_id = ac.organization_id
          WHERE ac.agent_url = $1
            AND mp.agents @> $2::jsonb
-           AND (ac.auth_token_encrypted IS NOT NULL OR ac.oauth_access_token_encrypted IS NOT NULL)
+           AND (
+             ac.auth_token_encrypted IS NOT NULL
+             OR ac.oauth_access_token_encrypted IS NOT NULL
+             OR (
+               ac.oauth_cc_token_endpoint IS NOT NULL
+               AND ac.oauth_cc_client_id IS NOT NULL
+               AND ac.oauth_cc_client_secret_encrypted IS NOT NULL
+             )
+           )
          ORDER BY ac.updated_at DESC NULLS LAST
          LIMIT 1`,
         [agentUrl, JSON.stringify([{ url: agentUrl }])],
@@ -659,6 +691,31 @@ export class ComplianceDatabase {
           oauth.client = client;
         }
         return oauth;
+      }
+
+      if (
+        row.oauth_cc_token_endpoint &&
+        row.oauth_cc_client_id &&
+        row.oauth_cc_client_secret_encrypted &&
+        row.oauth_cc_client_secret_iv
+      ) {
+        const clientSecret = decryptToken(
+          row.oauth_cc_client_secret_encrypted,
+          row.oauth_cc_client_secret_iv,
+          row.organization_id,
+        );
+        const credentials: Extract<ResolvedOwnerAuth, { type: 'oauth_client_credentials' }>['credentials'] = {
+          token_endpoint: row.oauth_cc_token_endpoint,
+          client_id: row.oauth_cc_client_id,
+          client_secret: clientSecret,
+        };
+        if (row.oauth_cc_scope) credentials.scope = row.oauth_cc_scope;
+        if (row.oauth_cc_resource) credentials.resource = row.oauth_cc_resource;
+        if (row.oauth_cc_audience) credentials.audience = row.oauth_cc_audience;
+        if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
+          credentials.auth_method = row.oauth_cc_auth_method;
+        }
+        return { type: 'oauth_client_credentials', credentials };
       }
 
       return undefined;

--- a/server/src/db/migrations/419_oauth_client_credentials.sql
+++ b/server/src/db/migrations/419_oauth_client_credentials.sql
@@ -1,0 +1,67 @@
+-- Migration: 419_oauth_client_credentials.sql
+-- OAuth 2.0 client-credentials (RFC 6749 §4.4) support for agent contexts
+--
+-- Complements the authorization-code flow already in place (migration 195):
+-- where auth-code flow requires a human to authorize once and we hold a
+-- long-lived refresh token, client-credentials flow is machine-to-machine.
+-- The server stores the token endpoint + client credentials and the SDK
+-- exchanges at `@adcp/client`-level before every call, refreshing on 401.
+--
+-- Stored fields mirror @adcp/client's AgentOAuthClientCredentials shape.
+-- The `oauth_cc_client_secret` column stores either the literal secret or a
+-- `$ENV:VAR_NAME` reference — the SDK resolves the reference at exchange
+-- time. Either way we encrypt at rest for uniform handling.
+
+ALTER TABLE agent_contexts
+ADD COLUMN IF NOT EXISTS oauth_cc_token_endpoint TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_client_id TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_client_secret_encrypted TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_client_secret_iv TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_scope TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_resource TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_audience TEXT,
+ADD COLUMN IF NOT EXISTS oauth_cc_auth_method TEXT;
+
+COMMENT ON COLUMN agent_contexts.oauth_cc_token_endpoint IS 'OAuth 2.0 token endpoint URL for client-credentials exchange (RFC 6749 §4.4). HTTPS-only in production.';
+COMMENT ON COLUMN agent_contexts.oauth_cc_client_id IS 'OAuth client ID (RFC 6749 §2.2 — public identifier, not a secret).';
+COMMENT ON COLUMN agent_contexts.oauth_cc_client_secret_encrypted IS 'OAuth client secret, AES-256-GCM encrypted. Value is either a literal secret or a `$ENV:VAR_NAME` reference (SDK resolves at exchange time).';
+COMMENT ON COLUMN agent_contexts.oauth_cc_scope IS 'Space-separated OAuth scope values requested at token exchange (optional).';
+COMMENT ON COLUMN agent_contexts.oauth_cc_resource IS 'RFC 8707 resource indicator (optional).';
+COMMENT ON COLUMN agent_contexts.oauth_cc_audience IS 'Audience claim for audience-validating ASes (optional).';
+COMMENT ON COLUMN agent_contexts.oauth_cc_auth_method IS 'Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). Optional; SDK default is basic.';
+
+-- Refresh the summary view to surface client-credentials availability.
+-- The view is a DB-level presentation layer for dashboards and callers
+-- that want a cheap "is this agent configured?" check without fetching
+-- encrypted bodies.
+DROP VIEW IF EXISTS agent_context_summary;
+
+CREATE VIEW agent_context_summary AS
+SELECT
+  ac.id,
+  ac.organization_id,
+  ac.agent_url,
+  ac.agent_name,
+  ac.agent_type,
+  ac.protocol,
+  ac.auth_token_hint,
+  ac.auth_token_encrypted IS NOT NULL as has_auth_token,
+  ac.oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
+  ac.oauth_token_expires_at,
+  ac.oauth_client_id IS NOT NULL as has_oauth_client,
+  ac.oauth_cc_token_endpoint IS NOT NULL
+    AND ac.oauth_cc_client_id IS NOT NULL
+    AND ac.oauth_cc_client_secret_encrypted IS NOT NULL as has_oauth_client_credentials,
+  ac.tools_discovered,
+  ac.last_test_scenario,
+  ac.last_test_passed,
+  ac.last_test_summary,
+  ac.last_tested_at,
+  ac.total_tests_run,
+  ac.created_at,
+  ac.updated_at,
+  (SELECT COUNT(*) FROM agent_test_history h WHERE h.agent_context_id = ac.id) as history_count,
+  (SELECT COUNT(*) FROM agent_test_history h WHERE h.agent_context_id = ac.id AND h.overall_passed) as history_passed_count
+FROM agent_contexts ac;
+
+COMMENT ON VIEW agent_context_summary IS 'Agent contexts with auth info and stats aggregated';

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -1,0 +1,116 @@
+/**
+ * Parse and validate untrusted `oauth_client_credentials` input for the
+ * Test-your-agent save paths. Shared between the REST endpoint
+ * (`PUT /registry/agents/:url/oauth-client-credentials`) and the Addie
+ * `save_agent` MCP tool so both apply identical rules — any divergence
+ * reopens SSRF or env-var exfiltration surfaces one of the paths closed.
+ */
+
+import type { OAuthClientCredentials } from '../../db/agent-context-db.js';
+
+/**
+ * `$ENV:VAR_NAME` references resolved at exchange time by `@adcp/client`.
+ * Constrained to an OAuth-scoped namespace so a caller with save access
+ * cannot smuggle an unrelated server env var (`DATABASE_URL`,
+ * `ENCRYPTION_SECRET`, cloud credentials, …) into `client_id` /
+ * `client_secret` and exfiltrate it to a chosen token endpoint.
+ *
+ * Operators who want to wire secrets through environment variables
+ * must name them with the `ADCP_OAUTH_` prefix.
+ */
+const ENV_REFERENCE_PATTERN = /^\$ENV:ADCP_OAUTH_[A-Z0-9_]+$/;
+const ENV_REFERENCE_ERROR =
+  '$ENV references must match pattern $ENV:ADCP_OAUTH_<NAME> (uppercase alphanumeric + underscore). Other env-var names are not accepted as credential references.';
+
+export type ParseOAuthClientCredentialsResult =
+  | { ok: true; creds: OAuthClientCredentials }
+  | { ok: false; error: string };
+
+export interface ParseOAuthClientCredentialsOptions {
+  /** Returns the raw URL on success, null if the endpoint fails SSRF / scheme checks. */
+  validateTokenEndpoint: (url: string) => string | null;
+}
+
+export function parseOAuthClientCredentialsInput(
+  input: unknown,
+  opts: ParseOAuthClientCredentialsOptions,
+): ParseOAuthClientCredentialsResult {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, error: 'oauth_client_credentials must be an object with token_endpoint, client_id, and client_secret.' };
+  }
+  const cc = input as Record<string, unknown>;
+
+  if (typeof cc.token_endpoint !== 'string' || !cc.token_endpoint) {
+    return { ok: false, error: 'oauth_client_credentials.token_endpoint is required.' };
+  }
+  if (!opts.validateTokenEndpoint(cc.token_endpoint)) {
+    return {
+      ok: false,
+      error:
+        'oauth_client_credentials.token_endpoint failed URL validation. Must be https:// (http://localhost is allowed in development), and cannot be a cloud metadata or private-network host.',
+    };
+  }
+
+  if (typeof cc.client_id !== 'string' || !cc.client_id) {
+    return { ok: false, error: 'oauth_client_credentials.client_id is required.' };
+  }
+  if (cc.client_id.length > 2048) {
+    return { ok: false, error: 'oauth_client_credentials.client_id exceeds maximum length.' };
+  }
+  if (cc.client_id.startsWith('$ENV:') && !ENV_REFERENCE_PATTERN.test(cc.client_id)) {
+    return { ok: false, error: `oauth_client_credentials.client_id: ${ENV_REFERENCE_ERROR}` };
+  }
+
+  if (typeof cc.client_secret !== 'string' || !cc.client_secret) {
+    return {
+      ok: false,
+      error:
+        'oauth_client_credentials.client_secret is required. Use $ENV:ADCP_OAUTH_<NAME> to reference an environment variable.',
+    };
+  }
+  if (cc.client_secret.length > 8192) {
+    return { ok: false, error: 'oauth_client_credentials.client_secret exceeds maximum length.' };
+  }
+  if (cc.client_secret.startsWith('$ENV:') && !ENV_REFERENCE_PATTERN.test(cc.client_secret)) {
+    return { ok: false, error: `oauth_client_credentials.client_secret: ${ENV_REFERENCE_ERROR}` };
+  }
+
+  const scope = parseOptionalString(cc.scope, 1024, 'oauth_client_credentials.scope');
+  if (typeof scope === 'object' && scope && 'error' in scope) return { ok: false, error: scope.error };
+  const resource = parseOptionalString(cc.resource, 2048, 'oauth_client_credentials.resource');
+  if (typeof resource === 'object' && resource && 'error' in resource) return { ok: false, error: resource.error };
+  const audience = parseOptionalString(cc.audience, 2048, 'oauth_client_credentials.audience');
+  if (typeof audience === 'object' && audience && 'error' in audience) return { ok: false, error: audience.error };
+
+  let authMethod: 'basic' | 'body' | undefined;
+  if (cc.auth_method !== undefined && cc.auth_method !== null && cc.auth_method !== '') {
+    if (cc.auth_method !== 'basic' && cc.auth_method !== 'body') {
+      return { ok: false, error: 'oauth_client_credentials.auth_method must be "basic" or "body".' };
+    }
+    authMethod = cc.auth_method;
+  }
+
+  return {
+    ok: true,
+    creds: {
+      token_endpoint: cc.token_endpoint,
+      client_id: cc.client_id,
+      client_secret: cc.client_secret,
+      ...(typeof scope === 'string' && scope && { scope }),
+      ...(typeof resource === 'string' && resource && { resource }),
+      ...(typeof audience === 'string' && audience && { audience }),
+      ...(authMethod && { auth_method: authMethod }),
+    },
+  };
+}
+
+function parseOptionalString(
+  value: unknown,
+  max: number,
+  field: string,
+): string | null | { error: string } {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') return { error: `${field} must be a string.` };
+  if (value.length > max) return { error: `${field} exceeds maximum length.` };
+  return value;
+}

--- a/server/src/routes/helpers/resolve-user-agent-auth.ts
+++ b/server/src/routes/helpers/resolve-user-agent-auth.ts
@@ -41,32 +41,41 @@ export async function resolveUserAgentAuth(
 
   try {
     const context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
-    if (!context?.has_oauth_token) return undefined;
+    if (!context) return undefined;
 
-    const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, agentUrl);
-    if (!tokens?.access_token) return undefined;
+    if (context.has_oauth_token) {
+      const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, agentUrl);
+      if (tokens?.access_token) {
+        if (!tokens.refresh_token) {
+          return { type: 'bearer', token: tokens.access_token };
+        }
 
-    if (!tokens.refresh_token) {
-      return { type: 'bearer', token: tokens.access_token };
+        const oauth: Extract<ResolvedOwnerAuth, { type: 'oauth' }> = {
+          type: 'oauth',
+          tokens: {
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            ...(tokens.expires_at && { expires_at: tokens.expires_at.toISOString() }),
+          },
+        };
+
+        const client = await agentContextDb.getOAuthClient(context.id);
+        if (client) {
+          oauth.client = {
+            client_id: client.client_id,
+            ...(client.client_secret && { client_secret: client.client_secret }),
+          };
+        }
+        return oauth;
+      }
     }
 
-    const oauth: Extract<ResolvedOwnerAuth, { type: 'oauth' }> = {
-      type: 'oauth',
-      tokens: {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        ...(tokens.expires_at && { expires_at: tokens.expires_at.toISOString() }),
-      },
-    };
-
-    const client = await agentContextDb.getOAuthClient(context.id);
-    if (client) {
-      oauth.client = {
-        client_id: client.client_id,
-        ...(client.client_secret && { client_secret: client.client_secret }),
-      };
+    if (context.has_oauth_client_credentials) {
+      const creds = await agentContextDb.getOAuthClientCredentialsByOrgAndUrl(orgId, agentUrl);
+      if (creds) return { type: 'oauth_client_credentials', credentials: creds };
     }
-    return oauth;
+
+    return undefined;
   } catch (err) {
     logger.warn({ err, agentUrl, orgId }, 'resolveUserAgentAuth: OAuth token lookup failed');
     return undefined;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1659,6 +1659,56 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "put",
+  path: "/api/registry/agents/{encodedUrl}/oauth-client-credentials",
+  operationId: "saveAgentOAuthClientCredentials",
+  summary: "Save OAuth 2.0 client-credentials for an agent",
+  description:
+    "Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.",
+  tags: ["Agent Compliance"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            token_endpoint: z.string().max(2048).openapi({ description: "Token endpoint URL (HTTPS required; localhost allowed in dev)." }),
+            client_id: z.string().max(2048).openapi({ description: "OAuth client ID. May be a `$ENV:VAR_NAME` reference." }),
+            client_secret: z.string().max(8192).openapi({ description: "OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest." }),
+            scope: z.string().max(1024).optional().openapi({ description: "Space-separated OAuth scope values." }),
+            resource: z.string().max(2048).optional().openapi({ description: "RFC 8707 resource indicator." }),
+            audience: z.string().max(2048).optional().openapi({ description: "Audience parameter for audience-validating authorization servers." }),
+            auth_method: z.enum(["basic", "body"]).optional().openapi({ description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic." }),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Credentials saved",
+      content: {
+        "application/json": {
+          schema: z.object({
+            connected: z.literal(true),
+            has_auth: z.literal(true),
+            agent_context_id: z.string(),
+            auth_type: z.literal("oauth_client_credentials"),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid parameters", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
   method: "get",
   path: "/api/registry/agents/{encodedUrl}/applicable-storyboards",
   operationId: "getApplicableStoryboards",
@@ -3806,7 +3856,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         [JSON.stringify([{ url: agentUrl }]), req.user.id],
       );
 
-      const noAuthResponse = { has_auth: false, agent_context_id: null, auth_type: null, has_oauth_token: false, has_valid_oauth: false, oauth_token_expires_at: null };
+      const noAuthResponse = {
+        has_auth: false,
+        agent_context_id: null,
+        auth_type: null,
+        has_oauth_token: false,
+        has_valid_oauth: false,
+        oauth_token_expires_at: null,
+        has_oauth_client_credentials: false,
+      };
 
       if (orgResult.rows.length === 0) {
         return res.json(noAuthResponse);
@@ -3820,14 +3878,22 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       const hasValidOAuth = agentContextDb.hasValidOAuthTokens(context);
+      const hasCC = context.has_oauth_client_credentials;
 
       res.json({
-        has_auth: context.has_auth_token || hasValidOAuth,
+        has_auth: context.has_auth_token || hasValidOAuth || hasCC,
         agent_context_id: context.id,
-        auth_type: context.has_auth_token ? context.auth_type : hasValidOAuth ? "oauth" : null,
+        auth_type: context.has_auth_token
+          ? context.auth_type
+          : hasValidOAuth
+            ? "oauth"
+            : hasCC
+              ? "oauth_client_credentials"
+              : null,
         has_oauth_token: context.has_oauth_token,
         has_valid_oauth: hasValidOAuth,
         oauth_token_expires_at: context.oauth_token_expires_at?.toISOString() || null,
+        has_oauth_client_credentials: hasCC,
       });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to get agent auth status");
@@ -3904,6 +3970,131 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       res.status(500).json({ error: "Failed to connect agent" });
     }
   });
+
+  /**
+   * Save OAuth 2.0 client-credentials (RFC 6749 §4.4) for an agent. Parallel
+   * to /connect but for the machine-to-machine flow. Stored encrypted at
+   * rest; the SDK exchanges at `token_endpoint` before every call and
+   * refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference —
+   * the SDK resolves at exchange time, the server just stores the value as
+   * written (encrypted uniformly either way).
+   */
+  router.put(
+    "/registry/agents/:encodedUrl/oauth-client-credentials",
+    brandCreationRateLimiter,
+    ...complianceWriteMiddleware,
+    async (req, res) => {
+      try {
+        const agentUrl = decodeURIComponent(req.params.encodedUrl);
+        if (!validateAgentUrlParam(agentUrl)) {
+          return res.status(400).json({ error: "Invalid agent URL" });
+        }
+        if (!req.user) {
+          return res.status(401).json({ error: "Authentication required" });
+        }
+
+        const body = req.body as Record<string, unknown>;
+        const tokenEndpoint = typeof body.token_endpoint === "string" ? body.token_endpoint : null;
+        const clientId = typeof body.client_id === "string" ? body.client_id : null;
+        const clientSecret = typeof body.client_secret === "string" ? body.client_secret : null;
+
+        if (!tokenEndpoint) {
+          return res.status(400).json({ error: "token_endpoint is required" });
+        }
+        if (!clientId) {
+          return res.status(400).json({ error: "client_id is required" });
+        }
+        if (!clientSecret) {
+          return res.status(400).json({ error: "client_secret is required" });
+        }
+        if (!validateAgentUrlParam(tokenEndpoint)) {
+          return res.status(400).json({
+            error:
+              "token_endpoint failed URL validation. Must be https:// (http://localhost is OK in development), not a cloud metadata or private-network host.",
+          });
+        }
+        // Length limits guard against accidental payload-as-credential pastes
+        // without being so tight they reject real tokens or env-var refs.
+        if (clientId.length > 2048) {
+          return res.status(400).json({ error: "client_id exceeds maximum length" });
+        }
+        if (clientSecret.length > 8192) {
+          return res.status(400).json({ error: "client_secret exceeds maximum length" });
+        }
+
+        const optionalString = (key: string, max: number): string | null | { error: string } => {
+          const value = body[key];
+          if (value === undefined || value === null || value === "") return null;
+          if (typeof value !== "string") return { error: `${key} must be a string` };
+          if (value.length > max) return { error: `${key} exceeds maximum length` };
+          return value;
+        };
+        const scopeRes = optionalString("scope", 1024);
+        const resourceRes = optionalString("resource", 2048);
+        const audienceRes = optionalString("audience", 2048);
+        for (const r of [scopeRes, resourceRes, audienceRes]) {
+          if (r && typeof r === "object" && "error" in r) {
+            return res.status(400).json({ error: r.error });
+          }
+        }
+        const scope = typeof scopeRes === "string" ? scopeRes : undefined;
+        const resource = typeof resourceRes === "string" ? resourceRes : undefined;
+        const audience = typeof audienceRes === "string" ? audienceRes : undefined;
+
+        let authMethod: "basic" | "body" | undefined;
+        if (body.auth_method !== undefined && body.auth_method !== null && body.auth_method !== "") {
+          if (body.auth_method !== "basic" && body.auth_method !== "body") {
+            return res.status(400).json({ error: 'auth_method must be "basic" or "body"' });
+          }
+          authMethod = body.auth_method;
+        }
+
+        const orgResult = await query<{ workos_organization_id: string }>(
+          `SELECT mp.workos_organization_id
+           FROM member_profiles mp
+           JOIN organization_memberships om
+             ON om.workos_organization_id = mp.workos_organization_id
+           WHERE mp.agents @> $1::jsonb
+             AND om.workos_user_id = $2
+           LIMIT 1`,
+          [JSON.stringify([{ url: agentUrl }]), req.user.id],
+        );
+        if (orgResult.rows.length === 0) {
+          return res.status(403).json({ error: "You do not have permission to modify this agent" });
+        }
+        const orgId = orgResult.rows[0].workos_organization_id;
+
+        let context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+        if (!context) {
+          context = await agentContextDb.create({
+            organization_id: orgId,
+            agent_url: agentUrl,
+            created_by: req.user.id,
+          });
+        }
+
+        await agentContextDb.saveOAuthClientCredentials(context.id, {
+          token_endpoint: tokenEndpoint,
+          client_id: clientId,
+          client_secret: clientSecret,
+          ...(scope && { scope }),
+          ...(resource && { resource }),
+          ...(audience && { audience }),
+          ...(authMethod && { auth_method: authMethod }),
+        });
+
+        res.json({
+          connected: true,
+          has_auth: true,
+          agent_context_id: context.id,
+          auth_type: "oauth_client_credentials",
+        });
+      } catch (error) {
+        logger.error({ err: error, path: req.path }, "Failed to save oauth client credentials");
+        res.status(500).json({ error: "Failed to save OAuth client credentials" });
+      }
+    },
+  );
 
   // ── Storyboards ────────────────────────────────────────────────
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -26,7 +26,7 @@ import {
 import { PUBLIC_TEST_AGENT } from "../config/test-agent.js";
 import * as policiesDb from "../db/policies-db.js";
 import { createLogger } from "../logger.js";
-import { validateCrawlDomain } from "../utils/url-security.js";
+import { validateCrawlDomain, validateExternalUrl } from "../utils/url-security.js";
 import {
   registry,
   ResolvedBrandSchema,
@@ -74,6 +74,7 @@ import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
+import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
@@ -3609,31 +3610,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     return (await resolveAgentOwnerOrg(userId, agentUrl)) !== null;
   }
 
-  function validateAgentUrlParam(raw: string): string | null {
-    try {
-      const url = new URL(raw);
-      if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-
-      const hostname = url.hostname.toLowerCase();
-
-      // Block cloud metadata endpoints
-      if (hostname === "169.254.169.254" || hostname === "metadata.google.internal") return null;
-
-      // Block private/loopback addresses in production
-      if (process.env.NODE_ENV === "production") {
-        if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "0.0.0.0") return null;
-        const ipMatch = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-        if (ipMatch) {
-          const [, a, b] = ipMatch.map(Number);
-          if (a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)) return null;
-        }
-      }
-
-      return raw;
-    } catch {
-      return null;
-    }
-  }
+  // Shared SSRF-resistant URL validator lives in utils/url-security.ts so the
+  // Addie tool handler (save_agent) can apply identical rules to OAuth
+  // token_endpoint values — any divergence reopens the cloud-metadata
+  // / private-IP exfiltration surface we closed here.
+  const validateAgentUrlParam = validateExternalUrl;
 
   /**
    * Ensure an agent_context exists so the UI can hand the user a working
@@ -3993,60 +3974,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const body = req.body as Record<string, unknown>;
-        const tokenEndpoint = typeof body.token_endpoint === "string" ? body.token_endpoint : null;
-        const clientId = typeof body.client_id === "string" ? body.client_id : null;
-        const clientSecret = typeof body.client_secret === "string" ? body.client_secret : null;
-
-        if (!tokenEndpoint) {
-          return res.status(400).json({ error: "token_endpoint is required" });
-        }
-        if (!clientId) {
-          return res.status(400).json({ error: "client_id is required" });
-        }
-        if (!clientSecret) {
-          return res.status(400).json({ error: "client_secret is required" });
-        }
-        if (!validateAgentUrlParam(tokenEndpoint)) {
-          return res.status(400).json({
-            error:
-              "token_endpoint failed URL validation. Must be https:// (http://localhost is OK in development), not a cloud metadata or private-network host.",
-          });
-        }
-        // Length limits guard against accidental payload-as-credential pastes
-        // without being so tight they reject real tokens or env-var refs.
-        if (clientId.length > 2048) {
-          return res.status(400).json({ error: "client_id exceeds maximum length" });
-        }
-        if (clientSecret.length > 8192) {
-          return res.status(400).json({ error: "client_secret exceeds maximum length" });
-        }
-
-        const optionalString = (key: string, max: number): string | null | { error: string } => {
-          const value = body[key];
-          if (value === undefined || value === null || value === "") return null;
-          if (typeof value !== "string") return { error: `${key} must be a string` };
-          if (value.length > max) return { error: `${key} exceeds maximum length` };
-          return value;
-        };
-        const scopeRes = optionalString("scope", 1024);
-        const resourceRes = optionalString("resource", 2048);
-        const audienceRes = optionalString("audience", 2048);
-        for (const r of [scopeRes, resourceRes, audienceRes]) {
-          if (r && typeof r === "object" && "error" in r) {
-            return res.status(400).json({ error: r.error });
-          }
-        }
-        const scope = typeof scopeRes === "string" ? scopeRes : undefined;
-        const resource = typeof resourceRes === "string" ? resourceRes : undefined;
-        const audience = typeof audienceRes === "string" ? audienceRes : undefined;
-
-        let authMethod: "basic" | "body" | undefined;
-        if (body.auth_method !== undefined && body.auth_method !== null && body.auth_method !== "") {
-          if (body.auth_method !== "basic" && body.auth_method !== "body") {
-            return res.status(400).json({ error: 'auth_method must be "basic" or "body"' });
-          }
-          authMethod = body.auth_method;
+        const parsed = parseOAuthClientCredentialsInput(req.body, {
+          validateTokenEndpoint: validateExternalUrl,
+        });
+        if (!parsed.ok) {
+          return res.status(400).json({ error: parsed.error });
         }
 
         const orgResult = await query<{ workos_organization_id: string }>(
@@ -4073,15 +4005,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           });
         }
 
-        await agentContextDb.saveOAuthClientCredentials(context.id, {
-          token_endpoint: tokenEndpoint,
-          client_id: clientId,
-          client_secret: clientSecret,
-          ...(scope && { scope }),
-          ...(resource && { resource }),
-          ...(audience && { audience }),
-          ...(authMethod && { auth_method: authMethod }),
-        });
+        await agentContextDb.saveOAuthClientCredentials(context.id, parsed.creds);
 
         res.json({
           connected: true,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -533,10 +533,11 @@ export const AgentAuthStatusSchema = z
   .object({
     has_auth: z.boolean(),
     agent_context_id: z.string().nullable(),
-    auth_type: z.enum(["bearer", "basic", "oauth"]).nullable(),
+    auth_type: z.enum(["bearer", "basic", "oauth", "oauth_client_credentials"]).nullable(),
     has_oauth_token: z.boolean(),
     has_valid_oauth: z.boolean(),
     oauth_token_expires_at: z.string().nullable(),
+    has_oauth_client_credentials: z.boolean(),
   })
   .openapi("AgentAuthStatus");
 

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -123,6 +123,49 @@ export async function validateCrawlDomain(domain: string): Promise<string> {
 }
 
 /**
+ * Validate an externally-reachable URL the server will contact on the caller's
+ * behalf (agent endpoints, OAuth token endpoints, etc.). Returns the raw URL on
+ * success, null when it fails any check. Behaves as a synchronous pre-flight
+ * (no DNS) so it can be used in request handlers without adding latency.
+ *
+ * Rules:
+ * - Must parse as a URL.
+ * - Protocol must be http or https.
+ * - Cloud metadata hosts are always blocked, every environment (AWS/GCP).
+ * - In production only: localhost/loopback and RFC1918 private IPv4 ranges
+ *   are blocked. Development keeps them allowed so local agents and local
+ *   auth servers are reachable.
+ *
+ * For stronger SSRF guarantees (DNS rebind defence, redirect-hop validation,
+ * IPv6, CGNAT, link-local), prefer `safeFetch` at fetch time.
+ */
+export function validateExternalUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+
+    const hostname = url.hostname.toLowerCase();
+
+    if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') return null;
+
+    if (process.env.NODE_ENV === 'production') {
+      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') {
+        return null;
+      }
+      const ipMatch = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+      if (ipMatch) {
+        const [, a, b] = ipMatch.map(Number);
+        if (a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)) return null;
+      }
+    }
+
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * SSRF-safe fetch: validates the URL and all redirect hops against private IP ranges,
  * then returns the response. Encapsulates the full validation + fetch cycle so that
  * callers receive a Response with no tainted URL flowing to fetch().

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -32,6 +32,14 @@ function mockRow(overrides: Record<string, unknown>) {
     oauth_client_id: null,
     oauth_client_secret_encrypted: null,
     oauth_client_secret_iv: null,
+    oauth_cc_token_endpoint: null,
+    oauth_cc_client_id: null,
+    oauth_cc_client_secret_encrypted: null,
+    oauth_cc_client_secret_iv: null,
+    oauth_cc_scope: null,
+    oauth_cc_resource: null,
+    oauth_cc_audience: null,
+    oauth_cc_auth_method: null,
     ...overrides,
   };
   mockedQuery.mockResolvedValueOnce({ rows: [base], rowCount: 1, command: '', oid: 0, fields: [] });
@@ -188,6 +196,106 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     expect(auth).toEqual({ type: 'bearer', token: 'static-bearer-plaintext' });
     // Exactly one decrypt call: the OAuth path must not execute.
     expect(mockedDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns oauth_client_credentials shape when configured', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_scope: 'adcp',
+      oauth_cc_resource: 'https://agent.example.com',
+      oauth_cc_audience: 'https://agent.example.com',
+      oauth_cc_auth_method: 'basic',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth_client_credentials',
+      credentials: {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'cc-secret-plaintext',
+        scope: 'adcp',
+        resource: 'https://agent.example.com',
+        audience: 'https://agent.example.com',
+        auth_method: 'basic',
+      },
+    });
+
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('returns oauth_client_credentials without optional fields when none are saved', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth_client_credentials',
+      credentials: {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'cc-secret-plaintext',
+      },
+    });
+  });
+
+  it('ignores an invalid oauth_cc_auth_method value instead of throwing', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      // A stale value from a migration or a rogue write — the resolver
+      // refuses to pass it through rather than break the SDK's type contract.
+      oauth_cc_auth_method: 'client_secret_post',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toEqual({
+      type: 'oauth_client_credentials',
+      credentials: {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'cc-secret-plaintext',
+      },
+    });
+  });
+
+  it('prefers auth-code OAuth over client-credentials when both are present', async () => {
+    mockRow({
+      oauth_access_token_encrypted: 'enc_access',
+      oauth_access_token_iv: 'iv_access',
+      oauth_refresh_token_encrypted: 'enc_refresh',
+      oauth_refresh_token_iv: 'iv_refresh',
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+    });
+    mockedDecrypt.mockImplementation((encrypted: string) => {
+      if (encrypted === 'enc_access') return 'access-plaintext';
+      if (encrypted === 'enc_refresh') return 'refresh-plaintext';
+      throw new Error(`unexpected decrypt call: ${encrypted}`);
+    });
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    // Auth-code with a refresh token has zero round-trip cost; client-creds
+    // always pays an exchange. Prefer the cheaper path when both exist.
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access-plaintext', refresh_token: 'refresh-plaintext' },
+    });
   });
 
   it('returns undefined when the query throws', async () => {

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -249,14 +249,16 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     });
   });
 
-  it('ignores an invalid oauth_cc_auth_method value instead of throwing', async () => {
+  it('drops (and logs warn on) an unrecognized oauth_cc_auth_method value', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',
       oauth_cc_client_secret_encrypted: 'enc_cc_secret',
       oauth_cc_client_secret_iv: 'iv_cc_secret',
-      // A stale value from a migration or a rogue write — the resolver
-      // refuses to pass it through rather than break the SDK's type contract.
+      // A stale value from a migration or a rogue write — the resolver drops
+      // it rather than poisoning the return type. The warn log surfaces the
+      // write-path validation gap; this test asserts only the behavior, the
+      // log is observed via the test runner's stderr capture.
       oauth_cc_auth_method: 'client_secret_post',
     });
     mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
@@ -270,6 +272,34 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
         client_secret: 'cc-secret-plaintext',
       },
     });
+  });
+
+  it('returns undefined when token_endpoint is set but client_id is missing (partial row)', async () => {
+    // Partial rows shouldn't happen given the write-path validation, but are
+    // defensive-guarded here — a botched migration or manual DB write must
+    // not lead to emitting an invalid { credentials } shape to the SDK.
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      // client_id intentionally null
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+    });
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toBeUndefined();
+  });
+
+  it('returns undefined when client_secret_encrypted is set but client_secret_iv is missing', async () => {
+    // Symmetric to the auth-code path's half-written-row guard.
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      // iv intentionally null — can't decrypt without it
+    });
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toBeUndefined();
   });
 
   it('prefers auth-code OAuth over client-credentials when both are present', async () => {

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { parseOAuthClientCredentialsInput } from '../../src/routes/helpers/oauth-client-credentials-input.js';
+
+// The real token-endpoint validator is tested elsewhere; here we just need
+// predictable accept/reject behavior so the parser's branches are isolable.
+const acceptAll = (url: string) => url;
+const rejectAll = () => null;
+
+describe('parseOAuthClientCredentialsInput', () => {
+  const validMinimal = {
+    token_endpoint: 'https://auth.example.com/oauth/token',
+    client_id: 'client_abc',
+    client_secret: 'literal-secret',
+  };
+
+  it('accepts a minimal valid blob', () => {
+    const result = parseOAuthClientCredentialsInput(validMinimal, { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.creds).toEqual(validMinimal);
+  });
+
+  it('accepts all optional fields when valid', () => {
+    const result = parseOAuthClientCredentialsInput(
+      {
+        ...validMinimal,
+        scope: 'adcp',
+        resource: 'https://agent.example.com',
+        audience: 'https://agent.example.com',
+        auth_method: 'body',
+      },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.creds.auth_method).toBe('body');
+    expect(result.creds.scope).toBe('adcp');
+  });
+
+  it('accepts $ENV: references that match the ADCP_OAUTH_ prefix', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: '$ENV:ADCP_OAUTH_SANDBOX_SECRET' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  // ── Required-field errors ──────────────────────────────
+
+  it('rejects non-object input', () => {
+    const result = parseOAuthClientCredentialsInput('oops', { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/must be an object/);
+  });
+
+  it('rejects an array input', () => {
+    const result = parseOAuthClientCredentialsInput([], { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects missing token_endpoint', () => {
+    const { token_endpoint: _, ...rest } = validMinimal;
+    const result = parseOAuthClientCredentialsInput(rest, { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/token_endpoint is required/);
+  });
+
+  it('rejects missing client_id', () => {
+    const { client_id: _, ...rest } = validMinimal;
+    const result = parseOAuthClientCredentialsInput(rest, { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/client_id is required/);
+  });
+
+  it('rejects missing client_secret', () => {
+    const { client_secret: _, ...rest } = validMinimal;
+    const result = parseOAuthClientCredentialsInput(rest, { validateTokenEndpoint: acceptAll });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/client_secret is required/);
+  });
+
+  // ── Validator rejection (SSRF / scheme) ────────────────
+
+  it('rejects when the token_endpoint validator returns null (SSRF / scheme failure)', () => {
+    const result = parseOAuthClientCredentialsInput(validMinimal, { validateTokenEndpoint: rejectAll });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/failed URL validation/);
+  });
+
+  // ── $ENV: allowlist (security must-fix) ────────────────
+
+  it('rejects $ENV: references in client_secret that do not match the ADCP_OAUTH_ prefix', () => {
+    // This is the server-secret exfiltration vector: a member saves
+    // `$ENV:DATABASE_URL` and the SDK sends the DATABASE_URL to a
+    // member-chosen token endpoint. The allowlist must block this.
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: '$ENV:DATABASE_URL' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/\$ENV references must match/);
+  });
+
+  it('rejects $ENV: references in client_id that do not match the ADCP_OAUTH_ prefix', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_id: '$ENV:ENCRYPTION_SECRET' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/\$ENV references must match/);
+  });
+
+  it('rejects lowercase in the $ENV: variable name', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: '$ENV:ADCP_OAUTH_lowercase' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a bare $ENV: prefix with no variable name', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: '$ENV:' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts literal secret values that happen to start with a dollar sign', () => {
+    // A literal secret like "$8s0meR@nd0m!" must pass through — only strings
+    // starting with "$ENV:" are treated as references.
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: '$8s0meR@nd0m!' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  // ── Type / length ──────────────────────────────────────
+
+  it('rejects a client_id that exceeds the length limit', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_id: 'x'.repeat(2049) },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/client_id exceeds maximum length/);
+  });
+
+  it('rejects a client_secret that exceeds the length limit', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, client_secret: 'x'.repeat(8193) },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a non-string scope', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, scope: 42 },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/scope must be a string/);
+  });
+
+  it('treats empty optional strings as absent (does not reject, does not persist)', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, scope: '', resource: '', audience: '' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.creds.scope).toBeUndefined();
+    expect(result.creds.resource).toBeUndefined();
+    expect(result.creds.audience).toBeUndefined();
+  });
+
+  it('rejects an auth_method outside the enum', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, auth_method: 'client_secret_post' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/auth_method must be "basic" or "body"/);
+  });
+
+  it('treats auth_method = undefined / null / "" as absent', () => {
+    for (const value of [undefined, null, '']) {
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, auth_method: value },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      expect(result.creds.auth_method).toBeUndefined();
+    }
+  });
+});

--- a/server/tests/unit/resolve-user-agent-auth.test.ts
+++ b/server/tests/unit/resolve-user-agent-auth.test.ts
@@ -5,7 +5,11 @@ import type { ResolvedOwnerAuth } from '../../src/db/compliance-db.js';
 
 type StubbedAgentContextDb = Pick<
   AgentContextDatabase,
-  'getAuthInfoByOrgAndUrl' | 'getByOrgAndUrl' | 'getOAuthTokensByOrgAndUrl' | 'getOAuthClient'
+  | 'getAuthInfoByOrgAndUrl'
+  | 'getByOrgAndUrl'
+  | 'getOAuthTokensByOrgAndUrl'
+  | 'getOAuthClient'
+  | 'getOAuthClientCredentialsByOrgAndUrl'
 >;
 
 function makeDb(): {
@@ -16,6 +20,7 @@ function makeDb(): {
     getByOrgAndUrl: vi.fn(),
     getOAuthTokensByOrgAndUrl: vi.fn(),
     getOAuthClient: vi.fn(),
+    getOAuthClientCredentialsByOrgAndUrl: vi.fn(),
   };
 }
 
@@ -161,12 +166,89 @@ describe('resolveUserAgentAuth', () => {
 
   it('returns undefined when the org has no stored credentials', async () => {
     db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
-    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: false });
+    db.getByOrgAndUrl.mockResolvedValueOnce({
+      id: 'ctx_1',
+      has_oauth_token: false,
+      has_oauth_client_credentials: false,
+    });
 
     const auth = await call();
 
     expect(auth).toBeUndefined();
     expect(db.getOAuthTokensByOrgAndUrl).not.toHaveBeenCalled();
+    expect(db.getOAuthClientCredentialsByOrgAndUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns oauth_client_credentials shape when configured', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({
+      id: 'ctx_1',
+      has_oauth_token: false,
+      has_oauth_client_credentials: true,
+    });
+    db.getOAuthClientCredentialsByOrgAndUrl.mockResolvedValueOnce({
+      token_endpoint: 'https://auth.example.com/oauth/token',
+      client_id: 'client_abc',
+      client_secret: 'cc-secret-plaintext',
+      scope: 'adcp',
+      audience: 'https://agent.example.com',
+      auth_method: 'basic',
+    });
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth_client_credentials',
+      credentials: {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'cc-secret-plaintext',
+        scope: 'adcp',
+        audience: 'https://agent.example.com',
+        auth_method: 'basic',
+      },
+    });
+    expect(db.getOAuthClientCredentialsByOrgAndUrl).toHaveBeenCalledWith(ORG, URL);
+
+    const _typed: ResolvedOwnerAuth = auth!;
+    void _typed;
+  });
+
+  it('returns undefined when flagged has_oauth_client_credentials but the lookup misses', async () => {
+    // Defensive — flag-vs-row divergence shouldn't crash, just return no auth.
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({
+      id: 'ctx_1',
+      has_oauth_token: false,
+      has_oauth_client_credentials: true,
+    });
+    db.getOAuthClientCredentialsByOrgAndUrl.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toBeUndefined();
+  });
+
+  it('prefers auth-code OAuth over client-credentials when both are configured', async () => {
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({
+      id: 'ctx_1',
+      has_oauth_token: true,
+      has_oauth_client_credentials: true,
+    });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({
+      access_token: 'access',
+      refresh_token: 'refresh',
+    });
+    db.getOAuthClient.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toEqual({
+      type: 'oauth',
+      tokens: { access_token: 'access', refresh_token: 'refresh' },
+    });
+    expect(db.getOAuthClientCredentialsByOrgAndUrl).not.toHaveBeenCalled();
   });
 
   it('returns undefined when agent_context is missing entirely', async () => {


### PR DESCRIPTION
Closes the **server leg** of [#2761](https://github.com/adcontextprotocol/adcp/issues/2761). Dashboard UI form is a separate follow-up PR.

Complements [#2738](https://github.com/adcontextprotocol/adcp/pull/2738)'s authorization-code plumbing by handing the SDK the [`oauth_client_credentials`](https://github.com/adcontextprotocol/adcp-client/pull/746) shape shipped in `@adcp/client` 5.9.0 for agents that use machine-to-machine OAuth (RFC 6749 §4.4) instead of a human authorize flow.

## What's in this PR

### Migration
`419_oauth_client_credentials.sql` — new `oauth_cc_token_endpoint`, `oauth_cc_client_id`, `oauth_cc_client_secret_*`, `oauth_cc_scope`, `oauth_cc_resource`, `oauth_cc_audience`, `oauth_cc_auth_method` columns on `agent_contexts`. Client secret AES-256-GCM encrypted via the existing `encryption.ts` (same salt-per-org pattern as the auth-code path). The `agent_context_summary` view surfaces a derived `has_oauth_client_credentials` flag.

### DB layer
`AgentContextDatabase.saveOAuthClientCredentials` / `getOAuthClientCredentialsByOrgAndUrl` / `removeOAuthClientCredentials`. New `OAuthClientCredentials` interface mirrors the SDK's `AgentOAuthClientCredentials` exactly — `auth_method: 'basic' | 'body'`, optional `scope` / `resource` / `audience`. `AgentContext.has_oauth_client_credentials: boolean` on every read path.

### Resolvers
`ResolvedOwnerAuth` gains the `{ type: 'oauth_client_credentials', credentials, tokens? }` variant. Both `ComplianceDatabase.resolveOwnerAuth` (compliance heartbeat cron) and the `resolveUserAgentAuth` helper behind the four Test-your-agent endpoints read the new columns and emit the SDK-ready shape.

**Precedence** when multiple auth modes are configured (edge case; typically only one is set):
1. Static bearer/basic (connect form)
2. Auth-code OAuth with refresh token
3. Client credentials
4. Bearer fallback (expired auth-code access token, no refresh)

Rationale: auth-code with refresh has zero extra round-trip; client-creds always pays a token-endpoint exchange.

### New endpoint
`PUT /api/registry/agents/:encodedUrl/oauth-client-credentials` — parallel to `/connect` but for the machine flow. Validates `token_endpoint` via the same SSRF-resistant helper that gates agent URLs (HTTPS-only in production, cloud-metadata + private-IP blocked). Same ownership check as `/connect`. Length limits on `client_id` / `client_secret` guard against accidental payload-as-credential pastes.

### Addie tool
`save_agent` accepts an `oauth_client_credentials` object alongside `auth_token`. The handler validates blob shape, short-circuits on bad URLs / missing fields with user-visible strings (caller is an LLM — raw exceptions summarize poorly), then persists via the new DB method.

### OpenAPI
Full schema registered for the new endpoint; `AgentAuthStatusSchema` extended with `has_oauth_client_credentials` flag and the `oauth_client_credentials` auth-type value. Coverage lint passes.

## `$ENV:VAR_NAME` handling

`client_id` and `client_secret` may be passed as `$ENV:VAR_NAME` references. The server stores them as-written (encrypted uniformly); the SDK resolves at exchange time. Operators who wire secrets through env vars keep zero plaintext on the server's disk.

## Test plan

- [x] `npm run typecheck` clean
- [x] 29 unit tests across `compliance-db-resolve-owner-auth.test.ts` + `resolve-user-agent-auth.test.ts` covering every resolver branch: all-optionals client-credentials, required-fields-only, invalid `auth_method` defensive-ignore, precedence vs auth-code OAuth, flag-vs-row divergence. `ResolvedOwnerAuth` type-assignability guards on the new variant.
- [x] Full server unit suite: 1728 passed / 34 skipped / 0 failed
- [x] OpenAPI coverage test passes
- [ ] Integration smoke against a real authorization server — follow-up, not blocking

## What's NOT in this PR

- **Dashboard UI form** for configuring client-credentials. Tracked as a separate follow-up. The change is end-to-end testable via the `save_agent` Addie tool or a direct PUT to the new endpoint.
- **Cached token persistence**. `agent_context.oauth_access_token_*` columns could cache an exchange result to skip the AS round-trip. Not wired up — the SDK exchanges before every call with a short-lived in-memory cache (see adcp-client#746), so the server-side cache is an optimization, not a correctness requirement.
- **Multi-resource (`resource: string[]`)** indicator support. Single-resource works; multi-resource would require JSON-encoding on write, decoding on read. Documented in the `OAuthClientCredentials` interface comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)