### PR TITLE
fix(addie): guard non-streaming path against empty slackText (closes #2951)

### DIFF
--- a/.changeset/fix-nonstream-empty-guard.md
+++ b/.changeset/fix-nonstream-empty-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Guard the non-streaming Addie response path against empty `slackText`. Same fix as #2947 applied to the non-streaming branch at `server/src/addie/bolt-app.ts:1689-1715`: if the model returns nothing (or validation/extraction produces empty text), send a plain apology via `say()` instead of a malformed Slack blocks payload with empty `mrkdwn` text. Closes #2951.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1692,24 +1692,31 @@ async function handleUserMessage({
       const { text: textWithoutImages, images } = extractMarkdownImages(outputValidation.sanitized);
       const slackText = wrapUrlsForSlack(textWithoutImages);
       try {
-        await say({
-          text: slackText,
-          blocks: [
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: slackText,
+        // Slack rejects section blocks with empty mrkdwn text. If the model
+        // returned nothing (or everything was sanitized/extracted), fall back
+        // to a plain apology instead of a malformed blocks payload.
+        if (!slackText.trim()) {
+          await say("I'm sorry, I encountered an error. Please try again.");
+        } else {
+          await say({
+            text: slackText,
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: slackText,
+                },
               },
-            },
-            ...images.slice(0, 3).map(img => ({
-              type: 'image' as const,
-              image_url: img.url,
-              alt_text: img.alt,
-            })),
-            buildFeedbackBlock(),
-          ],
-        });
+              ...images.slice(0, 3).map(img => ({
+                type: 'image' as const,
+                image_url: img.url,
+                alt_text: img.alt,
+              })),
+              buildFeedbackBlock(),
+            ],
+          });
+        }
       } catch (error) {
         logger.error({ error }, 'Addie Bolt: Failed to send response');
       }


### PR DESCRIPTION
## Summary

Follow-up to #2947. The non-streaming Addie response path at \`server/src/addie/bolt-app.ts:1689-1715\` had the same class of bug as the streaming fallback: if \`slackText\` ended up empty (model returned nothing, or validation/image extraction sanitized everything), the \`say()\` call built a Slack \`section\` block with empty \`mrkdwn\` text — which Slack rejects as \`invalid_blocks\`.

Same fix: check \`!slackText.trim()\` and send a plain \`say(apology)\` instead of a malformed blocks payload.

Closes #2951.

## Test plan

- [x] \`npm run test:unit\` (686 passed)
- [x] \`npm run typecheck\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)