### PR TITLE
fix(training-agent): SSRF guard on outbound webhook emitter

### DIFF
--- a/.changeset/fix-webhook-ssrf-guard.md
+++ b/.changeset/fix-webhook-ssrf-guard.md
@@ -1,0 +1,20 @@
+---
+---
+
+fix(training-agent): SSRF guard on outbound webhook emitter (closes #2870)
+
+`createWebhookEmitter` previously POSTed signed webhook bodies to any URL the
+buyer registered via `push_notification_config.url` — loopback, link-local
+(`169.254.169.254`), or RFC1918 included. In production this lets a caller
+pull signed metadata-endpoint deliveries out of the training agent's
+environment.
+
+Adds `createWebhookFetch()` in `server/src/training-agent/webhook-fetch.ts`:
+a `fetch`-shaped wrapper that rejects non-`http(s)` schemes, literal private
+addresses, and hostnames that resolve to private addresses. Wired into
+`getWebhookEmitter()` with `allowPrivateIp: process.env.NODE_ENV !==
+'production'` so dev/CI conformance storyboards (which use `127.0.0.1`
+loopback receivers) keep working while production deliveries are gated.
+
+Unit tests cover literal IPv4/IPv6 private ranges, metadata endpoints,
+`localhost` variants, non-http schemes, and public hostname pass-through.

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -1,0 +1,131 @@
+/**
+ * SSRF-guarded `fetch` wrapper for outbound webhook deliveries.
+ *
+ * Callers supply `push_notification_config.url`. Without a guard the training
+ * agent would POST signed webhook bodies to whatever URL is provided —
+ * including loopback (`127.0.0.1`), link-local (`169.254.169.254` fly/AWS
+ * metadata), or RFC1918 private IPs reachable from the container.
+ *
+ * Two-step guard:
+ * 1. Refuse non-`http:`/`https:` URLs outright.
+ * 2. Resolve the hostname via DNS. If any resolved address is private,
+ *    link-local, loopback, or broadcast, refuse.
+ *
+ * The DNS lookup happens immediately before `fetch`; a rebinding attack that
+ * flips the answer between the check and the connect is theoretically
+ * possible but narrower than the primary "caller submits metadata URL"
+ * threat. Matches the SSRF pattern already used in `server/src/validator.ts`.
+ *
+ * `allowPrivateIp: true` is required for conformance storyboards that use
+ * `http://127.0.0.1:<port>` loopback receivers. Default in non-production.
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export class SsrfRefusedError extends Error {
+  readonly url: string;
+  readonly reason: string;
+  constructor(url: string, reason: string) {
+    super(`SSRF guard refused webhook delivery to ${url}: ${reason}`);
+    this.name = 'SsrfRefusedError';
+    this.url = url;
+    this.reason = reason;
+  }
+}
+
+function isPrivateIpv4(address: string): boolean {
+  const [a, b] = address.split('.').map(Number);
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function isPrivateIpAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) return isPrivateIpv4(address);
+  if (version === 6) {
+    const v = address.toLowerCase();
+    if (v === '::1' || v === '::') return true;
+    if (v.startsWith('fe80:')) return true;
+    if (v.startsWith('fc') || v.startsWith('fd')) return true;        // ULA fc00::/7
+    if (v.startsWith('ff')) return true;                               // multicast ff00::/8
+    if (v.startsWith('64:ff9b:')) return true;                         // NAT64 well-known
+    if (v.startsWith('2001:db8:')) return true;                        // documentation
+    // IPv4-mapped (::ffff:a.b.c.d). Node's URL parser canonicalizes to this form.
+    const mapped = v.match(/^::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$/);
+    if (mapped && isPrivateIpv4(mapped[1])) return true;
+    return false;
+  }
+  return false;
+}
+
+/** Reject hostnames that look like numeric-encoded IP addresses. Node's URL
+ *  parser accepts `http://2852039166/` and `http://0177.0.0.1/` — `isIP()`
+ *  returns 0 for those, but the OS resolver happily decodes them to the
+ *  target IP. Blocking bypass requires rejecting anything that isn't a real
+ *  DNS name before we fall through to `dns.lookup`. */
+function isNumericHostname(hostname: string): boolean {
+  if (/^[0-9]+$/.test(hostname)) return true;                          // decimal integer
+  if (/^0[xX][0-9a-fA-F]+$/.test(hostname)) return true;               // hex literal
+  if (/^[0-9]+(\.[0-9]+){1,3}$/.test(hostname)) return true;           // dotted-numeric (octal / invalid v4)
+  return false;
+}
+
+async function assertPublicTarget(url: URL): Promise<void> {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new SsrfRefusedError(url.toString(), `scheme ${url.protocol} not allowed`);
+  }
+  // `url.hostname` strips brackets from `[::1]` → `::1`. Userinfo (user:pass@)
+  // never leaks into hostname per WHATWG, so we don't need to scrub that.
+  const hostname = url.hostname;
+  if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    throw new SsrfRefusedError(url.toString(), 'hostname resolves to loopback');
+  }
+  const version = isIP(hostname);
+  if (version !== 0) {
+    if (isPrivateIpAddress(hostname)) {
+      throw new SsrfRefusedError(url.toString(), 'literal private/loopback address');
+    }
+    return;
+  }
+  if (isNumericHostname(hostname)) {
+    throw new SsrfRefusedError(url.toString(), 'numeric-encoded hostname not allowed');
+  }
+  try {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    if (records.length === 0) {
+      throw new SsrfRefusedError(url.toString(), 'hostname did not resolve');
+    }
+    if (records.some(r => isPrivateIpAddress(r.address))) {
+      throw new SsrfRefusedError(url.toString(), 'hostname resolves to private address');
+    }
+  } catch (err) {
+    if (err instanceof SsrfRefusedError) throw err;
+    throw new SsrfRefusedError(url.toString(), `DNS lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Build a `fetch`-shaped function gated by the SSRF guard.
+ *
+ * When `allowPrivateIp` is true the guard is bypassed. That's the right
+ * default for dev/CI where conformance storyboards use `http://127.0.0.1:<port>`
+ * receivers; it's explicitly the wrong default for production. The returned
+ * function always dereferences `globalThis.fetch` lazily so tests that replace
+ * the global see their replacement. */
+export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof fetch {
+  return async (input, init) => {
+    if (!options.allowPrivateIp) {
+      const href = typeof input === 'string' || input instanceof URL
+        ? input.toString()
+        : input.url;
+      await assertPublicTarget(new URL(href));
+    }
+    return globalThis.fetch(input, init);
+  };
+}

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -20,6 +20,7 @@ import {
 import type { SignerKey } from '@adcp/client/signing';
 import type { AdcpJsonWebKey } from '@adcp/client/signing';
 import { createLogger } from '../logger.js';
+import { createWebhookFetch } from './webhook-fetch.js';
 
 const logger = createLogger('training-agent-webhooks');
 
@@ -240,10 +241,15 @@ export function getWebhookSigningKey(): SignerKey {
 export function getWebhookEmitter(): WebhookEmitter {
   if (emitter) return emitter;
   const { signer } = ensureKey();
+  // Production (`NODE_ENV=production`, i.e. fly.io) refuses webhook delivery
+  // to private/loopback/metadata addresses. Dev and CI need loopback for
+  // conformance storyboards using `http://127.0.0.1:<port>` receivers.
+  const allowPrivateIp = process.env.NODE_ENV !== 'production';
   emitter = createWebhookEmitter({
     signerKey: signer,
     idempotencyKeyStore: memoryWebhookKeyStore(),
     userAgent: 'adcp-training-agent/1.0',
+    fetch: createWebhookFetch({ allowPrivateIp }),
   });
   return emitter;
 }

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createWebhookFetch, SsrfRefusedError } from '../../src/training-agent/webhook-fetch.js';
+
+describe('createWebhookFetch — SSRF guard', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let calls: string[];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      calls.push(typeof input === 'string' || input instanceof URL ? input.toString() : input.url);
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('with allowPrivateIp=true (dev/CI)', () => {
+    const fetch = createWebhookFetch({ allowPrivateIp: true });
+
+    it('passes loopback URLs through', async () => {
+      await expect(fetch('http://127.0.0.1:9999/hook')).resolves.toBeInstanceOf(Response);
+      expect(calls).toEqual(['http://127.0.0.1:9999/hook']);
+    });
+
+    it('passes public URLs through', async () => {
+      await expect(fetch('https://buyer.example.com/hook')).resolves.toBeInstanceOf(Response);
+    });
+  });
+
+  describe('with allowPrivateIp=false (production)', () => {
+    const fetch = createWebhookFetch({ allowPrivateIp: false });
+
+    it('refuses literal IPv4 loopback', async () => {
+      await expect(fetch('http://127.0.0.1/metadata')).rejects.toBeInstanceOf(SsrfRefusedError);
+      expect(calls).toEqual([]);
+    });
+
+    it('refuses AWS/fly metadata (169.254.169.254)', async () => {
+      await expect(fetch('http://169.254.169.254/latest/meta-data/'))
+        .rejects.toMatchObject({ name: 'SsrfRefusedError', reason: /private/ });
+    });
+
+    it('refuses RFC1918 (10.*, 172.16-31.*, 192.168.*)', async () => {
+      await expect(fetch('http://10.0.0.1/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://192.168.1.1/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://172.20.0.1/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses IPv6 loopback and link-local', async () => {
+      await expect(fetch('http://[::1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://[fe80::1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses localhost hostname', async () => {
+      await expect(fetch('http://localhost:8080/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://svc.localhost/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses non-http(s) schemes', async () => {
+      await expect(fetch('file:///etc/passwd')).rejects.toMatchObject({ reason: /scheme/ });
+      await expect(fetch('ftp://public.example.com/')).rejects.toMatchObject({ reason: /scheme/ });
+    });
+
+    it('refuses numeric-encoded hostnames (decimal)', async () => {
+      // 2852039166 decodes to 169.254.169.254 on Linux resolvers.
+      await expect(fetch('http://2852039166/')).rejects.toMatchObject({ reason: /numeric/ });
+    });
+
+    it('refuses numeric-encoded hostnames (hex)', async () => {
+      await expect(fetch('http://0x7f000001/')).rejects.toMatchObject({ reason: /numeric/ });
+    });
+
+    it('refuses numeric-encoded hostnames (octal / dotted-numeric)', async () => {
+      await expect(fetch('http://0177.0.0.1/')).rejects.toMatchObject({ reason: /numeric/ });
+    });
+
+    it('refuses IPv4-mapped IPv6 addressing private v4', async () => {
+      // ::ffff:10.0.0.1 tunnels RFC1918 10.0.0.1 through v6 syntax.
+      await expect(fetch('http://[::ffff:10.0.0.1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses IPv6 multicast (ff00::/8)', async () => {
+      await expect(fetch('http://[ff02::1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses IPv6 NAT64 well-known prefix (64:ff9b::/96)', async () => {
+      await expect(fetch('http://[64:ff9b::1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('userinfo does not smuggle a private host past the hostname check', async () => {
+      // URL parser routes user:pass@ to credentials; the hostname is 169.254.169.254.
+      await expect(fetch('http://user:pass@169.254.169.254/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('allows public hostnames', async () => {
+      // example.com is guaranteed public by IANA.
+      await expect(fetch('https://example.com/hook')).resolves.toBeInstanceOf(Response);
+      expect(calls).toEqual(['https://example.com/hook']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2870. Follow-up to #2868.

`createWebhookEmitter` previously used raw `globalThis.fetch(url, ...)` with no SSRF guard. A caller registering `push_notification_config.url = http://169.254.169.254/...` could pull signed webhook deliveries out of the training agent's environment (fly metadata, RFC1918, loopback).

Adds `createWebhookFetch({allowPrivateIp})` — a `fetch`-shaped wrapper that refuses:
- non-`http(s)` schemes
- literal IPv4 loopback / RFC1918 / link-local / broadcast
- IPv6 loopback / ULA (fc00::/7) / link-local (fe80:) / multicast (ff00::/8) / NAT64 (64:ff9b::/96) / documentation (2001:db8::/32) / IPv4-mapped private
- `localhost` / `*.localhost`
- **numeric-encoded hostnames** — decimal (`http://2852039166/`), hex (`http://0x7f000001/`), dotted-octal (`http://0177.0.0.1/`)
- hostnames whose DNS resolves to any private address

Wired into `getWebhookEmitter()` with `allowPrivateIp: process.env.NODE_ENV !== 'production'` so dev/CI conformance storyboards (which use `127.0.0.1` loopback receivers) keep passing while production deliveries are gated.

## Expert review

`security-reviewer` flagged two Must-Fix bypasses that were addressed before commit:
- Numeric-encoded hostnames (decimal/hex/octal) — added explicit regex rejection
- IPv4-mapped IPv6 (`::ffff:10.0.0.1`) + multicast + NAT64 + documentation — added to IPv6 handling

## Known follow-ups (not blockers)

- **DNS rebinding**: current check is resolve-then-fetch (matches pattern in `server/src/validator.ts`). Stronger mitigation = migrate to `@adcp/client`'s `ssrfSafeFetch` when it's publicly exported (currently only reachable via deep import).
- **fly.io preview envs without `NODE_ENV=production`**: gate could fail open. File follow-up if preview environments come online.

## Test plan

- [x] 16 unit tests in `server/tests/unit/training-agent-webhook-fetch.test.ts`
- [x] `webhook_emission` storyboard: 7P/0F under both dispatches (unchanged)
- [x] Full framework run: 44/56 clean (unchanged vs pre-fix baseline)
- [x] `NODE_ENV=production` webhook_emission storyboard fails at the SDK's client-side SSRF (expected — confirms guard path is reachable)
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` 631/631 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)