### PR TITLE
fix(training-agent): require signing on webhook-auth registrations (#2840)

### DIFF
--- a/.changeset/training-agent-webhook-auth-signing.md
+++ b/.changeset/training-agent-webhook-auth-signing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Training agent `/mcp-strict` now enforces the webhook-registration downgrade-resistance rule from `security.mdx#webhook-callbacks`: unsigned requests carrying `push_notification_config.authentication` are rejected with `request_signature_required`, even when a valid bearer is presented. Closes the last `signed_requests` conformance gap (vector 027). The sandbox `/mcp` route stays permissive for pre-3.0 storyboards that wire legacy HMAC webhooks over bearer.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -29,7 +29,11 @@ import { startSessionCleanup } from './state.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
 import { getPublicJwks } from './webhooks.js';
-import { buildRequestSigningAuthenticator, STRICT_REQUIRED_FOR } from './request-signing.js';
+import {
+  buildRequestSigningAuthenticator,
+  enforceSigningWhenWebhookAuthPresent,
+  STRICT_REQUIRED_FOR,
+} from './request-signing.js';
 import { isWorkOSApiKeyFormat } from '../middleware/api-key-format.js';
 import { PUBLIC_TEST_AGENT } from '../config/test-agent.js';
 import type { TrainingContext } from './types.js';
@@ -112,6 +116,14 @@ function lazySigningAuth(): Authenticator {
  * pass through verifyApiKey; signed requests compose via anyOf. Present-but-
  * invalid signatures fall through to bearer (a known gap — closed on the
  * strict route, tracked upstream as adcp-client#659).
+ *
+ * The webhook-auth downgrade-resistance rule (security.mdx#webhook-callbacks)
+ * is enforced only on `/mcp-strict`. The sandbox `/mcp` route accepts
+ * unsigned `push_notification_config.authentication` for backward compat
+ * with pre-3.0 storyboards that wire legacy HMAC-SHA256 webhooks over
+ * bearer-auth'd `create_media_buy`. Updating those storyboards to
+ * 9421-sign the registration is tracked separately; the grader-facing
+ * strict route already matches the spec.
  */
 function buildDefaultAuthenticator(): Authenticator | null {
   const bearerAuth = buildBearerAuthenticator();
@@ -131,7 +143,7 @@ function buildDefaultAuthenticator(): Authenticator | null {
 function buildStrictAuthenticator(): Authenticator | null {
   const bearerAuth = buildBearerAuthenticator();
   if (!bearerAuth) return null;
-  return requireAuthenticatedOrSigned({
+  return enforceSigningWhenWebhookAuthPresent(requireAuthenticatedOrSigned({
     signature: lazySigningAuth(),
     fallback: bearerAuth,
     requiredFor: STRICT_REQUIRED_FOR,
@@ -148,7 +160,7 @@ function buildStrictAuthenticator(): Authenticator | null {
       }
       return undefined;
     },
-  });
+  }));
 }
 
 const defaultAuthenticator = buildDefaultAuthenticator();

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -25,9 +25,16 @@ import {
   StaticJwksResolver,
   InMemoryReplayStore,
   InMemoryRevocationStore,
+  RequestSignatureError,
 } from '@adcp/client/signing';
 import type { AdcpJsonWebKey, VerifierCapability } from '@adcp/client/signing';
-import { verifySignatureAsAuthenticator } from '@adcp/client/server';
+import {
+  verifySignatureAsAuthenticator,
+  AuthError,
+  tagAuthenticatorNeedsRawBody,
+  tagAuthenticatorPresenceGated,
+  isAuthenticatorPresenceGated,
+} from '@adcp/client/server';
 import type { Authenticator } from '@adcp/client/server';
 import { getComplianceCacheDir } from '@adcp/client/testing';
 import { createLogger } from '../logger.js';
@@ -169,6 +176,103 @@ function headerFirst(value: string | string[] | undefined): string | undefined {
   if (typeof value === 'string') return value;
   if (Array.isArray(value) && value.length > 0) return value[0];
   return undefined;
+}
+
+function headerNonEmpty(value: string | string[] | undefined): boolean {
+  if (typeof value === 'string') return value.length > 0;
+  if (Array.isArray(value)) return value.some(v => typeof v === 'string' && v.length > 0);
+  return false;
+}
+
+function requestCarriesSignatureHeader(headers: IncomingMessage['headers']): boolean {
+  return headerNonEmpty(headers['signature-input']) || headerNonEmpty(headers['signature']);
+}
+
+/**
+ * Detect `push_notification_config.authentication` (non-empty object) anywhere
+ * under the JSON-RPC `params.arguments` tree. The downgrade-resistance rule in
+ * docs/building/implementation/security.mdx (`#webhook-callbacks`) scopes the
+ * trigger to the webhook-registration field, so we only walk the argument
+ * subtree — not the whole body — and treat arrays as transparent containers
+ * so per-package webhook configs (e.g. an update carrying multiple packages)
+ * are matched.
+ */
+function bodyCarriesWebhookAuthentication(rawBody: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return false;
+  }
+  const args = (parsed as { params?: { arguments?: unknown } } | null)?.params?.arguments;
+  return subtreeHasWebhookAuthentication(args);
+}
+
+// Depth budget counts object hops only; array containers are transparent so a
+// per-package webhook config doesn't consume the budget for its position in
+// the packages[] array. Realistic AdCP payloads nest 4–6 object levels deep
+// (plan → packages[] → package → push_notification_config → authentication).
+const MAX_OBJECT_DEPTH = 10;
+
+function subtreeHasWebhookAuthentication(node: unknown, depth = 0): boolean {
+  if (Array.isArray(node)) {
+    return node.some(item => subtreeHasWebhookAuthentication(item, depth));
+  }
+  if (!node || typeof node !== 'object') return false;
+  if (depth > MAX_OBJECT_DEPTH) return false;
+  const obj = node as Record<string, unknown>;
+  const pnc = obj.push_notification_config;
+  if (pnc && typeof pnc === 'object' && !Array.isArray(pnc)) {
+    const auth = (pnc as Record<string, unknown>).authentication;
+    if (auth && typeof auth === 'object' && Object.keys(auth as object).length > 0) return true;
+  }
+  for (const child of Object.values(obj)) {
+    if (child && typeof child === 'object' && subtreeHasWebhookAuthentication(child, depth + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Enforce the webhook-registration downgrade-resistance rule from
+ * `docs/building/implementation/security.mdx#webhook-callbacks`:
+ *
+ *   Sellers that support request signing MUST require the inbound request to
+ *   be 9421-signed when `push_notification_config.authentication` is present,
+ *   rejecting with `request_signature_required`.
+ *
+ * The wrapper runs BEFORE the inner authenticator so it fires even when a
+ * valid bearer would otherwise authenticate — bearer bypass is the exact
+ * downgrade this rule prevents (an on-path mutator cannot inject or strip
+ * the `authentication` block once the request body is cryptographically
+ * committed to by the signature).
+ *
+ * When a signature header IS present, the wrapper delegates to the inner
+ * authenticator unchanged so the signing-path verifier does its normal work.
+ */
+export function enforceSigningWhenWebhookAuthPresent(inner: Authenticator): Authenticator {
+  const wrapped: Authenticator = async (req) => {
+    if (!requestCarriesSignatureHeader(req.headers)) {
+      const raw = (req as { rawBody?: string }).rawBody;
+      if (raw && bodyCarriesWebhookAuthentication(raw)) {
+        throw new AuthError(
+          'Signature required when push_notification_config.authentication is present.',
+          {
+            cause: new RequestSignatureError(
+              'request_signature_required',
+              0,
+              'Requests carrying push_notification_config.authentication MUST be signed per RFC 9421 (security.mdx webhook-callbacks downgrade resistance).',
+            ),
+          },
+        );
+      }
+    }
+    return inner(req);
+  };
+  tagAuthenticatorNeedsRawBody(wrapped);
+  if (isAuthenticatorPresenceGated(inner)) tagAuthenticatorPresenceGated(wrapped);
+  return wrapped;
 }
 
 /** Reset state — tests only. */

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -151,10 +151,10 @@ function summarize(sb: Storyboard, result: StoryboardResult | { error: string })
       const status = stepStatus(step as Parameters<typeof stepStatus>[0]);
       base[status] += 1;
       if (status === 'failed') {
-        const s = step as { id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
+        const s = step as { id?: string; step_id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
         const validationFails = (s.validations ?? []).filter(v => !v.passed).map(v => v.description ?? '(validation failed)').join('; ');
         base.failures.push({
-          step: s.id ?? '(unknown step)',
+          step: s.step_id ?? s.id ?? '(unknown step)',
           error: s.error ?? validationFails ?? '(failed without message)',
         });
       }

--- a/server/tests/unit/training-agent-webhook-auth-signing.test.ts
+++ b/server/tests/unit/training-agent-webhook-auth-signing.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import { enforceSigningWhenWebhookAuthPresent } from '../../src/training-agent/request-signing.js';
+import { AuthError } from '@adcp/client/server';
+import { RequestSignatureError } from '@adcp/client/signing';
+import type { Authenticator } from '@adcp/client/server';
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}): Parameters<Authenticator>[0] {
+  const raw = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    method: 'POST',
+    url: '/mcp-strict',
+    headers,
+    rawBody: raw,
+  } as unknown as Parameters<Authenticator>[0];
+}
+
+function toolsCall(name: string, args: unknown) {
+  return { jsonrpc: '2.0', id: '1', method: 'tools/call', params: { name, arguments: args } };
+}
+
+describe('enforceSigningWhenWebhookAuthPresent', () => {
+  it('delegates to inner when no signature header and no webhook authentication', async () => {
+    const inner: Authenticator = vi.fn(async () => ({ principal: 'bearer:ok' }));
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(toolsCall('create_media_buy', { plan_id: 'p1' }));
+    await expect(wrapped(req)).resolves.toEqual({ principal: 'bearer:ok' });
+    expect(inner).toHaveBeenCalledOnce();
+  });
+
+  it('throws request_signature_required when webhook authentication is present and unsigned', async () => {
+    const inner: Authenticator = vi.fn();
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(toolsCall('update_media_buy', {
+      media_buy_id: 'mb_1',
+      push_notification_config: {
+        url: 'https://buyer.example.com/webhook',
+        authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+      },
+    }));
+    await expect(wrapped(req)).rejects.toMatchObject({
+      name: 'AuthError',
+      cause: expect.objectContaining({ code: 'request_signature_required' }),
+    });
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('wraps the RFC 9421 error in AuthError so serve() unwraps the challenge scheme', async () => {
+    const inner: Authenticator = vi.fn();
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(toolsCall('create_media_buy', {
+      push_notification_config: {
+        url: 'https://buyer.example.com/webhook',
+        authentication: { scheme: 'Bearer', credentials: 'tok' },
+      },
+    }));
+    let caught: unknown;
+    try {
+      await wrapped(req);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).cause).toBeInstanceOf(RequestSignatureError);
+  });
+
+  it('defers to inner when a signature header is present', async () => {
+    const inner: Authenticator = vi.fn(async () => ({ principal: 'signing:kid' }));
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(
+      toolsCall('update_media_buy', {
+        push_notification_config: {
+          url: 'https://buyer.example.com/webhook',
+          authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+        },
+      }),
+      { 'signature-input': 'sig1=("@method");created=1;keyid="k"', signature: 'sig1=:AAAA:' },
+    );
+    await expect(wrapped(req)).resolves.toEqual({ principal: 'signing:kid' });
+    expect(inner).toHaveBeenCalledOnce();
+  });
+
+  it('detects webhook authentication nested inside arrays (per-package configs)', async () => {
+    const inner: Authenticator = vi.fn();
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(toolsCall('create_media_buy', {
+      plan_id: 'p1',
+      packages: [
+        { package_id: 'pkg_1', budget: { amount: 100, currency: 'USD' } },
+        {
+          package_id: 'pkg_2',
+          push_notification_config: {
+            url: 'https://buyer.example.com/webhook',
+            authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+          },
+        },
+      ],
+    }));
+    await expect(wrapped(req)).rejects.toMatchObject({
+      cause: expect.objectContaining({ code: 'request_signature_required' }),
+    });
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('ignores empty authentication objects', async () => {
+    const inner: Authenticator = vi.fn(async () => ({ principal: 'bearer:ok' }));
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(toolsCall('create_media_buy', {
+      push_notification_config: {
+        url: 'https://buyer.example.com/webhook',
+        authentication: {},
+      },
+    }));
+    await expect(wrapped(req)).resolves.toEqual({ principal: 'bearer:ok' });
+  });
+
+  it('delegates to inner when rawBody is missing', async () => {
+    const inner: Authenticator = vi.fn(async () => null);
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = { method: 'GET', url: '/mcp-strict', headers: {} } as unknown as Parameters<Authenticator>[0];
+    await expect(wrapped(req)).resolves.toBeNull();
+    expect(inner).toHaveBeenCalledOnce();
+  });
+
+  it('delegates to inner on malformed JSON bodies', async () => {
+    const inner: Authenticator = vi.fn(async () => null);
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest('{not valid json');
+    await expect(wrapped(req)).resolves.toBeNull();
+    expect(inner).toHaveBeenCalledOnce();
+  });
+
+  it('propagates inner signature-verifier errors on signed requests with webhook auth', async () => {
+    const signatureInvalid = new RequestSignatureError('request_signature_invalid', 10, 'bad sig');
+    const inner: Authenticator = vi.fn(async () => {
+      throw new AuthError('Signature rejected.', { cause: signatureInvalid });
+    });
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    const req = makeRequest(
+      toolsCall('update_media_buy', {
+        push_notification_config: {
+          url: 'https://buyer.example.com/webhook',
+          authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+        },
+      }),
+      { 'signature-input': 'sig1=("@method");created=1;keyid="k"', signature: 'sig1=:AAAA:' },
+    );
+    await expect(wrapped(req)).rejects.toMatchObject({
+      name: 'AuthError',
+      cause: expect.objectContaining({ code: 'request_signature_invalid' }),
+    });
+  });
+
+  it('detects webhook authentication at depths up to the object-hop cap', async () => {
+    const inner: Authenticator = vi.fn();
+    const wrapped = enforceSigningWhenWebhookAuthPresent(inner);
+    // 9 object hops from params.arguments (depth 0) to the push_notification_config
+    // owner, plus one for authentication's parent — exactly at MAX_OBJECT_DEPTH.
+    // Arrays do not consume the budget, so packages[] is free.
+    const deep: Record<string, unknown> = {
+      packages: [{
+        campaign: {
+          delivery: {
+            targeting: {
+              frequency: {
+                tracking: {
+                  notifications: {
+                    push_notification_config: {
+                      url: 'https://buyer.example.com/webhook',
+                      authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }],
+    };
+    const req = makeRequest(toolsCall('create_media_buy', deep));
+    await expect(wrapped(req)).rejects.toMatchObject({
+      cause: expect.objectContaining({ code: 'request_signature_required' }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `signed_requests` storyboard was failing on vector **027-webhook-registration-authentication-unsigned**, not 015/017/020 (those pass — the canned grader diagnostic that referenced them is template text).
- Root cause: the training agent's strict route doesn't enforce the `security.mdx#webhook-callbacks` "Downgrade and injection resistance" rule — sellers that support request signing MUST reject unsigned requests carrying `push_notification_config.authentication` with `request_signature_required`, regardless of `required_for` membership and regardless of whether a bearer would otherwise authenticate.
- Adds `enforceSigningWhenWebhookAuthPresent` — wrapped around `/mcp-strict`'s inner authenticator so the pre-check fires before bearer fall-through. The sandbox `/mcp` route stays permissive for backward compat with pre-3.0 storyboards that wire legacy HMAC webhooks over bearer-auth'd `create_media_buy` (documented in the code).
- Also fixes a reporting shape mismatch in `server/tests/manual/run-storyboards.ts` (`StoryboardStepResult.step_id`, not `.id`) so failing vectors are named instead of surfaced as `(unknown step)`.

Closes #2840.

## Test plan

- [x] `npx tsx server/tests/manual/run-storyboards.ts --filter signed_requests` — 31 passed / 0 failed / 9 skipped (was 30 passed / 1 failed).
- [x] Full `run-storyboards.ts` legacy dispatch — 46/56 clean, 323 passing steps (CI floor 36/295).
- [x] Full `run-storyboards.ts` framework dispatch (`TRAINING_AGENT_USE_FRAMEWORK=1`) — 27/56 clean, 261 passing steps (CI floor 21/241).
- [x] `npx vitest run server/tests/unit/training-agent-webhook-auth-signing.test.ts` — 10 cases covering no-body, JSON-parse failure, signature-present delegation, array-nested configs, depth boundary, signed-path error propagation.
- [x] `npx vitest run server/tests/unit/training-agent.test.ts server/tests/unit/training-agent-idempotency.test.ts` — 381 existing cases green.
- [x] `npx tsc --project server/tsconfig.json --noEmit` clean.
- [x] Expert review: code-reviewer and security-reviewer feedback addressed (array-transparent depth budget, two added test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)