### PR TITLE
fix(training-agent): presence-gated signing on sandbox /mcp (signed-requests vector 011)

### DIFF
--- a/.changeset/fix-signed-requests-vector-011-sandbox.md
+++ b/.changeset/fix-signed-requests-vector-011-sandbox.md
@@ -1,0 +1,26 @@
+---
+---
+
+Training agent: close signed-requests vector 011 on the sandbox `/mcp`
+route.
+
+Vector 011 (`negative/011-malformed-header.json`) sends a syntactically
+invalid `Signature-Input` header and requires the verifier to fail closed
+with `request_signature_header_malformed`. The sandbox route previously
+composed `anyOf(bearerAuth, signing)`, which caught the parser error and
+silently fell through to bearer — the exact downgrade the spec pre-check
+was written to prevent.
+
+Fix: swap the composition to
+`requireSignatureWhenPresent(signing, bearerAuth)` (shipped in
+`@adcp/client` 5.7, `src/lib/server/auth-signature.ts:314`). Callers with
+no `Signature-Input` header still fall through to bearer unchanged
+(sandbox AAO API keys keep working); callers that DO present a signature
+header now run the signing authenticator as the sole path and malformed
+headers 401 with the correct error code.
+
+Unrelated to the webhook-auth downgrade rule, which remains enforced
+only on `/mcp-strict` per `security.mdx#webhook-callbacks`.
+
+Added integration coverage in `training-agent-strict.test.ts` for the
+vector-011 shape (malformed Signature-Input + valid bearer → 401).

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -17,6 +17,7 @@ import {
   extractBearerToken,
   respondUnauthorized,
   requireAuthenticatedOrSigned,
+  requireSignatureWhenPresent,
   signatureErrorCodeFromCause,
   AuthError,
   type Authenticator,
@@ -127,23 +128,25 @@ function lazySigningAuth(): Authenticator {
 }
 
 /**
- * Default `/mcp` route: bearer OR valid signature. Unsigned bearer callers
- * pass through verifyApiKey; signed requests compose via anyOf. Present-but-
- * invalid signatures fall through to bearer (a known gap — closed on the
- * strict route, tracked upstream as adcp-client#659).
+ * Default `/mcp` route: presence-gated signature composition. Callers with no
+ * `Signature-Input` header fall through to bearer auth (sandbox backward
+ * compat — unsigned AAO API keys keep working). Callers that DO present a
+ * signature header MUST produce a valid one: malformed/invalid signatures
+ * fail closed with the signing-layer error code instead of silently
+ * downgrading to bearer. Closes signed-requests vector 011
+ * (`request_signature_header_malformed`) on the sandbox endpoint.
  *
  * The webhook-auth downgrade-resistance rule (security.mdx#webhook-callbacks)
  * is enforced only on `/mcp-strict`. The sandbox `/mcp` route accepts
  * unsigned `push_notification_config.authentication` for backward compat
  * with pre-3.0 storyboards that wire legacy HMAC-SHA256 webhooks over
- * bearer-auth'd `create_media_buy`. Updating those storyboards to
- * 9421-sign the registration is tracked separately; the grader-facing
- * strict route already matches the spec.
+ * bearer-auth'd `create_media_buy`. Presence-gating is orthogonal to that
+ * — it only changes behavior when a caller DOES present a signature header.
  */
 function buildDefaultAuthenticator(): Authenticator | null {
   const bearerAuth = buildBearerAuthenticator();
   if (!bearerAuth) return null;
-  return anyOf(bearerAuth, lazySigningAuth());
+  return requireSignatureWhenPresent(lazySigningAuth(), bearerAuth);
 }
 
 /**

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -125,6 +125,34 @@ describe('Training Agent /mcp-strict route', () => {
       expect(res.status).not.toBe(401);
     });
 
+    // signed-requests vector 011 (negative/011-malformed-header): a syntactically
+    // invalid Signature-Input header MUST fail closed even when a valid bearer
+    // is present. Silent fallthrough to bearer would be the exact downgrade
+    // attack the RFC 9421 verifier-checklist pre-check exists to prevent.
+    it('malformed Signature-Input on /mcp rejects despite valid bearer (vector 011)', async () => {
+      const res = await request(app)
+        .post('/api/training-agent/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set('Authorization', AUTH)
+        .set('Signature-Input', 'this-is-not-a-valid-rfc-9421-signature-input')
+        .set('Signature', 'sig1=:AAAA:')
+        .send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'get_products',
+            arguments: {
+              account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },
+              brand: { domain: 'strict-test.example.com' },
+              buying_mode: 'wholesale',
+            },
+          },
+        });
+      expect(res.status).toBe(401);
+    });
+
     it('unsigned get_products on /mcp-strict is allowed (not in required_for)', async () => {
       const res = await callTool(app, '/mcp-strict', 'get_products', {
         account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },


### PR DESCRIPTION
## Summary

Closes signed-requests vector 011 (`negative/011-malformed-header.json`) on the public sandbox `/mcp` route.

The spec pre-check requires the verifier to fail closed with `request_signature_header_malformed` when a caller presents a syntactically invalid `Signature-Input` header — silent fallback to bearer authentication is the exact downgrade the rule was written to prevent.

The prior composition was `anyOf(bearerAuth, signing)`, which caught the signing authenticator's throw and tried bearer next. A valid bearer then accepted the request — malformed signature silently downgraded.

Swap to `requireSignatureWhenPresent(signing, bearerAuth)` (shipped upstream in `@adcp/client` 5.7, `src/lib/server/auth-signature.ts:314`). Unsigned callers still fall through to bearer unchanged (sandbox AAO keys keep working). Callers that DO present a `Signature-Input` header now run the signing authenticator as the only path — malformed headers 401 with the correct signing-layer error code.

Unrelated to the webhook-auth downgrade rule, which is enforced only on `/mcp-strict` per `security.mdx#webhook-callbacks`.

## Test plan
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] Added integration case in `training-agent-strict.test.ts`: malformed `Signature-Input` + valid bearer on `/mcp` → 401
- [x] Existing `/mcp` bearer-fallthrough test still passes (unsigned create_media_buy accepted)
- [ ] storyboards (legacy + framework dispatch) in CI

## Notes
- Pre-existing flake noticed: `unsigned create_media_buy on /mcp-strict returns 401 request_signature_required` fails on clean `main` too (returns 200). Not caused by this PR — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)