### PR TITLE
fix(training-agent): declare account/brand on governance tools (closes #2845)

### DIFF
--- a/.changeset/fix-governance-session-keying.md
+++ b/.changeset/fix-governance-session-keying.md
@@ -1,0 +1,22 @@
+---
+---
+
+fix(training-agent): declare `account`/`brand` on governance tools so session keying holds across calls (closes #2845)
+
+The `@adcp/client` storyboard runner strips request fields the server's
+`tools/list` inputSchema does not declare. `check_governance`,
+`report_plan_outcome`, and `get_plan_audit_logs` omitted top-level `account`
+and `brand`, so those fields were stripped and `sessionKeyFromArgs` fell back
+to `open:default` — a different session from the `open:<brand.domain>` where
+`sync_plans` had stored the plan. Result: governance lookups returned
+`Plan not found` mid-flow, and the three governance storyboards
+(`media_buy_governance_escalation`, `governance_spend_authority`,
+`governance_delivery_monitor`) failed their cross-step assertions.
+
+Also adds a `create_media_buy` step to the `governance_delivery_monitor`
+storyboard source so `get_media_buy_delivery` operates on a real
+`media_buy_id` captured in context rather than the runner's `'unknown'`
+fallback. The storyboard-source edit takes effect once `@adcp/client`
+republishes its compliance cache; the inputSchema fix in
+`governance-handlers.ts` lands immediately and unblocks the escalation and
+spend-authority storyboards in CI.

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -352,6 +352,8 @@ export const GOVERNANCE_TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: { type: 'object', description: 'Account reference identifying the tenant.' },
+        brand: { type: 'object', description: 'Top-level brand reference identifying the tenant.' },
         plan_id: { type: 'string' },
         caller: { type: 'string', format: 'uri' },
         purchase_type: { type: 'string', enum: ['media_buy', 'rights_license', 'signal_activation', 'creative_services'], description: 'Type of financial commitment. Defaults to media_buy.' },
@@ -377,6 +379,8 @@ export const GOVERNANCE_TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: { type: 'object', description: 'Account reference identifying the tenant.' },
+        brand: { type: 'object', description: 'Top-level brand reference identifying the tenant.' },
         plan_id: { type: 'string' },
         check_id: { type: 'string' },
         governance_context: { type: 'string', description: 'Opaque governance context from the check_governance response that authorized this action.' },
@@ -397,6 +401,8 @@ export const GOVERNANCE_TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        account: { type: 'object', description: 'Account reference identifying the tenant.' },
+        brand: { type: 'object', description: 'Top-level brand reference identifying the tenant.' },
         plan_id: { type: 'string', description: 'Single plan ID (convenience alias for plan_ids)' },
         plan_ids: { type: 'array', items: { type: 'string' }, minItems: 1 },
         portfolio_plan_ids: { type: 'array', items: { type: 'string' } },

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4446,6 +4446,75 @@ describe('get_adcp_capabilities handler', () => {
   });
 });
 
+// ── Governance: tool inputSchema (#2845) ───────────────────────────
+//
+// The @adcp/client storyboard runner strips request fields the server's
+// inputSchema does not declare. Governance handlers use account.brand.domain
+// and brand.domain for session keying (see state.ts::sessionKeyFromArgs), so
+// these fields must appear in the declared schema — otherwise sync_plans and
+// check_governance land in different sessions and the plan lookup returns
+// "Plan not found".
+
+describe('governance tools expose session-key fields in inputSchema', () => {
+  const server = createTrainingAgentServer(DEFAULT_CTX);
+  const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
+  const listHandler = requestHandlers.get('tools/list')!;
+
+  it.each(['check_governance', 'report_plan_outcome', 'get_plan_audit_logs'])(
+    '%s declares account and brand at the top level',
+    async (toolName) => {
+      const response = await listHandler({ method: 'tools/list', params: {} }, {}) as {
+        tools: Array<{ name: string; inputSchema: { properties?: Record<string, unknown> } }>;
+      };
+      const tool = response.tools.find((t) => t.name === toolName);
+      expect(tool, `${toolName} not registered`).toBeDefined();
+      const props = tool!.inputSchema.properties ?? {};
+      expect(props, `${toolName} missing 'account' property`).toHaveProperty('account');
+      expect(props, `${toolName} missing 'brand' property`).toHaveProperty('brand');
+    },
+  );
+});
+
+// Cross-tool session keying contract: a plan synced under one brand.domain MUST
+// be visible to a subsequent check_governance call carrying the same tenant.
+// The storyboard runner injects `account` at the top level on every step, so
+// this is what "sync_plans ... check_governance" looks like in a real flow.
+describe('governance tools share session via account.brand.domain', () => {
+  beforeEach(() => {
+    invalidateCache();
+    clearSessions();
+  });
+
+  afterEach(() => {
+    clearSessions();
+  });
+
+  it('check_governance finds a plan synced with the same brand.domain', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const tenant = { account: { brand: { domain: 'acme.example' } } };
+
+    await simulateCallTool(server, 'sync_plans', {
+      ...tenant,
+      plans: [{
+        plan_id: 'plan-session-key',
+        brand: { domain: 'acme.example' },
+        objectives: 'verify session sharing across governance tools',
+        budget: { total: 100000, currency: 'USD', reallocation_threshold: 100000 },
+        flight: { start: '2027-01-01T00:00:00Z', end: '2027-12-31T23:59:59Z' },
+      }],
+    });
+
+    const { result } = await simulateCallTool(server, 'check_governance', {
+      ...tenant,
+      plan_id: 'plan-session-key',
+      caller: 'https://buyer.example',
+    });
+
+    expect(result.status).toBe('approved');
+    expect(result.findings).toBeUndefined();
+  });
+});
+
 // ── Governance: seller compliance ──────────────────────────────────
 
 describe('check_governance seller compliance', () => {

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -237,6 +237,70 @@ phases:
             path: "context.correlation_id"
             value: "governance_delivery_monitor--check_governance_approved"
             description: "Context correlation_id returned unchanged"
+  - id: create_buy
+    title: "Create media buy under governance approval"
+    narrative: |
+      With governance approved, the buyer creates the media buy. The seller confirms
+      and returns a media_buy_id the buyer will use to pull delivery metrics as the
+      campaign runs.
+
+    steps:
+      - id: create_media_buy
+        title: "Create a media buy"
+        narrative: |
+          The buyer creates the media buy with the governance_context from the approved
+          check. The seller confirms and returns a media_buy_id that subsequent delivery
+          monitoring steps reference.
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: governance_delivery_monitor
+        stateful: true
+        expected: |
+          Confirm the media buy:
+          - media_buy_id: platform-assigned identifier
+          - status: active
+          - packages: confirmed line items
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          brand:
+            domain: "acmeoutdoor.example"
+          governance_context: "gov_ctx_acme_delivery_approved"
+          start_time: "2026-04-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "sports_ctv_q2"
+              budget: 20000
+              pricing_option_id: "cpm_guaranteed"
+            - product_id: "outdoor_video_q2"
+              budget: 20000
+              pricing_option_id: "cpm_standard"
+
+          idempotency_key: "$generate:uuid_v4#governance_delivery_monitor_create_buy_create_media_buy"
+          context:
+            correlation_id: "governance_delivery_monitor--create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Response contains a media_buy_id for delivery monitoring"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "governance_delivery_monitor--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery metrics show budget drift"
     narrative: |
@@ -268,7 +332,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           media_buy_ids:
-            - "mb_acme_q2_2026"
+            - "$context.media_buy_id"
           include_package_daily_breakdown: true
 
           context:


### PR DESCRIPTION
## Summary

- Governance tool `inputSchema`s (`check_governance`, `report_plan_outcome`, `get_plan_audit_logs`) now declare top-level `account` and `brand`, so `@adcp/client`'s runner stops stripping them before send. That fixes the cross-step session-keying bug where governance lookups returned `Plan not found` mid-flow because the call landed in `open:default` instead of the `open:<brand.domain>` session where `sync_plans` had stored the plan.
- Adds a `create_media_buy` step to the `governance_delivery_monitor` storyboard source so `get_media_buy_delivery` runs against a real `media_buy_id` captured in context rather than the runner's `'unknown'` fallback (runner ignores `sample_request` for `get_media_buy_delivery` — see `@adcp/client`'s `testing/storyboard/request-builder.js`). The storyboard-source edit takes effect once `@adcp/client` republishes its compliance cache; the `inputSchema` fix lands immediately and unblocks the escalation + spend-authority storyboards in CI.
- Adds unit + integration tests covering both the schema surface and the cross-tool session-sharing contract.

## Test plan
- [x] `npx vitest run server/tests/unit/training-agent.test.ts` — 344 passing
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` (precommit) — 631 passing
- [x] Manual storyboard runs against `dist/compliance/latest` (via `ADCP_COMPLIANCE_DIR`):
  - `media_buy_governance_escalation`: **overall_passed = True**
  - `governance_spend_authority`: **overall_passed = True**
  - `governance_delivery_monitor`: **overall_passed = True**
- [x] Storyboard lint tests still green (`test:storyboard-sample-request-schema`, `test:storyboard-branch-sets`, `test:storyboard-contradictions`)

## Reviewers
- code-reviewer: clean, minor tightenings applied (description wording, integration test added)
- security-reviewer: clean. Fix is a correctness change, not a privilege expansion — `sessionKeyFromArgs` already read these fields when present; the schema change only stops client-side stripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)