### PR TITLE
fix(compliance): bridge oauth_client_credentials to the SDK (main typecheck break)

### DIFF
--- a/.changeset/fix-oauth-client-credentials-sdk-bridge.md
+++ b/.changeset/fix-oauth-client-credentials-sdk-bridge.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix main's typecheck after #2800 (OAuth 2.0 client-credentials for Test-your-agent). `@adcp/client`'s `ComplyOptions.auth` / `TestOptions.auth` unions only accept `bearer | basic | oauth`; PR #2800 added an `oauth_client_credentials` variant to the server's `ResolvedOwnerAuth` and passed it straight through to the SDK, producing four type errors in `compliance-heartbeat.ts` and `registry-api.ts` and — at runtime — silently breaking the compliance check for any agent saved with client-credentials (the SDK has no handler for that variant).
+
+Added a server-side RFC 6749 §4.4 exchange (`oauth-client-credentials-exchange.ts`) plus a narrowing adapter (`sdk-auth-adapter.ts`) that resolves `$ENV:ADCP_OAUTH_<NAME>` references, POSTs to the token endpoint with either HTTP Basic or form-body credentials, and hands the SDK a `{type:'bearer', token}` it already understands. Failed exchanges fall back to unauthenticated requests with a warn log rather than silently hanging or leaking the provider's error body.
+
+No caching yet — compliance heartbeat and the test-your-agent paths are low-frequency, so re-exchanging per call is fine. When @adcp/client learns native client-credentials support with 401-triggered refresh, delete the bridge and pass the configs straight through.
+
+Test coverage: 19 unit tests for the exchange logic (env resolution, basic vs body auth methods, scope/resource/audience passthrough, HTTP failures, non-JSON responses, missing access_token, network exceptions) plus the adapter narrowing path.

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -19,6 +19,7 @@ import { notifySystemError } from '../error-notifier.js';
 import { logger as baseLogger } from '../../logger.js';
 import { logOutboundRequest } from '../../db/outbound-log-db.js';
 import { AAO_UA_COMPLIANCE } from '../../config/user-agents.js';
+import { adaptAuthForSdk } from '../../services/sdk-auth-adapter.js';
 
 const logger = baseLogger.child({ module: 'compliance-heartbeat' });
 const complianceDb = new ComplianceDatabase();
@@ -59,11 +60,12 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
     const startTime = Date.now();
     try {
       const auth = await complianceDb.resolveOwnerAuth(agent.agent_url);
+      const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `heartbeat:${agent.agent_url}` });
 
       const complyOptions: ComplyOptions = {
         test_session_id: `heartbeat-${Date.now()}`,
         timeout_ms: 60_000,
-        auth,
+        auth: sdkAuth,
         userAgent: AAO_UA_COMPLIANCE,
       };
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -74,6 +74,7 @@ import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
+import { adaptAuthForSdk } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
@@ -4065,10 +4066,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
     try {
       const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+      const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `test-agent:${agentUrl}` });
 
       let profile;
       try {
-        const caps = await testCapabilityDiscovery(agentUrl, { ...(auth && { auth }) });
+        const caps = await testCapabilityDiscovery(agentUrl, { ...(sdkAuth && { auth: sdkAuth }) });
         profile = caps.profile;
 
         // The SDK swallows the agent's 401 into steps[0].error; surface it as
@@ -4297,11 +4299,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
 
         const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard:${agentUrl}` });
 
         const complyResult = await comply(agentUrl, {
           timeout_ms: 90_000,
           storyboards: [req.params.storyboardId],
-          ...(auth && { auth }),
+          ...(sdkAuth && { auth: sdkAuth }),
         });
 
         if (complyResult.overall_status === 'auth_required') {
@@ -4396,13 +4399,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
 
         const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-compare:${agentUrl}` });
         const storyboardIds = [req.params.storyboardId];
 
         const [userResult, referenceResult] = await Promise.all([
           comply(agentUrl, {
             timeout_ms: 90_000,
             storyboards: storyboardIds,
-            ...(auth && { auth }),
+            ...(sdkAuth && { auth: sdkAuth }),
           }),
           comply(PUBLIC_TEST_AGENT.url, {
             timeout_ms: 90_000,

--- a/server/src/services/oauth-client-credentials-exchange.ts
+++ b/server/src/services/oauth-client-credentials-exchange.ts
@@ -1,0 +1,167 @@
+/**
+ * Server-side RFC 6749 §4.4 (OAuth 2.0 Client Credentials) token exchange.
+ *
+ * Context: PR #2800 added an `oauth_client_credentials` variant to
+ * `ResolvedOwnerAuth` (the server's internal auth union for agents
+ * with saved credentials), but `@adcp/client`'s `ComplyOptions.auth`
+ * and `TestOptions.auth` unions only accept `bearer | basic | oauth`.
+ * Passing the client-credentials variant to the SDK is a type error and
+ * would also fail at runtime because the SDK doesn't implement the
+ * exchange.
+ *
+ * This module bridges the gap: given a parsed
+ * `OAuthClientCredentials` config, resolve `$ENV:ADCP_OAUTH_<NAME>`
+ * references, POST to `token_endpoint`, and return a bearer token the
+ * SDK can carry. Callers narrow the auth to `{ type: 'bearer', token }`
+ * before handing it to the SDK.
+ *
+ * Tradeoff: no caching / expiry tracking yet. Compliance heartbeat and
+ * the registry test paths are both low-frequency (minutes / per-request
+ * hit counts, not steady-state traffic), so re-exchanging each call is
+ * acceptable. When `@adcp/client` learns native client-credentials
+ * support with 401-triggered refresh, this bridge can be removed and
+ * the configs passed through untouched.
+ */
+
+import type { OAuthClientCredentials } from '../db/agent-context-db.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('oauth-client-credentials-exchange');
+
+/** Max size we'll read from the token endpoint response to keep a hostile server bounded. */
+const MAX_RESPONSE_BYTES = 32 * 1024;
+/** Request timeout for the exchange — short to avoid blocking the caller. */
+const EXCHANGE_TIMEOUT_MS = 10_000;
+
+/** `$ENV:ADCP_OAUTH_<NAME>` reference pattern, mirroring the input parser. */
+const ENV_REFERENCE_PATTERN = /^\$ENV:ADCP_OAUTH_([A-Z0-9_]+)$/;
+
+export type ExchangeResult =
+  | { ok: true; access_token: string; expires_in?: number }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a config value that may be a `$ENV:ADCP_OAUTH_<NAME>`
+ * reference. Returns the literal value if there's no prefix, the env
+ * var's value if the reference resolves, or `null` when the env var
+ * isn't set (treated as a hard failure by the caller).
+ */
+export function resolveEnvReference(value: string): string | null {
+  const match = ENV_REFERENCE_PATTERN.exec(value);
+  if (!match) return value;
+  const name = `ADCP_OAUTH_${match[1]}`;
+  const resolved = process.env[name];
+  return resolved !== undefined && resolved !== '' ? resolved : null;
+}
+
+/**
+ * Perform the client-credentials exchange and return a bearer token.
+ *
+ * `auth_method` picks between HTTP Basic auth (default, per RFC 6749
+ * §2.3.1 recommendation) and credentials-in-body. Some providers
+ * require one specifically — the form is caller-controlled.
+ *
+ * Network failures, non-2xx responses, and malformed JSON all collapse
+ * to a single `{ ok: false, error }` so callers have one branch to
+ * handle. The token-endpoint response body is capped to 32KB so a
+ * hostile server can't stream junk into our process.
+ */
+export async function exchangeClientCredentials(
+  creds: OAuthClientCredentials,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<ExchangeResult> {
+  const clientId = resolveEnvReference(creds.client_id);
+  const clientSecret = resolveEnvReference(creds.client_secret);
+
+  if (clientId === null) {
+    return { ok: false, error: 'OAuth client_credentials: client_id env reference did not resolve.' };
+  }
+  if (clientSecret === null) {
+    return { ok: false, error: 'OAuth client_credentials: client_secret env reference did not resolve.' };
+  }
+
+  const form = new URLSearchParams();
+  form.set('grant_type', 'client_credentials');
+  if (creds.scope) form.set('scope', creds.scope);
+  if (creds.resource) form.set('resource', creds.resource);
+  if (creds.audience) form.set('audience', creds.audience);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/json',
+  };
+
+  if (creds.auth_method === 'body') {
+    form.set('client_id', clientId);
+    form.set('client_secret', clientSecret);
+  } else {
+    // RFC 6749 §2.3.1: HTTP Basic is the default, preferred method.
+    const encoded = Buffer.from(`${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`).toString('base64');
+    headers['Authorization'] = `Basic ${encoded}`;
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EXCHANGE_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(creds.token_endpoint, {
+      method: 'POST',
+      headers,
+      body: form.toString(),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      // Don't surface the endpoint's raw error body to the caller —
+      // that can contain sensitive diagnostic info; the log has it.
+      const preview = await readCapped(response);
+      logger.warn(
+        { status: response.status, tokenEndpoint: creds.token_endpoint, bodyPreview: preview },
+        'OAuth client-credentials exchange returned non-2xx',
+      );
+      return { ok: false, error: `OAuth client_credentials exchange failed: HTTP ${response.status}` };
+    }
+
+    const body = await readCapped(response);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint did not return JSON.' };
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint returned non-object body.' };
+    }
+    const obj = parsed as Record<string, unknown>;
+    const accessToken = obj.access_token;
+    if (typeof accessToken !== 'string' || !accessToken) {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint response missing access_token.' };
+    }
+    const expiresIn = typeof obj.expires_in === 'number' ? obj.expires_in : undefined;
+    return { ok: true, access_token: accessToken, expires_in: expiresIn };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn({ err, tokenEndpoint: creds.token_endpoint }, 'OAuth client-credentials exchange threw');
+    return { ok: false, error: `OAuth client_credentials exchange failed: ${reason}` };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readCapped(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+      if (total >= MAX_RESPONSE_BYTES) break;
+    }
+  }
+  return Buffer.concat(chunks.map(c => Buffer.from(c)), Math.min(total, MAX_RESPONSE_BYTES)).toString('utf8');
+}

--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -1,0 +1,69 @@
+/**
+ * Narrow `ResolvedOwnerAuth` (server's internal auth union) down to the
+ * shape `@adcp/client`'s `ComplyOptions.auth` / `TestOptions.auth`
+ * accepts (bearer | basic | oauth).
+ *
+ * The server supports an `oauth_client_credentials` variant (#2800)
+ * that the SDK doesn't. For that variant we perform the RFC 6749 §4.4
+ * exchange here and hand the SDK the resulting bearer token. All
+ * other variants pass through unchanged. Failed exchanges yield
+ * `undefined` so the compliance / test path proceeds unauthenticated
+ * with a warning log — the alternative is dropping the entire check.
+ *
+ * Remove this bridge when @adcp/client learns native
+ * client_credentials with 401-triggered refresh.
+ */
+
+import type { ResolvedOwnerAuth } from '../db/compliance-db.js';
+import { exchangeClientCredentials } from './oauth-client-credentials-exchange.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('sdk-auth-adapter');
+
+/**
+ * The subset of `ResolvedOwnerAuth` the SDK accepts. Kept as a
+ * structural type so we aren't importing @adcp/client's internal types
+ * across the boundary.
+ */
+export type SdkAuth =
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | {
+      type: 'oauth';
+      tokens: { access_token: string; refresh_token: string; expires_at?: string };
+      client?: { client_id: string; client_secret?: string };
+    };
+
+/**
+ * Narrow server-resolved auth into the SDK's accepted shape. Exchanges
+ * client-credentials configs on the spot. Returns `undefined` for
+ * missing auth OR for exchange failures (caller proceeds unauthed).
+ */
+export async function adaptAuthForSdk(
+  auth: ResolvedOwnerAuth | undefined,
+  context: { tokenEndpointLabel?: string } = {},
+): Promise<SdkAuth | undefined> {
+  if (!auth) return undefined;
+
+  switch (auth.type) {
+    case 'bearer':
+    case 'basic':
+    case 'oauth':
+      return auth;
+    case 'oauth_client_credentials': {
+      const result = await exchangeClientCredentials(auth.credentials);
+      if (!result.ok) {
+        logger.warn(
+          {
+            tokenEndpoint: auth.credentials.token_endpoint,
+            context: context.tokenEndpointLabel,
+            reason: result.error,
+          },
+          'OAuth client-credentials exchange failed — falling back to unauthenticated request',
+        );
+        return undefined;
+      }
+      return { type: 'bearer', token: result.access_token };
+    }
+  }
+}

--- a/server/tests/unit/oauth-client-credentials-exchange.test.ts
+++ b/server/tests/unit/oauth-client-credentials-exchange.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  exchangeClientCredentials,
+  resolveEnvReference,
+} from '../../src/services/oauth-client-credentials-exchange.js';
+import { adaptAuthForSdk } from '../../src/services/sdk-auth-adapter.js';
+
+/**
+ * Tests for the server-side OAuth 2.0 client-credentials exchange
+ * (#2800 follow-up). `@adcp/client`'s ComplyOptions/TestOptions don't
+ * accept the `oauth_client_credentials` auth variant, so we exchange
+ * for a bearer token server-side before handing it to the SDK.
+ */
+
+function mockFetch(response: { status: number; body: string | object }) {
+  const bodyStr = typeof response.body === 'string' ? response.body : JSON.stringify(response.body);
+  const bytes = new TextEncoder().encode(bodyStr);
+  return vi.fn(async () => {
+    let sent = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sent) {
+          controller.enqueue(bytes);
+          sent = true;
+        } else {
+          controller.close();
+        }
+      },
+    });
+    return {
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      body: stream,
+    } as unknown as Response;
+  });
+}
+
+describe('resolveEnvReference', () => {
+  beforeEach(() => {
+    delete process.env.ADCP_OAUTH_TEST;
+  });
+
+  it('returns the literal value when no $ENV prefix', () => {
+    expect(resolveEnvReference('plaintext-secret')).toBe('plaintext-secret');
+  });
+
+  it('resolves a valid $ENV:ADCP_OAUTH_<NAME> reference from process.env', () => {
+    process.env.ADCP_OAUTH_TEST = 'super-secret';
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_TEST')).toBe('super-secret');
+  });
+
+  it('returns null when the env var is unset (treated as failure)', () => {
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_MISSING')).toBeNull();
+  });
+
+  it('returns null when the env var is empty', () => {
+    process.env.ADCP_OAUTH_TEST = '';
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_TEST')).toBeNull();
+  });
+
+  it('ignores $ENV prefixes that do not match ADCP_OAUTH_ (does not resolve arbitrary env vars)', () => {
+    process.env.DATABASE_URL = 'postgres://sensitive';
+    // The input validator rejects these at write time; the resolver
+    // still returns the literal so a mis-slipped reference becomes a
+    // hard exchange failure, not a silent env leak.
+    expect(resolveEnvReference('$ENV:DATABASE_URL')).toBe('$ENV:DATABASE_URL');
+  });
+});
+
+describe('exchangeClientCredentials', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const baseCreds = {
+    token_endpoint: 'https://idp.example.com/oauth/token',
+    client_id: 'client-abc',
+    client_secret: 'secret-xyz',
+  };
+
+  it('returns a bearer token from a successful exchange', async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      body: { access_token: 'new-token', expires_in: 3600, token_type: 'Bearer' },
+    });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result).toEqual({ ok: true, access_token: 'new-token', expires_in: 3600 });
+  });
+
+  it('defaults to HTTP Basic auth (RFC 6749 §2.3.1 preferred)', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const call = fetchImpl.mock.calls[0];
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^Basic /);
+    // body should NOT carry client_id/client_secret when using Basic
+    expect(init.body).not.toMatch(/client_id=/);
+    expect(init.body).not.toMatch(/client_secret=/);
+  });
+
+  it('puts credentials in the body when auth_method is "body"', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      { ...baseCreds, auth_method: 'body' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(init.body).toMatch(/client_id=client-abc/);
+    expect(init.body).toMatch(/client_secret=secret-xyz/);
+  });
+
+  it('includes scope / resource / audience in the form when set', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      { ...baseCreds, scope: 'foo bar', resource: 'https://api.example', audience: 'aud-1' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const body = (fetchImpl.mock.calls[0][1] as RequestInit).body as string;
+    expect(body).toMatch(/scope=foo\+bar/);
+    expect(body).toMatch(/resource=https%3A%2F%2Fapi.example/);
+    expect(body).toMatch(/audience=aud-1/);
+  });
+
+  it('resolves $ENV references before sending', async () => {
+    process.env.ADCP_OAUTH_ID = 'resolved-id';
+    process.env.ADCP_OAUTH_SEC = 'resolved-sec';
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      {
+        ...baseCreds,
+        client_id: '$ENV:ADCP_OAUTH_ID',
+        client_secret: '$ENV:ADCP_OAUTH_SEC',
+        auth_method: 'body',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const body = (fetchImpl.mock.calls[0][1] as RequestInit).body as string;
+    expect(body).toMatch(/client_id=resolved-id/);
+    expect(body).toMatch(/client_secret=resolved-sec/);
+  });
+
+  it('fails cleanly when a $ENV reference does not resolve', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: {} });
+    const result = await exchangeClientCredentials(
+      { ...baseCreds, client_secret: '$ENV:ADCP_OAUTH_MISSING' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/client_secret env reference/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('fails on a non-2xx response without surfacing the provider body', async () => {
+    const fetchImpl = mockFetch({ status: 401, body: '{"error":"invalid_client"}' });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/HTTP 401/);
+    expect((result as { error: string }).error).not.toMatch(/invalid_client/);
+  });
+
+  it('fails when the token endpoint returns non-JSON', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: 'not-json' });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/did not return JSON/);
+  });
+
+  it('fails when the response JSON is missing access_token', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { token_type: 'Bearer', expires_in: 100 } });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/missing access_token/);
+  });
+
+  it('fails cleanly on network exceptions', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe('adaptAuthForSdk', () => {
+  it('returns undefined for missing auth', async () => {
+    expect(await adaptAuthForSdk(undefined)).toBeUndefined();
+  });
+
+  it('passes bearer / basic / oauth through unchanged', async () => {
+    const bearer = { type: 'bearer', token: 'tok' } as const;
+    const basic = { type: 'basic', username: 'u', password: 'p' } as const;
+    const oauth = {
+      type: 'oauth',
+      tokens: { access_token: 'a', refresh_token: 'r' },
+      client: { client_id: 'c' },
+    } as const;
+    expect(await adaptAuthForSdk(bearer)).toBe(bearer);
+    expect(await adaptAuthForSdk(basic)).toBe(basic);
+    expect(await adaptAuthForSdk(oauth)).toBe(oauth);
+  });
+
+  it('exchanges oauth_client_credentials and narrows to bearer', async () => {
+    process.env.ADCP_OAUTH_BRIDGE_TEST = 'sec';
+    // Swap global fetch for this test only
+    const original = globalThis.fetch;
+    globalThis.fetch = mockFetch({
+      status: 200,
+      body: { access_token: 'exchanged-tok', expires_in: 600 },
+    }) as unknown as typeof fetch;
+    try {
+      const result = await adaptAuthForSdk({
+        type: 'oauth_client_credentials',
+        credentials: {
+          token_endpoint: 'https://idp.example/token',
+          client_id: 'client-x',
+          client_secret: '$ENV:ADCP_OAUTH_BRIDGE_TEST',
+        },
+      });
+      expect(result).toEqual({ type: 'bearer', token: 'exchanged-tok' });
+    } finally {
+      globalThis.fetch = original;
+      delete process.env.ADCP_OAUTH_BRIDGE_TEST;
+    }
+  });
+
+  it('returns undefined (falls back to unauthenticated) when the exchange fails', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = mockFetch({ status: 500, body: 'internal' }) as unknown as typeof fetch;
+    try {
+      const result = await adaptAuthForSdk({
+        type: 'oauth_client_credentials',
+        credentials: {
+          token_endpoint: 'https://idp.example/token',
+          client_id: 'c',
+          client_secret: 's',
+        },
+      });
+      expect(result).toBeUndefined();
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Main's typecheck is broken after #2800 (\"OAuth 2.0 client-credentials for Test-your-agent\"). That PR added an \`oauth_client_credentials\` variant to the server's \`ResolvedOwnerAuth\` and passed it directly to \`@adcp/client\`'s \`comply()\` / \`testCapabilityDiscovery()\`. The SDK's \`ComplyOptions.auth\` and \`TestOptions.auth\` unions (5.9.1, current) only accept \`bearer | basic | oauth\` — four TS errors in \`compliance-heartbeat.ts\` and \`registry-api.ts\`.

Runtime cost beyond the typecheck: the compliance/test path for any agent saved with client-credentials would silently break once the type was silenced — the SDK has no handler for this variant.

## What this PR adds

**`server/src/services/oauth-client-credentials-exchange.ts`** — RFC 6749 §4.4 exchange. Resolves \`\$ENV:ADCP_OAUTH_<NAME>\` references, POSTs to \`token_endpoint\` with either HTTP Basic (default, per §2.3.1) or form-body credentials, returns a bearer. Caps response body at 32KB, 10s timeout, non-2xx responses log the preview but don't surface the provider's error body to callers.

**`server/src/services/sdk-auth-adapter.ts`** — narrows \`ResolvedOwnerAuth\` to the SDK's accepted shape. Passes \`bearer\` / \`basic\` / \`oauth\` through unchanged; exchanges \`oauth_client_credentials\` on the spot. Failed exchanges yield \`undefined\` so the caller proceeds unauthenticated with a warn log — the alternative (throwing) would break the compliance check entirely.

Wired into the four boundaries:
- \`compliance-heartbeat.ts:66\`
- \`registry-api.ts:4071\` (\`testCapabilityDiscovery\`)
- \`registry-api.ts:4301\` (\`comply\` — run-storyboard)
- \`registry-api.ts:4402\` (\`comply\` — compare-against-reference)

## Why server-side, not in @adcp/client

- Server already owns \`\$ENV:ADCP_OAUTH_<NAME>\` resolution — SDK shouldn't know about our env-var scheme.
- No SDK release cycle blocking.
- When the SDK learns native client-credentials support with 401-triggered refresh, the bridge deletes in one commit and configs pass straight through.

## Out of scope / follow-ups

- No token caching yet. Heartbeat + test-your-agent are low-frequency, so re-exchanging per call is acceptable. Add cache if we see meaningful traffic.
- Upstream issue against \`@adcp/client\` to request native client-credentials: **TODO**, will file and link here.

## Test plan

- [x] \`npm run typecheck\` — clean (was 4 errors on main)
- [x] \`npm run test:server-unit\` — 1821 pass, 34 skipped
- [x] 19 new unit tests in \`oauth-client-credentials-exchange.test.ts\` covering env resolution, basic vs body auth, scope/resource/audience passthrough, HTTP 401 / 500, non-JSON responses, missing \`access_token\`, network exceptions, adapter pass-through, adapter exchange-success, adapter exchange-failure fallback
- [ ] Manual: run compliance heartbeat against a staging agent configured with \`oauth_client_credentials\`, verify \`Authorization: Bearer <exchanged>\` reaches the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)