### PR TITLE
fix(storyboards): sync fresh creative before rejection probe (closes #2851)

### DIFF
--- a/.changeset/fix-deterministic-archived-creative.md
+++ b/.changeset/fix-deterministic-archived-creative.md
@@ -1,0 +1,19 @@
+---
+---
+
+Storyboard: `deterministic_testing.force_creative_rejected` — split
+into a `sync_fresh_creative_for_rejection` step + the rejection force.
+
+The prior shape reused `$context.creative_id` from the previous phase,
+where the creative was forced to `archived` (terminal). The rejection
+step then expected `success: true` for `archived → rejected`, which
+any conformant creative-state machine rejects — directly contradicting
+the `invalid_creative_transition` step earlier in the same phase that
+asserts archived is terminal.
+
+Fix: sync a fresh creative first (captures
+`$context.fresh_creative_id`), then run the rejection against the
+fresh id (from `processing`), which is a valid transition per the
+creative-state machine.
+
+Closes #2851.

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -861,12 +861,62 @@ phases:
             path: "context.correlation_id"
             value: "deterministic_testing--invalid_creative_transition"
             description: "Context correlation_id returned unchanged"
+      - id: sync_fresh_creative_for_rejection
+        title: 'Sync a fresh creative to exercise rejection'
+        requires_tool: sync_creatives
+        narrative: |
+          The preceding phase archived the first creative — a terminal state
+          that cannot transition to rejected. Sync a second, fresh creative so
+          the rejection path starts from processing rather than archived.
+        task: sync_creatives
+        schema_ref: "media-buy/sync-creatives-request.json"
+        response_schema_ref: "media-buy/sync-creatives-response.json"
+        doc_ref: "/media-buy/task-reference/sync_creatives"
+        comply_scenario: deterministic_creative
+        stateful: true
+        expected: |
+          A new creative with a distinct creative_id, reusable by downstream
+          force_creative_status calls.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          creatives:
+            - creative_id: "deterministic-rejection-probe"
+              name: "Creative for rejection probe"
+              format_id:
+                agent_url: "https://your-platform.example.com"
+                id: "display_300x250"
+              assets:
+                image:
+                  asset_type: "image"
+                  url: "https://test-assets.adcontextprotocol.org/acme-outdoor/banner_300x250.jpg"
+                  width: 300
+                  height: 250
+          idempotency_key: "$generate:uuid_v4#deterministic_testing_sync_fresh_creative_for_rejection"
+          context:
+            correlation_id: "deterministic_testing--sync_fresh_creative_for_rejection"
+        context_outputs:
+          - path: "creatives[0].creative_id"
+            key: "fresh_creative_id"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-creatives-response.json schema"
+          - check: field_present
+            path: "creatives[0].creative_id"
+            description: "Response includes the seller's creative_id for the fresh creative"
+
       - id: force_creative_rejected
         title: 'Force fresh creative to rejected with reason'
         requires_tool: comply_test_controller
         narrative: |
-          Sync a fresh creative, force it to pending_review, then reject it with a
-          reason string. Verifies the controller supports rejection reasons.
+          Reject the fresh creative (captured as $context.fresh_creative_id)
+          with a reason string. Verifies the controller supports rejection
+          reasons. Uses the fresh id — NOT the archived one from the prior
+          phase, since archived→rejected is not a valid creative-state
+          transition.
         task: comply_test_controller
         comply_scenario: deterministic_creative
         stateful: true
@@ -876,7 +926,7 @@ phases:
         sample_request:
           scenario: 'force_creative_status'
           params:
-            creative_id: '$context.creative_id'
+            creative_id: '$context.fresh_creative_id'
             status: 'rejected'
             rejection_reason: 'Brand safety policy violation (comply test)'
 


### PR DESCRIPTION
## Summary
Fixes #2851. The `force_creative_rejected` step in `universal/deterministic-testing.yaml` reused `$context.creative_id` from the preceding phase, where the creative was forced to `archived` (terminal). The step then expected `success: true` for `archived → rejected` — which any conformant creative-state machine rejects, directly contradicting the `invalid_creative_transition` step earlier in the same phase that asserts archived is terminal.

## Fix
Split into two steps:
1. **`sync_fresh_creative_for_rejection`** — regular `sync_creatives` call that creates a new creative (`deterministic-rejection-probe`), captures `$context.fresh_creative_id`.
2. **`force_creative_rejected`** — uses `$context.fresh_creative_id`. Rejection fires from `processing`, which is a valid transition.

Narrative + expected text clarified to make the "fresh id, not archived" constraint explicit.

## Test plan
- [x] Verified locally against the adcp-1 training agent: storyboard now reaches the `force_creative_rejected` step against a `processing` creative, rejection succeeds with reason preserved, downstream validations pass.
- [x] `invalid_creative_transition` step (archived → processing) still asserts and passes, so the terminal-state contract remains tested.