### PR TITLE
fix(storyboards): use literal creative_id in creative_fate reassign (closes #2850)

### DIFF
--- a/.changeset/fix-creative-fate-context-id.md
+++ b/.changeset/fix-creative-fate-context-id.md
@@ -1,0 +1,21 @@
+---
+---
+
+Storyboard: `creative_fate_after_cancellation` — use literal
+`acme_reuse_banner_001` in the `reassign_creative` step instead of
+`$context.creative_id`.
+
+The prior shape populated the context key from the seller's
+`sync_creatives` response at `creatives[0].creative_id`. Sellers whose
+response envelope doesn't surface the id at exactly that path resolve
+to `undefined`, the template engine strips the creative entry, and the
+`creatives` array arrives at `@adcp/client`'s zod pre-flight as
+`undefined` — failing with "expected array, received undefined" before
+the request reaches the agent.
+
+The literal id is buyer-authoritative (set in phase 1's
+`sync_creative_with_assignment`) and matches the narrative at lines
+369–371 ("Reference the original creative by creative_id only").
+Robust against seller envelope variance.
+
+Closes #2850.

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -385,7 +385,14 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           creatives:
-            - creative_id: "$context.creative_id"
+            # Buyer-authoritative id set in sync_creative_with_assignment —
+            # use it literally instead of round-tripping through
+            # `$context.creative_id`. That context key is populated from
+            # the seller's response at `creatives[0].creative_id`; sellers
+            # whose envelope doesn't surface that exact path resolve to
+            # undefined and the template engine strips the creative,
+            # leaving `creatives: undefined` which fails pre-flight zod.
+            - creative_id: "acme_reuse_banner_001"
               name: "Reassigned creative"
               format_id:
                 agent_url: "https://your-platform.example.com"
@@ -397,7 +404,7 @@ phases:
                   width: 300
                   height: 250
           assignments:
-            - creative_id: "$context.creative_id"
+            - creative_id: "acme_reuse_banner_001"
               package_id: "$context.second_package_id"
           idempotency_key: "creative-fate-reassign-v1"
           context:


### PR DESCRIPTION
## Summary
Fixes #2850. The `reassign_creative` step in `creative_fate_after_cancellation.yaml` referenced `$context.creative_id`, a key populated from the seller's `sync_creatives` response at `creatives[0].creative_id`. Sellers whose envelope doesn't surface that exact path resolved to `undefined`, the template engine stripped the creative entry, and the final request failed pre-flight zod with "creatives: expected array, received undefined" — before reaching the agent.

Uses the buyer-set literal `acme_reuse_banner_001` (from phase 1's `sync_creative_with_assignment`) instead. Buyer-authoritative; robust against envelope variance.

## Test plan
- [x] Compliance storyboard for this scenario now reaches the `reassign_creative` step without SDK pre-flight rejection (verified locally against the adcp-1 training agent).