### PR TITLE
perf(registry): materialize agent health + capabilities in DB

### DIFF
--- a/.changeset/registry-agents-snapshot-tables.md
+++ b/.changeset/registry-agents-snapshot-tables.md
@@ -1,0 +1,4 @@
+---
+---
+
+Materialize agent health + capabilities into `agent_health_snapshot` and `agent_capabilities_snapshot` tables, written by the crawler and bulk-read by `GET /api/registry/agents`. Replaces the live MCP/A2A fan-out on every registry page load (which would hang when any single agent was slow) with two DB queries, matching the existing compliance-status pattern.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -6,6 +6,8 @@ import { BrandManager } from "./brand-manager.js";
 import { BrandDatabase } from "./db/brand-db.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { CapabilityDiscovery } from "./capabilities.js";
+import { HealthChecker } from "./health.js";
+import { AgentSnapshotDatabase } from "./db/agent-snapshot-db.js";
 import { AAO_HOST } from "./config/aao.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { createLogger } from "./logger.js";
@@ -27,6 +29,8 @@ export class CrawlerService {
   private brandDb: BrandDatabase;
   private memberDb: MemberDatabase;
   private capabilityDiscovery: CapabilityDiscovery;
+  private healthChecker: HealthChecker;
+  private snapshotDb: AgentSnapshotDatabase;
   private eventsDb?: CatalogEventsDatabase;
   private profilesDb?: AgentInventoryProfilesDatabase;
 
@@ -38,6 +42,8 @@ export class CrawlerService {
     this.brandDb = new BrandDatabase();
     this.memberDb = new MemberDatabase();
     this.capabilityDiscovery = new CapabilityDiscovery();
+    this.healthChecker = new HealthChecker();
+    this.snapshotDb = new AgentSnapshotDatabase();
     this.eventsDb = options?.eventsDb;
     this.profilesDb = options?.profilesDb;
   }
@@ -466,30 +472,26 @@ export class CrawlerService {
       // Stats are optional
     }
 
-    // 3. Probe all agents to discover and save their types
-    await this.probeAndUpdateAgentTypes(agents);
+    // 3. Probe all agents to discover capabilities+health, write snapshots,
+    //    and update type for any still-unknown agents.
+    await this.refreshAgentSnapshots(agents);
 
     return processedDomains;
   }
 
   /**
-   * Probe agents to discover their capabilities and infer their type.
-   * Updates the database with the inferred type for each agent.
+   * Probe every known agent to refresh capability + health snapshots in the DB,
+   * and fill in agent type for any that are still `unknown`. The registry
+   * page reads these snapshot tables instead of calling agents live, so this
+   * pass is the materialization step that keeps the public API fast.
    *
-   * Type indicators:
-   * - Sales: get_products, create_media_buy, list_authorized_properties
-   * - Creative: list_creative_formats, build_creative, generate_creative, validate_creative
-   * - Signals: get_signals, list_signals, match_audience, activate_signal, activate_audience
-   *
-   * Returns 'unknown' if no type-specific tools found or multiple types detected (hybrid agent).
+   * Type indicators (SALES_TOOLS / CREATIVE_TOOLS / SIGNALS_TOOLS) live in
+   * CapabilityDiscovery; inferTypeFromProfile collapses them to one.
    */
-  private async probeAndUpdateAgentTypes(agents: Agent[]): Promise<void> {
-    log.debug('Probing agents to discover types');
+  private async refreshAgentSnapshots(agents: Agent[]): Promise<void> {
+    log.debug('Refreshing agent health + capability snapshots');
 
-    // Get all unique agent URLs (from both registered and discovered)
     const allAgents = await this.federatedIndex.listAllAgents();
-
-    // Build a map of known types to skip already-typed agents
     const knownTypes = new Map<string, string>();
     for (const a of allAgents) {
       if (a.type && a.type !== 'unknown') {
@@ -497,45 +499,41 @@ export class CrawlerService {
       }
     }
 
-    const agentUrls = new Set([
-      ...agents.map(a => a.url),
-      ...allAgents.map(a => a.url),
-    ]);
-
-    // Filter out agents that already have a type or are paused
+    // Build one probe entry per unique URL; prefer registered-agent metadata
+    // (name/protocol) when we have it, else derive from URL.
     const pausedUrls = await this.getPausedAgentUrls();
-    const urlsToProbe = Array.from(agentUrls).filter(url => !knownTypes.has(url) && !pausedUrls.has(url));
+    const seen = new Set<string>();
+    const toProbe: Agent[] = [];
+    for (const src of [...agents, ...allAgents.map(a => ({
+      name: a.name || a.url,
+      url: a.url,
+      type: (a.type as Agent['type']) || 'unknown',
+      protocol: (a.protocol as 'mcp' | 'a2a') || 'mcp',
+      description: '',
+      mcp_endpoint: a.url,
+      contact: { name: '', email: '', website: '' },
+      added_date: new Date().toISOString().split('T')[0],
+    } satisfies Agent))]) {
+      if (seen.has(src.url) || pausedUrls.has(src.url)) continue;
+      seen.add(src.url);
+      toProbe.push(src);
+    }
 
-    if (urlsToProbe.length === 0) {
-      log.debug('All agents already typed, skipping probe');
+    if (toProbe.length === 0) {
+      log.debug('No agents to probe');
       return;
     }
 
-    log.debug({ toProbe: urlsToProbe.length, alreadyTyped: knownTypes.size }, 'Probing agents for type');
-
-    // Probe agents in parallel with concurrency limit
     const CONCURRENCY = 5;
     const PROBE_TIMEOUT_MS = 10000;
-    let updated = 0;
+    let typesUpdated = 0;
+    let snapshotsWritten = 0;
     let failed = 0;
 
-    // Process in batches for controlled concurrency
-    for (let i = 0; i < urlsToProbe.length; i += CONCURRENCY) {
-      const batch = urlsToProbe.slice(i, i + CONCURRENCY);
+    for (let i = 0; i < toProbe.length; i += CONCURRENCY) {
+      const batch = toProbe.slice(i, i + CONCURRENCY);
       const results = await Promise.allSettled(
-        batch.map(async (url) => {
-          const agent: Agent = {
-            name: url,
-            url,
-            type: 'unknown',
-            protocol: 'mcp',
-            description: '',
-            mcp_endpoint: url,
-            contact: { name: '', email: '', website: '' },
-            added_date: new Date().toISOString().split('T')[0],
-          };
-
-          // Add timeout to prevent hanging on unresponsive agents
+        batch.map(async (agent) => {
           const profile = await Promise.race([
             this.capabilityDiscovery.discoverCapabilities(agent),
             new Promise<never>((_, reject) =>
@@ -543,30 +541,59 @@ export class CrawlerService {
             ),
           ]);
 
-          // Infer type from capabilities
           const inferredType = this.capabilityDiscovery.inferTypeFromProfile(profile);
+          const effectiveType = knownTypes.get(agent.url) || inferredType;
+          const agentForHealth: Agent = { ...agent, type: effectiveType as Agent['type'], protocol: profile.protocol };
 
-          if (inferredType !== 'unknown') {
-            await this.federatedIndex.updateAgentMetadata(url, {
+          const [health, stats] = await Promise.all([
+            Promise.race([
+              this.healthChecker.checkHealth(agentForHealth),
+              new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('Health timeout')), PROBE_TIMEOUT_MS)
+              ),
+            ]).catch((err): import('./types.js').AgentHealth => ({
+              online: false,
+              checked_at: new Date().toISOString(),
+              error: err instanceof Error ? err.message : 'health check failed',
+            })),
+            Promise.race([
+              this.healthChecker.getStats(agentForHealth),
+              new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('Stats timeout')), PROBE_TIMEOUT_MS)
+              ),
+            ]).catch((): import('./types.js').AgentStats => ({})),
+          ]);
+
+          await Promise.all([
+            this.snapshotDb.upsertCapabilities(profile, inferredType === 'unknown' ? null : inferredType),
+            this.snapshotDb.upsertHealth(agent.url, health, stats),
+          ]);
+
+          if (!knownTypes.has(agent.url) && inferredType !== 'unknown') {
+            await this.federatedIndex.updateAgentMetadata(agent.url, {
               agent_type: inferredType,
               protocol: profile.protocol,
             });
-            return 'updated';
+            return 'type_updated';
           }
-          return 'skipped';
+          return 'snapshot_only';
         })
       );
 
       for (const result of results) {
-        if (result.status === 'fulfilled' && result.value === 'updated') {
-          updated++;
-        } else if (result.status === 'rejected') {
+        if (result.status === 'fulfilled') {
+          snapshotsWritten++;
+          if (result.value === 'type_updated') typesUpdated++;
+        } else {
           failed++;
         }
       }
     }
 
-    log.info({ updated, unreachable: failed }, 'Agent type discovery complete');
+    log.info(
+      { snapshotsWritten, typesUpdated, unreachable: failed, probed: toProbe.length },
+      'Agent snapshots refreshed',
+    );
   }
 
   /**

--- a/server/src/db/agent-snapshot-db.ts
+++ b/server/src/db/agent-snapshot-db.ts
@@ -1,0 +1,135 @@
+import { query } from './client.js';
+import { createLogger } from '../logger.js';
+import type { AgentHealth, AgentStats } from '../types.js';
+import type {
+  AgentCapabilityProfile,
+  StandardOperations,
+  CreativeCapabilities,
+  SignalsCapabilities,
+  ToolCapability,
+} from '../capabilities.js';
+
+const logger = createLogger('agent-snapshot-db');
+
+export interface AgentHealthSnapshotRow {
+  agent_url: string;
+  online: boolean;
+  response_time_ms: number | null;
+  tools_count: number | null;
+  resources_count: number | null;
+  error: string | null;
+  checked_at: Date;
+  stats_json: AgentStats | null;
+  updated_at: Date;
+}
+
+export interface AgentCapabilitiesSnapshotRow {
+  agent_url: string;
+  protocol: 'mcp' | 'a2a';
+  discovered_tools_json: ToolCapability[];
+  standard_operations_json: StandardOperations | null;
+  creative_capabilities_json: CreativeCapabilities | null;
+  signals_capabilities_json: SignalsCapabilities | null;
+  inferred_type: string | null;
+  discovery_error: string | null;
+  oauth_required: boolean;
+  last_discovered: Date;
+  updated_at: Date;
+}
+
+export class AgentSnapshotDatabase {
+  async bulkGetHealth(agentUrls: string[]): Promise<Map<string, AgentHealthSnapshotRow>> {
+    if (agentUrls.length === 0) return new Map();
+    const result = await query<AgentHealthSnapshotRow>(
+      `SELECT * FROM agent_health_snapshot WHERE agent_url = ANY($1)`,
+      [agentUrls],
+    );
+    const map = new Map<string, AgentHealthSnapshotRow>();
+    for (const row of result.rows) map.set(row.agent_url, row);
+    return map;
+  }
+
+  async bulkGetCapabilities(
+    agentUrls: string[],
+  ): Promise<Map<string, AgentCapabilitiesSnapshotRow>> {
+    if (agentUrls.length === 0) return new Map();
+    const result = await query<AgentCapabilitiesSnapshotRow>(
+      `SELECT * FROM agent_capabilities_snapshot WHERE agent_url = ANY($1)`,
+      [agentUrls],
+    );
+    const map = new Map<string, AgentCapabilitiesSnapshotRow>();
+    for (const row of result.rows) map.set(row.agent_url, row);
+    return map;
+  }
+
+  async upsertHealth(agentUrl: string, health: AgentHealth, stats: AgentStats): Promise<void> {
+    try {
+      await query(
+        `INSERT INTO agent_health_snapshot
+           (agent_url, online, response_time_ms, tools_count, resources_count, error, checked_at, stats_json, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+         ON CONFLICT (agent_url) DO UPDATE SET
+           online = EXCLUDED.online,
+           response_time_ms = EXCLUDED.response_time_ms,
+           tools_count = EXCLUDED.tools_count,
+           resources_count = EXCLUDED.resources_count,
+           error = EXCLUDED.error,
+           checked_at = EXCLUDED.checked_at,
+           stats_json = EXCLUDED.stats_json,
+           updated_at = NOW()`,
+        [
+          agentUrl,
+          health.online,
+          health.response_time_ms ?? null,
+          health.tools_count ?? null,
+          health.resources_count ?? null,
+          health.error ?? null,
+          health.checked_at,
+          JSON.stringify(stats ?? {}),
+        ],
+      );
+    } catch (err) {
+      logger.warn({ agentUrl, err }, 'Failed to upsert agent health snapshot');
+    }
+  }
+
+  async upsertCapabilities(
+    profile: AgentCapabilityProfile,
+    inferredType: string | null,
+  ): Promise<void> {
+    try {
+      await query(
+        `INSERT INTO agent_capabilities_snapshot
+           (agent_url, protocol, discovered_tools_json, standard_operations_json,
+            creative_capabilities_json, signals_capabilities_json, inferred_type,
+            discovery_error, oauth_required, last_discovered, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+         ON CONFLICT (agent_url) DO UPDATE SET
+           protocol = EXCLUDED.protocol,
+           discovered_tools_json = EXCLUDED.discovered_tools_json,
+           standard_operations_json = EXCLUDED.standard_operations_json,
+           creative_capabilities_json = EXCLUDED.creative_capabilities_json,
+           signals_capabilities_json = EXCLUDED.signals_capabilities_json,
+           inferred_type = EXCLUDED.inferred_type,
+           discovery_error = EXCLUDED.discovery_error,
+           oauth_required = EXCLUDED.oauth_required,
+           last_discovered = EXCLUDED.last_discovered,
+           updated_at = NOW()`,
+        [
+          profile.agent_url,
+          profile.protocol,
+          JSON.stringify(profile.discovered_tools ?? []),
+          profile.standard_operations ? JSON.stringify(profile.standard_operations) : null,
+          profile.creative_capabilities ? JSON.stringify(profile.creative_capabilities) : null,
+          profile.signals_capabilities ? JSON.stringify(profile.signals_capabilities) : null,
+          inferredType,
+          profile.discovery_error ?? null,
+          profile.oauth_required ?? false,
+          profile.last_discovered,
+        ],
+      );
+    } catch (err) {
+      logger.warn({ agentUrl: profile.agent_url, err }, 'Failed to upsert agent capabilities snapshot');
+    }
+  }
+}

--- a/server/src/db/migrations/422_agent_snapshot_tables.sql
+++ b/server/src/db/migrations/422_agent_snapshot_tables.sql
@@ -1,0 +1,39 @@
+-- Materialized per-agent health and capability snapshots.
+--
+-- Written by the crawler on each cycle; read in bulk by the public
+-- /registry/agents endpoint. Mirrors the agent_compliance_status pattern:
+-- one row per agent_url, single ANY($1) query for the registry page.
+-- Removes the need to fan out live MCP/A2A calls on page load.
+
+CREATE TABLE IF NOT EXISTS agent_health_snapshot (
+  agent_url TEXT PRIMARY KEY,
+  online BOOLEAN NOT NULL,
+  response_time_ms INTEGER,
+  tools_count INTEGER,
+  resources_count INTEGER,
+  error TEXT,
+  checked_at TIMESTAMPTZ NOT NULL,
+  stats_json JSONB,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_health_snapshot_checked_at
+  ON agent_health_snapshot(checked_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_capabilities_snapshot (
+  agent_url TEXT PRIMARY KEY,
+  protocol TEXT NOT NULL,
+  discovered_tools_json JSONB NOT NULL DEFAULT '[]',
+  standard_operations_json JSONB,
+  creative_capabilities_json JSONB,
+  signals_capabilities_json JSONB,
+  inferred_type TEXT,
+  discovery_error TEXT,
+  oauth_required BOOLEAN NOT NULL DEFAULT FALSE,
+  last_discovered TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT valid_snapshot_protocol CHECK (protocol IN ('mcp', 'a2a'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_capabilities_snapshot_last_discovered
+  ON agent_capabilities_snapshot(last_discovered DESC);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -74,6 +74,7 @@ import { PropertyCheckService } from "../services/property-check.js";
 import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
+import { AgentSnapshotDatabase } from "../db/agent-snapshot-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
@@ -88,6 +89,7 @@ const propertyCheckService = new PropertyCheckService();
 const propertyCheckDb = new PropertyCheckDatabase();
 const bulkCheckService = new BulkPropertyCheckService();
 const complianceDb = new ComplianceDatabase();
+const agentSnapshotDb = new AgentSnapshotDatabase();
 const agentContextDb = new AgentContextDatabase();
 
 /** Strip protocol, path, query, and fragment from a URL to extract the domain. */
@@ -2232,9 +2234,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     brandDb,
     propertyDb,
     adagentsManager,
-    healthChecker,
     crawler,
-    capabilityDiscovery,
     registryRequestsDb,
     requireAuth: authMiddleware,
   } = config;
@@ -3270,49 +3270,60 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return res.json({ agents, count: agents.length, sources: bySource });
       }
 
-      // Bulk-fetch compliance status and metadata if requested
+      // Bulk-fetch all enrichment data from DB snapshot tables up front.
+      // The crawler materializes health + capabilities into these tables on
+      // each cycle, so the registry API never does live MCP/A2A fan-out.
       const agentUrls = agents.map(a => a.url);
-      const complianceMap = withCompliance
-        ? await complianceDb.bulkGetComplianceStatus(agentUrls)
-        : null;
-      const metadataMap = withCompliance
-        ? await complianceDb.bulkGetRegistryMetadata(agentUrls)
-        : null;
+      const [complianceMap, metadataMap, healthMap, capsMap] = await Promise.all([
+        withCompliance ? complianceDb.bulkGetComplianceStatus(agentUrls) : Promise.resolve(null),
+        withCompliance ? complianceDb.bulkGetRegistryMetadata(agentUrls) : Promise.resolve(null),
+        withHealth ? agentSnapshotDb.bulkGetHealth(agentUrls) : Promise.resolve(null),
+        withCapabilities ? agentSnapshotDb.bulkGetCapabilities(agentUrls) : Promise.resolve(null),
+      ]);
 
       const enriched = await Promise.all(
         agents.map(async (agent): Promise<AgentWithStats> => {
           const enrichedAgent: AgentWithStats = { ...agent } as AgentWithStats;
 
-          if (withCapabilities) {
-            const capProfile = await capabilityDiscovery.discoverCapabilities(agent as Agent);
-            if (capProfile) {
+          if (capsMap) {
+            const cap = capsMap.get(agent.url);
+            if (cap) {
               enrichedAgent.capabilities = {
-                tools_count: capProfile.discovered_tools?.length || 0,
-                tools: capProfile.discovered_tools || [],
-                standard_operations: capProfile.standard_operations,
-                creative_capabilities: capProfile.creative_capabilities,
-                signals_capabilities: capProfile.signals_capabilities,
-                discovery_error: capProfile.discovery_error,
-                oauth_required: capProfile.oauth_required,
+                tools_count: cap.discovered_tools_json?.length || 0,
+                tools: cap.discovered_tools_json || [],
+                standard_operations: cap.standard_operations_json ?? undefined,
+                creative_capabilities: cap.creative_capabilities_json ?? undefined,
+                signals_capabilities: cap.signals_capabilities_json ?? undefined,
+                discovery_error: cap.discovery_error ?? undefined,
+                oauth_required: cap.oauth_required || undefined,
               };
 
-              if (!enrichedAgent.type || enrichedAgent.type === "unknown") {
-                const inferredType = capabilityDiscovery.inferTypeFromProfile(capProfile);
-                if (inferredType !== "unknown") {
-                  enrichedAgent.type = inferredType;
+              if ((!enrichedAgent.type || enrichedAgent.type === "unknown") && cap.inferred_type) {
+                if (isValidAgentType(cap.inferred_type)) {
+                  enrichedAgent.type = cap.inferred_type;
                 }
               }
             }
           }
 
-          const promises = [];
-
-          if (withHealth) {
-            promises.push(
-              healthChecker.checkHealth(agent as Agent),
-              healthChecker.getStats(agent as Agent)
-            );
+          if (healthMap) {
+            const h = healthMap.get(agent.url);
+            if (h) {
+              enrichedAgent.health = {
+                online: h.online,
+                checked_at: h.checked_at instanceof Date ? h.checked_at.toISOString() : String(h.checked_at),
+                response_time_ms: h.response_time_ms ?? undefined,
+                tools_count: h.tools_count ?? undefined,
+                resources_count: h.resources_count ?? undefined,
+                error: h.error ?? undefined,
+              };
+              if (h.stats_json) {
+                enrichedAgent.stats = h.stats_json;
+              }
+            }
           }
+
+          const promises = [];
 
           if (withProperties && enrichedAgent.type === "buying") {
             promises.push(
@@ -3323,11 +3334,6 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
           const results = await Promise.all(promises);
           let resultIndex = 0;
-
-          if (withHealth) {
-            enrichedAgent.health = results[resultIndex++] as any;
-            enrichedAgent.stats = results[resultIndex++] as any;
-          }
 
           if (withProperties && enrichedAgent.type === "buying") {
             const agentProperties = results[resultIndex++] as any[];


### PR DESCRIPTION
## Summary

- `GET /api/registry/agents` was fanning out live MCP/A2A calls to every registered agent on each page load. One hung agent blocked the entire response — which is why the registry page shows empty skeleton cards indefinitely.
- Follows the existing `agent_compliance_status` pattern: two new snapshot tables (`agent_health_snapshot`, `agent_capabilities_snapshot`) are materialized by the crawler and bulk-read by the registry API in a single `Promise.all`.
- Live MCP/A2A calls are removed from the HTTP path entirely. 200+ live network calls → 2-4 bulk `SELECT ... WHERE agent_url = ANY($1)` queries.

## Changes

- `server/src/db/migrations/422_agent_snapshot_tables.sql` — new tables (agent_url PK, JSONB payload, checked_at / last_discovered).
- `server/src/db/agent-snapshot-db.ts` — `AgentSnapshotDatabase` with `bulkGetHealth`, `bulkGetCapabilities`, `upsertHealth`, `upsertCapabilities`.
- `server/src/crawler.ts` — `probeAndUpdateAgentTypes` → `refreshAgentSnapshots`; probes every agent (not just untyped), writes both snapshots with 10s per-call timeouts and concurrency 5. Still updates `agent_type` for still-unknown agents.
- `server/src/routes/registry-api.ts` — `/registry/agents` now bulk-reads snapshot tables (grouped with compliance in one `Promise.all`). Removed the per-agent `healthChecker` / `capabilityDiscovery` calls from the config destructure in this file.

## Behavior notes

- Freshly-registered agents have no snapshot row until the next crawl cycle — health/capabilities fields are simply omitted from the response for those agents (same way properties already behave).
- Snapshots refresh on the existing hourly crawler cadence (`startPeriodicCrawl`); in-flight dev can lower that if real-time updates are needed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:unit` (precommit) — 631 passed
- [ ] Run migration 422 in staging, verify both tables created with primary keys on `agent_url`.
- [ ] Trigger a crawl in staging, verify both snapshot tables get rows for every non-paused federated agent.
- [ ] Hit `/api/registry/agents?health=true&capabilities=true&properties=true&compliance=true` in staging — confirm response time drops from 30s+ to <1s.
- [ ] Confirm UI at `/registry/?tab=agents` renders full cards (name, status badge, tool count, properties) instead of empty skeletons.
- [ ] Verify freshly-added agent shows up without health/capabilities fields, and picks up data after the next crawl.