### PR TITLE
fix(training-agent): IDEMPOTENCY_CONFLICT envelope redaction + webhook URL in idempotency storyboard (#2842)

### DIFF
--- a/.changeset/idempotency-conflict-redaction-and-webhook-url.md
+++ b/.changeset/idempotency-conflict-redaction-and-webhook-url.md
@@ -1,0 +1,24 @@
+---
+---
+
+Fix two idempotency storyboard failures (closes #2842):
+
+- **Framework dispatch IDEMPOTENCY_CONFLICT payload leak.** `@adcp/client/server`'s
+  `adcpError()` builder auto-injects `recovery` on every error envelope, but
+  the universal idempotency storyboard's `conflict_no_payload_leak` invariant
+  allows only a narrow set of envelope keys on `IDEMPOTENCY_CONFLICT` (`code`,
+  `message`, `status`, `retry_after`, `correlation_id`, `request_id`,
+  `operation_id`) to prevent stolen-key read oracles. The framework training
+  agent now intercepts outbound MCP response bytes and strips disallowed
+  envelope keys so the invariant passes without forking the SDK. Legacy
+  dispatch already builds a minimal envelope by hand and is unchanged.
+- **Universal idempotency storyboard: add `push_notification_config.url` to
+  the `create_media_buy` replay window.** The `no_duplicate_webhooks_on_replay`
+  step depends on observing outbound webhooks, but neither the initial nor
+  the replay step previously included a webhook destination in
+  `sample_request`, so the runner saw zero deliveries and failed the
+  assertion regardless of agent behavior. Both steps now bind to the same
+  `{{runner.webhook_url:create_media_buy_initial}}` endpoint (byte-identical
+  canonical payload → no false IDEMPOTENCY_CONFLICT on replay), and the
+  assertion's `triggered_by` is realigned so the default filter resolves
+  against the initial step's `stepOperationIds` entry.

--- a/server/src/training-agent/conflict-envelope.ts
+++ b/server/src/training-agent/conflict-envelope.ts
@@ -1,0 +1,119 @@
+/**
+ * Redaction helper for `IDEMPOTENCY_CONFLICT` response envelopes.
+ *
+ * The universal idempotency storyboard's `idempotency.conflict_no_payload_leak`
+ * invariant (ships as a default in `@adcp/client/testing`) allows only a narrow
+ * set of envelope keys on `adcp_error` when `code === 'IDEMPOTENCY_CONFLICT'`:
+ * `code, message, status, retry_after, correlation_id, request_id, operation_id`.
+ * Any other key is flagged as a potential stolen-key read oracle.
+ *
+ * `adcpError()` in `@adcp/client/server` auto-injects `recovery` for every
+ * error it produces, and the framework dispatch path's `IDEMPOTENCY_CONFLICT`
+ * branch routes through that builder — the `recovery: "correctable"` string
+ * is a constant classification, not prior payload, but the invariant is
+ * intentionally strict and flags it all the same. Rather than fork the SDK,
+ * the training agent filters the envelope at the HTTP layer before bytes
+ * leave the process. Legacy dispatch builds the envelope by hand so does not
+ * need this shim.
+ */
+const CONFLICT_ALLOWED_ENVELOPE_KEYS = new Set([
+  'code',
+  'message',
+  'status',
+  'retry_after',
+  'correlation_id',
+  'request_id',
+  'operation_id',
+]);
+
+const CONFLICT_CODE = 'IDEMPOTENCY_CONFLICT';
+
+function isConflictEnvelope(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && (value as { code?: unknown }).code === CONFLICT_CODE
+  );
+}
+
+function stripConflictEnvelope(env: Record<string, unknown>): void {
+  for (const key of Object.keys(env)) {
+    if (!CONFLICT_ALLOWED_ENVELOPE_KEYS.has(key)) {
+      delete env[key];
+    }
+  }
+}
+
+/**
+ * Walk a parsed MCP JSON-RPC response, stripping disallowed envelope keys
+ * from any `adcp_error` whose `code === 'IDEMPOTENCY_CONFLICT'`. Mutates in
+ * place so both the `structuredContent.adcp_error` object and any
+ * `content[].text`-embedded copy stay consistent.
+ */
+export function redactConflictEnvelopes(value: unknown): void {
+  if (value === null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (const item of value) redactConflictEnvelopes(item);
+    return;
+  }
+  const rec = value as Record<string, unknown>;
+  for (const [key, child] of Object.entries(rec)) {
+    if (key === 'adcp_error' && isConflictEnvelope(child)) {
+      stripConflictEnvelope(child);
+      continue;
+    }
+    if (
+      key === 'content'
+      && Array.isArray(child)
+    ) {
+      for (const item of child) {
+        if (
+          item
+          && typeof item === 'object'
+          && (item as { type?: unknown }).type === 'text'
+          && typeof (item as { text?: unknown }).text === 'string'
+        ) {
+          const textItem = item as { text: string };
+          // content[].text is the JSON-text fallback (L2). It must stay in
+          // sync with structuredContent so buyers that read either surface
+          // see the same envelope.
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(textItem.text);
+          } catch {
+            continue;
+          }
+          if (
+            parsed
+            && typeof parsed === 'object'
+            && isConflictEnvelope((parsed as { adcp_error?: unknown }).adcp_error)
+          ) {
+            stripConflictEnvelope((parsed as { adcp_error: Record<string, unknown> }).adcp_error);
+            textItem.text = JSON.stringify(parsed);
+          }
+        }
+      }
+      continue;
+    }
+    redactConflictEnvelopes(child);
+  }
+}
+
+/**
+ * Parse a JSON body, redact any `IDEMPOTENCY_CONFLICT` envelopes in place,
+ * and return the re-serialized JSON. Returns the original body unchanged
+ * when parsing fails — non-JSON responses (transport errors, SSE frames)
+ * pass through untouched.
+ */
+export function redactConflictEnvelopeInBody(body: string): string {
+  if (!body.includes(CONFLICT_CODE)) return body;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  redactConflictEnvelopes(parsed);
+  return JSON.stringify(parsed);
+}

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -25,6 +25,7 @@ import {
 import { createLogger } from '../logger.js';
 import { createTrainingAgentServer } from './task-handlers.js';
 import { createFrameworkTrainingAgentServer, useFrameworkServer } from './framework-server.js';
+import { redactConflictEnvelopeInBody } from './conflict-envelope.js';
 import { startSessionCleanup } from './state.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
@@ -205,6 +206,98 @@ function buildRequireToken(authenticator: Authenticator | null) {
 const requireTokenDefault = buildRequireToken(defaultAuthenticator);
 const requireTokenStrict = buildRequireToken(strictAuthenticator);
 
+/**
+ * Capture the response body as it's written by the MCP transport, redact any
+ * `IDEMPOTENCY_CONFLICT` envelopes (framework-dispatch's `adcpError()` emits
+ * `recovery` which the storyboard invariant treats as a payload leak), and
+ * flush the transformed body through the original writer. Idempotent: safe
+ * to call even when no conflict envelope is present (pass-through via a
+ * fast-path `includes('IDEMPOTENCY_CONFLICT')` probe inside the redactor).
+ *
+ * Works for the JSON-response mode (`enableJsonResponse: true`) the training
+ * agent forces for every request — the transport writes a single
+ * `res.write(body) ; res.end()` pair, which this wrapper buffers into one
+ * string before rewriting. Streaming/SSE would break this contract, so do
+ * not remove `enableJsonResponse: true` from the transport config above.
+ */
+function wrapResponseForConflictRedaction(res: Response): void {
+  const origWriteHead = res.writeHead.bind(res);
+  const origWrite = res.write.bind(res) as (chunk: unknown, ...rest: unknown[]) => boolean;
+  const origEnd = res.end.bind(res) as (chunk?: unknown, ...rest: unknown[]) => Response;
+  const chunks: Buffer[] = [];
+  let pendingHead: { status: number; headers: Record<string, string | number | string[]> } | null = null;
+
+  const collect = (chunk: unknown): void => {
+    if (chunk === undefined || chunk === null) return;
+    if (Buffer.isBuffer(chunk)) chunks.push(chunk);
+    else if (typeof chunk === 'string') chunks.push(Buffer.from(chunk, 'utf8'));
+    else if (chunk instanceof Uint8Array) chunks.push(Buffer.from(chunk));
+    else chunks.push(Buffer.from(String(chunk), 'utf8'));
+  };
+
+  // `@hono/node-server` flushes headers via `writeHead(status, headers)`
+  // before calling `write` — with content-length already computed from the
+  // original body length. Buffering headers here defers flush until `end`
+  // runs, so the final `Content-Length` reflects the redacted body size.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (res as any).writeHead = ((
+    status: number,
+    statusMessageOrHeaders?: string | Record<string, string | number | string[]>,
+    headersArg?: Record<string, string | number | string[]>,
+  ): Response => {
+    const headers = typeof statusMessageOrHeaders === 'object' && statusMessageOrHeaders !== null
+      ? statusMessageOrHeaders
+      : headersArg ?? {};
+    pendingHead = { status, headers: { ...headers } };
+    return res;
+  }) as typeof res.writeHead;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (res as any).write = (chunk: unknown, encoding?: unknown, cb?: unknown): boolean => {
+    collect(chunk);
+    const callback = typeof encoding === 'function' ? encoding : cb;
+    if (typeof callback === 'function') (callback as () => void)();
+    return true;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (res as any).end = (chunk?: unknown, encoding?: unknown, cb?: unknown): Response => {
+    if (chunk !== undefined && typeof chunk !== 'function') collect(chunk);
+    const callback = typeof chunk === 'function'
+      ? chunk
+      : typeof encoding === 'function'
+        ? encoding
+        : cb;
+    const body = Buffer.concat(chunks).toString('utf8');
+    const rewritten = redactConflictEnvelopeInBody(body);
+    if (pendingHead) {
+      // Hono's node-server path: the transport called `writeHead(status, headers)`
+      // up front. Patch content-length (case-insensitive) to the redacted
+      // length before flushing so the wire byte count matches the body.
+      const headers = pendingHead.headers;
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === 'content-length') delete headers[key];
+      }
+      headers['content-length'] = Buffer.byteLength(rewritten, 'utf8');
+      origWriteHead(pendingHead.status, headers);
+      pendingHead = null;
+    }
+    // When `pendingHead` is null, either no response was produced (e.g. an
+    // uncaught throw before the transport wrote anything) or Express's own
+    // error-path `.json()` handler flushed via `setHeader`+`end` rather than
+    // `writeHead`. Node's implicit-header emission fires on the first
+    // `origWrite`/`origEnd` in that case, using whatever headers Express
+    // already stacked via `setHeader`. Content-Length may be wrong if the
+    // error path pre-set it, but those responses never carry an
+    // IDEMPOTENCY_CONFLICT body so `rewritten === body` and the length is
+    // unchanged.
+    if (rewritten.length > 0) origWrite(rewritten);
+    const args: unknown[] = [];
+    if (typeof callback === 'function') args.push(callback);
+    return origEnd(...args);
+  };
+}
+
 function getBaseUrl(req: Request): string {
   if (process.env.BASE_URL) return process.env.BASE_URL.replace(/\/$/, '');
   const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
@@ -371,6 +464,17 @@ export function createTrainingAgentRouter(): Router {
         });
 
         await server.connect(transport);
+
+        // Framework-dispatch IDEMPOTENCY_CONFLICT envelopes route through
+        // `@adcp/client/server`'s `adcpError()` builder, which auto-injects
+        // `recovery` on every error. The universal idempotency storyboard's
+        // `conflict_no_payload_leak` invariant allows only a narrow set of
+        // envelope keys on conflict — anything else is flagged as a potential
+        // stolen-key read oracle. Intercept the response bytes before they
+        // leave the process and strip disallowed keys. Legacy dispatch builds
+        // a minimal envelope by hand, so the wrap is a no-op there in
+        // practice (it still runs but finds nothing to redact).
+        wrapResponseForConflictRedaction(res);
 
         logger.debug({ method: req.body?.method, ip: req.ip, strict }, 'Training agent: handling request');
 

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -151,10 +151,29 @@ function summarize(sb: Storyboard, result: StoryboardResult | { error: string })
       const status = stepStatus(step as Parameters<typeof stepStatus>[0]);
       base[status] += 1;
       if (status === 'failed') {
-        const s = step as { id?: string; error?: string; validations?: Array<{ passed: boolean; description?: string }> };
-        const validationFails = (s.validations ?? []).filter(v => !v.passed).map(v => v.description ?? '(validation failed)').join('; ');
+        // Surface the validator's `error` text alongside the description so
+        // failures like "Expected one of [false], got undefined" print the
+        // actionable detail instead of just the narrative — the description
+        // alone was collapsing distinct codes into the same summary line.
+        // Webhook-assertion pseudo-steps (expect_webhook*) return their id
+        // on `step_id`; every other step result uses `id`. Carry both so the
+        // failure summary never collapses to "(unknown step)".
+        const s = step as {
+          id?: string;
+          step_id?: string;
+          error?: string;
+          validations?: Array<{ passed: boolean; description?: string; error?: string; actual?: unknown }>;
+        };
+        const validationFails = (s.validations ?? [])
+          .filter(v => !v.passed)
+          .map(v => {
+            const desc = v.description ?? '(validation failed)';
+            const detail = v.error ?? (v.actual ? JSON.stringify(v.actual) : undefined);
+            return detail ? `${desc} — ${detail}` : desc;
+          })
+          .join('; ');
         base.failures.push({
-          step: s.id ?? '(unknown step)',
+          step: s.id ?? s.step_id ?? '(unknown step)',
           error: s.error ?? validationFails ?? '(failed without message)',
         });
       }

--- a/server/tests/unit/conflict-envelope.test.ts
+++ b/server/tests/unit/conflict-envelope.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Direct tests for the `IDEMPOTENCY_CONFLICT` envelope redactor. Guards the
+ * allowlist that the universal idempotency storyboard's
+ * `conflict_no_payload_leak` invariant enforces — adding a new envelope
+ * field here without updating the allowlist would regress the invariant.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  redactConflictEnvelopes,
+  redactConflictEnvelopeInBody,
+} from '../../src/training-agent/conflict-envelope.js';
+
+function buildConflictResponse(extraEnvelopeFields: Record<string, unknown>): Record<string, unknown> {
+  const envelope = {
+    code: 'IDEMPOTENCY_CONFLICT',
+    message: 'Key reuse rejected',
+    ...extraEnvelopeFields,
+  };
+  return {
+    jsonrpc: '2.0',
+    id: 42,
+    result: {
+      isError: true,
+      content: [{ type: 'text', text: JSON.stringify({ adcp_error: envelope }) }],
+      structuredContent: { adcp_error: { ...envelope } },
+    },
+  };
+}
+
+describe('redactConflictEnvelopes', () => {
+  it('strips disallowed envelope keys from structuredContent and the text fallback', () => {
+    const response = buildConflictResponse({
+      recovery: 'correctable',
+      field: '/packages/0/budget',
+      details: { prior_budget: 5000 },
+    });
+    redactConflictEnvelopes(response);
+
+    const structured = (response.result as { structuredContent: { adcp_error: Record<string, unknown> } })
+      .structuredContent.adcp_error;
+    expect(Object.keys(structured).sort()).toEqual(['code', 'message']);
+
+    const text = (response.result as { content: Array<{ text: string }> }).content[0].text;
+    const parsed = JSON.parse(text) as { adcp_error: Record<string, unknown> };
+    expect(Object.keys(parsed.adcp_error).sort()).toEqual(['code', 'message']);
+  });
+
+  it('preserves allowlisted envelope keys', () => {
+    const response = buildConflictResponse({
+      status: 'failed',
+      retry_after: 1,
+      correlation_id: 'req-1',
+      request_id: 'req-1',
+      operation_id: 'op-1',
+      recovery: 'correctable',
+    });
+    redactConflictEnvelopes(response);
+
+    const structured = (response.result as { structuredContent: { adcp_error: Record<string, unknown> } })
+      .structuredContent.adcp_error;
+    expect(structured.code).toBe('IDEMPOTENCY_CONFLICT');
+    expect(structured.message).toBe('Key reuse rejected');
+    expect(structured.status).toBe('failed');
+    expect(structured.retry_after).toBe(1);
+    expect(structured.correlation_id).toBe('req-1');
+    expect(structured.request_id).toBe('req-1');
+    expect(structured.operation_id).toBe('op-1');
+    expect('recovery' in structured).toBe(false);
+  });
+
+  it('leaves non-conflict envelopes untouched', () => {
+    const response = {
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: JSON.stringify({ adcp_error: { code: 'VALIDATION_ERROR', message: 'bad', recovery: 'correctable', field: '/x' } }) }],
+        structuredContent: { adcp_error: { code: 'VALIDATION_ERROR', message: 'bad', recovery: 'correctable', field: '/x' } },
+      },
+    };
+    redactConflictEnvelopes(response);
+    const env = (response.result.structuredContent as { adcp_error: Record<string, unknown> }).adcp_error;
+    expect(env).toEqual({ code: 'VALIDATION_ERROR', message: 'bad', recovery: 'correctable', field: '/x' });
+  });
+
+  it('handles success responses as a pass-through', () => {
+    const response = {
+      result: {
+        content: [{ type: 'text', text: JSON.stringify({ media_buy_id: 'mb_1' }) }],
+        structuredContent: { media_buy_id: 'mb_1' },
+      },
+    };
+    const clone = structuredClone(response);
+    redactConflictEnvelopes(response);
+    expect(response).toEqual(clone);
+  });
+
+  it('descends into nested arrays and strips every conflict envelope', () => {
+    const response = {
+      result: {
+        structuredContent: {
+          adcp_error: {
+            code: 'IDEMPOTENCY_CONFLICT',
+            message: 'outer',
+            recovery: 'correctable',
+          },
+          nested: [
+            {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    adcp_error: {
+                      code: 'IDEMPOTENCY_CONFLICT',
+                      message: 'inner',
+                      details: { prior_budget: 5000 },
+                    },
+                  }),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    redactConflictEnvelopes(response);
+
+    const outer = response.result.structuredContent.adcp_error as Record<string, unknown>;
+    expect(Object.keys(outer).sort()).toEqual(['code', 'message']);
+
+    const innerText = response.result.structuredContent.nested[0].content[0].text;
+    const innerEnv = (JSON.parse(innerText) as { adcp_error: Record<string, unknown> }).adcp_error;
+    expect(Object.keys(innerEnv).sort()).toEqual(['code', 'message']);
+  });
+
+  it('ignores malformed text entries without throwing', () => {
+    const response = {
+      result: {
+        content: [{ type: 'text', text: '{not-json' }],
+        structuredContent: { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: 'x', recovery: 'correctable' } },
+      },
+    };
+    expect(() => redactConflictEnvelopes(response)).not.toThrow();
+    const env = (response.result.structuredContent as { adcp_error: Record<string, unknown> }).adcp_error;
+    expect('recovery' in env).toBe(false);
+  });
+});
+
+describe('redactConflictEnvelopeInBody', () => {
+  it('returns the body unchanged when no conflict code appears', () => {
+    const body = JSON.stringify({ result: { structuredContent: { ok: true } } });
+    expect(redactConflictEnvelopeInBody(body)).toBe(body);
+  });
+
+  it('returns the body unchanged when parsing fails', () => {
+    const body = '{not-json IDEMPOTENCY_CONFLICT';
+    expect(redactConflictEnvelopeInBody(body)).toBe(body);
+  });
+
+  it('rewrites JSON bodies that carry a conflict envelope', () => {
+    const original = buildConflictResponse({ recovery: 'correctable', field: '/x' });
+    const body = JSON.stringify(original);
+    const rewritten = redactConflictEnvelopeInBody(body);
+    expect(rewritten).not.toBe(body);
+    const parsed = JSON.parse(rewritten);
+    const env = parsed.result.structuredContent.adcp_error;
+    expect(Object.keys(env).sort()).toEqual(['code', 'message']);
+    // Text fallback mirrors structuredContent
+    const inner = JSON.parse(parsed.result.content[0].text);
+    expect(Object.keys(inner.adcp_error).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -252,6 +252,15 @@ phases:
             - product_id: "test-product"
               budget: 5000
               pricing_option_id: "test-pricing"
+          # Both the initial call and the replay below use the SAME webhook URL
+          # so the canonical payload hash matches across the two calls. A
+          # different URL between the two requests would hash differently and
+          # trip IDEMPOTENCY_CONFLICT instead of exercising replay. The URL
+          # template resolves against the runner's ephemeral webhook receiver
+          # (webhook_receiver_runner contract); runners without a receiver
+          # grade `no_duplicate_webhooks_on_replay` as not_applicable.
+          push_notification_config:
+            url: "{{runner.webhook_url:create_media_buy_initial}}"
 
           context:
             correlation_id: "idempotency--create_media_buy_initial"
@@ -314,6 +323,11 @@ phases:
             - product_id: "test-product"
               budget: 5000
               pricing_option_id: "test-pricing"
+          # Byte-identical to the initial call above — same URL, same step id
+          # token — so the canonical payload hash matches and the request
+          # lands on the replay branch rather than IDEMPOTENCY_CONFLICT.
+          push_notification_config:
+            url: "{{runner.webhook_url:create_media_buy_initial}}"
 
           context:
             correlation_id: "idempotency--create_media_buy_replay"
@@ -363,9 +377,17 @@ phases:
           re-executes on replay emits a second set, catchable only by live
           observation.
         task: expect_webhook
-        triggered_by: create_media_buy_replay
-        filter:
-          operation_id: "{{prior_step.create_media_buy_initial.operation_id}}"
+        # `triggered_by` points at the initial call (not the replay) because the
+        # default filter resolves `step_id` + `operation_id` from `stepOperationIds`
+        # for that step — which is populated when the initial sample_request's
+        # `push_notification_config.url` expanded `{{runner.webhook_url:create_media_buy_initial}}`
+        # above. The execution-order wait still spans the replay window: this
+        # step runs after `create_media_buy_replay` in YAML order and `wait_all`
+        # drains the full `timeout_seconds` so any webhook re-fired by the
+        # replay is captured and counted against the cap below. A non-conformant
+        # seller that re-executes on replay would deliver a second webhook with
+        # a fresh idempotency_key and trip `duplicate_webhook_on_replay`.
+        triggered_by: create_media_buy_initial
         timeout_seconds: 30
         expect_max_deliveries_per_logical_event: 1
         requires_contract: webhook_receiver_runner


### PR DESCRIPTION
## Summary

Closes #2842. Two fixes so the universal idempotency storyboard passes end-to-end:

- **Framework dispatch `IDEMPOTENCY_CONFLICT` payload leak.** `@adcp/client/server`'s `adcpError()` builder auto-injects `recovery` on every error, but the storyboard's `conflict_no_payload_leak` invariant allows only a narrow envelope allowlist (`code, message, status, retry_after, correlation_id, request_id, operation_id`) to close stolen-key read-oracle surfaces. The training agent now intercepts outbound MCP response bytes and strips disallowed keys; legacy dispatch already emits a minimal envelope and is unchanged. New unit tests (`conflict-envelope.test.ts`) pin the allowlist against drift.
- **Webhook assertion never observed a delivery.** `no_duplicate_webhooks_on_replay` asserts on webhook arrivals, but `create_media_buy_initial` / `_replay` in the storyboard YAML carried no `push_notification_config.url`, so the runner saw zero webhooks regardless of agent behavior. Both steps now bind to the same `{{runner.webhook_url:create_media_buy_initial}}` endpoint (byte-identical canonical payload → replay branch, not false `IDEMPOTENCY_CONFLICT`), and the assertion's `triggered_by` realigns so the default filter resolves against the initial step's `stepOperationIds` entry.

Also surfaces validator `error` text in `run-storyboards.ts` failure summaries — prior output collapsed distinct codes into the same narrative line.

The `replayed: false` failure on `create_media_buy_initial` in framework mode is the SDK's `injectReplayed(false)` gap and stays tracked in #2839 per the issue text.

## Results

- Legacy idempotency storyboard: **8/8 steps pass** (previously 7/8).
- Framework idempotency storyboard: **5/6 steps pass** (previously 4/6); remaining failure is #2839.
- 1892 unit tests pass (34 skipped, zero new regressions).
- Independent `code-reviewer` + `security-reviewer` both returned ok-to-ship; nice-to-haves addressed in the same commit.

## Test plan

- [ ] CI runs `npm run test:unit` + `tsc --noEmit` (precommit hook already passed locally).
- [ ] `ADCP_COMPLIANCE_DIR=$(pwd)/dist/compliance/latest PUBLIC_TEST_AGENT_TOKEN=storyboard-ci-token npx tsx server/tests/manual/run-storyboards.ts --filter idempotency` → 1/1 clean in legacy mode.
- [ ] Same command with `TRAINING_AGENT_USE_FRAMEWORK=1` → only the #2839 `replayed: false` failure remains.
- [ ] Full legacy storyboard run shows no new regressions beyond pre-existing failures on other storyboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)