### PR TITLE
fix(registry): accept WorkOS OIDC access tokens on operator & agents

### DIFF
--- a/.changeset/fix-registry-oidc-jwt-auth.md
+++ b/.changeset/fix-registry-oidc-jwt-auth.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `/api/registry/operator` and `/api/registry/agents` to recognize WorkOS OIDC access tokens in the `Authorization: Bearer` header, not just API keys and sealed sessions. Previously, authenticated OAuth clients silently fell through to public-only visibility — `scope3.com` returned `agents: []` for a valid member JWT while returning 16 agents for an `sk_*` API key from the same org. The shared `resolveCallerOrgId` helper now extracts `org_id` from the verified JWT (via WorkOS JWKS) before falling back to API key or session-user lookup.

--- a/server/src/routes/helpers/resolve-caller-org.ts
+++ b/server/src/routes/helpers/resolve-caller-org.ts
@@ -1,0 +1,89 @@
+/**
+ * Resolve the caller's WorkOS organization ID across the three supported
+ * authentication shapes the registry API accepts:
+ *
+ *   1. WorkOS OIDC access token (RS256 JWT, `org_id` claim) — third-party
+ *      OAuth clients obtained via AuthKit's authorization-code flow. Verified
+ *      against the WorkOS JWKS endpoint.
+ *   2. WorkOS API key (sk_* / wos_api_key_* prefixes) — server-to-server
+ *      integrations. Validated via the existing `validateWorkOSApiKey` helper.
+ *   3. Sealed session — web/native app sessions whose cookie or bearer
+ *      unsealed in `optionalAuth`, producing `req.user`. Organization is
+ *      looked up via `users.primary_organization_id`.
+ */
+
+import type { Request } from 'express';
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey } from 'jose';
+import { isWorkOSApiKeyFormat } from '../../middleware/api-key-format.js';
+import { validateWorkOSApiKey } from '../../middleware/auth.js';
+import { query as dbQuery } from '../../db/client.js';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('resolve-caller-org');
+
+let cachedJwks: JWTVerifyGetKey | null | undefined;
+function getWorkOSJwks(): JWTVerifyGetKey | null {
+  if (cachedJwks !== undefined) return cachedJwks;
+  const clientId = process.env.WORKOS_CLIENT_ID;
+  cachedJwks = clientId
+    ? createRemoteJWKSet(new URL(`https://api.workos.com/sso/jwks/${clientId}`))
+    : null;
+  return cachedJwks;
+}
+
+export type MinimalReq = Pick<Request, 'headers'> & { user?: { id?: string } };
+
+/**
+ * Extract and verify a WorkOS OIDC access token. Returns the `org_id` claim
+ * on success, or `null` for API keys, sealed sessions, missing tokens, or
+ * failed verification. Never throws.
+ */
+export async function orgIdFromBearerJwt(
+  req: MinimalReq,
+  jwks: JWTVerifyGetKey | null = getWorkOSJwks(),
+): Promise<string | null> {
+  if (!jwks) return null;
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) return null;
+  const token = auth.slice(7);
+  if (isWorkOSApiKeyFormat(token)) return null;
+  // Sealed sessions are not JWTs — skip verification to avoid JWKS noise.
+  if (!token.startsWith('eyJ')) return null;
+  try {
+    const { payload } = await jwtVerify(token, jwks);
+    return typeof payload.org_id === 'string' ? payload.org_id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the caller's organization via (in order) OIDC JWT → API key →
+ * sealed-session user lookup. Returns `null` when no auth shape resolves.
+ */
+export async function resolveCallerOrgId(req: MinimalReq): Promise<string | null> {
+  const jwtOrg = await orgIdFromBearerJwt(req);
+  if (jwtOrg) return jwtOrg;
+
+  const apiKey = await validateWorkOSApiKey(req as Request);
+  if (apiKey) return apiKey.organizationId;
+
+  if (req.user?.id) {
+    try {
+      const row = await dbQuery<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [req.user.id],
+      );
+      return row.rows[0]?.primary_organization_id ?? null;
+    } catch (err) {
+      logger.warn({ err, userId: req.user.id }, 'caller org resolution failed — falling back to public-only');
+    }
+  }
+
+  return null;
+}
+
+/** Test hook: reset the memoized JWKS fetcher. */
+export function __resetJwksForTests(): void {
+  cachedJwks = undefined;
+}

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -85,8 +85,7 @@ import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
-import { query as dbQuery } from "../db/client.js";
-import { validateWorkOSApiKey } from "../middleware/auth.js";
+import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -3252,21 +3251,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // members (Professional+). Crawlers and anonymous callers only see
       // public agents.
       let includeMembersOnly = false;
-      if (req.user?.id) {
-        try {
-          const row = await dbQuery<{ primary_organization_id: string | null }>(
-            'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-            [req.user.id],
-          );
-          const orgId = row.rows[0]?.primary_organization_id;
-          if (orgId) {
-            const org = await orgDb.getOrganization(orgId);
-            if (org && hasApiAccess(resolveMembershipTier(org))) {
-              includeMembersOnly = true;
-            }
-          }
-        } catch (err) {
-          logger.warn({ err, userId: req.user.id }, 'members_only visibility check failed — falling back to public-only');
+      const callerOrgId = await resolveCallerOrgId(req);
+      if (callerOrgId) {
+        const org = await orgDb.getOrganization(callerOrgId);
+        if (org && hasApiAccess(resolveMembershipTier(org))) {
+          includeMembersOnly = true;
         }
       }
 
@@ -4679,23 +4668,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         ? { slug: profile.slug, display_name: profile.display_name }
         : null;
 
-      // Resolve caller's organization. API key path (optAuth skips Bearer
-      // API keys — see middleware/auth.ts:1332) takes precedence over session.
-      let callerOrgId: string | null = null;
-      const apiKey = await validateWorkOSApiKey(req);
-      if (apiKey) {
-        callerOrgId = apiKey.organizationId;
-      } else if (req.user?.id) {
-        try {
-          const row = await dbQuery<{ primary_organization_id: string | null }>(
-            'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-            [req.user.id],
-          );
-          callerOrgId = row.rows[0]?.primary_organization_id ?? null;
-        } catch (err) {
-          logger.warn({ err, userId: req.user.id }, 'operator: org resolution failed — falling back to public-only');
-        }
-      }
+      const callerOrgId = await resolveCallerOrgId(req);
 
       let includeMembersOnly = false;
       if (callerOrgId) {

--- a/server/tests/unit/resolve-caller-org.test.ts
+++ b/server/tests/unit/resolve-caller-org.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for `resolveCallerOrgId` — the shared auth-resolution helper
+ * used by `/api/registry/operator` and `/api/registry/agents` to decide which
+ * `members_only` / `private` agents a caller is allowed to see.
+ *
+ * Locks in the three token shapes the registry API must accept:
+ *   1. WorkOS OIDC access token (RS256 JWT, `org_id` claim)
+ *   2. WorkOS API key (sk_* / wos_api_key_*)
+ *   3. Sealed session (middleware sets `req.user`)
+ *
+ * Regression guard for the issue where OIDC JWTs silently fell through to
+ * public-only, leaving `agents: []` for authenticated callers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const validateWorkOSApiKeyMock = vi.fn();
+const jwtVerifyMock = vi.fn();
+const dbQueryMock = vi.fn();
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  validateWorkOSApiKey: (...args: unknown[]) => validateWorkOSApiKeyMock(...args),
+}));
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: () => 'fake-jwks-set',
+  jwtVerify: (...args: unknown[]) => jwtVerifyMock(...args),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: (...args: unknown[]) => dbQueryMock(...args),
+}));
+
+// Import under test *after* the mocks are registered.
+const { resolveCallerOrgId, orgIdFromBearerJwt, __resetJwksForTests } = await import(
+  '../../src/routes/helpers/resolve-caller-org.js'
+);
+
+function reqWith(authHeader?: string, user?: { id?: string }) {
+  return {
+    headers: authHeader ? { authorization: authHeader } : {},
+    user,
+  };
+}
+
+describe('resolveCallerOrgId', () => {
+  beforeEach(() => {
+    validateWorkOSApiKeyMock.mockReset();
+    jwtVerifyMock.mockReset();
+    dbQueryMock.mockReset();
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    __resetJwksForTests();
+  });
+
+  // ── OIDC JWT path (the new behavior this change adds) ───────────
+
+  it('returns org_id from a verified OIDC JWT', async () => {
+    jwtVerifyMock.mockResolvedValueOnce({ payload: { org_id: 'org_from_jwt', sub: 'user_123' } });
+
+    const orgId = await resolveCallerOrgId(reqWith('Bearer eyJabc.def.ghi'));
+
+    expect(orgId).toBe('org_from_jwt');
+    expect(jwtVerifyMock).toHaveBeenCalledTimes(1);
+    expect(validateWorkOSApiKeyMock).not.toHaveBeenCalled();
+    expect(dbQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to API key / session when JWT verification fails', async () => {
+    jwtVerifyMock.mockRejectedValueOnce(new Error('bad signature'));
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+
+    const orgId = await resolveCallerOrgId(reqWith('Bearer eyJabc.def.ghi'));
+
+    expect(orgId).toBeNull();
+    expect(jwtVerifyMock).toHaveBeenCalledTimes(1);
+    expect(validateWorkOSApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through when the JWT has no org_id claim', async () => {
+    jwtVerifyMock.mockResolvedValueOnce({ payload: { sub: 'user_123' } });
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+
+    const orgId = await resolveCallerOrgId(reqWith('Bearer eyJabc.def.ghi'));
+
+    expect(orgId).toBeNull();
+    expect(validateWorkOSApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── API key path (regression — must still work) ─────────────────
+
+  it('returns org from a valid WorkOS API key (sk_ prefix)', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce({ organizationId: 'org_from_apikey' });
+
+    const orgId = await resolveCallerOrgId(reqWith('Bearer sk_live_abc123'));
+
+    expect(orgId).toBe('org_from_apikey');
+    // JWT helper must skip API keys without calling jwtVerify.
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+    expect(validateWorkOSApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(dbQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns org from a legacy wos_api_key_ prefix key', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce({ organizationId: 'org_legacy' });
+
+    const orgId = await resolveCallerOrgId(reqWith('Bearer wos_api_key_legacy123'));
+
+    expect(orgId).toBe('org_legacy');
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  // ── Sealed-session path (existing behavior) ─────────────────────
+
+  it('falls back to users.primary_organization_id when only req.user is set', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: 'org_from_session' }] });
+
+    const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_session' }));
+
+    expect(orgId).toBe('org_from_session');
+    expect(dbQueryMock).toHaveBeenCalledWith(
+      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+      ['user_session'],
+    );
+  });
+
+  it('returns null when session user has no primary_organization_id', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: null }] });
+
+    const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_no_org' }));
+
+    expect(orgId).toBeNull();
+  });
+
+  it('swallows DB errors and returns null rather than throwing', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+    dbQueryMock.mockRejectedValueOnce(new Error('connection reset'));
+
+    const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_db_err' }));
+
+    expect(orgId).toBeNull();
+  });
+
+  // ── Unauthenticated / malformed ────────────────────────────────
+
+  it('returns null with no Authorization header and no session user', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+
+    const orgId = await resolveCallerOrgId(reqWith());
+
+    expect(orgId).toBeNull();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+    expect(dbQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a non-Bearer Authorization header', async () => {
+    validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+
+    const orgId = await resolveCallerOrgId(reqWith('Basic dXNlcjpwYXNz'));
+
+    expect(orgId).toBeNull();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('orgIdFromBearerJwt', () => {
+  beforeEach(() => {
+    jwtVerifyMock.mockReset();
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    __resetJwksForTests();
+  });
+
+  it('returns null when WORKOS_CLIENT_ID is unset (no JWKS configured)', async () => {
+    delete process.env.WORKOS_CLIENT_ID;
+    __resetJwksForTests();
+
+    const orgId = await orgIdFromBearerJwt(reqWith('Bearer eyJabc.def.ghi'));
+
+    expect(orgId).toBeNull();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for API-key-shaped bearer tokens', async () => {
+    expect(await orgIdFromBearerJwt(reqWith('Bearer sk_live_abc'))).toBeNull();
+    expect(await orgIdFromBearerJwt(reqWith('Bearer wos_api_key_abc'))).toBeNull();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for tokens that do not look like a JWT (no eyJ prefix)', async () => {
+    expect(await orgIdFromBearerJwt(reqWith('Bearer random-sealed-session-blob'))).toBeNull();
+    expect(jwtVerifyMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/registry/operator` and `/api/registry/agents` silently returned public-only agents for authenticated OAuth clients — `scope3.com` returned `agents: []` for a valid member JWT while the same org's `sk_*` API key returned all 16 agents.
- Root cause: auth resolution only recognized WorkOS API keys and sealed sessions. Raw OIDC access tokens (RS256 JWTs from AuthKit) fell through `loadSealedSession().authenticate()`, leaving `req.user` undefined and `callerOrgId = null`.
- Fix: extract a shared `resolveCallerOrgId` helper that verifies OIDC JWTs against the WorkOS JWKS endpoint (`jose.createRemoteJWKSet`) and pulls `org_id` from verified claims, falling back to the existing API-key then session-user paths. Both routes now share the same three-way ladder.

## Scope

- **New:** `server/src/routes/helpers/resolve-caller-org.ts` — exports `resolveCallerOrgId` + `orgIdFromBearerJwt`.
- **Changed:** `server/src/routes/registry-api.ts` — `/operator` and `/agents` delegate to the helper. No changes to the global `optionalAuth` middleware (zero blast radius on other routes).
- **New:** `server/tests/unit/resolve-caller-org.test.ts` — 13 unit tests covering all three token shapes, failure modes, and the API-key regression guard.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run server/tests/unit/resolve-caller-org.test.ts` — 13/13 pass
- [x] Precommit suite (`npm run test:unit`) — 686/686 pass
- [ ] After deploy: `curl -H "Authorization: Bearer <oidc-jwt>" https://agenticadvertising.org/api/registry/operator?domain=scope3.com` returns the same agents as an `sk_*` key for the owner org
- [ ] `curl` with no auth → still returns public-only (no regression)
- [ ] `curl` with `sk_*` key → still returns org's full set (no regression)