### PR TITLE
fix(training-agent): webhook envelope protocol uses AdCP domain, not 'mcp'

### DIFF
--- a/.changeset/fix-webhook-protocol-enum.md
+++ b/.changeset/fix-webhook-protocol-enum.md
@@ -1,0 +1,15 @@
+---
+---
+
+fix(training-agent): stamp webhook `protocol` with the AdCP domain, not `'mcp'`
+
+The completion-webhook envelope emitted `protocol: 'mcp'` (transport name), but
+`core/mcp-webhook-payload.json` references `enums/adcp-protocol.json`, whose
+values are the AdCP domain (`media-buy`, `signals`, `governance`, `creative`,
+`brand`, `sponsored-intelligence`). Any strict validator would reject the
+legacy value.
+
+Adds `TOOL_TO_PROTOCOL` mapping keyed off `TOOL_TO_TASK_TYPE` so tsc enforces
+both maps stay in sync. Creative + account operations stamp `media-buy`
+(matching the `sync_creatives → media-buy` example in the payload schema);
+signals / governance / brand stamp their own domain.

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -34,7 +34,7 @@ export type WebhookTaskType =
   | 'sync_audiences' | 'sync_catalogs' | 'log_event' | 'get_brand_identity'
   | 'get_rights' | 'acquire_rights';
 
-export const TOOL_TO_TASK_TYPE: Readonly<Record<string, WebhookTaskType>> = {
+export const TOOL_TO_TASK_TYPE = {
   create_media_buy: 'create_media_buy',
   update_media_buy: 'update_media_buy',
   sync_creatives: 'sync_creatives',
@@ -55,6 +55,40 @@ export const TOOL_TO_TASK_TYPE: Readonly<Record<string, WebhookTaskType>> = {
   get_brand_identity: 'get_brand_identity',
   get_rights: 'get_rights',
   acquire_rights: 'acquire_rights',
+} as const satisfies Record<string, WebhookTaskType>;
+
+type WebhookEmittingTool = keyof typeof TOOL_TO_TASK_TYPE;
+
+/** AdCP protocol domain for each webhook-emitting tool. Values are the kebab-case
+ *  enum from `enums/adcp-protocol.json`. Matches the spec's operational grouping:
+ *  creative operations bundled into a media-buy seller stamp as `media-buy`
+ *  (see `core/mcp-webhook-payload.json` example where `sync_creatives` → `media-buy`);
+ *  dedicated brand / signals / governance tools stamp their own domain. The
+ *  `Record<WebhookEmittingTool, ...>` type forces this map to stay in sync with
+ *  `TOOL_TO_TASK_TYPE` — adding a tool there without a protocol here fails tsc. */
+type WebhookProtocol = 'media-buy' | 'signals' | 'governance' | 'creative' | 'brand' | 'sponsored-intelligence';
+
+const TOOL_TO_PROTOCOL: Readonly<Record<WebhookEmittingTool, WebhookProtocol>> = {
+  create_media_buy: 'media-buy',
+  update_media_buy: 'media-buy',
+  sync_creatives: 'media-buy',
+  get_creative_delivery: 'media-buy',
+  sync_event_sources: 'media-buy',
+  sync_audiences: 'media-buy',
+  sync_catalogs: 'media-buy',
+  log_event: 'media-buy',
+  sync_accounts: 'governance',
+  get_account_financials: 'governance',
+  activate_signal: 'signals',
+  get_signals: 'signals',
+  create_property_list: 'governance',
+  update_property_list: 'governance',
+  get_property_list: 'governance',
+  list_property_lists: 'governance',
+  delete_property_list: 'governance',
+  get_brand_identity: 'brand',
+  get_rights: 'brand',
+  acquire_rights: 'brand',
 };
 
 function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
@@ -99,8 +133,8 @@ export function maybeEmitCompletionWebhook(opts: {
   requestIdempotencyKey?: string;
 }): void {
   const webhookUrl = extractWebhookUrl(opts.args);
-  const taskType = TOOL_TO_TASK_TYPE[opts.toolName];
-  if (!webhookUrl || !taskType) return;
+  if (!webhookUrl || !(opts.toolName in TOOL_TO_TASK_TYPE)) return;
+  const tool = opts.toolName as WebhookEmittingTool;
 
   const emitter = getWebhookEmitter();
   const operationId = deriveWebhookOperationId(opts.toolName, opts.response, opts.requestIdempotencyKey);
@@ -108,8 +142,8 @@ export function maybeEmitCompletionWebhook(opts: {
     ?? `tsk_${operationId.slice(0, 32).replace(/[^A-Za-z0-9_.:-]/g, '_')}`;
   const payload: Record<string, unknown> = {
     task_id: webhookTaskId,
-    task_type: taskType,
-    protocol: 'mcp',
+    task_type: TOOL_TO_TASK_TYPE[tool],
+    protocol: TOOL_TO_PROTOCOL[tool],
     status: 'completed',
     timestamp: new Date().toISOString(),
     result: opts.response,


### PR DESCRIPTION
## Summary

Webhook completion envelope emitted `protocol: 'mcp'` (a transport name), but `core/mcp-webhook-payload.json` references `enums/adcp-protocol.json` whose values are AdCP domain names (`media-buy`, `signals`, `governance`, `creative`, `brand`, `sponsored-intelligence`). Any strict schema validator rejects `'mcp'`.

Adds `TOOL_TO_PROTOCOL` in `server/src/training-agent/webhooks.ts`, keyed off `TOOL_TO_TASK_TYPE` so tsc enforces both maps stay in sync. Rule: operational context over task grouping — matches the normative `sync_creatives → media-buy` example in the payload schema.

## Mapping

- **media-buy**: create/update_media_buy, sync_creatives, get_creative_delivery, sync_event_sources, sync_audiences, sync_catalogs, log_event
- **governance**: sync_accounts, get_account_financials, create/update/get/list/delete_property_list
- **signals**: activate_signal, get_signals
- **brand**: get_brand_identity, get_rights, acquire_rights

## Expert review

`ad-tech-protocol-expert` signed off with one correction (accounts → governance, applied).

## Test plan

- [x] `webhook_emission` storyboard: 7P/0F under both dispatches
- [x] Full framework run: 27/56 clean (unchanged)
- [x] Full legacy run: 45/56 clean (unchanged)
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` 631/631 passing

Surfaced during review of #2868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)