### PR TITLE
fix(addie): guard non-streaming bolt path against empty-text Slack section

### DIFF
--- a/.changeset/fix-addie-bolt-non-streaming-empty-guard.md
+++ b/.changeset/fix-addie-bolt-non-streaming-empty-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `Addie Bolt: Failed to send response` errors on the non-streaming path when sanitization strips Claude's response to empty text. Mirrors the streaming-fallback guard in PR #2947: if `slackText` is empty, fall back to an image-only message (when images are present) or a rephrase prompt (when nothing is left). Slack rejects `section` blocks with empty `mrkdwn` text as `invalid_blocks`, which previously surfaced as a swallowed error and a silent UX.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1680,24 +1680,44 @@ async function handleUserMessage({
       const { text: textWithoutImages, images } = extractMarkdownImages(outputValidation.sanitized);
       const slackText = wrapUrlsForSlack(textWithoutImages);
       try {
-        await say({
-          text: slackText,
-          blocks: [
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: slackText,
+        // Slack rejects section blocks with empty mrkdwn text. If sanitization
+        // stripped the response to empty, fall back: image-only if we have
+        // images, otherwise a rephrase prompt — not an apology, since nothing
+        // errored (Claude responded; validateOutput removed it).
+        if (!slackText.trim() && images.length === 0) {
+          await say("I don't have anything readable to send back for that — could you rephrase?");
+        } else if (!slackText.trim()) {
+          await say({
+            text: 'Addie response (images)',
+            blocks: [
+              ...images.slice(0, 3).map(img => ({
+                type: 'image' as const,
+                image_url: img.url,
+                alt_text: img.alt,
+              })),
+              buildFeedbackBlock(),
+            ],
+          });
+        } else {
+          await say({
+            text: slackText,
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: slackText,
+                },
               },
-            },
-            ...images.slice(0, 3).map(img => ({
-              type: 'image' as const,
-              image_url: img.url,
-              alt_text: img.alt,
-            })),
-            buildFeedbackBlock(),
-          ],
-        });
+              ...images.slice(0, 3).map(img => ({
+                type: 'image' as const,
+                image_url: img.url,
+                alt_text: img.alt,
+              })),
+              buildFeedbackBlock(),
+            ],
+          });
+        }
       } catch (error) {
         logger.error({ error }, 'Addie Bolt: Failed to send response');
       }


### PR DESCRIPTION
## Summary

Closes #2951. Follow-up from PR #2947 — the non-streaming branch at `server/src/addie/bolt-app.ts:1678-1703` has the same `invalid_blocks` footgun as the streaming fallback that #2947 just fixed. If `validateOutput` or `extractMarkdownImages` sanitizes Claude's response to an empty string, the `section` block gets empty `mrkdwn` text, Slack rejects the payload, the outer `try/catch` swallows the error, and the user sees nothing.

Guards `slackText.trim()` and branches three ways:

- **text (with or without images):** unchanged — full blocks message (section + images + feedback).
- **images only (text stripped, images present):** image blocks + feedback, no section.
- **nothing left:** plain `say()` with a rephrase prompt — intentionally **not** an apology, because nothing errored here; Claude responded and `validateOutput` removed everything. The "error, try again" tone elsewhere in this file is reserved for actual exceptions.

## What I did *not* change

- The streaming-fallback branch at lines 1647-1670 still has the identical empty-text bug on `main`. **That's PR #2947's scope**, which is open and will land independently. This PR intentionally only touches the non-streaming `else` branch so the two fixes don't step on each other. The edits are in disjoint `if/else` arms of the same function — git merges cleanly in either order.
- No `handleUserMessage` unit test added. Matches PR #2947's "Why no test" — adding one here would require mocking Slack Bolt's `say`, the Claude streaming SDK, and the assistant middleware. Out of scope for a defensive one-file guard.

## Expert consensus

- **code-reviewer** (who flagged this in the #2947 review): reviewed this diff; no blockers. Pre-empted the "why only one path" reviewer question above.
- **internal-tools-strategist**: confirmed rephrase-oriented copy over "error, try again"; confirmed image-only path should render images + feedback (not apology) since that's a real response.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run test:server-unit`
- [ ] Watch admin channel — expect no `Addie Bolt: Failed to send response` errors from this path on empty sanitization.

Session: https://claude.ai/code/session_017xZmLs2B8C1cV8XfHnjMp9

---
_Generated by [Claude Code](https://claude.ai/code/session_017xZmLs2B8C1cV8XfHnjMp9)_