### PR TITLE
fix(dashboard): persist show-on-registry toggle and scope its handler

### DIFF
--- a/.changeset/fix-show-on-registry-toggle.md
+++ b/.changeset/fix-show-on-registry-toggle.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the "Show on registry" toggle on the Agents dashboard. The `/api/registry/agents/{url}/compliance` endpoint now returns `compliance_opt_out` so the checkbox reflects the persisted state on page refresh. Also scopes the toggle's change handler to a dedicated `registry-visibility-toggle` class so clicking "Pause automated checks" no longer accidentally flips registry visibility.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -924,7 +924,7 @@
               </div>
               <div style="display: flex; align-items: center; gap: var(--space-3); flex-shrink: 0;">
                 <label class="agent-toggle" title="Show compliance on public registry">
-                  <input type="checkbox" ${isPublic ? 'checked' : ''} data-agent-url="${escapeHtml(agent.url)}">
+                  <input type="checkbox" class="registry-visibility-toggle" ${isPublic ? 'checked' : ''} data-agent-url="${escapeHtml(agent.url)}">
                   <span class="agent-toggle-label">Show on registry</span>
                 </label>
               </div>
@@ -983,8 +983,8 @@
     }
 
     // Registry visibility toggle
-    document.addEventListener('click', async function(e) {
-      const checkbox = e.target.closest('.agent-toggle input[type="checkbox"]');
+    document.addEventListener('change', async function(e) {
+      const checkbox = e.target.closest('.registry-visibility-toggle');
       if (checkbox) {
         const agentUrl = checkbox.dataset.agentUrl;
         try {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3411,6 +3411,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           agent_url: agentUrl,
           status: "opted_out",
           lifecycle_stage: metadata.lifecycle_stage || "production",
+          compliance_opt_out: true,
         });
       }
 
@@ -3419,6 +3420,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           agent_url: agentUrl,
           status: "unknown",
           lifecycle_stage: metadata?.lifecycle_stage || "production",
+          compliance_opt_out: false,
           tracks: {},
           streak_days: 0,
           last_checked_at: null,
@@ -3441,6 +3443,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         agent_url: agentUrl,
         status: status.status,
         lifecycle_stage: metadata?.lifecycle_stage || "production",
+        compliance_opt_out: metadata?.compliance_opt_out ?? false,
         tracks: status.tracks_summary_json || {},
         streak_days: status.streak_days,
         last_checked_at: status.last_checked_at?.toISOString() || null,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -268,6 +268,7 @@ export const AgentComplianceDetailSchema = z
     agent_url: z.string(),
     status: z.enum(["passing", "degraded", "failing", "unknown", "opted_out"]),
     lifecycle_stage: z.enum(["development", "testing", "production", "deprecated"]),
+    compliance_opt_out: z.boolean().optional(),
     tracks: z.record(z.string(), z.string()).optional(),
     streak_days: z.number().int().optional(),
     last_checked_at: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

Fixes the "Show on registry" checkbox on the Agents dashboard, which always snapped back to checked on page refresh and could be flipped by unrelated clicks.

**Root cause 1 — response field was missing.** `GET /api/registry/agents/{url}/compliance` never returned `compliance_opt_out`. The frontend read `cs.compliance_opt_out ?? false`, so `isPublic` always resolved to `true` and the checkbox rendered checked even for opted-out agents (visible in the screenshot: four agents labeled `opted_out` with the box still checked). The endpoint now returns the field in all three response branches (`opted_out`, `unknown`, normal).

**Root cause 2 — click handler selector was too broad.** The handler used `.agent-toggle input[type=\"checkbox\"]`, which also matched the "Pause automated checks" checkbox (both inputs are wrapped in `.agent-toggle` labels). Clicking pause silently PUT `/compliance/opt-out`. Fixed by giving the registry input a dedicated `registry-visibility-toggle` class and switching the handler to `change` (consistent with the pause-toggle handler).

Also added `compliance_opt_out` (optional) to `AgentComplianceDetailSchema` so the OpenAPI contract matches the new response.

## Test plan

- [ ] Toggle "Show on registry" off on an agent, refresh the page — checkbox stays unchecked
- [ ] Agent labeled `opted_out` renders with an unchecked box (regression case from the screenshot)
- [ ] Click "Pause automated checks" — only the pause state changes; registry visibility is untouched
- [ ] Toggle back to checked, refresh — checkbox stays checked; agent re-appears in the public registry