### PR TITLE
fix(visibility): move brand.json write outside applyAgentVisibility tx (#2825)

### DIFF
--- a/.changeset/fix-apply-agent-visibility-tx-shape.md
+++ b/.changeset/fix-apply-agent-visibility-tx-shape.md
@@ -1,0 +1,8 @@
+---
+---
+
+Close #2825: move the brand.json manifest write in `applyAgentVisibility` outside the profile transaction. If the manifest write was inside the tx and succeeded while the commit later failed, we'd orphan a manifest entry pointing at an agent whose `visibility: 'public'` never committed — the exact drift the `/check` endpoint was built to detect. Mirrors the same pattern that landed for `demotePublicAgentsOnTierDowngrade` in #2822: stage the manifest op inside the locked tx, commit the JSONB, then execute the manifest write outside. A failed manifest write after commit logs a structured `brand_json_drift` event so the `/check` reconciler can surface it, and the profile JSONB stays authoritative.
+
+Drive-by: fixes the pre-existing integration-test signature mismatch for `demotePublicAgentsOnTierDowngrade` (argument list updated in #2822 but `tests/integration/agent-visibility-e2e.test.ts` wasn't touched — typecheck excludes `tests/`).
+
+New integration test pins the invariant: with `brandDb.updateManifestAgents` forced to throw, the POST `/publish` response is still 200, the manifest write was attempted (not skipped), and the profile JSONB reflects the new `visibility: 'public'`.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -859,7 +859,13 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
       throw err;
     } finally {
-      client.release();
+      // Don't let a release() failure mask whatever the try block threw
+      // (e.g. a COMMIT error we actually want to surface to the caller).
+      try {
+        client.release();
+      } catch (releaseErr) {
+        logger.warn({ err: releaseErr, orgId }, 'pg client release failed');
+      }
     }
 
     // Profile JSONB is committed. Apply the manifest change outside
@@ -874,9 +880,16 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           summary: manifestOp.summary,
         });
       } catch (manifestErr) {
+        // Narrow the error shape. pg driver errors and other library
+        // errors can carry `error.query` / `error.parameters` that
+        // pino's default err-serializer would emit — keep diagnostic
+        // logs free of raw SQL + parameter values.
+        const errPayload = manifestErr instanceof Error
+          ? { message: manifestErr.message, name: manifestErr.name }
+          : { message: String(manifestErr) };
         logger.warn(
           {
-            err: manifestErr,
+            err: errPayload,
             domain: manifestOp.domain,
             orgId,
             agentIndex: index,

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -680,6 +680,25 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
   > {
     const pool = getPool();
     const client = await pool.connect();
+
+    // Computed inside the tx, applied outside after the profile COMMIT.
+    // The brand.json manifest write (`brandDb.updateManifestAgents`) is
+    // against an external-ish surface (separate connection, different
+    // table, different consumers). Keeping it inside the tx means a
+    // manifest write that succeeds followed by a failed COMMIT orphans
+    // the manifest entry — the exact drift the `/check` endpoint
+    // exists to detect (#2825, mirror of the demote path's rewrite
+    // in #2822). So we stage the manifest work during the tx, commit
+    // the JSONB change, then execute manifest + log a structured
+    // drift event on post-commit failure.
+    type ManifestOp =
+      | { kind: 'add'; domain: string; updatedAgents: Array<{ type: string; url: string; id: string; description?: string }>; summary: string }
+      | { kind: 'remove'; domain: string; updatedAgents: Array<{ type: string; url: string; id: string }>; summary: string };
+    let manifestOp: ManifestOp | null = null;
+    let snippet: { type: string; url: string; id: string; description?: string } | undefined;
+    let finalTarget: AgentVisibility = target;
+    let committed = false;
+
     try {
       await client.query('BEGIN');
 
@@ -794,8 +813,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         ...(agent.name ? { description: agent.name } : {}),
       };
 
-      let snippet: typeof agentEntry | undefined;
-
       if (target === 'public' && domain) {
         if (isSelfHosted) {
           snippet = agentEntry;
@@ -804,11 +821,12 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           const currentAgents = Array.isArray(manifest.agents)
             ? manifest.agents as Array<{ type: string; url: string; id: string; description?: string }>
             : [];
-          const updatedAgents = [...currentAgents.filter(a => a.url !== agent.url), agentEntry];
-          await brandDb.updateManifestAgents(domain, updatedAgents, {
-            ...actor,
+          manifestOp = {
+            kind: 'add',
+            domain,
+            updatedAgents: [...currentAgents.filter(a => a.url !== agent.url), agentEntry],
             summary: `Published ${agent.type || 'brand'} agent to brand.json`,
-          });
+          };
         }
       } else if (domain && discovered && !isSelfHosted) {
         const manifest = (discovered.brand_manifest as Record<string, unknown>) || {};
@@ -816,11 +834,12 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           ? manifest.agents as Array<{ type: string; url: string; id: string }>
           : [];
         if (currentAgents.some(a => a.url === agent.url)) {
-          const updatedAgents = currentAgents.filter(a => a.url !== agent.url);
-          await brandDb.updateManifestAgents(domain, updatedAgents, {
-            ...actor,
+          manifestOp = {
+            kind: 'remove',
+            domain,
+            updatedAgents: currentAgents.filter(a => a.url !== agent.url),
             summary: `Removed ${agent.type || 'brand'} agent from brand.json`,
-          });
+          };
         }
       }
 
@@ -832,37 +851,68 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         [JSON.stringify(agents), row.id]
       );
       await client.query('COMMIT');
-
-      if (target === 'public' && snippet) {
-        return {
-          status: 200,
-          body: {
-            action: 'snippet',
-            message: 'Add this to the agents array in your brand.json',
-            visibility: target,
-            snippet,
-          },
-        };
-      }
-      return {
-        status: 200,
-        body: {
-          action: target === 'public' ? 'published' : target === 'private' ? 'unpublished' : 'members_only',
-          message:
-            target === 'public'
-              ? 'Agent published to brand.json'
-              : target === 'members_only'
-                ? 'Agent is visible to members with API access'
-                : 'Agent removed from brand.json',
-          visibility: target,
-        },
-      };
+      committed = true;
+      finalTarget = target;
     } catch (err) {
-      await client.query('ROLLBACK').catch(() => {});
+      if (!committed) {
+        await client.query('ROLLBACK').catch(() => {});
+      }
       throw err;
     } finally {
       client.release();
     }
+
+    // Profile JSONB is committed. Apply the manifest change outside
+    // the tx — if this throws, the JSONB is already authoritative and
+    // the `/check` endpoint's drift detection will surface the
+    // divergence. Logging as structured drift so reconciliation can
+    // pick it up automatically.
+    if (manifestOp) {
+      try {
+        await brandDb.updateManifestAgents(manifestOp.domain, manifestOp.updatedAgents, {
+          ...actor,
+          summary: manifestOp.summary,
+        });
+      } catch (manifestErr) {
+        logger.warn(
+          {
+            err: manifestErr,
+            domain: manifestOp.domain,
+            orgId,
+            agentIndex: index,
+            target: finalTarget,
+            kind: manifestOp.kind,
+            event: 'brand_json_drift',
+          },
+          'Profile visibility committed but brand.json manifest write failed — /check will surface as drift',
+        );
+      }
+    }
+
+    if (finalTarget === 'public' && snippet) {
+      return {
+        status: 200,
+        body: {
+          action: 'snippet',
+          message: 'Add this to the agents array in your brand.json',
+          visibility: finalTarget,
+          snippet,
+        },
+      };
+    }
+    return {
+      status: 200,
+      body: {
+        action: finalTarget === 'public' ? 'published' : finalTarget === 'private' ? 'unpublished' : 'members_only',
+        message:
+          finalTarget === 'public'
+            ? 'Agent published to brand.json'
+            : finalTarget === 'members_only'
+              ? 'Agent is visible to members with API access'
+              : 'Agent removed from brand.json',
+        visibility: finalTarget,
+      },
+    };
   }
 
   /**

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -697,7 +697,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
     let manifestOp: ManifestOp | null = null;
     let snippet: { type: string; url: string; id: string; description?: string } | undefined;
     let finalTarget: AgentVisibility = target;
-    let committed = false;
 
     try {
       await client.query('BEGIN');
@@ -851,12 +850,12 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         [JSON.stringify(agents), row.id]
       );
       await client.query('COMMIT');
-      committed = true;
       finalTarget = target;
     } catch (err) {
-      if (!committed) {
-        await client.query('ROLLBACK').catch(() => {});
-      }
+      // Safe to attempt rollback whether we got here before or after
+      // a successful COMMIT — pg no-ops a ROLLBACK on a finished tx
+      // and the .catch swallows any driver noise.
+      await client.query('ROLLBACK').catch(() => {});
       throw err;
     } finally {
       // Don't let a release() failure mask whatever the try block threw

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -306,7 +306,6 @@ describe('Agent visibility E2E', () => {
       orgId,
       'individual_professional',
       'individual_academic',
-      memberDb,
       brandDb,
     );
 
@@ -335,7 +334,6 @@ describe('Agent visibility E2E', () => {
       orgId,
       'company_leader',
       null,
-      memberDb,
       brandDb,
     );
 
@@ -451,5 +449,70 @@ describe('Agent visibility E2E', () => {
     expect(byUrl['https://old-priv.example']).toBe('private');
     // is_public key should be gone after migration transform
     expect((profile!.agents[0] as any).is_public).toBeUndefined();
+  });
+
+  it('POST /publish: profile JSONB commits even when brand.json manifest write fails (#2825)', async () => {
+    // The invariant this pins: `applyAgentVisibility` writes to two
+    // different surfaces — `member_profiles.agents` (inside the tx)
+    // and `brand_revisions` via `updateManifestAgents` (separate
+    // connection). If the manifest write is inside the tx and
+    // succeeds while the commit fails, we orphan a manifest entry.
+    // The rewrite in #2825 moved the manifest write to AFTER the
+    // profile commit, so a manifest failure leaves the committed
+    // JSONB authoritative and `/check`'s drift detection picks up
+    // the divergence.
+    const orgId = `${TEST_PREFIX}_manifest_fail`;
+    const userId = `${TEST_PREFIX}_manifest_fail_user`;
+    const domain = 'manifestfail.example';
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await memberDb.createProfile({
+      workos_organization_id: orgId,
+      display_name: 'Manifest Fail Org',
+      slug: 'manifestfail',
+      primary_brand_domain: domain,
+      is_public: true,
+      agents: [
+        { url: `https://agent.${domain}`, visibility: 'private' },
+      ],
+    });
+
+    // No brand row seeded on purpose — `applyAgentVisibility` still
+    // routes through `updateManifestAgents` when `discovered` is
+    // null (the non-self-hosted path treats missing discovery as an
+    // empty community manifest). Self-hosted brands (`source_type ===
+    // 'brand_json'`) skip the manifest write entirely; the drift
+    // scenario only applies to community-hosted / unknown brands.
+
+    // Spy on the real brandDb instance. `applyAgentVisibility` calls
+    // `brandDb.updateManifestAgents` — forcing it to throw simulates a
+    // failed community-manifest write.
+    const originalUpdate = brandDb.updateManifestAgents.bind(brandDb);
+    const updateSpy = vi
+      .spyOn(brandDb, 'updateManifestAgents')
+      .mockRejectedValueOnce(new Error('simulated manifest-write failure'));
+
+    try {
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).post('/api/me/member-profile/agents/0/publish');
+
+      // Response should still be 200 — the profile update is
+      // authoritative; manifest drift logs but doesn't fail the request.
+      expect(res.status).toBe(200);
+      expect(res.body.visibility).toBe('public');
+
+      // The manifest write was attempted (so this is a real drift
+      // scenario, not a skipped one).
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+
+      // Profile JSONB is authoritative and reflects the publish.
+      const profile = await memberDb.getProfileByOrgId(orgId);
+      expect(profile!.agents[0].visibility).toBe('public');
+    } finally {
+      updateSpy.mockRestore();
+      // Keep the closure around `originalUpdate` happy (some linters
+      // flag otherwise-unused bindings in the spy pattern).
+      void originalUpdate;
+    }
   });
 });

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -451,7 +451,7 @@ describe('Agent visibility E2E', () => {
     expect((profile!.agents[0] as any).is_public).toBeUndefined();
   });
 
-  it('POST /publish: profile JSONB commits even when brand.json manifest write fails (#2825)', async () => {
+  it('POST /publish on a community brand: profile JSONB commits even when brand.json manifest write fails (#2825)', async () => {
     // The invariant this pins: `applyAgentVisibility` writes to two
     // different surfaces — `member_profiles.agents` (inside the tx)
     // and `brand_revisions` via `updateManifestAgents` (separate
@@ -476,18 +476,20 @@ describe('Agent visibility E2E', () => {
         { url: `https://agent.${domain}`, visibility: 'private' },
       ],
     });
-
-    // No brand row seeded on purpose — `applyAgentVisibility` still
-    // routes through `updateManifestAgents` when `discovered` is
-    // null (the non-self-hosted path treats missing discovery as an
-    // empty community manifest). Self-hosted brands (`source_type ===
-    // 'brand_json'`) skip the manifest write entirely; the drift
-    // scenario only applies to community-hosted / unknown brands.
+    // Seed a community-hosted brand row so the publish hits the
+    // intended code path (`target==='public' && !isSelfHosted`). Without
+    // this, `discovered` is null and the test passes via the missing-
+    // discovery fallthrough — a future refactor that short-circuits
+    // null discovery would silently collapse the test.
+    await brandDb.upsertDiscoveredBrand({
+      domain,
+      source_type: 'community',
+      brand_manifest: { agents: [] },
+    });
 
     // Spy on the real brandDb instance. `applyAgentVisibility` calls
     // `brandDb.updateManifestAgents` — forcing it to throw simulates a
     // failed community-manifest write.
-    const originalUpdate = brandDb.updateManifestAgents.bind(brandDb);
     const updateSpy = vi
       .spyOn(brandDb, 'updateManifestAgents')
       .mockRejectedValueOnce(new Error('simulated manifest-write failure'));
@@ -510,9 +512,53 @@ describe('Agent visibility E2E', () => {
       expect(profile!.agents[0].visibility).toBe('public');
     } finally {
       updateSpy.mockRestore();
-      // Keep the closure around `originalUpdate` happy (some linters
-      // flag otherwise-unused bindings in the spy pattern).
-      void originalUpdate;
+    }
+  });
+
+  it('POST /publish on a self-hosted brand: does NOT call updateManifestAgents (proves the spy in the sibling test is real)', async () => {
+    // The manifest-write drift scenario applies only to community-
+    // hosted brands. Self-hosted brands (`source_type==='brand_json'`)
+    // skip the manifest write entirely and instead return a `snippet`
+    // for the owner to paste into their own brand.json. This test is
+    // the specificity check for the failing-manifest test above: if
+    // someone refactors `applyAgentVisibility` to always call
+    // `updateManifestAgents` (including on self-hosted), this test
+    // flips red.
+    const orgId = `${TEST_PREFIX}_self_hosted`;
+    const userId = `${TEST_PREFIX}_self_hosted_user`;
+    const domain = 'selfhosted.example';
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await memberDb.createProfile({
+      workos_organization_id: orgId,
+      display_name: 'Self Hosted Org',
+      slug: 'selfhosted',
+      primary_brand_domain: domain,
+      is_public: true,
+      agents: [
+        { url: `https://agent.${domain}`, visibility: 'private' },
+      ],
+    });
+    await brandDb.upsertDiscoveredBrand({
+      domain,
+      source_type: 'brand_json',
+      brand_manifest: { agents: [] },
+    });
+
+    const updateSpy = vi.spyOn(brandDb, 'updateManifestAgents');
+    try {
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).post('/api/me/member-profile/agents/0/publish');
+
+      expect(res.status).toBe(200);
+      expect(res.body.visibility).toBe('public');
+      // Self-hosted → snippet returned for the owner to paste; no
+      // manifest write from our side.
+      expect(res.body.action).toBe('snippet');
+      expect(res.body.snippet).toMatchObject({ url: `https://agent.${domain}` });
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      updateSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes #2825.

The sibling \`demotePublicAgentsOnTierDowngrade\` got this treatment in #2822 — commit the profile tx first, then do brand.json. \`applyAgentVisibility\` still had the old shape where \`updateManifestAgents\` ran **inside** the profile transaction, so a manifest-write success followed by a commit failure would orphan a manifest entry whose \`visibility: 'public'\` never committed on the profile row. That's the exact drift \`/check\` exists to detect.

## What changed

**\`applyAgentVisibility\`** (\`server/src/routes/member-profiles.ts\`):
- Keep the profile \`SELECT ... FOR UPDATE\`, inner-tx tier re-read, and agent/URL/domain validation where they are.
- Stage the manifest op inside the tx as a typed \`ManifestOp\` variant (\`add\` or \`remove\`, pre-computed \`updatedAgents\` array + summary).
- \`UPDATE member_profiles + COMMIT\`.
- Execute \`updateManifestAgents\` **after** the tx commits. If it throws, log a structured \`brand_json_drift\` event and return success — the JSONB is authoritative; \`/check\` will surface the divergence.

## Drive-by

\`tests/integration/agent-visibility-e2e.test.ts\` had two \`demotePublicAgentsOnTierDowngrade(...)\` calls with the pre-#2822 signature (passing \`memberDb\` as the 4th positional arg where \`brandDb\` is now expected). The root tsconfig excludes \`tests/\` so typecheck didn't catch this. Fixed.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:server-unit\` — 1833 pass, 34 skipped
- [x] New integration test in \`agent-visibility-e2e.test.ts\` pins the invariant: with \`brandDb.updateManifestAgents\` forced to throw, POST \`/publish\` returns 200, the manifest write was attempted (not skipped), and the profile JSONB shows \`visibility: 'public'\`.
- [ ] Manual on staging: force a manifest failure (e.g., misconfigure brand.json URL), publish an agent, verify: response succeeds, profile JSONB commits, \`/check\` surfaces the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)