### PR TITLE
chore(dashboard): remove dead platform_type UI (closes #2811)

### DIFF
--- a/.changeset/remove-platform-type-ui.md
+++ b/.changeset/remove-platform-type-ui.md
@@ -1,0 +1,18 @@
+---
+---
+
+chore(dashboard): remove dead platform_type UI (closes #2811)
+
+Migration [409](https://github.com/adcontextprotocol/adcp/blob/main/server/src/db/migrations/409_drop_platform_type.sql) dropped `platform_type` from `agent_registry_metadata` when `@adcp/client` 5.1.0 replaced the concept with specialisms. The dashboard `buildConnectForm` still rendered three `<select name="platform_type*">` selects (one per auth-type field group) and the save handlers still POSTed `body.platform_type` — the server silently ignored the field.
+
+Deletions from `server/public/dashboard-agents.html`:
+
+- Three `<label>Platform type<select …>` rows inside `buildConnectForm` (bearer/basic, oauth, oauth_client_credentials variants).
+- The 15-entry `platformTypes` array and its `platformTypeOptions` join in `renderAgentsSection`.
+- `buildConnectForm`'s `platformTypeOptions` parameter. Both call sites updated.
+- `platformType` reads + `body.platform_type = …` assignments in the bearer/basic save handler and the OAuth authorize flow's "context already exists" branch.
+- The OAuth authorize flow's dead second `PUT /connect` that was sent "to save platform type even if context already exists" — it's now a no-op.
+
+Post-delete: `buildConnectForm(escapedUrl, agentContextId)` — cleaner signature, no cross-render dependency on `platformTypeOptions`. Save handlers POST only the fields the server actually reads. Agent specialism discovery (via `get_adcp_capabilities`) replaces the classification the operator used to hand-set.
+
+Verified: all 16 isolated form tests still pass on the updated signature. Typecheck + HTML JS parse both clean.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -761,7 +761,7 @@
       `;
     }
 
-    function buildConnectForm(escapedUrl, platformTypeOptions, agentContextId) {
+    function buildConnectForm(escapedUrl, agentContextId) {
       const contextIdAttr = agentContextId ? ' data-agent-context-id="' + agentContextId + '"' : '';
       return '<div class="agent-connect-form" data-agent-url="' + escapedUrl + '"' + contextIdAttr + '>' +
         '<label>Auth type<select name="auth_type" class="auth-type-select">' +
@@ -772,12 +772,10 @@
         '</select></label>' +
         '<div class="auth-token-fields" style="display:none;">' +
           '<label>Auth token<input type="password" name="auth_token" placeholder="Bearer token or API key" autocomplete="off"></label>' +
-          '<label>Platform type<select name="platform_type"><option value="">Auto-detect</option>' + platformTypeOptions + '</select></label>' +
           '<button class="agent-connect-save">Save</button>' +
         '</div>' +
         '<div class="auth-oauth-fields">' +
           '<p style="font-size:var(--text-sm);color:var(--color-text-secondary);margin:var(--space-2) 0;">Securely authorize via the agent\'s OAuth flow. No tokens to copy.</p>' +
-          '<label>Platform type<select name="platform_type_oauth"><option value="">Auto-detect</option>' + platformTypeOptions + '</select></label>' +
           '<button class="agent-oauth-start">Authorize</button>' +
         '</div>' +
         '<div class="auth-cc-fields" style="display:none;">' +
@@ -802,7 +800,6 @@
             '<option value="basic">Basic (HTTP Basic header)</option>' +
             '<option value="body">Body (client_id/client_secret as form fields)</option>' +
           '</select></label>' +
-          '<label>Platform type<select name="platform_type_cc"><option value="">Auto-detect</option>' + platformTypeOptions + '</select></label>' +
           '<button class="agent-cc-save">Save credentials</button>' +
         '</div>' +
       '</div>';
@@ -819,27 +816,6 @@
           </div>
         `;
       }
-
-      const platformTypes = [
-        ['display_ad_server', 'Display ad server'],
-        ['video_ad_server', 'Video ad server'],
-        ['social_platform', 'Social platform'],
-        ['pmax_platform', 'Performance max'],
-        ['dsp', 'DSP'],
-        ['retail_media', 'Retail media'],
-        ['search_platform', 'Search platform'],
-        ['audio_platform', 'Audio platform'],
-        ['creative_transformer', 'Creative transformer'],
-        ['creative_library', 'Creative library'],
-        ['creative_ad_server', 'Creative ad server'],
-        ['si_platform', 'SI platform'],
-        ['ai_ad_network', 'AI ad network'],
-        ['ai_platform', 'AI platform'],
-        ['generative_dsp', 'Generative DSP'],
-      ];
-      const platformTypeOptions = platformTypes.map(([val, label]) =>
-        '<option value="' + val + '">' + label + '</option>'
-      ).join('');
 
       return agents.map(agent => {
         const data = complianceMap?.get(agent.url);
@@ -895,7 +871,7 @@
             </div>
             ${hasAuth
               ? '<div style="padding: var(--space-4) 0; color: var(--color-text-secondary); font-size: var(--text-sm);">Auth configured' + (authInfo?.auth_type === 'oauth' ? ' via OAuth' : authInfo?.auth_type === 'oauth_client_credentials' ? ' via OAuth client credentials' : '') + '. Compliance check will run on the next heartbeat cycle.</div>'
-              : buildConnectForm(escapeHtml(agent.url), platformTypeOptions, authInfo?.agent_context_id)}
+              : buildConnectForm(escapeHtml(agent.url), authInfo?.agent_context_id)}
             <div class="agent-meta-row">
               <span></span>
               <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Test your agent</button>
@@ -981,7 +957,7 @@
               </div>
             </div>
             <div id="${cardId}-connect" style="display:none;border-top:1px solid var(--color-border);margin-top:var(--space-3);padding-top:var(--space-3);">
-              ${buildConnectForm(escapeHtml(agent.url), platformTypeOptions, authInfo?.agent_context_id)}
+              ${buildConnectForm(escapeHtml(agent.url), authInfo?.agent_context_id)}
             </div>
             <div class="agent-storyboard-panel" id="${cardId}-storyboard" style="display:none;"></div>
             <div class="agent-history-panel" id="${cardId}-history" style="display:none;"></div>
@@ -1072,7 +1048,6 @@
       const agentUrl = form.dataset.agentUrl;
       const authToken = form.querySelector('[name="auth_token"]').value.trim();
       const authType = form.querySelector('[name="auth_type"]').value;
-      const platformType = form.querySelector('[name="platform_type"]').value;
 
       if (!authToken) {
         form.querySelector('[name="auth_token"]').focus();
@@ -1084,7 +1059,6 @@
 
       try {
         const body = { auth_token: authToken, auth_type: authType };
-        if (platformType) body.platform_type = platformType;
 
         const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/connect', {
           method: 'PUT',
@@ -1317,21 +1291,19 @@
 
       const agentUrl = form.dataset.agentUrl;
       let agentContextId = form.dataset.agentContextId;
-      const platformType = form.querySelector('[name="platform_type_oauth"]')?.value;
 
       btn.disabled = true;
       btn.textContent = 'Starting OAuth...';
 
       try {
-        // Ensure agent context exists (connect without token)
+        // Ensure agent context exists (connect without token) so the OAuth
+        // flow below has a persistent `agent_context_id` to bind tokens to.
         if (!agentContextId) {
-          const body = {};
-          if (platformType) body.platform_type = platformType;
           const connectRes = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/connect', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify(body),
+            body: JSON.stringify({}),
           });
           if (!connectRes.ok) {
             const data = await connectRes.json().catch(() => ({}));
@@ -1342,14 +1314,6 @@
           if (!agentContextId) {
             throw new Error('Failed to create agent context');
           }
-        } else if (platformType) {
-          // Save platform type even if context already exists
-          await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/connect', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({ platform_type: platformType }),
-          });
         }
 
         // Redirect to OAuth flow, asking it to return us here after completion


### PR DESCRIPTION
Closes [#2811](https://github.com/adcontextprotocol/adcp/issues/2811).

Migration [409](https://github.com/adcontextprotocol/adcp/blob/main/server/src/db/migrations/409_drop_platform_type.sql) dropped \`platform_type\` from \`agent_registry_metadata\` when \`@adcp/client\` 5.1.0 replaced the concept with specialisms. The dashboard still rendered three \`<select name="platform_type*">\` selects and POSTed \`body.platform_type\`; the server silently ignored the field. Dead UI shipping dead data.

## What's removed

- Three \`<label>Platform type<select …>\` rows in \`buildConnectForm\` (bearer/basic, oauth, oauth_client_credentials variants).
- The 15-entry \`platformTypes\` array and its \`platformTypeOptions\` join in \`renderAgentsSection\`.
- \`buildConnectForm\`'s \`platformTypeOptions\` parameter; both call sites updated (post-change signature: \`buildConnectForm(escapedUrl, agentContextId)\`).
- \`platformType\` reads + \`body.platform_type = …\` in the bearer/basic save handler and the OAuth authorize flow.
- The OAuth authorize flow's dead second \`PUT /connect\` that was sent purely to "save platform type even if context already exists."

Agent specialism discovery via \`get_adcp_capabilities\` replaces the classification the operator used to hand-set.

## Verification

- [x] All 16 isolated form tests still pass on the slimmer signature.
- [x] \`npm run typecheck\` clean.
- [x] HTML JS parse clean.
- [x] Grep confirms no remaining \`platform_type\` references outside historical migrations (331/342/409 — immutable, intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)