### PR TITLE
fix(agents): triage already-engaged + tighten label creation

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -86,6 +86,36 @@ the last 10 minutes. **Skip.** Do not apply `claude-triaged`. Do not
 spawn experts. Move to the next issue and note the skip in your run
 summary. This is the dedup lock — it costs one API call per issue.
 
+## Already-engaged check — before any expert work
+
+You can't see Conductor workspaces, local drafts, or Slack
+conversations. A human may be actively working on an issue without
+any on-GitHub signal. Before spawning experts, check whether a
+maintainer is already engaged. If **any** of these is true, apply
+`claude-triaged` silently and move on — do not post an analysis that
+competes with in-progress work:
+
+1. **Assigned to a repo member.** Check `issue.assignees[].login`
+   and each login's `author_association` on the issue (via the
+   `assignees` API); if any assignee is `OWNER | MEMBER |
+   COLLABORATOR`, silent-defer.
+2. **Open PR references the issue.**
+   `gh pr list --repo <owner>/<repo> --search "in:body #<N>" --state open`.
+   A human is mid-PR; silent-defer.
+3. **Recent repo-member comment.** Any comment from an
+   `OWNER | MEMBER | COLLABORATOR` (non-bot) posted in the last 7
+   days. Exception: the comment explicitly asks for triage help —
+   e.g., "@bokelley can we get triage on this?" — in which case
+   proceed to full consultation.
+
+A bot comment on an issue the maintainer is already deep on is
+noise at best and pre-framing at worst. The bot's value is highest
+on issues no human is currently working on. When in doubt, silent-
+defer and let the human decide if they want triage help.
+
+This check is cheap (2–3 API calls per issue) and saves expert
+cycles on issues where consultation adds no value.
+
 ## Decision order
 
 ### Step 1 — Pre-classification (cheap, no experts)

--- a/.changeset/triage-already-engaged.md
+++ b/.changeset/triage-already-engaged.md
@@ -1,0 +1,8 @@
+---
+---
+
+Two corrections from the second live v2 run of the AdCP issue-triage routine:
+
+1. **Already-engaged check.** The bot posted competing flag-for-review comments on issues `#2902` and `#2903`, which the maintainer was actively working on in a Conductor workspace — invisible to GitHub, so the bot thought they were untriaged. Add a check before expert consultation: silent-defer when the issue is assigned to a repo member, has an open PR referencing it, or has a repo-member comment in the last 7 days.
+
+2. **Tighten "never create labels".** The first v2 run ended with a `compliance-suite` label on two issues that had no description — likely bot-created despite the existing rule. Reinforce: the routine must run `gh label list` first and apply only labels whose names appear in the output. If a bucket doesn't have a matching label, put the bucket name in the comment body and flag the gap in the run summary — don't create the label.


### PR DESCRIPTION
## Summary

Two fixes from the second live v2 run on adcp:

### 1. Already-engaged check (before expert consultation)

The bot posted flag-for-review comments on [`#2902`](https://github.com/adcontextprotocol/adcp/issues/2902) and [`#2903`](https://github.com/adcontextprotocol/adcp/issues/2903) — two issues the maintainer was actively working on in a Conductor workspace with no GitHub-visible signal. The comments pre-framed in-progress thinking rather than adding value.

Fix: silent-defer when ANY of these is true:
- Issue is assigned to a repo `OWNER | MEMBER | COLLABORATOR`
- An open PR references the issue (`gh pr list --search "in:body #N"`)
- A repo-member comment was posted in the last 7 days (non-bot)

Exception: if the latest member comment explicitly asks for triage help, proceed to full consultation.

### 2. Tighten "never create labels"

The v2 run applied a `compliance-suite` label on two issues; it exists in the repo with a null description, suggesting the bot created it despite the existing "never invent" rule. Reinforce: run `gh label list` first, apply only names that appear in the output, never POST to `/labels`. Missing buckets → comment body + run summary, not a new label.

## Test plan

- [ ] Merge
- [ ] Fire the routine; verify #2902/#2903 (if reopened or not yet re-labeled) get silent-deferred rather than re-analyzed
- [ ] Open a fresh test issue to confirm normal triage still works on issues no human is engaged on
- [ ] Check label list over next few runs for any non-existent labels being applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)