### PR TITLE
refactor(org-db): DRY the tier-column SELECT + row type (#2826)

### DIFF
--- a/.changeset/dry-tier-column-selector.md
+++ b/.changeset/dry-tier-column-selector.md
@@ -1,0 +1,10 @@
+---
+---
+
+Close #2826: collapse the duplicated SQL + row-type pair for resolving an organization's membership tier inside a transaction. `applyAgentVisibility` (member-profiles.ts) and the seat-check path (organization-db.ts) both hand-rolled the same `SELECT membership_tier, subscription_price_lookup_key, ...` against a pg client and then fed the row into `resolveMembershipTier`. Every future tier-relevant column would have had to land in three places (resolver input type, both SELECTs) or silently degrade.
+
+- New `MembershipTierRow` type + `MEMBERSHIP_TIER_COLUMNS` tuple in `organization-db.ts` as the single source of truth for the resolver's input shape.
+- New `readMembershipTierFromClient(client, orgId, { forUpdate? })` helper that runs the SELECT with the shared column list, parses the row, and returns `MembershipTier | null`. Optional `forUpdate` for callers that need to lock the `organizations` row too.
+- Both inline call sites replaced.
+
+No behavior change. 1920 server + 631 root unit tests pass.

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1,3 +1,4 @@
+import type { PoolClient } from 'pg';
 import { getPool, query } from './client.js';
 import { getStripeSubscriptionInfo, listCustomersWithOrgIds } from '../billing/stripe-client.js';
 import { WorkOS } from '@workos-inc/node';
@@ -201,23 +202,67 @@ export function tierFromLookupKey(lookupKey: string | null | undefined): Members
 }
 
 /**
- * Resolve the effective membership tier for an organization.
- * Fallback chain: cached tier → stored lookup key → amount inference.
- * Only falls back for tier-preserving statuses (active, past_due, trialing).
+ * Input shape for `resolveMembershipTier`. Kept as a named type so the
+ * companion SQL helpers below can declare a matching row type, and so
+ * a future resolver change that needs a new column surfaces every
+ * consumer via TS.
  */
-export function resolveMembershipTier(org: {
+export interface MembershipTierRow {
   membership_tier: string | null;
   subscription_price_lookup_key?: string | null;
   subscription_status: string | null;
   subscription_amount: number | null;
   subscription_interval: string | null;
   is_personal: boolean;
-} | null | undefined): MembershipTier | null {
+}
+
+/**
+ * Column list the resolver requires from the `organizations` table.
+ * Single source of truth for handlers that issue their own SELECT
+ * (typically inside a transaction) and then hand the row to
+ * `resolveMembershipTier`. Extending the resolver to consider a new
+ * column means adding it here AND to `MembershipTierRow` — TS will
+ * then surface every call site that needs to be updated.
+ */
+export const MEMBERSHIP_TIER_COLUMNS = [
+  'membership_tier',
+  'subscription_price_lookup_key',
+  'subscription_status',
+  'subscription_amount',
+  'subscription_interval',
+  'is_personal',
+] as const;
+
+/**
+ * Resolve the effective membership tier for an organization.
+ * Fallback chain: cached tier → stored lookup key → amount inference.
+ * Only falls back for tier-preserving statuses (active, past_due, trialing).
+ */
+export function resolveMembershipTier(org: MembershipTierRow | null | undefined): MembershipTier | null {
   if (!org) return null;
   if (org.membership_tier) return org.membership_tier as MembershipTier;
   if (!(TIER_PRESERVING_STATUSES as readonly string[]).includes(org.subscription_status ?? '')) return null;
   return tierFromLookupKey(org.subscription_price_lookup_key)
     ?? inferMembershipTier(org.subscription_amount, org.subscription_interval, org.is_personal);
+}
+
+/**
+ * Read + resolve the current membership tier for `orgId` using a
+ * caller-held pg client. Prefer this to inline SQL when the read
+ * must share a transaction with subsequent writes (e.g.,
+ * `applyAgentVisibility` re-reads the tier under `FOR UPDATE` after
+ * locking `member_profiles`). Pass `{ forUpdate: true }` when the
+ * caller needs to lock the organizations row as well.
+ */
+export async function readMembershipTierFromClient(
+  client: PoolClient,
+  orgId: string,
+  opts: { forUpdate?: boolean } = {},
+): Promise<MembershipTier | null> {
+  const lockSuffix = opts.forUpdate ? ' FOR UPDATE' : '';
+  const sql = `SELECT ${MEMBERSHIP_TIER_COLUMNS.join(', ')} FROM organizations WHERE workos_organization_id = $1${lockSuffix}`;
+  const result = await client.query<MembershipTierRow>(sql, [orgId]);
+  return resolveMembershipTier(result.rows[0] ?? null);
 }
 
 /**
@@ -365,20 +410,9 @@ export async function canAddSeat(
   try {
     await client.query('BEGIN');
 
-    // Lock the org row to serialize concurrent seat checks
-    const orgResult = await client.query<{
-      membership_tier: string | null;
-      subscription_price_lookup_key: string | null;
-      subscription_amount: number | null;
-      subscription_interval: string | null;
-      subscription_status: string | null;
-      is_personal: boolean;
-    }>(
-      'SELECT membership_tier, subscription_price_lookup_key, subscription_amount, subscription_interval, subscription_status, is_personal FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
-      [orgId]
-    );
-    const org = orgResult.rows[0];
-    const tier = resolveMembershipTier(org);
+    // Lock the org row to serialize concurrent seat checks and resolve
+    // the tier from the same (locked) read.
+    const tier = await readMembershipTierFromClient(client, orgId, { forUpdate: true });
     const limits = getSeatLimits(tier);
 
     // Count active members (contributor = admin-assigned OR Slack-mapped OR in working group)

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -18,7 +18,7 @@ import { query, getPool } from "../db/client.js";
 import { MemberDatabase } from "../db/member-db.js";
 import { BrandDatabase, resolveBrandFromJson } from "../db/brand-db.js";
 import { BrandManager } from "../brand-manager.js";
-import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
+import { OrganizationDatabase, hasApiAccess, readMembershipTierFromClient, resolveMembershipTier } from "../db/organization-db.js";
 import { OrgKnowledgeDatabase } from "../db/org-knowledge-db.js";
 import { autoLinkByVerifiedDomain } from "../db/membership-db.js";
 import { AAO_HOST } from "../config/aao.js";
@@ -724,21 +724,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // ROLLBACK. The Stripe demote path locks member_profiles via
       // FOR UPDATE, so it can't interleave past our own lock.
       if (target === 'public') {
-        const orgRow = await client.query<{
-          membership_tier: string | null;
-          subscription_price_lookup_key: string | null;
-          subscription_status: string | null;
-          subscription_amount: number | null;
-          subscription_interval: string | null;
-          is_personal: boolean;
-        }>(
-          `SELECT membership_tier, subscription_price_lookup_key, subscription_status,
-                  subscription_amount, subscription_interval, is_personal
-           FROM organizations
-           WHERE workos_organization_id = $1`,
-          [orgId]
-        );
-        const currentTier = resolveMembershipTier(orgRow.rows[0] ?? null);
+        const currentTier = await readMembershipTierFromClient(client, orgId);
         if (!hasApiAccess(currentTier)) {
           await client.query('ROLLBACK');
           return {


### PR DESCRIPTION
## Summary

Closes #2826. Follow-up to #2822/#2830 — the inner-tx membership-tier read was duplicating the SQL column list and row type that \`resolveMembershipTier\` already documented via its function signature. A future column that the resolver's inference needed to consider would have silently missed one of the two inline SELECTs.

## What changed

- \`organization-db.ts\` now exports:
  - \`MembershipTierRow\` — the resolver's input type, named so other modules can reuse it.
  - \`MEMBERSHIP_TIER_COLUMNS\` — tuple of column names, single source of truth.
  - \`readMembershipTierFromClient(client, orgId, { forUpdate? })\` — runs the SELECT with the shared column list against a caller-held pg client, parses the row, returns \`MembershipTier | null\`. Optional \`forUpdate\` when the caller needs to lock the org row too (the seat-check path uses this).
- Two inline SELECT+resolve pairs replaced:
  - \`organization-db.ts:380\` (seat-check inside a tx) — uses \`forUpdate: true\`.
  - \`member-profiles.ts:727\` (\`applyAgentVisibility\` inner-tx tier re-read) — uses the default.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:server-unit\` — 1920 pass
- [x] \`npm run test:unit\` — 631 pass

No behavior change, pure DRY refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)