### PR TITLE
docs(governance): replace EHJ page with approved final content (closes #2905)

### DIFF
--- a/.changeset/ehj-page-approved-content.md
+++ b/.changeset/ehj-page-approved-content.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(governance): replace the Embedded Human Judgment page with the approved final content from the governance workstream — a manifesto plus oversight framework covering design principles, domains of human-owned judgment, governance architecture, data protection, decision/escalation framework, protocol vs runtime, and audit. Closes #2905.

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -2,11 +2,11 @@
 title: Embedded human judgment
 sidebarTitle: Embedded human judgment
 "og:image": /images/concepts/three-party-governance.png
-description: "Embedded Human Judgment (EHJ) is a manifesto and oversight framework for keeping humans accountable when AI agents allocate capital, shape information environments, and execute advertising decisions at scale."
+description: "Embedded Human Judgment (EHJ) is a set of principles and an oversight framework for keeping humans accountable when AI agents allocate capital, shape information environments, and execute advertising decisions at scale."
 "og:title": "AdCP — Embedded human judgment"
 ---
 
-*A manifesto for agentic advertising accountability — followed by the EHJ oversight framework.*
+*Principles for agentic advertising accountability — followed by the EHJ oversight framework.*
 
 ## The five principles
 

--- a/docs/governance/embedded-human-judgment.mdx
+++ b/docs/governance/embedded-human-judgment.mdx
@@ -2,29 +2,27 @@
 title: Embedded human judgment
 sidebarTitle: Embedded human judgment
 "og:image": /images/concepts/three-party-governance.png
-description: "Embedded Human Judgment (EHJ) defines five principles for keeping humans accountable when AI agents buy media autonomously in AdCP."
+description: "Embedded Human Judgment (EHJ) is a manifesto and oversight framework for keeping humans accountable when AI agents allocate capital, shape information environments, and execute advertising decisions at scale."
 "og:title": "AdCP — Embedded human judgment"
 ---
 
-As AI agents gain autonomy in advertising — discovering inventory, building creatives, spending budgets — the question is not whether to use automation but how to ensure human judgment remains embedded in the system's architecture.
-
-Embedded Human Judgment (EHJ) is AdCP's answer. It is not an after-the-fact review process. It is not a temporary safety phase while AI "matures." It is a permanent design constraint for accountable systems.
-
-<Note>
-**On register.** This page specifies *where* humans belong in the loop — which classes of decisions require human judgment — not *how* operators implement that judgment. AdCP uses a principles register here rather than RFC 2119 MUST/SHOULD because the enforceable surface is elsewhere: [`check_governance`](/docs/governance/campaign/tasks/check_governance) MUST be invoked on every spend-commit when a governance agent is configured on the plan (and sellers MUST reject any spend-commit lacking a valid `governance_context` token), `conditions` or `denied` MUST escalate, `TERMS_REJECTED` MUST route to human, and lifecycle tasks like [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) MUST be available to authorized humans. Those are where the normative rules live. The principles below tell you *which* decisions those rules must cover; they do not prescribe UI or workflow.
-</Note>
+*A manifesto for agentic advertising accountability — followed by the EHJ oversight framework.*
 
 ## The five principles
 
 ### 1. Humans remain the locus of judgment and accountability
 
-AI systems can analyze, predict, and execute. But responsibility cannot be delegated to software. Any system that allocates capital, shapes information environments, or affects public trust must retain human-owned judgment.
+AI systems can analyze, predict, and execute. But responsibility cannot be delegated to software.
 
-Humans define intent, acceptable risk, and reasonable trade-offs — even when execution is automated. Accountability must remain legible at every stage of automation.
+Any system that allocates capital, shapes information environments, or affects public trust must retain human-owned judgment.
+
+Humans define intent, acceptable risk, and reasonable trade-offs — even when execution is automated. Accountability must remain legible at every stage of automation. Oversight must operate under uncertainty. Human judgment defines what is reasonable, not what is perfect.
 
 ### 2. Automated decisioning without abdication
 
-As we embrace autonomous advertising agents, we need to scale execution without diluting accountability. Automation should:
+As we embrace autonomous advertising agents, we need to scale execution without diluting accountability.
+
+Automation should:
 
 - Scale execution
 - Increase precision in allocation decisions
@@ -35,7 +33,9 @@ But automation must not remove authorship and responsibility for value judgments
 
 ### 3. Optimization is not intelligence
 
-Not all decisions can be reduced to metrics. Certain classes of decisions must remain human-owned by design because they involve:
+Not all decisions can be reduced to metrics.
+
+Certain classes of decisions must remain human-owned by design because they involve:
 
 - Values
 - Strategy
@@ -64,13 +64,51 @@ Speed, scale, and optimization cannot justify:
 - Erosion of judgment
 - Opaque decision chains
 
-The goal is to ensure systems remain governable to avoid loss of legitimacy over time.
+The goal is to ensure they remain governable to avoid loss of legitimacy over time.
 
 ---
 
-## EHJ in AdCP's architecture
+## Humans are the locus of judgment and accountability
 
-EHJ operates at the protocol layer, not inside any individual agent and not at the execution layer. The protocol defines decision boundaries: which decisions require human judgment, when escalation is triggered, what must be logged and explainable. Agents implement their own internal logic and operate autonomously within those boundaries.
+AI agents exist to support, inform, and execute decisions, but they do not replace human ownership where risk tolerance, intent, or values judgments are at stake.
+
+Embedded Human Judgment (EHJ) ensures that certain decisions remain human-owned by design, even as agents automate analysis, optimization, and execution at scale.
+
+This is not an after-the-fact review process. It is about structurally designing accountability into the system.
+
+### EHJ in the AdCP architecture
+
+EHJ operates at the protocol layer, not inside any individual agent and not at the execution layer.
+
+The protocol defines decision boundaries: which decisions require human judgment, when escalation is triggered, and what must be logged and explainable. Agents implement their own internal logic and operate autonomously within those boundaries.
+
+Execution happens continuously and at speed within the structure the protocol defines.
+
+### What EHJ is not
+
+EHJ is not:
+
+- A temporary safety phase while AI "matures"
+- A UI approval system bolted on afterward
+- A mandate for humans to control execution
+- An attempt to eliminate agent autonomy
+
+EHJ is a permanent design constraint for accountable systems.
+
+## Why embedded human judgment matters
+
+Agentic systems will make mistakes. The question is not *if*, but *when* — and how costly.
+
+Key assumptions:
+
+- Agents can be technically correct but strategically wrong
+- Training data never covers all edge cases
+- Novel situations require judgment, not optimization
+- A single bad decision can outweigh years of efficiency gains
+
+EHJ exists to ensure that accountability attaches to intent and risk tolerance, not to the illusion of perfect outcomes.
+
+## Foundational principles
 
 ### Human judgment without human bottlenecks
 
@@ -87,90 +125,364 @@ The goal is not maximum human involvement, but human ownership where it structur
 
 "Human" refers to accountable roles, not individuals:
 
-- **Advertiser decision owners** — brand, budget, ethics
+- **Advertiser and publisher decision owners** — brand, budget, ethics. "Brand" refers to both buyers and sellers of media.
 - **Agency decision owners** — strategy, planning, execution
 - **Platform owners** — compliance, infrastructure
 - **Legal and regulatory authorities**
 
 Some decisions are human-owned permanently, by definition — not because AI is weak, but because accountability must remain human.
 
-## Governance layers
+## Domains of human-owned judgment
+
+EHJ defines decision domains where human ownership is required, even if agents provide analysis and recommendations:
+
+- Budget and capital allocation
+- Distribution and monetization partners
+- Brand suitability and context
+- Creative and messaging
+- Targeting and audience strategy
+- Pacing and performance monitoring
+
+### Budget and capital allocation
+
+**Principle.** Budget deployment beyond defined bounds is a human decision.
+
+Agents may:
+
+- Forecast outcomes
+- Optimize pacing
+- Propose reallocations
+
+Humans must decide when:
+
+- Spend exceeds absolute or relative thresholds
+- Cumulative spend accelerates unexpectedly
+- Pacing materially diverges from intent
+
+Accountability attaches to risk tolerance and intent, not perfect pacing.
+
+### Distribution and monetization partners
+
+**Principle.** New relationships imply new risk. Trusted execution with streamlined oversight is allowed for established, vetted partners.
+
+Human approval is required for:
+
+- First-time publishers or platforms
+- New contracts or personal data-sharing agreements
+- Quality or fraud concerns
+- Cross-border activations of personal data
+
+### Brand suitability and context
+
+**Principle.** Acceptable context and risk tolerance are human-defined.
+
+Humans define:
+
+- What is unacceptable
+- What requires review
+- What level of uncertainty is tolerable
+
+Agents classify and score risk probabilistically based on human-defined judgments. Decisions are tiered:
+
+- **Hard blocks** — always rejected
+- **Probabilistic review** — mandatory human decision
+- **Pre-campaign and post-placement audit** — logged and reviewable
+
+Escalation occurs whenever a reasonable human would want to decide.
+
+### Creative and messaging
+
+**Principle.** Messaging intent and claims remain human-owned.
+
+Trusted execution with streamlined oversight is allowed for:
+
+- Variations within approved templates
+- Localization using approved guidelines
+- DCO within guardrails
+
+Human validation is required for:
+
+- New core messaging
+- Claims with legal or reputational risk
+- Creative tied to current events
+- Assets that feel "technically on-brand but wrong"
+
+EHJ acknowledges that creative outcomes are probabilistic and context-dependent.
+
+### Targeting and audience strategy
+
+**Principle.** Targeting intent and acceptable risk are human-defined.
+
+Agents may optimize within approved strategies. Human review is required for:
+
+- New data sources
+- Sensitive or regulated attributes
+- Material shifts in targeting intent
+- Potentially discriminatory strategies
+
+In these cases, compliance, ethics, and jurisdictional risk override pure performance optimization.
+
+### Pacing and performance monitoring
+
+**Principle.** Significant deviations from expectations require explicit judgment.
+
+Agents must alert, escalate, and proportionally throttle activities when:
+
+- Performance collapses beyond thresholds
+- Fraud signals (IVT, click-fraud, publisher fraud) exceed tolerance
+- Budget exhaustion is imminent
+- Cross-platform metric discrepancies surpass thresholds
+
+Humans decide whether to continue, modify, or terminate. For termination, it would be advisable to include a description as to why.
+
+Not every anomaly is failure — but major deviations from intent must remain human-governed.
+
+## Governance architecture
 
 EHJ operates through a layered governance model that allows policy composition across organizations, brand portfolios, and campaigns.
 
-### Protocol layer
+### Governance layers
 
-Defines universal standards applied across the ecosystem: escalation requirements, confidence scoring rules, regulatory policy registry, minimum audit and logging standards. These rules apply to all participating agents.
+**Protocol layer.** Defines universal standards applied across the ecosystem: escalation requirements, confidence scoring rules, regulatory policy registry, minimum audit and logging standards. These rules apply to all participating agents. The registry is maintained as a shared ecosystem resource — organizations reference standardized policies by ID rather than maintaining independent compliance definitions.
 
-### Corporate governance layer
+**Corporate governance layer.** Large organizations may define corporate-level policies that apply across a brand portfolio: regulatory compliance requirements, global brand safety standards, prohibited targeting categories, data protection policies. Corporate policies act as baseline constraints for all brands within the organization.
 
-Large organizations define corporate-level policies that apply across a brand portfolio: regulatory compliance requirements, global brand safety standards, prohibited targeting categories, data protection policies. Corporate policies act as baseline constraints for all brands within the organization.
+**Brand governance layer.** Individual brands may define additional policies reflecting brand identity, positioning, and risk tolerance. A luxury brand may impose stricter placement rules; a mass-market brand may allow broader contextual environments; product categories may impose additional compliance constraints. Brand policies inherit corporate standards but may introduce stricter constraints or specialized rules.
 
-### Brand governance layer
+**Campaign governance layer.** Campaign-level configuration provides temporary execution parameters: budget thresholds, pacing constraints, creative eligibility rules, audience definitions. Campaign rules operate within the boundaries established by corporate and brand governance. Execution may be delegated to authorized agents operating within these constraints.
 
-Individual brands define additional policies reflecting brand identity, positioning, and risk tolerance. A luxury brand may impose stricter placement rules. A mass-market brand may allow broader contextual environments. Brand policies inherit corporate standards but may introduce stricter constraints.
+### Policy composition
 
-### Campaign governance layer
+Governance rules are applied hierarchically:
 
-Campaign-level configuration provides temporary execution parameters: budget thresholds, pacing constraints, creative eligibility rules, audience definitions. Campaign rules operate within the boundaries established by corporate and brand governance.
+```
+Corporate Governance
+      ↓
+Brand Governance
+      ↓
+Campaign Configuration
+```
 
-Each layer may add restrictions but cannot override higher-level governance constraints. If a lower governance layer attempts to relax a constraint defined by a higher layer, the governance agent treats the higher-level constraint as authoritative, rejects the conflicting rule, and records the conflict in the audit log.
+Each layer may add restrictions but cannot override higher-level governance constraints. If a lower governance layer attempts to relax or override a constraint defined by a higher layer, the governance agent treats the higher-level constraint as authoritative, rejects the conflicting rule, and records the conflict in the audit log.
 
-## Decision types
+This structure allows organizations with large brand portfolios to operate multiple governance profiles simultaneously while maintaining consistent regulatory and ethical standards.
+
+### Accountability across layers
+
+Accountability remains explicit at each layer:
+
+- Protocol designers define system safeguards
+- Corporate owners define enterprise risk tolerance
+- Brand teams define positioning constraints
+- Campaign operators manage execution
+
+All decisions remain traceable through the audit framework.
+
+### Delegated execution and authorized operators
+
+Brands may delegate campaign execution authority to external agencies or authorized agent operators. Delegation does not transfer governance authority. Delegated and authorized operators may rely on stricter policies than what brands have delegated.
+
+Authorized agents operate within the governance constraints defined by the corporate and brand policy layers. The brand remains the accountable entity for campaign intent and policy configuration, while the delegated operator executes decisions within those defined boundaries.
+
+## Data protection and regulatory compliance
+
+Data protection and regulatory compliance are treated as governance constraints within the protocol, not as external policy considerations. Agents must validate decisions against the policy registry during governance evaluation before execution occurs.
+
+### Regulatory policy registry
+
+The protocol maintains a policy registry containing machine-readable references to regulatory frameworks and jurisdiction-specific rules, including but not limited to:
+
+- GDPR
+- COPPA
+- CCPA / CPRA
+- LGPD
+- APAC jurisdictional frameworks
+
+Each policy entry specifies:
+
+- Applicable jurisdiction
+- Relevant data classifications
+- Sensitive data definitions
+- Enforcement requirements
+
+The policy registry may also list contracts created by trade bodies or collective-bargaining groups to communicate among participants. Agents and platforms must reference the policy registry during decision validation.
+
+### Personal and non-personal data
+
+Data protection regulations apply when personal data is processed. In the EEA, the ePrivacy Directive applies to device access and storage, but the AdCP protocol is communication between software systems — whether agent-to-agent (via A2A) or client-to-server tool calls (via MCP) — not consumer devices.
+
+Within AdCP workflows:
+
+- Planning and negotiation layers typically exchange non-personal contextual information and campaign parameters.
+- Real-time execution layers may involve device-level signals that can qualify as personal data depending on jurisdiction and recipient capability.
+
+The protocol must specify whether a recipient agent is reasonably capable of re-identifying an individual or household using the exchanged data. If re-identification is reasonably possible, the data must be treated as personal data and processed according to the applicable regulatory framework.
+
+### Sensitive data classification
+
+Sensitive information refers to categories of data that may expose individuals to discrimination or material harm. Because definitions vary by jurisdiction, the protocol must reference jurisdiction-specific definitions from the policy registry.
+
+Agents must classify whether a decision involves sensitive information based on:
+
+- The data attributes used
+- The intended delivery geography
+- The applicable regulatory framework
+
+If sensitive data is involved, stricter governance rules apply.
+
+Consumer protection laws apply when sensitive information is being handled. Different jurisdictions define specific categories of sensitive information differently, but one commonality is when the information has historically been used to illegally discriminate or cause material harm to individuals.
+
+Most online advertising does not involve sensitive information, but it is important for actors to classify when data exchanged does qualify as sensitive. The protocol must specify whether the information used by a recipient agent will or will not involve sensitive information. The geography associated with the intended content delivery should govern which region-specific definition of sensitive information applies. For example, if the intended delivery is within the European Economic Area, GDPR's definition should apply.
+
+### Jurisdictional compliance validation
+
+Before execution, agents must validate decisions using the protocol's governance validation process (for example, [`check_governance`](/docs/governance/campaign/tasks/check_governance)).
+
+Validation includes:
+
+- Applicable jurisdiction based on delivery geography
+- Applicable regulatory policies from the policy registry
+- Classification of the data used in the decision
+- Determination of whether sensitive data rules apply
+
+If a decision violates applicable regulatory policies, the system must:
+
+- Escalate for human review
+- Restrict execution
+- Or block the decision entirely, depending on risk tier
+
+### Intent and exposure
+
+AdCP records the intent of decision-makers as part of the protocol. This allows systems to distinguish between:
+
+- **Intentional targeting**
+- **Incidental exposure**
+
+For example, a campaign intended for adults may still appear in environments accessible to minors. Because the targeting intent is recorded, compliance evaluation can distinguish between intentional violations and unintended exposure. This design aligns accountability with reasonable intent rather than perfect outcomes.
+
+## Governance and decision framework
+
+### Decision types
 
 All agent decisions must be classifiable:
 
-| Type | Description | Example |
-|---|---|---|
-| **AI-owned, deterministic** | Rule-based, predictable outcomes | Format validation, schema compliance |
-| **AI-led, human-bounded** | Probabilistic optimization with thresholds | Budget pacing within approved limits |
-| **Human-owned, strategic** | Trade-offs, intent, ethics, and values | Brand positioning, risk tolerance |
-| **Human-owned by necessity** | Novel situations agents cannot confidently resolve | Emerging regulation, unprecedented market event |
+| Type | Description |
+|---|---|
+| **AI-owned, deterministic** | Rule-based, predictable outcomes |
+| **AI-led, human-bounded** | Probabilistic optimization with thresholds |
+| **Human-owned, strategic** | Trade-offs, intent, ethics, and values |
+| **Human-owned by necessity (novel)** | Unknown situations agents cannot confidently resolve |
 
 The decision type determines whether and how escalation occurs.
 
-## Confidence and escalation
+### Confidence and escalation
 
-Every agent recommendation must include a confidence score, an explanation of uncertainty, and a defined escalation rule.
+Every agent recommendation must include:
 
-### Risk-aware escalation
+- A confidence score
+- An explanation of uncertainty
+- A defined escalation rule
 
-Agents evaluate recommendations based on both:
+Confidence scores must reflect the agent's assessment of how reliably the recommendation aligns with the defined campaign intent and expected outcomes. This assessment should consider factors such as data completeness, model certainty, similarity to historical decisions, and variance in predicted outcomes.
+
+Confidence scores should be accompanied by a brief explanation of uncertainty, including factors such as:
+
+- Limited or incomplete data
+- Conflicting signals
+- Novel or out-of-distribution scenarios
+- Unusually high variance in predicted results
+
+Escalation decisions should follow a risk-aware framework. Agents must evaluate recommendations based on both:
 
 - **Decision confidence** — how certain the agent is
 - **Decision risk** — the potential impact if the decision is incorrect
 
 Risk may include financial exposure, brand safety implications, regulatory sensitivity, scale of audience reach, or deviation from defined campaign intent.
 
-When confidence is insufficient for the level of risk involved, agents must escalate to human oversight rather than execute autonomously.
+Human decision owners define acceptable risk levels and associated confidence thresholds. When confidence is insufficient for the level of risk involved, agents must escalate to human oversight rather than execute autonomously.
+
+Escalation triggers may include:
+
+- Confidence below defined thresholds for the risk level
+- Material deviation from defined campaign intent
+- Changes in data quality or signal reliability
+- Inability to provide a clear explanation of the recommendation
+
+Thresholds may be based on:
+
+- Metric-driven limits (for example, financial spend or exposure)
+- Execution deviation from intent (for example, geographic targeting or audience constraints)
+
+When escalation occurs, the agent must present:
+
+- The recommended action
+- The confidence score
+- The explanation of uncertainty
+- The specific rule that triggered escalation
+
+This ensures that human oversight focuses on decisions where uncertainty or potential impact exceeds predefined governance boundaries, rather than routine execution.
 
 ### Escalation mechanics
 
-EHJ defines three modes of invoking human judgment:
+EHJ defines how human judgment is invoked:
 
-| Mode | Behavior | When to use |
-|---|---|---|
-| **Synchronous** | Block until human decides | High-risk decisions: large budget commits, new partner approvals |
-| **Asynchronous** | Proceed conservatively, allow override | Medium-risk: agent acts within safe defaults, human reviews and can adjust |
-| **Audit-only** | Act, log, review later | Low-risk routine decisions with full traceability |
+| Mode | Behavior |
+|---|---|
+| **Synchronous** | Block until human decides |
+| **Asynchronous** | Proceed conservatively, allow override |
+| **Audit-only** | Act, log, review later |
 
 ### Timeout and fallback handling
 
 Timeouts follow a risk-tiered approach:
 
-- **Low-risk decisions**: Execution may proceed within predefined guardrails
-- **Medium-risk decisions**: Agents apply conservative defaults or limited execution while notifying human owners
-- **High-risk decisions**: Agents escalate for human review or temporarily restrict execution until guidance is received
+- **Low-risk decisions** — execution may proceed within predefined guardrails
+- **Medium-risk decisions** — agents apply conservative defaults or limited execution while notifying human owners
+- **High-risk decisions** — agents escalate for human review or temporarily restrict execution until guidance is received
 
-In cases of uncertainty, systems prioritize governable outcomes over maximum speed.
+This approach ensures that operational continuity is maintained where risk is limited, while decisions with greater potential impact receive appropriate human oversight. In cases of uncertainty, systems prioritize governable outcomes over maximum speed, recognizing that occasional opportunity cost is an acceptable trade-off for maintaining accountability.
+
+## Protocol and runtime distinctions
+
+AdCP separates two operational layers: the **protocol layer**, where governance and decision constraints are defined, and the **runtime layer**, where real-time execution occurs.
+
+### Protocol layer
+
+The protocol layer defines the structure and governance of decision-making. It includes:
+
+- JSON schemas and task definitions
+- Governance rules and escalation policies
+- [`brand.json`](/docs/brand-protocol/brand-json) and [`adagents.json`](/docs/governance/property/adagents) declarations
+- Confidence scoring standards
+- Policy registry and regulatory constraints
+
+At this layer, planning and negotiation agents define campaign goals, constraints, and acceptable risk boundaries. These parameters are authored and maintained by human operators but exchanged between agents to establish a machine-readable contract.
+
+This layer determines what decisions are permitted and when human judgment must be invoked.
+
+### Runtime layer
+
+The runtime layer executes decisions in real time, including:
+
+- Bid evaluation
+- Creative rendering
+- Audience activation
+- Pacing and budget allocation
+
+Real-time agents operate within the boundaries defined by the protocol layer. Human operators define governance constraints in advance and intervene only through configured escalation checkpoints.
+
+In short:
+
+- The **protocol layer** governs the rules of decision-making.
+- The **runtime layer** executes those decisions at speed.
 
 ## Audit, transparency, and learning
 
 Governable automation requires that all significant decisions remain observable, explainable, and reconstructable.
 
-### Immutable audit trail
+### Audit trail
 
-Every high-impact decision generates an auditable record including:
+Every high-impact decision must generate an auditable record including:
 
 - Decision inputs
 - Confidence score
@@ -182,73 +494,57 @@ Organizations retain their own logs to satisfy internal governance and regulator
 
 ### Explainability
 
-Decisions must be explainable at multiple levels:
+Decisions must be explainable at multiple levels depending on the audience:
 
 | Audience | Detail level |
 |---|---|
-| **Approvers and oversight** | Summary: what happened, what was decided, by whom |
-| **Campaign managers** | Operational: why this action was taken, what alternatives existed |
-| **Auditors and compliance** | Technical: full decision inputs, model confidence, policy chain |
+| **Approvers and oversight** | Summary level |
+| **System operators and campaign managers** | Operational level |
+| **Auditors and compliance reviewers** | Technical level |
 
 Decision intent is captured by design within the protocol for each message and targeting instruction.
 
-## Protocol mapping
+### Log attributes
 
-Each EHJ principle surfaces in specific protocol mechanisms:
-
-| EHJ Principle | Protocol surface | Where documented |
-|--------------|-----------------|-----------------|
-| Humans define boundaries | `budget.reallocation_threshold` on plans | [`sync_plans`](/docs/governance/campaign/tasks/sync_plans) |
-| Oversight is architectural | Three-party model (orchestrator, governance, seller) | [Safety model](/docs/governance/campaign/safety-model) |
-| Governance invocation is enforceable, not advisory | `check_governance` MUST be invoked on every spend-commit when a governance agent is configured on the plan; sellers MUST reject spend-commits without a valid `governance_context` token | [Spend-commit invocation](/docs/governance/campaign/specification#spend-commit-invocation) |
-| Judgment cannot be delegated to software | `plan.human_review_required: true` forces async human review — `check_governance` goes async and resolves to `approved` or `denied` | [`sync_plans`](/docs/governance/campaign/tasks/sync_plans), [`check_governance`](/docs/governance/campaign/tasks/check_governance) |
-| Accountability requires legibility | `get_plan_audit_logs`, structured findings with confidence scores | [`get_plan_audit_logs`](/docs/governance/campaign/tasks/get_plan_audit_logs) |
-| Adoption must be incremental | Governance agents choose their own enforcement strategy internally | [Campaign governance](/docs/governance/campaign/index) |
-
-Plan-level autonomy settings map directly to EHJ decision types. `budget.reallocation_threshold` at or above `budget.total` grants autonomous execution of reallocations; a positive value below the total sets guardrails; `0` requires human approval for every reallocation. Orthogonally, `plan.human_review_required: true` mandates human review of every action on the plan — set automatically when resolved policies or policy categories carry `requires_human_review: true`. When human review is needed, `check_governance` behaves as an async task: it returns async status and resolves to `approved` or `denied` once the human acts. The caller does not need to know whether a human was involved.
-
-## How human-in-the-loop enters the protocol
-
-AdCP does not enumerate per-task approval rules. Human review enters through two mechanisms.
-
-### Universal: any mutation can go async
-
-Any task that mutates state can be returned as `input-required` or `submitted` by the agent handling it, pausing until a human responds — see [task lifecycle](/docs/building/implementation/task-lifecycle). This applies equally to the orchestrator, the seller, the creative agent, and the governance agent. There is no protocol rule that forbids a human step at any boundary; only the operator's latency budget. This mechanism is per-call and opaque to the other side — it is not a substitute for the declarative, auditable enforcement campaign governance provides across sellers.
-
-### Formal buyer-side: campaign governance
-
-Campaign governance is the protocol's specified mechanism for the buyer to *declaratively* require review on campaign actions. The buyer declares constraints in [`sync_plans`](/docs/governance/campaign/tasks/sync_plans); the policies live on the governance agent, and [`check_governance`](/docs/governance/campaign/tasks/check_governance) enforces them on every campaign action. The orchestrator calls it as an **intent check** to the plan's governance agent before sending an action to a seller — the orchestrator does not evaluate policies locally. The seller calls it as an **execution check** to the same governance agent on accounts where `governance_agents` has been declared via [`sync_governance`](/docs/accounts/tasks/sync_governance). This two-sided structure ensures no party grades its own homework.
-
-The governance agent escalates to a human when any of the following are true:
-
-| Trigger | Declared in |
+| Dimension | Attribute |
 |---|---|
-| `plan.human_review_required: true` | `sync_plans` |
-| Budget reallocation exceeds `budget.reallocation_threshold` | `sync_plans` |
-| Resolved policy with `requires_human_review: true` | Policy registry / plan policies |
-| Governance agent's own judgment | Governance agent's internal logic |
+| **When** | Timestamp (millisecond precision) |
+| **Which** | Decision ID (unique, traceable across systems) |
+| **Who** | Agent ID (which agent made the decision); human ID (who reviewed, if applicable); advertiser responsible for the message; actor responsible for payment; actor owed payment for the decision; publisher responsible for delivery (for final steps in the supply chain) |
+| **What** | Input (full context), decision type and classification |
+| **How well** | Observed execution result |
 
-When the governance agent escalates, `check_governance` itself goes async and resolves to `approved` or `denied` once the human acts. The caller does not need to know whether a human was involved.
+Consistent definitions of actors are described in the following protocols:
 
-### What this means for specific operations
+- **Advertiser responsible for the message** — declared in [`brand.json`](/docs/brand-protocol/brand-json), including the brand's `keller_type` (`master`, `sub_brand`, `endorsed`, or `independent`) and its `parent_brand` where applicable.
+- **Actor responsible for payment** — declared in [`brand.json`](/docs/brand-protocol/brand-json) (the brand itself or its operator).
+- **Actor owed payment for the decision** — declared in [`adagents.json`](/docs/governance/property/adagents), via `seller_id` and the authorized `property_id`(s).
+- **Publisher responsible for delivery** — the property associated with the final impression, identified by `property_id` in `adagents.json`.
 
-Campaign governance covers the media-buy lifecycle in three phases (see [Governance phases](/docs/governance/campaign/specification#governance-phases)):
+## How this maps to AdCP today
 
-- **Purchase** — `create_media_buy`, `acquire_rights`, `activate_signal`, `build_creative`
-- **Modification** — `update_media_buy`, `update_rights`
-- **Delivery** — seller-initiated periodic checks
+The framework above is implementation-agnostic. For readers landing here to implement against AdCP, the principles currently surface through these protocol mechanisms:
 
-Operations outside this set — buy-terms negotiation, `sync_catalogs`, `sync_creatives`, and anything else — use the universal mechanism only: any party may take them async for human review, but the protocol does not require it.
+| Framework concept | AdCP mechanism |
+|---|---|
+| Humans define boundaries (budget, review) | [`sync_plans`](/docs/governance/campaign/tasks/sync_plans) — `budget.reallocation_threshold`, `plan.human_review_required` |
+| Governance invocation on every spend-commit | [`check_governance`](/docs/governance/campaign/tasks/check_governance) — called by orchestrator (intent check) and seller (execution check) |
+| Three-party separation of duties | [Safety model](/docs/governance/campaign/safety-model) — orchestrator, governance agent, seller |
+| Escalation to human via async task | `check_governance` returns async, resolves `approved` or `denied` once the human acts |
+| Audit trail and explainability | [`get_plan_audit_logs`](/docs/governance/campaign/tasks/get_plan_audit_logs) |
+| Regulatory policy registry | [Policy Registry](/docs/governance/policy-registry) |
 
-## How this manifests in practice
+## Policy Registry
 
-The [governance protocol overview](/docs/governance/overview) walks through a complete campaign scenario where every one of these principles is visible in action — from plan registration through human approval to audit trail. The [campaign governance safety model](/docs/governance/campaign/safety-model) details the structural controls that implement these principles at the protocol level.
+The [Policy Registry](/docs/governance/policy-registry) is a community-maintained library of standardized, machine-readable advertising policies — regulations like COPPA, GDPR, and UK HFSS, as well as industry standards.
+
+It gives governance agents a shared vocabulary to reference by policy ID, rather than each agent defining the same rules independently. The registry page covers how policies are structured, the difference between hard regulations (must) and best-practice standards (should), how governance agents resolve and apply them at runtime, and how to contribute new policies.
 
 <CardGroup cols={2}>
   <Card title="Governance overview" icon="shield-halved" href="/docs/governance/overview">
-    Follow Jordan through the trust model — see EHJ principles in action
+    See EHJ principles in action across a complete campaign scenario
   </Card>
-  <Card title="Safety model" icon="lock" href="/docs/governance/campaign/safety-model">
-    Three-party trust, separation of duties, confidence scoring, drift detection
+  <Card title="Policy Registry" icon="book" href="/docs/governance/policy-registry">
+    Shared library of machine-readable regulations and industry standards
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Replaces the Embedded Human Judgment page with the approved final content from the governance workstream (manifesto + oversight framework: design principles, domains of human-owned judgment, governance architecture, data protection, decision/escalation, protocol vs runtime, audit). Source is the Google Doc linked from #2905, approved by Benjamin Masse.
- Adds a compact **"How this maps to AdCP today"** table at the end so implementers can bridge the framework to `sync_plans`, `check_governance`, `get_plan_audit_logs`, Policy Registry, and the safety model without re-introducing the prior page's full protocol-mapping section.
- Flattens the source doc's I/II/III + numeric sub-sections to Mintlify-friendly H2/H3/H4 so the frontmatter-rendered H1 isn't duplicated.

Closes #2905.

## Notes for @rafhayem / @BenjaminMasse — please confirm before publishing

I made a few small corrections where the approved source either had an OCR-style artifact or stated a protocol detail that does not match the current AdCP spec. None of these change the framework's meaning; they're strictly about mapping to what AdCP actually ships. Flagging them explicitly so you can confirm or push back:

1. **`brand.json` brand taxonomy (Log attributes section).** Source says *"Brands have a main account**A** sub-brand, and an optional 'endorsed'"* — the concatenation looks like an export glitch, and "main account" is not a `brand.json` concept. The spec uses `keller_type` with values `master`, `sub_brand`, `endorsed`, `independent`, plus `parent_brand` for the house relationship. I rendered the bullet using those field names.
2. **`adagents.json` actor bullet.** Source listed *"Sellers have a `seller_ID` and a `package_ID`. Properties have a set of domains (`property_IDs`)."* In current AdCP, `adagents.json` declares `seller_id` and `property_id`; `package_id` is a media-buy construct (returned by `create_media_buy`), not an adagents field. I kept the actor mapping but replaced `package_id` with the correct fields and fixed the casing.
3. **A2A / MCP parenthetical.** Source said *"communication among agents (for example A2A) and servers (for example MCP)"*. A2A is agent-to-agent messaging; MCP is client/server tool-calling — both are transports AdCP rides on, not an agents-vs-servers split. I reworded to *"communication between software systems — whether agent-to-agent (via A2A) or client-to-server tool calls (via MCP)"*.
4. **Dropped sentence restored.** I had initially dropped one normative sentence from §2.3 during translation (*"The protocol must specify whether the information used by a recipient agent will or will not involve sensitive information."*) — restored.
5. **"Publisher responsible for delivery" actor bullet.** Present in the source Log attributes list but missing from my first draft — restored as its own bullet.

If any of these corrections go too far, I'll revert to the literal source wording on request.

## Test plan

- [ ] Render check in Mintlify preview — heading hierarchy is clean (frontmatter title + H2/H3/H4, no duplicate H1s)
- [ ] All internal links resolve: `/docs/governance/campaign/tasks/check_governance`, `/docs/governance/campaign/tasks/sync_plans`, `/docs/governance/campaign/tasks/get_plan_audit_logs`, `/docs/governance/campaign/safety-model`, `/docs/governance/policy-registry`, `/docs/brand-protocol/brand-json`, `/docs/governance/property/adagents`
- [ ] `docs.json` nav entries (lines 306, 807) still point at this page — unchanged
- [ ] Local precommit (unit tests + typecheck) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)