### PR TITLE
fix(schemas): accept envelope-level replayed on 15 response schemas (#2839)

### DIFF
--- a/.changeset/response-envelope-replayed-acceptance.md
+++ b/.changeset/response-envelope-replayed-acceptance.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+Response schemas across property-list, collection-list, and governance families now accept the envelope-level `replayed` field that the seller's idempotency layer injects at response time.
+
+Fifteen `*-response.json` schemas previously declared `additionalProperties: false` at the root, so AJV validators compiled from them rejected `replayed: true` / `replayed: false` — even though `docs/building/implementation/security.mdx` (the idempotency storyboard) requires sellers to emit it on mutating responses. This produced a two-faced contract where `create_media_buy` accepted the same envelope field (via branch-level `additionalProperties: true` on its `oneOf`) while `create_property_list`, `sync_plans`, and others did not. Media-buy, signals, creative, content-standards, and sponsored-intelligence responses already accept envelope-level fields through their `oneOf` branches and did not need changing — only schemas with a root-level seal were affected.
+
+Affected schemas: property-list family (`create`, `update`, `delete`, `get`, `list`, `validate_property_delivery`), collection-list family (`create`, `update`, `delete`, `get`, `list`), and governance (`check_governance`, `get_plan_audit_logs`, `report_plan_outcome`, `sync_plans`).
+
+Fix: root-level `additionalProperties` flipped to `true` on all 15 so envelope-level fields pass through. The eight mutating responses (`create_*`, `update_*`, `delete_*` × 2 families, `report_plan_outcome`, `sync_plans`) also declare `replayed: { type: boolean }` explicitly — consistent with how `context` and `ext` are declared today — so AJV still type-checks it. Nested body `additionalProperties: false` is left intact; envelope extensibility is a root-level concession, not a license for drift inside list bodies.
+
+Regression coverage added in `tests/composed-schema-validation.test.cjs`: per-schema acceptance tests, a negative test (`replayed: "true"` as string must fail), a structural lint that walks every task-family `*-response.json` (including `oneOf`/`anyOf`/`allOf` branches) and fails on any sealed envelope without `replayed` declared, and a drift guard that asserts every inlined `replayed` description matches the canonical definition in `core/protocol-envelope.json`.
+
+Resolves #2839.

--- a/static/schemas/source/collection/create-collection-list-response.json
+++ b/static/schemas/source/collection/create-collection-list-response.json
@@ -13,6 +13,11 @@
       "type": "string",
       "description": "Token that authorizes sellers to fetch this list via get_collection_list. Only returned at creation time — buyers MUST store it in a secret manager. Scoped to this one list_id; MUST NOT be reused across lists. Governance agents MUST issue a distinct token per seller so per-relationship revocation is possible. Tokens MUST NOT be logged, appear in cache keys, or echo in error responses. delete_collection_list MUST revoke the token immediately; compromise-driven revocation MUST also signal cache invalidation to sellers (reduced cache_valid_until or a list-changed webhook). See Security considerations in docs/governance/collection/tasks/collection_lists."
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -24,5 +29,5 @@
     "list",
     "auth_token"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/collection/delete-collection-list-response.json
+++ b/static/schemas/source/collection/delete-collection-list-response.json
@@ -14,6 +14,11 @@
       "description": "ID of the deleted list",
       "x-entity": "collection_list"
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -25,5 +30,5 @@
     "deleted",
     "list_id"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/collection/get-collection-list-response.json
+++ b/static/schemas/source/collection/get-collection-list-response.json
@@ -125,5 +125,5 @@
   "required": [
     "list"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/collection/list-collection-lists-response.json
+++ b/static/schemas/source/collection/list-collection-lists-response.json
@@ -25,5 +25,5 @@
   "required": [
     "lists"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/collection/update-collection-list-response.json
+++ b/static/schemas/source/collection/update-collection-list-response.json
@@ -9,6 +9,11 @@
       "$ref": "/schemas/collection/collection-list.json",
       "description": "The updated collection list"
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -19,5 +24,5 @@
   "required": [
     "list"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -149,7 +149,7 @@
     "plan_id",
     "explanation"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "allOf": [
     {
       "if": {

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -420,5 +420,5 @@
   "required": [
     "plans"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/governance/report-plan-outcome-response.json
+++ b/static/schemas/source/governance/report-plan-outcome-response.json
@@ -69,6 +69,11 @@
       },
       "additionalProperties": false
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -80,5 +85,5 @@
     "outcome_id",
     "status"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/governance/sync-plans-response.json
+++ b/static/schemas/source/governance/sync-plans-response.json
@@ -100,6 +100,11 @@
         "additionalProperties": false
       }
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -110,5 +115,5 @@
   "required": [
     "plans"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/create-property-list-response.json
+++ b/static/schemas/source/property/create-property-list-response.json
@@ -13,6 +13,11 @@
       "type": "string",
       "description": "Token that can be shared with sellers to authorize fetching this list. Store this - it is only returned at creation time."
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -24,5 +29,5 @@
     "list",
     "auth_token"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/delete-property-list-response.json
+++ b/static/schemas/source/property/delete-property-list-response.json
@@ -14,6 +14,11 @@
       "description": "ID of the deleted list",
       "x-entity": "property_list"
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -25,5 +30,5 @@
     "deleted",
     "list_id"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/get-property-list-response.json
+++ b/static/schemas/source/property/get-property-list-response.json
@@ -49,5 +49,5 @@
   "required": [
     "list"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/list-property-lists-response.json
+++ b/static/schemas/source/property/list-property-lists-response.json
@@ -25,5 +25,5 @@
   "required": [
     "lists"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/update-property-list-response.json
+++ b/static/schemas/source/property/update-property-list-response.json
@@ -9,6 +9,11 @@
       "$ref": "/schemas/property/property-list.json",
       "description": "The updated property list"
     },
+    "replayed": {
+      "type": "boolean",
+      "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
+      "default": false
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -19,5 +24,5 @@
   "required": [
     "list"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/static/schemas/source/property/validate-property-delivery-response.json
+++ b/static/schemas/source/property/validate-property-delivery-response.json
@@ -176,5 +176,5 @@
     "results",
     "validated_at"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -351,7 +351,178 @@ async function runTests() {
 
   log('');
 
-  // Test 5: Bundled schemas (no $ref resolution needed)
+  // Test 5: Envelope `replayed` field on mutating response roots (#2839)
+  // The seller's idempotency layer injects `replayed` into the response envelope at
+  // replay time. Every mutating response root must accept it — either by declaring
+  // the property or by keeping `additionalProperties` open at the root.
+  log('Envelope `replayed` acceptance on mutating response roots (#2839):', 'info');
+
+  const propertyListBody = {
+    list_id: 'pl_01HW7J8K9P0Q1R2S3T4U5V6W7X',
+    name: 'Spring 2026 brand-safe inventory'
+  };
+  const collectionListBody = {
+    list_id: 'cl_01HW7J8K9P0Q1R2S3T4U5V6W7X',
+    name: 'Premium CTV series'
+  };
+
+  await testSchemaValidation(
+    '/schemas/property/create-property-list-response.json',
+    {
+      list: propertyListBody,
+      auth_token: 'secret_token_at_least_32_chars_long__________',
+      replayed: true
+    },
+    'create_property_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/property/update-property-list-response.json',
+    { list: propertyListBody, replayed: false },
+    'update_property_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/property/delete-property-list-response.json',
+    { deleted: true, list_id: 'pl_01HW7J8K9P0Q1R2S3T4U5V6W7X', replayed: true },
+    'delete_property_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/collection/create-collection-list-response.json',
+    {
+      list: collectionListBody,
+      auth_token: 'secret_token_at_least_32_chars_long__________',
+      replayed: true
+    },
+    'create_collection_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/collection/update-collection-list-response.json',
+    { list: collectionListBody, replayed: false },
+    'update_collection_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/collection/delete-collection-list-response.json',
+    { deleted: true, list_id: 'cl_01HW7J8K9P0Q1R2S3T4U5V6W7X', replayed: true },
+    'delete_collection_list accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/governance/report-plan-outcome-response.json',
+    { outcome_id: 'outcome_abc123', status: 'accepted', replayed: true },
+    'report_plan_outcome accepts replayed on envelope'
+  );
+
+  await testSchemaValidation(
+    '/schemas/governance/sync-plans-response.json',
+    {
+      plans: [{ plan_id: 'plan_abc123', status: 'active', version: 1 }],
+      replayed: false
+    },
+    'sync_plans accepts replayed on envelope'
+  );
+
+  // Negative test: explicit `replayed` declaration must type-check. An AJV
+  // schema with `additionalProperties: true` alone would accept `replayed:
+  // "true"` as a string; the explicit property block is what enforces the
+  // boolean contract.
+  await testSchemaRejection(
+    '/schemas/governance/sync-plans-response.json',
+    {
+      plans: [{ plan_id: 'plan_abc123', status: 'active', version: 1 }],
+      replayed: 'true'
+    },
+    'sync_plans rejects replayed as string (type enforced)'
+  );
+
+  // Structural lint: no task-family response schema may seal the envelope with
+  // `additionalProperties: false` anywhere on the root or in a composition
+  // branch (oneOf/anyOf/allOf) unless `replayed` is declared on that seal. This
+  // catches the #2839 class of bug at author time. Skips `core/` (field
+  // sub-schemas that ship with `*-response.json` filenames but are not task
+  // response envelopes).
+  totalTests++;
+  const offenders = [];
+  const inspectEnvelope = (schema, where) => {
+    const localOffenders = [];
+    const sealed = schema.additionalProperties === false;
+    const declaresReplayed = !!(schema.properties && schema.properties.replayed);
+    if (sealed && !declaresReplayed) localOffenders.push(where);
+    for (const key of ['oneOf', 'anyOf', 'allOf']) {
+      if (Array.isArray(schema[key])) {
+        schema[key].forEach((branch, i) => {
+          if (branch && typeof branch === 'object') {
+            localOffenders.push(...inspectEnvelope(branch, `${where}.${key}[${i}]`));
+          }
+        });
+      }
+    }
+    return localOffenders;
+  };
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('-response.json')) {
+        const rel = path.relative(SCHEMA_BASE_DIR, p);
+        if (rel.startsWith('core/') || rel.startsWith('core' + path.sep)) continue;
+        const schema = JSON.parse(fs.readFileSync(p, 'utf8'));
+        const issues = inspectEnvelope(schema, 'root');
+        for (const issue of issues) offenders.push(`${rel} (${issue})`);
+      }
+    }
+  };
+  walk(SCHEMA_BASE_DIR);
+  if (offenders.length === 0) {
+    log(`  \u2713 All *-response.json schemas accept envelope-level passthrough (#2839 lint)`, 'success');
+    passedTests++;
+  } else {
+    log(`  \u2717 ${offenders.length} response schema(s) seal the envelope with additionalProperties: false:`, 'error');
+    for (const f of offenders) log(`      ${f}`, 'error');
+    log(`    Either flip additionalProperties to true, or declare envelope fields (replayed, context, ext).`, 'error');
+    failedTests++;
+  }
+
+  // Drift guard: every inlined `replayed` description must match the canonical
+  // definition in core/protocol-envelope.json so that a clarification there
+  // propagates or is deliberately diverged. Catches silent drift across the 8
+  // mutating response schemas.
+  totalTests++;
+  const envelopeSchemaPath = path.join(SCHEMA_BASE_DIR, 'core/protocol-envelope.json');
+  const canonicalReplayed = JSON.parse(fs.readFileSync(envelopeSchemaPath, 'utf8'))
+    .properties.replayed.description;
+  const driftOffenders = [];
+  const walkDrift = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walkDrift(p);
+      else if (entry.name.endsWith('-response.json')) {
+        const rel = path.relative(SCHEMA_BASE_DIR, p);
+        if (rel.startsWith('core/') || rel.startsWith('core' + path.sep)) continue;
+        const schema = JSON.parse(fs.readFileSync(p, 'utf8'));
+        const r = schema.properties && schema.properties.replayed;
+        if (r && r.description && r.description !== canonicalReplayed) {
+          driftOffenders.push(rel);
+        }
+      }
+    }
+  };
+  walkDrift(SCHEMA_BASE_DIR);
+  if (driftOffenders.length === 0) {
+    log(`  \u2713 Inlined replayed descriptions match core/protocol-envelope.json (drift guard)`, 'success');
+    passedTests++;
+  } else {
+    log(`  \u2717 ${driftOffenders.length} inlined replayed description(s) diverge from core/protocol-envelope.json:`, 'error');
+    for (const f of driftOffenders) log(`      ${f}`, 'error');
+    failedTests++;
+  }
+
+  log('');
+
+  // Test 6: Bundled schemas (no $ref resolution needed)
   // Only test against latest/ — versioned dirs in dist/ may be from a prior release
   // and are not updated on every source change.
   const BUNDLED_DIR = path.join(__dirname, '../dist/schemas');


### PR DESCRIPTION
## Summary

- Fifteen `*-response.json` schemas sealed their envelope with root `additionalProperties: false`, rejecting the envelope-level `replayed` boolean that `docs/building/implementation/security.mdx` requires sellers to inject on mutating responses. Property-list (6), collection-list (5), and governance (4) were affected; media-buy, signals, creative, content-standards, and sponsored-intelligence already accept envelope fields via `oneOf` branches.
- Root `additionalProperties` flipped to `true` on all 15; the 8 mutating responses (`create_*`, `update_*`, `delete_*` × property/collection, `report_plan_outcome`, `sync_plans`) also declare `replayed: { type: boolean }` explicitly so AJV still type-checks it. Nested-body `additionalProperties: false` left intact.
- Regression coverage in `tests/composed-schema-validation.test.cjs`: per-schema acceptance, a negative test (`replayed: "true"` as string must fail), a branch-aware structural lint (walks `oneOf`/`anyOf`/`allOf`), and a drift guard that pins every inlined `replayed` description to `core/protocol-envelope.json`.

Resolves #2839.

## Test plan

- [x] `npm run test:schemas` — 7/7 passed
- [x] `npm run test:composed` — 32/32 passed (including 8 new acceptance tests, 1 negative test, structural lint, and drift guard)
- [x] `npm run test:examples` — 34/34 passed
- [x] `npm run test:json-schema` — 249/249 passed
- [x] `npm run test:extension-schemas` — 11/11 passed
- [x] `npm run test:unit` — 631/631 passed (precommit hook)
- [x] `npm run typecheck` — clean (precommit hook)
- [x] Verified no other task-family responses seal the envelope (broad sweep over `account/`, `brand/`, `creative/`, etc. — zero additional offenders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)