### PR TITLE
refactor: consolidate UUID validation into isUuid() helper

### DIFF
--- a/.changeset/consolidate-uuid-validation.md
+++ b/.changeset/consolidate-uuid-validation.md
@@ -1,0 +1,7 @@
+---
+---
+
+Consolidate ~24 inline UUID-validation regexes into a single `isUuid()` helper at `server/src/utils/uuid.ts`. Fixes two latent bugs where the `/i` flag was missing, causing valid uppercase UUIDs to be rejected:
+
+- `GET /logos/brands/:domain/:id` (brand logo serving)
+- `GET /brand/logos/:id` (brand-logos route)

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -19,6 +19,7 @@ function safeSubscriptionStatus(status: string | null | undefined): string | nul
   return KNOWN_SUBSCRIPTION_STATUSES.has(status) ? status : 'unknown';
 }
 import * as certDb from '../../db/certification-db.js';
+import { isUuid } from '../../utils/uuid.js';
 import { query } from '../../db/client.js';
 import { createLogger } from '../../logger.js';
 import { notifySpecialistCredential } from '../jobs/credential-digest.js';
@@ -1926,9 +1927,8 @@ export function createCertificationToolHandlers(
       if (!attemptId || !scores || typeof scores !== 'object') return 'attempt_id and scores are required.';
 
       // Look up the active attempt: accept the UUID directly, or resolve from module ID
-      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(attemptId);
       let attempt: certDb.CertificationAttempt | null;
-      if (isUuid) {
+      if (isUuid(attemptId)) {
         attempt = await certDb.getAttempt(attemptId);
       } else {
         // Claude sometimes sends the module ID instead of the attempt UUID

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -10,6 +10,7 @@ import { createLogger } from '../../logger.js';
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
 import { ToolError } from '../tool-error.js';
+import { isUuid } from '../../utils/uuid.js';
 import {
   createEscalation,
   markNotificationSent,
@@ -287,7 +288,7 @@ export function createEscalationToolHandlers(
     const perspectiveSlug = input.perspective_slug as string | undefined;
 
     // Validate UUID format on perspective_id if provided.
-    if (perspectiveId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(perspectiveId)) {
+    if (perspectiveId && !isUuid(perspectiveId)) {
       throw new ToolError('perspective_id must be a UUID string if provided');
     }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -20,6 +20,7 @@ import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
 import { ToolError } from '../tool-error.js';
 import { checkToolRateLimit } from './tool-rate-limiter.js';
+import { isUuid } from '../../utils/uuid.js';
 import { neutralizeAndTruncate } from './untrusted-input.js';
 import { createEscalation } from '../../db/escalation-db.js';
 import { SlackDatabase } from '../../db/slack-db.js';
@@ -2820,8 +2821,7 @@ export function createMemberToolHandlers(
     const isFeatured = input.is_featured as boolean | undefined;
 
     // Validate UUID format before API call
-    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!UUID_REGEX.test(documentId)) {
+    if (!isUuid(documentId)) {
       return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
     }
 
@@ -2889,8 +2889,7 @@ export function createMemberToolHandlers(
     const documentId = input.document_id as string;
 
     // Validate UUID format before API call
-    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!UUID_REGEX.test(documentId)) {
+    if (!isUuid(documentId)) {
       return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
     }
 

--- a/server/src/db/insights-db.ts
+++ b/server/src/db/insights-db.ts
@@ -1,5 +1,6 @@
 import { query } from './client.js';
 import { logger } from '../logger.js';
+import { isUuid } from '../utils/uuid.js';
 
 // =====================================================
 // TYPES
@@ -372,8 +373,7 @@ export class InsightsDatabase {
    */
   async linkOutreachToThread(outreachId: number, threadId: string): Promise<void> {
     // Validate UUID format for data integrity
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(threadId)) {
+    if (!isUuid(threadId)) {
       throw new Error('Invalid thread ID format');
     }
     await query(

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -44,6 +44,7 @@ import { syncSlackUsers, getSyncStatus, tryAutoLinkWebsiteUserToSlack } from "./
 import { isSlackConfigured, testSlackConnection } from "./slack/client.js";
 import { handleSlashCommand } from "./slack/commands.js";
 import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js";
+import { isUuid } from "./utils/uuid.js";
 import { requireAuth, requireAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
@@ -926,7 +927,6 @@ export class HTTPServer {
 
     // Serve brand logos by UUID — public endpoint so agents can download them.
     const logoDomainPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
-    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
     const brandLogoDb = new BrandLogoDatabase();
 
     // LRU cache: bounded to ~100MB / ~200 entries, 5-minute TTL
@@ -973,7 +973,7 @@ export class HTTPServer {
           return res.redirect(301, `/logos/brands/${domain}/${newId}`);
         }
 
-        if (!uuidPattern.test(id)) {
+        if (!isUuid(id)) {
           return res.status(400).json({ error: 'Invalid logo ID' });
         }
 
@@ -2847,8 +2847,7 @@ export class HTTPServer {
     // GET /brand/:id/brand.json - Serve hosted brand.json
     this.app.get('/brand/:id/brand.json', async (req, res) => {
       try {
-        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidRegex.test(req.params.id)) {
+        if (!isUuid(req.params.id)) {
           return res.status(404).json({ error: 'Brand not found' });
         }
         const brand = await this.brandDb.getHostedBrandById(req.params.id);
@@ -3247,8 +3246,7 @@ export class HTTPServer {
     // GET /property/:id/adagents.json - Serve hosted adagents.json
     this.app.get('/property/:id/adagents.json', async (req, res) => {
       try {
-        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidRegex.test(req.params.id)) {
+        if (!isUuid(req.params.id)) {
           return res.status(404).json({ error: 'Property not found' });
         }
         const property = await this.propertyDb.getHostedPropertyById(req.params.id);
@@ -4598,8 +4596,7 @@ export class HTTPServer {
 
     // GET /api/admin/agreements/:id - Get single agreement with full text
     this.app.get('/api/admin/agreements/:id', requireAuth, requireAdmin, async (req, res) => {
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (!uuidRegex.test(req.params.id)) {
+      if (!isUuid(req.params.id)) {
         return res.status(400).json({ error: 'Invalid agreement ID format' });
       }
 
@@ -5651,7 +5648,7 @@ Disallow: /api/admin/
     this.app.put('/api/admin/content/:id/origin', requireAuth, requireAdmin, async (req, res) => {
       try {
         const { id } = req.params;
-        if (!isValidUUID(id)) return res.status(400).json({ error: 'Invalid content ID' });
+        if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         const { content_origin } = req.body;
         if (!content_origin || !['official', 'member', 'external'].includes(content_origin)) {
           return res.status(400).json({ error: 'content_origin must be official, member, or external' });
@@ -5668,13 +5665,11 @@ Disallow: /api/admin/
       }
     });
 
-    const isValidUUID = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
-
     // DELETE /api/admin/content/:id - Delete any perspective (admin only)
     this.app.delete('/api/admin/content/:id', requireAuth, requireAdmin, adminContentWriteRateLimiter, async (req, res) => {
       try {
         const { id } = req.params;
-        if (!isValidUUID(id)) return res.status(400).json({ error: 'Invalid content ID' });
+        if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         const pool = getPool();
         const result = await pool.query(
           `DELETE FROM perspectives WHERE id = $1 RETURNING id, title`,
@@ -5695,7 +5690,7 @@ Disallow: /api/admin/
     this.app.get('/api/admin/content/:id', requireAuth, requireAdmin, async (req, res) => {
       try {
         const { id } = req.params;
-        if (!isValidUUID(id)) return res.status(400).json({ error: 'Invalid content ID' });
+        if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         const pool = getPool();
         const result = await pool.query(
           `SELECT p.id, p.slug, p.content_type, p.title, p.subtitle, p.category,
@@ -5730,7 +5725,7 @@ Disallow: /api/admin/
     this.app.post('/api/admin/content/:id/social-drafts', requireAuth, requireAdmin, async (req, res) => {
       try {
         const { id } = req.params;
-        if (!isValidUUID(id)) return res.status(400).json({ error: 'Invalid content ID' });
+        if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         if (!isLLMConfigured()) {
           return res.status(503).json({ error: 'LLM not configured' });
         }
@@ -5802,7 +5797,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     this.app.put('/api/admin/content/:id/status', requireAuth, requireAdmin, adminContentWriteRateLimiter, async (req, res) => {
       try {
         const { id } = req.params;
-        if (!isValidUUID(id)) return res.status(400).json({ error: 'Invalid content ID' });
+        if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         const { status } = req.body;
         if (!status || !['draft', 'pending_review', 'published', 'archived'].includes(status)) {
           return res.status(400).json({ error: 'status must be draft, pending_review, published, or archived' });

--- a/server/src/registry-sync/poller.ts
+++ b/server/src/registry-sync/poller.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CatalogEvent, FeedResult, FeedError } from '../db/catalog-events-db.js';
+import { isUuid } from '../utils/uuid.js';
 
 export interface PollerConfig {
   apiKey: string;
@@ -181,7 +182,7 @@ export class FeedPoller {
 
   private async saveCursor(cursor: string): Promise<void> {
     // Validate cursor is a UUID before writing to disk (defense against untrusted API data)
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(cursor)) {
+    if (!isUuid(cursor)) {
       return;
     }
     try {

--- a/server/src/routes/admin/relationships.ts
+++ b/server/src/routes/admin/relationships.ts
@@ -21,6 +21,7 @@ import { createLogger } from '../../logger.js';
 import { requireAuth, requireAdmin } from '../../middleware/auth.js';
 import * as relationshipDb from '../../db/relationship-db.js';
 import * as personEvents from '../../db/person-events-db.js';
+import { isUuid } from '../../utils/uuid.js';
 
 const logger = createLogger('admin-relationships');
 
@@ -269,7 +270,7 @@ export function setupRelationshipRoutes(apiRouter: Router): void {
       const { personId } = req.params;
 
       // Basic UUID format validation
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(personId)) {
+      if (!isUuid(personId)) {
         return res.status(400).json({ error: 'Invalid person ID format' });
       }
 
@@ -314,7 +315,7 @@ export function setupRelationshipRoutes(apiRouter: Router): void {
     try {
       const { personId } = req.params;
 
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(personId)) {
+      if (!isUuid(personId)) {
         return res.status(400).json({ error: 'Invalid person ID format' });
       }
 

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -20,11 +20,11 @@ import {
   rebuildManifestLogos,
 } from '../services/brand-logo-service.js';
 import { createLogger } from '../logger.js';
+import { isUuid } from '../utils/uuid.js';
 
 const logger = createLogger('brand-logo-routes');
 
 const logoDomainPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
-const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const MAX_LOGOS_PER_BRAND = 10;
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
@@ -257,7 +257,7 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         if (!logoDomainPattern.test(domain)) {
           return res.status(400).json({ error: 'Invalid domain' });
         }
-        if (!uuidPattern.test(logoId)) {
+        if (!isUuid(logoId)) {
           return res.status(400).json({ error: 'Invalid logo ID' });
         }
 

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -6,6 +6,7 @@ import { enrichUserWithMembership } from '../utils/html-config.js';
 import * as certDb from '../db/certification-db.js';
 import { query } from '../db/client.js';
 import { notifyUser } from '../notifications/notification-service.js';
+import { isUuid } from '../utils/uuid.js';
 
 const logger = createLogger('certification-routes');
 
@@ -577,14 +578,12 @@ export function createCertificationRouters() {
   });
 
   // POST /api/organizations/:orgId/certification-invites/:id/resend — re-send a stale invitation
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
   orgRouter.post('/:orgId/certification-invites/:id/resend', requireAuth, async (req, res) => {
     try {
       const userId = req.user!.id;
       const { orgId, id } = req.params;
 
-      if (!UUID_RE.test(id)) {
+      if (!isUuid(id)) {
         return res.status(400).json({ error: 'Invalid invitation ID' });
       }
 
@@ -945,8 +944,7 @@ export function createCertificationRouters() {
   adminRouter.post('/attempts/:attemptId/resolve', async (req, res) => {
     try {
       const { attemptId } = req.params;
-      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (!UUID_RE.test(attemptId)) {
+      if (!isUuid(attemptId)) {
         return res.status(400).json({ error: 'Invalid attempt ID format' });
       }
 

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -9,6 +9,7 @@ import { Router, Request, Response } from "express";
 import { WorkOS } from "@workos-inc/node";
 import { getPool, query } from "../db/client.js";
 import { createLogger } from "../logger.js";
+import { isUuid } from "../utils/uuid.js";
 import { requireAuth, requireAdmin, optionalAuth, createRequireWorkingGroupLeader, createRequireWorkingGroupMember } from "../middleware/auth.js";
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { eventsDb } from "../db/events-db.js";
@@ -47,9 +48,6 @@ const documentUpload = multer({
     }
   },
 });
-
-// UUID validation regex
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Rate limiting for reindex endpoint (prevent API cost abuse)
 const reindexRateLimit = new Map<string, number[]>();
@@ -585,7 +583,7 @@ export function createCommitteeRouters(): {
   adminApiRouter.post('/:id/deactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      if (!UUID_REGEX.test(id)) {
+      if (!isUuid(id)) {
         return res.status(400).json({ error: 'Invalid working group ID' });
       }
       const deactivated = await workingGroupDb.deactivateWorkingGroup(id);
@@ -611,7 +609,7 @@ export function createCommitteeRouters(): {
   adminApiRouter.post('/:id/reactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      if (!UUID_REGEX.test(id)) {
+      if (!isUuid(id)) {
         return res.status(400).json({ error: 'Invalid working group ID' });
       }
       const reactivated = await workingGroupDb.reactivateWorkingGroup(id);
@@ -2203,7 +2201,7 @@ export function createCommitteeRouters(): {
     try {
       const { slug, documentId } = req.params;
 
-      if (!UUID_REGEX.test(documentId)) {
+      if (!isUuid(documentId)) {
         return res.status(400).json({ error: 'Invalid document ID' });
       }
 
@@ -2245,7 +2243,7 @@ export function createCommitteeRouters(): {
       const { slug, documentId } = req.params;
       const { title, description, document_url, document_type, display_order, is_featured } = req.body;
 
-      if (!UUID_REGEX.test(documentId)) {
+      if (!isUuid(documentId)) {
         return res.status(400).json({
           error: 'Invalid document ID',
           message: 'Document ID must be a valid UUID',
@@ -2316,7 +2314,7 @@ export function createCommitteeRouters(): {
         });
       }
 
-      if (!UUID_REGEX.test(documentId)) {
+      if (!isUuid(documentId)) {
         return res.status(400).json({
           error: 'Invalid document ID',
           message: 'Document ID must be a valid UUID',
@@ -2373,7 +2371,7 @@ export function createCommitteeRouters(): {
     try {
       const { slug, documentId } = req.params;
 
-      if (!UUID_REGEX.test(documentId)) {
+      if (!isUuid(documentId)) {
         return res.status(400).json({
           error: 'Invalid document ID',
           message: 'Document ID must be a valid UUID',
@@ -2418,7 +2416,7 @@ export function createCommitteeRouters(): {
     try {
       const { assetId } = req.params;
 
-      if (!UUID_REGEX.test(assetId)) {
+      if (!isUuid(assetId)) {
         return res.status(400).send('Invalid asset ID');
       }
 
@@ -2451,7 +2449,7 @@ export function createCommitteeRouters(): {
     try {
       const { documentId } = req.params;
 
-      if (!UUID_REGEX.test(documentId)) {
+      if (!isUuid(documentId)) {
         return res.status(400).json({ error: 'Invalid document ID' });
       }
 
@@ -2877,7 +2875,7 @@ export function createCommitteeRouters(): {
       const { slug, eventId } = req.params;
 
       // Validate UUID format
-      if (!UUID_REGEX.test(eventId)) {
+      if (!isUuid(eventId)) {
         return res.status(400).json({
           error: 'Invalid event ID',
           message: 'Event ID must be a valid UUID',
@@ -3024,7 +3022,7 @@ export function createCommitteeRouters(): {
       const { slug, eventId } = req.params;
 
       // Validate UUID format
-      if (!UUID_REGEX.test(eventId)) {
+      if (!isUuid(eventId)) {
         return res.status(400).json({
           error: 'Invalid event ID',
           message: 'Event ID must be a valid UUID',
@@ -3104,7 +3102,7 @@ export function createCommitteeRouters(): {
       const { slug, eventId } = req.params;
 
       // Validate UUID format
-      if (!UUID_REGEX.test(eventId)) {
+      if (!isUuid(eventId)) {
         return res.status(400).json({
           error: 'Invalid event ID',
           message: 'Event ID must be a valid UUID',

--- a/server/src/routes/community.ts
+++ b/server/src/routes/community.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { Router } from "express";
 import { createLogger } from "../logger.js";
+import { isUuid } from "../utils/uuid.js";
 import { requireAuth } from "../middleware/auth.js";
 import { CommunityDatabase, type CommunityProfile } from "../db/community-db.js";
 import { MemberDatabase } from "../db/member-db.js";
@@ -129,7 +130,7 @@ export function createCommunityRouters(config: CommunityRoutesConfig) {
       const user = req.user!;
       const { status } = req.body;
 
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(req.params.id)) {
+      if (!isUuid(req.params.id)) {
         return res.status(400).json({ error: 'Invalid connection ID' });
       }
 

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -10,6 +10,7 @@ import { Router, type Request, type Response } from "express";
 import { parse as parseCsvLib } from "csv-parse/sync";
 import DOMPurify from "isomorphic-dompurify";
 import { createLogger } from "../logger.js";
+import { isUuid } from "../utils/uuid.js";
 import { requireAuth, requireAdmin, optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { eventsDb } from "../db/events-db.js";
@@ -1342,8 +1343,7 @@ export function createEventsRouter(): {
         const { id } = req.params;
 
         // Validate UUID format
-        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidRegex.test(id)) {
+        if (!isUuid(id)) {
           return res.status(400).json({
             error: "Invalid event ID",
             message: "Event ID must be a valid UUID",
@@ -1381,8 +1381,7 @@ export function createEventsRouter(): {
         const { name, create_slack_channel } = req.body;
 
         // Validate UUID format
-        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidRegex.test(id)) {
+        if (!isUuid(id)) {
           return res.status(400).json({
             error: "Invalid event ID",
             message: "Event ID must be a valid UUID",

--- a/server/src/routes/network-health.ts
+++ b/server/src/routes/network-health.ts
@@ -24,10 +24,10 @@ import { z } from 'zod';
 import { createLogger } from '../logger.js';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import * as db from '../db/network-health-db.js';
+import { isUuid } from '../utils/uuid.js';
 
 const logger = createLogger('network-health');
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SLACK_WEBHOOK_PATTERN = /^https:\/\/hooks\.slack\.com\/services\//;
 
 const alertRuleSchema = z.object({
@@ -174,7 +174,7 @@ export function createNetworkHealthApiRouter(): Router {
   apiRouter.post('/:orgId/alerts/:alertId/resolve', requireAdmin, async (req, res) => {
     try {
       const { alertId } = req.params;
-      if (!UUID_PATTERN.test(alertId)) {
+      if (!isUuid(alertId)) {
         return res.status(400).json({ error: 'Invalid alert ID format' });
       }
       await db.resolveAlert(alertId);

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { NotificationDatabase } from '../db/notification-db.js';
 import { createLogger } from '../logger.js';
+import { isUuid } from '../utils/uuid.js';
 
 const logger = createLogger('notification-routes');
 
@@ -48,7 +49,7 @@ export function createNotificationRouter() {
   router.post('/:id/read', requireAuth, async (req: Request, res: Response) => {
     try {
       const user = req.user!;
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(req.params.id)) {
+      if (!isUuid(req.params.id)) {
         return res.status(400).json({ error: 'Invalid notification ID' });
       }
       const success = await notificationDb.markAsRead(req.params.id, user.id);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -15,6 +15,7 @@ import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
 import { query } from "../db/client.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
+import { isUuid } from "../utils/uuid.js";
 import { bulkResolveRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter } from "../middleware/rate-limit.js";
 import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../services/storyboards.js";
 import {
@@ -2985,8 +2986,6 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Property List Check ────────────────────────────────────────
 
-  const REPORT_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
   router.post("/properties/check", bulkResolveRateLimiter, async (req, res) => {
     try {
       const { domains } = req.body;
@@ -3010,7 +3009,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   router.get("/properties/check/:reportId", async (req, res) => {
     try {
       const { reportId } = req.params;
-      if (!REPORT_UUID_RE.test(reportId)) {
+      if (!isUuid(reportId)) {
         return res.status(404).json({ error: "Report not found or expired" });
       }
       const results = await propertyCheckDb.getReport(reportId);
@@ -3049,7 +3048,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   router.get("/properties/check/bulk/:reportId", async (req, res) => {
     try {
       const { reportId } = req.params;
-      if (!REPORT_UUID_RE.test(reportId)) {
+      if (!isUuid(reportId)) {
         return res.status(404).json({ error: "Report not found or expired" });
       }
       const results = await bulkCheckService.getReport(reportId);
@@ -5495,7 +5494,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         const rawLimit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
 
         // Validate cursor format (should be a UUID if provided)
-        if (cursor && !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(cursor)) {
+        if (cursor && !isUuid(cursor)) {
           return res.status(400).json({ error: "Invalid cursor format. Must be a UUID." });
         }
 

--- a/server/src/utils/uuid.ts
+++ b/server/src/utils/uuid.ts
@@ -1,3 +1,7 @@
+// Matches any RFC 4122-shaped hex string (no version/variant nibble check).
+// Intentional: callers guard Postgres UUID columns, and Postgres accepts any
+// well-formed hex UUID — tightening to a specific version would reject IDs
+// that the database already stores.
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function isUuid(value: unknown): boolean {

--- a/server/src/utils/uuid.ts
+++ b/server/src/utils/uuid.ts
@@ -1,0 +1,5 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: unknown): boolean {
+  return typeof value === 'string' && UUID_REGEX.test(value);
+}

--- a/tests/utils/uuid.test.ts
+++ b/tests/utils/uuid.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isUuid } from '../../server/src/utils/uuid.js';
+
+describe('isUuid', () => {
+  it('accepts canonical lowercase UUIDs', () => {
+    expect(isUuid('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+  });
+
+  it('accepts uppercase UUIDs (case-insensitive)', () => {
+    expect(isUuid('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
+  });
+
+  it('accepts mixed-case UUIDs', () => {
+    expect(isUuid('550e8400-E29B-41d4-A716-446655440000')).toBe(true);
+  });
+
+  it('rejects malformed strings', () => {
+    expect(isUuid('abc123')).toBe(false);
+    expect(isUuid('')).toBe(false);
+    expect(isUuid('not-a-uuid-at-all-definitely')).toBe(false);
+    expect(isUuid('550e8400e29b41d4a716446655440000')).toBe(false); // missing dashes
+    expect(isUuid('550e8400-e29b-41d4-a716-44665544000')).toBe(false); // too short
+    expect(isUuid('550e8400-e29b-41d4-a716-4466554400000')).toBe(false); // too long
+    expect(isUuid(' 550e8400-e29b-41d4-a716-446655440000')).toBe(false); // leading space
+  });
+
+  it('rejects non-string input', () => {
+    expect(isUuid(undefined)).toBe(false);
+    expect(isUuid(null)).toBe(false);
+    expect(isUuid(42)).toBe(false);
+    expect(isUuid({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces ~24 inline UUID-validation regex copies across 15 files with a single shared helper at \`server/src/utils/uuid.ts\`.

**Latent bugs fixed (side effect):** two sites had the regex without the \`/i\` flag, so valid uppercase UUIDs returned 400/404:
- \`server/src/http.ts:929\` — brand logo serving (\`GET /logos/brands/:domain/:id\`)
- \`server/src/routes/brand-logos.ts:27\`

Both now accept uppercase through the shared helper.

## Helper

\`\`\`ts
const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\$/i;

export function isUuid(value: unknown): boolean {
  return typeof value === 'string' && UUID_REGEX.test(value);
}
\`\`\`

Returns \`boolean\` (not a \`value is string\` predicate) so TypeScript doesn't narrow the else-branch to \`never\` at sites like \`certification-tools.ts\` that inspect the input after a negative check.

## Out of scope

\`server/src/middleware/request-metrics.ts:18\` and \`slow-response.ts:30\` use a non-anchored global regex for path normalization (stripping UUIDs from metrics labels) — different use case, left alone.

## Test plan

- [x] New unit test: \`tests/utils/uuid.test.ts\` — canonical, uppercase, mixed-case, malformed, non-string
- [x] \`npm run test:unit\` — 636 passed (631 baseline + 5 new)
- [x] \`npm run typecheck\`
- [x] Grep sweep — no anchored UUID regex remains in migrated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)