### PR TITLE
fix(registry): honor caller auth on /api/registry/operator

### DIFF
--- a/.changeset/fix-registry-operator-auth.md
+++ b/.changeset/fix-registry-operator-auth.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `GET /api/registry/operator` to honor caller auth. The endpoint now accepts a WorkOS Bearer API key (or session cookie) and tiers agent visibility accordingly: `public` always, `members_only` when the caller's org has API-access tier, and `private` when the caller's org owns the profile. Previously the route hardcoded `visibility === 'public'` and ignored the Authorization header, so members_only/private agents were never returned.

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -215,7 +215,7 @@ export interface ValidatedApiKey {
  * Validate a WorkOS API key from the Authorization header
  * Returns the validated API key info or null if invalid
  */
-async function validateWorkOSApiKey(req: Request): Promise<ValidatedApiKey | null> {
+export async function validateWorkOSApiKey(req: Request): Promise<ValidatedApiKey | null> {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) return null;
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -85,6 +85,7 @@ import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { query as dbQuery } from "../db/client.js";
+import { validateWorkOSApiKey } from "../middleware/auth.js";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -4660,7 +4661,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Lookups & Authorization ───────────────────────────────────
 
-  router.get("/registry/operator", async (req, res) => {
+  router.get("/registry/operator", optAuth, async (req, res) => {
     const rawDomain = req.query.domain as string;
     if (!rawDomain) {
       return res.status(400).json({ error: "Missing required query param: domain" });
@@ -4679,8 +4680,43 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         ? { slug: profile.slug, display_name: profile.display_name }
         : null;
 
+      // Resolve caller's organization. API key path (optAuth skips Bearer
+      // API keys — see middleware/auth.ts:1332) takes precedence over session.
+      let callerOrgId: string | null = null;
+      const apiKey = await validateWorkOSApiKey(req);
+      if (apiKey) {
+        callerOrgId = apiKey.organizationId;
+      } else if (req.user?.id) {
+        try {
+          const row = await dbQuery<{ primary_organization_id: string | null }>(
+            'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+            [req.user.id],
+          );
+          callerOrgId = row.rows[0]?.primary_organization_id ?? null;
+        } catch (err) {
+          logger.warn({ err, userId: req.user.id }, 'operator: org resolution failed — falling back to public-only');
+        }
+      }
+
+      let includeMembersOnly = false;
+      if (callerOrgId) {
+        const org = await orgDb.getOrganization(callerOrgId);
+        if (org && hasApiAccess(resolveMembershipTier(org))) {
+          includeMembersOnly = true;
+        }
+      }
+
+      const isProfileOwner = !!(
+        callerOrgId && profile?.workos_organization_id && profile.workos_organization_id === callerOrgId
+      );
+
       const displayName = profile?.display_name || domain;
-      const agentConfigs = (profile?.agents || []).filter(a => a.visibility === 'public').slice(0, 20);
+      const agentConfigs = (profile?.agents || []).filter(a => {
+        if (a.visibility === 'public') return true;
+        if (includeMembersOnly && a.visibility === 'members_only') return true;
+        if (isProfileOwner && a.visibility === 'private') return true;
+        return false;
+      }).slice(0, 20);
 
       const agents = await Promise.all(
         agentConfigs.map(async (ac) => {


### PR DESCRIPTION
## Summary

- `GET /api/registry/operator` now respects the Authorization header. Previously it hardcoded `visibility === 'public'` and ignored Bearer API keys, so authenticated members never saw `members_only` agents and owning orgs never saw their own `private` agents.
- Accepts WorkOS Bearer API key (inline-validated, since `optionalAuth` skips API keys per `middleware/auth.ts:1332`) or session cookie.
- Resolves caller org from `apiKey.organizationId` or `users.primary_organization_id`.
- Includes `members_only` agents when the caller's org has API-access tier (Professional+), matching the pattern from `/registry/agents` added in 647153793.
- Includes `private` agents when the caller's org owns the queried profile (matched via `workos_organization_id`).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` (631/631 passed)
- [ ] Hit `/api/registry/operator?domain=scope3.com` with no auth → only public agents
- [ ] Hit with Professional+ Bearer API key → public + members_only agents
- [ ] Hit with API key owning the scope3 profile → public + members_only + private agents