### PR TITLE
fix(training-agent): framework comply_test_controller error surface (#2844)

### DIFF
--- a/.changeset/training-agent-framework-comply-error-surface.md
+++ b/.changeset/training-agent-framework-comply-error-surface.md
@@ -1,0 +1,25 @@
+---
+---
+
+Training agent (framework path): close the `deterministic_testing`
+storyboard's error-surface gaps so the reference seller round-trips
+typed controller errors.
+
+- **`UNKNOWN_SCENARIO` on unrecognized scenarios**: the framework's
+  custom-tool zod input rejected unknown `scenario` values at MCP
+  validation, returning a generic validation error without the
+  controller's context echo. Loosen `COMPLY_TEST_CONTROLLER_SCHEMA.
+  scenario` from `z.enum([...])` to `z.string()` so the SDK handler
+  emits the typed `UNKNOWN_SCENARIO` envelope (with `success: false`,
+  `error`, and `context.correlation_id` preserved).
+- **`INVALID_TRANSITION` on cross-request state machine probes**: the
+  framework path never wrapped tool handlers in `runWithSessionContext`
+  / `flushDirtySessions`, so mutations from one request (e.g.
+  `sync_creatives`, `create_media_buy`) were discarded before the next
+  request (e.g. `force_creative_status` → `NOT_FOUND` instead of
+  `INVALID_TRANSITION`). Wrap both `adapt()` and `customToolFor()`
+  handlers in the same session-persistence envelope the legacy dispatch
+  uses at the MCP handler level. Closes #2844.
+
+Adds `tests/unit/training-agent-framework-comply.test.ts` to lock in
+the framework-path error surface for both probes.

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -29,6 +29,7 @@ import { getIdempotencyStore } from './idempotency.js';
 import { getWebhookSigningKey } from './webhooks.js';
 import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
 import { PUBLISHERS } from './publishers.js';
+import { runWithSessionContext, flushDirtySessions } from './state.js';
 import { createLogger } from '../logger.js';
 
 import {
@@ -210,13 +211,22 @@ function adapt(handler: LegacyHandler) {
       principal: ctx.authInfo?.clientId ?? 'anonymous',
     };
 
-    try {
-      const result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
+    return runWithSessionContext(async () => {
+      let result: unknown;
+      try {
+        result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
+      } catch (err) {
+        logger.error({ err }, 'framework handler threw');
+        return serviceUnavailable(err, callerContext);
+      }
+      try {
+        await flushDirtySessions();
+      } catch (err) {
+        logger.error({ err }, 'framework flushDirtySessions threw');
+        return serviceUnavailable(err, callerContext);
+      }
       return toAdaptedResponse(result, callerContext);
-    } catch (err) {
-      logger.error({ err }, 'framework handler threw');
-      return serviceUnavailable(err, callerContext);
-    }
+    });
   };
 }
 
@@ -270,13 +280,22 @@ export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpSe
           principal: authInfo?.clientId ?? 'anonymous',
         };
         const { context: callerContext, ...handlerArgs } = params;
-        try {
-          const result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
+        return runWithSessionContext(async () => {
+          let result: unknown;
+          try {
+            result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
+          } catch (err) {
+            logger.error({ err, tool: name }, 'framework custom-tool handler threw');
+            return serviceUnavailable(err, callerContext);
+          }
+          try {
+            await flushDirtySessions();
+          } catch (err) {
+            logger.error({ err, tool: name }, 'framework custom-tool flushDirtySessions threw');
+            return serviceUnavailable(err, callerContext);
+          }
           return toAdaptedResponse(result, callerContext);
-        } catch (err) {
-          logger.error({ err, tool: name }, 'framework custom-tool handler threw');
-          return serviceUnavailable(err, callerContext);
-        }
+        });
       },
     };
   }
@@ -375,16 +394,15 @@ export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpSe
     context: CONTEXT_REF,
   };
 
+  // `scenario` stays an open string rather than z.enum so unrecognized
+  // scenarios reach the SDK handler and get a typed `UNKNOWN_SCENARIO`
+  // response envelope. A zod enum here would reject at MCP input validation,
+  // returning a generic validation error without the controller's context
+  // echo — breaking the deterministic_testing storyboard's unknown-scenario
+  // probe. Seed scenarios (seed_product, seed_creative, etc.) are also
+  // accepted here for the same reason.
   const COMPLY_TEST_CONTROLLER_SCHEMA = {
-    scenario: z.enum([
-      'list_scenarios',
-      'force_creative_status',
-      'force_account_status',
-      'force_media_buy_status',
-      'force_session_status',
-      'simulate_delivery',
-      'simulate_budget_spend',
-    ]),
+    scenario: z.string(),
     params: z.record(z.string(), z.any()).optional(),
     account: ACCOUNT_REF,
     brand: BRAND_REF,

--- a/server/tests/unit/training-agent-framework-comply.test.ts
+++ b/server/tests/unit/training-agent-framework-comply.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import { createFrameworkTrainingAgentServer } from '../../src/training-agent/framework-server.js';
+import { clearSessions, getSession } from '../../src/training-agent/state.js';
+import { clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+type AnyServer = ReturnType<typeof createFrameworkTrainingAgentServer>;
+
+const ACCOUNT = { brand: { domain: 'comply-fw.example.com' }, operator: 'tester', sandbox: true };
+const BRAND = { domain: 'comply-fw.example.com' };
+
+async function callTool(server: AnyServer, name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const res = await server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name, arguments: args },
+  });
+  const text = res.content?.[0]?.text;
+  const parsed = typeof text === 'string' ? JSON.parse(text) : {};
+  return parsed.adcp_error ?? parsed;
+}
+
+async function syncCreative(server: AnyServer): Promise<string> {
+  const creativeId = `cr-fw-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const result = await callTool(server, 'sync_creatives', {
+    idempotency_key: crypto.randomUUID(),
+    account: ACCOUNT,
+    brand: BRAND,
+    creatives: [{
+      creative_id: creativeId,
+      name: 'FW Test Creative',
+      format_id: { agent_url: 'https://example.com', id: 'display_300x250' },
+      assets: {
+        image: {
+          asset_type: 'image',
+          url: 'https://via.placeholder.com/300x250',
+          width: 300,
+          height: 250,
+          mime_type: 'image/png',
+        },
+      },
+    }],
+  });
+  if ((result as { errors?: unknown[] }).errors) {
+    throw new Error(`sync_creatives failed: ${JSON.stringify(result)}`);
+  }
+  return creativeId;
+}
+
+describe('framework-server comply_test_controller', () => {
+  let server: AnyServer;
+
+  beforeEach(async () => {
+    await clearSessions();
+    clearIdempotencyCache();
+    const ctx: TrainingContext = { mode: 'open', principal: 'anonymous' };
+    server = createFrameworkTrainingAgentServer(ctx);
+  });
+
+  it('returns UNKNOWN_SCENARIO with context echoed on unrecognized scenario', async () => {
+    const correlationId = 'fw-unknown-scenario-test';
+    const result = await callTool(server, 'comply_test_controller', {
+      scenario: 'nonexistent_scenario',
+      params: {},
+      account: ACCOUNT,
+      brand: BRAND,
+      context: { correlation_id: correlationId },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('UNKNOWN_SCENARIO');
+    expect((result.context as { correlation_id?: string })?.correlation_id).toBe(correlationId);
+  });
+
+  it('returns INVALID_TRANSITION with context echoed when forcing a terminal creative back', async () => {
+    const creativeId = await syncCreative(server);
+    // approved -> archived (valid)
+    const archived = await callTool(server, 'comply_test_controller', {
+      scenario: 'force_creative_status',
+      params: { creative_id: creativeId, status: 'archived' },
+      account: ACCOUNT,
+      brand: BRAND,
+    });
+    expect(archived.success).toBe(true);
+
+    // Lock in the mechanism: archived state must be persisted to the session
+    // store between requests, otherwise the next probe hits NOT_FOUND. If a
+    // refactor ever changes session scoping so forceCreativeStatus reads from
+    // a different store than the creative was synced into, this assertion
+    // fires before the error-code check below.
+    const session = await getSession('open:comply-fw.example.com');
+    expect(session.creatives.get(creativeId)?.status).toBe('archived');
+
+    // archived -> processing (invalid; archived only allows -> approved)
+    const correlationId = 'fw-invalid-transition-test';
+    const invalid = await callTool(server, 'comply_test_controller', {
+      scenario: 'force_creative_status',
+      params: { creative_id: creativeId, status: 'processing' },
+      account: ACCOUNT,
+      brand: BRAND,
+      context: { correlation_id: correlationId },
+    });
+    expect(invalid.success).toBe(false);
+    expect(invalid.error).toBe('INVALID_TRANSITION');
+    expect((invalid.context as { correlation_id?: string })?.correlation_id).toBe(correlationId);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2844. The `deterministic_testing` storyboard failed two invariants on the training agent's framework dispatch path (opt-in via `TRAINING_AGENT_USE_FRAMEWORK=1`):

- **`UNKNOWN_SCENARIO` (framework only)**: the custom-tool zod input rejected unknown `scenario` values at MCP validation, so the SDK handler never ran. Loosen `COMPLY_TEST_CONTROLLER_SCHEMA.scenario` from `z.enum([...])` to `z.string()` — `handleTestControllerRequest` now emits the typed envelope with `context.correlation_id` echoed.
- **`INVALID_TRANSITION` (both paths, observed on framework)**: framework handlers didn't wrap in `runWithSessionContext` / `flushDirtySessions`, so a creative synced in one request wasn't visible to a force-status probe in the next → `NOT_FOUND` instead of `INVALID_TRANSITION`. Wrap both `adapt()` (domain handlers) and `customToolFor()` (custom tools) in the same envelope the legacy dispatch uses. Flush errors get a distinct catch so they don't get conflated with handler exceptions in logs.

## Why this matters

`comply_test_controller` is the public acceptance-testing surface for every seller — buyers use it to force state transitions during grading. If the reference agent can't round-trip typed errors (UNKNOWN_SCENARIO, INVALID_TRANSITION, NOT_FOUND, INVALID_PARAMS), other sellers won't either. 3.0-important.

The session-context fix also enables every other framework-path tool to persist session state across requests — a structural gap that would have blocked the framework default flip.

## Test plan

- [x] Added `server/tests/unit/training-agent-framework-comply.test.ts` using `dispatchTestRequest` against `createFrameworkTrainingAgentServer`. Covers UNKNOWN_SCENARIO and archived→processing INVALID_TRANSITION. Includes a direct `getSession` read to pin the session-persistence mechanism.
- [x] `npm run test:unit` — 631/631 passing.
- [x] `npm run typecheck` — clean.
- [x] Pre-existing legacy-path `comply-test-controller.test.ts` still green (40/40) — no behavior change to legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)