### PR TITLE
fix(storyboards): seed event_source_id in sales_social (closes #2909)

### DIFF
--- a/.changeset/fix-sales-social-orphan-event-source.md
+++ b/.changeset/fix-sales-social-orphan-event-source.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(storyboards): seed event_source_id via sync_event_sources in sales_social
+
+The sales_social specialism storyboard referenced `event_source_id: "acmeoutdoor_website"` in a
+log_event step without a preceding sync_event_sources call, producing an orphan reference that
+seller agents validating event-source existence would reject with EVENT_SOURCE_NOT_FOUND. Adds an
+`event_setup` phase that registers `acmeoutdoor_website` before `event_logging`, and adds
+`sync_event_sources` to `required_tools` — matching the sales_catalog_driven pattern. Closes #2909.

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -9,6 +9,7 @@ required_tools:
   - sync_audiences
   - sync_catalogs
   - sync_creatives
+  - sync_event_sources
 
 # Cross-step assertion (adcp#2664). status.monotonic rejects resource
 # status transitions observed across steps that aren't on the spec
@@ -424,6 +425,61 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "sales_social--sync_dpa_creative"
+            description: "Context correlation_id returned unchanged"
+  - id: event_setup
+    title: "Event source setup"
+    narrative: |
+      Before sending conversion events, the buyer registers the event sources the platform
+      should expect events from — a website pixel, a mobile SDK, or a server-to-server feed.
+      The platform returns setup instructions and binds the event_source_id that later
+      log_event calls will reference.
+
+    steps:
+      - id: sync_event_sources
+        title: "Register conversion event sources"
+        narrative: |
+          The buyer tells the platform where conversion events will come from. The
+          platform records each event_source_id, returns integration code, and will
+          accept log_event calls that reference it.
+        task: sync_event_sources
+        schema_ref: "media-buy/sync-event-sources-request.json"
+        response_schema_ref: "media-buy/sync-event-sources-response.json"
+        doc_ref: "/media-buy/task-reference/sync_event_sources"
+        stateful: true
+        expected: |
+          Return event sources with:
+          - event_source_id and seller_id
+          - setup.snippet: integration code (JavaScript pixel, HTML tag, or pixel URL)
+          - setup.instructions: human-readable integration guide
+          - action: created or updated
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_sources:
+            - event_source_id: "acmeoutdoor_website"
+              name: "Acme Outdoor Website"
+              event_types: ["purchase", "add_to_cart", "page_view", "lead"]
+              allowed_domains: ["acmeoutdoor.example"]
+
+          idempotency_key: "$generate:uuid_v4#sales_social_event_setup_sync_event_sources"
+          context:
+            correlation_id: "sales_social--sync_event_sources"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-event-sources-response.json schema"
+          - check: field_present
+            path: "event_sources[0].setup.snippet"
+            description: "Event source includes setup snippet"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sales_social--sync_event_sources"
             description: "Context correlation_id returned unchanged"
   - id: event_logging
     title: "Conversion event tracking"


### PR DESCRIPTION
## Summary

- Adds an `event_setup` phase with a `sync_event_sources` step to the `sales_social` specialism storyboard, registering `acmeoutdoor_website` before `event_logging` consumes it via `log_event`.
- Adds `sync_event_sources` to `required_tools`.
- Matches the precedent in `sales_catalog_driven` (option 1 from the issue).

## Why

Before this fix, the `sales_social` storyboard referenced `event_source_id: "acmeoutdoor_website"` in a `log_event` step without ever registering the source. Seller agents that validate event-source existence would return `EVENT_SOURCE_NOT_FOUND` on the last step of the storyboard — an authoring bug, not an agent bug.

Surfaced by the runner fix in adcontextprotocol/adcp-client#829, which now correctly threads storyboard-authored `event_source_id` values to the wire.

Closes #2909.

## Test plan

- [x] `npm run build:compliance` — all storyboard lints pass (scoping, branch-set, contradiction, context-entity, auth-shape, test-kits)
- [x] `npm run test:unit` — 631 passed
- [x] `npm run typecheck` — clean
- [ ] CI green on PR
- [ ] Downstream runner (adcp-client#829) reaches `log_event` without `EVENT_SOURCE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)