### PR TITLE
chore(release): strip non-protocol changeset bumps before 3.0 GA

### DIFF
--- a/.changeset/403fda3d22b05cdb.md
+++ b/.changeset/403fda3d22b05cdb.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Guard against missing brand_domain_aliases table in sweep job and undefined domain in WorkOS verification_failed webhook

--- a/.changeset/addie-event-attendees.md
+++ b/.changeset/addie-event-attendees.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add list_event_attendees tool so any member can see who's coming to an event

--- a/.changeset/archive-route-fix.md
+++ b/.changeset/archive-route-fix.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix digest archive route ordering to prevent param collision

--- a/.changeset/digest-content-fixes.md
+++ b/.changeset/digest-content-fixes.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix digest content hierarchy, dedup articles, inclusive tone

--- a/.changeset/digest-dedup-wg-fix.md
+++ b/.changeset/digest-dedup-wg-fix.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix article dedup by root domain and WG summaries showing descriptions

--- a/.changeset/digest-prod-fixes.md
+++ b/.changeset/digest-prod-fixes.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix digest editor note newlines, paid members only, biweekly lookback, legacy draft handling

--- a/.changeset/drop-jest-for-vitest.md
+++ b/.changeset/drop-jest-for-vitest.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Improve error diagnostics and migrate test runner from Jest to Vitest

--- a/.changeset/drop-redundant-assertion-modules.md
+++ b/.changeset/drop-redundant-assertion-modules.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Delete `server/src/compliance/assertions/` now that `@adcp/client@5.9.1` ships a widened `context.no_secret_echo` default (adcp-client#752/#753) that walks the whole response body, matches suspect property names at any depth, and extracts secrets from structured `auth` objects. The local override #2771 added as a stricter stand-in while upstream was a no-op for structured auth is no longer pulling any weight.

--- a/.changeset/event-tools-for-all.md
+++ b/.changeset/event-tools-for-all.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Give all authenticated users access to read-only event tools (list events, get details, register interest). Admin event tools remain gated. Fix dashboard upcoming events to match by email for Luma-synced registrations. Map Luma pending_approval to waitlisted. Sync Luma hosts as registered attendees.

--- a/.changeset/fix-billing-errors.md
+++ b/.changeset/fix-billing-errors.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix SQL parameter indexing bug in send_payment_request and improve billing lookup key error messages

--- a/.changeset/fix-dollar-sign-math.md
+++ b/.changeset/fix-dollar-sign-math.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 fix: escape dollar signs in docs to prevent LaTeX math rendering

--- a/.changeset/fix-membership-route.md
+++ b/.changeset/fix-membership-route.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add missing route handler for /dashboard-membership to fix "Cannot GET" errors

--- a/.changeset/legal-pumas-smell.md
+++ b/.changeset/legal-pumas-smell.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Event recaps: TipTap editor, public display with YouTube embed, newsletter integration, Slack nudges, member hub events.

--- a/.changeset/major-zebras-go.md
+++ b/.changeset/major-zebras-go.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Luma reverse sync: auto-import events from Luma calendar, Zoom attendee CSV import, webhook handling for all Luma actions.

--- a/.changeset/newsletter-admin-v2.md
+++ b/.changeset/newsletter-admin-v2.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": minor
 ---
 
 Unify newsletter admin with cherry-pick content model

--- a/.changeset/oauth-dashboard-connect.md
+++ b/.changeset/oauth-dashboard-connect.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Wire existing OAuth flow to agent dashboard UI. Members can now authorize agents via OAuth instead of manually pasting tokens. Adds auth-status endpoint and OAuth-first connect form.

--- a/.changeset/org-dashboard-redesign.md
+++ b/.changeset/org-dashboard-redesign.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Redesign organization dashboard: split into sidebar-navigated pages (Overview, Team, Agents), restore journey stepper with product-usage milestones, add upgrade teasers for all tiers with price reframing, wire team certification summary, show health score weights, and fix nonmember 403 error.

--- a/.changeset/personalized-nudge.md
+++ b/.changeset/personalized-nudge.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Personalized action nudge in newsletter based on recipient profile

--- a/.changeset/primary-email-select.md
+++ b/.changeset/primary-email-select.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Let users select a primary email from linked aliases via PUT /api/me/linked-emails/primary.

--- a/.changeset/regenerate-button.md
+++ b/.changeset/regenerate-button.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add Regenerate button to digest admin editor

--- a/.changeset/strip-nonprotocol-changeset-bumps.md
+++ b/.changeset/strip-nonprotocol-changeset-bumps.md
@@ -1,0 +1,6 @@
+---
+---
+
+Strip `"adcontextprotocol": patch|minor` frontmatter from 22 changesets that describe website, admin, newsletter, digest, Addie, or server-infra work. These were mislabeled as protocol bumps and would have polluted the 3.0.0 stable CHANGELOG with non-protocol entries. Converting to empty changesets preserves the PR trail while keeping them out of the published spec changelog.
+
+Affected: newsletter-admin-v2, oauth-dashboard-connect, org-dashboard-redesign, the-build-admin, regenerate-button, archive-route-fix, digest-content-fixes, digest-dedup-wg-fix, digest-prod-fixes, legal-pumas-smell, personalized-nudge, this-edition-split, major-zebras-go, fix-membership-route, fix-billing-errors, fix-dollar-sign-math, primary-email-select, 403fda3d22b05cdb, drop-jest-for-vitest, addie-event-attendees, event-tools-for-all, drop-redundant-assertion-modules.

--- a/.changeset/the-build-admin.md
+++ b/.changeset/the-build-admin.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add The Build admin editor and consolidate newsletter sidebar

--- a/.changeset/this-edition-split.md
+++ b/.changeset/this-edition-split.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Split newsletter into This Edition + Industry Intel sections


### PR DESCRIPTION
## Summary

Audit of the 600+ changesets pending in the [Version Packages release PR](https://github.com/adcontextprotocol/adcp/pull/1844) turned up **22 changesets describing website, admin, newsletter, digest, Addie, or server-infra work that were mislabeled as `"adcontextprotocol": patch|minor`**. Left as-is, they'd appear in the stable 3.0.0 CHANGELOG as if they were protocol changes.

This PR converts them to empty changesets (same pattern as `--empty`) so the PR trail stays intact while they drop out of the published spec changelog.

## Affected changesets

**Newsletter / digest (8):**
- `newsletter-admin-v2` (was: minor — the only non-protocol `minor` in the set)
- `archive-route-fix`, `digest-content-fixes`, `digest-dedup-wg-fix`, `digest-prod-fixes`, `legal-pumas-smell` (event recaps), `personalized-nudge`, `this-edition-split`, `regenerate-button`, `the-build-admin`

**Dashboard / admin UI (3):**
- `oauth-dashboard-connect`, `org-dashboard-redesign`, `fix-membership-route`

**Server / infra (6):**
- `fix-billing-errors`, `fix-dollar-sign-math` (docs LaTeX escape), `primary-email-select`, `403fda3d22b05cdb` (WorkOS guard), `drop-jest-for-vitest`, `drop-redundant-assertion-modules`

**Event sync / Addie (3):**
- `major-zebras-go` (Luma sync), `event-tools-for-all` (dashboard event tools), `addie-event-attendees`

## Kept as protocol bumps

- `wise-moments-clap` (minor): real protocol change — splits `pending_activation` into `pending_creatives`/`pending_start`. Kept even though the same changeset bundles a Postgres task store refactor.

## Why this matters

3.0.0 is the first stable AdCP release. The CHANGELOG gets referenced by implementers, partners, and conformance tooling — it should list protocol schema/task changes, not admin UI tweaks and digest editor fixes.

## Test plan

- [x] `git diff --stat` shows only single-line frontmatter deletes on each file
- [x] Precommit `npm run test:unit && npm run typecheck` passed
- [ ] After merge, confirm the [Version Packages PR #1844](https://github.com/adcontextprotocol/adcp/pull/1844) regenerates with these entries absent from the 3.0.0 CHANGELOG
- [ ] Confirm the 22 empty changesets are still consumed (deleted) by the `changeset version` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)