### PR TITLE
docs: surface adoption path and trust narrative for 3.0 GA

### DIFF
--- a/.changeset/adoption-audit-discoverability.md
+++ b/.changeset/adoption-audit-discoverability.md
@@ -1,0 +1,12 @@
+---
+---
+
+docs: adoption-path discoverability for 3.0
+
+The build and trust surfaces exist but are hard for newcomers and LLMs to find. This surfaces them without duplicating content:
+
+- New `docs/trust.mdx` — single entry point that unifies governance, regulatory, privacy, security, provenance, and disclosure chapters that already exist. Added to top-level nav alongside Quickstart.
+- Quickstart top callout — two-path `<CardGroup>` routes buyers vs publisher/seller builders before they invest in the wrong example.
+- `llms.txt` / `llms-full.txt` — add adoption path (quickstart → build → validate → operate → trust), SDK inventory (both-sides), `build-*-agent` skill inventory, and registry API paths.
+
+No new narrative, no moved content.

--- a/docs.json
+++ b/docs.json
@@ -71,6 +71,7 @@
             "pages": [
               "docs/intro",
               "docs/quickstart",
+              "docs/trust",
               {
                 "group": "Building with AdCP",
                 "expanded": false,
@@ -799,6 +800,7 @@
                 "group": "Governance",
                 "expanded": false,
                 "pages": [
+                  "docs/trust",
                   "docs/governance/overview",
                   "docs/governance/embedded-human-judgment",
                   "docs/governance/policy-registry",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,10 +1,19 @@
 ---
 title: Quickstart
-description: "Make your first AdCP call in 5 minutes. One MCP tool call, one error case, one media buy — with copy-pasteable curl commands and expected output."
+description: "Pick your path — buyers call an AdCP agent in 5 minutes, publishers and sellers stand up their own agent."
 "og:title": "AdCP — Quickstart"
 ---
 
-Make your first AdCP call in 5 minutes against the public test agent.
+Pick your path. Buyers call the public test agent in 5 minutes. Publishers and sellers stand up an agent others can call.
+
+<CardGroup cols={2}>
+  <Card title="I'm connecting to agents" icon="plug" href="#setup">
+    Buyer side. Call the public test agent with one curl command. Start below.
+  </Card>
+  <Card title="I'm building an agent" icon="server" href="/docs/building/build-an-agent">
+    Publisher or seller side. Stand up an agent others can call.
+  </Card>
+</CardGroup>
 
 ## Setup
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -8,7 +8,7 @@ Pick your path. Buyers call the public test agent in 5 minutes. Publishers and s
 
 <CardGroup cols={2}>
   <Card title="I'm connecting to agents" icon="plug" href="#setup">
-    Buyer side. Call the public test agent with one curl command. Start below.
+    Buyer side. Call the public test agent with the SDK in 5 minutes. Start below.
   </Card>
   <Card title="I'm building an agent" icon="server" href="/docs/building/build-an-agent">
     Publisher or seller side. Stand up an agent others can call.

--- a/docs/trust.mdx
+++ b/docs/trust.mdx
@@ -1,0 +1,128 @@
+---
+title: Trust by Design
+sidebarTitle: Trust
+description: "How AdCP enforces trust through architecture — governance, safety, privacy, security, provenance, and disclosure built into the wire protocol."
+"og:title": "AdCP — Trust by Design"
+---
+
+An AI agent just approved a \$2M upfront commitment on behalf of a bank. It negotiated the price, signed the terms, and moved the money. The buyer's compliance team finds out on Monday.
+
+This is the scenario AdCP was designed to prevent. Not by slowing agents down, and not by asking vendors to promise they'll behave — but by building the guardrails into the protocol itself. Every transaction passes through a governance agent the buyer controls. Every agent declares the authority it was granted, and cannot exceed it. Every creative, signal, and media buy carries provenance the next party can verify.
+
+**Trust in AdCP is architectural, not promised.**
+
+Safety, privacy, security, and human oversight are enforced in the wire protocol — across buyer, seller, and governance agents — so the same rules hold whether you're running one campaign or ten thousand.
+
+Here's how it works across the protocol.
+
+## Governance
+
+Three-party separation of duties: the agent that proposes a buy cannot approve it, the agent that validates cannot execute it, and the agent that fulfills cannot override either. Humans set policy; agents operate within it.
+
+<CardGroup cols={2}>
+  <Card title="Governance overview" href="/docs/governance/overview">
+    Three-party model, registered plans, and `check_governance` validation before money moves.
+  </Card>
+  <Card title="Embedded human judgment" href="/docs/governance/embedded-human-judgment">
+    Why oversight is architectural, not bolted-on — and how approval flows work.
+  </Card>
+  <Card title="Policy registry" href="/docs/governance/policy-registry">
+    Shared policy definitions across buyers, sellers, and governance agents.
+  </Card>
+  <Card title="Campaign safety model" href="/docs/governance/campaign/safety-model">
+    How budgets, flight windows, and scope constraints are enforced.
+  </Card>
+</CardGroup>
+
+## Regulatory compliance
+
+AdCP treats EU AI Act Annex III and GDPR Article 22 as design constraints, not compliance checkboxes. Human oversight, audit trails, and disclosure are protocol primitives.
+
+<CardGroup cols={2}>
+  <Card title="Annex III & Article 22 obligations" href="/docs/governance/annex-iii-obligations">
+    What EU AI Act Annex III and GDPR Article 22 require, and what AdCP provides.
+  </Card>
+  <Card title="Privacy considerations" href="/docs/reference/privacy-considerations">
+    Data minimization, consent signals, and jurisdiction-specific requirements.
+  </Card>
+</CardGroup>
+
+## Privacy
+
+Identity and targeting data flow through AdCP under a consent-first, minimization-first architecture. Buyers and sellers can collaborate on audiences without either party holding raw user data.
+
+<CardGroup cols={2}>
+  <Card title="Privacy architecture" href="/docs/trusted-match/privacy-architecture">
+    Router-mediated matching, federated identity, and what never crosses party boundaries.
+  </Card>
+  <Card title="Privacy considerations" href="/docs/reference/privacy-considerations">
+    What deployers are responsible for and where AdCP provides enforcement hooks.
+  </Card>
+</CardGroup>
+
+## Security
+
+Every AdCP transport — MCP or A2A — requires authenticated, signed, replay-protected exchanges. Webhooks are HMAC-signed. Financial operations are idempotent by construction.
+
+<CardGroup cols={3}>
+  <Card title="Security model" href="/docs/building/understanding/security-model">
+    The threat model AdCP addresses: impersonation, replay, tampering, and authority escalation.
+  </Card>
+  <Card title="Security implementation" href="/docs/building/implementation/security">
+    Authentication schemes, webhook verification, idempotency keys, and financial safeguards.
+  </Card>
+  <Card title="Report a vulnerability" href="https://github.com/adcontextprotocol/adcp/blob/main/SECURITY.md">
+    Responsible disclosure to security@adcontextprotocol.org. 72-hour initial response, coordinated disclosure after fix.
+  </Card>
+</CardGroup>
+
+## Provenance
+
+Creatives carry verifiable origin. Inventory is sold only by authorized agents. Buyers can prove where impressions ran and who was allowed to sell them.
+
+<CardGroup cols={2}>
+  <Card title="Creative provenance" href="/docs/governance/creative/provenance-verification">
+    How AI-generated and human-made creatives are signed, tracked, and verified.
+  </Card>
+  <Card title="Authorized properties" href="/docs/governance/property/adagents">
+    `adagents.json` — publisher-declared authorization for which agents may sell their inventory.
+  </Card>
+  <Card title="Content standards" href="/docs/governance/content-standards/index">
+    Brand safety rules enforced before, during, and after delivery.
+  </Card>
+</CardGroup>
+
+## Disclosure
+
+Agents declare what they are. AI-generated creatives are signed, agent-mediated transactions are labeled, and sponsored content inside conversational surfaces is disclosed to the end user.
+
+<CardGroup cols={1}>
+  <Card title="AI disclosure" href="/docs/ai-disclosure">
+    How AdCP surfaces AI involvement to end users and downstream agents.
+  </Card>
+</CardGroup>
+
+## For compliance reviewers
+
+Concrete enforcement artifacts — these are the wire-level tasks that implement the policies above.
+
+<CardGroup cols={2}>
+  <Card title="check_governance" href="/docs/governance/campaign/tasks/check_governance">
+    The validation call that runs before every buy. What gets blocked and why.
+  </Card>
+  <Card title="get_plan_audit_logs" href="/docs/governance/campaign/tasks/get_plan_audit_logs">
+    The decision trail. Every governance decision with timestamp, policy reference, and outcome.
+  </Card>
+  <Card title="validate_property_delivery" href="/docs/governance/property/tasks/validate_property_delivery">
+    Post-delivery proof that impressions ran only on authorized properties.
+  </Card>
+  <Card title="validate_content_delivery" href="/docs/governance/content-standards/tasks/validate_content_delivery">
+    Post-delivery proof that impressions complied with declared content standards.
+  </Card>
+</CardGroup>
+
+## For implementers
+
+- **[Validate your agent](/docs/building/validate-your-agent)** — storyboards exercise safety, authorization, and error paths, not just happy-path tool calls.
+- **[Build an agent](/docs/building/build-an-agent)** — skill files include governance, provenance, and safety handling by default.
+- **[Operating an agent](/docs/building/operating-an-agent)** — what sits behind the protocol, including the non-protocol pieces of trust (hosting, key management, monitoring).

--- a/server/public/llms-full.txt
+++ b/server/public/llms-full.txt
@@ -117,6 +117,22 @@ The registry provides centralized discovery of AdCP-compatible agents, brands, a
 
 Documentation: https://adcontextprotocol.org/docs/registry
 
+## Trust and safety
+
+Trust in AdCP is architectural, not promised. Safety, privacy, security, and human oversight are enforced in the wire protocol across buyer, seller, and governance agents.
+
+Six pillars:
+- **Governance**: three-party separation of duties. The agent that proposes a buy cannot approve it; the agent that validates cannot execute it; the agent that fulfills cannot override either. Humans set policy; agents operate within it.
+- **Regulatory compliance**: designed to satisfy EU AI Act Annex III and GDPR Article 22 for automated decision-making. Human oversight, audit trails, and disclosure are first-class primitives.
+- **Privacy**: identity and targeting data flow under a consent-first, minimization-first architecture. Router-mediated matching means buyers and sellers can collaborate on audiences without either holding raw user data.
+- **Security**: every transport (MCP or A2A) requires authenticated, signed, replay-protected exchanges. Webhooks are HMAC-signed. Financial operations are idempotent by construction.
+- **Provenance**: creatives carry verifiable origin. Inventory is sold only by authorized agents declared via adagents.json. Buyers can prove where impressions ran and who was allowed to sell them.
+- **Disclosure**: agents declare what they are. AI-generated creatives are signed, agent-mediated transactions are labeled, and sponsored content inside conversational surfaces is disclosed to the end user.
+
+Trust landing page: https://adcontextprotocol.org/docs/trust
+
+Responsible disclosure for security vulnerabilities: https://github.com/adcontextprotocol/adcp/blob/main/SECURITY.md — email security@adcontextprotocol.org, 72-hour initial response.
+
 ## Transport protocols
 
 AdCP is transport-agnostic and supports two primary mechanisms:
@@ -158,11 +174,58 @@ All AdCP request and response payloads are defined as JSON Schema. Schemas are p
 
 ## Getting started
 
-1. Read the introduction: https://adcontextprotocol.org/docs/intro
-2. Understand the architecture: https://adcontextprotocol.org/docs/building/understanding
-3. Choose your transport (MCP or A2A): https://adcontextprotocol.org/docs/building/integration
-4. Implement your first task: https://adcontextprotocol.org/docs/building/implementation
-5. Explore schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
+Adoption path:
+1. Quickstart — 5-minute curl example against the public test agent: https://adcontextprotocol.org/docs/quickstart
+2. Build an agent — point a coding agent at a SKILL.md from an AdCP SDK: https://adcontextprotocol.org/docs/building/build-an-agent
+3. Validate an agent — run storyboards against your endpoint for pass/fail conformance: https://adcontextprotocol.org/docs/building/validate-your-agent
+4. Operate an agent — what sits behind the protocol (hosting, products, monitoring): https://adcontextprotocol.org/docs/building/operating-an-agent
+5. Trust, safety, governance — the architectural trust story: https://adcontextprotocol.org/docs/trust
+
+For deeper reading:
+- Understand the architecture: https://adcontextprotocol.org/docs/building/understanding
+- Choose your transport (MCP or A2A): https://adcontextprotocol.org/docs/building/integration
+- Implementation patterns: https://adcontextprotocol.org/docs/building/implementation
+- Schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
+
+## SDKs
+
+AdCP SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+
+- JavaScript/TypeScript (`@adcp/client`): https://github.com/adcontextprotocol/adcp-client
+- Python (`adcp`): https://github.com/adcontextprotocol/adcp-python
+- Go (`adcp-go`): https://github.com/adcontextprotocol/adcp-go
+
+Each SDK ships both caller APIs and server primitives (tool registration, response builders, test controllers). The JavaScript SDK includes a storyboard runner that validates any endpoint for protocol compliance regardless of the implementation language.
+
+## Agent-building skills
+
+Each AdCP SDK ships `build-*-agent` skills — SKILL.md files a coding agent can load to scaffold a protocol-compliant, storyboard-validated agent.
+
+The JavaScript SDK ships eight skills (skill coverage varies by SDK):
+
+- **build-seller-agent**: publisher, SSP, or media network selling inventory to buyer agents
+- **build-signals-agent**: CDP or data provider serving audience and contextual signals
+- **build-creative-agent**: ad server or CMP rendering, previewing, and serving creatives
+- **build-generative-seller-agent**: AI ad network generating creatives from briefs
+- **build-retail-media-agent**: retail media network with catalog-driven creative
+- **build-brand-rights-agent**: brand identity, licensing, and creative approval
+- **build-governance-agent**: spending authority, property lists, and content standards enforcement
+- **build-si-agent**: conversational sponsored content within user sessions
+
+Skill locations:
+- JS/TS: https://github.com/adcontextprotocol/adcp-client/tree/main/skills
+- Python: https://github.com/adcontextprotocol/adcp-python/tree/main/skills
+- Go: https://github.com/adcontextprotocol/adcp-go/tree/main/skills
+
+## Registry APIs
+
+Served by AgenticAdvertising.org for agent, brand, and property discovery:
+
+- **Agent directory**: https://agenticadvertising.org/api/registry/agents
+- **Brand resolution**: https://agenticadvertising.org/api/brands/resolve
+- **Property resolution**: https://agenticadvertising.org/api/properties/resolve
+
+Agents discover each other through the registry rather than through per-integration configuration. Authorization is validated against `adagents.json` declared at the publisher domain.
 
 ## Key terms glossary
 

--- a/server/public/llms.txt
+++ b/server/public/llms.txt
@@ -41,6 +41,33 @@ AdCP supports two transport mechanisms:
 - Brand protocol: https://adcontextprotocol.org/docs/brand-protocol
 - Schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
 - Release notes: https://adcontextprotocol.org/docs/reference/release-notes
+- Trust, safety, governance: https://adcontextprotocol.org/docs/trust
+
+## Adoption path
+
+Build in this order:
+- Quickstart (5-minute curl example): https://adcontextprotocol.org/docs/quickstart
+- Build an agent: https://adcontextprotocol.org/docs/building/build-an-agent
+- Validate an agent: https://adcontextprotocol.org/docs/building/validate-your-agent
+- Operate an agent: https://adcontextprotocol.org/docs/building/operating-an-agent
+- Load a seller skill directly: https://github.com/adcontextprotocol/adcp-client/blob/main/skills/build-seller-agent/SKILL.md
+
+## SDKs and skills
+
+SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+
+- `@adcp/client` (JavaScript/TypeScript): https://github.com/adcontextprotocol/adcp-client
+- `adcp` (Python): https://github.com/adcontextprotocol/adcp-python
+- `adcp-go` (Go): https://github.com/adcontextprotocol/adcp-go
+
+Each SDK ships `build-*-agent` skills a coding agent can load to scaffold a compliant implementation. See https://adcontextprotocol.org/llms-full.txt for the full skill inventory.
+
+## Registry APIs
+
+Served by AgenticAdvertising.org:
+- Agent directory: https://agenticadvertising.org/api/registry/agents
+- Brand resolution: https://agenticadvertising.org/api/brands/resolve
+- Property resolution: https://agenticadvertising.org/api/properties/resolve
 
 ## Key terms
 


### PR DESCRIPTION
## Summary

The build path, conformance flow, SDK skill system, and safety story all exist — they're just hard for LLMs and newcomers to find. This surfaces them without duplicating content.

- **`docs/trust.mdx`** — new top-level landing page unifying the governance, regulatory, privacy, security, provenance, and disclosure chapters that already exist. Bolded tagline ("Trust in AdCP is architectural, not promised"), per-pillar card groups, a "For compliance reviewers" section with concrete enforcement artifacts (`check_governance`, `get_plan_audit_logs`, `validate_property_delivery`, `validate_content_delivery`), and the canonical vulnerability-disclosure link. Added to top-level nav and to the Governance group.
- **`docs/quickstart.mdx`** — two-path `<CardGroup>` at the fold and a reframed subtitle so publisher/seller readers don't bounce before finding `build-an-agent`.
- **`server/public/llms.txt` + `llms-full.txt`** — adoption-path ordering (quickstart → build → validate → operate → trust), both-sides SDK framing, full `build-*-agent` skill inventory, a direct SKILL.md URL for one-roundtrip scaffolding, registry API endpoints, and a responsible-disclosure pointer.

## Why

Adoption audit on the eve of 3.0 GA surfaced that claimed gaps (missing seller SDK, missing conformance harness, missing trust narrative) were all already built — just undiscoverable. An LLM fetching `llms.txt` learned what AdCP *is*, not how to build against it. A publisher landing on Quickstart saw a buyer-only hero and bounced. A CISO scanning for trust guarantees had to assemble eight chapters themselves.

## Reviewed by

docs-expert, copywriter, and dx-expert. All feedback addressed:
- Six pillars (not five); correct Disclosure bullet in `llms-full.txt`
- Content-standards description widened to before/during/after delivery
- Bureaucratic regulatory and disclosure summaries rewritten
- Bold quotable thesis line promoted with whitespace
- Coding-agent zero-to-SKILL.md cut from 3 roundtrips to 1
- Compliance reviewers get wire-level evidence, not policy claims

## Test plan

- [x] `npm run test:docs-nav` — passes (228 page files, no broken refs, no duplicates)
- [x] Pre-commit: `npm run test:unit` (631 tests pass) + `tsc --noEmit` clean
- [x] Mintlify validation: 865 MDX files, no accessibility or link issues
- [x] All 11 CardGroup targets on `docs/trust.mdx` verified to resolve
- [x] `href="#setup"` anchor verified against `## Setup` slug in quickstart

## Follow-ups (separate issues)

- `SECURITY.md` has stale references: points at non-existent `/docs/reference/security`, and supported-versions table says 2.x only (needs update for 3.0 GA + v2 security-only-until-Aug-1-2026 policy)
- Consider implementer-side SKILL.md for the repo's own `skills/` dir (current six are adcp-out / consumer skills)
- Publish a `/.well-known/security.txt` on the AAO domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)