### PR TITLE
fix(deps): bump @adcp/client to 5.11.0 for get_rights builder fix (closes #2846)

### DIFF
--- a/.changeset/bump-adcp-client-511-restore-governance-denied-storyboard.md
+++ b/.changeset/bump-adcp-client-511-restore-governance-denied-storyboard.md
@@ -1,0 +1,19 @@
+---
+---
+
+Bump @adcp/client to 5.11.0 to pick up the storyboard runner fix that
+honors `step.sample_request` in the `get_rights` request builder
+(adcontextprotocol/adcp-client#792).
+
+Restores the `brand_rights/governance_denied` scenario (and peer
+brand-rights scenarios) that relied on scenario-specific `query` /
+`uses` / `buyer` fields. With the prior builder, `get_rights` hit
+the wire with a generic fallback and a caller-domain `brand_id`,
+so `rights[0]` was undefined, `$context.rights_id` didn't resolve,
+and `acquire_rights` failed with `rights_not_found` before the
+training agent's existing `GOVERNANCE_DENIED` check could fire.
+
+CI floors rebaselined: legacy 36→43 clean / 295→336 steps,
+framework 21→25 clean / 241→244 steps.
+
+Closes #2846.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -40,21 +40,20 @@ jobs:
             # in the PR description. Rising is fine; regressing fails CI.
             # 35→27 temporarily after @adcp/client 5.6→5.8.1 bump (adcp#2663)
             # surfaced stricter schema checks; recovered to 36 in adcp#2666 by
-            # fixing training-agent fixtures (creative format asset_type/
-            # catalog_type/dimensions.unit), adding required total_budget on
-            # get_media_buys, and tightening validate_property_delivery
-            # response shape.
-            min_clean_storyboards: 36
-            min_passing_steps: 295
+            # fixing training-agent fixtures. Bumped to 43/336 in adcp#2846
+            # after @adcp/client 5.11.0 restored sample_request handling in
+            # the get_rights request builder (brand_rights/governance_denied
+            # and peer scenarios).
+            min_clean_storyboards: 43
+            min_passing_steps: 336
           - mode: framework
             flag_value: '1'
             # Framework path is opt-in and trails legacy until zod parity
             # lands. Gate keeps it from going backwards while we close the gap.
-            # Rebaselined alongside the legacy recovery in adcp#2666: the
-            # training-agent fixture fixes bought back the same 237→241
-            # passing-step delta for the framework path.
-            min_clean_storyboards: 21
-            min_passing_steps: 241
+            # Rebaselined alongside the legacy recovery in adcp#2666.
+            # 25/244 after the @adcp/client 5.11.0 bump in adcp#2846.
+            min_clean_storyboards: 25
+            min_passing_steps: 244
     steps:
       - uses: actions/checkout@v6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0-rc.3",
       "dependencies": {
-        "@adcp/client": "^5.10.0",
+        "@adcp/client": "^5.11.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-Ts1vf3IlYYNpkEtQvAkIRHUNX9rB30+XyH5XRAyFmCZ8DbxBXkAi4UNYRxnT4LjujouuVpZ4n0x9+tBnP7vJ/Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-UuSHIz9hbmAUQeFwZMBuZGuSIfx5ReJ+a4KUVSAVRb1g4M0rud8+LFpJ91eQZk3012c8ZQZlRS0YR5mVkUAWLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "^5.10.0",
+    "@adcp/client": "^5.11.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",


### PR DESCRIPTION
## Summary

- Bumps `@adcp/client` from `^5.10.0` to `^5.11.0` to pick up [adcontextprotocol/adcp-client#792](https://github.com/adcontextprotocol/adcp-client/pull/792), which restored `sample_request` handling in the storyboard runner's `get_rights` builder.
- Rebaselines the training-agent storyboard CI floors to lock in the gains (legacy 36→43 / 295→336, framework 21→25 / 241→244).

## Why

#2846 reported `brand_rights/governance_denied` failing with the wrong error code. Root cause was in the SDK, not the training agent: the `get_rights` builder hardcoded `query` / `uses` and derived `brand_id` from the caller's domain, silently discarding every field the storyboard declared. Rights-holder rosters rejected the caller-domain `brand_id` as unknown — `rights[0]` was undefined, `$context.rights_id` never resolved, and downstream `acquire_rights` failed with `rights_not_found` before the training agent's existing `GOVERNANCE_DENIED` check in `brand-handlers.ts:978` could run.

The training-agent code was already correct. The fix is the SDK bump.

## Test plan

- [x] `brand_rights/governance_denied` storyboard: 4P/1F → 5P/0F
- [x] Full storyboard suite (legacy dispatch): 43/56 clean, 336 passing steps
- [x] Full storyboard suite (framework dispatch): 25/56 clean, 244 passing steps
- [x] CI floors updated to match; regressing fails the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)