### PR TITLE
feat(membership): admin invitations replace direct invoices + invite-flow hardening

### DIFF
--- a/.changeset/stage-1-membership-invites-schema.md
+++ b/.changeset/stage-1-membership-invites-schema.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `membership_invites` table + `organizations.billing_address` JSONB column. Foundation for the upcoming "admin sends invitation, prospect self-serves agreement + invoice" flow that replaces the direct admin-invoice endpoint (see `.context/membership-invite-plan.md`).

--- a/.changeset/stage-2-tighten-invoice-request.md
+++ b/.changeset/stage-2-tighten-invoice-request.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tighten `/api/invoice-request` to require auth + org membership + signed agreement. Drops the free-text companyName/contactName/contactEmail inputs (which created orphan Stripe customers that webhooks couldn't link back to an org). Company name now comes from the org record, contact from the session. Billing address is stored on the org for future pre-fill. `createAndSendInvoice` also prefers the org's existing Stripe customer over dedup-by-email, fixing Stefan-style splits where auto-provisioned customers lacked org metadata.

--- a/.changeset/stage-3-admin-membership-invite.md
+++ b/.changeset/stage-3-admin-membership-invite.md
@@ -1,0 +1,4 @@
+---
+---
+
+Replace the direct admin-invoice endpoint with a membership invitation flow. Admin picks a tier and enters a contact email; system creates an invite token, emails the prospect a link (`/invite/:token`), and no Stripe invoice is issued until the prospect signs in, accepts the membership agreement, and confirms billing. Kills `POST /api/admin/accounts/:orgId/invoice` (returns 410 on legacy prospects path). New endpoints: `POST /api/admin/accounts/:orgId/invite-membership`, `GET /api/admin/accounts/:orgId/invites`, `POST /api/admin/accounts/:orgId/invites/:token/revoke`. Removes the typo-prone free-text form that caused split Stripe customers.

--- a/.changeset/stage-4-invite-acceptance-flow.md
+++ b/.changeset/stage-4-invite-acceptance-flow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Prospect-facing invite acceptance flow. `/invite/:token` landing page + `GET /api/invite/:token` (public metadata) + `POST /api/invite/:token/accept` (authed, issues Stripe invoice, joins WorkOS org, records agreement, stores billing address). Completes the admin-invites-replace-direct-invoices chain. The prospect gets one link, signs in, confirms billing, and the invoice goes out.

--- a/.changeset/stage-5-hardening.md
+++ b/.changeset/stage-5-hardening.md
@@ -1,0 +1,4 @@
+---
+---
+
+Hardening pass on the membership invite chain after expert review. Invite accept never auto-grants `owner` (always `member`); `createAndSendInvoice` no longer overwrites the linked Stripe customer's email on reuse; concurrent-accept clicks converge via Stripe idempotency keys (`invite_<token>`); server validates `agreement_version` against the current published agreement on both the invoice-request and invite-accept paths; two-step org updates merged into a single atomic write; billing address goes through a field-allowlist + length cap sanitizer before hitting the DB or Stripe; deleted-on-Stripe linked customers are cleared from the org row (instead of falling into the email-dedup path that caused the original bug); admin invite lowercases `contact_email` end-to-end; `invite.html` ships a `Referrer-Policy: same-origin` meta and blocks submit until the current agreement version has loaded.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -683,7 +683,7 @@
           </div>
           <div style="display: flex; gap: var(--space-2);">
             <button class="btn btn-secondary" onclick="openPaymentLinkModal()">Pay Link</button>
-            <button class="btn btn-secondary" onclick="openInvoiceModal()">Invoice</button>
+            <button class="btn btn-secondary" onclick="openInvoiceModal()">Invite</button>
             <button class="btn btn-secondary" onclick="openEditModal()">Edit</button>
             <button class="btn btn-secondary" onclick="openMergeSearch()" title="Merge another organization into this one">Merge with...</button>
             <button class="btn btn-secondary" onclick="openLogActivityModal()">Log Activity</button>
@@ -1293,105 +1293,52 @@
     </div>
   </div>
 
-  <!-- Invoice Modal -->
+  <!-- Membership Invite Modal -->
   <div id="invoiceModal" class="modal">
-    <div class="modal-content" style="max-width: 600px;">
+    <div class="modal-content" style="max-width: 520px;">
       <div class="modal-header">
-        <h2>Generate Invoice</h2>
+        <h2>Send Membership Invitation</h2>
         <button class="modal-close" onclick="closeModal('invoiceModal')">&times;</button>
       </div>
 
-      <p id="invoiceOrgName" style="margin-bottom: var(--space-4); color: var(--color-text-secondary);"></p>
-
-      <!-- Discount notice -->
-      <div id="invoiceDiscountNotice" style="display: none; margin-bottom: var(--space-4); padding: var(--space-3); background: var(--color-success-50); border-radius: var(--radius-sm);">
-        <div style="font-size: var(--text-sm);">
-          <strong style="color: var(--color-success-700);">Discount available:</strong>
-          <span id="invoiceDiscountText"></span>
-        </div>
-        <div style="margin-top: var(--space-2);">
-          <label style="font-size: var(--text-sm);">
-            <input type="checkbox" id="applyDiscountToInvoice" checked>
-            Apply discount to invoice
-          </label>
-        </div>
-      </div>
+      <p id="invoiceOrgName" style="margin-bottom: var(--space-3); color: var(--color-text-secondary);"></p>
+      <p style="margin-bottom: var(--space-4); font-size: var(--text-sm); color: var(--color-text-muted);">
+        The prospect receives an email with a link. They sign in, review the membership agreement, confirm billing details, and an invoice is issued automatically.
+      </p>
 
       <form id="invoiceForm" onsubmit="submitInvoice(event)">
-        <!-- Product Selection -->
         <div id="invoiceProductSection">
           <div class="form-group">
-            <label>Select Product</label>
+            <label>Select Tier</label>
             <div id="invoiceProducts" style="margin-bottom: var(--space-4);">
               Loading products...
             </div>
           </div>
         </div>
 
-        <!-- Billing Details (shown after product selection) -->
         <div id="invoiceBillingSection" style="display: none;">
           <div class="form-group">
-            <label>Selected Product</label>
+            <label>Selected Tier</label>
             <div id="selectedProductDisplay" style="padding: var(--space-2); background: var(--color-gray-50); border-radius: var(--radius-md); margin-bottom: var(--space-3);"></div>
           </div>
 
           <div class="form-row">
             <div class="form-group">
-              <label>Contact Name *</label>
-              <input type="text" id="invoiceContactName" required>
+              <label>Contact Name (optional)</label>
+              <input type="text" id="invoiceContactName" placeholder="For the email greeting">
             </div>
             <div class="form-group">
               <label>Contact Email *</label>
               <input type="email" id="invoiceContactEmail" required>
             </div>
           </div>
-
-          <div class="form-group">
-            <label>Company Name *</label>
-            <input type="text" id="invoiceCompanyName" required>
-          </div>
-
-          <h4 style="margin-top: var(--space-4); margin-bottom: var(--space-3); font-size: var(--text-sm); color: var(--color-text-heading);">Billing Address</h4>
-
-          <div class="form-group">
-            <label>Street Address *</label>
-            <input type="text" id="invoiceAddressLine1" required>
-          </div>
-
-          <div class="form-group">
-            <label>Address Line 2</label>
-            <input type="text" id="invoiceAddressLine2">
-          </div>
-
-          <div class="form-row">
-            <div class="form-group">
-              <label>City *</label>
-              <input type="text" id="invoiceCity" required>
-            </div>
-            <div class="form-group">
-              <label>State/Province *</label>
-              <input type="text" id="invoiceState" required>
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group">
-              <label>Postal Code *</label>
-              <input type="text" id="invoicePostalCode" required>
-            </div>
-            <div class="form-group">
-              <label>Country *</label>
-              <input type="text" id="invoiceCountry" value="US" required>
-            </div>
-          </div>
         </div>
 
-        <!-- Success Message -->
         <div id="invoiceResult" style="display: none;">
           <div style="background: var(--color-success-50); border: 1px solid var(--color-success-200); border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-4);">
-            <strong style="color: var(--color-success-700);">Invoice Sent!</strong>
+            <strong style="color: var(--color-success-700);">Invitation sent!</strong>
             <p style="margin: var(--space-2) 0 0; font-size: var(--text-sm); color: var(--color-text-secondary);">
-              The invoice has been emailed to the contact. You can also share this link:
+              The prospect has 30 days to accept. Share the link directly if helpful:
             </p>
           </div>
           <div style="display: flex; gap: var(--space-2);">
@@ -1402,7 +1349,7 @@
 
         <div class="modal-actions">
           <button type="button" class="btn btn-secondary" onclick="closeModal('invoiceModal')">Close</button>
-          <button type="submit" class="btn btn-primary" id="sendInvoiceBtn" style="display: none;">Send Invoice</button>
+          <button type="submit" class="btn btn-primary" id="sendInvoiceBtn" style="display: none;">Send Invitation</button>
         </div>
       </form>
     </div>
@@ -3693,33 +3640,9 @@
       document.getElementById('sendInvoiceBtn').style.display = 'none';
       document.getElementById('invoiceForm').reset();
 
-      // Show discount notice if org has a discount
-      const invoiceDiscountNotice = document.getElementById('invoiceDiscountNotice');
-      if (accountData.discount_percent || accountData.discount_amount_cents) {
-        invoiceDiscountNotice.style.display = 'block';
-        let discountText = '';
-        if (accountData.discount_percent) {
-          discountText = `${accountData.discount_percent}% off`;
-        } else {
-          discountText = `${new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(accountData.discount_amount_cents / 100)} off`;
-        }
-        if (accountData.stripe_promotion_code) {
-          discountText += ` (code: ${accountData.stripe_promotion_code})`;
-        }
-        document.getElementById('invoiceDiscountText').textContent = discountText;
-        document.getElementById('applyDiscountToInvoice').checked = true;
-        document.getElementById('applyDiscountToInvoice').onchange = () => {
-          if (invoiceProductsData.length > 0) renderInvoiceProducts(invoiceProductsData);
-        };
-      } else {
-        invoiceDiscountNotice.style.display = 'none';
-      }
-
-      // Pre-fill from account data
       if (accountData) {
         document.getElementById('invoiceContactName').value = accountData.prospect_contact_name || '';
         document.getElementById('invoiceContactEmail').value = accountData.prospect_contact_email || '';
-        document.getElementById('invoiceCompanyName').value = accountData.name || '';
       }
 
       openModal('invoiceModal');
@@ -3742,21 +3665,6 @@
       }
     }
 
-    function invoiceDiscountActive() {
-      return document.getElementById('applyDiscountToInvoice')?.checked &&
-        (accountData.discount_percent || accountData.discount_amount_cents);
-    }
-
-    function applyInvoiceDiscount(amountCents) {
-      if (accountData.discount_percent) {
-        return Math.round(amountCents * (1 - accountData.discount_percent / 100));
-      }
-      if (accountData.discount_amount_cents) {
-        return Math.max(0, amountCents - accountData.discount_amount_cents);
-      }
-      return amountCents;
-    }
-
     function renderInvoiceProducts(products) {
       const container = document.getElementById('invoiceProducts');
 
@@ -3765,18 +3673,9 @@
         return;
       }
 
-      const hasDiscount = invoiceDiscountActive();
-
       container.innerHTML = products.map((product, index) => {
         const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
         const price = fmt(product.amount_cents);
-
-        let discountedPriceHtml = '';
-        if (hasDiscount) {
-          const discountedCents = applyInvoiceDiscount(product.amount_cents);
-          discountedPriceHtml = `<span style="text-decoration: line-through; color: var(--color-text-muted); font-weight: normal;">${price}</span> <span style="color: var(--color-success-700); font-weight: var(--font-semibold);">${fmt(discountedCents)}</span>`;
-        }
-
         const interval = product.billing_interval ? `/${product.billing_interval}` : '';
         const displayName = escapeHtml(product.display_name || product.product_name);
         const description = product.description ? escapeHtml(product.description) : '';
@@ -3796,16 +3695,12 @@
           " onmouseover="this.style.borderColor='var(--color-brand)'" onmouseout="this.style.borderColor='var(--color-border)'">
             <strong>${displayName}</strong>
             <br>
-            ${hasDiscount
-              ? `${discountedPriceHtml}${interval}`
-              : `<span style="color: var(--color-brand); font-weight: var(--font-semibold);">${price}${interval}</span>`
-            }
+            <span style="color: var(--color-brand); font-weight: var(--font-semibold);">${price}${interval}</span>
             ${description ? `<br><span style="font-size: var(--text-xs); color: var(--color-text-muted);">${description}</span>` : ''}
           </button>
         `;
       }).join('');
 
-      // Event delegation for product selection
       container.onclick = function(e) {
         const btn = e.target.closest('[data-product-index]');
         if (!btn) return;
@@ -3827,12 +3722,7 @@
 
       const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
       const price = fmt(product.amount_cents);
-
-      let priceHtml = `<span style="color: var(--color-brand);">${price}</span>`;
-      if (invoiceDiscountActive()) {
-        const discountedCents = applyInvoiceDiscount(product.amount_cents);
-        priceHtml = `<span style="text-decoration: line-through; color: var(--color-text-muted);">${price}</span> <span style="color: var(--color-success-700);">${fmt(discountedCents)}</span>`;
-      }
+      const priceHtml = `<span style="color: var(--color-brand);">${price}</span>`;
 
       document.getElementById('selectedProductDisplay').innerHTML = `
         <strong>${escapeHtml(displayName)}</strong> - ${priceHtml}
@@ -3847,7 +3737,7 @@
       event.preventDefault();
 
       if (!selectedInvoiceProduct) {
-        alert('Please select a product first');
+        alert('Please select a tier first');
         return;
       }
 
@@ -3855,25 +3745,14 @@
       btn.disabled = true;
       btn.textContent = 'Sending...';
 
-      const applyDiscount = document.getElementById('applyDiscountToInvoice')?.checked;
       const data = {
         lookup_key: selectedInvoiceProduct.lookupKey,
-        company_name: document.getElementById('invoiceCompanyName').value,
-        contact_name: document.getElementById('invoiceContactName').value,
         contact_email: document.getElementById('invoiceContactEmail').value,
-        billing_address: {
-          line1: document.getElementById('invoiceAddressLine1').value,
-          line2: document.getElementById('invoiceAddressLine2').value || undefined,
-          city: document.getElementById('invoiceCity').value,
-          state: document.getElementById('invoiceState').value,
-          postal_code: document.getElementById('invoicePostalCode').value,
-          country: document.getElementById('invoiceCountry').value,
-        },
-        coupon_id: applyDiscount && accountData.stripe_coupon_id ? accountData.stripe_coupon_id : null,
+        contact_name: document.getElementById('invoiceContactName').value || undefined,
       };
 
       try {
-        const response = await fetch(`/api/admin/prospects/${accountId}/invoice`, {
+        const response = await fetch(`/api/admin/accounts/${accountId}/invite-membership`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
@@ -3881,29 +3760,26 @@
 
         if (!response.ok) {
           const error = await response.json();
-          throw new Error(error.error || error.message || 'Failed to send invoice');
+          throw new Error(error.error || error.message || 'Failed to send invitation');
         }
 
         const result = await response.json();
 
-        if (result.success && result.invoice_url) {
+        if (result.success && result.invite?.url) {
           document.getElementById('invoiceBillingSection').style.display = 'none';
-          document.getElementById('invoiceDiscountNotice').style.display = 'none';
           document.getElementById('sendInvoiceBtn').style.display = 'none';
-          document.getElementById('invoiceUrl').value = result.invoice_url;
+          document.getElementById('invoiceUrl').value = result.invite.url;
           document.getElementById('invoiceResult').style.display = 'block';
-
-          // Refresh page to show the new pending invoice
-          setTimeout(() => location.reload(), 2000);
+          setTimeout(() => location.reload(), 2500);
         } else {
           throw new Error(result.message || 'Unknown error');
         }
       } catch (error) {
-        console.error('Error sending invoice:', error);
+        console.error('Error sending invitation:', error);
         alert('Error: ' + error.message);
       } finally {
         btn.disabled = false;
-        btn.textContent = 'Send Invoice';
+        btn.textContent = 'Send Invitation';
       }
     }
 
@@ -3911,10 +3787,10 @@
       const input = document.getElementById('invoiceUrl');
       input.select();
       navigator.clipboard.writeText(input.value).then(() => {
-        showToast('Invoice link copied to clipboard!');
+        showToast('Invitation link copied to clipboard!');
       }).catch(() => {
         document.execCommand('copy');
-        showToast('Invoice link copied to clipboard!');
+        showToast('Invitation link copied to clipboard!');
       });
     }
 

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1032,28 +1032,14 @@
       </div>
       <form id="invoiceRequestForm" onsubmit="submitInvoiceRequest(event)">
         <div style="padding: 24px;">
-          <div style="margin-bottom: 16px;">
-            <label style="display: block; font-size: 14px; font-weight: 500; color: var(--color-text); margin-bottom: 4px;">Company Name *</label>
-            <input type="text" id="invoice-company" name="companyName" required placeholder="Acme Corporation" style="width: 100%; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 8px; font-size: 14px;">
+          <div id="invoice-summary" style="margin-bottom: 16px; padding: 12px 16px; background: var(--color-bg-subtle); border-radius: 8px; font-size: 14px;">
+            <div style="color: var(--color-text-muted); margin-bottom: 4px;">Invoicing</div>
+            <div style="font-weight: 600; color: var(--color-text-heading);" id="invoice-org-name">—</div>
+            <div style="color: var(--color-text-secondary); margin-top: 6px;" id="invoice-product-summary">—</div>
+            <div style="color: var(--color-text-muted); margin-top: 6px; font-size: 13px;" id="invoice-recipient-summary">—</div>
           </div>
 
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px;">
-            <div>
-              <label style="display: block; font-size: 14px; font-weight: 500; color: var(--color-text); margin-bottom: 4px;">Contact Name *</label>
-              <input type="text" id="invoice-contact" name="contactName" required placeholder="John Smith" style="width: 100%; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 8px; font-size: 14px;">
-            </div>
-            <div>
-              <label style="display: block; font-size: 14px; font-weight: 500; color: var(--color-text); margin-bottom: 4px;">Billing Email *</label>
-              <input type="email" id="invoice-email" name="contactEmail" required placeholder="billing@acme.com" style="width: 100%; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 8px; font-size: 14px;">
-            </div>
-          </div>
-
-          <div style="margin-bottom: 16px;">
-            <label style="display: block; font-size: 14px; font-weight: 500; color: var(--color-text); margin-bottom: 4px;">Product *</label>
-            <select id="invoice-product" name="lookupKey" required style="width: 100%; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 8px; font-size: 14px; background: white;">
-              <option value="">Select a product...</option>
-            </select>
-          </div>
+          <input type="hidden" id="invoice-lookup-key" name="lookupKey">
 
           <div style="margin-bottom: 16px;">
             <label style="display: block; font-size: 14px; font-weight: 500; color: var(--color-text); margin-bottom: 4px;">Billing Address Line 1 *</label>
@@ -1087,11 +1073,18 @@
             </div>
           </div>
 
+          <div style="background: var(--color-bg-subtle); border: 1px solid var(--color-border); border-radius: 8px; padding: 16px; margin-bottom: 16px;">
+            <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer;">
+              <input type="checkbox" id="invoice-agreement-checkbox" style="margin-top: 3px; cursor: pointer;">
+              <span style="font-size: 14px;">I have read and agree to the <a href="/membership-agreement" target="_blank" rel="noopener" style="color: var(--color-brand);">AgenticAdvertising.org Membership Agreement</a>.</span>
+            </label>
+          </div>
+
           <div id="invoiceFormError" style="display: none; color: var(--color-error-600); font-size: 14px; margin-bottom: 16px; padding: 12px; background: var(--color-error-50); border-radius: 8px;"></div>
         </div>
         <div style="padding: 16px 24px; border-top: 1px solid var(--color-border); display: flex; gap: 12px; justify-content: flex-end;">
           <button type="button" class="btn btn-secondary" onclick="closeInvoiceRequestModal()">Cancel</button>
-          <button type="submit" class="btn btn-primary" id="invoiceSubmitBtn">Send Invoice</button>
+          <button type="submit" class="btn btn-primary" id="invoiceSubmitBtn" disabled>Send Invoice</button>
         </div>
       </form>
     </div>
@@ -1222,6 +1215,7 @@
               suggested_company_type: billingData.suggested_company_type,
               suggested_revenue_tier: billingData.suggested_revenue_tier,
             };
+            currentOrg.billing_address = billingData.billing_address || null;
           }
         } catch (billingError) {
           console.error('Error loading billing info:', billingError);
@@ -1761,42 +1755,54 @@
     }
 
     function openInvoiceRequestModal(preSelectedLookupKey = null) {
-      const modal = document.getElementById('invoiceRequestModal');
-      const productSelect = document.getElementById('invoice-product');
-
-      // Populate product dropdown with subscription products only
-      // (excludes legacy one-time invoice products)
-      productSelect.innerHTML = '<option value="">Select a product...</option>';
-      if (membershipProducts && membershipProducts.length > 0) {
-        const subscriptionProducts = membershipProducts.filter(p => p.billing_type === 'subscription');
-        subscriptionProducts.forEach(product => {
-          const price = formatCurrency(product.amount_cents);
-          productSelect.innerHTML += `<option value="${escapeHtml(product.lookup_key)}">${escapeHtml(product.display_name)} - ${price}/year</option>`;
-        });
+      if (!currentOrg) {
+        showToast('Please sign in and select an organization first.', true);
+        return;
       }
 
-      // Pre-select product if specified
-      if (preSelectedLookupKey) {
-        productSelect.value = preSelectedLookupKey;
+      const product = preSelectedLookupKey
+        ? (membershipProducts || []).find(p => p.lookup_key === preSelectedLookupKey)
+        : null;
+
+      if (!product) {
+        showToast('Select a membership tier before requesting an invoice.', true);
+        return;
       }
 
-      // Pre-fill company name from org if available
-      const companyInput = document.getElementById('invoice-company');
-      if (currentOrg && currentOrg.name && !companyInput.value) {
-        companyInput.value = currentOrg.name;
+      document.getElementById('invoice-lookup-key').value = product.lookup_key;
+      document.getElementById('invoice-org-name').textContent = currentOrg.name || '(your organization)';
+      document.getElementById('invoice-product-summary').textContent =
+        `${product.display_name} — ${formatCurrency(product.amount_cents)}/year`;
+      const userEmail = (window.__APP_CONFIG__ && window.__APP_CONFIG__.user && window.__APP_CONFIG__.user.email) || '';
+      document.getElementById('invoice-recipient-summary').textContent =
+        userEmail ? `Invoice will be sent to ${userEmail}` : 'Invoice will be sent to your account email';
+
+      if (currentOrg.billing_address) {
+        const a = currentOrg.billing_address;
+        if (a.line1) document.getElementById('invoice-address1').value = a.line1;
+        if (a.line2) document.getElementById('invoice-address2').value = a.line2;
+        if (a.city) document.getElementById('invoice-city').value = a.city;
+        if (a.state) document.getElementById('invoice-state').value = a.state;
+        if (a.postal_code) document.getElementById('invoice-postal').value = a.postal_code;
+        if (a.country) document.getElementById('invoice-country').value = a.country;
       }
 
-      modal.style.display = 'flex';
-      document.getElementById('invoice-company').focus();
+      const agreementCheckbox = document.getElementById('invoice-agreement-checkbox');
+      const submitBtn = document.getElementById('invoiceSubmitBtn');
+      agreementCheckbox.checked = false;
+      submitBtn.disabled = true;
+      agreementCheckbox.onchange = () => { submitBtn.disabled = !agreementCheckbox.checked; };
+
+      document.getElementById('invoiceRequestModal').style.display = 'flex';
+      document.getElementById('invoice-address1').focus();
     }
 
     function closeInvoiceRequestModal() {
       document.getElementById('invoiceRequestModal').style.display = 'none';
       document.getElementById('invoiceFormError').style.display = 'none';
-      // Reset form and button state
       document.getElementById('invoiceRequestForm').reset();
       const submitBtn = document.getElementById('invoiceSubmitBtn');
-      submitBtn.disabled = false;
+      submitBtn.disabled = true;
       submitBtn.textContent = 'Send Invoice';
     }
 
@@ -1806,6 +1812,13 @@
       const form = event.target;
       const submitBtn = document.getElementById('invoiceSubmitBtn');
       const errorDiv = document.getElementById('invoiceFormError');
+      const agreementCheckbox = document.getElementById('invoice-agreement-checkbox');
+
+      if (!agreementCheckbox.checked) {
+        errorDiv.textContent = 'Please accept the membership agreement to continue.';
+        errorDiv.style.display = 'block';
+        return;
+      }
 
       submitBtn.disabled = true;
       submitBtn.textContent = 'Sending...';
@@ -1814,9 +1827,7 @@
       const formData = new FormData(form);
 
       const requestData = {
-        companyName: formData.get('companyName'),
-        contactName: formData.get('contactName'),
-        contactEmail: formData.get('contactEmail'),
+        orgId: currentOrg.id,
         lookupKey: formData.get('lookupKey'),
         billingAddress: {
           line1: formData.get('line1'),
@@ -1826,7 +1837,12 @@
           postal_code: formData.get('postal_code'),
           country: formData.get('country'),
         },
+        agreement_version: loadedAgreementVersion || undefined,
       };
+      const storedReferralCode = localStorage.getItem('aao_referral_code');
+      if (storedReferralCode) {
+        requestData.referral_code = storedReferralCode;
+      }
 
       try {
         const response = await fetch('/api/invoice-request', {
@@ -1842,7 +1858,6 @@
           throw new Error(result.message || 'Failed to send invoice');
         }
 
-        // Show success state
         const modalBody = form.querySelector('div:first-child');
         const modalFooter = form.querySelector('div:last-child');
 
@@ -1850,7 +1865,7 @@
           <div style="text-align: center; padding: 24px;">
             <div style="font-size: 48px; margin-bottom: 16px;">✅</div>
             <h3 style="color: var(--color-success-600); margin-bottom: 8px;">Invoice Sent!</h3>
-            <p style="color: var(--color-text-secondary); margin-bottom: 16px;">We've sent an invoice to <strong>${escapeHtml(requestData.contactEmail)}</strong>. Please check your email for payment instructions.</p>
+            <p style="color: var(--color-text-secondary); margin-bottom: 16px;">We've sent an invoice to your account email. Please check your inbox for payment instructions.</p>
             <p style="font-size: 14px; color: var(--color-text-muted);">The invoice is due within 30 days. You can pay online via the link in the email.</p>
           </div>
         `;

--- a/server/public/invite.html
+++ b/server/public/invite.html
@@ -190,7 +190,7 @@
 
       var agreementVersion = null;
       var agreementReady = false;
-      var agreementPromise = fetch('/api/agreement/current?type=membership')
+      fetch('/api/agreement/current?type=membership')
         .then(function (res) { return res.ok ? res.json() : null; })
         .then(function (data) {
           if (data && data.version) agreementVersion = data.version;

--- a/server/public/invite.html
+++ b/server/public/invite.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Membership Invitation - AgenticAdvertising.org</title>
+  <meta name="description" content="Accept your AgenticAdvertising.org membership invitation.">
+  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system.css">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      background: var(--color-bg-page);
+      min-height: 100vh;
+      display: flex; flex-direction: column;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    }
+    .wrapper { flex: 1; display: flex; align-items: center; justify-content: center; padding: var(--space-8) var(--space-5); }
+    .card {
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-2xl);
+      box-shadow: var(--shadow-lg);
+      padding: var(--space-10) var(--space-8);
+      max-width: 560px; width: 100%;
+    }
+    .muted { color: var(--color-text-muted); font-size: var(--text-sm); }
+    .tier-block {
+      background: var(--color-bg-subtle);
+      border-radius: var(--radius-xl);
+      padding: var(--space-4) var(--space-5);
+      margin: var(--space-5) 0;
+    }
+    .tier-label { font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .tier-name { font-size: var(--text-lg); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-top: 2px; }
+    .tier-price { font-size: var(--text-base); color: var(--color-text-secondary); margin-top: 6px; }
+    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); margin-bottom: var(--space-3); }
+    .form-group { margin-bottom: var(--space-3); }
+    label { display: block; font-size: var(--text-sm); font-weight: 500; color: var(--color-text); margin-bottom: var(--space-1); }
+    input[type=text], input[type=email] {
+      width: 100%; padding: 10px 12px;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      font-size: var(--text-sm);
+    }
+    .agreement-block {
+      background: var(--color-bg-subtle);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: var(--space-4);
+      margin: var(--space-4) 0;
+    }
+    .error {
+      color: var(--color-error-600);
+      background: var(--color-error-50);
+      padding: var(--space-3);
+      border-radius: var(--radius-md);
+      font-size: var(--text-sm);
+      margin: var(--space-3) 0;
+    }
+    .hidden { display: none !important; }
+    .btn-primary {
+      background: var(--color-brand);
+      color: white;
+      padding: 12px 28px;
+      border: none;
+      border-radius: var(--radius-md);
+      font-size: var(--text-base);
+      font-weight: 500;
+      cursor: pointer;
+      display: inline-block;
+      text-decoration: none;
+    }
+    .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-secondary {
+      background: white;
+      color: var(--color-text-heading);
+      padding: 12px 28px;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      font-size: var(--text-base);
+      cursor: pointer;
+      text-decoration: none;
+    }
+    ol { padding-left: 20px; margin: var(--space-4) 0; }
+    ol li { margin-bottom: var(--space-2); }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="card">
+      <div id="loadingState">
+        <p class="muted">Loading invitation…</p>
+      </div>
+
+      <div id="errorState" class="hidden">
+        <h1 id="errorTitle" style="margin-top: 0;">Something went wrong</h1>
+        <p id="errorMessage" class="muted"></p>
+        <p><a href="/" class="btn-secondary">Back to home</a></p>
+      </div>
+
+      <div id="successState" class="hidden">
+        <h1 style="margin-top: 0;" id="headline">You're invited to join AgenticAdvertising.org</h1>
+        <p class="muted" id="subhead"></p>
+
+        <div class="tier-block">
+          <div class="tier-label">Membership tier</div>
+          <div class="tier-name" id="tierName">—</div>
+          <div class="tier-price" id="tierPrice">—</div>
+        </div>
+
+        <div id="signInSection" class="hidden">
+          <p>Sign in (or create your account) to accept.</p>
+          <p>
+            <a id="signInBtn" class="btn-primary" href="#">Sign in to continue</a>
+          </p>
+          <p class="muted" style="margin-top: var(--space-3);">
+            The invitation was sent to <span id="contactEmailDisplay"></span>. You can sign in with any account email — we'll add you to the organization when you accept.
+          </p>
+        </div>
+
+        <div id="acceptSection" class="hidden">
+          <p><strong>Welcome, <span id="userName"></span>.</strong> Here's what happens next:</p>
+          <ol>
+            <li>Review and sign the membership agreement</li>
+            <li>Confirm your billing address</li>
+            <li>Receive the invoice — pay within 30 days to activate</li>
+          </ol>
+
+          <form id="acceptForm" onsubmit="submitAccept(event)">
+            <h3 style="margin-top: var(--space-5); margin-bottom: var(--space-3); font-size: var(--text-base);">Billing address</h3>
+            <div class="form-group">
+              <label for="line1">Street address *</label>
+              <input type="text" id="line1" name="line1" required>
+            </div>
+            <div class="form-group">
+              <label for="line2">Address line 2</label>
+              <input type="text" id="line2" name="line2">
+            </div>
+            <div class="form-row">
+              <div>
+                <label for="city">City *</label>
+                <input type="text" id="city" name="city" required>
+              </div>
+              <div>
+                <label for="state">State/Province *</label>
+                <input type="text" id="state" name="state" required>
+              </div>
+            </div>
+            <div class="form-row">
+              <div>
+                <label for="postal_code">Postal code *</label>
+                <input type="text" id="postal_code" name="postal_code" required>
+              </div>
+              <div>
+                <label for="country">Country *</label>
+                <input type="text" id="country" name="country" value="US" required>
+              </div>
+            </div>
+
+            <div class="agreement-block">
+              <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer; font-weight: normal;">
+                <input type="checkbox" id="agreementCheckbox" style="margin-top: 3px; cursor: pointer;">
+                <span>I have read and agree to the <a href="/membership-agreement" target="_blank" rel="noopener">AgenticAdvertising.org Membership Agreement</a>.</span>
+              </label>
+            </div>
+
+            <div id="acceptError" class="error hidden"></div>
+
+            <div style="display: flex; gap: var(--space-3); justify-content: flex-end;">
+              <a href="/" class="btn-secondary">Cancel</a>
+              <button type="submit" id="acceptBtn" class="btn-primary" disabled>Accept and issue invoice</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var pathParts = window.location.pathname.split('/');
+      var token = pathParts[pathParts.length - 1];
+
+      if (!token) {
+        showError('Invalid link', 'This invitation link is missing a token.');
+        return;
+      }
+
+      var agreementVersion = null;
+      fetch('/api/agreement/current?type=membership')
+        .then(function (res) { return res.ok ? res.json() : null; })
+        .then(function (data) { if (data) agreementVersion = data.version || null; })
+        .catch(function () { /* fall through — server will reject if missing */ });
+
+      fetch('/api/invite/' + encodeURIComponent(token))
+        .then(function (res) {
+          if (res.status === 404) throw Object.assign(new Error('Not found'), { status: 404 });
+          if (!res.ok) throw Object.assign(new Error('Error'), { status: res.status });
+          return res.json();
+        })
+        .then(function (invite) {
+          if (invite.status === 'expired') {
+            showError('Invitation expired', 'This invitation has expired. Ask the sender for a new one.');
+            return;
+          }
+          if (invite.status === 'revoked') {
+            showError('Invitation revoked', 'This invitation was revoked by the sender.');
+            return;
+          }
+          if (invite.status === 'accepted') {
+            showError('Already accepted', 'This invitation has already been accepted.');
+            return;
+          }
+          renderInvite(invite);
+        })
+        .catch(function (err) {
+          if (err.status === 404) {
+            showError('Invitation not found', "We couldn't find this invitation. Double-check the link.");
+          } else {
+            showError('Something went wrong', 'Please refresh in a moment or contact finance@agenticadvertising.org.');
+          }
+        });
+
+      function renderInvite(invite) {
+        document.getElementById('loadingState').classList.add('hidden');
+        document.getElementById('successState').classList.remove('hidden');
+
+        var priceStr = invite.amount_cents != null
+          ? '$' + (invite.amount_cents / 100).toLocaleString() + (invite.billing_interval ? '/' + invite.billing_interval : '')
+          : '';
+
+        document.getElementById('headline').textContent =
+          invite.org_name + ', you\'re invited to become a member.';
+        document.getElementById('subhead').textContent =
+          'Accept this invitation to become an AgenticAdvertising.org member. The invoice will be sent to your signed-in account email after you accept.';
+        document.getElementById('tierName').textContent = invite.tier_display_name || invite.lookup_key;
+        document.getElementById('tierPrice').textContent = priceStr;
+        document.getElementById('contactEmailDisplay').textContent = invite.contact_email;
+
+        if (invite.billing_address) {
+          var a = invite.billing_address;
+          if (a.line1) document.getElementById('line1').value = a.line1;
+          if (a.line2) document.getElementById('line2').value = a.line2;
+          if (a.city) document.getElementById('city').value = a.city;
+          if (a.state) document.getElementById('state').value = a.state;
+          if (a.postal_code) document.getElementById('postal_code').value = a.postal_code;
+          if (a.country) document.getElementById('country').value = a.country;
+        }
+
+        var cfg = window.__APP_CONFIG__;
+        if (cfg && cfg.user) {
+          document.getElementById('userName').textContent =
+            (cfg.user.firstName || cfg.user.email || 'there');
+          document.getElementById('acceptSection').classList.remove('hidden');
+
+          var checkbox = document.getElementById('agreementCheckbox');
+          var btn = document.getElementById('acceptBtn');
+          checkbox.addEventListener('change', function () {
+            btn.disabled = !checkbox.checked;
+          });
+        } else {
+          document.getElementById('signInSection').classList.remove('hidden');
+          var signIn = document.getElementById('signInBtn');
+          signIn.href = '/auth/login?return_to=' + encodeURIComponent(window.location.pathname);
+        }
+      }
+
+      function showError(title, message) {
+        document.getElementById('loadingState').classList.add('hidden');
+        document.getElementById('errorTitle').textContent = title;
+        document.getElementById('errorMessage').textContent = message;
+        document.getElementById('errorState').classList.remove('hidden');
+      }
+
+      window.submitAccept = function (ev) {
+        ev.preventDefault();
+        var btn = document.getElementById('acceptBtn');
+        var err = document.getElementById('acceptError');
+        err.classList.add('hidden');
+        btn.disabled = true;
+        btn.textContent = 'Submitting…';
+
+        var body = {
+          billingAddress: {
+            line1: document.getElementById('line1').value,
+            line2: document.getElementById('line2').value || undefined,
+            city: document.getElementById('city').value,
+            state: document.getElementById('state').value,
+            postal_code: document.getElementById('postal_code').value,
+            country: document.getElementById('country').value,
+          },
+          agreement_version: agreementVersion || '1.0',
+        };
+
+        fetch('/api/invite/' + encodeURIComponent(token) + '/accept', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+          .then(function (res) { return res.json().then(function (b) { return { ok: res.ok, body: b }; }); })
+          .then(function (r) {
+            if (r.ok) {
+              window.location.href = '/dashboard?invite=accepted';
+            } else {
+              err.textContent = (r.body && (r.body.message || r.body.error)) || 'Something went wrong.';
+              err.classList.remove('hidden');
+              btn.disabled = false;
+              btn.textContent = 'Accept and issue invoice';
+            }
+          })
+          .catch(function () {
+            err.textContent = 'Network error. Please try again.';
+            err.classList.remove('hidden');
+            btn.disabled = false;
+            btn.textContent = 'Accept and issue invoice';
+          });
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/server/public/invite.html
+++ b/server/public/invite.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="same-origin">
   <title>Membership Invitation - AgenticAdvertising.org</title>
   <meta name="description" content="Accept your AgenticAdvertising.org membership invitation.">
   <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
@@ -188,10 +189,14 @@
       }
 
       var agreementVersion = null;
-      fetch('/api/agreement/current?type=membership')
+      var agreementReady = false;
+      var agreementPromise = fetch('/api/agreement/current?type=membership')
         .then(function (res) { return res.ok ? res.json() : null; })
-        .then(function (data) { if (data) agreementVersion = data.version || null; })
-        .catch(function () { /* fall through — server will reject if missing */ });
+        .then(function (data) {
+          if (data && data.version) agreementVersion = data.version;
+          agreementReady = true;
+        })
+        .catch(function () { agreementReady = true; /* server will reject on submit */ });
 
       fetch('/api/invite/' + encodeURIComponent(token))
         .then(function (res) {
@@ -278,6 +283,15 @@
         var btn = document.getElementById('acceptBtn');
         var err = document.getElementById('acceptError');
         err.classList.add('hidden');
+
+        if (!agreementVersion) {
+          err.textContent = agreementReady
+            ? "We couldn't load the current membership agreement. Please refresh and try again."
+            : 'Still loading the membership agreement — please try again in a moment.';
+          err.classList.remove('hidden');
+          return;
+        }
+
         btn.disabled = true;
         btn.textContent = 'Submitting…';
 
@@ -290,7 +304,7 @@
             postal_code: document.getElementById('postal_code').value,
             country: document.getElementById('country').value,
           },
-          agreement_version: agreementVersion || '1.0',
+          agreement_version: agreementVersion,
         };
 
         fetch('/api/invite/' + encodeURIComponent(token) + '/accept', {

--- a/server/src/billing/billing-address.ts
+++ b/server/src/billing/billing-address.ts
@@ -1,0 +1,34 @@
+import type { BillingAddress } from '../db/organization-db.js';
+
+const MAX_ADDR_FIELD = 200;
+
+/**
+ * Return a billing address with only known fields and each string capped at
+ * MAX_ADDR_FIELD characters. Returns null if any required field is missing
+ * or exceeds the cap. We persist this to JSONB and pass it to Stripe —
+ * tightening here keeps malformed or attacker-controlled data out of both.
+ */
+export function sanitizeBillingAddress(input: unknown): BillingAddress | null {
+  if (!input || typeof input !== 'object') return null;
+  const a = input as Record<string, unknown>;
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const line1 = str(a.line1).trim();
+  const line2 = str(a.line2).trim();
+  const city = str(a.city).trim();
+  const state = str(a.state).trim();
+  const postalCode = str(a.postal_code).trim();
+  const country = str(a.country).trim();
+  if (!line1 || !city || !state || !postalCode || !country) return null;
+  for (const f of [line1, line2, city, state, postalCode, country]) {
+    if (f.length > MAX_ADDR_FIELD) return null;
+  }
+  const out: BillingAddress = {
+    line1,
+    city,
+    state,
+    postal_code: postalCode,
+    country,
+  };
+  if (line2) out.line2 = line2;
+  return out;
+}

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { createLogger } from '../logger.js';
 import { notifySystemError } from '../addie/error-notifier.js';
+import { getPool } from '../db/client.js';
 
 const logger = createLogger('stripe-client');
 
@@ -929,17 +930,55 @@ export async function createAndSendInvoice(
 
   let subscriptionId: string | undefined;
   try {
-    // Find or create customer using shared deduplication logic
-    const customerId = await createStripeCustomer({
-      email: data.contactEmail,
-      name: data.companyName,
-      updateEmail: true,
-      metadata: {
-        contact_name: data.contactName,
-        invoice_request: 'true',
-        ...(data.workosOrganizationId && { workos_organization_id: data.workosOrganizationId }),
-      },
-    });
+    // If the org already has a linked Stripe customer in our DB, reuse it
+    // directly. createStripeCustomer's dedup lookups (by workos_organization_id
+    // metadata, then by email) can miss customers that were auto-provisioned
+    // at org-creation time without the org metadata tag — causing a split
+    // where the org is linked to one customer but the invoice goes to a new
+    // one, and the webhook can't reconcile. DB is the source of truth.
+    let customerId: string | null = null;
+    if (data.workosOrganizationId && stripe) {
+      const existing = await getPool().query<{ stripe_customer_id: string | null }>(
+        'SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1',
+        [data.workosOrganizationId]
+      );
+      const linkedId = existing.rows[0]?.stripe_customer_id;
+      if (linkedId) {
+        try {
+          const existingCustomer = await stripe.customers.retrieve(linkedId);
+          if (!('deleted' in existingCustomer && existingCustomer.deleted)) {
+            await stripe.customers.update(linkedId, {
+              email: data.contactEmail,
+              name: data.companyName,
+              metadata: {
+                ...(existingCustomer as Stripe.Customer).metadata,
+                contact_name: data.contactName,
+                invoice_request: 'true',
+                workos_organization_id: data.workosOrganizationId,
+              },
+            });
+            customerId = linkedId;
+            logger.info({ customerId, orgId: data.workosOrganizationId }, 'Reusing org-linked Stripe customer for invoice');
+          }
+        } catch (err) {
+          logger.warn({ err, linkedId, orgId: data.workosOrganizationId },
+            'Org-linked Stripe customer could not be retrieved; falling back to dedup');
+        }
+      }
+    }
+
+    if (!customerId) {
+      customerId = await createStripeCustomer({
+        email: data.contactEmail,
+        name: data.companyName,
+        updateEmail: true,
+        metadata: {
+          contact_name: data.contactName,
+          invoice_request: 'true',
+          ...(data.workosOrganizationId && { workos_organization_id: data.workosOrganizationId }),
+        },
+      });
+    }
 
     if (!customerId) {
       logger.error({ email: data.contactEmail }, 'Failed to find or create Stripe customer for invoice');

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -903,6 +903,10 @@ export interface InvoiceRequestData {
   invoiceDate?: string; // ISO date (YYYY-MM-DD) for backdating the invoice
   dueDate?: string; // ISO date (YYYY-MM-DD) for explicit due date
   poNumber?: string; // Customer PO number to display on invoice
+  idempotencyKey?: string; // Passed through to Stripe as its Idempotency-Key header;
+                           // repeat calls with the same key return the same subscription/invoice.
+                           // Callers pass the invite token to prevent duplicate invoices from
+                           // concurrent accept clicks.
 }
 
 /**
@@ -937,6 +941,7 @@ export async function createAndSendInvoice(
     // where the org is linked to one customer but the invoice goes to a new
     // one, and the webhook can't reconcile. DB is the source of truth.
     let customerId: string | null = null;
+    let linkedCustomerDeletedOnStripe = false;
     if (data.workosOrganizationId && stripe) {
       const existing = await getPool().query<{ stripe_customer_id: string | null }>(
         'SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1',
@@ -946,16 +951,25 @@ export async function createAndSendInvoice(
       if (linkedId) {
         try {
           const existingCustomer = await stripe.customers.retrieve(linkedId);
-          if (!('deleted' in existingCustomer && existingCustomer.deleted)) {
+          if ('deleted' in existingCustomer && existingCustomer.deleted) {
+            linkedCustomerDeletedOnStripe = true;
+            logger.warn({ linkedId, orgId: data.workosOrganizationId },
+              'Org-linked Stripe customer is deleted on Stripe — clearing link and falling through to new-customer creation');
+          } else {
+            // Keep the customer's email and name stable — multiple people may
+            // run through this flow (different accepters, different admins)
+            // and rewriting the email on every call hands whoever clicks last
+            // control of future billing notifications. Only top up metadata +
+            // backfill name when it's missing.
+            const current = existingCustomer as Stripe.Customer;
+            const metadataUpdate = {
+              ...current.metadata,
+              workos_organization_id: data.workosOrganizationId,
+            };
+            const needsNameBackfill = !current.name?.trim();
             await stripe.customers.update(linkedId, {
-              email: data.contactEmail,
-              name: data.companyName,
-              metadata: {
-                ...(existingCustomer as Stripe.Customer).metadata,
-                contact_name: data.contactName,
-                invoice_request: 'true',
-                workos_organization_id: data.workosOrganizationId,
-              },
+              ...(needsNameBackfill && { name: data.companyName }),
+              metadata: metadataUpdate,
             });
             customerId = linkedId;
             logger.info({ customerId, orgId: data.workosOrganizationId }, 'Reusing org-linked Stripe customer for invoice');
@@ -965,6 +979,16 @@ export async function createAndSendInvoice(
             'Org-linked Stripe customer could not be retrieved; falling back to dedup');
         }
       }
+    }
+
+    // If the linked customer was deleted, clear the stale DB link so we
+    // don't re-enter the email-dedup path and re-bind an unrelated orphan
+    // (exactly the bug that hit Stefan).
+    if (linkedCustomerDeletedOnStripe && data.workosOrganizationId) {
+      await getPool().query(
+        'UPDATE organizations SET stripe_customer_id = NULL WHERE workos_organization_id = $1',
+        [data.workosOrganizationId]
+      );
     }
 
     if (!customerId) {
@@ -1089,21 +1113,27 @@ export async function createAndSendInvoice(
     // Create subscription with invoice billing
     // This creates a subscription AND generates an invoice for the first payment
     // When the invoice is paid, the subscription becomes active and will auto-renew
-    const subscription = await stripe.subscriptions.create({
-      customer: customer.id,
-      items: [{ price: priceId }],
-      collection_method: 'send_invoice',
-      days_until_due: daysUntilDue,
-      // Backdate subscription start if invoice date is in the past
-      ...(invoiceDateUnix && { backdate_start_date: invoiceDateUnix }),
-      // Apply coupon if validated
-      ...(validatedCouponId && { discounts: [{ coupon: validatedCouponId }] }),
-      metadata: {
-        lookup_key: data.lookupKey,
-        contact_name: data.contactName,
-        ...(data.workosOrganizationId && { workos_organization_id: data.workosOrganizationId }),
+    const subscription = await stripe.subscriptions.create(
+      {
+        customer: customer.id,
+        items: [{ price: priceId }],
+        collection_method: 'send_invoice',
+        days_until_due: daysUntilDue,
+        // Backdate subscription start if invoice date is in the past
+        ...(invoiceDateUnix && { backdate_start_date: invoiceDateUnix }),
+        // Apply coupon if validated
+        ...(validatedCouponId && { discounts: [{ coupon: validatedCouponId }] }),
+        metadata: {
+          lookup_key: data.lookupKey,
+          contact_name: data.contactName,
+          ...(data.workosOrganizationId && { workos_organization_id: data.workosOrganizationId }),
+        },
       },
-    });
+      // Idempotency-Key: concurrent accept clicks on the same invite converge
+      // to the same subscription/invoice on Stripe's side (24h window). Callers
+      // pass the invite token; without one we let Stripe generate a fresh call.
+      data.idempotencyKey ? { idempotencyKey: data.idempotencyKey } : undefined,
+    );
     subscriptionId = subscription.id;
 
     // Get the invoice that was created with the subscription

--- a/server/src/db/membership-invites-db.ts
+++ b/server/src/db/membership-invites-db.ts
@@ -1,0 +1,164 @@
+import { randomBytes } from 'node:crypto';
+import { query } from './client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('membership-invites-db');
+
+export interface MembershipInvite {
+  token: string;
+  workos_organization_id: string;
+  lookup_key: string;
+  contact_email: string;
+  contact_name: string | null;
+  referral_code: string | null;
+  invited_by_user_id: string;
+  created_at: Date;
+  expires_at: Date;
+  accepted_at: Date | null;
+  accepted_by_user_id: string | null;
+  invoice_id: string | null;
+  revoked_at: Date | null;
+  revoked_by_user_id: string | null;
+}
+
+export interface CreateMembershipInviteInput {
+  workos_organization_id: string;
+  lookup_key: string;
+  contact_email: string;
+  contact_name?: string;
+  referral_code?: string;
+  invited_by_user_id: string;
+  expires_in_days?: number;
+}
+
+export type InviteStatus =
+  | 'pending'
+  | 'accepted'
+  | 'expired'
+  | 'revoked';
+
+export function inviteStatus(invite: MembershipInvite, now: Date = new Date()): InviteStatus {
+  if (invite.revoked_at) return 'revoked';
+  if (invite.accepted_at) return 'accepted';
+  if (invite.expires_at.getTime() <= now.getTime()) return 'expired';
+  return 'pending';
+}
+
+function generateToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export async function createMembershipInvite(
+  input: CreateMembershipInviteInput
+): Promise<MembershipInvite> {
+  const token = generateToken();
+  const expiresInDays = input.expires_in_days ?? 30;
+
+  const result = await query<MembershipInvite>(
+    `INSERT INTO membership_invites
+       (token, workos_organization_id, lookup_key, contact_email, contact_name,
+        referral_code, invited_by_user_id, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + ($8 || ' days')::interval)
+     RETURNING *`,
+    [
+      token,
+      input.workos_organization_id,
+      input.lookup_key,
+      input.contact_email.trim().toLowerCase(),
+      input.contact_name?.trim() || null,
+      input.referral_code || null,
+      input.invited_by_user_id,
+      String(expiresInDays),
+    ]
+  );
+
+  const created = result.rows[0];
+  logger.info(
+    {
+      token: created.token.slice(0, 8) + '...',
+      orgId: created.workos_organization_id,
+      lookupKey: created.lookup_key,
+      contactEmail: created.contact_email,
+      invitedBy: created.invited_by_user_id,
+    },
+    'Membership invite created'
+  );
+  return created;
+}
+
+export async function getMembershipInviteByToken(
+  token: string
+): Promise<MembershipInvite | null> {
+  const result = await query<MembershipInvite>(
+    'SELECT * FROM membership_invites WHERE token = $1',
+    [token]
+  );
+  return result.rows[0] || null;
+}
+
+export async function listMembershipInvitesForOrg(
+  workosOrganizationId: string
+): Promise<MembershipInvite[]> {
+  const result = await query<MembershipInvite>(
+    `SELECT * FROM membership_invites
+     WHERE workos_organization_id = $1
+     ORDER BY created_at DESC`,
+    [workosOrganizationId]
+  );
+  return result.rows;
+}
+
+/**
+ * Marks the invite accepted and records the issued invoice. Returns the
+ * updated row if the invite was pending at this moment, null otherwise —
+ * the atomicity guards against a second accept racing with the first.
+ */
+export async function markMembershipInviteAccepted(
+  token: string,
+  acceptedByUserId: string,
+  invoiceId: string
+): Promise<MembershipInvite | null> {
+  const result = await query<MembershipInvite>(
+    `UPDATE membership_invites
+     SET accepted_at = NOW(),
+         accepted_by_user_id = $2,
+         invoice_id = $3
+     WHERE token = $1
+       AND accepted_at IS NULL
+       AND revoked_at IS NULL
+       AND expires_at > NOW()
+     RETURNING *`,
+    [token, acceptedByUserId, invoiceId]
+  );
+  if (result.rows.length === 0) {
+    return null;
+  }
+  const updated = result.rows[0];
+  logger.info(
+    {
+      token: token.slice(0, 8) + '...',
+      orgId: updated.workos_organization_id,
+      acceptedBy: acceptedByUserId,
+      invoiceId,
+    },
+    'Membership invite accepted'
+  );
+  return updated;
+}
+
+export async function revokeMembershipInvite(
+  token: string,
+  revokedByUserId: string
+): Promise<MembershipInvite | null> {
+  const result = await query<MembershipInvite>(
+    `UPDATE membership_invites
+     SET revoked_at = NOW(),
+         revoked_by_user_id = $2
+     WHERE token = $1
+       AND accepted_at IS NULL
+       AND revoked_at IS NULL
+     RETURNING *`,
+    [token, revokedByUserId]
+  );
+  return result.rows[0] || null;
+}

--- a/server/src/db/migrations/423_membership_invites.sql
+++ b/server/src/db/migrations/423_membership_invites.sql
@@ -1,0 +1,42 @@
+-- Migration: membership invitations + per-org billing address
+--
+-- Admin sends an invitation (not a direct invoice) to a prospect contact.
+-- The prospect accepts the invite link, signs the membership agreement,
+-- confirms billing details, and only then is an invoice issued. This
+-- prevents the "admin types wrong email, Stripe creates orphan customer,
+-- payment goes through without linking to an org" class of bugs.
+--
+-- billing_address is stored on the org so follow-up invoices don't need
+-- to re-collect it.
+
+CREATE TABLE IF NOT EXISTS membership_invites (
+  token TEXT PRIMARY KEY,
+  workos_organization_id TEXT NOT NULL REFERENCES organizations(workos_organization_id) ON DELETE CASCADE,
+  lookup_key TEXT NOT NULL,
+  contact_email TEXT NOT NULL,
+  contact_name TEXT,
+  referral_code TEXT,
+  invited_by_user_id TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  accepted_at TIMESTAMP WITH TIME ZONE,
+  accepted_by_user_id TEXT,
+  invoice_id TEXT,
+  revoked_at TIMESTAMP WITH TIME ZONE,
+  revoked_by_user_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_membership_invites_org ON membership_invites(workos_organization_id);
+CREATE INDEX IF NOT EXISTS idx_membership_invites_email ON membership_invites(contact_email);
+CREATE INDEX IF NOT EXISTS idx_membership_invites_pending ON membership_invites(expires_at)
+  WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+COMMENT ON TABLE membership_invites IS 'Admin-issued invitations for prospects to become paying members. Accepting the invite triggers agreement + billing collection, then issues the Stripe invoice.';
+COMMENT ON COLUMN membership_invites.token IS 'Random 32-byte hex. Used in the invite URL (/invite/:token). Not guessable.';
+COMMENT ON COLUMN membership_invites.lookup_key IS 'Stripe price lookup key identifying the tier (e.g. aao_membership_professional).';
+COMMENT ON COLUMN membership_invites.invoice_id IS 'Stripe invoice ID, set when invoice is issued on acceptance.';
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS billing_address JSONB;
+
+COMMENT ON COLUMN organizations.billing_address IS 'Billing address confirmed by the org (line1, line2, city, state, postal_code, country). Pre-fills future invoices.';

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -133,8 +133,18 @@ export interface Organization {
   discount_granted_at: Date | null;
   stripe_coupon_id: string | null;
   stripe_promotion_code: string | null;
+  billing_address: BillingAddress | null;
   created_at: Date;
   updated_at: Date;
+}
+
+export interface BillingAddress {
+  line1: string;
+  line2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
 }
 
 export interface SubscriptionInfo {
@@ -806,6 +816,7 @@ export class OrganizationDatabase {
       discount_granted_at: 'discount_granted_at',
       stripe_coupon_id: 'stripe_coupon_id',
       stripe_promotion_code: 'stripe_promotion_code',
+      billing_address: 'billing_address',
     };
 
     const setClauses: string[] = [];

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -81,6 +81,7 @@ import { createBillingRouter } from "./routes/billing.js";
 import { createPublicBillingRouter } from "./routes/billing-public.js";
 import { createOrganizationsRouter } from "./routes/organizations.js";
 import { createReferralsRouter } from "./routes/referrals.js";
+import { createInvitesRouter } from "./routes/invites.js";
 import { convertReferral, listAllReferralCodes } from "./db/referral-codes-db.js";
 import { createEventsRouter } from "./routes/events.js";
 import { createLatestRouter } from "./routes/latest.js";
@@ -872,6 +873,9 @@ export class HTTPServer {
     // Mount public referral routes
     const referralsRouter = createReferralsRouter();
     this.app.use('/api', referralsRouter); // Public referral routes: /api/referral/*
+
+    // Mount membership invite routes (GET /api/invite/:token public, POST /api/invite/:token/accept authed)
+    this.app.use('/api', createInvitesRouter());
 
     // Mount public Registry API routes (brands, properties, agents, search, validation)
     const registryApiRouter = createRegistryApiRouter({
@@ -2203,6 +2207,10 @@ export class HTTPServer {
     // Referral landing page - personalized invite page for prospects
     this.app.get("/join/:code", async (req, res) => {
       await this.serveHtmlWithConfig(req, res, 'join.html');
+    });
+
+    this.app.get("/invite/:token", async (req, res) => {
+      await this.serveHtmlWithConfig(req, res, 'invite.html');
     });
 
     // About AAO page - serve about.html at /about

--- a/server/src/notifications/email.ts
+++ b/server/src/notifications/email.ts
@@ -109,7 +109,8 @@ export type EmailType =
   | 'slack_invite'
   | 'email_link_verification'
   | 'escalation_resolution'
-  | 'newsletter_subscribe_confirmation';
+  | 'newsletter_subscribe_confirmation'
+  | 'membership_invite';
 
 /**
  * Send welcome email to new members after subscription is created
@@ -1687,6 +1688,144 @@ ${footerText}
     return true;
   } catch (error) {
     logger.error({ error, to: data.to }, 'Error sending newsletter confirmation');
+    return false;
+  }
+}
+
+/**
+ * Send a membership invitation to a prospect contact. The link drops them
+ * on /invite/:token where they sign in, join the org, sign the membership
+ * agreement, confirm billing details, and an invoice is issued.
+ */
+export async function sendMembershipInviteEmail(data: {
+  to: string;
+  contactName?: string | null;
+  orgName: string;
+  tierDisplayName: string;
+  priceDisplay: string;
+  inviteUrl: string;
+  invitedByName: string;
+  invitedByEmail: string;
+  expiresAt: Date;
+}): Promise<boolean> {
+  if (!resend) {
+    logger.debug('Resend not configured, skipping membership invite email');
+    return false;
+  }
+
+  const emailType: EmailType = 'membership_invite';
+  const subject = `You're invited to join ${data.orgName} on AgenticAdvertising.org`;
+
+  const escapeHtml = (str: string): string =>
+    str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+  const greeting = data.contactName ? `Hi ${escapeHtml(data.contactName)},` : 'Hi,';
+  const safeOrg = escapeHtml(data.orgName);
+  const safeTier = escapeHtml(data.tierDisplayName);
+  const safePrice = escapeHtml(data.priceDisplay);
+  const safeInviter = escapeHtml(data.invitedByName);
+  const safeInviterEmail = escapeHtml(data.invitedByEmail);
+  const expiresLocal = data.expiresAt.toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  try {
+    const emailEvent = await emailDb.createEmailEvent({
+      email_type: emailType,
+      recipient_email: data.to,
+      subject,
+      metadata: {
+        orgName: data.orgName,
+        tierDisplayName: data.tierDisplayName,
+        invitedByEmail: data.invitedByEmail,
+      },
+    });
+
+    const trackingId = emailEvent.tracking_id;
+    const trackedInviteUrl = trackedUrl(trackingId, 'cta_accept_invite', data.inviteUrl);
+    // Transactional email: no unsubscribe (this is a one-off invite).
+    const footerHtml = generateFooterHtml(trackingId, null);
+    const footerText = generateFooterText(null);
+
+    const { data: sendData, error } = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: data.to,
+      replyTo: data.invitedByEmail,
+      subject,
+      html: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="text-align: center; margin-bottom: 30px;">
+    <h1 style="color: #1a1a1a; font-size: 24px; margin: 0;">Membership Invitation</h1>
+  </div>
+
+  <p>${greeting}</p>
+
+  <p><strong>${safeInviter}</strong> from AgenticAdvertising.org has invited <strong>${safeOrg}</strong> to become a member.</p>
+
+  <div style="background: #f5f5f5; border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <div style="font-size: 13px; color: #666; margin-bottom: 4px;">Tier</div>
+    <div style="font-size: 18px; font-weight: 600; color: #1a1a1a; margin-bottom: 12px;">${safeTier}</div>
+    <div style="font-size: 13px; color: #666; margin-bottom: 4px;">Annual membership</div>
+    <div style="font-size: 16px; color: #1a1a1a;">${safePrice}</div>
+  </div>
+
+  <p>Accepting the invitation walks you through:</p>
+  <ol style="padding-left: 20px;">
+    <li>Sign in (or create your account)</li>
+    <li>Review and sign the membership agreement</li>
+    <li>Confirm your billing address</li>
+    <li>Receive your invoice for payment</li>
+  </ol>
+
+  <p style="text-align: center; margin: 30px 0;">
+    <a href="${trackedInviteUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 500;">Accept Invitation</a>
+  </p>
+
+  <p style="font-size: 13px; color: #666;">This invitation expires on ${escapeHtml(expiresLocal)}. If you have questions, reply to this email — it goes straight to ${safeInviterEmail}.</p>
+
+  ${footerHtml}
+</body>
+</html>
+      `.trim(),
+      text: `
+Membership Invitation — AgenticAdvertising.org
+
+${data.contactName ? `Hi ${data.contactName},` : 'Hi,'}
+
+${data.invitedByName} from AgenticAdvertising.org has invited ${data.orgName} to become a member.
+
+Tier: ${data.tierDisplayName}
+Annual membership: ${data.priceDisplay}
+
+Accept the invitation to sign in, review the membership agreement, confirm your billing address, and receive your invoice:
+
+${data.inviteUrl}
+
+This invitation expires on ${expiresLocal}. Questions? Reply to this email — it goes to ${data.invitedByEmail}.
+
+${footerText}
+      `.trim(),
+    });
+
+    if (error) {
+      logger.error({ error, to: data.to }, 'Failed to send membership invite email');
+      return false;
+    }
+
+    if (sendData?.id) {
+      await emailDb.markEmailSent(trackingId, sendData.id);
+    }
+
+    logger.info({ to: data.to, orgName: data.orgName, trackingId }, 'Membership invite sent');
+    return true;
+  } catch (error) {
+    logger.error({ error, to: data.to }, 'Error sending membership invite email');
     return false;
   }
 }

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -2742,10 +2742,12 @@ export function setupAccountRoutes(
           });
         }
 
+        const normalizedEmail = contact_email.trim().toLowerCase();
+
         const invite = await createMembershipInvite({
           workos_organization_id: orgId,
           lookup_key,
-          contact_email,
+          contact_email: normalizedEmail,
           contact_name: contact_name?.trim() || undefined,
           referral_code: referral_code?.trim() || undefined,
           invited_by_user_id: req.user!.id,
@@ -2760,7 +2762,7 @@ export function setupAccountRoutes(
           req.user!.email;
 
         const emailSent = await sendMembershipInviteEmail({
-          to: contact_email,
+          to: normalizedEmail,
           contactName: contact_name?.trim() || null,
           orgName: org.name,
           tierDisplayName: product.display_name,
@@ -2779,7 +2781,7 @@ export function setupAccountRoutes(
             prospect_contact_name = COALESCE($1, prospect_contact_name),
             prospect_contact_email = $2
            WHERE workos_organization_id = $3`,
-          [contact_name?.trim() || null, contact_email, orgId]
+          [contact_name?.trim() || null, normalizedEmail, orgId]
         );
 
         logger.info(

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -20,8 +20,14 @@ import {
   getPendingInvoices,
   createCheckoutSession,
   getProductsForCustomer,
-  createAndSendInvoice,
 } from "../../billing/stripe-client.js";
+import {
+  createMembershipInvite,
+  listMembershipInvitesForOrg,
+  inviteStatus,
+  revokeMembershipInvite,
+} from "../../db/membership-invites-db.js";
+import { sendMembershipInviteEmail } from "../../notifications/email.js";
 import { createProspect, updateProspect } from "../../services/prospect.js";
 import { WorkOS } from "@workos-inc/node";
 import {
@@ -2676,103 +2682,193 @@ export function setupAccountRoutes(
   );
 
   // POST /api/admin/accounts/:orgId/invoice - Generate and send a Stripe invoice
+  // POST /api/admin/accounts/:orgId/invite-membership
+  // Admin sends a membership invitation (not a direct invoice). The prospect
+  // clicks the emailed link, signs in, signs the membership agreement,
+  // confirms billing, and only then is the Stripe invoice issued. This
+  // replaces the previous admin-fills-out-a-form-and-invoice-goes-out flow,
+  // which was fragile (typos in email → orphan customers → unlinked payments).
   apiRouter.post(
-    "/accounts/:orgId/invoice",
+    "/accounts/:orgId/invite-membership",
     requireAuth,
     requireAdmin,
     async (req, res) => {
       try {
         const { orgId } = req.params;
-        const {
-          lookup_key,
-          company_name,
-          contact_name,
-          contact_email,
-          billing_address,
-          coupon_id,
-        } = req.body;
+        const { lookup_key, contact_email, contact_name, referral_code } = req.body as {
+          lookup_key?: string;
+          contact_email?: string;
+          contact_name?: string;
+          referral_code?: string;
+        };
 
-        if (!lookup_key || !company_name || !contact_name || !contact_email || !billing_address) {
+        if (!lookup_key || !contact_email) {
           return res.status(400).json({
             error: "Missing required fields",
-            message: "lookup_key, company_name, contact_name, contact_email, and billing_address are required",
+            message: "lookup_key and contact_email are required",
           });
         }
 
-        if (!billing_address.line1 || !billing_address.city || !billing_address.state ||
-            !billing_address.postal_code || !billing_address.country) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+        if (!emailRegex.test(contact_email)) {
           return res.status(400).json({
-            error: "Incomplete billing address",
-            message: "Billing address must include line1, city, state, postal_code, and country",
+            error: "Invalid email",
+            message: "Please provide a valid email address",
           });
         }
 
-        const pool = getPool();
-        const orgResult = await pool.query(
-          `SELECT workos_organization_id, name, stripe_coupon_id FROM organizations WHERE workos_organization_id = $1`,
-          [orgId]
-        );
+        if (!lookup_key.startsWith("aao_")) {
+          return res.status(400).json({
+            error: "Invalid product",
+            message: "Invalid product selection",
+          });
+        }
 
-        if (orgResult.rows.length === 0) {
+        const org = await orgDb.getOrganization(orgId);
+        if (!org) {
           return res.status(404).json({ error: "Organization not found" });
         }
 
-        const org = orgResult.rows[0];
-        // Only fall back to org coupon if coupon_id was not provided;
-        // explicit null means the admin opted out of the discount
-        const effectiveCouponId = coupon_id !== undefined ? coupon_id : org.stripe_coupon_id;
-
-        const result = await createAndSendInvoice({
-          lookupKey: lookup_key,
-          companyName: company_name,
-          contactName: contact_name,
-          contactEmail: contact_email,
-          billingAddress: {
-            line1: billing_address.line1,
-            line2: billing_address.line2,
-            city: billing_address.city,
-            state: billing_address.state,
-            postal_code: billing_address.postal_code,
-            country: billing_address.country,
-          },
-          workosOrganizationId: orgId,
-          couponId: effectiveCouponId,
+        const customerType = org.is_personal ? "individual" : "company";
+        const eligibleProducts = await getProductsForCustomer({
+          customerType,
+          category: "membership",
         });
-
-        if (!result) {
-          return res.status(500).json({
-            error: "Failed to create invoice",
-            message: "Stripe may not be configured or the product was not found",
+        const product = eligibleProducts.find((p) => p.lookup_key === lookup_key);
+        if (!product) {
+          return res.status(400).json({
+            error: "Product not available",
+            message: "This membership tier is not available for this organization.",
           });
         }
 
+        const invite = await createMembershipInvite({
+          workos_organization_id: orgId,
+          lookup_key,
+          contact_email,
+          contact_name: contact_name?.trim() || undefined,
+          referral_code: referral_code?.trim() || undefined,
+          invited_by_user_id: req.user!.id,
+        });
+
+        const baseUrl = process.env.BASE_URL || "https://agenticadvertising.org";
+        const inviteUrl = `${baseUrl}/invite/${invite.token}`;
+        const priceDisplay = `$${(product.amount_cents / 100).toLocaleString()}`;
+
+        const invitedByName =
+          [req.user!.firstName, req.user!.lastName].filter(Boolean).join(" ") ||
+          req.user!.email;
+
+        const emailSent = await sendMembershipInviteEmail({
+          to: contact_email,
+          contactName: contact_name?.trim() || null,
+          orgName: org.name,
+          tierDisplayName: product.display_name,
+          priceDisplay,
+          inviteUrl,
+          invitedByName,
+          invitedByEmail: req.user!.email,
+          expiresAt: invite.expires_at,
+        });
+
+        // Keep the prospect contact info on the org record for visibility.
+        const pool = getPool();
         await pool.query(
           `UPDATE organizations SET
             invoice_requested_at = NOW(),
-            prospect_contact_name = $1,
+            prospect_contact_name = COALESCE($1, prospect_contact_name),
             prospect_contact_email = $2
            WHERE workos_organization_id = $3`,
-          [contact_name, contact_email, orgId]
+          [contact_name?.trim() || null, contact_email, orgId]
         );
 
         logger.info(
-          { orgId, orgName: org.name, lookupKey: lookup_key, invoiceId: result.invoiceId, contactEmail: contact_email, adminEmail: req.user!.email },
-          "Admin sent invoice"
+          {
+            orgId,
+            orgName: org.name,
+            lookupKey: lookup_key,
+            contactEmail: contact_email,
+            inviteToken: invite.token.slice(0, 8) + "...",
+            emailSent,
+            adminEmail: req.user!.email,
+          },
+          "Admin sent membership invitation"
         );
 
         res.json({
           success: true,
-          invoice_id: result.invoiceId,
-          invoice_url: result.invoiceUrl,
+          invite: {
+            token: invite.token,
+            contact_email: invite.contact_email,
+            contact_name: invite.contact_name,
+            lookup_key: invite.lookup_key,
+            expires_at: invite.expires_at,
+            url: inviteUrl,
+          },
+          email_sent: emailSent,
           organization: { name: org.name },
-          contact: { name: contact_name, email: contact_email },
         });
       } catch (error) {
-        logger.error({ err: error }, "Error sending invoice");
+        logger.error({ err: error }, "Error sending membership invitation");
         res.status(500).json({
           error: "Internal server error",
-          message: "Unable to send invoice",
+          message: "Unable to send membership invitation",
         });
+      }
+    }
+  );
+
+  // GET /api/admin/accounts/:orgId/invites - List membership invitations for an org
+  apiRouter.get(
+    "/accounts/:orgId/invites",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const { orgId } = req.params;
+        const invites = await listMembershipInvitesForOrg(orgId);
+        res.json({
+          invites: invites.map((inv) => ({
+            token: inv.token,
+            contact_email: inv.contact_email,
+            contact_name: inv.contact_name,
+            lookup_key: inv.lookup_key,
+            invited_by_user_id: inv.invited_by_user_id,
+            created_at: inv.created_at,
+            expires_at: inv.expires_at,
+            accepted_at: inv.accepted_at,
+            accepted_by_user_id: inv.accepted_by_user_id,
+            invoice_id: inv.invoice_id,
+            revoked_at: inv.revoked_at,
+            status: inviteStatus(inv),
+          })),
+        });
+      } catch (error) {
+        logger.error({ err: error }, "Error listing invitations");
+        res.status(500).json({ error: "Internal server error" });
+      }
+    }
+  );
+
+  // POST /api/admin/accounts/:orgId/invites/:token/revoke - Revoke a pending invite
+  apiRouter.post(
+    "/accounts/:orgId/invites/:token/revoke",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const { token } = req.params;
+        const revoked = await revokeMembershipInvite(token, req.user!.id);
+        if (!revoked) {
+          return res.status(400).json({
+            error: "Cannot revoke",
+            message: "Invite is already accepted, revoked, or does not exist.",
+          });
+        }
+        res.json({ success: true, token: revoked.token });
+      } catch (error) {
+        logger.error({ err: error }, "Error revoking invitation");
+        res.status(500).json({ error: "Internal server error" });
       }
     }
   );

--- a/server/src/routes/admin/prospects.ts
+++ b/server/src/routes/admin/prospects.ts
@@ -29,9 +29,15 @@ export function setupProspectRoutes(apiRouter: Router, _config: { workos: any })
     res.redirect(308, `/api/admin/accounts/${req.params.orgId}/payment-link`);
   });
 
-  // POST /api/admin/prospects/:orgId/invoice → POST /api/admin/accounts/:orgId/invoice
-  apiRouter.post("/prospects/:orgId/invoice", requireAuth, requireAdmin, (req, res) => {
-    res.redirect(308, `/api/admin/accounts/${req.params.orgId}/invoice`);
+  // POST /api/admin/prospects/:orgId/invoice - removed (direct admin invoice killed;
+  // admins now send membership invitations via invite-membership). Return a 410
+  // rather than a redirect so stale callers surface the migration clearly.
+  apiRouter.post("/prospects/:orgId/invoice", requireAuth, requireAdmin, (_req, res) => {
+    res.status(410).json({
+      error: "Gone",
+      message:
+        "The direct admin-invoice endpoint has been removed. Use POST /api/admin/accounts/:orgId/invite-membership to send a membership invitation instead.",
+    });
   });
 
   // GET /api/admin/prospects/typeahead?q=... → GET /api/admin/accounts?view=all&search=...&limit=10

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -174,14 +174,26 @@ export function createPublicBillingRouter(): Router {
     }
   });
 
-  // POST /api/invoice-request - Request an invoice for a product (public endpoint)
-  router.post("/invoice-request", async (req: Request, res: Response) => {
+  // POST /api/invoice-request - Issue a Stripe invoice for the caller's org.
+  //
+  // Requires:
+  //   - Authenticated user who is a member of `orgId`
+  //   - `lookupKey` for a membership product eligible for that org type
+  //   - `billingAddress` (stored on the org for future invoices)
+  //   - The org has accepted the membership agreement for this tier —
+  //     either previously (via /api/organizations/:orgId/pending-agreement)
+  //     or inline via the `agreement_version` field in this request body.
+  //
+  // This replaces the old unauthenticated contact-form version, which could
+  // create orphaned Stripe customers (free-text email → new customer with no
+  // workos_organization_id metadata → webhook couldn't link payment to an org).
+  router.post("/invoice-request", requireAuth, async (req: Request, res: Response) => {
     try {
-      const { companyName, contactName, contactEmail, billingAddress, lookupKey, referral_code } =
+      const user = req.user!;
+      const { orgId, lookupKey, billingAddress, referral_code, agreement_version } =
         req.body as {
-          companyName: string;
-          contactName: string;
-          contactEmail: string;
+          orgId: string;
+          lookupKey: string;
           billingAddress: {
             line1: string;
             line2?: string;
@@ -190,22 +202,14 @@ export function createPublicBillingRouter(): Router {
             postal_code: string;
             country: string;
           };
-          lookupKey: string;
           referral_code?: string;
+          agreement_version?: string;
         };
 
-      // Validate required fields
-      if (
-        !companyName ||
-        !contactName ||
-        !contactEmail ||
-        !billingAddress ||
-        !lookupKey
-      ) {
+      if (!orgId || !lookupKey || !billingAddress) {
         return res.status(400).json({
           error: "Missing required fields",
-          message:
-            "Please provide companyName, contactName, contactEmail, billingAddress, and lookupKey",
+          message: "Please provide orgId, lookupKey, and billingAddress",
         });
       }
 
@@ -222,7 +226,6 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      // Validate lookup key starts with our prefix
       if (!lookupKey.startsWith("aao_")) {
         logger.warn({ lookupKey }, 'Invoice request rejected: invalid lookup key prefix');
         return res.status(400).json({
@@ -231,22 +234,81 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      logger.info({
-        lookupKey,
-        companyName,
-        contactEmail,
-      }, 'Invoice request received');
-
-      // Validate email format
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-      if (!emailRegex.test(contactEmail)) {
-        return res.status(400).json({
-          error: "Invalid email format",
-          message: "Please provide a valid email address",
+      const org = await orgDb.getOrganization(orgId);
+      if (!org) {
+        return res.status(404).json({
+          error: "Organization not found",
+          message: "The specified organization does not exist",
         });
       }
 
-      // Validate referral code and create a Stripe coupon if it carries a discount
+      const isDevUserInvoice =
+        isDevModeEnabled() &&
+        Object.values(DEV_USERS).some((du) => du.id === user.id) &&
+        orgId.startsWith("org_dev_");
+
+      if (!isDevUserInvoice) {
+        const membership = await workos?.userManagement.listOrganizationMemberships({
+          userId: user.id,
+          organizationId: orgId,
+        });
+        if (!membership?.data?.length) {
+          return res.status(403).json({
+            error: "Access denied",
+            message: "You are not a member of this organization",
+          });
+        }
+      }
+
+      // Product must be eligible for this org type (individual → personal
+      // workspace, company → non-personal org).
+      const customerType = org.is_personal ? 'individual' : 'company';
+      const eligibleProducts = await getProductsForCustomer({
+        customerType,
+        category: 'membership',
+      });
+      const product = eligibleProducts.find((p) => p.lookup_key === lookupKey);
+      if (!product) {
+        return res.status(400).json({
+          error: "Product not available",
+          message: "This membership tier is not available for your organization.",
+        });
+      }
+
+      // Agreement gate. Caller either already accepted (pending_agreement_version
+      // set on the org) or accepts inline. We store the acceptance as "pending"
+      // here; the webhook on invoice.paid / subscription.created records it
+      // permanently (existing machinery from the checkout flow).
+      const pendingVersion = agreement_version?.trim() || org.pending_agreement_version;
+      if (!pendingVersion) {
+        return res.status(400).json({
+          error: "Membership agreement required",
+          message:
+            "Please accept the membership agreement before requesting an invoice.",
+          required: "agreement_version",
+        });
+      }
+      if (agreement_version) {
+        await orgDb.updateOrganization(orgId, {
+          pending_agreement_version: agreement_version,
+          pending_agreement_accepted_at: new Date(),
+        });
+      }
+
+      // Store the confirmed billing address on the org so future invoices
+      // pre-fill from it.
+      await orgDb.updateOrganization(orgId, {
+        billing_address: {
+          line1: billingAddress.line1,
+          line2: billingAddress.line2,
+          city: billingAddress.city,
+          state: billingAddress.state,
+          postal_code: billingAddress.postal_code,
+          country: billingAddress.country,
+        },
+      });
+
+      // Referral discount (same logic as checkout).
       let invoiceCouponId: string | undefined;
       let validatedInvoiceReferralCode: Awaited<ReturnType<typeof referralDb.getReferralCode>> = null;
 
@@ -279,14 +341,20 @@ export function createPublicBillingRouter(): Router {
         }
       }
 
+      const displayName =
+        [user.firstName, user.lastName].filter(Boolean).join(' ') || user.email;
+
       const invoiceData: InvoiceRequestData = {
-        companyName,
-        contactName,
-        contactEmail,
+        companyName: org.name,
+        contactName: displayName,
+        contactEmail: user.email,
         billingAddress,
         lookupKey,
-        couponId: invoiceCouponId,
+        workosOrganizationId: orgId,
+        couponId: invoiceCouponId ?? org.stripe_coupon_id ?? undefined,
       };
+
+      logger.info({ orgId, lookupKey, userId: user.id }, 'Invoice request received');
 
       const result = await createAndSendInvoice(invoiceData);
 
@@ -298,33 +366,25 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      // Record referral after invoice is confirmed
       if (validatedInvoiceReferralCode) {
         try {
-          await referralDb.redeemReferralCodeForInvoice(validatedInvoiceReferralCode.code, companyName, contactEmail);
+          await referralDb.redeemReferralCodeForInvoice(
+            validatedInvoiceReferralCode.code,
+            org.name,
+            user.email,
+          );
         } catch (err) {
-          logger.warn({ err, referral_code, companyName }, 'Failed to record referral for invoice — continuing');
+          logger.warn({ err, referral_code, orgId }, 'Failed to record referral for invoice — continuing');
         }
       }
 
-      // Get product details for the notification
-      const products = await getInvoiceableProducts();
-      const product = products.find((p) => p.lookup_key === lookupKey);
-      const productDisplay = product
-        ? `${product.display_name} ($${(product.amount_cents / 100).toLocaleString()})`
-        : lookupKey;
+      const productDisplay = `${product.display_name} ($${(product.amount_cents / 100).toLocaleString()})`;
 
       logger.info(
-        {
-          invoiceId: result.invoiceId,
-          companyName,
-          contactEmail,
-          lookupKey,
-        },
+        { invoiceId: result.invoiceId, orgId, lookupKey, userId: user.id },
         "Invoice request processed successfully"
       );
 
-      // Send Slack notification for invoice request
       if (process.env.SLACK_WEBHOOK_URL) {
         fetch(process.env.SLACK_WEBHOOK_URL, {
           method: "POST",
@@ -336,7 +396,7 @@ export function createPublicBillingRouter(): Router {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `*New Invoice Request*\n\n*Company:* ${companyName}\n*Contact:* ${contactName} (${contactEmail})\n*Product:* ${productDisplay}\n*Invoice ID:* ${result.invoiceId}`,
+                  text: `*New Invoice Request*\n\n*Org:* ${org.name}\n*Requested by:* ${displayName} (${user.email})\n*Product:* ${productDisplay}\n*Invoice ID:* ${result.invoiceId}`,
                 },
               },
             ],
@@ -348,7 +408,7 @@ export function createPublicBillingRouter(): Router {
 
       res.json({
         success: true,
-        message: `Invoice sent to ${contactEmail}. Please check your email for payment instructions.`,
+        message: `Invoice sent to ${user.email}. Please check your email for payment instructions.`,
         invoiceId: result.invoiceId,
         invoiceUrl: result.invoiceUrl,
       });
@@ -756,6 +816,7 @@ export function createPublicBillingRouter(): Router {
           revenue_tier: org.revenue_tier || null,
           is_personal: org.is_personal || false,
           pending_invoices: pendingInvoices,
+          billing_address: org.billing_address || null,
           // Enrichment-based suggestions for prefilling the profile modal
           suggested_company_type: suggestedCompanyType,
           suggested_revenue_tier: suggestedRevenueTier,

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -23,6 +23,7 @@ import {
   type CheckoutSessionData,
 } from "../billing/stripe-client.js";
 import * as referralDb from "../db/referral-codes-db.js";
+import { sanitizeBillingAddress } from "../billing/billing-address.js";
 import {
   OrganizationDatabase,
   type CompanyType,
@@ -213,16 +214,11 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      if (
-        !billingAddress.line1 ||
-        !billingAddress.city ||
-        !billingAddress.state ||
-        !billingAddress.postal_code ||
-        !billingAddress.country
-      ) {
+      const sanitizedAddress = sanitizeBillingAddress(billingAddress);
+      if (!sanitizedAddress) {
         return res.status(400).json({
           error: "Incomplete billing address",
-          message: "Please provide line1, city, state, postal_code, and country",
+          message: "Please provide line1, city, state, postal_code, and country (each ≤ 200 chars)",
         });
       }
 
@@ -275,11 +271,24 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      // Agreement gate. Caller either already accepted (pending_agreement_version
-      // set on the org) or accepts inline. We store the acceptance as "pending"
-      // here; the webhook on invoice.paid / subscription.created records it
-      // permanently (existing machinery from the checkout flow).
-      const pendingVersion = agreement_version?.trim() || org.pending_agreement_version;
+      // Agreement gate. If the caller is accepting inline we validate the
+      // version against the currently-published agreement. If they're
+      // relying on a previous acceptance we use whatever was stored on the
+      // org. Either way, store the acceptance as "pending"; the webhook on
+      // invoice.paid / subscription.created records it permanently.
+      let pendingVersion = org.pending_agreement_version;
+      if (agreement_version?.trim()) {
+        const currentAgreement = await orgDb.getCurrentAgreementByType('membership');
+        if (!currentAgreement || agreement_version.trim() !== currentAgreement.version) {
+          return res.status(400).json({
+            error: "Agreement version mismatch",
+            message:
+              "The membership agreement has changed. Please reload and accept the current version.",
+            current_version: currentAgreement?.version ?? null,
+          });
+        }
+        pendingVersion = currentAgreement.version;
+      }
       if (!pendingVersion) {
         return res.status(400).json({
           error: "Membership agreement required",
@@ -288,24 +297,14 @@ export function createPublicBillingRouter(): Router {
           required: "agreement_version",
         });
       }
-      if (agreement_version) {
-        await orgDb.updateOrganization(orgId, {
-          pending_agreement_version: agreement_version,
-          pending_agreement_accepted_at: new Date(),
-        });
-      }
 
-      // Store the confirmed billing address on the org so future invoices
-      // pre-fill from it.
+      // Atomic: record (or re-affirm) the pending agreement + store the
+      // billing address in a single UPDATE so a partial failure can't leave
+      // one set without the other.
       await orgDb.updateOrganization(orgId, {
-        billing_address: {
-          line1: billingAddress.line1,
-          line2: billingAddress.line2,
-          city: billingAddress.city,
-          state: billingAddress.state,
-          postal_code: billingAddress.postal_code,
-          country: billingAddress.country,
-        },
+        pending_agreement_version: pendingVersion,
+        pending_agreement_accepted_at: new Date(),
+        billing_address: sanitizedAddress,
       });
 
       // Referral discount (same logic as checkout).
@@ -348,7 +347,7 @@ export function createPublicBillingRouter(): Router {
         companyName: org.name,
         contactName: displayName,
         contactEmail: user.email,
-        billingAddress,
+        billingAddress: sanitizedAddress,
         lookupKey,
         workosOrganizationId: orgId,
         couponId: invoiceCouponId ?? org.stripe_coupon_id ?? undefined,

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -24,6 +24,7 @@ import {
   getProductsForCustomer,
   createCoupon,
 } from '../billing/stripe-client.js';
+import { sanitizeBillingAddress } from '../billing/billing-address.js';
 import * as referralDb from '../db/referral-codes-db.js';
 
 const logger = createLogger('invites-routes');
@@ -103,8 +104,27 @@ export function createInvitesRouter(): Router {
       ) {
         return res.status(400).json({ error: 'Incomplete billing address' });
       }
+      // Build a clean, length-capped address object. We persist this to
+      // organizations.billing_address (JSONB) and pass to Stripe, so we don't
+      // want arbitrary client fields leaking through.
+      const sanitizedAddress = sanitizeBillingAddress(billingAddress);
+      if (!sanitizedAddress) {
+        return res.status(400).json({ error: 'Billing address fields exceed length limits' });
+      }
+
       if (!agreement_version?.trim()) {
         return res.status(400).json({ error: 'agreement_version is required' });
+      }
+      // Server validates against the currently-published agreement version.
+      // Accepting arbitrary strings would let a caller record a "signed" state
+      // against a version that never existed, defeating the audit trail.
+      const currentAgreement = await orgDb.getCurrentAgreementByType('membership');
+      if (!currentAgreement || agreement_version.trim() !== currentAgreement.version) {
+        return res.status(400).json({
+          error: 'Agreement version mismatch',
+          message: 'The membership agreement has changed. Please reload and accept the current version.',
+          current_version: currentAgreement?.version ?? null,
+        });
       }
 
       const invite = await getMembershipInviteByToken(token);
@@ -133,8 +153,14 @@ export function createInvitesRouter(): Router {
         });
       }
 
-      // Ensure the accepting user is a member of the target org. First user
-      // in becomes owner (new-org common case); everyone else is a member.
+      // Ensure the accepting user is a member of the target org.
+      //
+      // Role is always 'member'. We never auto-grant 'owner' via invite accept:
+      // the invite token is a bearer capability and could be forwarded or
+      // intercepted (email logs, proxy logs, shared Slack links). An admin can
+      // promote a member to owner through the normal admin UI once they've
+      // confirmed the person is the right one. This closes the "anyone with a
+      // leaked link becomes owner of an empty prospect org" escalation path.
       if (workos) {
         try {
           const existing = await workos.userManagement.listOrganizationMemberships({
@@ -142,30 +168,21 @@ export function createInvitesRouter(): Router {
             organizationId: org.workos_organization_id,
           });
           if (!existing.data || existing.data.length === 0) {
-            const current = await workos.userManagement.listOrganizationMemberships({
-              organizationId: org.workos_organization_id,
-            });
-            const hasAnyMember = (current.data?.length ?? 0) > 0;
-            const roleSlug = hasAnyMember ? 'member' : 'owner';
             try {
               await workos.userManagement.createOrganizationMembership({
                 userId: user.id,
                 organizationId: org.workos_organization_id,
-                roleSlug,
+                roleSlug: 'member',
               });
               logger.info(
-                {
-                  userId: user.id,
-                  orgId: org.workos_organization_id,
-                  roleSlug,
-                },
-                'Added user to org via invite accept'
+                { userId: user.id, orgId: org.workos_organization_id },
+                'Added user to org via invite accept (role: member)'
               );
             } catch (membershipErr) {
               const code = (membershipErr as { code?: string }).code;
               if (code === 'organization_membership_already_exists') {
                 logger.info({ userId: user.id, orgId: org.workos_organization_id },
-                  'Membership already exists (race)');
+                  'Membership already exists (race) — continuing');
               } else {
                 throw membershipErr;
               }
@@ -181,11 +198,13 @@ export function createInvitesRouter(): Router {
         }
       }
 
-      // Record pending agreement + store billing address on the org.
+      // Record pending agreement + store billing address on the org in one
+      // atomic write so a partial failure can't leave pending_agreement set
+      // without an address (or vice versa).
       await orgDb.updateOrganization(org.workos_organization_id, {
-        pending_agreement_version: agreement_version.trim(),
+        pending_agreement_version: currentAgreement.version,
         pending_agreement_accepted_at: new Date(),
-        billing_address: billingAddress,
+        billing_address: sanitizedAddress,
       });
 
       // Referral discount (if invite carried one).
@@ -219,9 +238,13 @@ export function createInvitesRouter(): Router {
         companyName: org.name,
         contactName,
         contactEmail: user.email,
-        billingAddress,
+        billingAddress: sanitizedAddress,
         workosOrganizationId: org.workos_organization_id,
         couponId: couponId ?? org.stripe_coupon_id ?? undefined,
+        // Token-keyed idempotency. Two concurrent clicks converge to one
+        // subscription on Stripe's side; the DB atomic mark below then picks
+        // one winner and the other sees 409.
+        idempotencyKey: `invite_${invite.token}`,
       });
 
       if (!invoiceResult) {

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -1,0 +1,286 @@
+/**
+ * Public + authed invite acceptance routes.
+ *
+ *   GET  /api/invite/:token          - public metadata for the invite page
+ *   POST /api/invite/:token/accept   - authed: join org, record agreement,
+ *                                      store billing address, issue invoice
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { WorkOS } from '@workos-inc/node';
+import { createLogger } from '../logger.js';
+import { requireAuth } from '../middleware/auth.js';
+import {
+  getMembershipInviteByToken,
+  markMembershipInviteAccepted,
+  inviteStatus,
+} from '../db/membership-invites-db.js';
+import {
+  OrganizationDatabase,
+  type BillingAddress,
+} from '../db/organization-db.js';
+import {
+  createAndSendInvoice,
+  getProductsForCustomer,
+  createCoupon,
+} from '../billing/stripe-client.js';
+import * as referralDb from '../db/referral-codes-db.js';
+
+const logger = createLogger('invites-routes');
+const orgDb = new OrganizationDatabase();
+
+const AUTH_ENABLED = !!(
+  process.env.WORKOS_API_KEY &&
+  process.env.WORKOS_CLIENT_ID
+);
+const workos = AUTH_ENABLED
+  ? new WorkOS(process.env.WORKOS_API_KEY!, {
+      clientId: process.env.WORKOS_CLIENT_ID!,
+    })
+  : null;
+
+export function createInvitesRouter(): Router {
+  const router = Router();
+
+  // Public metadata — callable before login so the landing page can render.
+  router.get('/invite/:token', async (req: Request, res: Response) => {
+    try {
+      const invite = await getMembershipInviteByToken(req.params.token);
+      if (!invite) return res.status(404).json({ error: 'Invite not found' });
+
+      const status = inviteStatus(invite);
+      const org = await orgDb.getOrganization(invite.workos_organization_id);
+      if (!org) return res.status(404).json({ error: 'Organization no longer exists' });
+
+      const customerType = org.is_personal ? 'individual' : 'company';
+      const eligible = await getProductsForCustomer({
+        customerType,
+        category: 'membership',
+      });
+      const product = eligible.find((p) => p.lookup_key === invite.lookup_key);
+
+      return res.json({
+        token: invite.token,
+        status,
+        org_name: org.name,
+        org_is_personal: org.is_personal,
+        contact_email: invite.contact_email,
+        contact_name: invite.contact_name,
+        lookup_key: invite.lookup_key,
+        tier_display_name: product?.display_name || invite.lookup_key,
+        amount_cents: product?.amount_cents ?? null,
+        currency: product?.currency ?? null,
+        billing_interval: product?.billing_interval ?? null,
+        billing_address: org.billing_address,
+        expires_at: invite.expires_at,
+        referral_code: invite.referral_code,
+      });
+    } catch (err) {
+      logger.error({ err }, 'Error loading invite metadata');
+      return res.status(500).json({ error: 'Internal error' });
+    }
+  });
+
+  // Authed accept. Body: { billingAddress, agreement_version, marketing_opt_in? }
+  router.post('/invite/:token/accept', requireAuth, async (req: Request, res: Response) => {
+    try {
+      const user = req.user!;
+      const { token } = req.params;
+      const { billingAddress, agreement_version } = req.body as {
+        billingAddress?: BillingAddress;
+        agreement_version?: string;
+      };
+
+      if (!billingAddress) {
+        return res.status(400).json({ error: 'billingAddress is required' });
+      }
+      if (
+        !billingAddress.line1 ||
+        !billingAddress.city ||
+        !billingAddress.state ||
+        !billingAddress.postal_code ||
+        !billingAddress.country
+      ) {
+        return res.status(400).json({ error: 'Incomplete billing address' });
+      }
+      if (!agreement_version?.trim()) {
+        return res.status(400).json({ error: 'agreement_version is required' });
+      }
+
+      const invite = await getMembershipInviteByToken(token);
+      if (!invite) return res.status(404).json({ error: 'Invite not found' });
+
+      const status = inviteStatus(invite);
+      if (status !== 'pending') {
+        return res.status(409).json({ error: `Invite is ${status}` });
+      }
+
+      const org = await orgDb.getOrganization(invite.workos_organization_id);
+      if (!org) {
+        return res.status(410).json({ error: 'Organization no longer exists' });
+      }
+
+      const customerType = org.is_personal ? 'individual' : 'company';
+      const eligible = await getProductsForCustomer({
+        customerType,
+        category: 'membership',
+      });
+      const product = eligible.find((p) => p.lookup_key === invite.lookup_key);
+      if (!product) {
+        return res.status(410).json({
+          error: 'Tier no longer available',
+          message: 'The membership tier in this invite is no longer available.',
+        });
+      }
+
+      // Ensure the accepting user is a member of the target org. First user
+      // in becomes owner (new-org common case); everyone else is a member.
+      if (workos) {
+        try {
+          const existing = await workos.userManagement.listOrganizationMemberships({
+            userId: user.id,
+            organizationId: org.workos_organization_id,
+          });
+          if (!existing.data || existing.data.length === 0) {
+            const current = await workos.userManagement.listOrganizationMemberships({
+              organizationId: org.workos_organization_id,
+            });
+            const hasAnyMember = (current.data?.length ?? 0) > 0;
+            const roleSlug = hasAnyMember ? 'member' : 'owner';
+            try {
+              await workos.userManagement.createOrganizationMembership({
+                userId: user.id,
+                organizationId: org.workos_organization_id,
+                roleSlug,
+              });
+              logger.info(
+                {
+                  userId: user.id,
+                  orgId: org.workos_organization_id,
+                  roleSlug,
+                },
+                'Added user to org via invite accept'
+              );
+            } catch (membershipErr) {
+              const code = (membershipErr as { code?: string }).code;
+              if (code === 'organization_membership_already_exists') {
+                logger.info({ userId: user.id, orgId: org.workos_organization_id },
+                  'Membership already exists (race)');
+              } else {
+                throw membershipErr;
+              }
+            }
+          }
+        } catch (err) {
+          logger.error({ err, userId: user.id, orgId: org.workos_organization_id },
+            'Failed to ensure org membership on invite accept');
+          return res.status(500).json({
+            error: 'Could not add you to the organization',
+            message: 'Please contact finance@agenticadvertising.org.',
+          });
+        }
+      }
+
+      // Record pending agreement + store billing address on the org.
+      await orgDb.updateOrganization(org.workos_organization_id, {
+        pending_agreement_version: agreement_version.trim(),
+        pending_agreement_accepted_at: new Date(),
+        billing_address: billingAddress,
+      });
+
+      // Referral discount (if invite carried one).
+      let couponId: string | undefined;
+      if (invite.referral_code) {
+        try {
+          const code = await referralDb.getReferralCode(invite.referral_code);
+          if (code && code.status === 'active' && code.discount_percent) {
+            const coupon = await createCoupon({
+              name: `Referral: ${code.code}`,
+              percent_off: code.discount_percent,
+              duration: 'once',
+              max_redemptions: 1,
+              metadata: { referral_code: code.code },
+            });
+            if (coupon) couponId = coupon.coupon_id;
+          }
+        } catch (err) {
+          logger.warn({ err, referral_code: invite.referral_code },
+            'Failed to resolve referral coupon — continuing without discount');
+        }
+      }
+
+      const contactName =
+        invite.contact_name ||
+        [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+        user.email;
+
+      const invoiceResult = await createAndSendInvoice({
+        lookupKey: invite.lookup_key,
+        companyName: org.name,
+        contactName,
+        contactEmail: user.email,
+        billingAddress,
+        workosOrganizationId: org.workos_organization_id,
+        couponId: couponId ?? org.stripe_coupon_id ?? undefined,
+      });
+
+      if (!invoiceResult) {
+        logger.error({ orgId: org.workos_organization_id, lookupKey: invite.lookup_key },
+          'createAndSendInvoice returned null on invite accept');
+        return res.status(500).json({
+          error: 'Failed to issue invoice',
+          message:
+            "We couldn't issue your invoice. Please contact finance@agenticadvertising.org.",
+        });
+      }
+
+      const accepted = await markMembershipInviteAccepted(
+        token,
+        user.id,
+        invoiceResult.invoiceId,
+      );
+      if (!accepted) {
+        // Another tab accepted between our check and now. Still OK — the
+        // invoice went out; just return a benign response.
+        logger.warn({ token: token.slice(0, 8) + '...', userId: user.id },
+          'Invite already accepted concurrently');
+      }
+
+      // Mark referral as accepted if the invite carried one.
+      if (invite.referral_code) {
+        try {
+          await referralDb.acceptReferralCode(
+            invite.referral_code,
+            org.workos_organization_id,
+            user.id,
+          );
+        } catch (err) {
+          logger.warn({ err, referral_code: invite.referral_code },
+            'Failed to record referral acceptance — invoice already sent');
+        }
+      }
+
+      logger.info(
+        {
+          token: token.slice(0, 8) + '...',
+          orgId: org.workos_organization_id,
+          userId: user.id,
+          invoiceId: invoiceResult.invoiceId,
+        },
+        'Membership invite accepted'
+      );
+
+      res.json({
+        success: true,
+        invoice_id: invoiceResult.invoiceId,
+        invoice_url: invoiceResult.invoiceUrl,
+        organization: { id: org.workos_organization_id, name: org.name },
+      });
+    } catch (err) {
+      logger.error({ err }, 'Error accepting membership invite');
+      res.status(500).json({ error: 'Internal error' });
+    }
+  });
+
+  return router;
+}

--- a/server/tests/integration/membership-invites-db.test.ts
+++ b/server/tests/integration/membership-invites-db.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { getPool, initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import {
+  createMembershipInvite,
+  getMembershipInviteByToken,
+  listMembershipInvitesForOrg,
+  markMembershipInviteAccepted,
+  revokeMembershipInvite,
+  inviteStatus,
+} from '../../src/db/membership-invites-db.js';
+import { OrganizationDatabase, type BillingAddress } from '../../src/db/organization-db.js';
+import type { Pool } from 'pg';
+
+const TEST_ORG_PREFIX = 'org_invites_db_test';
+const TEST_ADMIN_ID = 'user_invites_admin';
+const TEST_ACCEPTOR_ID = 'user_invites_acceptor';
+
+describe('membership-invites-db', () => {
+  let pool: Pool;
+
+  const createTestOrg = async (orgId: string, name = 'Test Org') => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, $2, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, name]
+    );
+  };
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM membership_invites WHERE workos_organization_id LIKE $1', [`${TEST_ORG_PREFIX}%`]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id LIKE $1', [`${TEST_ORG_PREFIX}%`]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM membership_invites WHERE workos_organization_id LIKE $1', [`${TEST_ORG_PREFIX}%`]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id LIKE $1', [`${TEST_ORG_PREFIX}%`]);
+  });
+
+  it('creates an invite with a unique 64-char hex token', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_create`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'Finance@Example.COM',
+      contact_name: 'Finance Team',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    expect(invite.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(invite.contact_email).toBe('finance@example.com'); // normalized
+    expect(invite.contact_name).toBe('Finance Team');
+    expect(invite.lookup_key).toBe('aao_membership_professional');
+    expect(invite.accepted_at).toBeNull();
+    expect(invite.revoked_at).toBeNull();
+    expect(invite.expires_at.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('honors expires_in_days', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_expiry`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'x@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+      expires_in_days: 7,
+    });
+
+    const daysUntilExpiry = (invite.expires_at.getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+    expect(daysUntilExpiry).toBeGreaterThan(6.9);
+    expect(daysUntilExpiry).toBeLessThan(7.1);
+  });
+
+  it('looks up invites by token and lists by org', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_list`;
+    await createTestOrg(orgId);
+
+    const a = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'a@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    const b = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_builder',
+      contact_email: 'b@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    const fetched = await getMembershipInviteByToken(a.token);
+    expect(fetched?.contact_email).toBe('a@example.com');
+
+    const list = await listMembershipInvitesForOrg(orgId);
+    expect(list.map(i => i.contact_email).sort()).toEqual(['a@example.com', 'b@example.com']);
+  });
+
+  it('returns null for unknown tokens', async () => {
+    const fetched = await getMembershipInviteByToken('nope');
+    expect(fetched).toBeNull();
+  });
+
+  it('markAccepted succeeds exactly once (second attempt returns null)', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_accept`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'x@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    const first = await markMembershipInviteAccepted(invite.token, TEST_ACCEPTOR_ID, 'in_test1');
+    expect(first).not.toBeNull();
+    expect(first?.accepted_by_user_id).toBe(TEST_ACCEPTOR_ID);
+    expect(first?.invoice_id).toBe('in_test1');
+
+    const second = await markMembershipInviteAccepted(invite.token, TEST_ACCEPTOR_ID, 'in_test2');
+    expect(second).toBeNull();
+  });
+
+  it('markAccepted rejects revoked or expired invites', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_reject`;
+    await createTestOrg(orgId);
+
+    const revoked = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'r@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await revokeMembershipInvite(revoked.token, TEST_ADMIN_ID);
+    const revokedAccept = await markMembershipInviteAccepted(revoked.token, TEST_ACCEPTOR_ID, 'in_r');
+    expect(revokedAccept).toBeNull();
+
+    // Force-expire a fresh invite by updating directly
+    const expired = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'e@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await pool.query(
+      `UPDATE membership_invites SET expires_at = NOW() - INTERVAL '1 minute' WHERE token = $1`,
+      [expired.token]
+    );
+    const expiredAccept = await markMembershipInviteAccepted(expired.token, TEST_ACCEPTOR_ID, 'in_e');
+    expect(expiredAccept).toBeNull();
+  });
+
+  it('revoke marks invite revoked and blocks future acceptance', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_revoke`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'r@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    const revoked = await revokeMembershipInvite(invite.token, TEST_ADMIN_ID);
+    expect(revoked?.revoked_at).toBeInstanceOf(Date);
+    expect(revoked?.revoked_by_user_id).toBe(TEST_ADMIN_ID);
+
+    const status = inviteStatus(revoked!);
+    expect(status).toBe('revoked');
+  });
+
+  it('revoke is idempotent only for pending invites — already-accepted invites cannot be revoked', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_revoke_accepted`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'ra@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await markMembershipInviteAccepted(invite.token, TEST_ACCEPTOR_ID, 'in_ra');
+
+    const revokeAttempt = await revokeMembershipInvite(invite.token, TEST_ADMIN_ID);
+    expect(revokeAttempt).toBeNull();
+  });
+
+  it('cascades invite deletion when the org is deleted', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_cascade`;
+    await createTestOrg(orgId);
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: 'c@example.com',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [orgId]);
+
+    const found = await getMembershipInviteByToken(invite.token);
+    expect(found).toBeNull();
+  });
+});
+
+describe('organizations.billing_address', () => {
+  let pool: Pool;
+  let orgDb: OrganizationDatabase;
+  const ADDRESS_ORG_ID = `${TEST_ORG_PREFIX}_addr`;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    orgDb = new OrganizationDatabase();
+  }, 60000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [ADDRESS_ORG_ID]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [ADDRESS_ORG_ID]);
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, $2, NOW(), NOW())`,
+      [ADDRESS_ORG_ID, 'Addr Test Org']
+    );
+  });
+
+  it('round-trips a billing_address through updateOrganization', async () => {
+    const address: BillingAddress = {
+      line1: '123 Main St',
+      line2: 'Suite 400',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    };
+    await orgDb.updateOrganization(ADDRESS_ORG_ID, { billing_address: address });
+    const org = await orgDb.getOrganization(ADDRESS_ORG_ID);
+    expect(org?.billing_address).toEqual(address);
+  });
+
+  it('stores NULL when billing_address is not set', async () => {
+    const org = await orgDb.getOrganization(ADDRESS_ORG_ID);
+    expect(org?.billing_address).toBeNull();
+  });
+});

--- a/server/tests/integration/membership-invites-db.test.ts
+++ b/server/tests/integration/membership-invites-db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { getPool, initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import {
   createMembershipInvite,

--- a/server/tests/integration/membership-invites-db.test.ts
+++ b/server/tests/integration/membership-invites-db.test.ts
@@ -94,7 +94,7 @@ describe('membership-invites-db', () => {
       contact_email: 'a@example.com',
       invited_by_user_id: TEST_ADMIN_ID,
     });
-    const b = await createMembershipInvite({
+    await createMembershipInvite({
       workos_organization_id: orgId,
       lookup_key: 'aao_membership_builder',
       contact_email: 'b@example.com',

--- a/server/tests/unit/sanitize-billing-address.test.ts
+++ b/server/tests/unit/sanitize-billing-address.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeBillingAddress } from '../../src/billing/billing-address.js';
+
+describe('sanitizeBillingAddress', () => {
+  it('returns a clean object when all required fields are present', () => {
+    const result = sanitizeBillingAddress({
+      line1: '123 Main',
+      line2: 'Apt 5',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    });
+    expect(result).toEqual({
+      line1: '123 Main',
+      line2: 'Apt 5',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    });
+  });
+
+  it('trims whitespace', () => {
+    const result = sanitizeBillingAddress({
+      line1: '  123 Main  ',
+      city: ' Amsterdam ',
+      state: ' NH ',
+      postal_code: ' 1011 ',
+      country: ' NL ',
+    });
+    expect(result?.line1).toBe('123 Main');
+    expect(result?.city).toBe('Amsterdam');
+  });
+
+  it('omits line2 when empty or whitespace-only', () => {
+    const result = sanitizeBillingAddress({
+      line1: '123 Main',
+      line2: '   ',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    });
+    expect(result).not.toHaveProperty('line2');
+  });
+
+  it('rejects when any required field is missing', () => {
+    expect(sanitizeBillingAddress({
+      line1: '123 Main',
+      city: 'Amsterdam',
+      state: '',
+      postal_code: '1011',
+      country: 'NL',
+    })).toBeNull();
+  });
+
+  it('rejects when any field exceeds 200 chars', () => {
+    expect(sanitizeBillingAddress({
+      line1: 'x'.repeat(201),
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    })).toBeNull();
+  });
+
+  it('drops unknown keys (allowlist behaviour)', () => {
+    const result = sanitizeBillingAddress({
+      line1: '123 Main',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+      // Extra attacker-controlled payload should not survive
+      __proto__: { polluted: true },
+      extra: 'x'.repeat(10_000),
+      injected_script: '<script>',
+    } as unknown);
+    expect(result).toEqual({
+      line1: '123 Main',
+      city: 'Amsterdam',
+      state: 'NH',
+      postal_code: '1011',
+      country: 'NL',
+    });
+    expect(result).not.toHaveProperty('extra');
+    expect(result).not.toHaveProperty('injected_script');
+  });
+
+  it('returns null for non-object input', () => {
+    expect(sanitizeBillingAddress(null)).toBeNull();
+    expect(sanitizeBillingAddress(undefined)).toBeNull();
+    expect(sanitizeBillingAddress('string')).toBeNull();
+    expect(sanitizeBillingAddress(42)).toBeNull();
+  });
+});

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -546,17 +546,23 @@ describe('stripe-client', () => {
       expect(result?.subscriptionId).toBe('sub_xyz789');
       expect(result?.invoiceUrl).toBe('https://invoice.stripe.com/i/acct_xxx/test_xxx');
 
-      // Verify subscription was created with correct parameters
-      expect(mockStripeInstance.subscriptions.create).toHaveBeenCalledWith({
-        customer: 'cus_new123',
-        items: [{ price: 'price_abc123' }],
-        collection_method: 'send_invoice',
-        days_until_due: 30,
-        metadata: expect.objectContaining({
-          lookup_key: 'aao_membership_corporate_5m',
-          contact_name: 'Ruben Schreurs',
-        }),
-      });
+      // Verify subscription was created with correct parameters.
+      // createAndSendInvoice now passes a second argument (Stripe RequestOptions)
+      // when an idempotency key is supplied — undefined here since this test
+      // doesn't exercise that path.
+      expect(mockStripeInstance.subscriptions.create).toHaveBeenCalledWith(
+        {
+          customer: 'cus_new123',
+          items: [{ price: 'price_abc123' }],
+          collection_method: 'send_invoice',
+          days_until_due: 30,
+          metadata: expect.objectContaining({
+            lookup_key: 'aao_membership_corporate_5m',
+            contact_name: 'Ruben Schreurs',
+          }),
+        },
+        undefined,
+      );
     });
 
     test('returns null when price has zero amount', async () => {


### PR DESCRIPTION
## Summary

Fixes the class of bug that broke Stefan Colijn's membership (paid $250, no org activation). Root cause: `/api/invoice-request` was unauthenticated and took free-text company + contact email → Stripe created an orphan customer with no `workos_organization_id` metadata → webhook couldn't link the paid invoice back to any org. Stefan's account was already force-relinked in prod via the admin API; this PR closes the door.

Invoices are now only issued after a signed membership agreement, an authenticated user, and a confirmed billing address. Admins no longer send invoices directly — they send **membership invitations**. The prospect clicks the link, signs in, signs the agreement, confirms billing, and the invoice is issued atomically.

See `.context/membership-invite-plan.md` for the original four-stage plan. Expert-review hardening is commit 5.

## What changed

**DB**
- `membership_invites` table (token-keyed, expiry, revocation, accepted_at + invoice_id)
- `organizations.billing_address` JSONB, pre-fills future invoices
- Full CRUD + cascade tests (11 integration tests)

**Self-serve invoice (`/api/invoice-request`)**
- Was public; now `requireAuth`
- Body shape: `{orgId, lookupKey, billingAddress, referral_code?, agreement_version?}`
- Validates user is an org member, product is eligible for org type, agreement version matches the currently-published membership agreement
- Atomic single UPDATE for pending-agreement + billing address
- Company/contact derived from org + session (no free-text fields)

**`createAndSendInvoice`**
- Prefers `organizations.stripe_customer_id` when `workosOrganizationId` is provided; keeps customer email stable (only backfills name if empty, tops up metadata) — no more overwriting the linked customer's contact
- Clears the stale DB link when the linked customer is deleted on Stripe's side, so fallback doesn't re-bind an unrelated email-matched orphan (this is the Stefan bug)
- Accepts an optional Stripe idempotency key — invite accept passes `invite_<token>` so concurrent clicks converge to one subscription/invoice

**Admin endpoints**
- NEW: `POST /api/admin/accounts/:orgId/invite-membership` — `{lookup_key, contact_email, contact_name?, referral_code?}`
- NEW: `GET /api/admin/accounts/:orgId/invites` — list with status
- NEW: `POST /api/admin/accounts/:orgId/invites/:token/revoke`
- DELETED: `POST /api/admin/accounts/:orgId/invoice` (returns 410 on the legacy prospects redirect)
- `contact_email` normalized to lowercase end-to-end

**Prospect acceptance (new)**
- `GET /invite/:token` — landing page, shows org / tier / price, handles expired/revoked/accepted states
- `GET /api/invite/:token` — public JSON metadata
- `POST /api/invite/:token/accept` — authed; joins user to WorkOS org (always as `member`, never auto-owner), records pending agreement, stores billing address, issues invoice — all in the same request
- `server/public/invite.html` with `Referrer-Policy: same-origin`; submit blocks until the current agreement version loads (no hardcoded fallback)

**Billing address hygiene**
- New `server/src/billing/billing-address.ts` with `sanitizeBillingAddress` — field allowlist + 200-char cap. 7 unit tests. Reused by both invoice-request and invite accept paths

**Email**
- New `sendMembershipInviteEmail` in `server/src/notifications/email.ts` — Resend, HTML literal matching existing style, `replyTo` the inviting admin

**UIs**
- `dashboard-membership.html` invoice modal: dropped the free-text contact fields; pre-fills billing address from `org.billing_address`; agreement checkbox required
- `admin-account-detail.html`: `Invoice` button renamed `Invite`; modal simplified to tier + email

## Expert review addressed

Ran the branch past code-reviewer, security-reviewer, and nodejs-testing-expert before merge. Two BLOCKERs and two HIGHs were fixed in commit 5: auto-owner escalation on empty orgs, Stripe customer email overwrite, concurrent-accept double invoice, and the client-side `agreement_version || '1.0'` fallback. Deferred items (click-tracker token persistence, rate limits on public invite routes, contact_email in public metadata, supertest HTTP tests) are tracked in `.context/membership-invite-followups.md`.

## Test plan

- [x] `npm run test:unit` — 631 tests pass, typecheck clean
- [x] `server/tests/integration/membership-invites-db.test.ts` — 11 DB tests pass
- [x] `server/tests/unit/sanitize-billing-address.test.ts` — 7 unit tests pass
- [x] End-to-end Playwright against local stack: anonymous lands on sign-in prompt; authed admin sees accept form with agreement-gated button; invalid token shows error state
- [x] curl tests: admin creates invite, public metadata returns pending, server rejects bogus agreement_version (400 with current_version), server rejects oversized billing fields (400), revoke flips public status to `revoked`, email lowercasing confirmed
- [x] Deleted `/api/admin/prospects/:orgId/invoice` → 410 with migration message
- [x] `/api/invoice-request` without auth → 403 (CSRF blocks); with ADMIN_API_KEY → rejects non-member as expected

## Commits

```
6957bca17 fix(membership): harden invite flow per expert review
820aa9033 feat(membership): prospect invite acceptance page + API
3221c37ff feat(membership): admin invites replace direct-invoice endpoint
e557da0dc feat(membership): tighten /api/invoice-request to require auth + agreement
2b1ecec50 feat(membership): add membership_invites table + org billing_address
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)