### PR TITLE
docs(cli): pin @latest in npx examples

### DIFF
--- a/.changeset/pin-npx-latest.md
+++ b/.changeset/pin-npx-latest.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin `@latest` in every documented `npx @adcp/client` invocation. Unpinned `npx` silently reuses whatever version is cached in `~/.npm/_npx/` — users follow our docs, run months-old CLI code, hit bugs that are already fixed, and don't realize they're on a stale version. Touches all five `docs/building/` guides, the buyer/publisher/platform learning tracks + instructional-design, the `create_media_buy` task reference, `server/public/llms.txt` + `llms-full.txt`, Addie's certification-tools + prompts + knowledge rules (so Addie recommends the pinned form and can diagnose stale-cache symptoms), and `scripts/build-protocol-tarball.cjs`. Mirrors adcontextprotocol/adcp-client#835, which also adds a CLI startup staleness check for every path that `@latest` doesn't cover (global installs, locked `package.json`, corporate forks, `pnpm dlx`).

--- a/docs/building/build-an-agent.mdx
+++ b/docs/building/build-an-agent.mdx
@@ -151,15 +151,15 @@ Once the agent is running, validate it against the matching storyboard:
 ```bash
 # JS/TS agent
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --json
 
 # Python agent
 python agent.py &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --json
 
 # Go agent
 go run main.go &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
 Storyboards exercise every required tool call and validate response shapes. The storyboard runner uses sandbox mode by default — your agent receives `sandbox: true` on all account references and should return simulated data without real platform calls. A passing run means your agent is protocol-compliant.
@@ -183,7 +183,7 @@ media_buy_seller (9 steps)
 </Warning>
 
 <Tip>
-Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, proposal mode, and more. Run `npx @adcp/client storyboard list` to see all available storyboards.
+Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, proposal mode, and more. Run `npx @adcp/client@latest storyboard list` to see all available storyboards.
 </Tip>
 
 See **[Validate Your Agent](/docs/building/validate-your-agent)** for the full testing workflow — debugging failing steps, running compliance checks, and validating interactively through Addie.

--- a/docs/building/get-test-ready.mdx
+++ b/docs/building/get-test-ready.mdx
@@ -5,7 +5,7 @@ description: "What a sales agent operator must have in place before running stor
 "og:title": "AdCP — Get Test-Ready"
 ---
 
-Storyboards are the versioned buyer-simulation suite that decides whether your agent is published as **conformant**. Buyer agents filter on that status — overclaiming or failing storyboards is a public, permanent signal, not a CI warning. This page is the checklist between "I built an agent" and "I can run `npx @adcp/client storyboard run`."
+Storyboards are the versioned buyer-simulation suite that decides whether your agent is published as **conformant**. Buyer agents filter on that status — overclaiming or failing storyboards is a public, permanent signal, not a CI warning. This page is the checklist between "I built an agent" and "I can run `npx @adcp/client@latest storyboard run`."
 
 ## The three surfaces the runner needs
 
@@ -159,8 +159,8 @@ For custom MCP wrappers — AsyncLocalStorage for per-request auth, transport-le
 Once the three surfaces are in place, the runner takes over:
 
 ```bash
-npx @adcp/client --save-auth my-agent http://localhost:3001/mcp
-npx @adcp/client storyboard run my-agent
+npx @adcp/client@latest --save-auth my-agent http://localhost:3001/mcp
+npx @adcp/client@latest storyboard run my-agent
 ```
 
 The runner discovers your capabilities, obtains a sandbox account, seeds fixtures via the controller, and walks each matching storyboard. See [Validate Your Agent](/docs/building/validate-your-agent) for the full CLI, debug flags, and Addie workflows.

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -7,7 +7,7 @@ description: "Build with AdCP: integration guides for MCP and A2A protocols, aut
 
 {/* Remove after 2026-04-25 */}
 <Info>
-**`adcp comply` is now `npx @adcp/client storyboard run`.** Running without a storyboard ID discovers your agent's tools and runs all matching storyboards — same behavior, one less concept. See [Validate Your Agent](/docs/building/validate-your-agent) for the updated CLI reference.
+**`adcp comply` is now `npx @adcp/client@latest storyboard run`.** Running without a storyboard ID discovers your agent's tools and runs all matching storyboards — same behavior, one less concept. See [Validate Your Agent](/docs/building/validate-your-agent) for the updated CLI reference.
 </Info>
 
 This section provides everything you need to understand, integrate, and build robust systems with AdCP.

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -205,8 +205,8 @@ The JavaScript and Python SDKs include command-line tools for testing and develo
 ### JavaScript CLI
 
 ```bash
-npx @adcp/client --help
-npx @adcp/client get-products --agent https://sales.example.com --brief "CTV campaign"
+npx @adcp/client@latest --help
+npx @adcp/client@latest get-products --agent https://sales.example.com --brief "CTV campaign"
 ```
 
 ### Python CLI

--- a/docs/building/validate-your-agent.mdx
+++ b/docs/building/validate-your-agent.mdx
@@ -26,13 +26,13 @@ Declare your `supported_protocols` and `specialisms` in `get_adcp_capabilities` 
 Save your agent as a named alias so you can reference it by name:
 
 ```bash
-npx @adcp/client --save-auth my-agent http://localhost:3001/mcp
+npx @adcp/client@latest --save-auth my-agent http://localhost:3001/mcp
 ```
 
 This stores the alias in `~/.adcp/config.json`. You only need to do this once. Built-in aliases `test-mcp` and `test-a2a` point to the public test agents — no setup needed.
 
 <Tip>
-You can also pass a URL directly instead of an alias: `npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller`
+You can also pass a URL directly instead of an alias: `npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller`
 </Tip>
 
 ## Run a storyboard
@@ -40,7 +40,7 @@ You can also pass a URL directly instead of an alias: `npx @adcp/client storyboa
 ### 1. List available storyboards
 
 ```bash
-npx @adcp/client storyboard list
+npx @adcp/client@latest storyboard list
 ```
 
 Each storyboard targets a specific agent type. The [Build an Agent](/docs/building/build-an-agent) page maps skills to their matching storyboards.
@@ -48,7 +48,7 @@ Each storyboard targets a specific agent type. The [Build an Agent](/docs/buildi
 ### 2. Preview what a storyboard tests
 
 ```bash
-npx @adcp/client storyboard show media_buy_seller
+npx @adcp/client@latest storyboard show media_buy_seller
 ```
 
 This shows the phases, steps, and validations without running anything.
@@ -56,7 +56,7 @@ This shows the phases, steps, and validations without running anything.
 ### 3. Run the storyboard
 
 ```bash
-npx @adcp/client storyboard run my-agent media_buy_seller
+npx @adcp/client@latest storyboard run my-agent media_buy_seller
 ```
 
 Output shows each step with pass/fail:
@@ -82,13 +82,13 @@ Pass `--json` for machine-readable results. Pass `--debug` to see full request/r
 If a step fails, run it individually:
 
 ```bash
-npx @adcp/client storyboard step my-agent media_buy_seller create_media_buy --json --debug
+npx @adcp/client@latest storyboard step my-agent media_buy_seller create_media_buy --json --debug
 ```
 
 Pass `--context` to provide state from earlier steps (account IDs, product IDs):
 
 ```bash
-npx @adcp/client storyboard step my-agent media_buy_seller get_products \
+npx @adcp/client@latest storyboard step my-agent media_buy_seller get_products \
   --context '{"account_id":"acct-123"}' --json
 ```
 
@@ -97,7 +97,7 @@ npx @adcp/client storyboard step my-agent media_buy_seller get_products \
 Run without a storyboard ID to test everything. The CLI discovers your agent's tools via `tools/list` and selects matching storyboards automatically:
 
 ```bash
-npx @adcp/client storyboard run my-agent
+npx @adcp/client@latest storyboard run my-agent
 ```
 
 Add `--json` for structured output.
@@ -165,8 +165,8 @@ The protocol requires that `(brand, account)`-scoped state [survive across agent
 **Verify by multi-instance testing.** If you deploy long-running processes (containers, VMs, a classic app server behind a load balancer), put ≥2 replicas behind round-robin routing and run storyboards against the shared endpoint:
 
 ```bash
-npx @adcp/client --save-auth my-agent https://my-agent.example/mcp
-npx @adcp/client storyboard run my-agent
+npx @adcp/client@latest --save-auth my-agent https://my-agent.example/mcp
+npx @adcp/client@latest storyboard run my-agent
 ```
 
 The compliance runner rotates requests across replicas for any storyboard that contains a step marked `stateful: true` — the write→read sequences most likely to catch in-process state. Stateless probes (capability discovery, auth rejection, schema validation) are unaffected.
@@ -207,12 +207,12 @@ Anything else the two tenants share — audit shards, rate-limit buckets keyed b
 
 ```bash
 # Cross-tenant (full MUST)
-npx @adcp/client fuzz my-agent \
+npx @adcp/client@latest fuzz my-agent \
   --auth-token $TENANT_A_TOKEN \
   --auth-token-cross-tenant $TENANT_B_TOKEN
 
 # Baseline (partial coverage)
-npx @adcp/client fuzz my-agent --auth-token $TOKEN
+npx @adcp/client@latest fuzz my-agent --auth-token $TOKEN
 ```
 
 Tokens may also be supplied via `ADCP_AUTH_TOKEN` and `ADCP_AUTH_TOKEN_CROSS_TENANT`. See the [`@adcp/client` uniform-error-response invariant guide](https://github.com/adcontextprotocol/adcp-client/blob/main/docs/guides/VALIDATE-YOUR-AGENT.md#uniform-error-response-invariant-paired-probe) for the full flag list, the header allowlist, and the list of tools currently probed.
@@ -227,10 +227,10 @@ The typical development workflow:
 
 1. **Build** — Point a coding agent at a [skill file](/docs/building/build-an-agent) to generate your agent
 2. **Run** — Start the agent locally (`npx tsx agent.ts`)
-3. **Validate** — Run the matching storyboard (`npx @adcp/client storyboard run my-agent media_buy_seller`)
+3. **Validate** — Run the matching storyboard (`npx @adcp/client@latest storyboard run my-agent media_buy_seller`)
 4. **Fix** — Address any failures (missing fields, wrong status values, invalid transitions)
 5. **Repeat** — Run the storyboard again until all steps pass
-6. **Full check** — Run `npx @adcp/client storyboard run my-agent` (no storyboard ID) for a full assessment before going live
+6. **Full check** — Run `npx @adcp/client@latest storyboard run my-agent` (no storyboard ID) for a full assessment before going live
 
 <Info>
 For [Practitioner certification](https://agenticadvertising.org/certification), passing storyboard validation is the capstone — it proves your agent handles the complete protocol workflow for your chosen role track.
@@ -240,13 +240,13 @@ For [Practitioner certification](https://agenticadvertising.org/certification), 
 
 | Command | Description |
 |---------|-------------|
-| `npx @adcp/client storyboard list` | List all available storyboards |
-| `npx @adcp/client storyboard show <id>` | Preview storyboard structure |
-| `npx @adcp/client storyboard run <agent> [id]` | Run one storyboard, or all matching if no ID given |
-| `npx @adcp/client storyboard step <agent> <id> <step>` | Run a single step |
-| `npx @adcp/client <agent> [tool] [payload]` | Call any tool directly |
-| `npx @adcp/client --save-auth <alias> <url>` | Save agent alias |
-| `npx @adcp/client --list-agents` | List saved aliases |
+| `npx @adcp/client@latest storyboard list` | List all available storyboards |
+| `npx @adcp/client@latest storyboard show <id>` | Preview storyboard structure |
+| `npx @adcp/client@latest storyboard run <agent> [id]` | Run one storyboard, or all matching if no ID given |
+| `npx @adcp/client@latest storyboard step <agent> <id> <step>` | Run a single step |
+| `npx @adcp/client@latest <agent> [tool] [payload]` | Call any tool directly |
+| `npx @adcp/client@latest --save-auth <alias> <url>` | Save agent alias |
+| `npx @adcp/client@latest --list-agents` | List saved aliases |
 
 All commands support `--json`, `--debug`, `--auth TOKEN`, and `--protocol mcp|a2a`.
 

--- a/docs/learning/instructional-design.mdx
+++ b/docs/learning/instructional-design.mdx
@@ -184,7 +184,7 @@ Modules B4, C4, and D4 use a five-phase approach built on the same tools develop
 
 1. **Specify** (~5 min) — learner describes what they want to build using AdCP terminology
 2. **Build** (~5 min) — learner points their AI coding assistant at the matching skill file from `@adcp/client`, which generates a working agent from the specification
-3. **Validate** (~10 min) — learner runs the matching storyboard from the CLI (`npx @adcp/client storyboard run my-agent media_buy_seller`), shares results with Addie, and iterates on failures with their coding assistant
+3. **Validate** (~10 min) — learner runs the matching storyboard from the CLI (`npx @adcp/client@latest storyboard run my-agent media_buy_seller`), shares results with Addie, and iterates on failures with their coding assistant
 4. **Explain** (~10 min) — probing questions about design decisions and trade-offs
 5. **Extend** (~15 min) — learner adds a capability, re-runs the storyboard, demonstrating they can iterate
 

--- a/docs/learning/tracks/buyer.mdx
+++ b/docs/learning/tracks/buyer.mdx
@@ -218,10 +218,10 @@ Create a working buyer agent that discovers products and executes media buys. Us
 
 ### How you'll validate
 
-Your buyer agent runs against the public test agent (`test-mcp`). Use `npx @adcp/client` to execute tool calls and verify your agent handles the complete buying workflow:
+Your buyer agent runs against the public test agent (`test-mcp`). Use `npx @adcp/client@latest` to execute tool calls and verify your agent handles the complete buying workflow:
 
 ```bash
-npx @adcp/client test-mcp get_products '{"brief":"your campaign brief"}'
+npx @adcp/client@latest test-mcp get_products '{"brief":"your campaign brief"}'
 ```
 
 See [Validate Your Agent](/docs/building/validate-your-agent) for CLI setup and the full testing workflow.

--- a/docs/learning/tracks/platform.mdx
+++ b/docs/learning/tracks/platform.mdx
@@ -182,7 +182,7 @@ Build working AdCP infrastructure using any AI coding assistant (Claude Code, Cu
 Run the matching storyboard against your running agent:
 
 ```bash
-npx @adcp/client storyboard run my-agent media_buy_seller
+npx @adcp/client@latest storyboard run my-agent media_buy_seller
 ```
 
 The storyboard validates protocol compliance across the complete workflow. See [Validate Your Agent](/docs/building/validate-your-agent) for setup, debugging, and the full CLI reference.

--- a/docs/learning/tracks/publisher.mdx
+++ b/docs/learning/tracks/publisher.mdx
@@ -197,7 +197,7 @@ Create a working sales agent that responds to real buyer queries. Point your AI 
 Run the `media_buy_seller` storyboard against your running agent:
 
 ```bash
-npx @adcp/client storyboard run my-agent media_buy_seller
+npx @adcp/client@latest storyboard run my-agent media_buy_seller
 ```
 
 The storyboard exercises the complete buyer workflow — discovery, account sync, media buy, creatives, delivery — and validates every response. See [Validate Your Agent](/docs/building/validate-your-agent) for setup and debugging.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -144,7 +144,7 @@ asyncio.run(create_campaign())
 ```
 
 ```bash CLI test=false
-npx @adcp/client \
+npx @adcp/client@latest \
   https://test-agent.adcontextprotocol.org/mcp \
   create_media_buy \
   '{"brand":{"domain":"acmecorp.com"},"packages":[{"product_id":"prod_d979b543","pricing_option_id":"cpm_usd_auction","format_ids":[{"agent_url":"https://creative.adcontextprotocol.org","id":"display_300x250_image"}],"budget":30000,"bid_price":5.00},{"product_id":"prod_e8fd6012","pricing_option_id":"cpm_usd_auction","format_ids":[{"agent_url":"https://creative.adcontextprotocol.org","id":"display_300x250_html"}],"budget":20000,"bid_price":4.50}],"start_time":"2025-06-01T00:00:00Z","end_time":"2025-08-31T23:59:59Z"}' \

--- a/scripts/build-protocol-tarball.cjs
+++ b/scripts/build-protocol-tarball.cjs
@@ -129,7 +129,7 @@ ${quickstart}
 ## Validate an agent
 
 \`\`\`bash
-npx @adcp/client storyboard run https://my-agent.example.com
+npx @adcp/client@latest storyboard run https://my-agent.example.com
 \`\`\`
 
 The CLI uses the same \`compliance/\` tree bundled here. For offline runs, point it at

--- a/server/public/llms-full.txt
+++ b/server/public/llms-full.txt
@@ -178,7 +178,7 @@ Each AdCP SDK includes both caller APIs (for buyers calling agents) and server p
 - Python (`adcp`): https://github.com/adcontextprotocol/adcp-client-python
 - Go (`adcp-go`): https://github.com/adcontextprotocol/adcp-go
 
-The JavaScript SDK also ships a storyboard runner (`npx @adcp/client storyboard run`) that validates endpoints against the spec. Teams building agents in Python or Go still run the JS runner for validation — it's spec-aware, not language-specific.
+The JavaScript SDK also ships a storyboard runner (`npx @adcp/client@latest storyboard run`) that validates endpoints against the spec. Teams building agents in Python or Go still run the JS runner for validation — it's spec-aware, not language-specific.
 
 ## Agent-building skills
 

--- a/server/public/llms.txt
+++ b/server/public/llms.txt
@@ -54,7 +54,7 @@ Coding-agent shortcut — skip (2) and load a seller skill directly: https://git
 
 ## SDKs and skills
 
-Each AdCP SDK ships both caller APIs (for buyers) and server primitives (for sellers). The JavaScript SDK also ships a storyboard runner (`npx @adcp/client storyboard run`) that validates any endpoint against the spec — use it regardless of the language your agent is written in.
+Each AdCP SDK ships both caller APIs (for buyers) and server primitives (for sellers). The JavaScript SDK also ships a storyboard runner (`npx @adcp/client@latest storyboard run`) that validates any endpoint against the spec — use it regardless of the language your agent is written in.
 
 - `@adcp/client` (JavaScript/TypeScript): https://github.com/adcontextprotocol/adcp-client
 - `adcp` (Python): https://github.com/adcontextprotocol/adcp-client-python

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -2170,7 +2170,7 @@ PRESENT THESE INSTRUCTIONS TO THE LEARNER:
 
 Run your buyer agent against the public test agent and share the output. Use the \`adcp\` CLI:
 \`\`\`
-npx @adcp/client test-mcp get_products '{"brief":"<your campaign brief>"}'
+npx @adcp/client@latest test-mcp get_products '{"brief":"<your campaign brief>"}'
 \`\`\`
 
 Replace \`<your campaign brief>\` with your actual brief. Then run the full buying flow: get_products → create_media_buy → list_creative_formats → sync_creatives.
@@ -2226,11 +2226,11 @@ DO NOT rewrite these instructions. DO NOT write your own build prompt. The skill
     if (phase === 'validate') {
       const storyboardNote = moduleId === 'B4'
         ? 'The storyboard for B4 is `media_buy_seller`.'
-        : `Look up the matching storyboard for the learner's agent type on the Build an Agent page: ${BUILD_AN_AGENT_URL} — the skill-to-storyboard table shows which storyboard to run. You can also run \`npx @adcp/client storyboard list\` to see all options.`;
+        : `Look up the matching storyboard for the learner's agent type on the Build an Agent page: ${BUILD_AN_AGENT_URL} — the skill-to-storyboard table shows which storyboard to run. You can also run \`npx @adcp/client@latest storyboard list\` to see all options.`;
 
       const storyboardCmd = moduleId === 'B4'
-        ? 'npx @adcp/client storyboard run my-agent media_buy_seller'
-        : 'npx @adcp/client storyboard run my-agent <STORYBOARD_NAME>';
+        ? 'npx @adcp/client@latest storyboard run my-agent media_buy_seller'
+        : 'npx @adcp/client@latest storyboard run my-agent <STORYBOARD_NAME>';
 
       const placeholderNote = moduleId !== 'B4'
         ? '\n\nIMPORTANT: Replace `<STORYBOARD_NAME>` with the actual storyboard name before presenting to the learner.'
@@ -2244,7 +2244,7 @@ PRESENT THESE INSTRUCTIONS TO THE LEARNER:
 
 Save your agent and run the storyboard:
 \`\`\`
-npx @adcp/client --save-auth my-agent http://localhost:3001/mcp
+npx @adcp/client@latest --save-auth my-agent http://localhost:3001/mcp
 ${storyboardCmd}
 \`\`\`
 
@@ -2260,8 +2260,8 @@ DO NOT ask the learner to run individual tool calls. DO NOT ask them to paste JS
 
     if (phase === 'extend') {
       const extendCmd = moduleId === 'B4'
-        ? 'npx @adcp/client storyboard run my-agent media_buy_seller'
-        : 'npx @adcp/client storyboard run my-agent <STORYBOARD_NAME>';
+        ? 'npx @adcp/client@latest storyboard run my-agent media_buy_seller'
+        : 'npx @adcp/client@latest storyboard run my-agent <STORYBOARD_NAME>';
       const extendNote = moduleId !== 'B4'
         ? ' Replace `<STORYBOARD_NAME>` with the storyboard used in the Validate phase.'
         : '';

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -212,7 +212,7 @@ When someone wants to build an agent or integrate with AdCP, start with the SDKs
 - "Build an agent" is ambiguous. Ask: are you building a **buyer agent** (calls seller agents to discover and buy media) or a **seller agent** (exposes your inventory to buyer agents via MCP)? The SDK, docs, and starting point differ.
 - **Buyer agent**: Use the client SDKs — JavaScript/TypeScript (\`npm install @adcp/client\`) or Python (\`pip install adcp\`). The public test agent at \`${PUBLIC_TEST_AGENT.url}\` with token \`${PUBLIC_TEST_AGENT.token}\` is a live seller to test against (no signup required). Docs: https://docs.adcontextprotocol.org/docs/quickstart
 - **Seller agent**: Build an MCP server that implements AdCP tools. Start with the seller integration guide: https://docs.adcontextprotocol.org/docs/building/implementation/seller-integration. Schemas: https://docs.adcontextprotocol.org/docs/building/schemas-and-sdks
-- Both SDKs include CLI tools for quick testing (\`npx @adcp/client\`, \`uvx adcp\`).
+- Both SDKs include CLI tools for quick testing (\`npx @adcp/client@latest\`, \`uvx adcp\`).
 - Full docs: https://docs.adcontextprotocol.org. MCP integration docs for AI coding agents: https://docs.adcontextprotocol.org/mcp
 
 **Account Linking:**

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -342,7 +342,7 @@ When someone asks about building an agent, getting started with AdCP, testing th
 
 3. **Has an agent, needs to validate / "how do I test my agent?"** → Point them to Validate Your Agent: https://docs.adcontextprotocol.org/docs/building/validate-your-agent — explains the full build-validate-fix loop. Two paths:
    - **Through Addie (interactive):** Paste the agent URL in chat. You will use recommend_storyboards to discover tools and suggest storyboards, then run_storyboard to execute them with coaching.
-   - **From the CLI (local development):** `npx @adcp/client storyboard run my-agent media_buy_seller` runs a specific storyboard. `npx @adcp/client storyboard run my-agent` (no ID) runs all matching storyboards. No install needed.
+   - **From the CLI (local development):** `npx @adcp/client@latest storyboard run my-agent media_buy_seller` runs a specific storyboard. `npx @adcp/client@latest storyboard run my-agent` (no ID) runs all matching storyboards. No install needed.
 
 4. **Building a buyer agent** → They don't need save_agent or compliance monitoring. They need the client SDK and the public test agent to call. Point them to Schemas and SDKs: https://docs.adcontextprotocol.org/docs/building/schemas-and-sdks
 
@@ -355,9 +355,9 @@ When someone asks about building an agent, getting started with AdCP, testing th
 **CLI setup for storyboards:**
 The `adcp` CLI stores agent aliases in `~/.adcp/config.json`. Users save agents with:
 ```
-npx @adcp/client --save-auth my-agent http://localhost:3001/mcp
+npx @adcp/client@latest --save-auth my-agent http://localhost:3001/mcp
 ```
-Then they can use the alias everywhere: `npx @adcp/client my-agent get_products '{...}'`, `npx @adcp/client storyboard run my-agent media_buy_seller`. Built-in aliases `test-mcp` and `test-a2a` point to the public test agents.
+Then they can use the alias everywhere: `npx @adcp/client@latest my-agent get_products '{...}'`, `npx @adcp/client@latest storyboard run my-agent media_buy_seller`. Built-in aliases `test-mcp` and `test-a2a` point to the public test agents.
 
 **Connect to certification when relevant:**
 Practitioner certification culminates in building a working agent that passes storyboard validation. If someone is working toward certification, remind them that passing storyboards is the finish line — and you can help them get there interactively.

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -540,7 +540,7 @@ These libraries handle protocol details, authentication, and provide typed inter
 - **Schemas and SDKs** (https://docs.adcontextprotocol.org/docs/building/schemas-and-sdks) — Schema access, CLI tools, SDK exports. Includes the `adcp` CLI for both JS and Python.
 
 **CLI tools in @adcp/client:**
-The `adcp` CLI runs via `npx @adcp/client@latest`. Key commands:
+The `adcp` CLI runs via `npx @adcp/client@latest`. Always include the `@latest` pin when you suggest a command — unpinned `npx @adcp/client` silently reuses whatever version is cached in `~/.npm/_npx/`, which can be months stale. If a user reports behavior that does not match current docs (a missing flag, an old warning, wrong output shape), suspect a stale cache first and tell them: "run `npx @adcp/client@latest …` to force a fresh resolution, or `rm -rf ~/.npm/_npx` to clear all cached versions." Key commands:
 - `npx @adcp/client@latest <agent> [tool] [payload]` — Call any tool on an agent
 - `npx @adcp/client@latest storyboard list` — List all available storyboards
 - `npx @adcp/client@latest storyboard run <agent> [storyboard_id]` — Run a storyboard, or all matching if no ID given

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -540,10 +540,10 @@ These libraries handle protocol details, authentication, and provide typed inter
 - **Schemas and SDKs** (https://docs.adcontextprotocol.org/docs/building/schemas-and-sdks) — Schema access, CLI tools, SDK exports. Includes the `adcp` CLI for both JS and Python.
 
 **CLI tools in @adcp/client:**
-The `adcp` CLI runs via `npx @adcp/client`. Key commands:
-- `npx @adcp/client <agent> [tool] [payload]` — Call any tool on an agent
-- `npx @adcp/client storyboard list` — List all available storyboards
-- `npx @adcp/client storyboard run <agent> [storyboard_id]` — Run a storyboard, or all matching if no ID given
-- `npx @adcp/client --save-auth <alias> <url>` — Save an agent alias to `~/.adcp/config.json`
+The `adcp` CLI runs via `npx @adcp/client@latest`. Key commands:
+- `npx @adcp/client@latest <agent> [tool] [payload]` — Call any tool on an agent
+- `npx @adcp/client@latest storyboard list` — List all available storyboards
+- `npx @adcp/client@latest storyboard run <agent> [storyboard_id]` — Run a storyboard, or all matching if no ID given
+- `npx @adcp/client@latest --save-auth <alias> <url>` — Save an agent alias to `~/.adcp/config.json`
 
 Built-in aliases: `test-mcp`, `test-a2a`, `test-no-auth`, `test-a2a-no-auth`, `creative`.


### PR DESCRIPTION
## Summary

Mirror of [adcontextprotocol/adcp-client#835](https://github.com/adcontextprotocol/adcp-client/pull/835). The primary docs for `@adcp/client` live here, so the CLI-fix issue fires here too.

`npx @adcp/client` silently reuses stale cached versions from `~/.npm/_npx/` indefinitely. A user following our docs can have six different CLI versions cached (4.14 → 5.13) and npx will happily reuse any of them. The user runs old code, misses bug fixes, and doesn't realize it — the output looks normal.

Fix: pin `@latest` in every documented invocation. Touches:

- `docs/building/` — all five building guides (validate, build, get-test-ready, index, schemas-and-sdks)
- `docs/learning/tracks/` — buyer/publisher/platform tracks + instructional-design
- `docs/media-buy/task-reference/create_media_buy.mdx`
- `server/public/llms.txt` + `llms-full.txt`
- `server/src/addie/` — addie's certification tools, prompts, and knowledge rules (so Addie recommends the pinned form)
- `scripts/build-protocol-tarball.cjs`

17 files, 56 refs updated.

## Test plan

- [x] `grep -r "npx @adcp/client[^@]"` returns zero results under tracked docs/code
- [ ] Spot-check a docs page rendering looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)