### PR TITLE
fix(storyboards): make list_formats_integrity actually send format_ids (closes #2848)

### DIFF
--- a/.changeset/storyboard-list-formats-integrity-context-input.md
+++ b/.changeset/storyboard-list-formats-integrity-context-input.md
@@ -12,8 +12,8 @@ assertion then fails on a coincidence (`display_static` ≠ the captured
 format. The training-agent's filter logic was already correct.
 
 Use the runner's `context_inputs` (applied after the builder) to inject the
-captured `{agent_url, id}` object at `format_ids[0]`. Drop once
-adcontextprotocol/adcp-client#797 ships and we bump the SDK pin.
+captured `{agent_url, id}` object at `format_ids[0]`. Drop once we bump past
+the @adcp/client release that ships adcontextprotocol/adcp-client#789.
 
 Second sub-issue from #2848 (`creative_fate_after_cancellation` sync_creatives
 shape) was already addressed by #2867 / #2850.

--- a/.changeset/storyboard-list-formats-integrity-context-input.md
+++ b/.changeset/storyboard-list-formats-integrity-context-input.md
@@ -1,0 +1,19 @@
+---
+---
+
+fix(storyboards): inject `format_ids[0]` via `context_inputs` in `media_buy_seller / list_formats_integrity` (closes #2848)
+
+The `@adcp/client` (≤5.11) `list_creative_formats` request builder returns `{}`
+and discards the storyboard's `sample_request`, so the `format_ids:
+[$context.product_format_id]` filter never reaches the wire and the seller
+answers with its full format catalog. The `formats[0].format_id` round-trip
+assertion then fails on a coincidence (`display_static` ≠ the captured
+`sponsored_product`) rather than because the seller actually substituted a
+format. The training-agent's filter logic was already correct.
+
+Use the runner's `context_inputs` (applied after the builder) to inject the
+captured `{agent_url, id}` object at `format_ids[0]`. Drop once
+adcontextprotocol/adcp-client#797 ships and we bump the SDK pin.
+
+Second sub-issue from #2848 (`creative_fate_after_cancellation` sync_creatives
+shape) was already addressed by #2867 / #2850.

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -337,6 +337,19 @@ phases:
             - "$context.product_format_id"
           context:
             correlation_id: "media_buy_seller--list_formats_integrity"
+        # The @adcp/client (≤5.11) `list_creative_formats` request builder
+        # returns `{}` and the runner only merges envelope fields
+        # (context/ext/idempotency_key/push_notification_config) from
+        # sample_request — so `format_ids` above never reaches the wire and
+        # the seller answers with its full format catalog. context_inputs
+        # is applied after the builder runs, so this injects the captured
+        # `product_format_id` (the `{agent_url, id}` object from
+        # `products[0].format_ids[0]`) at `format_ids[0]` and lets the
+        # round-trip invariant actually grade. Drop once
+        # adcontextprotocol/adcp-client#797 ships and we bump the SDK pin.
+        context_inputs:
+          - key: product_format_id
+            inject_at: "format_ids[0]"
         validations:
           - check: response_schema
             description: "Response matches list-creative-formats-response.json schema"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -337,16 +337,18 @@ phases:
             - "$context.product_format_id"
           context:
             correlation_id: "media_buy_seller--list_formats_integrity"
-        # The @adcp/client (≤5.11) `list_creative_formats` request builder
-        # returns `{}` and the runner only merges envelope fields
-        # (context/ext/idempotency_key/push_notification_config) from
-        # sample_request — so `format_ids` above never reaches the wire and
-        # the seller answers with its full format catalog. context_inputs
-        # is applied after the builder runs, so this injects the captured
-        # `product_format_id` (the `{agent_url, id}` object from
-        # `products[0].format_ids[0]`) at `format_ids[0]` and lets the
-        # round-trip invariant actually grade. Drop once we bump past the
-        # @adcp/client release that ships adcontextprotocol/adcp-client#789.
+        # The @adcp/client `list_creative_formats` request builder up
+        # through 5.10.0 (the currently-published release) returns `{}`,
+        # and the runner's post-builder merge only forwards envelope
+        # fields (context / ext / idempotency_key /
+        # push_notification_config) from sample_request — so `format_ids`
+        # above never reaches the wire and the seller answers with its
+        # full format catalog. `context_inputs` is applied after the
+        # builder runs, so this injects the captured `product_format_id`
+        # (the `{agent_url, id}` object from `products[0].format_ids[0]`)
+        # at `format_ids[0]` and lets the round-trip invariant actually
+        # grade. Drop once we bump past the @adcp/client release that
+        # ships adcontextprotocol/adcp-client#789.
         context_inputs:
           - key: product_format_id
             inject_at: "format_ids[0]"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -345,8 +345,8 @@ phases:
         # is applied after the builder runs, so this injects the captured
         # `product_format_id` (the `{agent_url, id}` object from
         # `products[0].format_ids[0]`) at `format_ids[0]` and lets the
-        # round-trip invariant actually grade. Drop once
-        # adcontextprotocol/adcp-client#797 ships and we bump the SDK pin.
+        # round-trip invariant actually grade. Drop once we bump past the
+        # @adcp/client release that ships adcontextprotocol/adcp-client#789.
         context_inputs:
           - key: product_format_id
             inject_at: "format_ids[0]"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -283,6 +283,32 @@
 #     reader — the capture declared a contract that the response did not meet.
 #   - The accumulator is storyboard-run-scoped; values do not leak across runs.
 #
+# context_inputs: array of ContextInput objects (optional — inject captured
+#   context values into the request at a specific path AFTER the request
+#   builder runs). Each entry:
+#     - key: string (the context variable name populated by a prior
+#            `context_outputs` capture)
+#       inject_at: string (JSON path inside the request to write to,
+#                  e.g. "format_ids[0]", "filters.creative_ids[0]")
+#   When to use:
+#   - The default substitution path is `$context.<name>` placeholders inside
+#     `sample_request:`. Prefer that path — the request body is honest about
+#     what the agent will receive.
+#   - `context_inputs` exists as a documented escape hatch for the case where
+#     the @adcp/client per-task request builder strips body fields from
+#     `sample_request` and the runner only forwards envelope fields
+#     (`context`, `ext`, `idempotency_key`, `push_notification_config`). In
+#     that case `$context.<name>` placeholders inside body fields never
+#     reach the wire and the storyboard grades on whatever the builder's
+#     fallback shape happens to be. `context_inputs` is applied after the
+#     builder, so it round-trips the captured value to the wire.
+#   - Document the workaround inline. Each `context_inputs` entry is a
+#     temporary bridge until the upstream builder is fixed; the comment
+#     should name the SDK gap and the upstream issue. See
+#     `static/compliance/source/protocols/media-buy/index.yaml`
+#     (`list_formats_integrity` step) for a worked example tied to
+#     adcontextprotocol/adcp-client#797.
+#
 # validations: array of Validation objects (optional)
 #
 # --- Phase (optional fields for conditional execution) ---

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -222,6 +222,11 @@
 # stateful: boolean (does this step depend on state from a previous step?)
 #
 # sample_request: object (optional — example request payload for this step)
+#   Placeholders: `$context.<name>` and `{{prior_step.<id>.<field>}}`. See
+#   the "Substitution" section below for the full semantics. For the narrow
+#   case where the SDK's per-task request builder discards a body field
+#   from `sample_request`, use `context_inputs:` (above) as the
+#   post-builder injection path.
 # sample_response: object (optional — example expected response; also surfaces in published docs)
 #
 # auth: "none" | object (optional — overrides the transport's default credentials for this step)
@@ -284,30 +289,51 @@
 #   - The accumulator is storyboard-run-scoped; values do not leak across runs.
 #
 # context_inputs: array of ContextInput objects (optional — inject captured
-#   context values into the request at a specific path AFTER the request
-#   builder runs). Each entry:
-#     - key: string (the context variable name populated by a prior
-#            `context_outputs` capture)
-#       inject_at: string (JSON path inside the request to write to,
-#                  e.g. "format_ids[0]", "filters.creative_ids[0]")
-#   When to use:
-#   - The default substitution path is `$context.<name>` placeholders inside
-#     `sample_request:`. Prefer that path — the request body is honest about
-#     what the agent will receive.
-#   - `context_inputs` exists as a documented escape hatch for the case where
-#     the @adcp/client per-task request builder strips body fields from
-#     `sample_request` and the runner only forwards envelope fields
-#     (`context`, `ext`, `idempotency_key`, `push_notification_config`). In
-#     that case `$context.<name>` placeholders inside body fields never
-#     reach the wire and the storyboard grades on whatever the builder's
-#     fallback shape happens to be. `context_inputs` is applied after the
-#     builder, so it round-trips the captured value to the wire.
-#   - Document the workaround inline. Each `context_inputs` entry is a
-#     temporary bridge until the upstream builder is fixed; the comment
-#     should name the SDK gap and the upstream PR. See
-#     `static/compliance/source/protocols/media-buy/index.yaml`
-#     (`list_formats_integrity` step) for a worked example tied to
-#     adcontextprotocol/adcp-client#789.
+#   context values into the request at a specific path AFTER the per-task
+#   request builder runs).
+#
+#   Shape:
+#     context_inputs:
+#       - key: product_format_id        # name populated by a prior context_outputs capture
+#         inject_at: "format_ids[0]"    # JSON path inside the request body
+#
+#   Do NOT use `context_inputs` unless `$context.<name>` inside
+#   `sample_request:` has been tried and verified not to reach the wire.
+#   The default substitution path is `$context.<name>` placeholders inside
+#   `sample_request:` — keep the request body honest about what the agent
+#   will receive. Reasons the default is preferred:
+#   - The published sample_response/sample_request pair is what seller
+#     engineers read to implement against the storyboard; anything the
+#     runner injects out-of-band is invisible there.
+#   - `$context.<name>` produces a pointed `unresolved_substitution` failure
+#     when the referenced capture is missing. `context_inputs` is
+#     silently a no-op on a missing `key` (runner:
+#     `if (input.key in context) setPath(...)`) — a typo in `key` or a
+#     failed capture produces an empty field rather than a loud error.
+#
+#   Legitimate uses:
+#   - The @adcp/client per-task request builder for a given tool discards
+#     body fields from `sample_request` (the runner's post-builder merge
+#     only forwards envelope fields: `context`, `ext`, `idempotency_key`,
+#     `push_notification_config`). The observable symptom is that the
+#     agent answers with an unfiltered/default result and a round-trip
+#     or substitution-observer validation grades on fabricated state.
+#     `context_inputs` runs AFTER the builder, so it round-trips the
+#     captured value to the wire regardless.
+#   - Dependency-aware multi-instance dispatch, where the runner needs to
+#     route a step to a specific replica URL derived from a prior step's
+#     response (not applicable to single-instance storyboards).
+#
+#   Value types are preserved. The captured value is written to `inject_at`
+#   as-is — object and numeric captures are NOT stringified, matching the
+#   `$context.<name>` behavior described below.
+#
+#   Document every SDK-gap-workaround entry inline. The comment MUST name
+#   the SDK version that carries the gap and the upstream PR that closes
+#   it, so the entry can be removed when we bump past that release. See
+#   `static/compliance/source/protocols/media-buy/index.yaml`
+#   (`list_formats_integrity` step) for a worked example tied to
+#   adcontextprotocol/adcp-client#789.
 #
 # validations: array of Validation objects (optional)
 #
@@ -926,6 +952,13 @@
 #   - Captured values are typed as the JSON path resolved against the response;
 #     numeric and object captures are preserved (they do not round-trip through
 #     string coercion).
+#   - When the per-task request builder discards body fields and
+#     `$context.<name>` inside `sample_request` never reaches the wire (the
+#     observable symptom is the agent answering with an unfiltered result
+#     and the round-trip assertion grading on fabricated state), use
+#     `context_inputs:` as the post-builder injection path. See the
+#     `context_inputs:` field definition above for the full semantics and
+#     when it is acceptable to reach for.
 #
 # --- Context echo contract (agent-facing) ---
 #

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -304,10 +304,10 @@
 #     builder, so it round-trips the captured value to the wire.
 #   - Document the workaround inline. Each `context_inputs` entry is a
 #     temporary bridge until the upstream builder is fixed; the comment
-#     should name the SDK gap and the upstream issue. See
+#     should name the SDK gap and the upstream PR. See
 #     `static/compliance/source/protocols/media-buy/index.yaml`
 #     (`list_formats_integrity` step) for a worked example tied to
-#     adcontextprotocol/adcp-client#797.
+#     adcontextprotocol/adcp-client#789.
 #
 # validations: array of Validation objects (optional)
 #


### PR DESCRIPTION
## Summary
- The `media_buy_seller / list_formats_integrity` storyboard step asserts the seller round-trips a `format_id` filter verbatim, but the assertion was failing because the filter never reached the wire — the `@adcp/client` (≤5.11) `list_creative_formats` request builder returns `{}` and only envelope fields (`context`, `ext`, `idempotency_key`, `push_notification_config`) survive the runner's merge. The seller responded with its full unfiltered catalog and `formats[0].format_id` happened to be `display_static` ≠ the captured `sponsored_product`. Training-agent filter logic was already correct.
- Use the runner's `context_inputs` (applied after the builder runs) to inject the captured `{agent_url, id}` object at `format_ids[0]`. This is the documented escape hatch for "builder strips body fields"; first in-repo use, so the storyboard schema doc gets a corresponding `context_inputs` block tied to adcontextprotocol/adcp-client#797.
- Second sub-issue from #2848 (`creative_fate_after_cancellation` sync_creatives shape) was already fixed by #2867 / #2850.

## Test plan
- [x] `npm run build:compliance` — clean
- [x] `npm run typecheck` — clean
- [x] All storyboard lints (`scoping`, `branch-sets`, `contradictions`, `context-entity`, `auth-shape`, `test-kits`, `sample-request-schema`) — pass
- [x] `ADCP_COMPLIANCE_DIR=dist/compliance/latest run-storyboards.ts --filter media_buy_seller` (legacy dispatch) — 14/14 clean, 73 passed
- [x] `TRAINING_AGENT_USE_FRAMEWORK=1 ADCP_COMPLIANCE_DIR=… run-storyboards.ts --filter media_buy_seller` — `list_formats_integrity` now passes; remaining failures on framework path are pre-existing session-state issues unrelated to #2848.

## Follow-up
- Drop `context_inputs` and rely on `sample_request.format_ids` once adcontextprotocol/adcp-client#797 ships and we bump the SDK pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)