### PR TITLE
feat(dashboard): OAuth client-credentials form (closes #2761 UI leg)

### DIFF
--- a/.changeset/oauth-cc-dashboard-ui.md
+++ b/.changeset/oauth-cc-dashboard-ui.md
@@ -1,0 +1,22 @@
+---
+---
+
+feat(dashboard): OAuth client-credentials form on the agent compliance page
+
+Closes the UI leg of [#2761](https://github.com/adcontextprotocol/adcp/issues/2761). Completes the server-side work in [#2800](https://github.com/adcontextprotocol/adcp/pull/2800).
+
+Adds a third option to the existing Auth-type select on `dashboard-agents.html` — "OAuth client credentials (machine-to-machine)" — alongside the existing OAuth (authorization-code) and bearer/basic options. Selecting it reveals fields for:
+
+- `token_endpoint` (URL, required, validated server-side for SSRF)
+- `client_id`, `client_secret` (required; both accept `$ENV:ADCP_OAUTH_<NAME>` references that the SDK resolves at exchange time)
+- `scope`, `resource`, `audience` (optional)
+- `auth_method` select (basic = HTTP Basic header, or body = form fields)
+
+Submit calls `PUT /api/registry/agents/:encodedUrl/oauth-client-credentials` (shipped in #2800), validates through the shared `parseOAuthClientCredentialsInput` server-side, and persists encrypted. The "Auth configured" label distinguishes `oauth_client_credentials` from plain OAuth in the post-save state.
+
+## Test plan
+
+- [x] Isolated Playwright test — 16/16 assertions pass: form renders, select has the new option, toggle shows the correct field group, PUT fires with the correctly-encoded URL and full JSON body, empty optionals omitted, success state replaces the form
+- [x] JS in the HTML parses cleanly
+- [x] Typecheck clean
+- [ ] In-browser validation against a running dev server (requires WorkOS / PG / encryption secret — recommended before merge)

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -257,7 +257,8 @@
     }
     .agent-connect-form input { min-width: 260px; }
     .agent-connect-save,
-    .agent-oauth-start {
+    .agent-oauth-start,
+    .agent-cc-save {
       background: var(--color-primary-600);
       color: white;
       border: none;
@@ -267,9 +268,11 @@
       cursor: pointer;
     }
     .agent-connect-save:hover,
-    .agent-oauth-start:hover { background: var(--color-primary-700); }
+    .agent-oauth-start:hover,
+    .agent-cc-save:hover { background: var(--color-primary-700); }
     .agent-connect-save:disabled,
-    .agent-oauth-start:disabled { opacity: 0.6; cursor: not-allowed; }
+    .agent-oauth-start:disabled,
+    .agent-cc-save:disabled { opacity: 0.6; cursor: not-allowed; }
     .agent-oauth-start { align-self: flex-end; }
     .agent-connect-msg {
       font-size: var(--text-xs);
@@ -776,15 +779,21 @@
         '</div>' +
         '<div class="auth-cc-fields" style="display:none;">' +
           '<p style="font-size:var(--text-sm);color:var(--color-text-secondary);margin:var(--space-2) 0;">' +
-            'Server-to-server OAuth (RFC 6749 §4.4). The SDK exchanges at the token endpoint before each call. ' +
-            'For secrets wired through environment variables, use <code>$ENV:ADCP_OAUTH_&lt;NAME&gt;</code> references (uppercase + underscore).' +
+            'Server-to-server OAuth (RFC 6749 §4.4). The SDK exchanges at the token endpoint before each call and refreshes on 401. ' +
+            'For secrets wired through environment variables, use <code>$ENV:ADCP_OAUTH_&lt;NAME&gt;</code> references. ' +
+            'The <code>ADCP_OAUTH_</code> prefix is required — other env-var names are rejected server-side so a misconfigured agent can\'t read unrelated secrets.' +
           '</p>' +
           '<label>Token endpoint<input type="url" name="cc_token_endpoint" placeholder="https://auth.example.com/oauth/token" autocomplete="off" required></label>' +
+          '<p style="font-size:var(--text-xs);color:var(--color-text-secondary);margin:calc(-1 * var(--space-2)) 0 var(--space-2) 0;">' +
+            'Auth0: <code>https://{tenant}.auth0.com/oauth/token</code> · Okta: <code>https://{org}.okta.com/oauth2/default/v1/token</code> · Azure AD: <code>https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token</code> · Keycloak: <code>https://{host}/realms/{realm}/protocol/openid-connect/token</code>' +
+          '</p>' +
           '<label>Client ID<input type="text" name="cc_client_id" placeholder="client_abc or $ENV:ADCP_OAUTH_CLIENT_ID" autocomplete="off" required></label>' +
           '<label>Client secret<input type="password" name="cc_client_secret" placeholder="literal secret or $ENV:ADCP_OAUTH_CLIENT_SECRET" autocomplete="off" required></label>' +
           '<label>Scope <span style="color:var(--color-text-secondary);">(optional)</span><input type="text" name="cc_scope" placeholder="adcp" autocomplete="off"></label>' +
           '<label>Resource <span style="color:var(--color-text-secondary);">(optional, RFC 8707)</span><input type="text" name="cc_resource" placeholder="https://agent.example.com" autocomplete="off"></label>' +
+          '<p style="font-size:var(--text-xs);color:var(--color-text-secondary);margin:calc(-1 * var(--space-2)) 0 var(--space-2) 0;">The agent URL the token is for. Okta and Keycloak typically use <code>resource</code>.</p>' +
           '<label>Audience <span style="color:var(--color-text-secondary);">(optional)</span><input type="text" name="cc_audience" placeholder="https://agent.example.com" autocomplete="off"></label>' +
+          '<p style="font-size:var(--text-xs);color:var(--color-text-secondary);margin:calc(-1 * var(--space-2)) 0 var(--space-2) 0;">Auth0\'s name for the same thing (the <code>aud</code> claim). Use either <code>resource</code> OR <code>audience</code> — not both unless your IdP asks for it.</p>' +
           '<label>Auth method<select name="cc_auth_method">' +
             '<option value="">Basic (default — HTTP Basic header)</option>' +
             '<option value="basic">Basic (HTTP Basic header)</option>' +

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -760,6 +760,7 @@
       return '<div class="agent-connect-form" data-agent-url="' + escapedUrl + '"' + contextIdAttr + '>' +
         '<label>Auth type<select name="auth_type" class="auth-type-select">' +
           '<option value="oauth">OAuth (recommended)</option>' +
+          '<option value="oauth_client_credentials">OAuth client credentials (machine-to-machine)</option>' +
           '<option value="bearer">Bearer token</option>' +
           '<option value="basic">Basic auth</option>' +
         '</select></label>' +
@@ -772,6 +773,25 @@
           '<p style="font-size:var(--text-sm);color:var(--color-text-secondary);margin:var(--space-2) 0;">Securely authorize via the agent\'s OAuth flow. No tokens to copy.</p>' +
           '<label>Platform type<select name="platform_type_oauth"><option value="">Auto-detect</option>' + platformTypeOptions + '</select></label>' +
           '<button class="agent-oauth-start">Authorize</button>' +
+        '</div>' +
+        '<div class="auth-cc-fields" style="display:none;">' +
+          '<p style="font-size:var(--text-sm);color:var(--color-text-secondary);margin:var(--space-2) 0;">' +
+            'Server-to-server OAuth (RFC 6749 §4.4). The SDK exchanges at the token endpoint before each call. ' +
+            'For secrets wired through environment variables, use <code>$ENV:ADCP_OAUTH_&lt;NAME&gt;</code> references (uppercase + underscore).' +
+          '</p>' +
+          '<label>Token endpoint<input type="url" name="cc_token_endpoint" placeholder="https://auth.example.com/oauth/token" autocomplete="off" required></label>' +
+          '<label>Client ID<input type="text" name="cc_client_id" placeholder="client_abc or $ENV:ADCP_OAUTH_CLIENT_ID" autocomplete="off" required></label>' +
+          '<label>Client secret<input type="password" name="cc_client_secret" placeholder="literal secret or $ENV:ADCP_OAUTH_CLIENT_SECRET" autocomplete="off" required></label>' +
+          '<label>Scope <span style="color:var(--color-text-secondary);">(optional)</span><input type="text" name="cc_scope" placeholder="adcp" autocomplete="off"></label>' +
+          '<label>Resource <span style="color:var(--color-text-secondary);">(optional, RFC 8707)</span><input type="text" name="cc_resource" placeholder="https://agent.example.com" autocomplete="off"></label>' +
+          '<label>Audience <span style="color:var(--color-text-secondary);">(optional)</span><input type="text" name="cc_audience" placeholder="https://agent.example.com" autocomplete="off"></label>' +
+          '<label>Auth method<select name="cc_auth_method">' +
+            '<option value="">Basic (default — HTTP Basic header)</option>' +
+            '<option value="basic">Basic (HTTP Basic header)</option>' +
+            '<option value="body">Body (client_id/client_secret as form fields)</option>' +
+          '</select></label>' +
+          '<label>Platform type<select name="platform_type_cc"><option value="">Auto-detect</option>' + platformTypeOptions + '</select></label>' +
+          '<button class="agent-cc-save">Save credentials</button>' +
         '</div>' +
       '</div>';
     }
@@ -862,7 +882,7 @@
               </div>
             </div>
             ${hasAuth
-              ? '<div style="padding: var(--space-4) 0; color: var(--color-text-secondary); font-size: var(--text-sm);">Auth configured' + (authInfo?.auth_type === 'oauth' ? ' via OAuth' : '') + '. Compliance check will run on the next heartbeat cycle.</div>'
+              ? '<div style="padding: var(--space-4) 0; color: var(--color-text-secondary); font-size: var(--text-sm);">Auth configured' + (authInfo?.auth_type === 'oauth' ? ' via OAuth' : authInfo?.auth_type === 'oauth_client_credentials' ? ' via OAuth client credentials' : '') + '. Compliance check will run on the next heartbeat cycle.</div>'
               : buildConnectForm(escapeHtml(agent.url), platformTypeOptions, authInfo?.agent_context_id)}
             <div class="agent-meta-row">
               <span></span>
@@ -1083,7 +1103,7 @@
       }
     });
 
-    // Auth type toggle — show/hide token vs OAuth fields
+    // Auth type toggle — show exactly one of the three field groups.
     document.addEventListener('change', function(e) {
       const select = e.target.closest('.auth-type-select');
       if (!select) return;
@@ -1091,12 +1111,68 @@
       if (!form) return;
       const tokenFields = form.querySelector('.auth-token-fields');
       const oauthFields = form.querySelector('.auth-oauth-fields');
-      if (select.value === 'oauth') {
-        tokenFields.style.display = 'none';
-        oauthFields.style.display = '';
-      } else {
-        tokenFields.style.display = '';
-        oauthFields.style.display = 'none';
+      const ccFields = form.querySelector('.auth-cc-fields');
+      tokenFields.style.display = select.value === 'bearer' || select.value === 'basic' ? '' : 'none';
+      oauthFields.style.display = select.value === 'oauth' ? '' : 'none';
+      ccFields.style.display = select.value === 'oauth_client_credentials' ? '' : 'none';
+    });
+
+    // OAuth client-credentials save handler (PUT /oauth-client-credentials).
+    // Parallel to the bearer/basic "Save" handler, different endpoint.
+    document.addEventListener('click', async function(e) {
+      const saveBtn = e.target.closest('.agent-cc-save');
+      if (!saveBtn) return;
+      const form = saveBtn.closest('.agent-connect-form');
+      if (!form) return;
+
+      const agentUrl = form.dataset.agentUrl;
+      const tokenEndpoint = form.querySelector('[name="cc_token_endpoint"]').value.trim();
+      const clientId = form.querySelector('[name="cc_client_id"]').value.trim();
+      const clientSecret = form.querySelector('[name="cc_client_secret"]').value;
+      const scope = form.querySelector('[name="cc_scope"]').value.trim();
+      const resource = form.querySelector('[name="cc_resource"]').value.trim();
+      const audience = form.querySelector('[name="cc_audience"]').value.trim();
+      const authMethod = form.querySelector('[name="cc_auth_method"]').value;
+
+      if (!tokenEndpoint) { form.querySelector('[name="cc_token_endpoint"]').focus(); return; }
+      if (!clientId) { form.querySelector('[name="cc_client_id"]').focus(); return; }
+      if (!clientSecret) { form.querySelector('[name="cc_client_secret"]').focus(); return; }
+
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+
+      try {
+        const body = { token_endpoint: tokenEndpoint, client_id: clientId, client_secret: clientSecret };
+        if (scope) body.scope = scope;
+        if (resource) body.resource = resource;
+        if (audience) body.audience = audience;
+        if (authMethod) body.auth_method = authMethod;
+
+        const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/oauth-client-credentials', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to save credentials');
+        }
+
+        form.innerHTML = '<div class="agent-connect-msg" style="color:var(--color-success-600);">Credentials saved. Compliance check will run on the next heartbeat cycle.</div>';
+        setTimeout(() => location.reload(), 1500);
+      } catch (err) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save credentials';
+        let msg = form.querySelector('.agent-connect-msg');
+        if (!msg) {
+          msg = document.createElement('div');
+          msg.className = 'agent-connect-msg';
+          form.appendChild(msg);
+        }
+        msg.style.color = 'var(--color-error-600)';
+        msg.textContent = err.message;
       }
     });
 


### PR DESCRIPTION
Closes the **UI leg** of [#2761](https://github.com/adcontextprotocol/adcp/issues/2761). Completes the feature — server-side persistence and resolution landed in [#2800](https://github.com/adcontextprotocol/adcp/pull/2800).

> **Rebase dependency:** [#2813](https://github.com/adcontextprotocol/adcp/pull/2813) renumbers the colliding migration 419 to 420. Merge that first, then this PR rebases onto clean main.

## What this PR adds

A third option on the agent-compliance page's Auth-type select — **OAuth client credentials (machine-to-machine)** — alongside the existing OAuth (authorization-code) and bearer/basic options. Selecting it reveals:

| Field | Notes |
|---|---|
| `token_endpoint` | HTTPS URL, required. Validated server-side for SSRF (same helper as agent URLs). Inline hint shows Auth0/Okta/Azure AD/Keycloak URL patterns. |
| `client_id` | Required. May be `$ENV:ADCP_OAUTH_<NAME>`. |
| `client_secret` | Required, masked. May be `$ENV:ADCP_OAUTH_<NAME>`. Stored encrypted at rest. |
| `scope` | Optional. Space-separated. |
| `resource` | Optional. RFC 8707 resource indicator. Hint clarifies Okta/Keycloak use this one. |
| `audience` | Optional. Hint clarifies this is Auth0's name for the same thing (`aud` claim). |
| `auth_method` | `basic` (HTTP Basic header, default, RFC 6749 §2.3.1 preferred) or `body` (form fields). |

Submit fires `PUT /api/registry/agents/:encodedUrl/oauth-client-credentials` (the endpoint from #2800), which runs the input through the shared `parseOAuthClientCredentialsInput` validator — same rules (SSRF, `$ENV:ADCP_OAUTH_` allowlist, length limits) whether the save came from this form or the Addie `save_agent` tool.

The "Auth configured" label on the post-save state now distinguishes `oauth_client_credentials` from plain OAuth.

## Review cycle

Ran through code-reviewer, security-reviewer, and dx-expert. Addressed in this PR:

- **Code (should-fix):** Added `.agent-cc-save` to the CSS selector lists so the new button matches the branded primary-colored look of the other two save buttons.
- **DX:** IdP URL pattern hint under `token_endpoint`; one-line clarifications distinguishing `resource` (RFC 8707, Okta/Keycloak) from `audience` (Auth0's `aud` claim); expanded `$ENV:ADCP_OAUTH_` hint to explain *why* the prefix is mandatory (server-side allowlist — prevents a misconfigured agent from referencing unrelated env vars).
- **Security:** Clean bill (verified CSRF is enforced globally via the `/csrf.js` fetch monkey-patch, no local guard needed).

Deferred as follow-ups:
- [#2809](https://github.com/adcontextprotocol/adcp/issues/2809) — "Test now" dry-run button
- [#2810](https://github.com/adcontextprotocol/adcp/issues/2810) — Structured error codes on credential-save endpoints
- [#2811](https://github.com/adcontextprotocol/adcp/issues/2811) — Dedupe platform_type across auth-variant field groups

## Verification

- [x] **Isolated Playwright test** — 16/16 assertions pass. Loads the real `buildConnectForm` + toggle + submit handlers, stubs `fetch`, drives the form end-to-end, and asserts on the captured request.
- [x] **E2E against Docker-booted dev server** — 10/10 assertions pass. Verified after rebuilding the image that the served `/dashboard-agents.html` includes every new marker: `OAuth client credentials` option, `auth-cc-fields` container, `cc_token_endpoint` input, `$ENV:ADCP_OAUTH_` policy hint, IdP URL patterns (Auth0/Okta/Azure AD/Keycloak), RFC 8707 resource hint, `agent-cc-save` CSS class.
- [x] JS in the HTML parses cleanly.
- [x] `npm run typecheck` clean.

## Screenshot

Full-page screenshot of the empty-state dashboard served from Docker available at `.context/oauth-cc-dashboard.png` locally; the form-visible render is covered by the isolated Playwright test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)