### PR TITLE
feat(addie): index adcp-go repo in Addie knowledge base

### DIFF
--- a/.changeset/index-adcp-go-repo.md
+++ b/.changeset/index-adcp-go-repo.md
@@ -1,0 +1,4 @@
+---
+---
+
+Index the adcp-go repository in Addie's external-repos knowledge base. Adds the Go SDK to the Dockerfile clone script, the EXTERNAL_REPOS registry, and the search_repos tool metadata so Addie can answer questions about the Go SDK, TMP router, and Go types.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ git clone --depth=1 --branch main https://github.com/prebid/salesagent.git sales
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/signals-agent.git signals-agent & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp-client.git adcp-client & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp-client-python.git adcp-client-python & pids="$pids $!"
+git clone --depth=1 --branch main https://github.com/adcontextprotocol/adcp-go.git adcp-go & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/a2aproject/A2A.git a2a & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/a2aproject/a2a-samples.git a2a-samples & pids="$pids $!"
 git clone --depth=1 --branch main https://github.com/modelcontextprotocol/modelcontextprotocol.git mcp-spec & pids="$pids $!"

--- a/server/src/addie/mcp/external-repos.ts
+++ b/server/src/addie/mcp/external-repos.ts
@@ -115,7 +115,7 @@ const EXTERNAL_REPOS: ExternalRepo[] = [
     url: 'https://github.com/adcontextprotocol/adcp-go',
     name: 'AdCP Go SDK',
     description: 'Official Go SDK for AdCP — types, request parsing, response builders, TMP client/server, and reference router implementation',
-    indexPatterns: ['README.md', 'docs/**/*.md', 'CHANGELOG.md', '**/*.md'],
+    indexPatterns: ['README.md', 'docs/**/*.md', 'CHANGELOG.md'],
     branch: 'main',
   },
 

--- a/server/src/addie/mcp/external-repos.ts
+++ b/server/src/addie/mcp/external-repos.ts
@@ -110,6 +110,14 @@ const EXTERNAL_REPOS: ExternalRepo[] = [
     indexPatterns: ['README.md', 'docs/**/*.md', 'CHANGELOG.md'],
     branch: 'main',
   },
+  {
+    id: 'adcp-go',
+    url: 'https://github.com/adcontextprotocol/adcp-go',
+    name: 'AdCP Go SDK',
+    description: 'Official Go SDK for AdCP — types, request parsing, response builders, TMP client/server, and reference router implementation',
+    indexPatterns: ['README.md', 'docs/**/*.md', 'CHANGELOG.md', '**/*.md'],
+    branch: 'main',
+  },
 
   // ============================================
   // Agent Protocols - A2A

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -200,7 +200,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
     name: 'search_repos',
     description:
       'Search indexed external GitHub repositories for ad tech specifications and protocols. Includes: ' +
-      'AdCP (core protocol spec, sales agent, signals agent, JS/Python clients), ' +
+      'AdCP (core protocol spec, sales agent, signals agent, JS/Python/Go clients), ' +
       'A2A (Google Agent-to-Agent protocol and samples), ' +
       'MCP (Model Context Protocol spec, TypeScript/Python SDKs, reference servers), ' +
       'IAB Tech Lab specs (OpenRTB 2.x/3.0, AdCOM, OpenDirect, ARTF, UCP, GPP, TCF, US Privacy, UID2, VAST, ads.cert), ' +
@@ -219,7 +219,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
         repo_id: {
           type: 'string',
           description:
-            'Optional filter to search only a specific repo: adcp, salesagent, signals-agent, adcp-client, adcp-client-python, a2a, a2a-samples, mcp-spec, mcp-typescript-sdk, mcp-python-sdk, mcp-servers, iab-artf, iab-ucp, iab-openrtb2, iab-openrtb3, iab-adcom, iab-opendirect, iab-gpp, iab-tcf, iab-usprivacy, iab-uid2-docs, iab-vast, iab-adscert, prebid-js, prebid-server, prebid-docs, langgraph',
+            'Optional filter to search only a specific repo: adcp, salesagent, signals-agent, adcp-client, adcp-client-python, adcp-go, a2a, a2a-samples, mcp-spec, mcp-typescript-sdk, mcp-python-sdk, mcp-servers, iab-artf, iab-ucp, iab-openrtb2, iab-openrtb3, iab-adcom, iab-opendirect, iab-gpp, iab-tcf, iab-usprivacy, iab-uid2-docs, iab-vast, iab-adscert, prebid-js, prebid-server, prebid-docs, langgraph',
         },
         limit: {
           type: 'number',


### PR DESCRIPTION
## Summary

Index the [adcp-go](https://github.com/adcontextprotocol/adcp-go) repository in Addie's external-repos knowledge base so she can answer questions about the Go SDK, TMP client/server, reference router, and Go types.

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Clone `adcp-go` alongside other AdCP ecosystem repos at Docker build time |
| `server/src/addie/mcp/external-repos.ts` | Add `adcp-go` to `EXTERNAL_REPOS` registry with broad `**/*.md` index patterns |
| `server/src/addie/mcp/knowledge-search.ts` | Add `adcp-go` to `search_repos` tool `repo_id` enum and update description to mention Go |

## Pattern

Follows the exact same pattern as `adcp-client-python` — the Go SDK was already referenced in docs (`docs/intro.mdx`, `docs/building/build-an-agent.mdx`, `docs/building/schemas-and-sdks.mdx`, `llms.txt`, `llms-full.txt`) but was missing from Addie's indexed repos.

## Changeset

Empty changeset (`--empty`) — this is an Addie infrastructure change with no protocol impact.