### PR TITLE
spec(compliance): wire audience-sync with status.monotonic (adcp-client#782)

### DIFF
--- a/.changeset/wire-audience-sync-status-monotonic.md
+++ b/.changeset/wire-audience-sync-status-monotonic.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Wire the `audience-sync` specialism storyboard (`static/compliance/source/specialisms/audience-sync/index.yaml`) with `invariants: [status.monotonic]`, closing the last gap from [adcp#2829](https://github.com/adcontextprotocol/adcp/pull/2829). `sync_audiences` responses now get the same cross-step lifecycle gating as media-buy, creative, account, si_session, catalog_item, proposal, and creative_approval.
+
+`status.monotonic` was extended to track the audience lifecycle in [adcp-client#782](https://github.com/adcontextprotocol/adcp-client/pull/782), shipped in `@adcp/client@5.11.0`. Bump the repo's `@adcp/client` dep `^5.10.0 → ^5.11.0` to pick up the graph. Transition table is fully bidirectional across `processing / ready / too_small`, matching the "MAY transition" hedging on `audience-status.json`'s prose (landed in [adcp#2836](https://github.com/adcontextprotocol/adcp/pull/2836)).
+
+No wire change. Any seller that was passing the `audience-sync` storyboard on the old `@adcp/client` will continue to pass unless they were emitting an off-graph status transition — which is exactly what the assertion should catch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-rc.3",
       "dependencies": {
-        "@adcp/client": "^5.10.0",
+        "@adcp/client": "^5.11.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-Ts1vf3IlYYNpkEtQvAkIRHUNX9rB30+XyH5XRAyFmCZ8DbxBXkAi4UNYRxnT4LjujouuVpZ4n0x9+tBnP7vJ/Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-UuSHIz9hbmAUQeFwZMBuZGuSIfx5ReJ+a4KUVSAVRb1g4M0rud8+LFpJ91eQZk3012c8ZQZlRS0YR5mVkUAWLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "^5.10.0",
+    "@adcp/client": "^5.11.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -8,6 +8,18 @@ track: audiences
 required_tools:
   - list_accounts
   - sync_audiences
+
+# Cross-step assertion (adcp#2664, extended in adcp-client#782). status.monotonic
+# rejects audience status transitions observed across steps that aren't on
+# the spec lifecycle graph. Audience lifecycle is fully bidirectional across
+# processing / ready / too_small — the graph allows ready ↔ processing on
+# re-sync, ready ↔ too_small as counts cross minimum_size, and the re-sync
+# path too_small → processing → ready. Off-graph regressions (e.g. a seller
+# silently downgrading from ready to an unknown enum value) fail here rather
+# than slipping past per-step schema checks.
+invariants:
+  - status.monotonic
+
 platform_types:
   - display_ad_server
   - social_platform


### PR DESCRIPTION
## Summary

- Wires `audience-sync/index.yaml` with `invariants: [status.monotonic]`, closing the last gap from [adcp#2829](https://github.com/adcontextprotocol/adcp/pull/2829). `sync_audiences` responses now carry the same cross-step lifecycle gating as media_buy, creative, account, si_session, catalog_item, proposal, and creative_approval.
- Bumps `@adcp/client` `^5.10.0 → ^5.11.0` to pick up the audience transition graph added in [adcp-client#782](https://github.com/adcontextprotocol/adcp-client/pull/782).

## How the arc ends

1. [adcp#2829](https://github.com/adcontextprotocol/adcp/pull/2829) wired `status.monotonic` on 20 specialisms; `audience-sync` was skipped (no named enum).
2. [adcp#2836](https://github.com/adcontextprotocol/adcp/pull/2836) extracted `/schemas/enums/audience-status.json` and documented the permissive transitions in prose.
3. [adcp-client#782](https://github.com/adcontextprotocol/adcp-client/pull/782) added `AUDIENCE_TRANSITIONS` to the bundled `status.monotonic` default + extractor for `sync_audiences`. Shipped in `@adcp/client@5.11.0`.
4. **This PR** — the one-line wire-up.

## Transition table

Fully bidirectional across `processing / ready / too_small` — the graph allows `ready ↔ processing` on re-sync, `ready ↔ too_small` as counts cross `minimum_size`, and the re-sync path `too_small → processing → ready`. Off-graph regressions (e.g. seller silently downgrading `ready` to an unknown enum value) fail here rather than slipping past per-step schema checks. `action: deleted | failed` rows omit `status` on the envelope per spec — the extractor's id+status guard makes those silent (absence isn't a transition — [adcp#2838](https://github.com/adcontextprotocol/adcp/issues/2838) tracks the separate seller-initiated-archival gap).

## Test plan

- [x] `npm run build:compliance` — 10 universal, 6 protocols, 24 specialisms bundled, no lint regressions
- [x] Local `run-storyboards --filter audience` against the training agent — `1/1 clean`, zero `status.monotonic` hits
- [x] `package-lock.json` updated to `@adcp/client@5.11.0`
- [ ] CI: storyboard framework + legacy dispatches stay on the baseline floors

## Closes the arc

With this merged, every specialism whose phases exercise a lifecycle-bearing resource is gated by `status.monotonic`. The [#2639 umbrella](https://github.com/adcontextprotocol/adcp/issues/2639) was closed on 2026-04-22; this PR completes the audience-shaped follow-up that was outstanding from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)