### PR TITLE
fix: truncate thread titles and validate UUID on brand.json route

### DIFF
--- a/.changeset/fix-admin-error-triage.md
+++ b/.changeset/fix-admin-error-triage.md
@@ -1,0 +1,7 @@
+---
+---
+
+Two admin-channel errors fixed:
+
+- `updateThreadTitle` truncates titles to 500 chars so generated titles can't overflow `addie_threads.title VARCHAR(500)`.
+- `/brand/:id/brand.json` rejects non-UUID ids with a 404 instead of letting Postgres throw a 500 on malformed input (e.g. `abc123`).

--- a/.changeset/fix-admin-error-triage.md
+++ b/.changeset/fix-admin-error-triage.md
@@ -4,4 +4,4 @@
 Two admin-channel errors fixed:
 
 - `updateThreadTitle` truncates titles to 500 chars so generated titles can't overflow `addie_threads.title VARCHAR(500)`.
-- `/brand/:id/brand.json` rejects non-UUID ids with a 404 instead of letting Postgres throw a 500 on malformed input (e.g. `abc123`).
+- `/brand/:id/brand.json` and `/property/:id/adagents.json` reject non-UUID ids with a 404 instead of letting Postgres throw a 500 on malformed input (e.g. `abc123`).

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -334,7 +334,7 @@ export class ThreadService {
   async updateThreadTitle(threadId: string, title: string): Promise<void> {
     await query(
       `UPDATE addie_threads SET title = $2, updated_at = NOW() WHERE thread_id = $1`,
-      [threadId, title]
+      [threadId, title.slice(0, 500)]
     );
   }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -2838,6 +2838,10 @@ export class HTTPServer {
     // GET /brand/:id/brand.json - Serve hosted brand.json
     this.app.get('/brand/:id/brand.json', async (req, res) => {
       try {
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRegex.test(req.params.id)) {
+          return res.status(404).json({ error: 'Brand not found' });
+        }
         const brand = await this.brandDb.getHostedBrandById(req.params.id);
         if (!brand || !brand.is_public) {
           return res.status(404).json({ error: 'Brand not found' });

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3238,6 +3238,10 @@ export class HTTPServer {
     // GET /property/:id/adagents.json - Serve hosted adagents.json
     this.app.get('/property/:id/adagents.json', async (req, res) => {
       try {
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRegex.test(req.params.id)) {
+          return res.status(404).json({ error: 'Property not found' });
+        }
         const property = await this.propertyDb.getHostedPropertyById(req.params.id);
         if (!property || !property.is_public) {
           return res.status(404).json({ error: 'Property not found' });


### PR DESCRIPTION
## Summary

Three admin-channel errors observed in production:

- **`Addie Bolt: Failed to update thread title — value too long for type character varying(500)`**  
  LLM-generated titles could exceed the 500-char column. `updateThreadTitle` now truncates to 500 before the UPDATE.
- **`Failed to serve hosted brand.json — invalid input syntax for type uuid: "abc123"`**  
  `GET /brand/:id/brand.json` (public, unauth) passed raw params into a UUID column. Now regex-validates UUID shape and returns 404 for anything else.
- **Same anti-pattern on `GET /property/:id/adagents.json`** (public, unauth). Same fix applied.

Security-reviewer called out that collapsing `malformed → 500` and `not-found → 404` into a single 404 also closes a weak enumeration oracle and cuts log noise from fuzzing.

## Not in this PR (follow-ups)

- The UUID regex is duplicated ~24× across the codebase with inconsistent case-insensitivity flags (`http.ts:924` and `routes/brand-logos.ts:27` reject valid uppercase UUIDs — latent bug). A shared `isUuid()` helper is worth extracting separately.
- Three admin-authed routes share the raw-UUID-to-Postgres pattern (`http.ts:3227`, `3334`, `3369`). Lower priority since attacker must already be admin-auth'd.

## Test plan

- [x] `npm run test:unit` (631 passed)
- [x] `npm run typecheck`
- [ ] Manual smoke: `/brand/abc123/brand.json` → 404, not 500
- [ ] Manual smoke: `/property/abc123/adagents.json` → 404, not 500
- [ ] Manual smoke: >500-char title through Bolt → no error in admin channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)