### PR TITLE
fix(training-agent): security_baseline storyboard passes end-to-end (closes #2841)

### DIFF
--- a/.changeset/fix-security-baseline-storyboard.md
+++ b/.changeset/fix-security-baseline-storyboard.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix the `security_baseline` storyboard against the embedded training agent (closes #2841).
+
+- Remove the RFC 9728 PRM stub from `run-storyboards.ts` / `run-one-storyboard.ts`: the training agent is API-key-only, so advertising an unsupported OAuth issuer triggered the exact failure the storyboard was written to catch. The API-key path alone now carries `auth_mechanism_verified`.
+- Thread the declared test-kit `auth.api_key` / `auth.probe_task` through to `runStoryboard()` so `api_key_path` executes instead of being silently skipped by `skip_if: "!test_kit.auth.api_key"`.
+- Accept the documented `demo-<kit>-v<n>` conformance handle on the training-agent bearer authenticator so storyboard-declared API keys actually authenticate.
+- Emit `structuredContent` on tool success so the storyboard runner's `rawMcpProbe` can resolve JSON-pointer paths (`context.correlation_id`); keep `content: []` empty to avoid the SDK unwrapper's `_message` injection failing strict per-task response schemas.
+- Fix `summarize()` in `run-storyboards.ts` to read `step_id` instead of `id`, so failure output names the actual failing step instead of `(unknown step)`.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -67,6 +67,14 @@ function setCORSHeaders(res: Response): void {
  * check (e.g., `if (!allowedOrgs.has(result.apiKey.owner.id)) return null`)
  * or layer an `anyOf` with a separate scope-aware authenticator.
  */
+// Conformance handle documented in every test-kit header
+// (static/compliance/source/test-kits/*.yaml, auth.api_key comment): agents
+// SHOULD accept any Bearer matching `demo-<kit>-v<n>` so the suffix can rotate
+// across spec versions without breaking previously-conformant agents. The
+// training agent IS the reference — so it accepts the handle directly.
+// Anchored to forbid `demo--v1` / `demo-v1` and lock alg-num segments.
+const DEMO_TEST_KIT_KEY_PATTERN = /^demo-[a-z0-9]+(?:-[a-z0-9]+)*-v\d+$/;
+
 function buildBearerAuthenticator(): Authenticator | null {
   if (!TRAINING_AGENT_TOKEN && !PUBLIC_TEST_AGENT_TOKEN && !workos) {
     return null; // dev mode: open
@@ -79,6 +87,12 @@ function buildBearerAuthenticator(): Authenticator | null {
   if (Object.keys(staticKeys).length > 0) {
     authenticators.push(verifyApiKey({ keys: staticKeys }));
   }
+  authenticators.push(verifyApiKey({
+    verify: (token) => {
+      if (!DEMO_TEST_KIT_KEY_PATTERN.test(token)) return null;
+      return { principal: `static:demo:${token}` };
+    },
+  }));
   if (workos) {
     const workosClient = workos; // narrow for closure
     authenticators.push(verifyApiKey({

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -3455,8 +3455,14 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         if (name === 'create_media_buy') envelope.replayed = false;
         if (callerContext !== undefined) envelope.context = callerContext;
         const response = { ...inner, ...envelope };
+        // `structuredContent` is authoritative on success so raw-probe
+        // callers (storyboard runner's rawMcpProbe) can validate envelope
+        // fields. `content` stays empty: the SDK unwrapper folds text
+        // content into `_message` on the returned object, which trips
+        // strict `additionalProperties: false` per-task response schemas.
         toolResult = {
-          content: [{ type: 'text', text: JSON.stringify(response) }],
+          content: [],
+          structuredContent: response,
         };
       }
     } catch (error) {

--- a/server/tests/integration/training-agent-demo-key.test.ts
+++ b/server/tests/integration/training-agent-demo-key.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration test for issue #2841 — security_baseline authentication surface.
+ *
+ * Asserts the two behaviors the storyboard asserts against:
+ *   1. The training agent accepts any Bearer matching the documented
+ *      `demo-<kit>-v<n>` conformance handle (the handle every test-kit
+ *      advertises in its `auth.api_key` header comment).
+ *   2. 401 responses to protected tools include `WWW-Authenticate: Bearer`
+ *      per RFC 6750 §3, and unrelated bearers that don't match the demo
+ *      pattern still fail.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-demo-key';
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+function postList(app: express.Application, authHeader: string | undefined) {
+  const req = request(app)
+    .post('/api/training-agent/mcp')
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream');
+  if (authHeader) req.set('Authorization', authHeader);
+  return req.send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name: 'list_creatives', arguments: {} },
+  });
+}
+
+describe('Training Agent conformance-handle bearer auth (issue #2841)', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  it('accepts a test-kit `demo-<kit>-v<n>` bearer without needing env-configured tokens', async () => {
+    const res = await postList(app, 'Bearer demo-acme-outdoor-v1');
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts the multi-segment handle documented across test-kits', async () => {
+    const res = await postList(app, 'Bearer demo-osei-natural-v1');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an unauthenticated request with 401 + WWW-Authenticate per RFC 6750', async () => {
+    const res = await postList(app, undefined);
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+  });
+
+  it('rejects a bearer that does not match the conformance handle', async () => {
+    // Obviously wrong shape — must not be accepted by the demo-key verifier.
+    const res = await postList(app, 'Bearer not-a-demo-key');
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+  });
+
+  it('rejects an almost-matching bearer missing the version suffix', async () => {
+    // The pattern requires `-v<digits>` at the end.
+    const res = await postList(app, 'Bearer demo-acme-outdoor');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects `demo--v1` (empty kit segment)', async () => {
+    const res = await postList(app, 'Bearer demo--v1');
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -50,21 +50,25 @@ async function callTool(
   });
 }
 
-/** Parse a StreamableHTTP `text/event-stream` response into the JSON-RPC
- *  envelope. The transport writes `event: message\ndata: {...}\n\n` for
- *  successful tools/call responses. */
-function parseSse(res: request.Response): Record<string, unknown> {
+/** Parse a StreamableHTTP response. Depending on Accept negotiation the
+ *  transport returns either SSE-framed (`event: message\ndata: {...}`) or
+ *  plain JSON; handle both so the test harness isn't brittle to transport
+ *  changes. */
+function parseEnvelope(res: request.Response): Record<string, unknown> {
   const text = res.text ?? '';
-  const match = text.match(/^data: (.*)$/m);
-  if (!match) throw new Error(`No data line in SSE response: ${text.slice(0, 200)}`);
-  return JSON.parse(match[1]) as Record<string, unknown>;
+  const sseMatch = text.match(/^data: (.*)$/m);
+  const raw = sseMatch ? sseMatch[1] : text;
+  return JSON.parse(raw) as Record<string, unknown>;
 }
 
-/** Extract the tool's inner response (parsed from the MCP text content). */
+/** Extract the tool's inner response. Prefers structuredContent (the
+ *  authoritative body on success / error paths) and falls back to parsing
+ *  content[0].text for legacy wire shapes. */
 function innerResponse(res: request.Response): Record<string, unknown> {
-  const envelope = parseSse(res) as { result?: { content?: Array<{ text?: string }> } };
+  const envelope = parseEnvelope(res) as { result?: { structuredContent?: Record<string, unknown>; content?: Array<{ text?: string }> } };
+  if (envelope.result?.structuredContent) return envelope.result.structuredContent;
   const text = envelope.result?.content?.[0]?.text;
-  if (!text) throw new Error(`No content text in envelope: ${JSON.stringify(envelope)}`);
+  if (!text) throw new Error(`No structuredContent or content text in envelope: ${JSON.stringify(envelope)}`);
   return JSON.parse(text) as Record<string, unknown>;
 }
 

--- a/server/tests/manual/run-one-storyboard.ts
+++ b/server/tests/manual/run-one-storyboard.ts
@@ -27,16 +27,17 @@ const { getPublicJwks } = await import('../../src/training-agent/webhooks.js');
 const sb = listAllComplianceStoryboards().find(s => s.id === id);
 if (!sb) { console.error(`storyboard ${id} not found`); process.exit(2); }
 
-function brandForStoryboard(s: Storyboard): StoryboardRunOptions['brand'] | undefined {
+interface LoadedKit {
+  brand?: { house?: { domain?: string } };
+  auth?: { api_key?: string; probe_task?: string };
+}
+
+function loadKit(s: Storyboard): LoadedKit | undefined {
   const kitRef = s.prerequisites?.test_kit;
   if (!kitRef) return undefined;
   const path = join(getComplianceCacheDir(), kitRef);
   if (!existsSync(path)) return undefined;
-  const kit = YAML.parse(readFileSync(path, 'utf-8')) as {
-    brand?: { house?: { domain?: string } };
-  };
-  const domain = kit.brand?.house?.domain;
-  return domain ? { domain } : undefined;
+  return YAML.parse(readFileSync(path, 'utf-8')) as LoadedKit;
 }
 
 const app = express();
@@ -46,17 +47,9 @@ app.use(express.json({
     (req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8');
   },
 }));
-app.get(/^\/\.well-known\/oauth-protected-resource(\/.*)?$/, (req, res) => {
-  const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
-  const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost';
-  const suffix = req.path.replace(/^\/\.well-known\/oauth-protected-resource/, '') || '/';
-  res.setHeader('Cache-Control', 'public, max-age=300');
-  res.json({
-    resource: `${proto}://${host}${suffix}`,
-    authorization_servers: [`${proto}://${host}/auth`],
-    bearer_methods_supported: ['header'],
-  });
-});
+// API-key-only agent: MUST NOT serve RFC 9728 PRM. See
+// server/tests/manual/run-storyboards.ts and
+// static/compliance/source/universal/security.yaml lines 37–47.
 app.use('/api/training-agent', createTrainingAgentRouter());
 const server = http.createServer(app);
 server.listen(0, '127.0.0.1', async () => {
@@ -64,21 +57,38 @@ server.listen(0, '127.0.0.1', async () => {
   const url = `http://127.0.0.1:${port}/api/training-agent/mcp`;
   // Intentionally do not log agent URL to stdout — this script's stdout is
   // piped through `jq` / `python -c` by the storyboard debugging workflow.
-  const brand = brandForStoryboard(sb);
-  const result = await runStoryboard(url, sb, {
-    auth: { type: 'bearer', token: AUTH_TOKEN },
-    allow_http: true,
-    contracts: ['webhook_receiver_runner'],
-    webhook_receiver: { mode: 'loopback_mock' },
-    webhook_signing: {
-      jwks: new StaticJwksResolver(getPublicJwks().keys as AdcpJsonWebKey[]),
-      replayStore: new InMemoryReplayStore(),
-      revocationStore: new InMemoryRevocationStore(),
-    },
-    request_signing: { transport: 'mcp' },
-    ...(brand && { brand }),
-  });
-  console.log(JSON.stringify(result, null, 2));
-  stopSessionCleanup();
-  server.close();
+  const kit = loadKit(sb);
+  const domain = kit?.brand?.house?.domain;
+  const brand: StoryboardRunOptions['brand'] | undefined = domain ? { domain } : undefined;
+  const testKit: StoryboardRunOptions['test_kit'] | undefined = (() => {
+    const a = kit?.auth;
+    if (!a?.api_key && !a?.probe_task) return undefined;
+    if (!a.probe_task) throw new Error('test kit declares auth.api_key without auth.probe_task');
+    return {
+      auth: {
+        ...(a.api_key !== undefined && { api_key: a.api_key }),
+        probe_task: a.probe_task,
+      },
+    };
+  })();
+  try {
+    const result = await runStoryboard(url, sb, {
+      auth: { type: 'bearer', token: AUTH_TOKEN },
+      allow_http: true,
+      contracts: ['webhook_receiver_runner'],
+      webhook_receiver: { mode: 'loopback_mock' },
+      webhook_signing: {
+        jwks: new StaticJwksResolver(getPublicJwks().keys as AdcpJsonWebKey[]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+      },
+      request_signing: { transport: 'mcp' },
+      ...(brand && { brand }),
+      ...(testKit && { test_kit: testKit }),
+    });
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    stopSessionCleanup();
+    server.close();
+  }
 });

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -66,22 +66,14 @@ async function startLocalAgent(): Promise<{ url: string; close: () => Promise<vo
       (req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8');
     },
   }));
-  // RFC 9728 protected-resource metadata — the graders probe
-  // `${origin}/.well-known/oauth-protected-resource${pathname}`, which is the
-  // origin root regardless of where the training-agent router is mounted.
-  // Mount the endpoint on the top-level app so `/.well-known/oauth-protected-
-  // resource/api/training-agent/mcp` is reachable.
-  app.get(/^\/\.well-known\/oauth-protected-resource(\/.*)?$/, (req, res) => {
-    const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
-    const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost';
-    const suffix = req.path.replace(/^\/\.well-known\/oauth-protected-resource/, '') || '/';
-    res.setHeader('Cache-Control', 'public, max-age=300');
-    res.json({
-      resource: `${proto}://${host}${suffix}`,
-      authorization_servers: [`${proto}://${host}/auth`],
-      bearer_methods_supported: ['header'],
-    });
-  });
+  // The training agent is API-key-only — no OAuth issuer. Per
+  // static/compliance/source/universal/security.yaml (lines 37–47), such
+  // agents MUST NOT serve RFC 9728 protected-resource metadata; doing so
+  // advertises an issuer the agent cannot back with an RFC 8414 auth-server
+  // metadata document and triggers the exact failure security_baseline was
+  // written to catch (presenceDetected flips and the `optional` OAuth phase
+  // becomes a hard fail). api_key_path carries `auth_mechanism_verified`
+  // on its own.
   app.use('/api/training-agent', createTrainingAgentRouter());
   return await new Promise((resolve, reject) => {
     const srv = http.createServer(app);
@@ -118,17 +110,43 @@ function isApplicable(sb: Storyboard): boolean {
  * brand into options.brand forces every outgoing request onto the same
  * session key.
  */
-function brandForStoryboard(sb: Storyboard): StoryboardRunOptions['brand'] | undefined {
+interface LoadedTestKit {
+  brand?: { house?: { domain?: string }; brand_id?: string };
+  auth?: { api_key?: string; probe_task?: string };
+}
+
+function loadTestKit(sb: Storyboard): LoadedTestKit | undefined {
   const kitRef = sb.prerequisites?.test_kit;
   if (!kitRef) return undefined;
   const path = join(getComplianceCacheDir(), kitRef);
   if (!existsSync(path)) return undefined;
-  const kit = YAML.parse(readFileSync(path, 'utf-8')) as {
-    brand?: { house?: { domain?: string }; brand_id?: string };
+  return YAML.parse(readFileSync(path, 'utf-8')) as LoadedTestKit;
+}
+
+function brandFromKit(kit: LoadedTestKit | undefined): StoryboardRunOptions['brand'] | undefined {
+  const domain = kit?.brand?.house?.domain;
+  return domain ? { domain } : undefined;
+}
+
+/**
+ * Thread the test-kit's `auth.api_key` / `auth.probe_task` through to the
+ * runner so `api_key_path` in security_baseline (and any future kit-gated
+ * phase) executes instead of being skipped by `skip_if: "!test_kit.auth.api_key"`.
+ * `probe_task` is required by the runner whenever `auth` is declared — surface
+ * missing values as a hard failure rather than silently defaulting.
+ */
+function testKitOptionsFromKit(kit: LoadedTestKit | undefined): StoryboardRunOptions['test_kit'] | undefined {
+  const auth = kit?.auth;
+  if (!auth?.api_key && !auth?.probe_task) return undefined;
+  if (!auth.probe_task) {
+    throw new Error('test kit declares auth.api_key without auth.probe_task — required by runner');
+  }
+  return {
+    auth: {
+      ...(auth.api_key !== undefined && { api_key: auth.api_key }),
+      probe_task: auth.probe_task,
+    },
   };
-  const domain = kit.brand?.house?.domain;
-  if (!domain) return undefined;
-  return { domain };
 }
 
 function stepStatus(s: { passed?: boolean; skipped?: boolean; not_applicable?: boolean; validations?: Array<{ passed: boolean }>; error?: string }): 'passed' | 'failed' | 'skipped' | 'not_applicable' {
@@ -151,11 +169,21 @@ function summarize(sb: Storyboard, result: StoryboardResult | { error: string })
       const status = stepStatus(step as Parameters<typeof stepStatus>[0]);
       base[status] += 1;
       if (status === 'failed') {
-        const s = step as { id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
-        const validationFails = (s.validations ?? []).filter(v => !v.passed).map(v => v.description ?? '(validation failed)').join('; ');
+        const s = step as { step_id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
+        const validationFails = (s.validations ?? [])
+          .filter(v => !v.passed)
+          .map(v => v.description ?? '(validation failed)')
+          .join('; ');
+        // Prefer the step-level error; fall back to the concatenated failed-
+        // validation descriptions so runs don't collapse to the one-liner
+        // "Probe validations failed" without surfacing the actual checks that
+        // didn't pass (issue #2841).
+        const errorDetail = validationFails
+          ? (s.error ? `${s.error} — ${validationFails}` : validationFails)
+          : (s.error ?? '(failed without message)');
         base.failures.push({
-          step: s.id ?? '(unknown step)',
-          error: s.error ?? validationFails ?? '(failed without message)',
+          step: s.step_id ?? '(unknown step)',
+          error: errorDetail,
         });
       }
     }
@@ -185,7 +213,9 @@ async function main() {
     await clearSessions();
     process.stdout.write(`  ${sb.id.padEnd(40)} `);
     try {
-      const brand = brandForStoryboard(sb);
+      const kit = loadTestKit(sb);
+      const brand = brandFromKit(kit);
+      const testKit = testKitOptionsFromKit(kit);
       // The default `/mcp` route is the public sandbox (bearer OR signed,
       // no `required_for` enforcement). The `/mcp-strict` route is the
       // grader target with presence-gated signing + required_for. Point
@@ -225,6 +255,7 @@ async function main() {
           skipRateAbuse: true,
         },
         ...(brand && { brand }),
+        ...(testKit && { test_kit: testKit }),
       });
       const summary = summarize(sb, result);
       results.push(summary);

--- a/server/tests/unit/account-handlers.test.ts
+++ b/server/tests/unit/account-handlers.test.ts
@@ -36,8 +36,10 @@ async function simulateCallTool(
     {},
   );
   const text = response.content?.[0]?.text;
-  const parsed = text ? JSON.parse(text) : {};
-  const result = parsed.adcp_error ?? parsed;
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
+  const result = (parsed.adcp_error as Record<string, unknown> | undefined) ?? parsed;
   return {
     result,
     isError: response.isError,

--- a/server/tests/unit/collection-lists-storyboard.test.ts
+++ b/server/tests/unit/collection-lists-storyboard.test.ts
@@ -77,8 +77,10 @@ async function simulateCallTool(
     {},
   );
   const text = response.content?.[0]?.text;
-  const parsed = text ? JSON.parse(text) : {};
-  const result = parsed.adcp_error ?? parsed;
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
+  const result = (parsed.adcp_error as Record<string, unknown> | undefined) ?? parsed;
   return { result, isError: response.isError };
 }
 

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -34,9 +34,11 @@ async function simulateCallTool(
     {},
   );
   const text = response.content?.[0]?.text;
-  const parsed = text ? JSON.parse(text) : {};
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
   // Unwrap adcp_error envelope for error responses (L3 compliance format)
-  const result = parsed.adcp_error ?? parsed;
+  const result = (parsed.adcp_error as Record<string, unknown> | undefined) ?? parsed;
   return { result, isError: response.isError };
 }
 

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -40,7 +40,10 @@ async function call(
     {},
   );
   const text = response.content?.[0]?.text;
-  return { parsed: text ? JSON.parse(text) : {}, isError: response.isError };
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
+  return { parsed, isError: response.isError };
 }
 
 const basePayload = () => ({

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -91,8 +91,13 @@ async function simulateCallTool(
     { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
     {},
   );
+  // Success responses carry the body on `structuredContent`; error / replay
+  // paths additionally stuff a JSON-stringified copy in `content[0].text`.
+  // Prefer structuredContent and fall back to content text for error paths.
   const text = response.content?.[0]?.text;
-  const parsed = text ? JSON.parse(text) : {};
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
   // Unwrap adcp_error envelope (MCP isError responses) and errors-in-body
   // responses (spec-compliant oneOf error variant) uniformly so tests can
   // assert against `result.code` regardless of surface.
@@ -4877,12 +4882,10 @@ describe('MCP Tasks protocol', () => {
     const taskId = (createResponse.task as Record<string, unknown>).taskId as string;
 
     const result = await simulateGetTaskResult(server, taskId);
-    expect(result.content).toBeDefined();
-    const content = result.content as Array<{ type: string; text: string }>;
-    expect(content[0].type).toBe('text');
-    const parsed = JSON.parse(content[0].text);
-    expect(Array.isArray(parsed.products)).toBe(true);
-    expect(parsed.products.length).toBeGreaterThan(0);
+    const parsed = result.structuredContent as Record<string, unknown> | undefined;
+    expect(parsed).toBeDefined();
+    expect(Array.isArray(parsed!.products)).toBe(true);
+    expect((parsed!.products as unknown[]).length).toBeGreaterThan(0);
 
     // Must include related-task metadata
     const meta = result._meta as Record<string, unknown>;
@@ -6369,7 +6372,10 @@ async function simulateCallToolRaw(
     {},
   );
   const text = response.content?.[0]?.text;
-  return { parsed: text ? JSON.parse(text) : {}, isError: response.isError };
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
+  return { parsed, isError: response.isError };
 }
 
 describe('context echo', () => {
@@ -7525,5 +7531,32 @@ describe('human_review registry parity and edge cases', () => {
       }],
     });
     expect(isError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #2841 — security_baseline conformance
+// ---------------------------------------------------------------------------
+// Two regressions the security_baseline storyboard was catching silently:
+//   1. Success responses omitted `structuredContent`, so the storyboard
+//      runner's rawMcpProbe (which validates `context.correlation_id` via
+//      JSON-pointer paths) saw only `content[].text` and couldn't resolve
+//      field paths.
+//   2. The bearer authenticator only accepted the env-configured token, so
+//      the `demo-<kit>-v<n>` handle documented in every test-kit header was
+//      rejected and the `probe_api_key` phase failed against the canonical
+//      conformance handle the storyboard asserts against.
+describe('issue #2841 — security_baseline conformance surface', () => {
+  it('success responses include structuredContent mirroring the body', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const requestHandlers = (server as unknown as { _requestHandlers: Map<string, (req: unknown, ctx: unknown) => Promise<unknown>> })._requestHandlers;
+    const handler = requestHandlers.get('tools/call');
+    if (!handler) throw new Error('CallTool handler not found');
+    const response = await handler(
+      { method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: { context: { correlation_id: 'security_baseline--probe_api_key' } } } },
+      {},
+    ) as { structuredContent?: Record<string, unknown>; content?: unknown[] };
+    expect(response.structuredContent).toBeDefined();
+    expect((response.structuredContent as { context?: { correlation_id?: string } }).context?.correlation_id).toBe('security_baseline--probe_api_key');
   });
 });


### PR DESCRIPTION
## Summary

Closes #2841. The `security_baseline` storyboard — the auth conformance baseline every AdCP agent MUST pass — was failing against the embedded training agent. Three compounding bugs collapsed into the unactionable `× (unknown step): Probe validations failed` that the issue flagged.

- Harness served RFC 9728 PRM pointing at a `/auth` issuer it never backed with RFC 8414 metadata. The storyboard was written specifically to catch this (advertising OAuth without serving the metadata document). Removed the stub — the training agent is API-key-only and `api_key_path` carries `auth_mechanism_verified` on its own (see `static/compliance/source/universal/security.yaml:37-47`).
- `options.test_kit` was never threaded through to `runStoryboard()`, so `api_key_path` silently skipped via `skip_if: "!test_kit.auth.api_key"`. Now loaded from the storyboard's declared test kit.
- Training agent rejected the `demo-<kit>-v<n>` handle documented in every test-kit header. Added regex-gated acceptance (anchored `^demo-[a-z0-9]+(?:-[a-z0-9]+)*-v\d+$`, principal-tagged `static:demo:<token>`).
- Tool success responses omitted `structuredContent`, so the runner's `rawMcpProbe` couldn't resolve JSON-pointer paths like `context.correlation_id`. Emit structuredContent; keep `content: []` empty so the SDK unwrapper's `_message` injection doesn't trip strict per-task response schemas.
- `run-storyboards.ts:summarize()` read `s.id` but the step result shape is `step_id` — the reason the issue saw `(unknown step)`. Fixed, plus error strings now include the failed-validation descriptions when no step-level error is present.

## Clean-storyboard floor

| | Before (issue #2667 baseline after 5.8.1 bump) | After |
|---|---|---|
| Legacy dispatch | 27/56 | 46/56 |
| Framework dispatch | 19/56 | 27/56 |

`security_baseline` passes in both dispatch modes. Remaining step failures are unrelated handler gaps (`MEDIA_BUY_NOT_FOUND`, governance approvals, etc.) already tracked in #2667.

## Test plan

- [x] `PUBLIC_TEST_AGENT_TOKEN=storyboard-ci-token TRAINING_AGENT_USE_FRAMEWORK=0 npx tsx server/tests/manual/run-one-storyboard.ts security_baseline` — `overall_passed: true`
- [x] `PUBLIC_TEST_AGENT_TOKEN=storyboard-ci-token TRAINING_AGENT_USE_FRAMEWORK=1 npx tsx server/tests/manual/run-one-storyboard.ts security_baseline` — `overall_passed: true`
- [x] `npx vitest run server/tests/unit/training-agent.test.ts` — 340 passed
- [x] `npx vitest run server/tests/integration/training-agent-demo-key.test.ts` — 6 new regression tests passing
- [x] Pre-commit hook: 631 unit tests + typecheck green
- [x] Full legacy storyboard suite confirms 45→46/56 clean floor
- [x] Reviewer-recommended fallbacks: tests that read `content[0].text` now prefer `structuredContent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)