### PR TITLE
fix(storyboards): make creative-ad-server pricing/billing optional

### DIFF
--- a/.changeset/creative-ad-server-optional-pricing.md
+++ b/.changeset/creative-ad-server-optional-pricing.md
@@ -1,0 +1,40 @@
+---
+---
+
+creative-ad-server storyboard: pricing and billing are now modeled as optional,
+matching the spec schema. The specialism no longer fails ad servers that bill
+out of band (flat license, SaaS contract, bundled enterprise — CM360-shaped
+agents).
+
+Changes in creative-ad-server/index.yaml:
+- Removed hard `field_present` assertions on `creatives[0].pricing_options` and
+  nested `pricing_option_id` from the list_creatives step. `response_schema`
+  already validates shape when pricing is present (vendor-pricing-option.json
+  requires pricing_option_id + a valid pricing model + ISO-4217 currency, so
+  malformed pricing is still caught when any is returned).
+- Removed hard `field_present` on `pricing_option_id` from the build_creative
+  step for the same reason.
+- Softened the report_billing assertion: removed the `accepted == 1` requirement.
+  Agents that bill through AdCP still return accepted: 1 with empty errors;
+  agents that bill out of band return accepted: 0 with an errors entry pointing
+  at the offending record and a message explaining that billing is handled out
+  of band. Both shapes pass response_schema. Narrative explicitly discourages
+  fake-acceptance — silent drops break buyer-side reconciliation.
+- Updated narratives and `expected` fields throughout the storyboard to call
+  out the conditional nature of pricing/billing — authors won't re-introduce
+  the hard assertions on the next edit.
+- Updated summary and top-level narrative to reflect "optionally bills through
+  AdCP" rather than "with pricing and billing."
+
+Also documents the signal-specialism asymmetry:
+- signal-marketplace/index.yaml and signal-owned/index.yaml narratives now
+  explain why pricing stays hard-required there (signals are rate-carded goods
+  by definition; a signal agent without pricing is non-commercial and belongs
+  on a different surface). Preempts "why not signals?" questions from
+  implementers comparing specialisms.
+
+Audited the rest of the specialisms and protocols for similar over-assertions
+on business-model-dependent fields (pricing, measurement, DCO, concept
+grouping). No other cases found — `field_present` assertions on pricing fields
+were localized to creative-ad-server and the signal specialisms (where the
+assertion is correct).

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -3,7 +3,7 @@ version: "1.1.0"
 title: "Creative ad server"
 protocol: creative
 category: creative_ad_server
-summary: "Stateful ad server with pre-loaded creatives. Generates serving tags per media buy with pricing and billing."
+summary: "Stateful ad server with pre-loaded creatives. Generates serving tags per media buy. Optionally bills through AdCP."
 track: creative
 required_tools:
   - build_creative
@@ -23,9 +23,14 @@ narrative: |
   assets to you. Instead, they browse your library, pick creatives, and ask you to generate
   tags for specific placements. For a campaign with 25 media buys, you'll generate 25 tags.
 
-  If you charge for your services, pricing is part of the flow. The buyer's account
-  determines the rate card. list_creatives shows the applicable pricing, build_creative
-  returns the cost, and report_usage closes the billing loop after delivery.
+  Billing is optional. If you bill through AdCP, the buyer's account drives the
+  rate card: list_creatives surfaces pricing_options, build_creative returns the
+  applied pricing_option_id and vendor_cost, and report_usage closes the loop
+  after delivery. If you bill out of band (flat license, SaaS contract, bundled
+  enterprise agreement — CM360 is the canonical example), omit the pricing fields
+  and surface report_usage records as not accepted rather than fake-accepting.
+  response_schema validates shape in both cases; the specialism doesn't force a
+  billing business model on you.
 
   This storyboard walks through that flow from the buyer's perspective.
 
@@ -48,8 +53,12 @@ prerequisites:
     platform's own UI or API. The buyer does not push assets — they browse and
     request tags for what's already there.
 
-    For pricing steps, the buyer must have an established account with the ad server.
-    The account's rate card determines creative pricing.
+    Pricing is optional. Ad servers that bill through AdCP (rate-carded creative
+    serving) expose pricing_options on creatives and pricing_option_id on build
+    responses. Ad servers that bill out of band (flat license, SaaS contract, or
+    bundled enterprise agreement — e.g. CM360) return creatives and tags without
+    those fields. Both shapes are conformant; response_schema validates shape when
+    the fields are present.
   controller_seeding: true
 
 fixtures:
@@ -108,19 +117,24 @@ phases:
       available for a campaign. They call list_creatives to browse concepts and
       individual creatives in your library.
 
-      When the buyer provides an account and requests pricing, each creative
-      includes the applicable rate from the account's rate card.
+      If your agent bills through AdCP and the buyer provides an account, each
+      creative includes the applicable rate from the account's rate card. If you
+      bill out of band, pricing_options is omitted.
 
     steps:
       - id: list_creatives
-        title: "Browse available creatives with pricing"
+        title: "Browse available creatives"
         narrative: |
-          The buyer asks: "What creatives do you have for this advertiser, and what
-          do they cost?" This is the primary entry point for ad server interactions.
+          The buyer asks: "What creatives do you have for this advertiser?" This is
+          the primary entry point for ad server interactions.
 
-          With include_pricing=true and an account reference, the response includes
-          pricing_options on each creative. Vendors may offer multiple options —
-          volume tiers, context-specific rates, or different models per product line.
+          The buyer sends include_pricing=true and an account reference. If your
+          agent bills through AdCP, each creative returns pricing_options from the
+          account's rate card; vendors may offer multiple options (volume tiers,
+          context-specific rates, or different models per product line). If your
+          agent bills out of band (flat license, SaaS contract, or bundled
+          enterprise agreement), omit pricing_options — response_schema validates
+          shape either way.
         task: list_creatives
         schema_ref: "creative/list-creatives-request.json"
         response_schema_ref: "creative/list-creatives-response.json"
@@ -133,8 +147,9 @@ phases:
           - format_id referencing the creative's format
           - name and status (approved, pending_review, rejected)
           - concept_id grouping related creatives across sizes
-          - pricing_options array with pricing_option_id, model, rate, currency
-            (when include_pricing=true and account provided)
+          - pricing_options array with pricing_option_id, model, rate, currency —
+            only when your agent bills through AdCP and include_pricing=true with
+            an account provided. Agents that bill out of band omit this field.
 
         sample_request:
           account:
@@ -148,13 +163,7 @@ phases:
             correlation_id: "creative_ad_server--list_creatives"
         validations:
           - check: response_schema
-            description: "Response matches list-creatives-response.json schema"
-          - check: field_present
-            path: "creatives[0].pricing_options"
-            description: "First creative includes pricing_options from account rate card"
-          - check: field_present
-            path: "creatives[0].pricing_options[0].pricing_option_id"
-            description: "Pricing option includes pricing_option_id for billing reference"
+            description: "Response matches list-creatives-response.json schema. Validates pricing_options shape when present; absence is conformant for agents that bill out of band."
 
           - check: field_present
             path: "context"
@@ -188,10 +197,10 @@ phases:
       combination, passing the creative_id, account, and the context needed to
       generate the right tag.
 
-      When an account is provided, the response includes pricing fields — the
-      pricing_option_id that was applied and the vendor_cost for this build.
-      For CPM-priced creatives, vendor_cost is zero at build time because cost
-      accrues when impressions are served.
+      If your agent bills through AdCP, the response carries pricing_option_id and
+      vendor_cost (zero at build time for CPM — cost accrues on impressions). If
+      your agent bills out of band, omit these fields; the manifest is the
+      required output.
 
     steps:
       - id: build_tag
@@ -204,8 +213,9 @@ phases:
           this might produce an HTML tag for a display placement. The media_buy_id and
           package_id provide the trafficking context.
 
-          The response includes pricing_option_id and vendor_cost so the buyer knows
-          which rate applies and what the build cost (zero for CPM).
+          Agents that bill through AdCP return pricing_option_id and vendor_cost so
+          the buyer knows which rate applies. Agents that bill out of band omit
+          those fields.
         task: build_creative
         schema_ref: "media-buy/build-creative-request.json"
         response_schema_ref: "media-buy/build-creative-response.json"
@@ -217,9 +227,8 @@ phases:
           - An HTML, JavaScript, or VAST asset containing the tag
           - The format_id matching the target format
           - Macro placeholders (CLICK_URL, CACHEBUSTER) if applicable
-          - pricing_option_id from the account's rate card
-          - vendor_cost (0 for CPM — cost accrues at serve time)
-          - currency (ISO 4217)
+          - pricing_option_id, vendor_cost, and currency — only when your agent
+            bills through AdCP. Agents billing out of band omit these fields.
 
         sample_request:
           creative_id: "campaign_hero_video"
@@ -240,9 +249,6 @@ phases:
           - check: field_present
             path: "creative_manifest.assets"
             description: "Output includes a serving tag asset"
-          - check: field_present
-            path: "pricing_option_id"
-            description: "Response includes pricing_option_id"
 
           - check: field_present
             path: "context"
@@ -304,13 +310,13 @@ phases:
   - id: report_billing
     title: "Report usage for billing"
     narrative: |
-      After delivery, the buyer reports creative usage to the ad server for billing
-      reconciliation. Each usage record includes the creative_id and pricing_option_id
-      from the build_creative response, along with impressions served and the computed
-      vendor_cost.
-
-      The ad server validates that the pricing_option_id matches its records. If the
-      IDs don't match, the record is rejected with a descriptive error.
+      After delivery, the buyer reports creative usage to the ad server. The billing
+      path is optional at the specialism level — agents that bill through AdCP
+      accept the record and reconcile against their rate card; agents that bill
+      out of band return accepted: 0 with an entry in the errors array pointing at
+      the offending usage record and a message explaining that billing is handled
+      out of band for this account. response_schema validates the response shape
+      either way.
 
     steps:
       - id: report_usage
@@ -318,8 +324,19 @@ phases:
         narrative: |
           The buyer sends a usage report covering a billing period. Each record
           includes the creative_id, pricing_option_id (from the build_creative
-          response), impressions served, and the computed vendor_cost. The ad server
-          verifies the rate matches its rate card and accepts the record.
+          response — omitted by agents that bill out of band), impressions served,
+          and the computed vendor_cost. The sample_request below is written for
+          the AdCP-billed case; out-of-band agents receive the same request shape
+          and decide the response.
+
+          Agents that bill through AdCP verify the rate and return accepted: 1
+          with empty errors. Agents that bill out of band return accepted: 0 and
+          populate errors with a field pointing at the offending record (e.g.
+          `usage[0].pricing_option_id`) and a human-readable message. Don't
+          fake-accept records you won't bill on — silent acceptance breaks
+          reconciliation for buyers who trust the response. A standard error
+          code for "billing is handled out of band" is not yet defined in the
+          spec; vendor codes are fine today.
         task: report_usage
         schema_ref: "account/report-usage-request.json"
         response_schema_ref: "account/report-usage-response.json"
@@ -327,9 +344,11 @@ phases:
         comply_scenario: creative_flow
         stateful: true
         expected: |
-          Response includes:
-          - accepted count (number of records successfully stored)
-          - errors array (empty if all records pass validation)
+          Return a response matching the report-usage-response.json schema.
+          Agents that bill through AdCP return accepted: 1 and empty errors.
+          Agents that bill out of band return accepted: 0 with an errors entry
+          pointing at the offending record and explaining that billing is
+          handled out of band.
 
         sample_request:
           account:
@@ -354,10 +373,6 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches report-usage-response.json schema"
-          - check: field_value
-            path: "accepted"
-            value: 1
-            description: "One usage record accepted"
 
           - check: field_present
             path: "context"

--- a/static/compliance/source/specialisms/signal-marketplace/index.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/index.yaml
@@ -28,6 +28,12 @@ narrative: |
   activating directly on a DSP (buyer manages targeting) and activating on a sales agent
   (SA handles downstream coordination).
 
+  Pricing is hard-required for signal marketplaces. Signals are rate-carded goods by
+  definition — the value exchange is paying for access to audience data. Unlike creative
+  ad servers (where billing can be handled via out-of-band enterprise contracts), a signal
+  marketplace without pricing_options is either non-commercial or misconfigured; buyers
+  cannot activate without a pricing_option_id to anchor billing.
+
 agent:
   interaction_model: marketplace_catalog
   capabilities:

--- a/static/compliance/source/specialisms/signal-owned/index.yaml
+++ b/static/compliance/source/specialisms/signal-owned/index.yaml
@@ -24,6 +24,11 @@ narrative: |
 
   This storyboard walks through discovery and both activation patterns.
 
+  Pricing is hard-required here for the same reason as signal marketplaces: signals
+  are rate-carded goods. Buyers cannot activate without a pricing_option_id to anchor
+  billing. Agents distributing first-party signals without commercial terms belong on
+  list_authorized_properties or a different specialism, not this one.
+
 agent:
   interaction_model: owned_signals
   capabilities: []


### PR DESCRIPTION
## Summary
- The `creative-ad-server` specialism was hard-asserting `pricing_options` on `list_creatives`, `pricing_option_id` on `build_creative`, and `accepted == 1` on `report_usage`. Those fields are optional per schema — ad servers that bill out of band (flat license, SaaS contract, bundled enterprise contracts; **CM360 is the canonical example**) were failing conformance despite being spec-valid.
- Removed the three hard `field_present` / `field_value` assertions. `response_schema` still catches malformed pricing when it IS present (`vendor-pricing-option.json` requires `pricing_option_id` + valid pricing model + ISO-4217 currency).
- Narratives across the storyboard now explicitly describe the two billing shapes — authors won't re-introduce the hard assertions on the next edit. Specifically calls out that out-of-band agents should return `accepted: 0` with an `errors` entry pointing at the offending record, **not** fake-accept (silent drops break buyer-side reconciliation).
- Documents the signal-specialism asymmetry: `signal-marketplace` and `signal-owned` legitimately keep pricing hard-required — signals are rate-carded goods by definition, and a signal agent without pricing belongs on a different surface. Preempts "why not signals?" from implementers comparing specialisms.

## Why it matters
Conformance was stricter than the spec. An agent builder reading the schema and implementing correctly to it still failed. That's a bug in the test, not a gap in the agent.

## What I audited
- `field_present.*pricing` across all storyboards: only creative-ad-server had the over-assertion. Remaining pricing references in creative-generative are `sample_request` payloads (correct, not assertions).
- Signal specialisms DO hard-require pricing — verified that asymmetry is justified.
- Other business-model-dependent fields (measurement vendors, DCO vars, concept grouping) — no similar over-assertions found.

## Reviewer feedback addressed
- **code-reviewer**: dropped the "or an error-shaped response" clause from the report_usage narrative (`report-usage-response.json` has no error-shaped variant — `accepted` is required). Tightened sample_request guidance.
- **security-reviewer**: acceptable as-is. Shape validation still catches malformed pricing; correlation_id echo still asserted; no prompt-injection / tenancy / idempotency impact.
- **ad-tech-protocol-expert**: ship it. Flagged two worthwhile follow-ups (see below).
- **adtech-product-expert**: ship it. Don't cascade implicit-observation to capabilities where buyers need pre-filtering (measurement, targeting).

## Follow-ups (not in this PR)
- Add `bills_through_adcp` (or similar) to the creative capability block in `get_adcp_capabilities` — gives buyers pre-call discoverability for routing decisions without forcing a declaration on every seller.
- Define a standard error code for "agent does not accept usage records" (today vendor codes are fine; a shared enum would let buyers build deterministic handling).
- Update the S2 training module in `specs/creative-agent-pricing.md` to cover out-of-band billing — otherwise the curriculum will recreate the teach-to-test pattern that was just fixed in conformance.

## Test plan
- [x] `npm run build:compliance` passes
- [x] All 8 storyboard lints pass (scoping, branch-sets, contradictions, context-entity, auth-shape, test-kits, sample-request-schema)
- [x] `npm run test:unit` — 631 tests pass
- [x] `npm run typecheck` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)