### PR TITLE
fix(dashboard): clear autoRetriedAgents on success + retry re-entry guard

### DIFF
--- a/.changeset/fix-dashboard-retry-stale-state.md
+++ b/.changeset/fix-dashboard-retry-stale-state.md
@@ -1,0 +1,9 @@
+---
+---
+
+Close #2938: fix two stale-state bugs in the Agents dashboard 429 UX introduced with PR #2933.
+
+- **Clear `autoRetriedAgents` on success.** `pageState.autoRetriedAgents` was a session-lifetime `Set` — an agent that hit 429 at 9am and auto-retried once would, on a genuine manual retry at 5pm (long after the rate-limit window closed), render the "refreshed too quickly" copy on the next 429. `retryAgentCard` now deletes the agent's entry from the set in the `try` branch after a successful fetch, so the marker only persists while an auto-retry is actually pending.
+- **Re-entry guard on `retryAgentCard`.** If a user clicks Retry at the exact moment the countdown interval enables the button, the click handler and the interval's post-countdown call could race. A `data-retry-in-flight="1"` attribute set on the card at the top of `retryAgentCard` causes concurrent calls to early-return. The flag lives on the DOM so successful retries drop it for free when `card.replaceWith(newCard)` runs; failures clear it in the `catch` branch.
+
+No test changes — `dashboard-agents.html` has no frontend unit harness in this repo, consistent with #2933.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1289,6 +1289,12 @@
     async function retryAgentCard(agentUrl, cardId, { auto = false } = {}) {
       const card = document.getElementById(cardId);
       if (!card) return;
+      // Re-entry guard: drop concurrent retries (e.g., the countdown
+      // interval firing at the moment a user clicks Retry). The flag
+      // lives on the DOM — successful retries replace the card and
+      // lose it; failures clear it in the catch branch below.
+      if (card.dataset.retryInFlight === '1') return;
+      card.dataset.retryInFlight = '1';
       const retryBtn = card.querySelector('.agent-reload-btn');
       if (retryBtn) {
         retryBtn.disabled = true;
@@ -1304,12 +1310,17 @@
         wrapper.innerHTML = newHtml.trim();
         const newCard = wrapper.firstElementChild;
         if (newCard) card.replaceWith(newCard);
+        // Clear the auto-retry marker on success so a genuine 429 later
+        // in the same session doesn't render "refreshed too quickly" on
+        // its first strike.
+        pageState.autoRetriedAgents.delete(agentUrl);
       } catch (err) {
         console.error('Retry failed:', err);
         if (retryBtn) {
           retryBtn.disabled = false;
           retryBtn.textContent = 'Retry';
         }
+        card.dataset.retryInFlight = '';
       }
     }
 


### PR DESCRIPTION
Closes #2938.

## Summary

Two stale-state bugs from #2933 on the Agents dashboard 429 UX:

1. **`pageState.autoRetriedAgents` was session-lifetime.** `retryAgentCard` now deletes the entry in the `try` branch after a successful fetch, so a genuine 429 later in the same session (long after the original rate-limit window closed) doesn't render "refreshed too quickly" on its first strike.
2. **Re-entry guard.** A `data-retry-in-flight="1"` attribute set at the top of `retryAgentCard` early-returns concurrent calls — covers the race where a user clicks Retry at the exact moment the countdown interval fires its auto-retry. The flag lives on the DOM so successful retries drop it for free when `card.replaceWith(newCard)` runs; failures clear it in the `catch` branch.

## What I did not change

- Kept the decision to add the auto-retry marker **before** the try (line 1303). The marker should be set even if the fetch throws a non-429 — otherwise a retry that happens to error with a network blip, then succeeds, would lose the "has auto-retried once" state.
- No TTL-based expiration of `autoRetriedAgents` — the successful-retry clear is a stronger signal than a wall-clock TTL, and the set is bounded by number of agents per session.
- No new tests. `dashboard-agents.html` has no frontend unit harness in this repo (consistent with #2933).

## Test plan

- [ ] Manual: force a 429, wait past the countdown, let auto-retry succeed, force another 429 later — confirm countdown + auto-retry fire normally instead of "refreshed too quickly" on first strike.
- [ ] Manual: force a 429, open devtools, click Retry at `~0s` remaining — confirm only one retry fires.
- [ ] Manual: force a 429, let auto-retry fail (e.g., offline) — confirm Retry button re-enables and a manual click works.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}


---
_Generated by [Claude Code](https://claude.ai/code/session_018N6XtNbjEC2sChTe2yevMJ)_