### PR TITLE
fix(addie): guard fallback say() against empty text on upstream overload

### DIFF
--- a/.changeset/fix-fallback-say-empty-guard.md
+++ b/.changeset/fix-fallback-say-empty-guard.md
@@ -1,0 +1,7 @@
+---
+---
+
+Fix `Addie Bolt: Fallback say() also failed` errors during upstream Anthropic overloads:
+
+- When streaming fails before producing any text, the stream-stop fallback built a Slack `section` block with empty `mrkdwn` text, which Slack rejects as `invalid_blocks`. Now falls back to a plain apology (`say(apology)`) when `slackText` is empty.
+- Demote the "fallback also failed" log from `error` to `warn` when the root cause is an already-logged retries-exhausted error, so upstream outages don't page twice.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1652,20 +1652,31 @@ async function handleUserMessage({
           const fallbackValidation = validateOutput(guarded.text);
           const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
           const slackText = wrapUrlsForSlack(fallbackText);
-          await say({
-            text: slackText,
-            blocks: [
-              { type: 'section', text: { type: 'mrkdwn', text: slackText } },
-              ...fallbackImages.slice(0, 3).map(img => ({
-                type: 'image' as const,
-                image_url: img.url,
-                alt_text: img.alt,
-              })),
-              buildFeedbackBlock(),
-            ],
-          });
+          // Slack rejects section blocks with empty mrkdwn text. If streaming
+          // produced nothing (e.g. upstream overload before any deltas), fall
+          // back to a plain apology so the user isn't left silent.
+          if (!slackText.trim()) {
+            const apology = isRetriesExhaustedError(stopError)
+              ? `${stopError.reason}. Please try again in a moment.`
+              : "I'm sorry, I encountered an error. Please try again.";
+            await say(apology);
+          } else {
+            await say({
+              text: slackText,
+              blocks: [
+                { type: 'section', text: { type: 'mrkdwn', text: slackText } },
+                ...fallbackImages.slice(0, 3).map(img => ({
+                  type: 'image' as const,
+                  image_url: img.url,
+                  alt_text: img.alt,
+                })),
+                buildFeedbackBlock(),
+              ],
+            });
+          }
         } catch (sayError) {
-          logger.error({ sayError }, 'Addie Bolt: Fallback say() also failed');
+          const logLevel = isRetriesExhaustedError(stopError) ? 'warn' : 'error';
+          logger[logLevel]({ sayError, stopError }, 'Addie Bolt: Fallback say() also failed');
         }
       }
     } else {

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1675,8 +1675,9 @@ async function handleUserMessage({
             });
           }
         } catch (sayError) {
-          const logLevel = isRetriesExhaustedError(stopError) ? 'warn' : 'error';
-          logger[logLevel]({ sayError, stopError }, 'Addie Bolt: Fallback say() also failed');
+          const rootCause = isRetriesExhaustedError(stopError) ? 'retries-exhausted' : 'other';
+          const logLevel = rootCause === 'retries-exhausted' ? 'warn' : 'error';
+          logger[logLevel]({ sayError, stopError, rootCause }, 'Addie Bolt: Fallback say() also failed');
         }
       }
     } else {


### PR DESCRIPTION
## Summary

Addresses \`Addie Bolt: Fallback say() also failed\` errors in the admin channel that fired during Anthropic overload incidents.

**Root cause:** when streaming fails before any text deltas arrive (upstream overload), \`fullText\` is empty. The fallback then builds a Slack \`section\` block with empty \`mrkdwn\` text, which Slack rejects as \`invalid_blocks\` — escalating a silent user experience into a noisy \`error\` log.

**Fix:** at \`server/src/addie/bolt-app.ts:1647-1669\` —
- If \`slackText\` is empty, send a plain apology via \`say(text)\` (no blocks) so the user gets a response.
- When the root cause is an already-logged \`RetriesExhaustedError\`, demote the fallback-failure log from \`error\` to \`warn\` so upstream outages don't page twice.

## Why no test

\`handleUserMessage\` has no existing unit coverage. Adding one here would require mocking Slack's Bolt \`say\`, the Claude streaming SDK, and the assistant middleware. Out of scope for a defensive one-file guard.

## Test plan

- [x] \`npm run test:unit\` (631 passed, no regressions)
- [x] \`npm run typecheck\`
- [ ] Watch admin channel during next Anthropic overload — expect no \`error\` entries from this path, at most a \`warn\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)