### PR TITLE
docs: surface adoption path in quickstart and llms.txt

### DIFF
--- a/.changeset/adoption-path-llms-quickstart.md
+++ b/.changeset/adoption-path-llms-quickstart.md
@@ -1,0 +1,10 @@
+---
+---
+
+Surface the adoption path for coding agents and a publisher/seller entry point, without a marketing landing page.
+
+- **`docs/quickstart.mdx`** — two-path `<CardGroup>` at the fold so publisher/seller readers ("I'm building an agent") don't bounce before finding `build-an-agent`. Buyer path stays at `#setup` and is unchanged below the fold.
+- **`server/public/llms.txt`** — adds an Adoption path section (quickstart → build → validate → operate + direct SKILL.md URL), an SDKs and skills section (both-sides framing), and a Registry APIs section. Points coding agents at the shortest route from discovery to a working implementation.
+- **`server/public/llms-full.txt`** — same reframe: Getting started becomes an explicit four-step adoption path, plus full SDK inventory, all eight `build-*-agent` skills with what each targets, and the Registry APIs. Both-sides SDK framing matches the llms.txt.
+
+Deliberately excludes the `docs/trust.mdx` landing page and "Trust and safety" block that were in #2814 — those are tracked for rewrite in #2817 because the draft framing contradicted this release's self-attested/known-limitations posture. This PR is the small, low-risk subset.

--- a/.changeset/fix-oauth-client-credentials-sdk-bridge.md
+++ b/.changeset/fix-oauth-client-credentials-sdk-bridge.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix main's typecheck after #2800 (OAuth 2.0 client-credentials for Test-your-agent). `@adcp/client`'s `ComplyOptions.auth` / `TestOptions.auth` unions only accept `bearer | basic | oauth`; PR #2800 added an `oauth_client_credentials` variant to the server's `ResolvedOwnerAuth` and passed it straight through to the SDK, producing four type errors in `compliance-heartbeat.ts` and `registry-api.ts` and — at runtime — silently breaking the compliance check for any agent saved with client-credentials (the SDK has no handler for that variant).
+
+Added a server-side RFC 6749 §4.4 exchange (`oauth-client-credentials-exchange.ts`) plus a narrowing adapter (`sdk-auth-adapter.ts`) that resolves `$ENV:ADCP_OAUTH_<NAME>` references, POSTs to the token endpoint with either HTTP Basic or form-body credentials, and hands the SDK a `{type:'bearer', token}` it already understands. Failed exchanges fall back to unauthenticated requests with a warn log rather than silently hanging or leaking the provider's error body.
+
+No caching yet — compliance heartbeat and the test-your-agent paths are low-frequency, so re-exchanging per call is fine. When @adcp/client learns native client-credentials support with 401-triggered refresh, delete the bridge and pass the configs straight through.
+
+Test coverage: 19 unit tests for the exchange logic (env resolution, basic vs body auth methods, scope/resource/audience passthrough, HTTP failures, non-JSON responses, missing access_token, network exceptions) plus the adapter narrowing path.

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -49,7 +49,7 @@ serve(MySeller(), name="my-seller")
 Response builders (`adcp.server.responses`) handle schema compliance so you don't construct raw JSON. Use them for every tool return.
 
 - [PyPI Package](https://pypi.org/project/adcp/)
-- [GitHub Repository](https://github.com/adcontextprotocol/adcp-python)
+- [GitHub Repository](https://github.com/adcontextprotocol/adcp-client-python)
 </Tab>
 <Tab title="Go">
 ```bash
@@ -90,7 +90,7 @@ Each SDK ships skills that walk a coding agent through building a specific agent
 For example, the JS/TS seller skill lives at [`adcp-client/skills/build-seller-agent/SKILL.md`](https://github.com/adcontextprotocol/adcp-client/tree/main/skills/build-seller-agent). Skill coverage and naming vary per language since each SDK includes implementation guidance specific to its stack. Browse the directory for your language:
 
 - **JS/TS** — [adcp-client/skills](https://github.com/adcontextprotocol/adcp-client/tree/main/skills)
-- **Python** — [adcp-python/skills](https://github.com/adcontextprotocol/adcp-python/tree/main/skills)
+- **Python** — [adcp-client-python/skills](https://github.com/adcontextprotocol/adcp-client-python/tree/main/skills)
 - **Go** — [adcp-go/skills](https://github.com/adcontextprotocol/adcp-go/tree/main/skills)
 
 ## Build the agent
@@ -105,10 +105,10 @@ Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skill
 </Tab>
 <Tab title="Python">
 ```
-Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-python/main/skills/build-seller-agent/SKILL.md, then build a seller agent for a premium sports news publisher with guaranteed CTV and OLV inventory.
+Fetch https://raw.githubusercontent.com/adcontextprotocol/adcp-client-python/main/skills/build-seller-agent/SKILL.md, then build a seller agent for a premium sports news publisher with guaranteed CTV and OLV inventory.
 ```
 
-Point at the `adcp-python` skill for your agent type. If the exact skill isn't there yet, browse [adcp-python/skills](https://github.com/adcontextprotocol/adcp-python/tree/main/skills) for the closest match.
+Point at the `adcp-client-python` skill for your agent type. If the exact skill isn't there yet, browse [adcp-client-python/skills](https://github.com/adcontextprotocol/adcp-client-python/tree/main/skills) for the closest match.
 </Tab>
 <Tab title="Go">
 ```
@@ -181,7 +181,7 @@ The JS/TS SDK includes documentation designed for both humans and coding agents:
 | Protocol spec | `node_modules/@adcp/client/docs/llms.txt` | Full protocol in one file — tools, types, error codes, examples |
 | Server guide | `node_modules/@adcp/client/docs/guides/BUILD-AN-AGENT.md` | Server-side implementation patterns |
 
-Python and Go equivalents are in each SDK's GitHub repository. See [adcp-python](https://github.com/adcontextprotocol/adcp-python) and [adcp-go](https://github.com/adcontextprotocol/adcp-go).
+Python and Go equivalents are in each SDK's GitHub repository. See [adcp-client-python](https://github.com/adcontextprotocol/adcp-client-python) and [adcp-go](https://github.com/adcontextprotocol/adcp-go).
 
 ## What's next
 

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -163,7 +163,7 @@ products = client.get_products(
 
 **Resources:**
 - [PyPI Package](https://pypi.org/project/adcp/)
-- [GitHub Repository](https://github.com/adcontextprotocol/adcp-python)
+- [GitHub Repository](https://github.com/adcontextprotocol/adcp-client-python)
 
 ### Go
 

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -693,7 +693,7 @@ go get github.com/adcontextprotocol/adcp-go/adcp
 </CodeGroup>
 
 - **NPM**: [@adcp/client](https://www.npmjs.com/package/@adcp/client) | [GitHub](https://github.com/adcontextprotocol/adcp-client)
-- **PyPI**: [adcp](https://pypi.org/project/adcp/) | [GitHub](https://github.com/adcontextprotocol/adcp-python)
+- **PyPI**: [adcp](https://pypi.org/project/adcp/) | [GitHub](https://github.com/adcontextprotocol/adcp-client-python)
 - **Go**: [adcp-go](https://github.com/adcontextprotocol/adcp-go)
 
 ## Open-source examples

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -4,14 +4,14 @@ description: "Pick your path — buyers call an AdCP agent in 5 minutes, publish
 "og:title": "AdCP — Quickstart"
 ---
 
-Pick your path. Buyers call the public test agent in 5 minutes. Publishers and sellers stand up an agent others can call.
+Pick your path. Buyers call the public test agent in 5 minutes. Publishers and sellers stand up an agent buyers can call.
 
 <CardGroup cols={2}>
-  <Card title="I'm connecting to agents" icon="plug" href="#setup">
-    Buyer side. Call the public test agent with the SDK in 5 minutes. Start below.
+  <Card title="I'm calling an agent" icon="plug">
+    Buyer side. The rest of this page walks through calling the public test agent — no signup, copy-pasteable curl.
   </Card>
   <Card title="I'm building an agent" icon="server" href="/docs/building/build-an-agent">
-    Publisher or seller side. Stand up an agent others can call.
+    Publisher or seller side. Stand up an agent buyers can call.
   </Card>
 </CardGroup>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,10 +1,19 @@
 ---
 title: Quickstart
-description: "Make your first AdCP call in 5 minutes. One MCP tool call, one error case, one media buy — with copy-pasteable curl commands and expected output."
+description: "Pick your path — buyers call an AdCP agent in 5 minutes, publishers and sellers stand up their own agent."
 "og:title": "AdCP — Quickstart"
 ---
 
-Make your first AdCP call in 5 minutes against the public test agent.
+Pick your path. Buyers call the public test agent in 5 minutes. Publishers and sellers stand up an agent others can call.
+
+<CardGroup cols={2}>
+  <Card title="I'm connecting to agents" icon="plug" href="#setup">
+    Buyer side. Call the public test agent with the SDK in 5 minutes. Start below.
+  </Card>
+  <Card title="I'm building an agent" icon="server" href="/docs/building/build-an-agent">
+    Publisher or seller side. Stand up an agent others can call.
+  </Card>
+</CardGroup>
 
 ## Setup
 

--- a/server/public/llms-full.txt
+++ b/server/public/llms-full.txt
@@ -158,11 +158,57 @@ All AdCP request and response payloads are defined as JSON Schema. Schemas are p
 
 ## Getting started
 
-1. Read the introduction: https://adcontextprotocol.org/docs/intro
-2. Understand the architecture: https://adcontextprotocol.org/docs/building/understanding
-3. Choose your transport (MCP or A2A): https://adcontextprotocol.org/docs/building/integration
-4. Implement your first task: https://adcontextprotocol.org/docs/building/implementation
-5. Explore schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
+Adoption path:
+1. Quickstart — 5-minute curl example against the public test agent: https://adcontextprotocol.org/docs/quickstart
+2. Build an agent — point a coding agent at a SKILL.md from an AdCP SDK: https://adcontextprotocol.org/docs/building/build-an-agent
+3. Validate an agent — run storyboards against your endpoint for pass/fail conformance: https://adcontextprotocol.org/docs/building/validate-your-agent
+4. Operate an agent — what sits behind the protocol (hosting, products, monitoring): https://adcontextprotocol.org/docs/building/operating-an-agent
+
+For deeper reading:
+- Understand the architecture: https://adcontextprotocol.org/docs/building/understanding
+- Choose your transport (MCP or A2A): https://adcontextprotocol.org/docs/building/integration
+- Implementation patterns: https://adcontextprotocol.org/docs/building/implementation
+- Schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
+
+## SDKs
+
+AdCP SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+
+- JavaScript/TypeScript (`@adcp/client`): https://github.com/adcontextprotocol/adcp-client
+- Python (`adcp`): https://github.com/adcontextprotocol/adcp-python
+- Go (`adcp-go`): https://github.com/adcontextprotocol/adcp-go
+
+Each SDK ships both caller APIs and server primitives (tool registration, response builders, test controllers). The JavaScript SDK includes a storyboard runner that validates any endpoint for protocol compliance regardless of the implementation language.
+
+## Agent-building skills
+
+Each AdCP SDK ships `build-*-agent` skills — SKILL.md files a coding agent can load to scaffold a protocol-compliant, storyboard-validated agent.
+
+The JavaScript SDK ships eight skills (skill coverage varies by SDK):
+
+- **build-seller-agent**: publisher, SSP, or media network selling inventory to buyer agents
+- **build-signals-agent**: CDP or data provider serving audience and contextual signals
+- **build-creative-agent**: ad server or CMP rendering, previewing, and serving creatives
+- **build-generative-seller-agent**: AI ad network generating creatives from briefs
+- **build-retail-media-agent**: retail media network with catalog-driven creative
+- **build-brand-rights-agent**: brand identity, licensing, and creative approval
+- **build-governance-agent**: spending authority, property lists, and content standards enforcement
+- **build-si-agent**: conversational sponsored content within user sessions
+
+Skill locations:
+- JS/TS: https://github.com/adcontextprotocol/adcp-client/tree/main/skills
+- Python: https://github.com/adcontextprotocol/adcp-python/tree/main/skills
+- Go: https://github.com/adcontextprotocol/adcp-go/tree/main/skills
+
+## Registry APIs
+
+Served by AgenticAdvertising.org for agent, brand, and property discovery:
+
+- **Agent directory**: https://agenticadvertising.org/api/registry/agents
+- **Brand resolution**: https://agenticadvertising.org/api/brands/resolve
+- **Property resolution**: https://agenticadvertising.org/api/properties/resolve
+
+Agents discover each other through the registry rather than through per-integration configuration. Authorization is validated against `adagents.json` declared at the publisher domain.
 
 ## Key terms glossary
 

--- a/server/public/llms-full.txt
+++ b/server/public/llms-full.txt
@@ -161,7 +161,7 @@ All AdCP request and response payloads are defined as JSON Schema. Schemas are p
 Adoption path:
 1. Quickstart — 5-minute curl example against the public test agent: https://adcontextprotocol.org/docs/quickstart
 2. Build an agent — point a coding agent at a SKILL.md from an AdCP SDK: https://adcontextprotocol.org/docs/building/build-an-agent
-3. Validate an agent — run storyboards against your endpoint for pass/fail conformance: https://adcontextprotocol.org/docs/building/validate-your-agent
+3. Validate an agent — run storyboards against your endpoint to surface spec gaps: https://adcontextprotocol.org/docs/building/validate-your-agent
 4. Operate an agent — what sits behind the protocol (hosting, products, monitoring): https://adcontextprotocol.org/docs/building/operating-an-agent
 
 For deeper reading:
@@ -172,32 +172,32 @@ For deeper reading:
 
 ## SDKs
 
-AdCP SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+Each AdCP SDK includes both caller APIs (for buyers calling agents) and server primitives (tool registration, response builders, test controllers — for sellers implementing them).
 
 - JavaScript/TypeScript (`@adcp/client`): https://github.com/adcontextprotocol/adcp-client
-- Python (`adcp`): https://github.com/adcontextprotocol/adcp-python
+- Python (`adcp`): https://github.com/adcontextprotocol/adcp-client-python
 - Go (`adcp-go`): https://github.com/adcontextprotocol/adcp-go
 
-Each SDK ships both caller APIs and server primitives (tool registration, response builders, test controllers). The JavaScript SDK includes a storyboard runner that validates any endpoint for protocol compliance regardless of the implementation language.
+The JavaScript SDK also ships a storyboard runner (`npx @adcp/client storyboard run`) that validates endpoints against the spec. Teams building agents in Python or Go still run the JS runner for validation — it's spec-aware, not language-specific.
 
 ## Agent-building skills
 
-Each AdCP SDK ships `build-*-agent` skills — SKILL.md files a coding agent can load to scaffold a protocol-compliant, storyboard-validated agent.
+Each AdCP SDK ships `build-*-agent` skills — SKILL.md files a coding agent can load to scaffold an agent and wire it to the storyboard runner.
 
-The JavaScript SDK ships eight skills (skill coverage varies by SDK):
+The JavaScript SDK ships eight skills. Python and Go currently ship a subset — see each repo's `skills/` directory for the current list:
 
 - **build-seller-agent**: publisher, SSP, or media network selling inventory to buyer agents
 - **build-signals-agent**: CDP or data provider serving audience and contextual signals
 - **build-creative-agent**: ad server or CMP rendering, previewing, and serving creatives
-- **build-generative-seller-agent**: AI ad network generating creatives from briefs
+- **build-generative-seller-agent**: seller agent that generates creatives on demand from briefs
 - **build-retail-media-agent**: retail media network with catalog-driven creative
-- **build-brand-rights-agent**: brand identity, licensing, and creative approval
+- **build-brand-rights-agent**: brand-side agent that handles licensing and creative approvals
 - **build-governance-agent**: spending authority, property lists, and content standards enforcement
-- **build-si-agent**: conversational sponsored content within user sessions
+- **build-si-agent**: agent that serves sponsored responses inside an AI chat product (si_* tasks)
 
 Skill locations:
 - JS/TS: https://github.com/adcontextprotocol/adcp-client/tree/main/skills
-- Python: https://github.com/adcontextprotocol/adcp-python/tree/main/skills
+- Python: https://github.com/adcontextprotocol/adcp-client-python/tree/main/skills
 - Go: https://github.com/adcontextprotocol/adcp-go/tree/main/skills
 
 ## Registry APIs

--- a/server/public/llms.txt
+++ b/server/public/llms.txt
@@ -45,21 +45,22 @@ AdCP supports two transport mechanisms:
 ## Adoption path
 
 Build in this order:
-- Quickstart (5-minute curl example): https://adcontextprotocol.org/docs/quickstart
-- Build an agent: https://adcontextprotocol.org/docs/building/build-an-agent
-- Validate an agent: https://adcontextprotocol.org/docs/building/validate-your-agent
-- Operate an agent: https://adcontextprotocol.org/docs/building/operating-an-agent
-- Load a seller skill directly: https://github.com/adcontextprotocol/adcp-client/blob/main/skills/build-seller-agent/SKILL.md
+1. Quickstart (5-minute curl example): https://adcontextprotocol.org/docs/quickstart
+2. Build an agent: https://adcontextprotocol.org/docs/building/build-an-agent
+3. Validate an agent: https://adcontextprotocol.org/docs/building/validate-your-agent
+4. Operate an agent: https://adcontextprotocol.org/docs/building/operating-an-agent
+
+Coding-agent shortcut — skip (2) and load a seller skill directly: https://github.com/adcontextprotocol/adcp-client/blob/main/skills/build-seller-agent/SKILL.md
 
 ## SDKs and skills
 
-SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+Each AdCP SDK ships both caller APIs (for buyers) and server primitives (for sellers). The JavaScript SDK also ships a storyboard runner (`npx @adcp/client storyboard run`) that validates any endpoint against the spec — use it regardless of the language your agent is written in.
 
 - `@adcp/client` (JavaScript/TypeScript): https://github.com/adcontextprotocol/adcp-client
-- `adcp` (Python): https://github.com/adcontextprotocol/adcp-python
+- `adcp` (Python): https://github.com/adcontextprotocol/adcp-client-python
 - `adcp-go` (Go): https://github.com/adcontextprotocol/adcp-go
 
-Each SDK ships `build-*-agent` skills a coding agent can load to scaffold a compliant implementation. See https://adcontextprotocol.org/llms-full.txt for the full skill inventory.
+Each SDK ships `build-*-agent` skills a coding agent can load to scaffold an agent and wire it to the storyboard runner. See https://adcontextprotocol.org/llms-full.txt for the full skill inventory.
 
 ## Registry APIs
 

--- a/server/public/llms.txt
+++ b/server/public/llms.txt
@@ -42,6 +42,32 @@ AdCP supports two transport mechanisms:
 - Schemas and SDKs: https://adcontextprotocol.org/docs/building/schemas-and-sdks
 - Release notes: https://adcontextprotocol.org/docs/reference/release-notes
 
+## Adoption path
+
+Build in this order:
+- Quickstart (5-minute curl example): https://adcontextprotocol.org/docs/quickstart
+- Build an agent: https://adcontextprotocol.org/docs/building/build-an-agent
+- Validate an agent: https://adcontextprotocol.org/docs/building/validate-your-agent
+- Operate an agent: https://adcontextprotocol.org/docs/building/operating-an-agent
+- Load a seller skill directly: https://github.com/adcontextprotocol/adcp-client/blob/main/skills/build-seller-agent/SKILL.md
+
+## SDKs and skills
+
+SDKs are both-sides: the same package powers buyers calling agents and sellers implementing them.
+
+- `@adcp/client` (JavaScript/TypeScript): https://github.com/adcontextprotocol/adcp-client
+- `adcp` (Python): https://github.com/adcontextprotocol/adcp-python
+- `adcp-go` (Go): https://github.com/adcontextprotocol/adcp-go
+
+Each SDK ships `build-*-agent` skills a coding agent can load to scaffold a compliant implementation. See https://adcontextprotocol.org/llms-full.txt for the full skill inventory.
+
+## Registry APIs
+
+Served by AgenticAdvertising.org:
+- Agent directory: https://agenticadvertising.org/api/registry/agents
+- Brand resolution: https://agenticadvertising.org/api/brands/resolve
+- Property resolution: https://agenticadvertising.org/api/properties/resolve
+
 ## Key terms
 
 - **Agentic advertising**: The practice of using AI agents to automate advertising workflows

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1243,7 +1243,7 @@ export class AdAgentsManager {
           result.card_endpoint = endpoint;
 
           // Check content-type header
-          const contentType = response.headers['content-type'] || '';
+          const contentType = String(response.headers['content-type'] ?? '');
           const isJsonContentType = contentType.includes('application/json');
 
           // Basic validation of card structure

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -19,6 +19,7 @@ import { notifySystemError } from '../error-notifier.js';
 import { logger as baseLogger } from '../../logger.js';
 import { logOutboundRequest } from '../../db/outbound-log-db.js';
 import { AAO_UA_COMPLIANCE } from '../../config/user-agents.js';
+import { adaptAuthForSdk } from '../../services/sdk-auth-adapter.js';
 
 const logger = baseLogger.child({ module: 'compliance-heartbeat' });
 const complianceDb = new ComplianceDatabase();
@@ -59,11 +60,12 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
     const startTime = Date.now();
     try {
       const auth = await complianceDb.resolveOwnerAuth(agent.agent_url);
+      const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `heartbeat:${agent.agent_url}` });
 
       const complyOptions: ComplyOptions = {
         test_session_id: `heartbeat-${Date.now()}`,
         timeout_ms: 60_000,
-        auth,
+        auth: sdkAuth,
         userAgent: AAO_UA_COMPLIANCE,
       };
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -74,6 +74,7 @@ import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
+import { adaptAuthForSdk } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
@@ -4065,10 +4066,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
     try {
       const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+      const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `test-agent:${agentUrl}` });
 
       let profile;
       try {
-        const caps = await testCapabilityDiscovery(agentUrl, { ...(auth && { auth }) });
+        const caps = await testCapabilityDiscovery(agentUrl, { ...(sdkAuth && { auth: sdkAuth }) });
         profile = caps.profile;
 
         // The SDK swallows the agent's 401 into steps[0].error; surface it as
@@ -4297,11 +4299,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
 
         const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard:${agentUrl}` });
 
         const complyResult = await comply(agentUrl, {
           timeout_ms: 90_000,
           storyboards: [req.params.storyboardId],
-          ...(auth && { auth }),
+          ...(sdkAuth && { auth: sdkAuth }),
         });
 
         if (complyResult.overall_status === 'auth_required') {
@@ -4396,13 +4399,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
 
         const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-compare:${agentUrl}` });
         const storyboardIds = [req.params.storyboardId];
 
         const [userResult, referenceResult] = await Promise.all([
           comply(agentUrl, {
             timeout_ms: 90_000,
             storyboards: storyboardIds,
-            ...(auth && { auth }),
+            ...(sdkAuth && { auth: sdkAuth }),
           }),
           comply(PUBLIC_TEST_AGENT.url, {
             timeout_ms: 90_000,

--- a/server/src/services/oauth-client-credentials-exchange.ts
+++ b/server/src/services/oauth-client-credentials-exchange.ts
@@ -1,0 +1,167 @@
+/**
+ * Server-side RFC 6749 §4.4 (OAuth 2.0 Client Credentials) token exchange.
+ *
+ * Context: PR #2800 added an `oauth_client_credentials` variant to
+ * `ResolvedOwnerAuth` (the server's internal auth union for agents
+ * with saved credentials), but `@adcp/client`'s `ComplyOptions.auth`
+ * and `TestOptions.auth` unions only accept `bearer | basic | oauth`.
+ * Passing the client-credentials variant to the SDK is a type error and
+ * would also fail at runtime because the SDK doesn't implement the
+ * exchange.
+ *
+ * This module bridges the gap: given a parsed
+ * `OAuthClientCredentials` config, resolve `$ENV:ADCP_OAUTH_<NAME>`
+ * references, POST to `token_endpoint`, and return a bearer token the
+ * SDK can carry. Callers narrow the auth to `{ type: 'bearer', token }`
+ * before handing it to the SDK.
+ *
+ * Tradeoff: no caching / expiry tracking yet. Compliance heartbeat and
+ * the registry test paths are both low-frequency (minutes / per-request
+ * hit counts, not steady-state traffic), so re-exchanging each call is
+ * acceptable. When `@adcp/client` learns native client-credentials
+ * support with 401-triggered refresh, this bridge can be removed and
+ * the configs passed through untouched.
+ */
+
+import type { OAuthClientCredentials } from '../db/agent-context-db.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('oauth-client-credentials-exchange');
+
+/** Max size we'll read from the token endpoint response to keep a hostile server bounded. */
+const MAX_RESPONSE_BYTES = 32 * 1024;
+/** Request timeout for the exchange — short to avoid blocking the caller. */
+const EXCHANGE_TIMEOUT_MS = 10_000;
+
+/** `$ENV:ADCP_OAUTH_<NAME>` reference pattern, mirroring the input parser. */
+const ENV_REFERENCE_PATTERN = /^\$ENV:ADCP_OAUTH_([A-Z0-9_]+)$/;
+
+export type ExchangeResult =
+  | { ok: true; access_token: string; expires_in?: number }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a config value that may be a `$ENV:ADCP_OAUTH_<NAME>`
+ * reference. Returns the literal value if there's no prefix, the env
+ * var's value if the reference resolves, or `null` when the env var
+ * isn't set (treated as a hard failure by the caller).
+ */
+export function resolveEnvReference(value: string): string | null {
+  const match = ENV_REFERENCE_PATTERN.exec(value);
+  if (!match) return value;
+  const name = `ADCP_OAUTH_${match[1]}`;
+  const resolved = process.env[name];
+  return resolved !== undefined && resolved !== '' ? resolved : null;
+}
+
+/**
+ * Perform the client-credentials exchange and return a bearer token.
+ *
+ * `auth_method` picks between HTTP Basic auth (default, per RFC 6749
+ * §2.3.1 recommendation) and credentials-in-body. Some providers
+ * require one specifically — the form is caller-controlled.
+ *
+ * Network failures, non-2xx responses, and malformed JSON all collapse
+ * to a single `{ ok: false, error }` so callers have one branch to
+ * handle. The token-endpoint response body is capped to 32KB so a
+ * hostile server can't stream junk into our process.
+ */
+export async function exchangeClientCredentials(
+  creds: OAuthClientCredentials,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<ExchangeResult> {
+  const clientId = resolveEnvReference(creds.client_id);
+  const clientSecret = resolveEnvReference(creds.client_secret);
+
+  if (clientId === null) {
+    return { ok: false, error: 'OAuth client_credentials: client_id env reference did not resolve.' };
+  }
+  if (clientSecret === null) {
+    return { ok: false, error: 'OAuth client_credentials: client_secret env reference did not resolve.' };
+  }
+
+  const form = new URLSearchParams();
+  form.set('grant_type', 'client_credentials');
+  if (creds.scope) form.set('scope', creds.scope);
+  if (creds.resource) form.set('resource', creds.resource);
+  if (creds.audience) form.set('audience', creds.audience);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/json',
+  };
+
+  if (creds.auth_method === 'body') {
+    form.set('client_id', clientId);
+    form.set('client_secret', clientSecret);
+  } else {
+    // RFC 6749 §2.3.1: HTTP Basic is the default, preferred method.
+    const encoded = Buffer.from(`${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`).toString('base64');
+    headers['Authorization'] = `Basic ${encoded}`;
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EXCHANGE_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(creds.token_endpoint, {
+      method: 'POST',
+      headers,
+      body: form.toString(),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      // Don't surface the endpoint's raw error body to the caller —
+      // that can contain sensitive diagnostic info; the log has it.
+      const preview = await readCapped(response);
+      logger.warn(
+        { status: response.status, tokenEndpoint: creds.token_endpoint, bodyPreview: preview },
+        'OAuth client-credentials exchange returned non-2xx',
+      );
+      return { ok: false, error: `OAuth client_credentials exchange failed: HTTP ${response.status}` };
+    }
+
+    const body = await readCapped(response);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint did not return JSON.' };
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint returned non-object body.' };
+    }
+    const obj = parsed as Record<string, unknown>;
+    const accessToken = obj.access_token;
+    if (typeof accessToken !== 'string' || !accessToken) {
+      return { ok: false, error: 'OAuth client_credentials: token endpoint response missing access_token.' };
+    }
+    const expiresIn = typeof obj.expires_in === 'number' ? obj.expires_in : undefined;
+    return { ok: true, access_token: accessToken, expires_in: expiresIn };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn({ err, tokenEndpoint: creds.token_endpoint }, 'OAuth client-credentials exchange threw');
+    return { ok: false, error: `OAuth client_credentials exchange failed: ${reason}` };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readCapped(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+      if (total >= MAX_RESPONSE_BYTES) break;
+    }
+  }
+  return Buffer.concat(chunks.map(c => Buffer.from(c)), Math.min(total, MAX_RESPONSE_BYTES)).toString('utf8');
+}

--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -1,0 +1,69 @@
+/**
+ * Narrow `ResolvedOwnerAuth` (server's internal auth union) down to the
+ * shape `@adcp/client`'s `ComplyOptions.auth` / `TestOptions.auth`
+ * accepts (bearer | basic | oauth).
+ *
+ * The server supports an `oauth_client_credentials` variant (#2800)
+ * that the SDK doesn't. For that variant we perform the RFC 6749 §4.4
+ * exchange here and hand the SDK the resulting bearer token. All
+ * other variants pass through unchanged. Failed exchanges yield
+ * `undefined` so the compliance / test path proceeds unauthenticated
+ * with a warning log — the alternative is dropping the entire check.
+ *
+ * Remove this bridge when @adcp/client learns native
+ * client_credentials with 401-triggered refresh.
+ */
+
+import type { ResolvedOwnerAuth } from '../db/compliance-db.js';
+import { exchangeClientCredentials } from './oauth-client-credentials-exchange.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('sdk-auth-adapter');
+
+/**
+ * The subset of `ResolvedOwnerAuth` the SDK accepts. Kept as a
+ * structural type so we aren't importing @adcp/client's internal types
+ * across the boundary.
+ */
+export type SdkAuth =
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | {
+      type: 'oauth';
+      tokens: { access_token: string; refresh_token: string; expires_at?: string };
+      client?: { client_id: string; client_secret?: string };
+    };
+
+/**
+ * Narrow server-resolved auth into the SDK's accepted shape. Exchanges
+ * client-credentials configs on the spot. Returns `undefined` for
+ * missing auth OR for exchange failures (caller proceeds unauthed).
+ */
+export async function adaptAuthForSdk(
+  auth: ResolvedOwnerAuth | undefined,
+  context: { tokenEndpointLabel?: string } = {},
+): Promise<SdkAuth | undefined> {
+  if (!auth) return undefined;
+
+  switch (auth.type) {
+    case 'bearer':
+    case 'basic':
+    case 'oauth':
+      return auth;
+    case 'oauth_client_credentials': {
+      const result = await exchangeClientCredentials(auth.credentials);
+      if (!result.ok) {
+        logger.warn(
+          {
+            tokenEndpoint: auth.credentials.token_endpoint,
+            context: context.tokenEndpointLabel,
+            reason: result.error,
+          },
+          'OAuth client-credentials exchange failed — falling back to unauthenticated request',
+        );
+        return undefined;
+      }
+      return { type: 'bearer', token: result.access_token };
+    }
+  }
+}

--- a/server/tests/unit/oauth-client-credentials-exchange.test.ts
+++ b/server/tests/unit/oauth-client-credentials-exchange.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  exchangeClientCredentials,
+  resolveEnvReference,
+} from '../../src/services/oauth-client-credentials-exchange.js';
+import { adaptAuthForSdk } from '../../src/services/sdk-auth-adapter.js';
+
+/**
+ * Tests for the server-side OAuth 2.0 client-credentials exchange
+ * (#2800 follow-up). `@adcp/client`'s ComplyOptions/TestOptions don't
+ * accept the `oauth_client_credentials` auth variant, so we exchange
+ * for a bearer token server-side before handing it to the SDK.
+ */
+
+function mockFetch(response: { status: number; body: string | object }) {
+  const bodyStr = typeof response.body === 'string' ? response.body : JSON.stringify(response.body);
+  const bytes = new TextEncoder().encode(bodyStr);
+  return vi.fn(async () => {
+    let sent = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sent) {
+          controller.enqueue(bytes);
+          sent = true;
+        } else {
+          controller.close();
+        }
+      },
+    });
+    return {
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      body: stream,
+    } as unknown as Response;
+  });
+}
+
+describe('resolveEnvReference', () => {
+  beforeEach(() => {
+    delete process.env.ADCP_OAUTH_TEST;
+  });
+
+  it('returns the literal value when no $ENV prefix', () => {
+    expect(resolveEnvReference('plaintext-secret')).toBe('plaintext-secret');
+  });
+
+  it('resolves a valid $ENV:ADCP_OAUTH_<NAME> reference from process.env', () => {
+    process.env.ADCP_OAUTH_TEST = 'super-secret';
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_TEST')).toBe('super-secret');
+  });
+
+  it('returns null when the env var is unset (treated as failure)', () => {
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_MISSING')).toBeNull();
+  });
+
+  it('returns null when the env var is empty', () => {
+    process.env.ADCP_OAUTH_TEST = '';
+    expect(resolveEnvReference('$ENV:ADCP_OAUTH_TEST')).toBeNull();
+  });
+
+  it('ignores $ENV prefixes that do not match ADCP_OAUTH_ (does not resolve arbitrary env vars)', () => {
+    process.env.DATABASE_URL = 'postgres://sensitive';
+    // The input validator rejects these at write time; the resolver
+    // still returns the literal so a mis-slipped reference becomes a
+    // hard exchange failure, not a silent env leak.
+    expect(resolveEnvReference('$ENV:DATABASE_URL')).toBe('$ENV:DATABASE_URL');
+  });
+});
+
+describe('exchangeClientCredentials', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const baseCreds = {
+    token_endpoint: 'https://idp.example.com/oauth/token',
+    client_id: 'client-abc',
+    client_secret: 'secret-xyz',
+  };
+
+  it('returns a bearer token from a successful exchange', async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      body: { access_token: 'new-token', expires_in: 3600, token_type: 'Bearer' },
+    });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result).toEqual({ ok: true, access_token: 'new-token', expires_in: 3600 });
+  });
+
+  it('defaults to HTTP Basic auth (RFC 6749 §2.3.1 preferred)', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const call = fetchImpl.mock.calls[0];
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^Basic /);
+    // body should NOT carry client_id/client_secret when using Basic
+    expect(init.body).not.toMatch(/client_id=/);
+    expect(init.body).not.toMatch(/client_secret=/);
+  });
+
+  it('puts credentials in the body when auth_method is "body"', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      { ...baseCreds, auth_method: 'body' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(init.body).toMatch(/client_id=client-abc/);
+    expect(init.body).toMatch(/client_secret=secret-xyz/);
+  });
+
+  it('includes scope / resource / audience in the form when set', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      { ...baseCreds, scope: 'foo bar', resource: 'https://api.example', audience: 'aud-1' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const body = (fetchImpl.mock.calls[0][1] as RequestInit).body as string;
+    expect(body).toMatch(/scope=foo\+bar/);
+    expect(body).toMatch(/resource=https%3A%2F%2Fapi.example/);
+    expect(body).toMatch(/audience=aud-1/);
+  });
+
+  it('resolves $ENV references before sending', async () => {
+    process.env.ADCP_OAUTH_ID = 'resolved-id';
+    process.env.ADCP_OAUTH_SEC = 'resolved-sec';
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      {
+        ...baseCreds,
+        client_id: '$ENV:ADCP_OAUTH_ID',
+        client_secret: '$ENV:ADCP_OAUTH_SEC',
+        auth_method: 'body',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const body = (fetchImpl.mock.calls[0][1] as RequestInit).body as string;
+    expect(body).toMatch(/client_id=resolved-id/);
+    expect(body).toMatch(/client_secret=resolved-sec/);
+  });
+
+  it('fails cleanly when a $ENV reference does not resolve', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: {} });
+    const result = await exchangeClientCredentials(
+      { ...baseCreds, client_secret: '$ENV:ADCP_OAUTH_MISSING' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/client_secret env reference/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('fails on a non-2xx response without surfacing the provider body', async () => {
+    const fetchImpl = mockFetch({ status: 401, body: '{"error":"invalid_client"}' });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/HTTP 401/);
+    expect((result as { error: string }).error).not.toMatch(/invalid_client/);
+  });
+
+  it('fails when the token endpoint returns non-JSON', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: 'not-json' });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/did not return JSON/);
+  });
+
+  it('fails when the response JSON is missing access_token', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { token_type: 'Bearer', expires_in: 100 } });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/missing access_token/);
+  });
+
+  it('fails cleanly on network exceptions', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const result = await exchangeClientCredentials(baseCreds, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe('adaptAuthForSdk', () => {
+  it('returns undefined for missing auth', async () => {
+    expect(await adaptAuthForSdk(undefined)).toBeUndefined();
+  });
+
+  it('passes bearer / basic / oauth through unchanged', async () => {
+    const bearer = { type: 'bearer', token: 'tok' } as const;
+    const basic = { type: 'basic', username: 'u', password: 'p' } as const;
+    const oauth = {
+      type: 'oauth',
+      tokens: { access_token: 'a', refresh_token: 'r' },
+      client: { client_id: 'c' },
+    } as const;
+    expect(await adaptAuthForSdk(bearer)).toBe(bearer);
+    expect(await adaptAuthForSdk(basic)).toBe(basic);
+    expect(await adaptAuthForSdk(oauth)).toBe(oauth);
+  });
+
+  it('exchanges oauth_client_credentials and narrows to bearer', async () => {
+    process.env.ADCP_OAUTH_BRIDGE_TEST = 'sec';
+    // Swap global fetch for this test only
+    const original = globalThis.fetch;
+    globalThis.fetch = mockFetch({
+      status: 200,
+      body: { access_token: 'exchanged-tok', expires_in: 600 },
+    }) as unknown as typeof fetch;
+    try {
+      const result = await adaptAuthForSdk({
+        type: 'oauth_client_credentials',
+        credentials: {
+          token_endpoint: 'https://idp.example/token',
+          client_id: 'client-x',
+          client_secret: '$ENV:ADCP_OAUTH_BRIDGE_TEST',
+        },
+      });
+      expect(result).toEqual({ type: 'bearer', token: 'exchanged-tok' });
+    } finally {
+      globalThis.fetch = original;
+      delete process.env.ADCP_OAUTH_BRIDGE_TEST;
+    }
+  });
+
+  it('returns undefined (falls back to unauthenticated) when the exchange fails', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = mockFetch({ status: 500, body: 'internal' }) as unknown as typeof fetch;
+    try {
+      const result = await adaptAuthForSdk({
+        type: 'oauth_client_credentials',
+        credentials: {
+          token_endpoint: 'https://idp.example/token',
+          client_id: 'c',
+          client_secret: 's',
+        },
+      });
+      expect(result).toBeUndefined();
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The safe subset extracted from closed PR #2814 after review. Three small changes to improve discoverability of the existing build/validate/operate path for newcomers (especially coding agents):

- **\`docs/quickstart.mdx\`** — two-path \`<CardGroup>\` at the fold (\"I'm connecting to agents\" → below-the-fold buyer quickstart, \"I'm building an agent\" → \`build-an-agent\`). Publishers and sellers landing on Quickstart don't bounce before finding the build path.
- **\`server/public/llms.txt\`** — adds an **Adoption path** section (quickstart → build → validate → operate + a direct SKILL.md URL so a coding agent can go from discovery to scaffold in one roundtrip), an **SDKs and skills** section with both-sides framing, and a **Registry APIs** section.
- **\`server/public/llms-full.txt\`** — same reframe applied in depth: \"Getting started\" becomes an explicit four-step adoption path, plus the full SDK inventory, all eight \`build-*-agent\` skills with what each targets, and the Registry APIs.

## Out of scope (split off from #2814)

- The new \`docs/trust.mdx\` landing page and the \"Trust and safety\" block that was added to \`llms-full.txt\` in #2814. Both carried framing that contradicted this release's self-attested / known-limitations posture (\"architectural, not promised\", \"Webhooks are HMAC-signed\" [RFC 9421 baseline ships in 3.0], \"agents... cannot exceed [authority]\", money-movement opening scenario). Rewrite tracked in **#2817** for post-GA.
- \`SECURITY.md\` stale refs — tracked in **#2812**.

## Dependency

Includes the oauth_client_credentials → SDK bridge fix as a cherry-pick of \`455c843e9\` from **#2818**. Main typecheck is currently broken (PR #2800 added a variant to \`ResolvedOwnerAuth\` that the SDK's auth union doesn't accept yet), and the pre-commit hook runs typecheck project-wide. When #2818 merges, rebase-merge here will deduplicate cleanly.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] Pre-commit (\`test:unit\` + \`typecheck\`) — passes
- [x] Mintlify broken-links + a11y — clean
- [x] 865 MDX files validated; no broken references in llms-full.txt (no link to the unbuilt \`docs/trust\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)