### PR TITLE
fix(training-agent): emit completion webhooks on framework dispatch

### DIFF
--- a/.changeset/fix-framework-webhook-emission-parity.md
+++ b/.changeset/fix-framework-webhook-emission-parity.md
@@ -1,0 +1,15 @@
+---
+---
+
+fix(training-agent): emit completion webhooks on the framework dispatch path
+
+The `adapt()` wrapper in `framework-server.ts` called the domain handler but
+never fired a completion webhook when the buyer supplied
+`push_notification_config.url`. That broke three `webhook_emission` storyboard
+invariants under `TRAINING_AGENT_USE_FRAMEWORK=1`: payload/idempotency_key
+presence, retry dedupe, and RFC 9421 signature verification. Legacy dispatch
+already handled this inline in `task-handlers.ts`.
+
+Extracts the emission logic into `maybeEmitCompletionWebhook` in
+`webhooks.ts` and calls it from both paths so the framework and legacy
+dispatchers emit byte-identical webhook envelopes. Closes #2843.

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -26,7 +26,7 @@ import { MediaChannelSchema } from '@adcp/client/types';
 import { z } from 'zod';
 import type { TrainingContext, ToolArgs } from './types.js';
 import { getIdempotencyStore } from './idempotency.js';
-import { getWebhookSigningKey } from './webhooks.js';
+import { getWebhookSigningKey, maybeEmitCompletionWebhook } from './webhooks.js';
 import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
 import { PUBLISHERS } from './publishers.js';
 import { createLogger } from '../logger.js';
@@ -191,8 +191,11 @@ function versionUnsupported(requested: unknown, callerContext: unknown): Adapted
  *   it on the response (so handlers never see or forward `context` and the
  *   framework's own injectContextIntoResponse doesn't double-echo).
  * - Wraps thrown exceptions as `SERVICE_UNAVAILABLE` per legacy behavior.
+ * - Fires a completion webhook after a successful handler when the buyer
+ *   supplied `push_notification_config.url` and the tool maps to a webhook
+ *   task type. Matches legacy dispatch behavior in `task-handlers.ts`.
  */
-function adapt(handler: LegacyHandler) {
+function adapt(toolName: string, handler: LegacyHandler) {
   return async (params: unknown, ctx: HandlerContext): Promise<AdaptedResponse> => {
     const rawParams = (params as Record<string, unknown> | undefined) ?? {};
     const { context: callerContext, ...handlerArgs } = rawParams;
@@ -212,7 +215,17 @@ function adapt(handler: LegacyHandler) {
 
     try {
       const result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
-      return toAdaptedResponse(result, callerContext);
+      const response = toAdaptedResponse(result, callerContext);
+      if (!response.isError) {
+        const idk = (handlerArgs as { idempotency_key?: unknown }).idempotency_key;
+        maybeEmitCompletionWebhook({
+          toolName,
+          args: handlerArgs as Record<string, unknown>,
+          response: (result ?? {}) as Record<string, unknown>,
+          requestIdempotencyKey: typeof idk === 'string' ? idk : undefined,
+        });
+      }
+      return response;
     } catch (err) {
       logger.error({ err }, 'framework handler threw');
       return serviceUnavailable(err, callerContext);
@@ -492,56 +505,56 @@ export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpSe
     },
 
     mediaBuy: {
-      getProducts: adapt(handleGetProducts),
-      createMediaBuy: adapt(handleCreateMediaBuy),
-      updateMediaBuy: adapt(handleUpdateMediaBuy),
-      getMediaBuys: adapt(handleGetMediaBuys),
-      getMediaBuyDelivery: adapt(handleGetMediaBuyDelivery),
-      providePerformanceFeedback: adapt(handleProvidePerformanceFeedback),
-      listCreativeFormats: adapt(handleListCreativeFormats),
-      syncCreatives: adapt(handleSyncCreatives),
-      listCreatives: adapt(handleListCreatives),
+      getProducts: adapt('get_products', handleGetProducts),
+      createMediaBuy: adapt('create_media_buy', handleCreateMediaBuy),
+      updateMediaBuy: adapt('update_media_buy', handleUpdateMediaBuy),
+      getMediaBuys: adapt('get_media_buys', handleGetMediaBuys),
+      getMediaBuyDelivery: adapt('get_media_buy_delivery', handleGetMediaBuyDelivery),
+      providePerformanceFeedback: adapt('provide_performance_feedback', handleProvidePerformanceFeedback),
+      listCreativeFormats: adapt('list_creative_formats', handleListCreativeFormats),
+      syncCreatives: adapt('sync_creatives', handleSyncCreatives),
+      listCreatives: adapt('list_creatives', handleListCreatives),
     },
     creative: {
-      buildCreative: adapt(handleBuildCreative),
-      previewCreative: adapt(handlePreviewCreative),
-      getCreativeDelivery: adapt(handleGetCreativeDelivery),
+      buildCreative: adapt('build_creative', handleBuildCreative),
+      previewCreative: adapt('preview_creative', handlePreviewCreative),
+      getCreativeDelivery: adapt('get_creative_delivery', handleGetCreativeDelivery),
     },
     signals: {
-      getSignals: adapt(handleGetSignals),
-      activateSignal: adapt(handleActivateSignal),
+      getSignals: adapt('get_signals', handleGetSignals),
+      activateSignal: adapt('activate_signal', handleActivateSignal),
     },
     governance: {
-      syncPlans: adapt(handleSyncPlans),
-      checkGovernance: adapt(handleCheckGovernance),
-      reportPlanOutcome: adapt(handleReportPlanOutcome),
-      getPlanAuditLogs: adapt(handleGetPlanAuditLogs),
-      createPropertyList: adapt(handleCreatePropertyList),
-      listPropertyLists: adapt(handleListPropertyLists),
-      getPropertyList: adapt(handleGetPropertyList),
-      updatePropertyList: adapt(handleUpdatePropertyList),
-      deletePropertyList: adapt(handleDeletePropertyList),
-      createContentStandards: adapt(handleCreateContentStandards),
-      listContentStandards: adapt(handleListContentStandards),
-      getContentStandards: adapt(handleGetContentStandards),
-      updateContentStandards: adapt(handleUpdateContentStandards),
-      calibrateContent: adapt(handleCalibrateContent),
-      validateContentDelivery: adapt(handleValidateContentDelivery),
+      syncPlans: adapt('sync_plans', handleSyncPlans),
+      checkGovernance: adapt('check_governance', handleCheckGovernance),
+      reportPlanOutcome: adapt('report_plan_outcome', handleReportPlanOutcome),
+      getPlanAuditLogs: adapt('get_plan_audit_logs', handleGetPlanAuditLogs),
+      createPropertyList: adapt('create_property_list', handleCreatePropertyList),
+      listPropertyLists: adapt('list_property_lists', handleListPropertyLists),
+      getPropertyList: adapt('get_property_list', handleGetPropertyList),
+      updatePropertyList: adapt('update_property_list', handleUpdatePropertyList),
+      deletePropertyList: adapt('delete_property_list', handleDeletePropertyList),
+      createContentStandards: adapt('create_content_standards', handleCreateContentStandards),
+      listContentStandards: adapt('list_content_standards', handleListContentStandards),
+      getContentStandards: adapt('get_content_standards', handleGetContentStandards),
+      updateContentStandards: adapt('update_content_standards', handleUpdateContentStandards),
+      calibrateContent: adapt('calibrate_content', handleCalibrateContent),
+      validateContentDelivery: adapt('validate_content_delivery', handleValidateContentDelivery),
     },
     accounts: {
-      syncAccounts: adapt(handleSyncAccounts),
-      syncGovernance: adapt(handleSyncGovernance),
-      reportUsage: adapt(handleReportUsage),
+      syncAccounts: adapt('sync_accounts', handleSyncAccounts),
+      syncGovernance: adapt('sync_governance', handleSyncGovernance),
+      reportUsage: adapt('report_usage', handleReportUsage),
     },
     eventTracking: {
-      syncEventSources: adapt(handleSyncEventSources),
-      logEvent: adapt(handleLogEvent),
-      syncCatalogs: adapt(handleSyncCatalogs),
+      syncEventSources: adapt('sync_event_sources', handleSyncEventSources),
+      logEvent: adapt('log_event', handleLogEvent),
+      syncCatalogs: adapt('sync_catalogs', handleSyncCatalogs),
     },
     brandRights: {
-      getBrandIdentity: adapt(handleGetBrandIdentity),
-      getRights: adapt(handleGetRights),
-      acquireRights: adapt(handleAcquireRights),
+      getBrandIdentity: adapt('get_brand_identity', handleGetBrandIdentity),
+      getRights: adapt('get_rights', handleGetRights),
+      acquireRights: adapt('acquire_rights', handleAcquireRights),
     },
 
     customTools: {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -237,17 +237,8 @@ import {
   scopedPrincipal,
   getIdempotencyStore,
 } from './idempotency.js';
-import { getWebhookEmitter } from './webhooks.js';
+import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
-
-// MCP webhook envelope's `task_type` enum (core.generated TaskType — not re-exported).
-type WebhookTaskType =
-  | 'create_media_buy' | 'update_media_buy' | 'sync_creatives' | 'activate_signal'
-  | 'get_signals' | 'create_property_list' | 'update_property_list' | 'get_property_list'
-  | 'list_property_lists' | 'delete_property_list' | 'sync_accounts'
-  | 'get_account_financials' | 'get_creative_delivery' | 'sync_event_sources'
-  | 'sync_audiences' | 'sync_catalogs' | 'log_event' | 'get_brand_identity'
-  | 'get_rights' | 'acquire_rights';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
 const MAX_PACKAGES_PER_BUY = 50;
@@ -335,62 +326,6 @@ function governanceErrorDetails(check: import('./types.js').GovernanceCheckState
     }));
   }
   return details;
-}
-
-/** Map tool name → TaskType for webhook envelopes. Only tools that emit
- * webhooks need an entry — tools absent from this map never fire an emission
- * even if the caller supplies a push_notification_config.url. */
-const TOOL_TO_TASK_TYPE: Readonly<Record<string, WebhookTaskType>> = {
-  create_media_buy: 'create_media_buy',
-  update_media_buy: 'update_media_buy',
-  sync_creatives: 'sync_creatives',
-  activate_signal: 'activate_signal',
-  get_signals: 'get_signals',
-  create_property_list: 'create_property_list',
-  update_property_list: 'update_property_list',
-  get_property_list: 'get_property_list',
-  list_property_lists: 'list_property_lists',
-  delete_property_list: 'delete_property_list',
-  sync_accounts: 'sync_accounts',
-  get_account_financials: 'get_account_financials',
-  get_creative_delivery: 'get_creative_delivery',
-  sync_event_sources: 'sync_event_sources',
-  sync_audiences: 'sync_audiences',
-  sync_catalogs: 'sync_catalogs',
-  log_event: 'log_event',
-  get_brand_identity: 'get_brand_identity',
-  get_rights: 'get_rights',
-  acquire_rights: 'acquire_rights',
-};
-
-function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
-  const pnc = args.push_notification_config as { url?: unknown } | undefined;
-  if (!pnc || typeof pnc !== 'object') return undefined;
-  return typeof pnc.url === 'string' && pnc.url.length > 0 ? pnc.url : undefined;
-}
-
-/**
- * Derive a stable logical event id for webhook idempotency.
- *
- * The `operation_id` feeds `WebhookIdempotencyKeyStore` — two emissions with
- * the same operation_id reuse the same `idempotency_key`, which is the
- * cross-attempt invariant receiver-side dedup depends on. We prefer a
- * buyer-facing entity id from the response (media_buy_id, creative_id,
- * activation_id, etc.) so retries from the same buyer collapse; if the
- * response has none, we fall back to the request's idempotency_key which
- * is already unique per logical submission.
- */
-function deriveWebhookOperationId(
-  toolName: string,
-  response: Record<string, unknown>,
-  requestIdempotencyKey: string | undefined,
-): string {
-  for (const field of ['media_buy_id', 'creative_id', 'activation_id', 'signal_activation_id', 'task_id', 'list_id', 'account_id']) {
-    const v = response[field];
-    if (typeof v === 'string' && v.length > 0) return `${toolName}.${v}`;
-  }
-  if (requestIdempotencyKey) return `${toolName}.${requestIdempotencyKey}`;
-  return `${toolName}.${randomUUID()}`;
 }
 
 /** Wire-format error shared by all training agent responses. */
@@ -3502,33 +3437,17 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     // Fire completion webhook if the buyer supplied a push URL and the tool
     // mapped to a TaskType. Emission is fire-and-forget so the sync response
     // doesn't wait on the receiver; retries/backoff live inside the emitter.
-    const webhookUrl = extractWebhookUrl(handlerArgs);
-    const taskType = TOOL_TO_TASK_TYPE[name];
     if (
-      webhookUrl
-      && taskType
-      && cachableResponse !== null
+      cachableResponse !== null
       && !toolResult.isError
       && !handlerThrew
     ) {
-      const emitter = getWebhookEmitter();
-      const operationId = deriveWebhookOperationId(
-        name,
-        cachableResponse,
-        typeof idempotencyKey === 'string' ? idempotencyKey : undefined,
-      );
-      const webhookTaskId = (cachableResponse.task_id as string | undefined)
-        ?? `tsk_${operationId.slice(0, 32).replace(/[^A-Za-z0-9_.:-]/g, '_')}`;
-      const payload: Record<string, unknown> = {
-        task_id: webhookTaskId,
-        task_type: taskType,
-        protocol: 'mcp',
-        status: 'completed',
-        timestamp: new Date().toISOString(),
-        result: cachableResponse,
-      };
-      void emitter.emit({ url: webhookUrl, payload, operation_id: operationId })
-        .catch(err => logger.warn({ err, tool: name, url: webhookUrl }, 'Webhook emission failed'));
+      maybeEmitCompletionWebhook({
+        toolName: name,
+        args: handlerArgs,
+        response: cachableResponse,
+        requestIdempotencyKey: typeof idempotencyKey === 'string' ? idempotencyKey : undefined,
+      });
     }
 
     // If not task-augmented, return result directly.

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -11,7 +11,7 @@
  * router so buyers can verify incoming webhooks against a real JWKS endpoint.
  */
 
-import { createHash, generateKeyPairSync } from 'node:crypto';
+import { createHash, generateKeyPairSync, randomUUID } from 'node:crypto';
 import {
   createWebhookEmitter,
   memoryWebhookKeyStore,
@@ -22,6 +22,101 @@ import type { AdcpJsonWebKey } from '@adcp/client/signing';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('training-agent-webhooks');
+
+/** MCP webhook envelope's `task_type` enum. Only tools in this map emit a
+ *  completion webhook when the caller supplies `push_notification_config.url`.
+ *  Keep in sync with `static/schemas/source/core/mcp-webhook-payload.json`. */
+export type WebhookTaskType =
+  | 'create_media_buy' | 'update_media_buy' | 'sync_creatives' | 'activate_signal'
+  | 'get_signals' | 'create_property_list' | 'update_property_list' | 'get_property_list'
+  | 'list_property_lists' | 'delete_property_list' | 'sync_accounts'
+  | 'get_account_financials' | 'get_creative_delivery' | 'sync_event_sources'
+  | 'sync_audiences' | 'sync_catalogs' | 'log_event' | 'get_brand_identity'
+  | 'get_rights' | 'acquire_rights';
+
+export const TOOL_TO_TASK_TYPE: Readonly<Record<string, WebhookTaskType>> = {
+  create_media_buy: 'create_media_buy',
+  update_media_buy: 'update_media_buy',
+  sync_creatives: 'sync_creatives',
+  activate_signal: 'activate_signal',
+  get_signals: 'get_signals',
+  create_property_list: 'create_property_list',
+  update_property_list: 'update_property_list',
+  get_property_list: 'get_property_list',
+  list_property_lists: 'list_property_lists',
+  delete_property_list: 'delete_property_list',
+  sync_accounts: 'sync_accounts',
+  get_account_financials: 'get_account_financials',
+  get_creative_delivery: 'get_creative_delivery',
+  sync_event_sources: 'sync_event_sources',
+  sync_audiences: 'sync_audiences',
+  sync_catalogs: 'sync_catalogs',
+  log_event: 'log_event',
+  get_brand_identity: 'get_brand_identity',
+  get_rights: 'get_rights',
+  acquire_rights: 'acquire_rights',
+};
+
+function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
+  const pnc = args.push_notification_config as { url?: unknown } | undefined;
+  if (!pnc || typeof pnc !== 'object') return undefined;
+  return typeof pnc.url === 'string' && pnc.url.length > 0 ? pnc.url : undefined;
+}
+
+/** Derive a stable logical event id for webhook idempotency. Two emissions
+ *  with the same operation_id reuse the same `idempotency_key` across retries.
+ *  Prefers a buyer-facing entity id from the response so retries from the same
+ *  buyer collapse; falls back to the request's idempotency_key. */
+function deriveWebhookOperationId(
+  toolName: string,
+  response: Record<string, unknown>,
+  requestIdempotencyKey: string | undefined,
+): string {
+  for (const field of ['media_buy_id', 'creative_id', 'activation_id', 'signal_activation_id', 'task_id', 'list_id', 'account_id']) {
+    const v = response[field];
+    if (typeof v === 'string' && v.length > 0) return `${toolName}.${v}`;
+  }
+  if (requestIdempotencyKey) return `${toolName}.${requestIdempotencyKey}`;
+  return `${toolName}.${randomUUID()}`;
+}
+
+/**
+ * Fire a completion webhook for a successful tool call if the buyer supplied
+ * `push_notification_config.url` and the tool maps to a webhook task type.
+ *
+ * Fire-and-forget: the emitter handles RFC 9421 signing, `idempotency_key`
+ * stability across retries, and retry/backoff on 5xx/429 internally. Any
+ * delivery failure is logged but never surfaces to the caller — the sync
+ * response has already been returned.
+ *
+ * Shared between legacy dispatch (`task-handlers.ts`) and the framework
+ * adapter (`framework-server.ts`) so both paths emit byte-identical envelopes.
+ */
+export function maybeEmitCompletionWebhook(opts: {
+  toolName: string;
+  args: Record<string, unknown>;
+  response: Record<string, unknown>;
+  requestIdempotencyKey?: string;
+}): void {
+  const webhookUrl = extractWebhookUrl(opts.args);
+  const taskType = TOOL_TO_TASK_TYPE[opts.toolName];
+  if (!webhookUrl || !taskType) return;
+
+  const emitter = getWebhookEmitter();
+  const operationId = deriveWebhookOperationId(opts.toolName, opts.response, opts.requestIdempotencyKey);
+  const webhookTaskId = (opts.response.task_id as string | undefined)
+    ?? `tsk_${operationId.slice(0, 32).replace(/[^A-Za-z0-9_.:-]/g, '_')}`;
+  const payload: Record<string, unknown> = {
+    task_id: webhookTaskId,
+    task_type: taskType,
+    protocol: 'mcp',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    result: opts.response,
+  };
+  void emitter.emit({ url: webhookUrl, payload, operation_id: operationId })
+    .catch(err => logger.warn({ err, tool: opts.toolName, url: webhookUrl }, 'Webhook emission failed'));
+}
 
 const ENV_KEY = 'WEBHOOK_SIGNING_KEY_JWK';
 


### PR DESCRIPTION
## Summary

- Fixes three `webhook_emission` storyboard invariants that fail under `TRAINING_AGENT_USE_FRAMEWORK=1`: payload/`idempotency_key` presence, retry dedupe, and RFC 9421 signature verification (#2843).
- Framework dispatch's `adapt()` wrapper called the handler but never emitted the completion webhook when the buyer supplied `push_notification_config.url`. Legacy dispatch did this inline in `task-handlers.ts`.
- Extracts emission into `maybeEmitCompletionWebhook` in `webhooks.ts` and calls it from both paths so framework and legacy emit byte-identical envelopes. `adapt()` now takes the tool name so the shared helper can look up `TOOL_TO_TASK_TYPE`.

## Results

- `webhook_emission` storyboard (framework): **4P/3F → 7P/0F**
- Framework clean count: **26/56 → 27/56** storyboards
- Legacy path unchanged (45/56 clean before and after)
- Unit tests: 631/631 passing locally; typecheck clean
- Expert review (code-reviewer, ad-tech-protocol-expert) confirmed parity, no double-emit risk, no regressions

## Test plan

- [x] `webhook_emission` passes under `TRAINING_AGENT_USE_FRAMEWORK=1`
- [x] `webhook_emission` still passes on legacy dispatch
- [x] Framework full run shows +1 clean, no regressions
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` clean (631 passed)

## Follow-up

Pre-existing spec-compliance bug surfaced during review but scoped out of this fix: the webhook envelope emits `protocol: 'mcp'` (a transport value) where `core/mcp-webhook-payload.json` `$ref`s `enums/adcp-protocol.json` (domain values: `media-buy`, `signals`, `governance`, etc.). Legacy dispatch has always had this. Worth a separate issue if the schema validator starts enforcing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)