### PR TITLE
feat(slack): show signup name/email on prospect notifications

### DIFF
--- a/.changeset/prospect-slack-contact-info.md
+++ b/.changeset/prospect-slack-contact-info.md
@@ -1,0 +1,4 @@
+---
+---
+
+Include the signup contact name and email on prospect Slack notifications so owners know who just signed up.

--- a/server/src/notifications/prospect.ts
+++ b/server/src/notifications/prospect.ts
@@ -20,6 +20,16 @@ const MATCH_METHOD_LABELS: Record<string, string> = {
   redirect: 'HTTP redirect',
 };
 
+function signedUpByBlock(name?: string, email?: string): SlackBlock | null {
+  if (!name && !email) return null;
+  const emailPart = email ? `<mailto:${email}|${email}>` : '';
+  const parts = [name, emailPart ? `(${emailPart})` : ''].filter(Boolean).join(' ');
+  return {
+    type: 'section',
+    text: { type: 'mrkdwn', text: `*Signed up by:* ${parts}` },
+  };
+}
+
 export async function notifyAliasMatch(data: {
   signupDomain: string;
   matchedDomain: string;
@@ -69,13 +79,8 @@ export async function notifyAliasMatch(data: {
     },
   ];
 
-  if (data.contactName || data.contactEmail) {
-    const contactParts = [data.contactName, data.contactEmail ? `(${data.contactEmail})` : ''].filter(Boolean).join(' ');
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: `*New contact:* ${contactParts}` },
-    });
-  }
+  const aliasContactBlock = signedUpByBlock(data.contactName, data.contactEmail);
+  if (aliasContactBlock) blocks.push(aliasContactBlock);
 
   blocks.push({
     type: 'actions',
@@ -120,6 +125,8 @@ export async function notifyNewProspect(data: {
   companyType?: string;
   source: string;
   orgId?: string;
+  contactName?: string;
+  contactEmail?: string;
 }): Promise<boolean> {
   if (!isSlackConfigured()) {
     logger.debug('Slack not configured, skipping prospect notification');
@@ -165,6 +172,12 @@ export async function notifyNewProspect(data: {
         { type: 'mrkdwn', text: `*Source:*\n${sourceLabel}` },
       ],
     },
+  ];
+
+  const contactBlock = signedUpByBlock(data.contactName, data.contactEmail);
+  if (contactBlock) blocks.push(contactBlock);
+
+  blocks.push(
     {
       type: 'section',
       fields: [
@@ -176,7 +189,7 @@ export async function notifyNewProspect(data: {
       type: 'section',
       text: { type: 'mrkdwn', text: `*Assessment:*\n${data.verdict}` },
     },
-  ];
+  );
 
   // Add action buttons for human-needed prospects
   if (isHumanNeeded && data.orgId) {

--- a/server/src/services/prospect-triage.ts
+++ b/server/src/services/prospect-triage.ts
@@ -487,6 +487,8 @@ export async function triageAndNotify(
     verdict: result.verdict,
     companyType: result.companyType,
     source: context?.source ?? 'inbound',
+    contactName: context?.name,
+    contactEmail: context?.email,
     // No orgId — the user will create their own org during onboarding
   }).catch(err => {
     logger.warn({ err, domain }, 'Prospect notification failed');
@@ -586,6 +588,8 @@ export async function triageAndCreateProspect(
     companyType: result.companyType,
     source: context?.source ?? 'inbound',
     orgId,
+    contactName: context?.name,
+    contactEmail: context?.email,
   }).catch(err => {
     logger.warn({ err, domain }, 'Prospect notification failed');
   });


### PR DESCRIPTION
## Summary
- Prospect Slack notifications now identify the person who signed up, not just the company.
- Threads `contactName`/`contactEmail` from `TriageContext` through `notifyNewProspect` and renders a *Signed up by* section adjacent to the company identity fields.
- Unifies the contact block between `notifyNewProspect` and `notifyAliasMatch` via a shared helper (`signedUpByBlock`) and makes the email a clickable `mailto:` link.

## Why
Today a notification like "Enterprise prospect needs an owner — Diageo" has no indication of which Diageo employee signed up. Owners had to go dig in the DB or activity log to find the contact. The triage context already carries name/email; this just surfaces it.

## Test plan
- [x] `npm run test:unit` — 631/631 pass
- [x] `npm run typecheck` — clean
- [ ] Manual: next real signup should render a *Signed up by* row with a clickable email in the prospect Slack channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)