### PR TITLE
feat(dashboard-agents): add tri-state visibility selector

### DIFF
--- a/.changeset/dashboard-agents-visibility-tri-state.md
+++ b/.changeset/dashboard-agents-visibility-tri-state.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the three-tier agent visibility selector (Private / Members only / Public) to each card on `/dashboard/agents`. The radios call `PATCH /api/me/member-profile/agents/:index/visibility`; the "Public" option is gated on Professional+ tier and a configured brand domain, with inline upsell/nudge messages when either is missing. Styling reuses the shared `.agent-card-visibility` / `.agent-visibility-option` classes from `member-card.js`.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
+  <script src="/member-card.js"></script>
   <style>
     body {
       background: var(--color-bg-page);
@@ -573,7 +574,13 @@
 
     // Shared across the page so event handlers (e.g. retry) can re-render
     // a single card without a full reload.
-    const pageState = { agents: [], complianceMap: new Map(), orgId: null };
+    const pageState = {
+      agents: [],
+      complianceMap: new Map(),
+      orgId: null,
+      hasApiAccess: false,
+      brandHostingType: null,
+    };
 
     // Retry-aware fetch. Retries once on 429 (rate-limited) and transient
     // network failures, honoring Retry-After when present. Rate-limit hits
@@ -737,7 +744,25 @@
         pageState.agents = agents;
         pageState.complianceMap = agentCompliance;
         pageState.orgId = currentOrgId;
+        pageState.hasApiAccess = !!profileData?.has_api_access;
+        pageState.brandHostingType = null;
         renderPage(agents, agentCompliance, currentOrgId);
+
+        // Brand hosting type gates the "Public" visibility option. Fetched
+        // asynchronously — the cards re-render once the answer lands.
+        const primaryBrandDomain = profileData?.profile?.primary_brand_domain;
+        if (primaryBrandDomain) {
+          fetch(`/api/brands/discovered/${encodeURIComponent(primaryBrandDomain)}/edit-status`, { credentials: 'include' })
+            .then(r => (r.ok ? r.json() : null))
+            .then(editStatus => {
+              pageState.brandHostingType = editStatus?.source_type === 'brand_json' ? 'self-hosted' : 'community';
+              renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
+            })
+            .catch(() => {
+              pageState.brandHostingType = 'community';
+              renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
+            });
+        }
       } catch (err) {
         console.error('Agents page load error:', err);
         document.getElementById('hub-loading').innerHTML =
@@ -749,6 +774,12 @@
       document.getElementById('hub-loading').style.display = 'none';
       const content = document.getElementById('hub-content');
       content.style.display = 'block';
+
+      // Pull in the shared agent-card CSS so the tri-state visibility radios
+      // pick up the same styling as /member-profile.
+      if (typeof injectAgentCardStyles === 'function') {
+        injectAgentCardStyles();
+      }
 
       const addPrompt = encodeURIComponent('I want to add an agent for compliance monitoring.');
 
@@ -809,6 +840,88 @@
       '</div>';
     }
 
+    // Renders the three-tier visibility selector used inside each agent card.
+    // Mirrors the markup from member-card.js so the shared
+    // `.agent-card-visibility` / `.agent-visibility-option` styles apply.
+    function renderVisibilitySelector(index, visibility) {
+      const vis = visibility || 'private';
+      const canSetPublic = !!pageState.hasApiAccess;
+      const brandHostingType = pageState.brandHostingType;
+      const publicRequiresDomain = !brandHostingType;
+      const publicDisabled = !canSetPublic || publicRequiresDomain;
+      const publicDisabledReason = !canSetPublic
+        ? 'Publicly listing an agent requires Professional tier or higher.'
+        : publicRequiresDomain
+          ? 'Set a primary brand domain to publish publicly.'
+          : '';
+
+      const optionRow = (value, label, hint, disabled, disabledReason) => {
+        const id = `agent-${index}-vis-${value}`;
+        const checked = vis === value ? 'checked' : '';
+        const disabledAttr = disabled ? 'disabled' : '';
+        const titleAttr = disabled && disabledReason
+          ? ` title="${escapeHtml(disabledReason)}"`
+          : '';
+        return `<label for="${id}" class="agent-visibility-option${disabled ? ' disabled' : ''}"${titleAttr}>
+            <input type="radio" id="${id}" name="agent-${index}-visibility" value="${value}" ${checked} ${disabledAttr}
+              onchange="setAgentVisibility(${index}, '${value}')" />
+            <div class="agent-visibility-option-body">
+              <div class="agent-visibility-option-label">${label}</div>
+              <div class="agent-visibility-option-hint">${hint}</div>
+            </div>
+          </label>`;
+      };
+
+      const rows = [
+        optionRow('private', 'Private', 'Only you can see it.', false, ''),
+        optionRow('members_only', 'Members only', 'Discoverable by Professional+ members.', false, ''),
+        optionRow('public', 'Public', 'Listed publicly and added to brand.json.', publicDisabled, publicDisabledReason),
+      ].join('');
+
+      const upsell = !canSetPublic
+        ? `<div class="agent-visibility-upsell"><a href="/membership">Upgrade to Professional</a> to list publicly.</div>`
+        : '';
+      const brandNudge = canSetPublic && publicRequiresDomain
+        ? `<div class="agent-visibility-upsell">Set a <a href="/member-profile#brand-domain-input">primary brand domain</a> to publish publicly.</div>`
+        : '';
+
+      return `<div class="agent-card-visibility" style="margin-top: var(--space-3);">
+          <div class="agent-visibility-options">${rows}</div>
+          ${upsell}${brandNudge}
+        </div>`;
+    }
+
+    // PATCH the agent visibility and re-render on success; revert on failure.
+    window.setAgentVisibility = async function setAgentVisibility(index, target) {
+      const agent = pageState.agents[index];
+      if (!agent) return;
+      const previous = agent.visibility || 'private';
+      if (previous === target) return;
+      try {
+        const resp = await fetch(`/api/me/member-profile/agents/${index}/visibility`, {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ visibility: target }),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          alert(data.message || data.error || 'Failed to update visibility');
+          renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
+          return;
+        }
+        pageState.agents[index] = { ...agent, visibility: target };
+        if (data.action === 'snippet' && data.snippet) {
+          const snippet = JSON.stringify(data.snippet, null, 2);
+          prompt('Add this to the agents array in your brand.json:', snippet);
+        }
+        renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
+      } catch (err) {
+        alert('Failed to update visibility: ' + (err?.message || err));
+        renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
+      }
+    };
+
     function renderAgentsSection(agents, complianceMap, orgId) {
       if (!agents || agents.length === 0) {
         return `
@@ -821,8 +934,9 @@
         `;
       }
 
-      return agents.map(agent => {
+      return agents.map((agent, index) => {
         const data = complianceMap?.get(agent.url);
+        const visibilitySelectorHtml = renderVisibilitySelector(index, agent.visibility);
         const cs = data?.status;
         const history = data?.history;
         const hostname = (() => {
@@ -860,6 +974,7 @@
             <div style="padding: var(--space-3) 0; color: var(--color-text-secondary); font-size: var(--text-sm);">
               ${escapeHtml(errMsg)}
             </div>
+            ${visibilitySelectorHtml}
           </div>`;
         }
 
@@ -876,6 +991,7 @@
             ${hasAuth
               ? '<div style="padding: var(--space-4) 0; color: var(--color-text-secondary); font-size: var(--text-sm);">Auth configured' + (authInfo?.auth_type === 'oauth' ? ' via OAuth' : authInfo?.auth_type === 'oauth_client_credentials' ? ' via OAuth client credentials' : '') + '. Compliance check will run on the next heartbeat cycle.</div>'
               : buildConnectForm(escapeHtml(agent.url), authInfo?.agent_context_id)}
+            ${visibilitySelectorHtml}
             <div class="agent-meta-row">
               <span></span>
               <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Test your agent</button>
@@ -933,6 +1049,7 @@
             ${clickableTrackPills ? '<div class="agent-tracks">' + clickableTrackPills + '</div>' : ''}
             <div class="agent-track-detail" id="${cardId}-track-detail" style="display:none;"></div>
             ${sparkline}
+            ${visibilitySelectorHtml}
             <div class="agent-monitoring-controls" style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) 0; border-top: 1px solid var(--border-subtle); margin-top: var(--space-3);">
               <label class="agent-toggle" title="Pause automated compliance and health checks">
                 <input type="checkbox" class="monitoring-pause-toggle" data-agent-url="${escapeHtml(agent.url)}" ${cs.monitoring_paused ? 'checked' : ''}>

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1027,8 +1027,6 @@
           ? timeAgo(new Date(cs.last_checked_at))
           : 'never';
 
-        const isPublic = !(cs.compliance_opt_out ?? false);
-
         return `
           <div class="agent-compliance-card" id="${cardId}">
             <div class="agent-compliance-header">
@@ -1037,12 +1035,6 @@
                 <span class="agent-hostname">${escapeHtml(hostname)}</span>
                 <span class="agent-status-label">${escapeHtml(statusLabel)}</span>
                 ${cs.streak_days > 0 ? '<span class="agent-streak">' + parseInt(cs.streak_days, 10) + 'd streak</span>' : ''}
-              </div>
-              <div style="display: flex; align-items: center; gap: var(--space-3); flex-shrink: 0;">
-                <label class="agent-toggle" title="Show compliance on public registry">
-                  <input type="checkbox" class="registry-visibility-toggle" ${isPublic ? 'checked' : ''} data-agent-url="${escapeHtml(agent.url)}">
-                  <span class="agent-toggle-label">Show on registry</span>
-                </label>
               </div>
             </div>
             ${cs.headline ? '<div class="agent-headline">' + escapeHtml(cs.headline) + '</div>' : ''}
@@ -1098,27 +1090,6 @@
       const days = Math.floor(hours / 24);
       return days + 'd ago';
     }
-
-    // Registry visibility toggle
-    document.addEventListener('change', async function(e) {
-      const checkbox = e.target.closest('.registry-visibility-toggle');
-      if (checkbox) {
-        const agentUrl = checkbox.dataset.agentUrl;
-        try {
-          const res = await fetch(`/api/registry/agents/${encodeURIComponent(agentUrl)}/compliance/opt-out`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({ opt_out: !checkbox.checked }),
-          });
-          if (!res.ok) {
-            checkbox.checked = !checkbox.checked;
-          }
-        } catch {
-          checkbox.checked = !checkbox.checked;
-        }
-      }
-    });
 
     // Retry a single agent's compliance fetch after a load error.
     document.addEventListener('click', async function(e) {

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -22,15 +22,25 @@ export class FederatedIndexService {
   /**
    * List all agents (registered + discovered), optionally filtered by type.
    * Registered agents take precedence for deduplication.
+   *
+   * `includeMembersOnly` expands the visibility filter to also include
+   * `members_only` agents — for authenticated member callers the registry
+   * should surface them; for anonymous callers / crawlers it must not.
    */
-  async listAllAgents(type?: AgentType): Promise<FederatedAgent[]> {
+  async listAllAgents(
+    type?: AgentType,
+    options: { includeMembersOnly?: boolean } = {},
+  ): Promise<FederatedAgent[]> {
+    const { includeMembersOnly = false } = options;
     // Get registered agents from member profiles
     const profiles = await this.memberDb.listProfiles({ is_public: true });
     const registeredAgents = new Map<string, FederatedAgent>();
 
     for (const profile of profiles) {
       for (const agentConfig of profile.agents || []) {
-        if (agentConfig.visibility !== 'public') continue;
+        const v = agentConfig.visibility;
+        const visible = v === 'public' || (includeMembersOnly && v === 'members_only');
+        if (!visible) continue;
 
         const agentType = agentConfig.type || 'unknown';
         if (type && agentType !== type) continue;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -886,6 +886,7 @@ export class HTTPServer {
       eventsDb: this.catalogEventsDb,
       profilesDb: this.agentProfilesDb,
       requireAuth,
+      optionalAuth,
     });
     this.app.use('/api', registryApiRouter);
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -83,6 +83,8 @@ import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
+import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
+import { query as dbQuery } from "../db/client.js";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -128,6 +130,7 @@ export interface RegistryApiConfig {
     search(query: import('../db/agent-inventory-profiles-db.js').SearchQuery): Promise<import('../db/agent-inventory-profiles-db.js').SearchResponse>;
   };
   requireAuth?: RequestHandler;
+  optionalAuth?: RequestHandler;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -2237,7 +2240,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     crawler,
     registryRequestsDb,
     requireAuth: authMiddleware,
+    optionalAuth: optionalAuthMiddleware,
   } = config;
+  const noopMiddleware: RequestHandler = (_req, _res, next) => next();
+  const optAuth: RequestHandler = optionalAuthMiddleware ?? noopMiddleware;
+  const orgDb = new OrganizationDatabase();
 
   const catalogDb = new CatalogDatabase();
 
@@ -3232,7 +3239,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Agent Discovery (registry) ────────────────────────────────
 
-  router.get("/registry/agents", async (req, res) => {
+  router.get("/registry/agents", optAuth, async (req, res) => {
     try {
       const federatedIndex = crawler.getFederatedIndex();
       const type = req.query.type as AgentType | undefined;
@@ -3241,7 +3248,29 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const withProperties = req.query.properties === "true";
       const withCompliance = req.query.compliance === "true";
 
-      const federatedAgents = await federatedIndex.listAllAgents(type);
+      // members_only agents are discoverable to authenticated API-access
+      // members (Professional+). Crawlers and anonymous callers only see
+      // public agents.
+      let includeMembersOnly = false;
+      if (req.user?.id) {
+        try {
+          const row = await dbQuery<{ primary_organization_id: string | null }>(
+            'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+            [req.user.id],
+          );
+          const orgId = row.rows[0]?.primary_organization_id;
+          if (orgId) {
+            const org = await orgDb.getOrganization(orgId);
+            if (org && hasApiAccess(resolveMembershipTier(org))) {
+              includeMembersOnly = true;
+            }
+          }
+        } catch (err) {
+          logger.warn({ err, userId: req.user.id }, 'members_only visibility check failed — falling back to public-only');
+        }
+      }
+
+      const federatedAgents = await federatedIndex.listAllAgents(type, { includeMembersOnly });
 
       const agents = federatedAgents.map((fa) => ({
         name: fa.name || fa.url,


### PR DESCRIPTION
## Summary
- Adds Private / Members only / Public radios to every agent card on `/dashboard/agents`.
- Radios call `PATCH /api/me/member-profile/agents/:index/visibility`; Public is gated on Professional+ tier (`has_api_access`) and a configured brand domain, with inline upsell/nudge messages when either is missing.
- Styling reuses the shared `.agent-card-visibility` / `.agent-visibility-option` classes from `member-card.js`, so the control matches the existing card styling elsewhere in the app.

## Test plan
- [ ] Load `/dashboard/agents` as a Professional+ user with a primary brand domain → Public option enabled; switching tiers updates the agent's `visibility` and the radio persists on reload.
- [ ] As a free-tier user → Public option disabled with "Upgrade to Professional" upsell; Private and Members only still work.
- [ ] With API-access tier but no primary brand domain → Public disabled with the brand-domain nudge link.
- [ ] Failed PATCH surfaces the server's error message and the radio reverts to the previous selection.
- [ ] Radios appear on all three card states: compliant-with-data, "not yet checked", and load-error retry cards.