### PR TITLE
spec(compliance): wire status.monotonic across lifecycle-bearing specialisms (adcp#2664)

### DIFF
--- a/.changeset/wire-status-monotonic-specialisms.md
+++ b/.changeset/wire-status-monotonic-specialisms.md
@@ -1,0 +1,23 @@
+---
+"adcontextprotocol": minor
+---
+
+Wire the fourth default cross-step assertion `status.monotonic` onto the compliance specialisms that exercise lifecycle-bearing resources, and pick up the SDK implementation in [`@adcp/client@5.10.0`](https://github.com/adcontextprotocol/adcp-client/pull/760).
+
+`status.monotonic` (adcp#2664) rejects resource status transitions observed across storyboard steps that aren't on the spec-published lifecycle graph for their resource type — catches regressions like `active → pending_creatives` on a media_buy or `approved → processing` on a creative asset that per-step `response_schema` validations can't detect. Silent on runs that don't observe any status (no steps that read lifecycle-bearing resources produce observations → no transitions → silent pass).
+
+**Specialisms wired (20 files):**
+
+- Sales (9): `sales-guaranteed`, `sales-non-guaranteed`, `sales-broadcast-tv`, `sales-streaming-tv`, `sales-social`, `sales-exchange`, `sales-catalog-driven`, `sales-retail-media`, `sales-proposal-mode` — media_buy lifecycle primarily; `sales-catalog-driven` also touches catalog_item.
+- Creative (4 YAMLs across 3 specialisms): `creative-ad-server`, `creative-template`, `creative-generative/index.yaml` + `creative-generative/generative-seller.yaml` — creative asset lifecycle.
+- Governance (4): `governance-spend-authority/index.yaml` + `denied.yaml`, `governance-delivery-monitor`, `governance-aware-seller` — media_buy lifecycle under the governance handshake. Appended to the existing `governance.denial_blocks_mutation` invariant; both run on every storyboard run in these specialisms.
+- Lists (3): `property-lists`, `collection-lists`, `content-standards` — no tracked lifecycle resource in their current phases, so silent today; wired so future phases that touch `media_buy` or `account` status (e.g. validation runs against delivery) are automatically gated.
+
+**Not wired:**
+
+- `brand-rights`, `signal-marketplace`, `signal-owned` — no formal lifecycle enum in the spec today. No observations, no value in wiring.
+- `audience-sync` — separate resource lifecycle not yet in the bundled transition tables.
+- `measurement-verification`, `signed-requests` — cross-cutting / preview; revisit once phases populate.
+- Sponsored intelligence (`si_session` is a tracked lifecycle) — specialism's `phases: []`, nothing to observe.
+
+**Dep bump:** `@adcp/client` `^5.9.1 → ^5.10.0`. 5.10.0 bundles `status.monotonic` as the fourth auto-registered default assertion; the side-effect import from `@adcp/client/testing` registers it so these YAML `invariants:` ids resolve without any additional loading.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-rc.3",
       "dependencies": {
-        "@adcp/client": "^5.9.1",
+        "@adcp/client": "^5.10.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.9.1.tgz",
-      "integrity": "sha512-ZxhavK9s3gGs1G8B9BHUt1QLoi6ZsnABoqAT28tyQu3DfOXlKwMFanHCwXF2tNDpu/xvE88LQM3eNTifZLImJA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-Ts1vf3IlYYNpkEtQvAkIRHUNX9rB30+XyH5XRAyFmCZ8DbxBXkAi4UNYRxnT4LjujouuVpZ4n0x9+tBnP7vJ/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "^5.9.1",
+    "@adcp/client": "^5.10.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2785,7 +2785,7 @@ function getDimensions(format: { renders: Array<Record<string, unknown>> } | und
 }
 
 function buildHtmlAssets(html: string): AdcpCreativeManifest['assets'] {
-  return { serving_tag: { content: html } };
+  return { serving_tag: { asset_type: 'html', content: html } };
 }
 
 export async function handleBuildCreative(args: ToolArgs, ctx: TrainingContext): Promise<BuildCreativeResponse & { pricing_option_id?: string; vendor_cost?: number; currency?: string; consumption?: Record<string, unknown>; governance_context?: string }> {

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -8,6 +8,14 @@ track: governance
 required_tools:
   - create_collection_list
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph. Silent on collection-list-only runs (no tracked
+# lifecycle resource), but wired so phases that touch media_buy /
+# account status are automatically gated.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a governance agent that manages collection lists for brand safety. Unlike
   property lists which operate on technical surfaces (domains, apps), collection lists

--- a/static/compliance/source/specialisms/content-standards/index.yaml
+++ b/static/compliance/source/specialisms/content-standards/index.yaml
@@ -8,6 +8,14 @@ track: governance
 required_tools:
   - list_content_standards
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph. Silent on content-standards-only runs (no tracked
+# lifecycle resource), but wired so phases that touch creative /
+# account status are automatically gated.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a governance agent that manages content standards — rules that define what
   creative content is acceptable for a brand or campaign. Buyers create standards that

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -8,6 +8,12 @@ track: creative
 required_tools:
   - build_creative
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. approved → processing on a creative asset.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a creative ad server — think Innovid, Flashtalking, or CM360. Your clients
   have already uploaded their creatives through your UI. Buyers connect to browse your

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -14,6 +14,13 @@ requires_scenarios:
   - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy or
+# approved → processing on a creative asset.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a generative sell-side platform — an AI ad network, generative DSP, or any system that
   both sells inventory and generates creatives from a brief. The buyer doesn't upload finished

--- a/static/compliance/source/specialisms/creative-generative/index.yaml
+++ b/static/compliance/source/specialisms/creative-generative/index.yaml
@@ -11,6 +11,12 @@ required_tools:
 # the other phases without claiming catalog support. Agents that do not implement
 # sync_catalogs grade that phase not_applicable rather than fail the specialism.
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. approved → processing on a creative asset.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a generative creative platform — an AI ad network, a generative DSP, or any system
   that creates ad creatives from a natural-language brief and brand identity. The buyer doesn't

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -8,6 +8,12 @@ track: creative
 required_tools:
   - build_creative
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. approved → processing on a creative asset.
+invariants:
+  - status.monotonic
+
 narrative: |
   You build a creative management or rich media platform — think Celtra, a format
   conversion service, or any tool that defines ad templates and transforms input assets

--- a/static/compliance/source/specialisms/governance-aware-seller/index.yaml
+++ b/static/compliance/source/specialisms/governance-aware-seller/index.yaml
@@ -13,8 +13,13 @@ required_tools:
 # the surface this assertion protects. If a seller propagates a denial
 # response from its governance agent but then creates the media buy
 # anyway, no per-step validation notices — this assertion does.
+# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
+# status transitions observed across steps against the spec lifecycle
+# graph — catches an approved-with-conditions buy jumping from
+# pending_creatives back to pending_start, or active → pending_creatives.
 invariants:
   - governance.denial_blocks_mutation
+  - status.monotonic
 requires_scenarios:
   - media_buy_seller/governance_approved
   - media_buy_seller/governance_conditions

--- a/static/compliance/source/specialisms/governance-aware-seller/index.yaml
+++ b/static/compliance/source/specialisms/governance-aware-seller/index.yaml
@@ -13,10 +13,10 @@ required_tools:
 # the surface this assertion protects. If a seller propagates a denial
 # response from its governance agent but then creates the media buy
 # anyway, no per-step validation notices — this assertion does.
-# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
-# status transitions observed across steps against the spec lifecycle
-# graph — catches an approved-with-conditions buy jumping from
-# pending_creatives back to pending_start, or active → pending_creatives.
+# Cross-step assertion (adcp#2664): status.monotonic rejects media_buy
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — catches an approved-with-conditions buy jumping
+# from pending_creatives back to pending_start, or active → pending_creatives.
 invariants:
   - governance.denial_blocks_mutation
   - status.monotonic

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -12,10 +12,10 @@ required_tools:
 # re-evaluation. The assertion gates any post-denial mutation on the
 # affected plan, catching sellers that ignore a mid-campaign denial and
 # keep delivering / committing new spend.
-# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
-# status transitions observed across steps against the spec lifecycle
-# graph — paused → active → paused is fine, active → pending_creatives
-# fails.
+# Cross-step assertion (adcp#2664): status.monotonic rejects media_buy
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — paused → active → paused is fine,
+# active → pending_creatives fails.
 invariants:
   - governance.denial_blocks_mutation
   - status.monotonic

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -12,8 +12,13 @@ required_tools:
 # re-evaluation. The assertion gates any post-denial mutation on the
 # affected plan, catching sellers that ignore a mid-campaign denial and
 # keep delivering / committing new spend.
+# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
+# status transitions observed across steps against the spec lifecycle
+# graph — paused → active → paused is fine, active → pending_creatives
+# fails.
 invariants:
   - governance.denial_blocks_mutation
+  - status.monotonic
 
 narrative: |
   After a media buy is confirmed with governance approval, the governance agent monitors

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -13,8 +13,12 @@ required_tools:
 # failure mode where a seller surfaces the denial response but still
 # creates the media buy / activates the signal / syncs the property list
 # anyway. Plan-scoped — unrelated plans proceed normally.
+# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
+# status transitions observed across steps against the spec lifecycle
+# graph (e.g. rejects active → pending_creatives).
 invariants:
   - governance.denial_blocks_mutation
+  - status.monotonic
 
 narrative: |
   The buyer's governance agent registers a plan with strict spending authority. The buyer

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -13,9 +13,9 @@ required_tools:
 # failure mode where a seller surfaces the denial response but still
 # creates the media buy / activates the signal / syncs the property list
 # anyway. Plan-scoped — unrelated plans proceed normally.
-# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
-# status transitions observed across steps against the spec lifecycle
-# graph (e.g. rejects active → pending_creatives).
+# Cross-step assertion (adcp#2664): status.monotonic rejects media_buy
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives.
 invariants:
   - governance.denial_blocks_mutation
   - status.monotonic

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -13,9 +13,9 @@ required_tools:
 # if a seller surfaces a denial signal mid-flow and then still mutates
 # the plan's resources. Kept wired here so any future "conditions not
 # met → denied" phase added to this storyboard is automatically gated.
-# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
-# status transitions observed across steps against the spec lifecycle
-# graph (e.g. rejects active → pending_creatives).
+# Cross-step assertion (adcp#2664): status.monotonic rejects media_buy
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives.
 invariants:
   - governance.denial_blocks_mutation
   - status.monotonic

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -13,8 +13,12 @@ required_tools:
 # if a seller surfaces a denial signal mid-flow and then still mutates
 # the plan's resources. Kept wired here so any future "conditions not
 # met → denied" phase added to this storyboard is automatically gated.
+# Cross-step assertion (adcp#2664): status.monotonic gates media_buy
+# status transitions observed across steps against the spec lifecycle
+# graph (e.g. rejects active → pending_creatives).
 invariants:
   - governance.denial_blocks_mutation
+  - status.monotonic
 
 narrative: |
   The buyer's governance agent evaluates a media buy that falls within spending authority but

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -8,6 +8,15 @@ track: governance
 required_tools:
   - create_property_list
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph. Silent on property-list-only runs (no tracked
+# lifecycle resource), but wired so phases that touch media_buy /
+# account status (e.g. via a validation run against delivery) are
+# automatically gated.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a governance agent that manages property lists for brand safety. Buyers create
   inclusion and exclusion lists that define where their ads can and cannot appear. Your

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -17,6 +17,12 @@ requires_scenarios:
   - media_buy_seller/inventory_list_no_match
   - media_buy_seller/invalid_transitions
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a broadcast television platform — a local TV station group, network affiliate,
   or television rep firm that sells linear advertising inventory. A buyer agent connects

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -14,6 +14,13 @@ requires_scenarios:
   - media_buy_seller/pending_creatives_to_start
   - media_buy_seller/invalid_transitions
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy or
+# approved → pending on a catalog_item.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a platform that supports catalog-driven advertising — think Snap Dynamic Ads,
   Meta Product Catalogs, or retail media product listing ads. The buyer pushes a product

--- a/static/compliance/source/specialisms/sales-exchange/index.yaml
+++ b/static/compliance/source/specialisms/sales-exchange/index.yaml
@@ -6,6 +6,14 @@ status: preview
 summary: "Programmatic exchange or SSP — auction-based inventory access with real-time bidding semantics and multi-seller inventory pooling."
 track: media-buy
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy.
+# Wired eagerly so the assertion applies automatically once the 3.1
+# exchange-specific phases are populated.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a programmatic exchange or supply-side platform. Buyers reach inventory
   via auction — you aggregate inventory from many publishers and expose it through

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -17,6 +17,12 @@ requires_scenarios:
   - media_buy_seller/inventory_list_no_match
   - media_buy_seller/invalid_transitions
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a sell-side platform that requires human approval before guaranteed media buys go
   live. When a buyer creates a guaranteed buy, your platform returns an A2A task in the

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -15,6 +15,12 @@ requires_scenarios:
   - media_buy_seller/inventory_list_no_match
   - media_buy_seller/invalid_transitions
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a sell-side platform with auction-based inventory. Non-guaranteed buys don't
   require IOs or human approval — the buyer sets a bid price and budget, and your platform

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -17,6 +17,13 @@ requires_scenarios:
   - media_buy_seller/inventory_list_no_match
   - media_buy_seller/invalid_transitions
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. committed → draft on a proposal or active →
+# pending_creatives on a media_buy.
+invariants:
+  - status.monotonic
+
 narrative: |
   Your seller generates curated media plan proposals. The buyer sends a brief, your platform
   returns products alongside proposals — curated bundles with budget allocations and rationale

--- a/static/compliance/source/specialisms/sales-retail-media/index.yaml
+++ b/static/compliance/source/specialisms/sales-retail-media/index.yaml
@@ -8,6 +8,12 @@ track: media-buy
 required_tools:
   - sync_catalogs
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. approved → pending on a catalog_item.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a retail media network. Inventory spans owned-and-operated digital
   properties (site, app, kiosks), offsite extensions syndicated through DSPs, and

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -10,6 +10,13 @@ required_tools:
   - sync_catalogs
   - sync_creatives
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. approved → processing on a creative asset or
+# active → pending_creatives on a media_buy.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a social media platform — Snap, Meta, TikTok, Pinterest, or any walled garden that
   sells advertising through audience-based targeting and native creative formats. A buyer agent

--- a/static/compliance/source/specialisms/sales-streaming-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-streaming-tv/index.yaml
@@ -6,6 +6,14 @@ status: preview
 summary: "Connected TV and streaming sellers — ad-supported video inventory, audience-based buying, and frequency management across CTV apps."
 track: media-buy
 
+# Cross-step assertion (adcp#2664). status.monotonic rejects resource
+# status transitions observed across steps that aren't on the spec
+# lifecycle graph — e.g. active → pending_creatives on a media_buy.
+# Wired eagerly so the assertion applies automatically once the 3.1
+# streaming-specific phases are populated.
+invariants:
+  - status.monotonic
+
 narrative: |
   You run a streaming TV seller (SSAI, ad-supported streaming service, or CTV
   platform). Inventory is sold as video impressions against audiences rather than


### PR DESCRIPTION
## Summary

- Wires the fourth default cross-step assertion `status.monotonic` — shipped in [`@adcp/client@5.10.0`](https://github.com/adcontextprotocol/adcp-client/pull/760) — into the `invariants:` list of every specialism that exercises a lifecycle-bearing resource (media_buy, creative asset, account, si_session, catalog_item, proposal, creative_approval).
- Bumps `@adcp/client` `^5.9.1 → ^5.10.0`. The testing side-effect import registers `status.monotonic` so the new YAML ids resolve without any additional loading.
- Adds the `asset_type: 'html'` discriminator to `server/src/training-agent/task-handlers.ts::buildHtmlAssets`, which 5.10.0's tightened `HTMLAsset` type (via [adcp-client#764](https://github.com/adcontextprotocol/adcp-client/pull/764)) now requires.

## What `status.monotonic` does

Rejects resource status transitions observed across storyboard steps that aren't on the spec-published lifecycle graph for their resource type. Catches regressions like `active → pending_creatives` on a media_buy or `approved → processing` on a creative asset that per-step `response_schema` validations cannot detect. See the bundled implementation and transition tables in [adcp-client#760](https://github.com/adcontextprotocol/adcp-client/pull/760) for the full spec-aligned graph per resource type.

Silent pass on runs that don't observe any lifecycle-bearing response — no observations means no transitions to check. Self-edges (same status re-read) are silent pass. Unknown enum values reset the anchor rather than failing (`response_schema` catches enum violations).

## Specialisms wired (20 files)

**Sales (9):** `sales-guaranteed`, `sales-non-guaranteed`, `sales-broadcast-tv`, `sales-streaming-tv`, `sales-social`, `sales-exchange`, `sales-catalog-driven`, `sales-retail-media`, `sales-proposal-mode` — media_buy lifecycle primarily; `sales-catalog-driven` also touches catalog_item; `sales-proposal-mode` also touches proposal.

**Creative (4 YAMLs across 3 specialisms):** `creative-ad-server`, `creative-template`, `creative-generative/index.yaml` + `creative-generative/generative-seller.yaml` — creative asset lifecycle.

**Governance (4):** `governance-spend-authority/index.yaml` + `denied.yaml`, `governance-delivery-monitor`, `governance-aware-seller`. Appended to the existing `governance.denial_blocks_mutation` invariant; both run on every storyboard run in these specialisms.

**Lists (3):** `property-lists`, `collection-lists`, `content-standards` — no tracked lifecycle resource in current phases (silent today); wired so future phases that touch `media_buy` or `account` status are automatically gated.

## Not wired (and why)

- `brand-rights`, `signal-marketplace`, `signal-owned` — no formal lifecycle enum in the spec today.
- `audience-sync` — separate resource lifecycle not yet in the bundled transition tables. Product review flagged as a future follow-up: file an upstream issue to add the audience transition table, then wire in a subsequent PR.
- `measurement-verification`, `signed-requests` — cross-cutting / preview; revisit once phases populate.
- Sponsored intelligence — `si_session` is tracked but the specialism's `phases: []`, nothing to observe.

## What re-grading will surface

Agents that were previously "clean" on these storyboards and emit a status transition that isn't on the spec lifecycle graph will start failing this assertion. Example failure:

```
media_buy mb-1: active → pending_creatives (step "create_media_buy" → step "update_media_buy") is not in the lifecycle graph.
```

This is the intended effect — previously-silent lifecycle bugs now fail the grader. Sellers hitting it should either (a) fix the emitted status to a legal target for the anchor state, or (b) re-register the assertion with `registerAssertion(spec, { override: true })` if they need a stricter variant.

## Known latent path in the training agent

Code review surfaced one lifecycle path in `server/src/training-agent/task-handlers.ts` (`handleUpdateMediaBuy` with `creative_assignments: []` on an active buy, lines 2223-2230 + `deriveStatus` line 546) that would emit `active → pending_creatives`, which is NOT in `MEDIA_BUY_TRANSITIONS`. **No current scenario exercises this path**, so CI stays green today. Keeping as-is — this is exactly the kind of drift `status.monotonic` is designed to catch; if a future storyboard touches "buyer replaces all creatives", the assertion's diagnostic will name the problem correctly. Tracked for follow-up.

## Expert-review follow-ups (out of scope for this PR)

- **Upstream `@adcp/client`:** consider flipping bundled defaults from opt-in (`invariants: [...]`) to default-on-with-`invariants.disable: [...]` escape hatch. Product review flagged this as the larger product-design call — forks and new specialisms currently ship with zero cross-step gating silently. Belongs in a separate adcp-client PR touching the runner.
- **Upstream `@adcp/client`:** extend the `status.monotonic` failure message with the expected legal targets from the anchor state and a link to the relevant enum spec section (e.g. `/enums/media-buy-status`). Current message is debuggable; this makes it self-serve.
- **adcp spec:** add `audience` lifecycle enum + transition table so `audience-sync` can be wired in a follow-up.
- **Compliance grader UI:** render wired-but-not-observed assertions distinctly from "passed" so readers don't infer false protection on the three silent-today list specialisms.

## Test plan

- [x] `npm run build:compliance` — storyboard linters green (scoping, branch-set, contradiction, context-entity, auth-shape, test-kits), 24 specialisms bundled
- [x] `npm run test:storyboard-scoping` — 3/3 pass
- [x] `npm run test:storyboard-sample-request-schema` — 8/8 pass
- [x] `npm run test:server-unit` — 631/631 pass
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean across full server after the `HTMLAsset` fix
- [x] Expert review (code-reviewer + adtech-product-expert) — findings folded in; verb drift normalized, latent path documented, follow-ups enumerated above
- [ ] CI: watch storyboard grader floors — see "Known latent path" note above; if floors drop, the right move is to fix the training agent, not to pin the invariant off

🤖 Generated with [Claude Code](https://claude.com/claude-code)