### PR TITLE
feat(dashboard): 'Test now' button for OAuth client-credentials (closes #2809)

### DIFF
--- a/.changeset/oauth-cc-test-now.md
+++ b/.changeset/oauth-cc-test-now.md
@@ -1,0 +1,25 @@
+---
+---
+
+feat(dashboard): "Test now" button for OAuth client-credentials save flow (closes #2809)
+
+Operators pasting client_id/client_secret from their IdP console no longer have to wait for the next compliance heartbeat (15–60 minutes) to confirm the config works. After save, the form replaces itself with a save-confirmation + a **Test now** button that POSTs to a new dry-run endpoint, exchanges at the token endpoint, discards the resulting token, and renders the result inline in under 2 seconds.
+
+**New endpoint.** `POST /api/registry/agents/:encodedUrl/oauth-client-credentials/test` — same auth + ownership gate as the save endpoint. Loads the saved credentials, calls `@adcp/client`'s `exchangeClientCredentials()`, returns one of:
+
+- `{ ok: true, latency_ms }` on a clean exchange.
+- `{ ok: false, latency_ms, error: { kind, message, oauth_error?, oauth_error_description?, http_status? } }` on failure. `kind` is the SDK's `ClientCredentialsExchangeError` discriminator (`oauth` / `malformed` / `network`) so UI can branch cleanly.
+
+Same-origin response always `200 OK` — the error is in the payload, not the HTTP status, so the UI doesn't confuse "valid response saying exchange failed" with "our endpoint crashed."
+
+**UI.** Inline button on the post-save state. Click → spinner → typed result:
+- Success: `✅ Token exchange succeeded in Xms.`
+- `oauth` failure: `❌ <message> (oauth) — AS returned invalid_client: <description> [HTTP 401]`
+- `network` failure: `❌ <message> (network)`
+- `malformed` failure: `❌ <message> (malformed)`
+
+The form no longer auto-reloads after save — operators can test, fix, and re-save without losing state.
+
+Verified via Playwright isolated test: 11/11 assertions pass (correct URL + method, latency rendering, oauth-error plumbing with description + HTTP status, network-error plumbing, client-thrown fetch errors). Server unit suite remains green (1802 passed).
+
+Follow-up still open: [#2810](https://github.com/adcontextprotocol/adcp/issues/2810) — structured error codes on the *save* path would let the UI highlight which field triggered a rejection the same way this renders the AS's `oauth_error`.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1176,10 +1176,14 @@
         // The test endpoint exchanges at the AS and discards the token, so
         // the operator gets same-second confirmation instead of waiting for
         // the next compliance heartbeat. See #2809.
+        //
+        // Button has no data-agent-url of its own — the handler reads from
+        // the parent form's already-escaped dataset. Prevents any chance of
+        // attribute-breakout if a future caller passes an un-escaped URL.
         form.innerHTML =
           '<div class="agent-connect-msg" style="color:var(--color-success-600);">Credentials saved.</div>' +
           '<div style="display:flex;gap:var(--space-2);align-items:center;margin-top:var(--space-2);">' +
-            '<button class="agent-cc-test-now" data-agent-url="' + agentUrl + '">Test now</button>' +
+            '<button class="agent-cc-test-now">Test now</button>' +
             '<span style="font-size:var(--text-sm);color:var(--color-text-secondary);">Exchanges a token at the AS and discards it.</span>' +
           '</div>' +
           '<div class="agent-cc-test-result" style="margin-top:var(--space-2);"></div>';
@@ -1197,20 +1201,63 @@
       }
     });
 
+    // One-line actionable hints keyed off the SDK's ClientCredentialsExchangeError
+    // kind / oauth_error. Aimed at a non-engineer ad-ops operator: "here's the
+    // first thing to check." The primary (technical) line stays intact so
+    // engineers can copy-paste into issues; the hint is a muted second line.
+    function ccTestHint(err) {
+      const byOAuth = {
+        invalid_client: 'Check client_id and client_secret for typos or trailing whitespace.',
+        invalid_scope: 'Remove the scope field or confirm the value with the AS operator.',
+        unauthorized_client: 'This client isn\'t allowed to use the client_credentials grant. Ask the AS operator.',
+        invalid_request: 'The AS rejected the request shape. Double-check token_endpoint and auth_method (Basic vs Body).',
+        invalid_grant: 'The grant was rejected. Common cause: credentials revoked or the audience/resource is wrong.',
+      };
+      if (err.oauth_error && byOAuth[err.oauth_error]) return byOAuth[err.oauth_error];
+      if (err.kind === 'network') return 'Check that token_endpoint is correct and the AS is reachable from this server.';
+      if (err.kind === 'malformed') return 'The AS response wasn\'t valid OAuth. Confirm token_endpoint points at the token URL, not the authorize URL.';
+      return '';
+    }
+
     // "Test now" button: POST to /oauth-client-credentials/test and show the
     // typed result inline (success latency, or SDK ClientCredentialsExchangeError
     // kind + message + oauth_error if the AS returned one).
     document.addEventListener('click', async function(e) {
       const btn = e.target.closest('.agent-cc-test-now');
       if (!btn) return;
-      const agentUrl = btn.dataset.agentUrl;
       const form = btn.closest('.agent-connect-form');
-      const resultEl = form?.querySelector('.agent-cc-test-result');
+      if (!form) return;
+      // Read from the parent form's already-escaped data attribute rather
+      // than re-embedding the URL in the button's own HTML.
+      const agentUrl = form.dataset.agentUrl;
+      const resultEl = form.querySelector('.agent-cc-test-result');
       if (!resultEl) return;
 
       btn.disabled = true;
       btn.textContent = 'Testing...';
       resultEl.textContent = '';
+      resultEl.innerHTML = '';
+
+      const setResult = (primary, hint, color, extraHtml) => {
+        resultEl.style.color = color;
+        const primaryNode = document.createElement('div');
+        primaryNode.textContent = primary;
+        resultEl.appendChild(primaryNode);
+        if (hint) {
+          const hintNode = document.createElement('div');
+          hintNode.style.fontSize = 'var(--text-xs)';
+          hintNode.style.color = 'var(--color-text-secondary)';
+          hintNode.style.marginTop = '2px';
+          hintNode.textContent = hint;
+          resultEl.appendChild(hintNode);
+        }
+        if (extraHtml) {
+          const extra = document.createElement('div');
+          extra.style.marginTop = 'var(--space-1)';
+          extra.innerHTML = extraHtml;
+          resultEl.appendChild(extra);
+        }
+      };
 
       try {
         const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/oauth-client-credentials/test', {
@@ -1220,31 +1267,45 @@
         });
         const data = await res.json().catch(() => ({}));
 
-        if (!res.ok) {
-          resultEl.style.color = 'var(--color-error-600)';
-          resultEl.textContent = data.error || ('Request failed: ' + res.status);
+        if (res.status === 429) {
+          setResult('Testing too fast — wait a moment and retry.', '', 'var(--color-error-600)', '');
+        } else if (!res.ok) {
+          setResult(data.error || ('Request failed: ' + res.status), '', 'var(--color-error-600)', '');
         } else if (data.ok) {
-          resultEl.style.color = 'var(--color-success-600)';
-          resultEl.textContent = '✅ Token exchange succeeded in ' + data.latency_ms + 'ms.';
+          // Subtle exit affordance on success so operators can return to the
+          // dashboard (which reloads the compliance card with fresh auth
+          // state). No auto-reload — the retest loop stays available.
+          setResult(
+            '✅ Token exchange succeeded in ' + data.latency_ms + 'ms.',
+            '',
+            'var(--color-success-600)',
+            '<a href="#" class="agent-cc-reload" style="font-size:var(--text-sm);">Reload to refresh the dashboard →</a>',
+          );
         } else {
           // Typed failure from the SDK.
           const err = data.error || {};
-          resultEl.style.color = 'var(--color-error-600)';
           let text = '❌ ' + (err.message || 'Exchange failed') + ' (' + (err.kind || 'unknown') + ')';
           if (err.oauth_error) {
             text += ' — AS returned ' + err.oauth_error;
             if (err.oauth_error_description) text += ': ' + err.oauth_error_description;
           }
           if (err.http_status) text += ' [HTTP ' + err.http_status + ']';
-          resultEl.textContent = text;
+          setResult(text, ccTestHint(err), 'var(--color-error-600)', '');
         }
       } catch (err) {
-        resultEl.style.color = 'var(--color-error-600)';
-        resultEl.textContent = 'Test request failed: ' + err.message;
+        setResult('Test request failed: ' + err.message, '', 'var(--color-error-600)', '');
       } finally {
         btn.disabled = false;
         btn.textContent = 'Test now';
       }
+    });
+
+    // Reload handler for the success-state "Reload to refresh" link.
+    document.addEventListener('click', function(e) {
+      const link = e.target.closest('.agent-cc-reload');
+      if (!link) return;
+      e.preventDefault();
+      location.reload();
     });
 
     // OAuth authorize button

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -258,7 +258,8 @@
     .agent-connect-form input { min-width: 260px; }
     .agent-connect-save,
     .agent-oauth-start,
-    .agent-cc-save {
+    .agent-cc-save,
+    .agent-cc-test-now {
       background: var(--color-primary-600);
       color: white;
       border: none;
@@ -269,10 +270,12 @@
     }
     .agent-connect-save:hover,
     .agent-oauth-start:hover,
-    .agent-cc-save:hover { background: var(--color-primary-700); }
+    .agent-cc-save:hover,
+    .agent-cc-test-now:hover { background: var(--color-primary-700); }
     .agent-connect-save:disabled,
     .agent-oauth-start:disabled,
-    .agent-cc-save:disabled { opacity: 0.6; cursor: not-allowed; }
+    .agent-cc-save:disabled,
+    .agent-cc-test-now:disabled { opacity: 0.6; cursor: not-allowed; }
     .agent-oauth-start { align-self: flex-end; }
     .agent-connect-msg {
       font-size: var(--text-xs);
@@ -1169,8 +1172,17 @@
           throw new Error(data.error || 'Failed to save credentials');
         }
 
-        form.innerHTML = '<div class="agent-connect-msg" style="color:var(--color-success-600);">Credentials saved. Compliance check will run on the next heartbeat cycle.</div>';
-        setTimeout(() => location.reload(), 1500);
+        // Replace the form with a save-confirmation + a "Test now" button.
+        // The test endpoint exchanges at the AS and discards the token, so
+        // the operator gets same-second confirmation instead of waiting for
+        // the next compliance heartbeat. See #2809.
+        form.innerHTML =
+          '<div class="agent-connect-msg" style="color:var(--color-success-600);">Credentials saved.</div>' +
+          '<div style="display:flex;gap:var(--space-2);align-items:center;margin-top:var(--space-2);">' +
+            '<button class="agent-cc-test-now" data-agent-url="' + agentUrl + '">Test now</button>' +
+            '<span style="font-size:var(--text-sm);color:var(--color-text-secondary);">Exchanges a token at the AS and discards it.</span>' +
+          '</div>' +
+          '<div class="agent-cc-test-result" style="margin-top:var(--space-2);"></div>';
       } catch (err) {
         saveBtn.disabled = false;
         saveBtn.textContent = 'Save credentials';
@@ -1182,6 +1194,56 @@
         }
         msg.style.color = 'var(--color-error-600)';
         msg.textContent = err.message;
+      }
+    });
+
+    // "Test now" button: POST to /oauth-client-credentials/test and show the
+    // typed result inline (success latency, or SDK ClientCredentialsExchangeError
+    // kind + message + oauth_error if the AS returned one).
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('.agent-cc-test-now');
+      if (!btn) return;
+      const agentUrl = btn.dataset.agentUrl;
+      const form = btn.closest('.agent-connect-form');
+      const resultEl = form?.querySelector('.agent-cc-test-result');
+      if (!resultEl) return;
+
+      btn.disabled = true;
+      btn.textContent = 'Testing...';
+      resultEl.textContent = '';
+
+      try {
+        const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/oauth-client-credentials/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        });
+        const data = await res.json().catch(() => ({}));
+
+        if (!res.ok) {
+          resultEl.style.color = 'var(--color-error-600)';
+          resultEl.textContent = data.error || ('Request failed: ' + res.status);
+        } else if (data.ok) {
+          resultEl.style.color = 'var(--color-success-600)';
+          resultEl.textContent = '✅ Token exchange succeeded in ' + data.latency_ms + 'ms.';
+        } else {
+          // Typed failure from the SDK.
+          const err = data.error || {};
+          resultEl.style.color = 'var(--color-error-600)';
+          let text = '❌ ' + (err.message || 'Exchange failed') + ' (' + (err.kind || 'unknown') + ')';
+          if (err.oauth_error) {
+            text += ' — AS returned ' + err.oauth_error;
+            if (err.oauth_error_description) text += ': ' + err.oauth_error_description;
+          }
+          if (err.http_status) text += ' [HTTP ' + err.http_status + ']';
+          resultEl.textContent = text;
+        }
+      } catch (err) {
+        resultEl.style.color = 'var(--color-error-600)';
+        resultEl.textContent = 'Test request failed: ' + err.message;
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Test now';
       }
     });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -8,7 +8,7 @@
 import { Router } from "express";
 import type { RequestHandler } from "express";
 import { z } from "zod";
-import { CreativeAgentClient, SingleAgentClient } from "@adcp/client";
+import { CreativeAgentClient, SingleAgentClient, exchangeClientCredentials, ClientCredentialsExchangeError } from "@adcp/client";
 import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities, loadComplianceIndex } from "@adcp/client/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
@@ -1705,6 +1705,54 @@ registry.registerPath({
     400: { description: "Invalid parameters", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/agents/{encodedUrl}/oauth-client-credentials/test",
+  operationId: "testAgentOAuthClientCredentials",
+  summary: "Dry-run the saved OAuth 2.0 client-credentials config",
+  description:
+    "Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.",
+  tags: ["Agent Compliance"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+    }),
+  },
+  responses: {
+    200: {
+      description:
+        "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it).",
+      content: {
+        "application/json": {
+          schema: z.union([
+            z.object({
+              ok: z.literal(true),
+              latency_ms: z.number().int(),
+            }),
+            z.object({
+              ok: z.literal(false),
+              latency_ms: z.number().int(),
+              error: z.object({
+                kind: z.enum(["oauth", "malformed", "network"]).openapi({ description: "Category of failure: `oauth` = AS returned a typed error (e.g. invalid_client), `malformed` = AS returned an unexpected 2xx payload, `network` = couldn't reach the AS." }),
+                message: z.string(),
+                oauth_error: z.string().optional().openapi({ description: "RFC 6749 `error` field when kind=oauth." }),
+                oauth_error_description: z.string().optional().openapi({ description: "RFC 6749 `error_description` field when kind=oauth." }),
+                http_status: z.number().int().optional().openapi({ description: "Status code when the AS returned a non-2xx." }),
+              }),
+            }),
+          ]),
+        },
+      },
+    },
+    400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "No saved client-credentials config for this agent", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -4016,6 +4064,67 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       } catch (error) {
         logger.error({ err: error, path: req.path }, "Failed to save oauth client credentials");
         res.status(500).json({ error: "Failed to save OAuth client credentials" });
+      }
+    },
+  );
+
+  /**
+   * Dry-run the saved client-credentials config by exchanging at the token
+   * endpoint and discarding the result. Converts the dashboard's "save and
+   * pray and wait for the next heartbeat" flow into "save and verify in
+   * under 2s" — see #2809. Returns `{ok: true, latency_ms}` on a successful
+   * exchange, or `{ok: false, error: {kind, message, ...}}` mapping the
+   * SDK's ClientCredentialsExchangeError kinds (oauth / malformed / network).
+   */
+  router.post(
+    "/registry/agents/:encodedUrl/oauth-client-credentials/test",
+    brandCreationRateLimiter,
+    ...complianceWriteMiddleware,
+    async (req, res) => {
+      try {
+        const agentUrl = decodeURIComponent(req.params.encodedUrl);
+        if (!validateAgentUrlParam(agentUrl)) {
+          return res.status(400).json({ error: "Invalid agent URL" });
+        }
+        if (!req.user) {
+          return res.status(401).json({ error: "Authentication required" });
+        }
+
+        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        if (!orgId) {
+          return res.status(403).json({ error: "You do not have permission to test this agent" });
+        }
+
+        const creds = await agentContextDb.getOAuthClientCredentialsByOrgAndUrl(orgId, agentUrl);
+        if (!creds) {
+          return res.status(404).json({ error: "No client-credentials config saved for this agent. Save credentials first, then test." });
+        }
+
+        const start = Date.now();
+        try {
+          await exchangeClientCredentials(creds);
+          return res.json({ ok: true, latency_ms: Date.now() - start });
+        } catch (err) {
+          if (err instanceof ClientCredentialsExchangeError) {
+            const body: Record<string, unknown> = {
+              ok: false,
+              error: {
+                kind: err.kind,
+                message: err.message,
+              },
+              latency_ms: Date.now() - start,
+            };
+            const errorRec = body.error as Record<string, unknown>;
+            if (err.oauthError) errorRec.oauth_error = err.oauthError;
+            if (err.oauthErrorDescription) errorRec.oauth_error_description = err.oauthErrorDescription;
+            if (err.httpStatus) errorRec.http_status = err.httpStatus;
+            return res.json(body);
+          }
+          throw err;
+        }
+      } catch (error) {
+        logger.error({ err: error, path: req.path }, "Failed to test oauth client credentials");
+        res.status(500).json({ error: "Failed to test OAuth client credentials" });
       }
     },
   );


### PR DESCRIPTION
Closes [#2809](https://github.com/adcontextprotocol/adcp/issues/2809). The DX review on [#2808](https://github.com/adcontextprotocol/adcp/pull/2808) called this the single highest-ROI addition — converts "save and pray, wait 15–60 min for the next heartbeat" into "save and verify in under 2 seconds."

## What's new

### Endpoint
`POST /api/registry/agents/:encodedUrl/oauth-client-credentials/test`

- Same auth + ownership gate as `PUT /oauth-client-credentials`.
- Loads the saved credentials, calls `@adcp/client`'s `exchangeClientCredentials()`, discards the resulting token.
- Returns either:
  - `{ ok: true, latency_ms }` on a clean exchange.
  - `{ ok: false, latency_ms, error: { kind, message, oauth_error?, oauth_error_description?, http_status? } }` on failure. `kind` is the SDK's `ClientCredentialsExchangeError` discriminator (`oauth` / `malformed` / `network`) so UI branches cleanly.

HTTP status is always `200` when the test ran — the payload carries success/failure. This separation keeps the UI from confusing "the AS said no" with "our endpoint crashed."

### UI
After save succeeds, the form is replaced with a save-confirmation + a **Test now** button. Click:

- Success: `✅ Token exchange succeeded in Xms.`
- `oauth` failure: `❌ Client authentication failed (oauth) — AS returned invalid_client: Client credentials did not match any registered client [HTTP 401]`
- `network` failure: `❌ Token endpoint unreachable: ENOTFOUND (network)`
- `malformed` failure: `❌ AS returned a 200 without access_token (malformed)`

Removed the auto-reload after save. Operators can test, fix, re-save, test again — without losing state to a page refresh.

## Verification

- [x] Isolated Playwright test: **11/11** assertions pass. Covers: correct URL + method, latency rendering, oauth error with description + HTTP status, network error, client-thrown fetch error.
- [x] Server unit suite: **1802** passed / 0 failed.
- [x] Typecheck clean.
- [x] HTML JS blocks parse cleanly.

## Still open (filed as follow-ups during #2808 review)

- [#2810](https://github.com/adcontextprotocol/adcp/issues/2810) — Structured error codes on the *save* path. Would let the UI highlight which field triggered a save rejection the same way this renders the AS's `oauth_error`. Not blocked by this PR; complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)