### PR TITLE
fix(schemas): pin docs to /schemas/v3/ and drive Addie lookup from live registry

### DIFF
--- a/.changeset/fix-schema-link-pinning-and-addie-registry.md
+++ b/.changeset/fix-schema-link-pinning-and-addie-registry.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin all `docs/` schema links from `/schemas/latest/` to `/schemas/v3/` so the current stable docs stay aligned with v3 schemas after v4 development begins. Addie's schema tools now fetch the live `index.json` registry instead of a stale hardcoded list — fuzzy match and error messages cover every schema the spec ships, so guesses like `core/get-capabilities-response.json` resolve to `protocol/get-adcp-capabilities-response.json` instead of 404ing. Dist-docs rewriter also pins major-version aliases to the exact release version on snapshot, and `check-schema-links.yml` now flags any new `/schemas/latest/` references in `docs/`.

--- a/.github/workflows/check-schema-links.yml
+++ b/.github/workflows/check-schema-links.yml
@@ -33,6 +33,16 @@ jobs:
             fi
           done
 
+          # Also flag /schemas/latest/ in docs/. Docs describe a specific
+          # major version and must pin to its alias (e.g. /schemas/v3/) so
+          # links stay stable across major releases. The one historical
+          # reference in release-notes.mdx documenting the alias concept
+          # itself is excluded.
+          LATEST_MATCHES=$(grep -rn "schemas/latest/" docs/ --include='*.md' --include='*.mdx' | grep -v 'docs/reference/release-notes' || true)
+          if [ -n "$LATEST_MATCHES" ]; then
+            STALE_FOUND="$STALE_FOUND\n$LATEST_MATCHES"
+          fi
+
           if [ -n "$STALE_FOUND" ]; then
             echo "❌ Found stale schema version references in docs/ (current major version is v${CURRENT_MAJOR}):"
             echo -e "$STALE_FOUND"

--- a/docs/accounts/tasks/get_account_financials.mdx
+++ b/docs/accounts/tasks/get_account_financials.mdx
@@ -11,8 +11,8 @@ Query financial status for an operator-billed account — spend summary, credit 
 
 **Response Time**: ~1s.
 
-**Request Schema**: [`/schemas/latest/account/get-account-financials-request.json`](https://adcontextprotocol.org/schemas/latest/account/get-account-financials-request.json)
-**Response Schema**: [`/schemas/latest/account/get-account-financials-response.json`](https://adcontextprotocol.org/schemas/latest/account/get-account-financials-response.json)
+**Request Schema**: [`/schemas/v3/account/get-account-financials-request.json`](https://adcontextprotocol.org/schemas/v3/account/get-account-financials-request.json)
+**Response Schema**: [`/schemas/v3/account/get-account-financials-response.json`](https://adcontextprotocol.org/schemas/v3/account/get-account-financials-response.json)
 
 ## Quick start
 

--- a/docs/accounts/tasks/list_accounts.mdx
+++ b/docs/accounts/tasks/list_accounts.mdx
@@ -11,8 +11,8 @@ Returns all accounts the authenticated agent can operate on this vendor agent. U
 
 **Response Time**: ~1s.
 
-**Request Schema**: [`/schemas/latest/account/list-accounts-request.json`](https://adcontextprotocol.org/schemas/latest/account/list-accounts-request.json)
-**Response Schema**: [`/schemas/latest/account/list-accounts-response.json`](https://adcontextprotocol.org/schemas/latest/account/list-accounts-response.json)
+**Request Schema**: [`/schemas/v3/account/list-accounts-request.json`](https://adcontextprotocol.org/schemas/v3/account/list-accounts-request.json)
+**Response Schema**: [`/schemas/v3/account/list-accounts-response.json`](https://adcontextprotocol.org/schemas/v3/account/list-accounts-response.json)
 
 ## Quick Start
 

--- a/docs/accounts/tasks/report_usage.mdx
+++ b/docs/accounts/tasks/report_usage.mdx
@@ -11,8 +11,8 @@ Each usage record is self-contained — it carries its own `account` and `media_
 
 **Response Time**: ~1s.
 
-**Request Schema**: [`/schemas/latest/account/report-usage-request.json`](https://adcontextprotocol.org/schemas/latest/account/report-usage-request.json)
-**Response Schema**: [`/schemas/latest/account/report-usage-response.json`](https://adcontextprotocol.org/schemas/latest/account/report-usage-response.json)
+**Request Schema**: [`/schemas/v3/account/report-usage-request.json`](https://adcontextprotocol.org/schemas/v3/account/report-usage-request.json)
+**Response Schema**: [`/schemas/v3/account/report-usage-response.json`](https://adcontextprotocol.org/schemas/v3/account/report-usage-response.json)
 
 ## Request Parameters
 

--- a/docs/accounts/tasks/sync_accounts.mdx
+++ b/docs/accounts/tasks/sync_accounts.mdx
@@ -11,8 +11,8 @@ Sync advertiser accounts with a seller for one or more brand/operator pairs. The
 
 **Response Time**: ~1s. Account provisioning is synchronous; credit and legal review may require human action (indicated by `status: "pending_approval"` with a `setup.url`).
 
-**Request Schema**: [`/schemas/latest/account/sync-accounts-request.json`](https://adcontextprotocol.org/schemas/latest/account/sync-accounts-request.json)
-**Response Schema**: [`/schemas/latest/account/sync-accounts-response.json`](https://adcontextprotocol.org/schemas/latest/account/sync-accounts-response.json)
+**Request Schema**: [`/schemas/v3/account/sync-accounts-request.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-request.json)
+**Response Schema**: [`/schemas/v3/account/sync-accounts-response.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-response.json)
 
 ## Quick start
 

--- a/docs/accounts/tasks/sync_governance.mdx
+++ b/docs/accounts/tasks/sync_governance.mdx
@@ -11,8 +11,8 @@ This uses **replace semantics** — each call replaces any previously registered
 
 **Response Time**: ~1s.
 
-**Request Schema**: [`/schemas/latest/account/sync-governance-request.json`](https://adcontextprotocol.org/schemas/latest/account/sync-governance-request.json)
-**Response Schema**: [`/schemas/latest/account/sync-governance-response.json`](https://adcontextprotocol.org/schemas/latest/account/sync-governance-response.json)
+**Request Schema**: [`/schemas/v3/account/sync-governance-request.json`](https://adcontextprotocol.org/schemas/v3/account/sync-governance-request.json)
+**Response Schema**: [`/schemas/v3/account/sync-governance-response.json`](https://adcontextprotocol.org/schemas/v3/account/sync-governance-response.json)
 
 ## Quick Start
 
@@ -249,7 +249,7 @@ asyncio.run(main())
 
 ```json Request
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/account/sync-governance-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/account/sync-governance-request.json",
   "idempotency_key": "e5b9f2c3-1234-48a0-1234-56789012345e",
   "accounts": [
     {

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -30,7 +30,7 @@ Points to a hosted brand.json at another URL:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "authoritative_location": "https://adcontextprotocol.org/brand/abc123/brand.json"
 }
 ```
@@ -46,7 +46,7 @@ Points to the house domain that contains the full brand portfolio:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "house": "nikeinc.com",
   "note": "Regional site - see house for brand portfolio"
 }
@@ -67,7 +67,7 @@ Designates an MCP agent that provides brand information:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://agent.acme.com/mcp",
@@ -87,7 +87,7 @@ Contains the full brand hierarchy with all brands and properties:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -719,7 +719,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "bobsburgers.com",
@@ -746,7 +746,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://brand-agent.enterprise.com/mcp",
@@ -763,7 +763,7 @@ Maximum redirect depth: 3 hops.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -814,7 +814,7 @@ A talent agency managing athlete brands with licensable rights:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "lotientertainment.com",
@@ -857,7 +857,7 @@ On `nike.cn/.well-known/brand.json`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "house": "nikeinc.com",
   "region": "CN"
 }

--- a/docs/brand-protocol/building-a-brand-agent.mdx
+++ b/docs/brand-protocol/building-a-brand-agent.mdx
@@ -186,7 +186,7 @@ server.tool(
 );
 ```
 
-`acquire_rights` follows the same pattern — accept a `rights_id` and `pricing_option_id` from `get_rights`, clear against existing contracts, and return terms with generation credentials. The response includes an authenticated `approval_webhook` (using [`push-notification-config`](https://adcontextprotocol.org/schemas/latest/core/push-notification-config.json)) so buyers can submit creatives for review. See the [acquire_rights task reference](/docs/brand-protocol/tasks/acquire_rights) for the full schema.
+`acquire_rights` follows the same pattern — accept a `rights_id` and `pricing_option_id` from `get_rights`, clear against existing contracts, and return terms with generation credentials. The response includes an authenticated `approval_webhook` (using [`push-notification-config`](https://adcontextprotocol.org/schemas/v3/core/push-notification-config.json)) so buyers can submit creatives for review. See the [acquire_rights task reference](/docs/brand-protocol/tasks/acquire_rights) for the full schema.
 
 ## Confidential brand rules
 

--- a/docs/brand-protocol/index.mdx
+++ b/docs/brand-protocol/index.mdx
@@ -55,7 +55,7 @@ The smallest useful `brand.json` is just a name and a logo:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": { "domain": "novabrands.com", "name": "Nova Brands" },
   "brands": [{

--- a/docs/brand-protocol/key-concepts.mdx
+++ b/docs/brand-protocol/key-concepts.mdx
@@ -66,7 +66,7 @@ A house domain with multiple brands:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "nikeinc.com",
@@ -107,7 +107,7 @@ A brand with an MCP agent that provides brand information:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "brand_agent": {
     "url": "https://agent.acme.com/mcp",
@@ -124,7 +124,7 @@ A brand domain pointing to its house:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "house": "nikeinc.com"
 }
 ```

--- a/docs/brand-protocol/tasks/acquire_rights.mdx
+++ b/docs/brand-protocol/tasks/acquire_rights.mdx
@@ -13,8 +13,8 @@ Binding contractual request to acquire rights from a brand agent. Parallels `cre
 
 ## Schema
 
-- **Request**: [`acquire-rights-request.json`](https://adcontextprotocol.org/schemas/latest/brand/acquire-rights-request.json)
-- **Response**: [`acquire-rights-response.json`](https://adcontextprotocol.org/schemas/latest/brand/acquire-rights-response.json)
+- **Request**: [`acquire-rights-request.json`](https://adcontextprotocol.org/schemas/v3/brand/acquire-rights-request.json)
+- **Response**: [`acquire-rights-response.json`](https://adcontextprotocol.org/schemas/v3/brand/acquire-rights-response.json)
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
@@ -187,7 +187,7 @@ Seconds to minutes for `acquired` or `rejected`. The `pending_approval` status m
 | `campaign.estimated_impressions` | integer | No | Estimated total impressions |
 | `campaign.start_date` | date | No | Campaign start date |
 | `campaign.end_date` | date | No | Campaign end date |
-| `revocation_webhook` | push-notification-config | Yes | Webhook for revocation notifications. If the rights holder needs to revoke rights, they POST a [revocation-notification](https://adcontextprotocol.org/schemas/latest/brand/revocation-notification.json) to this URL. |
+| `revocation_webhook` | push-notification-config | Yes | Webhook for revocation notifications. If the rights holder needs to revoke rights, they POST a [revocation-notification](https://adcontextprotocol.org/schemas/v3/brand/revocation-notification.json) to this URL. |
 | `idempotency_key` | string | No | Client-generated key for safe retries. Resubmitting with the same key returns the original response. |
 | `push_notification_config` | push-notification-config | No | Webhook for async status updates if the acquisition requires approval. See [push notifications](/docs/building/implementation/webhooks). |
 
@@ -235,7 +235,7 @@ After acquiring rights:
 
 1. **Generate**: Creative agent uses `generation_credentials` to produce content
 2. **Manifest**: Embed the `rights_constraint` from the `acquire_rights` response directly into the creative manifest's `rights` array. The rights agent pre-builds this constraint with the correct validity period, country restrictions, and impression cap from the agreed terms.
-3. **Approve**: POST a [`creative-approval-request`](https://adcontextprotocol.org/schemas/latest/brand/creative-approval-request.json) to the `approval_webhook` URL, authenticating with the provided credentials. The response is a [`creative-approval-response`](https://adcontextprotocol.org/schemas/latest/brand/creative-approval-response.json) with status `approved`, `rejected`, or `pending_review`. If `pending_review`, poll the returned `status_url` for updates (suggested: every 5 minutes, back off to every 30 minutes after 1 hour).
+3. **Approve**: POST a [`creative-approval-request`](https://adcontextprotocol.org/schemas/v3/brand/creative-approval-request.json) to the `approval_webhook` URL, authenticating with the provided credentials. The response is a [`creative-approval-response`](https://adcontextprotocol.org/schemas/v3/brand/creative-approval-response.json) with status `approved`, `rejected`, or `pending_review`. If `pending_review`, poll the returned `status_url` for updates (suggested: every 5 minutes, back off to every 30 minutes after 1 hour).
 4. **Serve**: Place approved creative via `create_media_buy`, respecting country and date restrictions
 5. **Report**: Use [`report_usage`](/docs/accounts/tasks/report_usage) with `rights_id` for cap tracking and billing
 
@@ -243,7 +243,7 @@ If `acquire_rights` returns `pending_approval` and you provided `push_notificati
 
 ## Revocation
 
-If the rights holder needs to revoke rights (talent controversy, contract violation, etc.), they POST a [`revocation-notification`](https://adcontextprotocol.org/schemas/latest/brand/revocation-notification.json) to the buyer's `revocation_webhook`, authenticating with the credentials provided at acquisition time. The notification contains an `idempotency_key` (required, used for deduplication across retries), `rights_id`, `brand_id`, `reason`, and `effective_at` timestamp.
+If the rights holder needs to revoke rights (talent controversy, contract violation, etc.), they POST a [`revocation-notification`](https://adcontextprotocol.org/schemas/v3/brand/revocation-notification.json) to the buyer's `revocation_webhook`, authenticating with the credentials provided at acquisition time. The notification contains an `idempotency_key` (required, used for deduplication across retries), `rights_id`, `brand_id`, `reason`, and `effective_at` timestamp.
 
 The buyer is responsible for:
 - Deduplicating by `idempotency_key` — the same revocation may be delivered multiple times; see [Push Notifications — Reliability](/docs/building/implementation/webhooks#reliability) for the canonical dedup contract

--- a/docs/brand-protocol/tasks/get_brand_identity.mdx
+++ b/docs/brand-protocol/tasks/get_brand_identity.mdx
@@ -9,8 +9,8 @@ Retrieve brand identity data from a brand agent. Core identity (house, names, de
 
 ## Schema
 
-- **Request**: [`get-brand-identity-request.json`](https://adcontextprotocol.org/schemas/latest/brand/get-brand-identity-request.json)
-- **Response**: [`get-brand-identity-response.json`](https://adcontextprotocol.org/schemas/latest/brand/get-brand-identity-response.json)
+- **Request**: [`get-brand-identity-request.json`](https://adcontextprotocol.org/schemas/v3/brand/get-brand-identity-request.json)
+- **Response**: [`get-brand-identity-response.json`](https://adcontextprotocol.org/schemas/v3/brand/get-brand-identity-response.json)
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}

--- a/docs/brand-protocol/tasks/get_rights.mdx
+++ b/docs/brand-protocol/tasks/get_rights.mdx
@@ -13,8 +13,8 @@ Search for licensable rights across a brand agent's roster. Returns matches with
 
 ## Schema
 
-- **Request**: [`get-rights-request.json`](https://adcontextprotocol.org/schemas/latest/brand/get-rights-request.json)
-- **Response**: [`get-rights-response.json`](https://adcontextprotocol.org/schemas/latest/brand/get-rights-response.json)
+- **Request**: [`get-rights-request.json`](https://adcontextprotocol.org/schemas/v3/brand/get-rights-request.json)
+- **Response**: [`get-rights-response.json`](https://adcontextprotocol.org/schemas/v3/brand/get-rights-response.json)
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}

--- a/docs/brand-protocol/tasks/update_rights.mdx
+++ b/docs/brand-protocol/tasks/update_rights.mdx
@@ -13,8 +13,8 @@ Modify an existing rights grant — extend dates, adjust impression caps, change
 
 ## Schema
 
-- **Request**: [`update-rights-request.json`](https://adcontextprotocol.org/schemas/latest/brand/update-rights-request.json)
-- **Response**: [`update-rights-response.json`](https://adcontextprotocol.org/schemas/latest/brand/update-rights-response.json)
+- **Request**: [`update-rights-request.json`](https://adcontextprotocol.org/schemas/v3/brand/update-rights-request.json)
+- **Response**: [`update-rights-response.json`](https://adcontextprotocol.org/schemas/v3/brand/update-rights-response.json)
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}

--- a/docs/brand-protocol/walkthrough-rights-licensing.mdx
+++ b/docs/brand-protocol/walkthrough-rights-licensing.mdx
@@ -55,7 +55,7 @@ The `rights_agent` field tells the buyer agent everything it needs to know befor
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "version": "1.0",
   "house": {
     "domain": "lotientertainment.com",

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -35,7 +35,7 @@ If a `comply_test_controller` call references a non-sandbox account, the control
 
 ## Tool definition
 
-**Schemas**: [`comply-test-controller-request.json`](https://adcontextprotocol.org/schemas/latest/compliance/comply-test-controller-request.json) | [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/latest/compliance/comply-test-controller-response.json)
+**Schemas**: [`comply-test-controller-request.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-request.json) | [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-response.json)
 
 Sellers that implement compliance test controller MUST:
 - Only expose the tool in sandbox mode (see sandbox gating above)
@@ -491,7 +491,7 @@ Controllers MUST use structured error codes so the storyboard runner can assert 
 | `INTERNAL_ERROR` | Transient seller-side failure (e.g., sandbox database unavailable). The runner SHOULD retry once before treating as a failure. |
 
 <Note>
-**Controller-specific enum.** The `error` field on controller responses uses a controller-specific vocabulary defined in [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-response.json), distinct from the canonical seller-response [`error-code.json`](https://adcontextprotocol.org/schemas/latest/enums/error-code.json) enum that governs task-level errors. `INVALID_TRANSITION` is controller-specific (state-machine primitives expose the transition-vs-state distinction that seller-level error codes collapse into `INVALID_STATE`). Storyboard assertions on controller responses use `path: "error"` or direct `field_value` checks, not `check: error_code` — the shape-agnostic `error_code` check is for task-response errors (`adcp_error` / payload `errors[]`), not the controller's own response schema.
+**Controller-specific enum.** The `error` field on controller responses uses a controller-specific vocabulary defined in [`comply-test-controller-response.json`](https://adcontextprotocol.org/schemas/v3/compliance/comply-test-controller-response.json), distinct from the canonical seller-response [`error-code.json`](https://adcontextprotocol.org/schemas/v3/enums/error-code.json) enum that governs task-level errors. `INVALID_TRANSITION` is controller-specific (state-machine primitives expose the transition-vs-state distinction that seller-level error codes collapse into `INVALID_STATE`). Storyboard assertions on controller responses use `path: "error"` or direct `field_value` checks, not `check: error_code` — the shape-agnostic `error_code` check is for task-response errors (`adcp_error` / payload `errors[]`), not the controller's own response schema.
 </Note>
 
 

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -54,7 +54,7 @@ Malformed requests that fail schema validation:
 
 ## Error Response Format
 
-Failed operations return status `failed` with error details. The error object follows the [`error.json`](https://adcontextprotocol.org/schemas/latest/core/error.json) schema:
+Failed operations return status `failed` with error details. The error object follows the [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) schema:
 
 ```json
 {
@@ -82,8 +82,8 @@ AdCP exposes errors in two distinct places, and implementers need to populate th
 
 | Layer | Key | When to populate | Shape |
 |---|---|---|---|
-| **Task payload** | `payload.errors[]` (or top-level `errors[]`, depending on transport) | The task ran; the payload reports one or more issues (fatal or non-fatal) | Array of error objects per [`error.json`](https://adcontextprotocol.org/schemas/latest/core/error.json) |
-| **Transport envelope** | `adcp_error` | The task failed and the transport needs a typed, extractable signal | Single error object per [`error.json`](https://adcontextprotocol.org/schemas/latest/core/error.json) |
+| **Task payload** | `payload.errors[]` (or top-level `errors[]`, depending on transport) | The task ran; the payload reports one or more issues (fatal or non-fatal) | Array of error objects per [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) |
+| **Transport envelope** | `adcp_error` | The task failed and the transport needs a typed, extractable signal | Single error object per [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) |
 
 **A fatal task failure SHOULD populate both layers.** The payload carries the structured `errors[]` array that any protocol can read verbatim, and the transport envelope carries `adcp_error` so MCP/A2A clients can extract a typed error without re-parsing the payload. Populating only one of the two is the source-of-truth for most interop bugs — a runner that reads the transport envelope sees no error, and a runner that reads the payload sees no error signal on the transport:
 
@@ -123,7 +123,7 @@ AdCP exposes errors in two distinct places, and implementers need to populate th
 
 ### Error Object Fields
 
-These fields are defined by the [`error.json`](https://adcontextprotocol.org/schemas/latest/core/error.json) schema:
+These fields are defined by the [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) schema:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -137,7 +137,7 @@ These fields are defined by the [`error.json`](https://adcontextprotocol.org/sch
 
 ## Standard Error Codes
 
-Standard error codes are defined in [`error-code.json`](https://adcontextprotocol.org/schemas/latest/enums/error-code.json). Sellers MAY use codes not in this vocabulary for platform-specific errors. Agents MUST handle unknown codes by falling back to the `recovery` classification.
+Standard error codes are defined in [`error-code.json`](https://adcontextprotocol.org/schemas/v3/enums/error-code.json). Sellers MAY use codes not in this vocabulary for platform-specific errors. Agents MUST handle unknown codes by falling back to the `recovery` classification.
 
 **Not-found precedence.** When a referenced identifier does not resolve, sellers SHOULD return the resource-specific code when the resolved type is known from the request: `PRODUCT_NOT_FOUND` for `product_id`, `PACKAGE_NOT_FOUND` for `package_id`, `MEDIA_BUY_NOT_FOUND` for `media_buy_id`, `CREATIVE_NOT_FOUND` for `creative_id`, `SIGNAL_NOT_FOUND` for `signal_id`, `SESSION_NOT_FOUND` for SI `session_id`, `ACCOUNT_NOT_FOUND` for `account_id`, `PLAN_NOT_FOUND` for governance `plan_id`. Fall back to `REFERENCE_NOT_FOUND` for resource types without a dedicated code (e.g., property lists, content standards, rights grants, SI offerings, proposals, catalogs, event sources, collection lists, brands, individual properties). Typed parameters that lack a dedicated standard code MUST use `REFERENCE_NOT_FOUND` rather than minting a custom `*_NOT_FOUND` code — the vocabulary grows by upstream spec change, not by per-seller inflation. Clients SHOULD switch on `error.code` first; the resource-specific codes let clients dispatch without parsing `error.field`.
 
@@ -246,14 +246,14 @@ function isRetryable(error) {
 
 ### Normative throttling behavior
 
-These rules apply when a caller receives a throttling-category error (`RATE_LIMITED`, or any error whose `recovery` is `transient` and whose `details` conform to the [`rate-limited`](https://adcontextprotocol.org/schemas/latest/error-details/rate-limited.json) detail shape):
+These rules apply when a caller receives a throttling-category error (`RATE_LIMITED`, or any error whose `recovery` is `transient` and whose `details` conform to the [`rate-limited`](https://adcontextprotocol.org/schemas/v3/error-details/rate-limited.json) detail shape):
 
 - Callers **MUST** honor `retry_after` when present and **MUST NOT** retry the same request sooner than the indicated number of seconds.
 - Callers **SHOULD** use exponential backoff with jitter when `retry_after` is absent. A base of 2 seconds, a cap of 60 seconds, and ±25% jitter is a safe default.
 - Callers **MUST NOT** treat non-throttling errors (e.g., `INVALID_REQUEST`, `CREATIVE_REJECTED`) as if they were throttled. Retrying a rejected-for-other-reasons response at backoff cadence is a bug, not a defensive posture.
 - Callers **SHOULD** surface repeated throttling to their operator rather than retrying indefinitely; a persistent `RATE_LIMITED` response is a capacity or policy signal, not a transient blip.
 - Sellers **SHOULD** return `RATE_LIMITED` with a populated `retry_after` rather than silently queuing or dropping requests, so well-behaved callers can back off intentionally.
-- Sellers **MAY** populate the [`rate-limited`](https://adcontextprotocol.org/schemas/latest/error-details/rate-limited.json) detail shape (`limit`, `remaining`, `window_seconds`, `scope`) to let callers plan ahead rather than react per-429.
+- Sellers **MAY** populate the [`rate-limited`](https://adcontextprotocol.org/schemas/v3/error-details/rate-limited.json) detail shape (`limit`, `remaining`, `window_seconds`, `scope`) to let callers plan ahead rather than react per-429.
 
 ### Exponential Backoff
 

--- a/docs/building/implementation/transport-errors.mdx
+++ b/docs/building/implementation/transport-errors.mdx
@@ -4,7 +4,7 @@ description: "How AdCP structured errors travel over MCP and A2A transports: ext
 "og:title": "AdCP — Transport Error Mapping"
 ---
 
-AdCP errors are **application-layer** errors. They belong in the tool/task response, not in the transport error channel. This page defines how the [`error.json`](https://adcontextprotocol.org/schemas/latest/core/error.json) schema maps to MCP and A2A response envelopes.
+AdCP errors are **application-layer** errors. They belong in the tool/task response, not in the transport error channel. This page defines how the [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) schema maps to MCP and A2A response envelopes.
 
 For the error schema itself, standard codes, and recovery strategies, see [Error Handling](/docs/building/implementation/error-handling).
 
@@ -539,26 +539,26 @@ Sellers SHOULD keep `details` compact. Error responses flow through LLM context 
 
 JSON Schemas for all recommended `details` shapes are published alongside the error code enum:
 
-- [`/schemas/latest/error-details/rate-limited.json`](https://adcontextprotocol.org/schemas/latest/error-details/rate-limited.json)
-- [`/schemas/latest/error-details/budget-too-low.json`](https://adcontextprotocol.org/schemas/latest/error-details/budget-too-low.json)
-- [`/schemas/latest/error-details/audience-too-small.json`](https://adcontextprotocol.org/schemas/latest/error-details/audience-too-small.json)
-- [`/schemas/latest/error-details/account-setup-required.json`](https://adcontextprotocol.org/schemas/latest/error-details/account-setup-required.json)
-- [`/schemas/latest/error-details/creative-rejected.json`](https://adcontextprotocol.org/schemas/latest/error-details/creative-rejected.json)
-- [`/schemas/latest/error-details/policy-violation.json`](https://adcontextprotocol.org/schemas/latest/error-details/policy-violation.json)
-- [`/schemas/latest/error-details/conflict.json`](https://adcontextprotocol.org/schemas/latest/error-details/conflict.json)
+- [`/schemas/v3/error-details/rate-limited.json`](https://adcontextprotocol.org/schemas/v3/error-details/rate-limited.json)
+- [`/schemas/v3/error-details/budget-too-low.json`](https://adcontextprotocol.org/schemas/v3/error-details/budget-too-low.json)
+- [`/schemas/v3/error-details/audience-too-small.json`](https://adcontextprotocol.org/schemas/v3/error-details/audience-too-small.json)
+- [`/schemas/v3/error-details/account-setup-required.json`](https://adcontextprotocol.org/schemas/v3/error-details/account-setup-required.json)
+- [`/schemas/v3/error-details/creative-rejected.json`](https://adcontextprotocol.org/schemas/v3/error-details/creative-rejected.json)
+- [`/schemas/v3/error-details/policy-violation.json`](https://adcontextprotocol.org/schemas/v3/error-details/policy-violation.json)
+- [`/schemas/v3/error-details/conflict.json`](https://adcontextprotocol.org/schemas/v3/error-details/conflict.json)
 
 These schemas are recommended, not required. Sellers that omit `details` entirely are conformant. Agents MUST NOT require specific `details` keys — fall back to `code`, `message`, and `recovery` when `details` is absent or has unexpected shape.
 
 ## Seller-Specific Error Codes
 
-Sellers MAY use error codes not in the [standard vocabulary](https://adcontextprotocol.org/schemas/latest/enums/error-code.json). To distinguish seller-specific codes from standard codes and avoid collisions between sellers:
+Sellers MAY use error codes not in the [standard vocabulary](https://adcontextprotocol.org/schemas/v3/enums/error-code.json). To distinguish seller-specific codes from standard codes and avoid collisions between sellers:
 
 - Seller-specific codes MUST use the format `X_{VENDOR}_{CODE}` (e.g., `X_STREAMHAUS_FLOOR_NOT_MET`)
 - `{VENDOR}` MUST be an uppercase alphanumeric identifier (matching `/^[A-Z][A-Z0-9]{1,19}$/`) registered in the vendor error code registry
 - `{CODE}` MUST be uppercase alphanumeric with underscores (matching `/^[A-Z][A-Z0-9_]{1,39}$/`)
 - Agents MUST handle unknown codes by falling back to the `recovery` classification
 - If `recovery` is absent on an unknown code, treat as `terminal`
-- Sellers SHOULD register their vendor prefix and codes in the [vendor error code registry](https://adcontextprotocol.org/schemas/latest/error-details/vendor-error-codes.json) by submitting a PR
+- Sellers SHOULD register their vendor prefix and codes in the [vendor error code registry](https://adcontextprotocol.org/schemas/v3/error-details/vendor-error-codes.json) by submitting a PR
 
 ```javascript
 function handleError(error) {

--- a/docs/building/integration/a2a-guide.mdx
+++ b/docs/building/integration/a2a-guide.mdx
@@ -408,7 +408,7 @@ During execution, interim status updates can include optional data in `status.me
 }
 ```
 
-**All status payloads use AdCP schemas**: Both final statuses (completed/failed) and interim statuses (working, input-required, submitted) have corresponding AdCP schemas referenced in [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json). Note that interim status schemas are evolving and may change in future versions, so implementors may choose to handle them more loosely.
+**All status payloads use AdCP schemas**: Both final statuses (completed/failed) and interim statuses (working, input-required, submitted) have corresponding AdCP schemas referenced in [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json). Note that interim status schemas are evolving and may change in future versions, so implementors may choose to handle them more loosely.
 
 ### A2A Webhook Payload Types
 
@@ -453,7 +453,7 @@ The `status.message.parts[].data` field in A2A webhooks uses status-specific sch
 | `input-required` | `[task]-async-response-input-required.json` | Requirements, approval data |
 | `submitted` | `[task]-async-response-submitted.json` | Acknowledgment (usually minimal) |
 
-Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json)
+Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json)
 
 ### Webhook Handler Example
 

--- a/docs/building/integration/authentication.mdx
+++ b/docs/building/integration/authentication.mdx
@@ -96,7 +96,7 @@ AdCP distinguishes between the **agent** (who is making requests) and the **acco
 
 An agent may have access to multiple accounts (e.g., an agency managing several clients). See [Accounts and Agents](/docs/building/integration/accounts-and-agents) for details on account selection and billing attribution.
 
-For schema definitions, see [`account.json`](https://adcontextprotocol.org/schemas/latest/core/account.json).
+For schema definitions, see [`account.json`](https://adcontextprotocol.org/schemas/v3/core/account.json).
 
 ## Tenant resolution
 

--- a/docs/building/integration/mcp-guide.mdx
+++ b/docs/building/integration/mcp-guide.mdx
@@ -440,7 +440,7 @@ The `result` field contains the AdCP data payload. For `completed`/`failed` stat
 
 #### MCP Webhook Envelope Fields
 
-The [`mcp-webhook-payload.json`](https://adcontextprotocol.org/schemas/latest/core/mcp-webhook-payload.json) envelope includes:
+The [`mcp-webhook-payload.json`](https://adcontextprotocol.org/schemas/v3/core/mcp-webhook-payload.json) envelope includes:
 
 **Required fields:**
 - `task_id` — Unique task identifier for correlation
@@ -487,7 +487,7 @@ The `result` field in MCP webhooks uses status-specific schemas:
 | `input-required` | `[task]-async-response-input-required.json` | Requirements, approval data |
 | `submitted` | `[task]-async-response-submitted.json` | Acknowledgment (usually minimal) |
 
-Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/latest/core/async-response-data.json)
+Schema reference: [`async-response-data.json`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json)
 
 #### Webhook Handler Example
 

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -12,7 +12,7 @@ AdCP schemas are available from two sources:
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Website | `https://adcontextprotocol.org/schemas/latest/` | Runtime fetching, version aliases |
+| Website | `https://adcontextprotocol.org/schemas/v3/` | Runtime fetching, version aliases |
 | GitHub | `https://github.com/adcontextprotocol/adcp/tree/main/dist/schemas` | Offline access, CI/CD pipelines |
 
 Both sources contain identical schemas. The GitHub repository includes all released versions with bundled schemas committed directly to the codebase.
@@ -97,10 +97,10 @@ Declare `supported_protocols` (for protocol baselines) and `specialisms` (for na
 
 | Schema | URL |
 |--------|-----|
-| Product | `https://adcontextprotocol.org/schemas/latest/core/product.json` |
-| Media Buy | `https://adcontextprotocol.org/schemas/latest/core/media-buy.json` |
-| Creative Format | `https://adcontextprotocol.org/schemas/latest/core/format.json` |
-| Schema Registry | `https://adcontextprotocol.org/schemas/latest/index.json` |
+| Product | `https://adcontextprotocol.org/schemas/v3/core/product.json` |
+| Media Buy | `https://adcontextprotocol.org/schemas/v3/core/media-buy.json` |
+| Creative Format | `https://adcontextprotocol.org/schemas/v3/core/format.json` |
+| Schema Registry | `https://adcontextprotocol.org/schemas/v3/index.json` |
 
 ### For AI Coding Agents
 
@@ -223,7 +223,7 @@ AdCP uses semantic versioning. Choose the right path for your use case:
 | Path | Example | Best For |
 |------|---------|----------|
 | Exact version | `/schemas/3.0.0/`, `/compliance/3.0.0/`, `/protocol/3.0.0.tgz` | Production, SDK generation |
-| Major version | `/schemas/latest/`, `/compliance/v3/` | Development, documentation |
+| Major version | `/schemas/v3/`, `/compliance/v3/` | Development, documentation |
 | Minor version | `/schemas/v3.0/`, `/compliance/v3.0/` | Stable development (patch updates only) |
 
 The same version semantics apply to `/schemas`, `/compliance`, and `/protocol/{version}.tgz` — one release cuts all three.
@@ -245,7 +245,7 @@ Use the major version alias to stay current with backward-compatible updates:
 
 ```javascript
 const schema = await fetch(
-  'https://adcontextprotocol.org/schemas/latest/core/product.json'
+  'https://adcontextprotocol.org/schemas/v3/core/product.json'
 );
 ```
 
@@ -319,13 +319,13 @@ All request/response task schemas are bundled:
 | `bundled/protocol/` | get-adcp-capabilities |
 | `bundled/core/` | tasks-get, tasks-list |
 
-See the [schema registry](https://adcontextprotocol.org/schemas/latest/index.json) for all available schemas.
+See the [schema registry](https://adcontextprotocol.org/schemas/v3/index.json) for all available schemas.
 
 ## Version Discovery
 
 ```bash
 # Get current version
-curl https://adcontextprotocol.org/schemas/latest/index.json | jq '.adcp_version'
+curl https://adcontextprotocol.org/schemas/v3/index.json | jq '.adcp_version'
 ```
 
 Check [Release Notes](/docs/reference/release-notes) for version history and migration guides.

--- a/docs/creative/asset-types.mdx
+++ b/docs/creative/asset-types.mdx
@@ -12,8 +12,8 @@ Standardizing asset types ensures consistency across formats and makes requireme
 ## Important: Payload vs Requirements
 
 For payload schemas (the structure of the actual asset data supplied in creative manifests), see:
-- [Asset Type Registry](https://adcontextprotocol.org/schemas/latest/creative/asset-types/index.json) - Links to all payload schemas
-- Core Asset Schemas at `/schemas/latest/core/assets/` - Individual asset payload definitions
+- [Asset Type Registry](https://adcontextprotocol.org/schemas/v3/creative/asset-types/index.json) - Links to all payload schemas
+- Core Asset Schemas at `/schemas/v3/core/assets/` - Individual asset payload definitions
 
 **Key distinction:**
 
@@ -232,7 +232,7 @@ VAST (Video Ad Serving Template) tags for third-party video ad serving.
 - `vpaid_enabled`: Whether VPAID (Video Player-Ad Interface Definition) is supported
 - `max_wrapper_depth`: Maximum allowed wrapper/redirect depth
 - `duration_ms`: Expected video duration in milliseconds (if known)
-- `tracking_events`: Array of supported tracking events. Valid values are defined by the [VAST Tracking Event](https://adcontextprotocol.org/schemas/latest/enums/vast-tracking-event.json) enum. Includes IAB VAST 4.2 TrackingEvents plus flattened representations of Impression, Error, VideoClicks, and ViewableImpression elements:
+- `tracking_events`: Array of supported tracking events. Valid values are defined by the [VAST Tracking Event](https://adcontextprotocol.org/schemas/v3/enums/vast-tracking-event.json) enum. Includes IAB VAST 4.2 TrackingEvents plus flattened representations of Impression, Error, VideoClicks, and ViewableImpression elements:
   - **Playback**: `impression` (billing event), `creativeView`, `loaded`, `start`, `firstQuartile`, `midpoint`, `thirdQuartile`, `complete`
   - **Interaction**: `mute`, `unmute`, `pause`, `resume`, `rewind`, `skip`, `playerExpand`, `playerCollapse`, `fullscreen` (pre-4.0 compat), `exitFullscreen` (pre-4.0 compat), `otherAdInteraction`, `interactiveStart` (SIMID)
   - **Progress**: `progress` (for custom progress points via VAST `offset` attribute), `notUsed` (prefetched but not played)
@@ -278,7 +278,7 @@ DAAST (Digital Audio Ad Serving Template) tags for third-party audio ad serving.
 - `content`: Inline DAAST XML content (required when delivery_type is "inline")
 - `daast_version`: DAAST specification version (1.0, 1.1)
 - `duration_ms`: Expected audio duration in milliseconds (if known)
-- `tracking_events`: Array of supported tracking events. Valid values are defined by the [DAAST Tracking Event](https://adcontextprotocol.org/schemas/latest/enums/daast-tracking-event.json) enum. Includes DAAST-applicable events plus flattened Impression, Error, and ViewableImpression elements:
+- `tracking_events`: Array of supported tracking events. Valid values are defined by the [DAAST Tracking Event](https://adcontextprotocol.org/schemas/v3/enums/daast-tracking-event.json) enum. Includes DAAST-applicable events plus flattened Impression, Error, and ViewableImpression elements:
   - **Playback**: `impression` (billing event), `creativeView` (companion ad display), `loaded`, `start`, `firstQuartile`, `midpoint`, `thirdQuartile`, `complete`
   - **Interaction**: `mute`, `unmute`, `pause`, `resume`, `skip`
   - **Progress**: `progress`

--- a/docs/creative/catalog-schemas.mdx
+++ b/docs/creative/catalog-schemas.mdx
@@ -29,7 +29,7 @@ In addition to the domain-specific fields listed in each vertical's table, all v
 
 Job postings for recruitment campaigns. Maps to LinkedIn Jobs XML, Google DynamicJobsAsset, and schema.org JobPosting.
 
-**Schema**: [`/schemas/core/job-item.json`](https://adcontextprotocol.org/schemas/latest/core/job-item.json)
+**Schema**: [`/schemas/core/job-item.json`](https://adcontextprotocol.org/schemas/v3/core/job-item.json)
 **Required**: `job_id`, `title`, `company_name`, `description`
 **Conversion events**: `submit_application`, `complete_registration`
 
@@ -56,7 +56,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/job-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
   "job_id": "eng-sr-2025-042",
   "title": "Senior Software Engineer",
   "company_name": "Acme Corp",
@@ -68,7 +68,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/job-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/job-item.json",
   "job_id": "eng-sr-2025-042",
   "title": "Senior Software Engineer",
   "company_name": "Acme Corp",
@@ -90,7 +90,7 @@ Full example with optional fields:
 
 Hotel and lodging properties for travel ads and dynamic remarketing. Maps to Google Hotel Center feeds and Meta hotel catalogs.
 
-**Schema**: [`/schemas/core/hotel-item.json`](https://adcontextprotocol.org/schemas/latest/core/hotel-item.json)
+**Schema**: [`/schemas/core/hotel-item.json`](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json)
 **Required**: `hotel_id`, `name`, `location`
 **Conversion events**: `purchase` (booking)
 
@@ -119,7 +119,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/hotel-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
   "hotel_id": "grand-amsterdam",
   "name": "Grand Hotel Amsterdam",
   "location": { "lat": 52.3676, "lng": 4.9041 }
@@ -130,7 +130,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/hotel-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/hotel-item.json",
   "hotel_id": "grand-amsterdam",
   "name": "Grand Hotel Amsterdam",
   "description": "Five-star canal-side hotel in the heart of Amsterdam with rooftop bar and spa.",
@@ -157,7 +157,7 @@ Full example with optional fields:
 
 Vehicle listings for automotive inventory ads. Maps to Meta Automotive Inventory Ads, Microsoft Auto Inventory feeds, and Google vehicle ads.
 
-**Schema**: [`/schemas/core/vehicle-item.json`](https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json)
+**Schema**: [`/schemas/core/vehicle-item.json`](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json)
 **Required**: `vehicle_id`, `title`, `make`, `model`, `year`
 **Conversion events**: `lead`, `schedule` (test drive)
 
@@ -187,7 +187,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
   "vehicle_id": "dlr-2024-horizon-001",
   "title": "2024 Apex Horizon EX Sedan",
   "make": "Apex",
@@ -200,7 +200,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json",
   "vehicle_id": "dlr-2024-horizon-001",
   "title": "2024 Apex Horizon EX Sedan",
   "make": "Apex",
@@ -223,7 +223,7 @@ Full example with optional fields:
 
 Flight routes for travel ads and dynamic remarketing. Maps to Google DynamicFlightsAsset and Meta flight catalogs.
 
-**Schema**: [`/schemas/core/flight-item.json`](https://adcontextprotocol.org/schemas/latest/core/flight-item.json)
+**Schema**: [`/schemas/core/flight-item.json`](https://adcontextprotocol.org/schemas/v3/core/flight-item.json)
 **Required**: `flight_id`, `origin`, `destination`
 **Conversion events**: `purchase` (booking)
 
@@ -247,7 +247,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/flight-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
   "flight_id": "ams-jfk-summer",
   "origin": { "airport_code": "AMS" },
   "destination": { "airport_code": "JFK" }
@@ -258,7 +258,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/flight-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/flight-item.json",
   "flight_id": "ams-jfk-summer",
   "origin": { "airport_code": "AMS", "city": "Amsterdam" },
   "destination": { "airport_code": "JFK", "city": "New York" },
@@ -275,7 +275,7 @@ Full example with optional fields:
 
 Property listings for real estate ads. Maps to Google DynamicRealEstateAsset and Meta home listing catalogs.
 
-**Schema**: [`/schemas/core/real-estate-item.json`](https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json)
+**Schema**: [`/schemas/core/real-estate-item.json`](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json)
 **Required**: `listing_id`, `title`, `address`
 **Conversion events**: `lead`, `schedule` (viewing)
 
@@ -302,7 +302,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
   "listing_id": "ams-jordaan-3br",
   "title": "Spacious 3BR Apartment in Jordaan",
   "address": { "city": "Amsterdam", "country": "NL" }
@@ -313,7 +313,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json",
   "listing_id": "ams-jordaan-3br",
   "title": "Spacious 3BR Apartment in Jordaan",
   "description": "Bright canal-view apartment with original features and modern kitchen, steps from Noordermarkt.",
@@ -341,7 +341,7 @@ Full example with optional fields:
 
 Educational programs and courses for student recruitment. Maps to Google DynamicEducationAsset and schema.org Course.
 
-**Schema**: [`/schemas/core/education-item.json`](https://adcontextprotocol.org/schemas/latest/core/education-item.json)
+**Schema**: [`/schemas/core/education-item.json`](https://adcontextprotocol.org/schemas/v3/core/education-item.json)
 **Required**: `program_id`, `name`, `school`
 **Conversion events**: `submit_application`, `complete_registration`
 
@@ -368,7 +368,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/education-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
   "program_id": "pinnacle-msc-cs-2025",
   "name": "MSc Computer Science",
   "school": "Pinnacle University"
@@ -379,7 +379,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/education-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/education-item.json",
   "program_id": "pinnacle-msc-cs-2025",
   "name": "MSc Computer Science",
   "school": "Pinnacle University",
@@ -402,7 +402,7 @@ Full example with optional fields:
 
 Travel destinations for destination ads and travel remarketing. Maps to Meta destination catalogs and Google travel ads.
 
-**Schema**: [`/schemas/core/destination-item.json`](https://adcontextprotocol.org/schemas/latest/core/destination-item.json)
+**Schema**: [`/schemas/core/destination-item.json`](https://adcontextprotocol.org/schemas/v3/core/destination-item.json)
 **Required**: `destination_id`, `name`
 **Conversion events**: `purchase` (booking)
 
@@ -426,7 +426,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/destination-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
   "destination_id": "barcelona",
   "name": "Barcelona"
 }
@@ -436,7 +436,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/destination-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/destination-item.json",
   "destination_id": "barcelona",
   "name": "Barcelona",
   "description": "Mediterranean city blending Gaudí architecture, beaches, and world-class dining.",
@@ -457,7 +457,7 @@ Full example with optional fields:
 
 Mobile applications for app install and re-engagement campaigns. Maps to Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, and Snapchat App Install Ads. iOS and Android variants are separate items.
 
-**Schema**: [`/schemas/core/app-item.json`](https://adcontextprotocol.org/schemas/latest/core/app-item.json)
+**Schema**: [`/schemas/core/app-item.json`](https://adcontextprotocol.org/schemas/v3/core/app-item.json)
 **Required**: `app_id`, `name`, `platform`
 **Conversion events**: `app_install`, `app_launch`
 
@@ -488,7 +488,7 @@ Minimal — just required fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/app-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
   "app_id": "puzzlequest-ios",
   "name": "Puzzle Quest: Match 3",
   "platform": "ios"
@@ -499,7 +499,7 @@ Full example with optional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/app-item.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/app-item.json",
   "app_id": "puzzlequest-ios",
   "name": "Puzzle Quest: Match 3",
   "platform": "ios",

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -108,10 +108,10 @@ Catalog types fall into two categories: **structural** types that describe the d
 
 | Type | Item Schema | Description |
 |------|-------------|-------------|
-| `offering` | [Offering](https://adcontextprotocol.org/schemas/latest/core/offering.json) | AdCP Offering objects — campaigns, vacancies, events, services |
+| `offering` | [Offering](https://adcontextprotocol.org/schemas/v3/core/offering.json) | AdCP Offering objects — campaigns, vacancies, events, services |
 | `product` | *(your existing feed format)* | Ecommerce product entries (Google Merchant Center, Shopify, etc.) |
 | `inventory` | *(your existing feed format)* | Stock and availability per product per location |
-| `store` | [StoreItem](https://adcontextprotocol.org/schemas/latest/core/store-item.json) | Physical locations with addresses and catchment areas |
+| `store` | [StoreItem](https://adcontextprotocol.org/schemas/v3/core/store-item.json) | Physical locations with addresses and catchment areas |
 | `promotion` | *(your existing feed format)* | Sales, deals, and promotional pricing |
 
 ### Vertical types
@@ -120,14 +120,14 @@ Each vertical type has a defined AdCP item schema, so formats can declare `catal
 
 | Type | Item Schema | Maps To |
 |------|-------------|---------|
-| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/latest/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
-| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/latest/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
-| `job` | [JobItem](https://adcontextprotocol.org/schemas/latest/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
-| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/latest/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
-| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/latest/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
-| `education` | [EducationItem](https://adcontextprotocol.org/schemas/latest/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
-| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/latest/core/destination-item.json) | Meta destination catalogs, Google travel ads |
-| `app` | [AppItem](https://adcontextprotocol.org/schemas/latest/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
+| `hotel` | [HotelItem](https://adcontextprotocol.org/schemas/v3/core/hotel-item.json) | Google Hotel Center, Meta hotel catalogs |
+| `flight` | [FlightItem](https://adcontextprotocol.org/schemas/v3/core/flight-item.json) | Google DynamicFlightsAsset, Meta flight catalogs |
+| `job` | [JobItem](https://adcontextprotocol.org/schemas/v3/core/job-item.json) | LinkedIn Jobs XML, Google DynamicJobsAsset, schema.org JobPosting |
+| `vehicle` | [VehicleItem](https://adcontextprotocol.org/schemas/v3/core/vehicle-item.json) | Meta Automotive Inventory, Microsoft Auto Inventory feeds |
+| `real_estate` | [RealEstateItem](https://adcontextprotocol.org/schemas/v3/core/real-estate-item.json) | Google DynamicRealEstateAsset, Meta home listing catalogs |
+| `education` | [EducationItem](https://adcontextprotocol.org/schemas/v3/core/education-item.json) | Google DynamicEducationAsset, schema.org Course |
+| `destination` | [DestinationItem](https://adcontextprotocol.org/schemas/v3/core/destination-item.json) | Meta destination catalogs, Google travel ads |
+| `app` | [AppItem](https://adcontextprotocol.org/schemas/v3/core/app-item.json) | Google App Campaigns, Apple Search Ads, Meta App Ads, TikTok App Campaigns, Snapchat App Install Ads |
 
 ## Typed catalog assets
 
@@ -173,7 +173,7 @@ Formats use `field_bindings` (see [Format catalog requirements](#format-catalog-
 
 ## The Catalog object
 
-**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/latest/core/catalog.json)
+**Schema URL**: [`/schemas/core/catalog.json`](https://adcontextprotocol.org/schemas/v3/core/catalog.json)
 
 ```typescript test=false
 interface Catalog {
@@ -620,7 +620,7 @@ When a format declares catalog asset types, the buying agent syncs the required 
 
 ## Offerings
 
-**Schema URL**: [`/schemas/core/offering.json`](https://adcontextprotocol.org/schemas/latest/core/offering.json)
+**Schema URL**: [`/schemas/core/offering.json`](https://adcontextprotocol.org/schemas/v3/core/offering.json)
 
 An Offering is an individual promotable item within an `offering`-type catalog — a campaign, product, service, promotion, or vacancy. Each offering is a semantic unit with its own name, validity window, landing URL, creative assets, and geographic scope.
 
@@ -676,7 +676,7 @@ interface Offering {
 
 ### OfferingAssetGroup
 
-**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/latest/core/offering-asset-group.json)
+**Schema URL**: [`/schemas/core/offering-asset-group.json`](https://adcontextprotocol.org/schemas/v3/core/offering-asset-group.json)
 
 A typed pool of creative assets within an offering. Uses the same `asset_group_id` vocabulary as format-level asset definitions, enabling formats to declare per-group constraints on what each offering must provide.
 
@@ -696,7 +696,7 @@ interface OfferingAssetGroup {
 
 ### OfferingAssetConstraint
 
-**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/latest/core/requirements/offering-asset-constraint.json)
+**Schema URL**: [`/schemas/core/requirements/offering-asset-constraint.json`](https://adcontextprotocol.org/schemas/v3/core/requirements/offering-asset-constraint.json)
 
 Declared by a format to specify what asset groups each offering must provide. Used within a catalog asset's `requirements` to constrain what offerings in a catalog must provide.
 
@@ -776,7 +776,7 @@ Call `list_creative_formats` and check the format's `assets` array for `catalog`
 
 ## Stores
 
-**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/latest/core/store-item.json)
+**Schema URL**: [`/schemas/core/store-item.json`](https://adcontextprotocol.org/schemas/v3/core/store-item.json)
 
 A StoreItem represents a physical location within a `store`-type catalog. Each store carries coordinates, an optional address, and one or more catchment areas that define the geographic reach around that location.
 
@@ -816,7 +816,7 @@ interface StoreItem {
 
 ### Catchment areas
 
-**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/latest/core/catchment.json)
+**Schema URL**: [`/schemas/core/catchment.json`](https://adcontextprotocol.org/schemas/v3/core/catchment.json)
 
 A catchment defines the geographic area a store serves. Three methods are supported — provide exactly one per catchment:
 

--- a/docs/creative/creative-manifests.mdx
+++ b/docs/creative/creative-manifests.mdx
@@ -331,7 +331,7 @@ When a creative agent receives a manifest for validation:
    - Look up the `asset_id` in `format.assets`
    - If not found → **reject** with error "Unknown asset_id 'banner_imag' not defined in format"
    - If found → determine the expected `asset_type` from the format requirement
-   - Fetch the asset type schema (e.g., `/schemas/latest/core/assets/image-asset.json`)
+   - Fetch the asset type schema (e.g., `/schemas/v3/core/assets/image-asset.json`)
    - Validate the asset payload against that schema
    - Validate the asset meets any additional constraints in the format's `requirements` field
 4. **Check all required assets are present** (where `required: true` in format spec)
@@ -459,9 +459,9 @@ For carousel, slideshow, and multi-asset formats, see the [Carousel & Multi-Asse
 
 ## Schema Reference
 
-- [Creative Manifest Schema](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json)
-- [Preview Creative Request](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-request.json)
-- [Preview Creative Response](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-response.json)
+- [Creative Manifest Schema](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json)
+- [Preview Creative Request](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-request.json)
+- [Preview Creative Response](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-response.json)
 
 ## Related Documentation
 

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -61,7 +61,7 @@ Formats may be sourced from:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-response.json",
   "formats": [
     {
       "format_id": {
@@ -90,7 +90,7 @@ Each format includes an `agent_url` that identifies the authoritative creative a
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_30s_hosted"
@@ -127,7 +127,7 @@ This approach allows publishers to present complex formats without constraining 
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
   "format_id": {
     "agent_url": "https://publisher.com",
     "id": "homepage_takeover_premium"
@@ -149,7 +149,7 @@ AdCP uses structured format identifiers everywhere to avoid ambiguity and namesp
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format-id.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format-id.json",
   "agent_url": "https://creative.adcontextprotocol.org",
   "id": "display_300x250"
 }
@@ -220,7 +220,7 @@ Formats are JSON objects with the following key fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_30s_hosted"
@@ -448,7 +448,7 @@ Formats specify their rendered outputs via the `renders` array. Most formats pro
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "display_300x250"
@@ -474,7 +474,7 @@ Formats specify their rendered outputs via the `renders` array. Most formats pro
 **Multi-render example (companion ad):**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/format.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
   "format_id": {
     "agent_url": "https://creative.adcontextprotocol.org",
     "id": "video_with_companion_300x250"

--- a/docs/creative/multi-agent-orchestration.mdx
+++ b/docs/creative/multi-agent-orchestration.mdx
@@ -28,7 +28,7 @@ Before routing any requests, the orchestrator needs a map of what each agent sup
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/creative/provenance.mdx
+++ b/docs/creative/provenance.mdx
@@ -15,7 +15,7 @@ EU AI Act Article 50 enforcement begins August 2026. California SB 942 is alread
 
 Provenance is an optional object that can attach to creative assets, creative manifests, individual typed assets, and content artifacts. No fields are required at the provenance level -- each section is independently useful.
 
-**Schema**: [provenance.json](https://adcontextprotocol.org/schemas/latest/core/provenance.json)
+**Schema**: [provenance.json](https://adcontextprotocol.org/schemas/v3/core/provenance.json)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -116,7 +116,7 @@ For content with no AI involvement, provenance is even simpler:
 
 The `digital_source_type` enum classifies AI involvement in content production, aligned with the [IPTC digitalsourcetype vocabulary](https://cv.iptc.org/newscodes/digitalsourcetype/).
 
-**Schema**: [digital-source-type.json](https://adcontextprotocol.org/schemas/latest/enums/digital-source-type.json)
+**Schema**: [digital-source-type.json](https://adcontextprotocol.org/schemas/v3/enums/digital-source-type.json)
 
 | Value | Description | When to use |
 |-------|-------------|-------------|
@@ -515,12 +515,12 @@ This field is surfaced in product discovery through `get_products`, so buyers kn
 
 | Schema | Location |
 |--------|----------|
-| Provenance object | [`/schemas/core/provenance.json`](https://adcontextprotocol.org/schemas/latest/core/provenance.json) |
-| Digital source type enum | [`/schemas/enums/digital-source-type.json`](https://adcontextprotocol.org/schemas/latest/enums/digital-source-type.json) |
-| Creative asset (with provenance) | [`/schemas/core/creative-asset.json`](https://adcontextprotocol.org/schemas/latest/core/creative-asset.json) |
-| Creative manifest (with provenance) | [`/schemas/core/creative-manifest.json`](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json) |
-| Creative policy (provenance_required) | [`/schemas/core/creative-policy.json`](https://adcontextprotocol.org/schemas/latest/core/creative-policy.json) |
-| Artifact (with provenance) | [`/schemas/content-standards/artifact.json`](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json) |
+| Provenance object | [`/schemas/core/provenance.json`](https://adcontextprotocol.org/schemas/v3/core/provenance.json) |
+| Digital source type enum | [`/schemas/enums/digital-source-type.json`](https://adcontextprotocol.org/schemas/v3/enums/digital-source-type.json) |
+| Creative asset (with provenance) | [`/schemas/core/creative-asset.json`](https://adcontextprotocol.org/schemas/v3/core/creative-asset.json) |
+| Creative manifest (with provenance) | [`/schemas/core/creative-manifest.json`](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json) |
+| Creative policy (provenance_required) | [`/schemas/core/creative-policy.json`](https://adcontextprotocol.org/schemas/v3/core/creative-policy.json) |
+| Artifact (with provenance) | [`/schemas/content-standards/artifact.json`](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json) |
 
 ## Related
 

--- a/docs/creative/sales-agent-creative-capabilities.mdx
+++ b/docs/creative/sales-agent-creative-capabilities.mdx
@@ -15,7 +15,7 @@ A sales agent declares Creative Protocol support in `get_adcp_capabilities`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/creative/specification.mdx
+++ b/docs/creative/specification.mdx
@@ -43,7 +43,7 @@ Creative agents MUST declare Creative Protocol support via `get_adcp_capabilitie
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -156,7 +156,7 @@ Sales agents MUST translate universal macros to their ad server's native syntax.
 
 ## Creative Status Lifecycle
 
-**Schema**: [`enums/creative-status.json`](https://adcontextprotocol.org/schemas/latest/enums/creative-status.json)
+**Schema**: [`enums/creative-status.json`](https://adcontextprotocol.org/schemas/v3/enums/creative-status.json)
 
 Creatives in a library progress through a defined set of states. `archived` is the only buyer-initiated state change; all others are seller-initiated (processing, review, approval/rejection).
 
@@ -199,7 +199,7 @@ Pricing is discovered via two surfaces depending on the agent's interaction mode
 - **`list_creatives`** — ad servers and library-based agents expose `pricing_options[]` on each creative. The buyer discovers pricing for specific creatives they want to use.
 - **`list_creative_formats`** — transformation and generation agents expose `pricing_options[]` on each format. The buyer discovers pricing for the formats the agent can produce, before any creative exists.
 
-Both surfaces use the same `pricing_options[]` array of [`vendor-pricing-option`](https://adcontextprotocol.org/schemas/latest/core/vendor-pricing-option.json) objects. Both require `account` and `include_pricing: true` on the request.
+Both surfaces use the same `pricing_options[]` array of [`vendor-pricing-option`](https://adcontextprotocol.org/schemas/v3/core/vendor-pricing-option.json) objects. Both require `account` and `include_pricing: true` on the request.
 
 An agent MAY expose pricing on both surfaces (e.g., a creative management platform that has both a library and transformation capabilities).
 
@@ -212,7 +212,7 @@ An agent MAY expose pricing on both surfaces (e.g., a creative management platfo
 
 ### Pricing models
 
-Creative agents reuse the vendor pricing models defined in [`vendor-pricing-option.json`](https://adcontextprotocol.org/schemas/latest/core/vendor-pricing-option.json):
+Creative agents reuse the vendor pricing models defined in [`vendor-pricing-option.json`](https://adcontextprotocol.org/schemas/v3/core/vendor-pricing-option.json):
 
 | Model | Creative use case |
 |---|---|
@@ -223,7 +223,7 @@ Creative agents reuse the vendor pricing models defined in [`vendor-pricing-opti
 
 ### Consumption details
 
-**Schema**: [`core/creative-consumption.json`](https://adcontextprotocol.org/schemas/latest/core/creative-consumption.json)
+**Schema**: [`core/creative-consumption.json`](https://adcontextprotocol.org/schemas/v3/core/creative-consumption.json)
 
 The `build_creative` response includes a `consumption` object with structured details about what was consumed. Well-known fields: `tokens` (LLM tokens consumed), `images_generated`, `renders` (render passes), `duration_seconds` (processing time). Agents MAY include additional fields.
 
@@ -295,7 +295,7 @@ Generate preview renderings of creative manifests.
 
 ### list_creatives
 
-**Schema**: [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json) / [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json)
+**Schema**: [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-request.json) / [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-response.json)
 
 **Reference**: [`list_creatives` task](/docs/creative/task-reference/list_creatives)
 
@@ -308,7 +308,7 @@ Browse and filter creative assets in a creative library. Implemented by any agen
 - Agents SHOULD support filtering by `concept_ids` and `format_ids` when the platform organizes creatives into concepts
 - Agents MAY include dynamic content variable definitions when `include_variables=true`
 - Agents MAY include a lightweight delivery snapshot when `include_snapshot=true`. The snapshot provides lifetime impressions and last-served date for operational use — detailed analytics belong in `get_creative_delivery`.
-- When `account` and `include_pricing=true` are provided, agents that charge MUST include `pricing_options` on each creative — an array of [`vendor-pricing-option`](https://adcontextprotocol.org/schemas/latest/core/vendor-pricing-option.json) objects. Vendors may offer multiple options per creative (volume tiers, context-specific rates, different pricing models).
+- When `account` and `include_pricing=true` are provided, agents that charge MUST include `pricing_options` on each creative — an array of [`vendor-pricing-option`](https://adcontextprotocol.org/schemas/v3/core/vendor-pricing-option.json) objects. Vendors may offer multiple options per creative (volume tiers, context-specific rates, different pricing models).
 
 **Account requirements:**
 - Creative agents that charge for their services MUST implement the [Accounts Protocol](/docs/accounts/overview). This applies to any creative agent with pricing — ad servers, generation platforms, and transformation agents that bill for usage.
@@ -320,7 +320,7 @@ Browse and filter creative assets in a creative library. Implemented by any agen
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
-**Schema**: [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json) / [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json)
+**Schema**: [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json) / [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-response.json)
 
 **Reference**: [`sync_creatives` task](/docs/creative/task-reference/sync_creatives)
 
@@ -466,12 +466,12 @@ Some creative protocol schemas (`build_creative`, `list_creative_formats`, `prev
 
 | Schema | Description |
 |--------|-------------|
-| [`core/format.json`](https://adcontextprotocol.org/schemas/latest/core/format.json) | Format definition |
-| [`core/creative-manifest.json`](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json) | Creative manifest |
-| [`core/creative-asset.json`](https://adcontextprotocol.org/schemas/latest/core/creative-asset.json) | Asset definition |
-| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) | list_creative_formats request |
-| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json) | list_creative_formats response |
-| [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json) | list_creatives request |
-| [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json) | list_creatives response |
-| [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json) | sync_creatives request |
-| [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json) | sync_creatives response |
+| [`core/format.json`](https://adcontextprotocol.org/schemas/v3/core/format.json) | Format definition |
+| [`core/creative-manifest.json`](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json) | Creative manifest |
+| [`core/creative-asset.json`](https://adcontextprotocol.org/schemas/v3/core/creative-asset.json) | Asset definition |
+| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) | list_creative_formats request |
+| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json) | list_creative_formats response |
+| [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-request.json) | list_creatives request |
+| [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-response.json) | list_creatives response |
+| [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json) | sync_creatives request |
+| [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-response.json) | sync_creatives response |

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -20,7 +20,7 @@ For information about format IDs and how to reference formats, see [Creative For
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `message` | string | No | Natural language instructions for the creative agent. For generation, this provides creative direction. For transformation, this guides how to adapt the creative. For refinement, this describes the desired changes. |
-| `creative_manifest` | object | No | Creative manifest to transform or generate from (see [Creative Manifest](https://adcontextprotocol.org/schemas/latest/core/creative-manifest.json)). For pure generation, this should include the target format_id and any required input assets. For transformation, this is the complete creative to adapt. When `creative_id` is provided, the agent resolves the creative from its library and this field is ignored. |
+| `creative_manifest` | object | No | Creative manifest to transform or generate from (see [Creative Manifest](https://adcontextprotocol.org/schemas/v3/core/creative-manifest.json)). For pure generation, this should include the target format_id and any required input assets. For transformation, this is the complete creative to adapt. When `creative_id` is provided, the agent resolves the creative from its library and this field is ignored. |
 | `creative_id` | string | No | Reference to a creative in the agent's library. The creative agent resolves this to a manifest from its library. Use this instead of `creative_manifest` when retrieving an existing creative for tag generation or format adaptation. |
 | `concept_id` | string | No | Creative concept containing the creative. Used to disambiguate when the same `creative_id` exists in multiple concepts. |
 | `media_buy_id` | string | No | Buyer's media buy reference for tag generation context. When the creative agent is also the ad server (e.g., CM360), this provides the trafficking context needed to generate placement-specific tags. Omit when the platform generates tags at the creative level (Flashtalking, Celtra). This is the buyer's reference — the seller-assigned identifier from `create_media_buy`. |
@@ -46,7 +46,7 @@ When the creative agent charges and `account` is provided, the response includes
 | `pricing_option_id` | string | Which rate card pricing option was applied |
 | `vendor_cost` | number | Cost incurred for this build. May be 0 for CPM-priced creatives where cost accrues at serve time. |
 | `currency` | string | ISO 4217 currency code |
-| `consumption` | object | Structured consumption details — `tokens`, `images_generated`, `renders`, `duration_seconds`. See [`creative-consumption.json`](https://adcontextprotocol.org/schemas/latest/core/creative-consumption.json). Informational for cost verification; `vendor_cost` is the billing source of truth. |
+| `consumption` | object | Structured consumption details — `tokens`, `images_generated`, `renders`, `duration_seconds`. See [`creative-consumption.json`](https://adcontextprotocol.org/schemas/v3/core/creative-consumption.json). Informational for cost verification; `vendor_cost` is the billing source of truth. |
 
 For async builds (`status: "working"` with `context_id` polling), pricing fields appear on the final completed response only.
 

--- a/docs/creative/task-reference/get_creative_delivery.mdx
+++ b/docs/creative/task-reference/get_creative_delivery.mdx
@@ -9,8 +9,8 @@ Retrieve creative delivery data including variant-level breakdowns with manifest
 
 This is a Creative Protocol task. Call it on any agent that declares `"creative"` in `supported_protocols` and `"delivery"` in its [creative agent capabilities](#capability-declaration) — whether that's a dedicated creative service or a [sales agent implementing the Creative Protocol](/docs/creative/sales-agent-creative-capabilities).
 
-**Request Schema**: [`/schemas/latest/creative/get-creative-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/creative/get-creative-delivery-request.json)
-**Response Schema**: [`/schemas/latest/creative/get-creative-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/creative/get-creative-delivery-response.json)
+**Request Schema**: [`/schemas/v3/creative/get-creative-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/creative/get-creative-delivery-request.json)
+**Response Schema**: [`/schemas/v3/creative/get-creative-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/creative/get-creative-delivery-response.json)
 
 ## Request Parameters
 

--- a/docs/creative/task-reference/list_creative_formats.mdx
+++ b/docs/creative/task-reference/list_creative_formats.mdx
@@ -12,8 +12,8 @@ Discover creative formats supported by a creative agent. Returns full format spe
 
 **Authentication**: None required (public endpoint for format discovery)
 
-**Request Schema**: [`/schemas/latest/creative/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-request.json)
-**Response Schema**: [`/schemas/latest/creative/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-response.json)
+**Request Schema**: [`/schemas/v3/creative/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-request.json)
+**Response Schema**: [`/schemas/v3/creative/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-response.json)
 
 ## Behavior by agent type
 
@@ -67,7 +67,7 @@ Formats may produce multiple rendered pieces (e.g., video + companion banner). D
 | `formats` | Array of full format definitions (format_id, name, assets, renders). The `type` field is deprecated and may be omitted. |
 | `creative_agents` | Optional array of other creative agents providing additional formats |
 
-See [Format schema](https://adcontextprotocol.org/schemas/latest/core/format.json) for complete format object structure.
+See [Format schema](https://adcontextprotocol.org/schemas/v3/core/format.json) for complete format object structure.
 
 ### Recursive Discovery
 
@@ -676,6 +676,6 @@ After discovering formats:
 
 ## Learn More
 
-- [Format Schema](https://adcontextprotocol.org/schemas/latest/core/format.json) - Complete format structure
+- [Format Schema](https://adcontextprotocol.org/schemas/v3/core/format.json) - Complete format structure
 - [Asset Types](/docs/creative/asset-types) - Asset specification details
 - [Standard Formats](/docs/media-buy/capability-discovery/implementing-standard-formats) - IAB-compatible reference formats

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -26,7 +26,7 @@ Implemented by any agent that hosts a creative library — creative agents (ad s
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
-**Schema**: [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json)
+**Schema**: [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-request.json)
 
 ### Core parameters
 
@@ -114,7 +114,7 @@ Control result set size with cursor-based pagination:
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
-**Schema**: [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json)
+**Schema**: [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-response.json)
 
 The response provides creative data with optional enrichment:
 

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -7,8 +7,8 @@ description: "preview_creative generates visual previews of ad creative manifest
 
 Generate preview renderings of creative manifests. Supports both single creative preview and batch preview (5-10x faster for multiple creatives).
 
-**Request Schema**: [`/schemas/latest/creative/preview-creative-request.json`](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-request.json)
-**Response Schema**: [`/schemas/latest/creative/preview-creative-response.json`](https://adcontextprotocol.org/schemas/latest/creative/preview-creative-response.json)
+**Request Schema**: [`/schemas/v3/creative/preview-creative-request.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-request.json)
+**Response Schema**: [`/schemas/v3/creative/preview-creative-response.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-response.json)
 
 ## Quick Start
 

--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -12,8 +12,8 @@ Upload and manage creative assets in a creative library. Supports bulk uploads, 
 
 {/* Using latest because these schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
-**Request Schema**: [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json)
-**Response Schema**: [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json)
+**Request Schema**: [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json)
+**Response Schema**: [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-response.json)
 
 ## Quick start
 
@@ -202,11 +202,11 @@ The final per-creative `creatives` array lands on the task completion artifact, 
 - All request fields
 - `platform_id` - Platform's internal ID (when `action` is not `failed`)
 - `action` - Lifecycle operation performed by this sync: `created`, `updated`, `unchanged`, `failed`, `deleted`
-- `status` - **Advisory** review-lifecycle state ([`CreativeStatus`](https://adcontextprotocol.org/schemas/latest/enums/creative-status.json)): `processing`, `pending_review`, `approved`, `rejected`, `archived`. A UI hint and polling-scheduling signal — **not** a spend-authorization gate. Orthogonal to `action` — `action` describes what the sync did, `status` describes where the creative is in the review lifecycle. Values come from `CreativeStatus` only, never from `CreativeAction` (never put `created`/`updated`/`failed` in `status`). Sellers with async review return `processing` or `pending_review`; sellers with synchronous review MAY return a terminal value (`approved`/`rejected`). **Buyers MUST NOT gate downstream spend or package activation on `status: approved` from this response** — reconcile via `list_creatives` or a signed review webhook before committing spend. Authoritative state is always via `list_creatives`. **MUST be omitted** when `action` is `failed` or `deleted` — failed items have no meaningful review state (see `errors`); deleted items are gone from the library. The schema enforces the omission rule via a conditional constraint.
+- `status` - **Advisory** review-lifecycle state ([`CreativeStatus`](https://adcontextprotocol.org/schemas/v3/enums/creative-status.json)): `processing`, `pending_review`, `approved`, `rejected`, `archived`. A UI hint and polling-scheduling signal — **not** a spend-authorization gate. Orthogonal to `action` — `action` describes what the sync did, `status` describes where the creative is in the review lifecycle. Values come from `CreativeStatus` only, never from `CreativeAction` (never put `created`/`updated`/`failed` in `status`). Sellers with async review return `processing` or `pending_review`; sellers with synchronous review MAY return a terminal value (`approved`/`rejected`). **Buyers MUST NOT gate downstream spend or package activation on `status: approved` from this response** — reconcile via `list_creatives` or a signed review webhook before committing spend. Authoritative state is always via `list_creatives`. **MUST be omitted** when `action` is `failed` or `deleted` — failed items have no meaningful review state (see `errors`); deleted items are gone from the library. The schema enforces the omission rule via a conditional constraint.
 - `errors` - Array of error messages (only when `action: "failed"`)
 - `warnings` - Array of non-fatal warnings (optional)
 
-**See schema for complete field list**: [sync-creatives-response.json](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json)
+**See schema for complete field list**: [sync-creatives-response.json](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-response.json)
 
 ## Common scenarios
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -94,7 +94,7 @@ Three pillars support the mission: [open standards](https://docs.adcontextprotoc
 </Accordion>
 
 <Accordion title="Is AdCP free and open to implement?">
-Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). There is no cost to use, implement, or license the protocol, and no permission required. The specification, [JSON schemas](https://adcontextprotocol.org/schemas/latest/), and documentation are freely available — no fee, no license agreement, no membership requirement.
+Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). There is no cost to use, implement, or license the protocol, and no permission required. The specification, [JSON schemas](https://adcontextprotocol.org/schemas/v3/), and documentation are freely available — no fee, no license agreement, no membership requirement.
 </Accordion>
 
 <Accordion title="How mature is the protocol?">
@@ -144,7 +144,7 @@ As of April 2026:
 | **Maturity** | Emerging framework across multiple sub-initiatives | 3.0 GA (released April 2026) |
 | **Scope** | Umbrella for multiple agentic initiatives | Single specification covering media buying, creative, signals, brand governance, and execution (TMP) |
 | **Governance verification** | Being defined | Signed governance context with 15-step verification (Layer 4 of the [security model](/docs/building/understanding/security-model)) |
-| **Public schemas** | Being defined | [Published](https://adcontextprotocol.org/schemas/latest/), Apache 2.0 |
+| **Public schemas** | Being defined | [Published](https://adcontextprotocol.org/schemas/v3/), Apache 2.0 |
 
 We do not yet publish a formal technical comparison because AAMP is still defining its normative surface. Implementers interested in both should watch both specifications as they stabilize.
 </Accordion>
@@ -313,7 +313,7 @@ Read the [introduction](/docs/intro) for an overview, then explore the domain th
 - **Data providers**: Start with [signals](/docs/signals/overview) to make audiences addressable by agents
 - **Orchestrators and agencies**: Start with the [integration guide](/docs/building/integration) to connect to existing AdCP agents
 
-JSON schemas for all tasks are available at [adcontextprotocol.org/schemas](https://adcontextprotocol.org/schemas/latest/).
+JSON schemas for all tasks are available at [adcontextprotocol.org/schemas](https://adcontextprotocol.org/schemas/v3/).
 </Accordion>
 
 <Accordion title="Is this for individual practitioners, or just businesses and engineers?">

--- a/docs/governance/collection/tasks/collection_lists.mdx
+++ b/docs/governance/collection/tasks/collection_lists.mdx
@@ -108,7 +108,7 @@ Create a new collection list on a governance agent.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/create-collection-list-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/create-collection-list-request.json",
   "idempotency_key": "c5d6e7f8-a9b0-4123-c456-123456789012",
   "name": "Nova Motors CTV Do Not Air — 2026",
   "description": "Programs excluded from Nova Motors CTV advertising",
@@ -144,7 +144,7 @@ Create a new collection list on a governance agent.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/create-collection-list-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/create-collection-list-response.json",
   "list": {
     "list_id": "cl_novamotors_dna_2026",
     "name": "Nova Motors CTV Do Not Air — 2026",
@@ -166,7 +166,7 @@ Retrieve a collection list with resolved collections. Sellers call this to fetch
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/get-collection-list-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/get-collection-list-request.json",
   "list_id": "cl_novamotors_dna_2026",
   "resolve": true,
   "pagination": {
@@ -179,7 +179,7 @@ Retrieve a collection list with resolved collections. Sellers call this to fetch
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/get-collection-list-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/get-collection-list-response.json",
   "list": {
     "list_id": "cl_novamotors_dna_2026",
     "name": "Nova Motors CTV Do Not Air — 2026",
@@ -219,7 +219,7 @@ Modify an existing collection list. `base_collections` and `filters` are complet
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/update-collection-list-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/update-collection-list-request.json",
   "idempotency_key": "d6e7f8a9-b0c1-4234-d567-234567890123",
   "list_id": "cl_novamotors_dna_2026",
   "base_collections": [
@@ -247,7 +247,7 @@ List collection lists for an account. Returns metadata only, not resolved collec
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/list-collection-lists-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/list-collection-lists-request.json",
   "account": { "brand": { "domain": "novamotors.com" }, "operator": "pinnacleagency.com" },
   "pagination": { "max_results": 50 }
 }
@@ -259,7 +259,7 @@ Remove a collection list. Sellers with cached copies will stop receiving webhook
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/delete-collection-list-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/delete-collection-list-request.json",
   "idempotency_key": "e7f8a9b0-c1d2-4345-e678-345678901234",
   "list_id": "cl_novamotors_dna_2026"
 }
@@ -294,7 +294,7 @@ Live sports is one of the largest CTV brand safety concerns. Collection lists ha
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/collection/create-collection-list-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/collection/create-collection-list-request.json",
   "idempotency_key": "f8a9b0c1-d2e3-4456-f789-456789012345",
   "name": "Acme Outdoor — Excluded Sports Events",
   "base_collections": [

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -24,7 +24,7 @@ Artifacts are identified by `property_id` + `artifact_id` - the property defines
 
 ## Structure
 
-**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json)
+**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json)
 
 Web article:
 

--- a/docs/governance/content-standards/tasks/calibrate_content.mdx
+++ b/docs/governance/content-standards/tasks/calibrate_content.mdx
@@ -19,7 +19,7 @@ Unlike high-volume runtime evaluation, calibration is a **dialogue-based process
 
 ## Request
 
-**Schema**: [calibrate-content-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/calibrate-content-request.json)
+**Schema**: [calibrate-content-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/calibrate-content-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -28,7 +28,7 @@ Unlike high-volume runtime evaluation, calibration is a **dialogue-based process
 
 ### Artifact
 
-**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json)
+**Schema**: [artifact.json](https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json)
 
 An artifact represents content context where ad placements occur - identified by `property_rid` + `artifact_id` and represented as a collection of assets:
 
@@ -48,7 +48,7 @@ An artifact represents content context where ad placements occur - identified by
 
 ## Response
 
-**Schema**: [calibrate-content-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/calibrate-content-response.json)
+**Schema**: [calibrate-content-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/calibrate-content-response.json)
 
 ### Passing Response
 

--- a/docs/governance/content-standards/tasks/create_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/create_content_standards.mdx
@@ -12,7 +12,7 @@ Create a new content standards configuration.
 
 ## Request
 
-**Schema**: [create-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/create-content-standards-request.json)
+**Schema**: [create-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/create-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -80,7 +80,7 @@ Implementors MUST apply a brand safety floor regardless of what policy is define
 
 ## Response
 
-**Schema**: [create-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/create-content-standards-response.json)
+**Schema**: [create-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/create-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/get_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/get_content_standards.mdx
@@ -10,7 +10,7 @@ Retrieve content safety policies for a specific standards configuration.
 
 ## Request
 
-**Schema**: [get-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-content-standards-request.json)
+**Schema**: [get-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -18,7 +18,7 @@ Retrieve content safety policies for a specific standards configuration.
 
 ## Response
 
-**Schema**: [get-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-content-standards-response.json)
+**Schema**: [get-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
+++ b/docs/governance/content-standards/tasks/get_media_buy_artifacts.mdx
@@ -28,7 +28,7 @@ The buyer retrieves artifacts the seller has collected per the sampling configur
 
 ## Request
 
-**Schema**: [get-media-buy-artifacts-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-media-buy-artifacts-request.json)
+**Schema**: [get-media-buy-artifacts-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-media-buy-artifacts-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -54,7 +54,7 @@ Uses higher limits than standard pagination because artifact result sets can be 
 
 ## Response
 
-**Schema**: [get-media-buy-artifacts-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/get-media-buy-artifacts-response.json)
+**Schema**: [get-media-buy-artifacts-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/get-media-buy-artifacts-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/list_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/list_content_standards.mdx
@@ -12,7 +12,7 @@ List available content standards configurations.
 
 ## Request
 
-**Schema**: [list-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/list-content-standards-request.json)
+**Schema**: [list-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/list-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -23,7 +23,7 @@ List available content standards configurations.
 
 ## Response
 
-**Schema**: [list-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/list-content-standards-response.json)
+**Schema**: [list-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/list-content-standards-response.json)
 
 Returns an abbreviated list of standards configurations. Use [get_content_standards](./get_content_standards) to retrieve full details including policy text and calibration data.
 

--- a/docs/governance/content-standards/tasks/update_content_standards.mdx
+++ b/docs/governance/content-standards/tasks/update_content_standards.mdx
@@ -12,7 +12,7 @@ Update an existing content standards configuration. Creates a new version.
 
 ## Request
 
-**Schema**: [update-content-standards-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/update-content-standards-request.json)
+**Schema**: [update-content-standards-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/update-content-standards-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -70,7 +70,7 @@ Update an existing content standards configuration. Creates a new version.
 
 ## Response
 
-**Schema**: [update-content-standards-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/update-content-standards-response.json)
+**Schema**: [update-content-standards-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/update-content-standards-response.json)
 
 ### Success Response
 

--- a/docs/governance/content-standards/tasks/validate_content_delivery.mdx
+++ b/docs/governance/content-standards/tasks/validate_content_delivery.mdx
@@ -37,7 +37,7 @@ This keeps responsibilities clear: sellers provide content samples via `get_medi
 
 ## Request
 
-**Schema**: [validate-content-delivery-request.json](https://adcontextprotocol.org/schemas/latest/content-standards/validate-content-delivery-request.json)
+**Schema**: [validate-content-delivery-request.json](https://adcontextprotocol.org/schemas/v3/content-standards/validate-content-delivery-request.json)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -81,7 +81,7 @@ This keeps responsibilities clear: sellers provide content samples via `get_medi
 
 ## Response
 
-**Schema**: [validate-content-delivery-response.json](https://adcontextprotocol.org/schemas/latest/content-standards/validate-content-delivery-response.json)
+**Schema**: [validate-content-delivery-response.json](https://adcontextprotocol.org/schemas/v3/content-standards/validate-content-delivery-response.json)
 
 ### Success Response
 

--- a/docs/governance/policy-registry.mdx
+++ b/docs/governance/policy-registry.mdx
@@ -70,7 +70,7 @@ Governance agents are LLMs that interpret natural language policy text -- the sa
 
 ## Policy structure
 
-Each policy in the registry follows the [policy-entry schema](https://adcontextprotocol.org/schemas/latest/governance/policy-entry.json):
+Each policy in the registry follows the [policy-entry schema](https://adcontextprotocol.org/schemas/v3/governance/policy-entry.json):
 
 ```json
 {

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -95,7 +95,7 @@ The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Example Publisher Ad Operations",
     "email": "adops@example.com",
@@ -199,7 +199,7 @@ For publishers with complex infrastructure or CDN distribution, `adagents.json` 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "authoritative_location": "https://cdn.example.com/adagents/v2/adagents.json",
   "last_updated": "2025-01-15T10:00:00Z"
 }
@@ -221,7 +221,7 @@ A publisher with multiple domains can maintain one authoritative file:
 **On each domain** (`https://domain1.com/.well-known/adagents.json`, `https://domain2.com/.well-known/adagents.json`, etc.):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "authoritative_location": "https://cdn.publisher.com/adagents/v2/adagents.json",
   "last_updated": "2025-01-15T10:00:00Z"
 }
@@ -230,7 +230,7 @@ A publisher with multiple domains can maintain one authoritative file:
 **Authoritative file** (`https://cdn.publisher.com/adagents/v2/adagents.json`):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Publisher Ad Operations",
     "email": "adops@publisher.com"
@@ -733,7 +733,7 @@ Publishers can declare which governance agents have data about their properties 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Premium News Publisher",
     "email": "adops@news.example.com",
@@ -1013,5 +1013,5 @@ After implementing adagents.json validation:
 
 - [AdCP Basics: Authorized Properties](https://bokonads.com/p/adcp-basics-authorized-properties) - Accessible introduction to AdCP authorization
 - [get_adcp_capabilities](/docs/protocol/get_adcp_capabilities) - Discover agent capabilities and portfolio
-- [Property Schema](https://adcontextprotocol.org/schemas/latest/core/property.json) - Property definition structure
+- [Property Schema](https://adcontextprotocol.org/schemas/v3/core/property.json) - Property definition structure
 - [AdAgents.json Builder](https://agenticadvertising.org/adagents/builder) - Web-based validator and creator

--- a/docs/governance/property/authorized-properties.mdx
+++ b/docs/governance/property/authorized-properties.mdx
@@ -46,7 +46,7 @@ Publishers authorize sales agents by hosting an `adagents.json` file at `/.well-
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Sports Network Media",
     "email": "adops@sportsnetwork.com",
@@ -276,5 +276,5 @@ See the **[adagents.json Tech Spec](./adagents)** for complete implementation gu
 
 - **[`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities)** - Discover agent capabilities and portfolio information
 - **[Product Discovery](../../media-buy/product-discovery/)** - How authorization integrates with product discovery
-- **[Properties Schema](https://adcontextprotocol.org/schemas/latest/core/property.json)** - Technical property data model
+- **[Properties Schema](https://adcontextprotocol.org/schemas/v3/core/property.json)** - Technical property data model
 - **[adagents.json Tech Spec](./adagents)** - Complete `adagents.json` implementation guide

--- a/docs/governance/property/index.mdx
+++ b/docs/governance/property/index.mdx
@@ -32,7 +32,7 @@ Publishers declare their properties, authorize sales agents, and reference gover
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "properties": [
     {
       "property_id": "example_site",

--- a/docs/governance/property/managed-networks.mdx
+++ b/docs/governance/property/managed-networks.mdx
@@ -31,7 +31,7 @@ Each managed domain hosts a minimal pointer file at `/.well-known/adagents.json`
 **Pointer file** (on each domain):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
   "last_updated": "2025-06-01T00:00:00Z"
 }
@@ -42,7 +42,7 @@ The `last_updated` timestamp in the pointer file reflects when the pointer itsel
 **Authoritative file** (at the network):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Example Network Ad Operations",
     "email": "adops@network.example.com",
@@ -338,7 +338,7 @@ export default {
     const url = new URL(request.url);
     if (url.pathname === '/.well-known/adagents.json') {
       return new Response(JSON.stringify({
-        "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+        "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
         "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
         "last_updated": "2025-06-01T00:00:00Z"
       }), {
@@ -367,7 +367,7 @@ function handler(event) {
         'access-control-allow-origin': { value: '*' }
       },
       body: JSON.stringify({
-        "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+        "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
         "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
         "last_updated": "2025-06-01T00:00:00Z"
       })
@@ -389,7 +389,7 @@ add_action('init', function () {
         header('Content-Type: application/json');
         header('Cache-Control: public, max-age=86400');
         echo json_encode([
-            '$schema' => 'https://adcontextprotocol.org/schemas/latest/adagents.json',
+            '$schema' => 'https://adcontextprotocol.org/schemas/v3/adagents.json',
             'authoritative_location' => 'https://network.example.com/adagents/v2/adagents.json',
             'last_updated' => '2025-06-01T00:00:00Z',
         ]);
@@ -426,7 +426,7 @@ jobs:
             mkdir -p "dist/${domain}/.well-known"
             cat > "dist/${domain}/.well-known/adagents.json" <<EOF
           {
-            "\$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+            "\$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
             "authoritative_location": "https://network.example.com/adagents/v2/adagents.json",
             "last_updated": "${TIMESTAMP}"
           }

--- a/docs/governance/property/specification.mdx
+++ b/docs/governance/property/specification.mdx
@@ -202,7 +202,7 @@ Create a new property list with filters and optional brand reference.
 - **`identifiers`**: `{ "selection_type": "identifiers", "identifiers": [...] }` - no publisher context needed
 - **Omitted**: Query the agent's entire property database
 
-See the [base-property-source schema](https://adcontextprotocol.org/schemas/latest/property/base-property-source.json) for the full specification.
+See the [base-property-source schema](https://adcontextprotocol.org/schemas/v3/property/base-property-source.json) for the full specification.
 
 **Filter Logic** (explicit in field names):
 - `countries_all`: Property must have feature data for **ALL** listed countries

--- a/docs/governance/property/tasks/property_lists.mdx
+++ b/docs/governance/property/tasks/property_lists.mdx
@@ -112,7 +112,7 @@ The agent resolves the brand identity and applies rules based on its domain expe
 - A brand safety agent infers content categories from the brand's industry
 - A sustainability agent applies requirements from the brand's profile
 
-The brand reference uses the standard [core/brand-ref](https://adcontextprotocol.org/schemas/latest/core/brand-ref.json) schema. The governance agent resolves the domain to discover the brand's identity via its `brand.json` file.
+The brand reference uses the standard [core/brand-ref](https://adcontextprotocol.org/schemas/v3/core/brand-ref.json) schema. The governance agent resolves the domain to discover the brand's identity via its `brand.json` file.
 
 ## Webhooks
 
@@ -277,7 +277,7 @@ Each entry must include `selection_type`:
 
 If `base_properties` is omitted, the agent queries its entire property database for properties matching the filters.
 
-See the [base-property-source schema](https://adcontextprotocol.org/schemas/latest/property/base-property-source.json) for the full specification.
+See the [base-property-source schema](https://adcontextprotocol.org/schemas/v3/property/base-property-source.json) for the full specification.
 
 ---
 

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -90,7 +90,7 @@ AdCP standardizes this with the accounts protocol. Sam, Alex's media buyer, sets
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/account/sync-accounts-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/account/sync-accounts-request.json",
   "idempotency_key": "f6c0a3d4-2345-48b1-2345-6789012345ab",
   "accounts": [
     {
@@ -122,7 +122,7 @@ With AdCP, `get_products` sends the same brief to every connected seller. Sam de
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json",
   "buying_mode": "brief",
   "brief": "Premium sports video inventory, Q2 2026, targeting 25-45 males interested in outdoor recreation. Budget $50K across CTV and display.",
   "brand": { "domain": "acmeoutdoor.com" }
@@ -164,7 +164,7 @@ But Sam isn't done. He likes StreamHaus's sports package but wants to shift budg
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json",
   "buying_mode": "refine",
   "refine": [
     {
@@ -199,7 +199,7 @@ First, Maya discovers what each seller accepts:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/list-creative-formats-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-request.json",
   "type": "video"
 }
 ```
@@ -210,7 +210,7 @@ Then Maya briefs the creative agent. One brief produces all formats:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/build-creative-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/build-creative-request.json",
   "idempotency_key": "c1d2e3f4-a5b6-4789-c012-789012345678",
   "message": "Adventurous, aspirational summer campaign — gear for people who live outside",
   "brand": { "domain": "acmeoutdoor.com" },
@@ -229,7 +229,7 @@ Once approved, `sync_creatives` distributes the finished assets to every seller 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json",
   "idempotency_key": "d2e3f4a5-b6c7-4890-d123-890123456789",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "creatives": [
@@ -259,7 +259,7 @@ Sam has products, creatives, and accounts. Time to buy. One call to `create_medi
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json",
   "idempotency_key": "e3f4a5b6-c7d8-4901-e234-901234567890",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "brand": { "domain": "acmeoutdoor.com" },
@@ -305,7 +305,7 @@ Sam's campaign needs targeting beyond what the sellers provide. His client has C
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-request.json",
   "idempotency_key": "a7d1b4e5-3456-48c2-3456-789012345abc",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "audiences": [
@@ -322,7 +322,7 @@ Sam's campaign needs targeting beyond what the sellers provide. His client has C
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json",
   "signal_spec": "Outdoor recreation enthusiasts near sporting goods retailers, 25-45"
 }
 ```
@@ -331,7 +331,7 @@ Kai's Meridian Geo returns matching signal segments with pricing, coverage, and 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
   "idempotency_key": "f4a5b6c7-d8e9-4012-f345-012345678901",
   "signal_agent_segment_id": "meridian_outdoor_rec_25_45",
   "destinations": [
@@ -358,7 +358,7 @@ Before any of Sam's campaigns go live, they pass through governance. Jordan, Pin
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/governance/check-governance-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/governance/check-governance-request.json",
   "plan_id": "acme_outdoor_q2_plan",
   "caller": "https://buyer.pinnacle-agency.com/a2a",
   "tool": "create_media_buy",
@@ -436,7 +436,7 @@ For deeper performance tracking, AdCP provides two more tools:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json",
   "idempotency_key": "a5b6c7d8-e9f0-4123-a456-123456789012",
   "event_source_id": "acme_website_pixel",
   "events": [
@@ -455,7 +455,7 @@ For deeper performance tracking, AdCP provides two more tools:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json",
   "idempotency_key": "b6c7d8e9-f0a1-4234-b567-234567890123",
   "media_buy_id": "mb_acme_q2_001",
   "measurement_period": {
@@ -478,7 +478,7 @@ Acme Outdoor has a Shopify store with 200 products. They want their catalog avai
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-request.json",
   "idempotency_key": "b8e2c5f6-4567-48d3-4567-89012345abcd",
   "account": { "brand": { "domain": "acmeoutdoor.com" }, "operator": "pinnacle-agency.com" },
   "catalogs": [
@@ -510,7 +510,7 @@ https://novamotors.com/.well-known/brand.json
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
   "house": {
     "domain": "novamotors.com",
     "name": "Nova Motors"

--- a/docs/media-buy/advanced-topics/pricing-models.mdx
+++ b/docs/media-buy/advanced-topics/pricing-models.mdx
@@ -163,7 +163,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_guaranteed",
   "pricing_model": "cpm",
   "fixed_price": 12.50,
@@ -188,7 +188,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/vcpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/vcpm-option.json",
   "pricing_option_id": "vcpm_usd_guaranteed",
   "pricing_model": "vcpm",
   "fixed_price": 18.50,
@@ -211,7 +211,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpcv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpcv-option.json",
   "pricing_option_id": "cpcv_usd_guaranteed",
   "pricing_model": "cpcv",
   "fixed_price": 0.15,
@@ -231,7 +231,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpv-option.json",
   "pricing_option_id": "cpv_usd_50pct",
   "pricing_model": "cpv",
   "fixed_price": 0.08,
@@ -257,7 +257,7 @@ Unlike `measurement_terms`, cancellation policy is not a negotiation surface —
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpp-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpp-option.json",
   "pricing_option_id": "cpp_usd_a18-49",
   "pricing_model": "cpp",
   "fixed_price": 250.00,
@@ -337,7 +337,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpa-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpa-option.json",
   "pricing_option_id": "cpa_usd_purchase",
   "pricing_model": "cpa",
   "event_type": "purchase",
@@ -392,7 +392,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example** (sponsorship):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
   "pricing_option_id": "flat_rate_usd_sponsorship",
   "pricing_model": "flat_rate",
   "fixed_price": 50000.00,
@@ -403,7 +403,7 @@ Buyers should verify the measurement provider meets their campaign requirements 
 **Example** (DOOH slot with parameters):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
   "pricing_option_id": "flat_rate_usd_dooh_morning",
   "pricing_model": "flat_rate",
   "fixed_price": 5000.00,
@@ -442,7 +442,7 @@ Sponsorship flat_rate options omit `parameters` — the fixed price covers the p
 **Example**:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/time-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/time-option.json",
   "pricing_option_id": "time_usd_daily",
   "pricing_model": "time",
   "fixed_price": 50000.00,

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -239,7 +239,7 @@ Use for **legal compliance** requirements:
 }
 ```
 
-**Verification methods** (defined in [`age-verification-method.json`](https://adcontextprotocol.org/schemas/latest/enums/age-verification-method.json), based on ISO/IEC 27566-1 age assurance standards):
+**Verification methods** (defined in [`age-verification-method.json`](https://adcontextprotocol.org/schemas/v3/enums/age-verification-method.json), based on ISO/IEC 27566-1 age assurance standards):
 - `facial_age_estimation` - AI-based age estimation (Yoti, etc.)
 - `id_document` - Government ID scan
 - `digital_id` - Verified digital identity credentials
@@ -260,7 +260,7 @@ Use for **technical requirements**:
 }
 ```
 
-**Available platforms** (defined in [`device-platform.json`](https://adcontextprotocol.org/schemas/latest/enums/device-platform.json), based on Sec-CH-UA-Platform standard extended for CTV):
+**Available platforms** (defined in [`device-platform.json`](https://adcontextprotocol.org/schemas/v3/enums/device-platform.json), based on Sec-CH-UA-Platform standard extended for CTV):
 - Browser: `ios`, `android`, `windows`, `macos`, `linux`, `chromeos`
 - CTV: `tvos`, `tizen`, `webos`, `fire_os`, `roku_os`
 - Other: `unknown`
@@ -287,7 +287,7 @@ Use for **performance optimization** targeting by hardware category rather than 
 }
 ```
 
-**Available types** (defined in [`device-type.json`](https://adcontextprotocol.org/schemas/latest/enums/device-type.json)):
+**Available types** (defined in [`device-type.json`](https://adcontextprotocol.org/schemas/v3/enums/device-type.json)):
 - `desktop`, `mobile`, `tablet`, `ctv`, `dooh`, `unknown`
 
 **Device type vs device platform**: `device_type` targets form factors (mobile, desktop, CTV). `device_platform` targets operating systems (iOS, Android, tvOS). Use `device_type` for performance optimization; use `device_platform` for technical compatibility.

--- a/docs/media-buy/conversion-tracking/index.mdx
+++ b/docs/media-buy/conversion-tracking/index.mdx
@@ -65,7 +65,7 @@ To discover all sources on an account (including seller-managed), call `sync_eve
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json",
   "idempotency_key": "c9f3d6a7-5678-48e4-5678-9012345abcde",
   "account": { "account_id": "acct_12345" }
 }
@@ -79,7 +79,7 @@ Send events with [`log_event`](/docs/media-buy/task-reference/log_event):
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/event.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/event.json",
   "event_id": "evt_purchase_12345",
   "event_type": "purchase",
   "event_time": "2026-01-15T14:30:00Z",
@@ -118,7 +118,7 @@ User identifiers enable the seller to attribute conversions to ad impressions. P
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/user-match.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/user-match.json",
   "hashed_email": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
   "uids": [
     { "type": "uid2", "value": "AbC123XyZ..." }
@@ -150,7 +150,7 @@ Event-specific data for attribution and reporting. For purchase events, always i
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/event-custom-data.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/event-custom-data.json",
   "value": 149.99,
   "currency": "USD",
   "order_id": "order_98765",
@@ -267,7 +267,7 @@ Sellers with native API-accessible quality scores (Snap EQS, Meta EMQ) relay the
 
 When sellers compute health from reporting data, the `evaluated_at` timestamp tells the buyer how fresh the assessment is. Assessments older than 24 hours may not reflect recent changes to tag configuration or event volume. The `detail` object is absent for these sellers — there is no native score to relay.
 
-**Schema**: [`/schemas/latest/core/event-source-health.json`](https://adcontextprotocol.org/schemas/latest/core/event-source-health.json)
+**Schema**: [`/schemas/v3/core/event-source-health.json`](https://adcontextprotocol.org/schemas/v3/core/event-source-health.json)
 
 ## Measurement readiness
 
@@ -331,7 +331,7 @@ for (const seller of sellers) {
 }
 ```
 
-**Schema**: [`/schemas/latest/core/measurement-readiness.json`](https://adcontextprotocol.org/schemas/latest/core/measurement-readiness.json)
+**Schema**: [`/schemas/v3/core/measurement-readiness.json`](https://adcontextprotocol.org/schemas/v3/core/measurement-readiness.json)
 
 ### Trust boundaries
 
@@ -341,7 +341,7 @@ The `issues[].message`, `measurement_readiness.notes`, and `detail.label` fields
 
 Optimization goals tell the seller what to optimize delivery toward. Set them on a package in [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy#campaign-with-conversion-optimization). A package accepts an array of goals — each with an optional `priority` (1 = highest). Products declare `max_optimization_goals` when they limit how many goals a package can carry (most social platforms accept only 1).
 
-**Schema**: [`/schemas/latest/core/optimization-goal.json`](https://adcontextprotocol.org/schemas/latest/core/optimization-goal.json)
+**Schema**: [`/schemas/v3/core/optimization-goal.json`](https://adcontextprotocol.org/schemas/v3/core/optimization-goal.json)
 
 There are two kinds of goals, discriminated by `kind`:
 

--- a/docs/media-buy/product-discovery/collections-and-installments.mdx
+++ b/docs/media-buy/product-discovery/collections-and-installments.mdx
@@ -61,7 +61,7 @@ A collection is a persistent content program that produces installments over tim
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/collection.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/collection.json",
   "collection_id": "pinnacle_challenge",
   "name": "The Pinnacle Challenge",
   "description": "Competition reality collection with extreme physical and mental challenges",
@@ -151,7 +151,7 @@ Buyer agents evaluate both levels: the collection baseline provides the default 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/installment.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/installment.json",
   "installment_id": "s1e03_the_wall",
   "collection_id": "pinnacle_challenge",
   "name": "The Wall",
@@ -387,7 +387,7 @@ A special is content anchored to a real-world event or occasion. The `special` o
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/collection.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/collection.json",
   "collection_id": "apex_finals_2026",
   "name": "Apex Championship Finals 2026",
   "genre": ["IAB17", "IAB17-12"],
@@ -420,7 +420,7 @@ A limited series is a bounded content run with a defined arc. Unlike ongoing ser
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/collection.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/collection.json",
   "collection_id": "ember_s3",
   "name": "The Ember",
   "description": "Award-winning drama following a chef navigating the pressure of running a top restaurant",

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -106,7 +106,7 @@ Publishers declare which pricing models they support for each product. Buyers se
 Each pricing option includes:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpcv-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpcv-option.json",
   "pricing_option_id": "cpcv_usd_guaranteed",
   "pricing_model": "cpcv",
   "fixed_price": 0.15,
@@ -118,7 +118,7 @@ Each pricing option includes:
 For auction-based pricing (no `fixed_price`), use `floor_price` for minimum bid constraints and optional `price_guidance` for percentile hints. Bid-based auction models (`cpm`, `vcpm`, `cpc`, `cpcv`, `cpv`) may also include `max_bid` as a boolean signal that `bid_price` switches from exact honored price to buyer ceiling mode:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_auction",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -171,7 +171,7 @@ For products that include outcome measurement (common in retail media):
 Defines creative requirements and restrictions:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-policy.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-policy.json",
   "co_branding": "required",
   "landing_page": "retailer_site_only",
   "templates_available": true
@@ -193,7 +193,7 @@ Products can optionally declare specific ad placements within their inventory. W
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/placement.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/placement.json",
   "placement_id": "homepage_banner",
   "name": "Homepage Banner",
   "description": "Above-the-fold banner on the homepage",

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -43,7 +43,7 @@ Sales agents MUST declare Media Buy Protocol support via `get_adcp_capabilities`
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -146,7 +146,7 @@ Packages follow the same pause/cancel pattern as media buys. Additionally:
 
 ### Creative Approval on Packages
 
-**Schema**: [`enums/creative-approval-status.json`](https://adcontextprotocol.org/schemas/latest/enums/creative-approval-status.json)
+**Schema**: [`enums/creative-approval-status.json`](https://adcontextprotocol.org/schemas/v3/enums/creative-approval-status.json)
 
 Each package tracks per-creative approval status separately from the creative's library-level status. A creative may be `approved` in the library but `rejected` on a specific package (e.g., wrong format for the placement).
 
@@ -175,7 +175,7 @@ The Media Buy Protocol defines the following tasks. See task reference pages for
 
 ### get_products
 
-**Schema**: [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json) / [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
+**Schema**: [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json) / [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
 
 **Reference**: [`get_products` task](/docs/media-buy/task-reference/get_products)
 
@@ -212,7 +212,7 @@ Each `get_products` request with `buying_mode: "refine"` is self-contained — s
 
 ### list_creative_formats
 
-**Schema**: [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) / [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json)
+**Schema**: [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) / [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json)
 
 **Reference**: [`list_creative_formats` task](/docs/creative/task-reference/list_creative_formats)
 
@@ -225,7 +225,7 @@ Discover creative format requirements and specifications.
 
 ### create_media_buy
 
-**Schema**: [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json) / [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json)
+**Schema**: [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json) / [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json)
 
 **Reference**: [`create_media_buy` task](/docs/media-buy/task-reference/create_media_buy)
 
@@ -242,7 +242,7 @@ Create a media buy from selected packages or execute a proposal.
 
 ### update_media_buy
 
-**Schema**: [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json) / [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json)
+**Schema**: [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json) / [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json)
 
 **Reference**: [`update_media_buy` task](/docs/media-buy/task-reference/update_media_buy)
 
@@ -274,7 +274,7 @@ Modify an existing media buy's budget, targeting, or settings.
 
 ### sync_catalogs
 
-**Schema**: [`media-buy/sync-catalogs-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-request.json) / [`media-buy/sync-catalogs-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-response.json)
+**Schema**: [`media-buy/sync-catalogs-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-request.json) / [`media-buy/sync-catalogs-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-response.json)
 
 **Reference**: [`sync_catalogs` task](/docs/media-buy/task-reference/sync_catalogs)
 
@@ -301,7 +301,7 @@ Synchronize catalogs (products, inventory, stores, and vertical feeds) on a sell
 
 ### get_media_buys
 
-**Schema**: [`media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buys-request.json) / [`media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buys-response.json)
+**Schema**: [`media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-request.json) / [`media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-response.json)
 
 **Reference**: [`get_media_buys` task](/docs/media-buy/task-reference/get_media_buys)
 
@@ -333,7 +333,7 @@ Sellers MAY omit actions based on business rules (e.g., omit `cancel` when contr
 
 ### get_media_buy_delivery
 
-**Schema**: [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json) / [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json)
+**Schema**: [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json) / [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
 
 **Reference**: [`get_media_buy_delivery` task](/docs/media-buy/task-reference/get_media_buy_delivery)
 
@@ -347,7 +347,7 @@ Track performance metrics and campaign delivery.
 
 ### provide_performance_feedback
 
-**Schema**: [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json) / [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json)
+**Schema**: [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json) / [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json)
 
 **Reference**: [`provide_performance_feedback` task](/docs/media-buy/task-reference/provide_performance_feedback)
 
@@ -360,7 +360,7 @@ Submit performance signals to enable publisher optimization.
 
 ### sync_event_sources
 
-**Schema**: [`media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json) / [`media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
+**Schema**: [`media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json) / [`media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
 
 **Reference**: [`sync_event_sources` task](/docs/media-buy/task-reference/sync_event_sources)
 
@@ -377,7 +377,7 @@ Configure event sources on a seller account for conversion tracking with upsert 
 
 ### log_event
 
-**Schema**: [`media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json) / [`media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-response.json)
+**Schema**: [`media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json) / [`media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-response.json)
 
 **Reference**: [`log_event` task](/docs/media-buy/task-reference/log_event)
 
@@ -395,7 +395,7 @@ Send conversion or marketing events for attribution and optimization.
 
 {/* Using latest because sync-audiences schemas are not yet released in any version.
      Update to correct version alias after the next release. */}
-**Schema**: [`media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-request.json) / [`media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-response.json)
+**Schema**: [`media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-request.json) / [`media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-response.json)
 
 **Reference**: [`sync_audiences` task](/docs/media-buy/task-reference/sync_audiences)
 
@@ -513,19 +513,19 @@ Sales agents MAY require human approval for any operation. Approval is modelled 
 
 | Schema | Description |
 |--------|-------------|
-| [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json) | get_products request |
-| [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json) | get_products response |
-| [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json) | create_media_buy request |
-| [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json) | create_media_buy response |
-| [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json) | update_media_buy request |
-| [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json) | update_media_buy response |
-| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-request.json) | list_creative_formats request |
-| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/list-creative-formats-response.json) | list_creative_formats response |
-| [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-request.json) | list_creatives request (Creative Protocol) |
-| [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/list-creatives-response.json) | list_creatives response (Creative Protocol) |
-| [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-request.json) | sync_creatives request (Creative Protocol) |
-| [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/latest/creative/sync-creatives-response.json) | sync_creatives response (Creative Protocol) |
-| [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json) | get_media_buy_delivery request |
-| [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json) | get_media_buy_delivery response |
-| [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json) | provide_performance_feedback request |
-| [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json) | provide_performance_feedback response |
+| [`media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json) | get_products request |
+| [`media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json) | get_products response |
+| [`media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json) | create_media_buy request |
+| [`media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json) | create_media_buy response |
+| [`media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json) | update_media_buy request |
+| [`media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json) | update_media_buy response |
+| [`media-buy/list-creative-formats-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-request.json) | list_creative_formats request |
+| [`media-buy/list-creative-formats-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/list-creative-formats-response.json) | list_creative_formats response |
+| [`creative/list-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-request.json) | list_creatives request (Creative Protocol) |
+| [`creative/list-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/list-creatives-response.json) | list_creatives response (Creative Protocol) |
+| [`creative/sync-creatives-request.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-request.json) | sync_creatives request (Creative Protocol) |
+| [`creative/sync-creatives-response.json`](https://adcontextprotocol.org/schemas/v3/creative/sync-creatives-response.json) | sync_creatives response (Creative Protocol) |
+| [`media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json) | get_media_buy_delivery request |
+| [`media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) | get_media_buy_delivery response |
+| [`media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json) | provide_performance_feedback request |
+| [`media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json) | provide_performance_feedback response |

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -14,8 +14,8 @@ Supports two modes:
 
 **Response Time**: Instant to days (returns `completed`, `working` < 120s, or `submitted` for hours/days)
 
-**Request Schema**: [`/schemas/latest/media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/create-media-buy-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/create-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/create-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -10,8 +10,8 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 **Response Time**: ~60 seconds (reporting query)
 
-**Request Schema**: [`/schemas/latest/media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
 
 ## Request Parameters
 
@@ -59,7 +59,7 @@ Returns delivery report with aggregated totals and per-media-buy breakdowns:
 | `by_package` | Package-level breakdowns with delivery_status, paused state, and pacing_index |
 | `daily_breakdown` | Day-by-day delivery (date, impressions, spend, conversions, conversion_value, roas, new_to_brand_rate) |
 
-See [schema](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buy-delivery-response.json) for complete field list.
+See [schema](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) for complete field list.
 
 ### Billing-grade vs best-effort numbers
 

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -10,8 +10,8 @@ Retrieve the current operational state of media buys: configuration, creative ap
 
 **Response Time**: ~1 second
 
-**Request Schema**: [`/schemas/latest/media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buys-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-media-buys-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-response.json)
 
 ## Request Parameters
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -11,8 +11,8 @@ Discover available advertising products based on campaign requirements using nat
 
 **Response Time**: ~60 seconds (AI inference with back-end systems)
 
-**Request Schema**: [`/schemas/latest/media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/get-products-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
 
 ## Quick Start
 
@@ -317,7 +317,7 @@ When the seller cannot complete all work within the `time_budget` (or due to its
 | `description` | string | Yes | Human-readable explanation of what is missing and why. |
 | `estimated_wait` | Duration | No | How much additional time would resolve this scope. |
 
-**See schema for complete field list**: [`get-products-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-products-response.json)
+**See schema for complete field list**: [`get-products-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json)
 
 ## Common Scenarios
 

--- a/docs/media-buy/task-reference/index.mdx
+++ b/docs/media-buy/task-reference/index.mdx
@@ -106,8 +106,8 @@ Upload and manage first-party CRM audiences for targeting.
 
 All tasks include JSON schema definitions for requests and responses:
 
-- **Request Schemas**: `/schemas/latest/media-buy/[task-name]-request.json`
-- **Response Schemas**: `/schemas/latest/media-buy/[task-name]-response.json`
+- **Request Schemas**: `/schemas/v3/media-buy/[task-name]-request.json`
+- **Response Schemas**: `/schemas/v3/media-buy/[task-name]-response.json`
 
 **Task Management**: For tracking async operations across all AdCP domains, see [Task Lifecycle](/docs/building/implementation/task-lifecycle).
 

--- a/docs/media-buy/task-reference/log_event.mdx
+++ b/docs/media-buy/task-reference/log_event.mdx
@@ -10,8 +10,8 @@ Send conversion or marketing events for attribution and optimization. Supports b
 
 **Response Time**: ~1s (events are queued for processing)
 
-**Request Schema**: [`/schemas/latest/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/log-event-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/log-event-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/log-event-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/log-event-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/provide_performance_feedback.mdx
+++ b/docs/media-buy/task-reference/provide_performance_feedback.mdx
@@ -9,8 +9,8 @@ Share performance outcomes with publishers to enable data-driven optimization an
 
 **Response Time**: ~5 seconds (data ingestion)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/provide-performance-feedback-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/provide-performance-feedback-response.json)
 
 ## Request Parameters
 

--- a/docs/media-buy/task-reference/sync_audiences.mdx
+++ b/docs/media-buy/task-reference/sync_audiences.mdx
@@ -12,8 +12,8 @@ Audiences are distinct from [signals](/docs/signals/): signals are third-party d
 
 **Response Time**: Upload accepted in ~1–2s. The task remains active until matching completes (1–48 hours depending on the seller). Configure `push_notification_config` to receive a webhook when the audience is ready.
 
-**Request Schema**: [`/schemas/latest/media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-audiences-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-response.json)
 
 ## Quick Start
 

--- a/docs/media-buy/task-reference/sync_catalogs.mdx
+++ b/docs/media-buy/task-reference/sync_catalogs.mdx
@@ -9,8 +9,8 @@ Manage catalog feeds on a seller account. Sync product feeds, inventory data, st
 
 **Response Time**: Instant to days (returns `completed` for small catalogs, or `submitted` for large feeds requiring platform review)
 
-**Request Schema**: [`/schemas/latest/media-buy/sync-catalogs-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/sync-catalogs-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-catalogs-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/sync-catalogs-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/sync-catalogs-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-catalogs-response.json)
 
 ## Who calls whom
 

--- a/docs/media-buy/task-reference/sync_event_sources.mdx
+++ b/docs/media-buy/task-reference/sync_event_sources.mdx
@@ -10,8 +10,8 @@ Configure event sources on a seller account for conversion tracking. Supports up
 
 **Response Time**: ~1s (synchronous configuration)
 
-**Request Schema**: [`/schemas/latest/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/sync-event-sources-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/sync-event-sources-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
 
 ## Quick Start
 
@@ -126,7 +126,7 @@ asyncio.run(main())
 - `health` - Event source health assessment (when seller supports health scoring)
 - `errors` - Per-source errors (only when `action: "failed"`)
 
-**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/latest/media-buy/sync-event-sources-response.json)
+**See schema for complete field list**: [sync-event-sources-response.json](https://adcontextprotocol.org/schemas/v3/media-buy/sync-event-sources-response.json)
 
 ### Event Source Health
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -12,8 +12,8 @@ Modify an existing media buy using PATCH semantics. Supports campaign-level and 
 
 **PATCH Semantics**: Only specified fields are updated; omitted fields remain unchanged.
 
-**Request Schema**: [`/schemas/latest/media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-request.json)
-**Response Schema**: [`/schemas/latest/media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/update-media-buy-response.json)
+**Request Schema**: [`/schemas/v3/media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json)
+**Response Schema**: [`/schemas/v3/media-buy/update-media-buy-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-response.json)
 
 ## Quick Start
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -15,8 +15,8 @@ Discover a seller's protocol support and capabilities across all AdCP protocols.
 - **Auth model** - Does this seller trust the agent directly, or must each operator authenticate independently?
 - **Detailed capabilities** - Features, execution integrations, geo targeting, portfolio
 
-**Request Schema**: [`/schemas/latest/protocol/get-adcp-capabilities-request.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-request.json)
-**Response Schema**: [`/schemas/latest/protocol/get-adcp-capabilities-response.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json)
+**Request Schema**: [`/schemas/v3/protocol/get-adcp-capabilities-request.json`](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-request.json)
+**Response Schema**: [`/schemas/v3/protocol/get-adcp-capabilities-response.json`](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json)
 
 ## Tool-Based Discovery
 
@@ -133,7 +133,7 @@ Optional specialization claims. Each entry corresponds to a narrow storyboard at
 }
 ```
 
-See the full [Compliance Catalog](/docs/building/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/latest/enums/specialism.json) for the authoritative list.
+See the full [Compliance Catalog](/docs/building/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/v3/enums/specialism.json) for the authoritative list.
 
 ### account
 

--- a/docs/reference/media-channel-taxonomy.mdx
+++ b/docs/reference/media-channel-taxonomy.mdx
@@ -579,7 +579,7 @@ The following channels do not have corresponding property types because they lac
 Channels are defined in the AdCP schema at:
 
 ```
-/schemas/latest/enums/channels.json
+/schemas/v3/enums/channels.json
 ```
 
 ```json

--- a/docs/reference/migration/attribution.mdx
+++ b/docs/reference/migration/attribution.mdx
@@ -37,7 +37,7 @@ AdCP 3.0 renames attribution window fields and replaces integer day counts with 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/attribution-window.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/attribution-window.json",
   "post_click": {
     "interval": 7,
     "unit": "days"

--- a/docs/reference/migration/audiences.mdx
+++ b/docs/reference/migration/audiences.mdx
@@ -21,7 +21,7 @@ AdCP 3.0 rc.1 promotes `external_id` from a value in the `uid-type` enum to a re
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/audience-member.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/audience-member.json",
   "external_id": "crm_user_12345",
   "hashed_email": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
   "uids": [

--- a/docs/reference/migration/brand-identity.mdx
+++ b/docs/reference/migration/brand-identity.mdx
@@ -23,7 +23,7 @@ A brand reference identifies a brand by domain and optional `brand_id`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/brand-ref.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/brand-ref.json",
   "domain": "nova-brands.com",
   "brand_id": "spark"
 }

--- a/docs/reference/migration/channels.mdx
+++ b/docs/reference/migration/channels.mdx
@@ -102,7 +102,7 @@ v3 products declare an array of channels, so a single product can span multiple 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }

--- a/docs/reference/migration/creatives.mdx
+++ b/docs/reference/migration/creatives.mdx
@@ -73,7 +73,7 @@ Replace `format_types` filters with `asset_types` (what the format needs) or `fo
 **v3 — omit `weight` for equal distribution:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-assignment.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-assignment.json",
   "creative_id": "creative_1"
 }
 ```
@@ -143,7 +143,7 @@ Each assignment object:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/creative-assignment.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/creative-assignment.json",
   "creative_id": "hero_video",
   "weight": 60,
   "placement_ids": ["homepage_hero"]

--- a/docs/reference/migration/geo-targeting.mdx
+++ b/docs/reference/migration/geo-targeting.mdx
@@ -32,7 +32,7 @@ Fields that didn't change: `geo_countries`, `geo_countries_exclude`, `geo_region
 **v3** — codes grouped by system:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
   "geo_metros": [
     { "system": "nielsen_dma", "values": ["501", "602"] }
   ]
@@ -43,7 +43,7 @@ Each entry specifies a system and the codes within that system. Multiple systems
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
   "geo_metros": [
     { "system": "nielsen_dma", "values": ["501", "602"] },
     { "system": "uk_itl2", "values": ["UKC1", "UKD3"] }
@@ -77,7 +77,7 @@ Supported systems are defined in the `metro-system.json` enum: `nielsen_dma`, `u
 **v3** — renamed to `geo_postal_areas`, codes grouped by system:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
   "geo_postal_areas": [
     { "system": "us_zip", "values": ["10001", "90210"] }
   ]
@@ -108,7 +108,7 @@ v3 adds `_exclude` variants for metro and postal targeting:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
   "geo_countries": ["US"],
   "geo_metros_exclude": [
     { "system": "nielsen_dma", "values": ["501"] }
@@ -124,7 +124,7 @@ Before sending geo targeting, buyers should verify the seller supports the reque
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [3],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -155,7 +155,7 @@ A v3 targeting overlay combining geo restrictions:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/targeting.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/targeting.json",
   "geo_countries": ["US", "CA"],
   "geo_regions": ["US-NY", "US-CA"],
   "geo_metros": [

--- a/docs/reference/migration/optimization-goals.mdx
+++ b/docs/reference/migration/optimization-goals.mdx
@@ -29,7 +29,7 @@ Every goal has a `kind` discriminator:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/optimization-goal.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/optimization-goal.json",
   "kind": "metric",
   "metric": "clicks",
   "target": {
@@ -50,7 +50,7 @@ Target types:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/optimization-goal.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/optimization-goal.json",
   "kind": "event",
   "event_sources": [
     {
@@ -83,7 +83,7 @@ Reach is a metric goal with additional fields:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/optimization-goal.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/optimization-goal.json",
   "kind": "metric",
   "metric": "reach",
   "reach_unit": "individuals",

--- a/docs/reference/migration/pricing.mdx
+++ b/docs/reference/migration/pricing.mdx
@@ -62,7 +62,7 @@ PG and Preferred Deals both use `fixed_price`. The distinction between them is i
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_fixed",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -91,7 +91,7 @@ Rename `fixed_rate` to `fixed_price`. No structural changes.
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_auction",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -113,7 +113,7 @@ The v3 `price_guidance` object contains only statistical percentiles:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/price-guidance.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/price-guidance.json",
   "p25": 8.50,
   "p50": 15.00,
   "p75": 18.00,
@@ -143,7 +143,7 @@ All fields are optional. Publishers include whichever percentiles they can provi
 **v3:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/flat-rate-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/flat-rate-option.json",
   "pricing_option_id": "dooh_times_square",
   "pricing_model": "flat_rate",
   "currency": "USD",
@@ -169,7 +169,7 @@ v3 adds an optional `min_spend_per_package` field to all pricing options:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/pricing-options/cpm-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/pricing-options/cpm-option.json",
   "pricing_option_id": "cpm_usd_premium",
   "pricing_model": "cpm",
   "currency": "USD",
@@ -214,7 +214,7 @@ v3 writers should only emit the new field names. Old field names (`fixed_rate`, 
     Verify floor enforcement works with the new field location.
   </Step>
   <Step title="Validate against schemas">
-    Each pricing model has its own schema in `/schemas/latest/pricing-options/`.
+    Each pricing model has its own schema in `/schemas/v3/pricing-options/`.
   </Step>
 </Steps>
 

--- a/docs/reference/migration/signals.mdx
+++ b/docs/reference/migration/signals.mdx
@@ -59,7 +59,7 @@ The legacy `pricing` object (with a single `cpm` field) is replaced by a `pricin
 **CPM** — Fixed cost per thousand impressions:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/signal-pricing-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/signal-pricing-option.json",
   "pricing_option_id": "po_auto_cpm",
   "model": "cpm",
   "cpm": 2.50,
@@ -70,7 +70,7 @@ The legacy `pricing` object (with a single `cpm` field) is replaced by a `pricin
 **Percent of media** — Percentage of media spend, with optional CPM cap:
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/signal-pricing-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/signal-pricing-option.json",
   "pricing_option_id": "po_auto_pom",
   "model": "percent_of_media",
   "percent": 15,
@@ -82,7 +82,7 @@ The legacy `pricing` object (with a single `cpm` field) is replaced by a `pricin
 **Flat fee** — Fixed charge per reporting period (monthly licensed segments):
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/core/signal-pricing-option.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/signal-pricing-option.json",
   "pricing_option_id": "po_auto_flat",
   "model": "flat_fee",
   "amount": 10000.00,
@@ -120,7 +120,7 @@ When activating a signal, pass the selected `pricing_option_id`:
 **rc.1 usage report:**
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/account/report-usage-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/account/report-usage-request.json",
   "idempotency_key": "550e8400-e29b-41d4-a716-446655440000",
   "reporting_period": {
     "start": "2025-03-01T00:00:00Z",

--- a/docs/signals/data-providers.mdx
+++ b/docs/signals/data-providers.mdx
@@ -66,7 +66,7 @@ Following [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) well-known U
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Pinnacle Auto Data",
     "email": "partnerships@pinnacle-auto-data.com",
@@ -339,7 +339,7 @@ A full signal catalog for an automotive data provider:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Pinnacle Auto Data",
     "email": "partnerships@pinnacle-auto-data.com",

--- a/docs/signals/ecosystem.mdx
+++ b/docs/signals/ecosystem.mdx
@@ -112,7 +112,7 @@ Every company that owns targetable data can publish a **signal catalog** via `/.
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Meridian Geo",
     "email": "partnerships@meridiangeo.example",
@@ -223,7 +223,7 @@ Your first-party purchase data (category buyers, loyalty tiers, basket value, ne
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/adagents.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/adagents.json",
   "contact": {
     "name": "Acme Marketplace",
     "email": "partnerships@acme-marketplace.example",

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -24,7 +24,7 @@ Sam's agency platform translates the brief into a `get_signals` call. No need to
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json",
   "signal_spec": "In-market EV buyers with high purchase propensity, near auto dealerships"
 }
 ```
@@ -129,7 +129,7 @@ Each activation call specifies the destination platform and account:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
   "idempotency_key": "c3d4e5f6-a7b8-4901-c234-901234567890",
   "signal_agent_segment_id": "shopgrid_new_to_brand",
   "pricing_option_id": "po_shopgrid_retail_cpm",
@@ -151,7 +151,7 @@ Sam also wants to run a sponsored article campaign through Wonderstruck, a premi
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
   "idempotency_key": "d4e5f6a7-b8c9-4012-d345-012345678901",
   "signal_agent_segment_id": "shopgrid_new_to_brand",
   "pricing_option_id": "po_shopgrid_retail_cpm",
@@ -183,7 +183,7 @@ The campaign runs. Two weeks in, display CPAs are running 40% above target while
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
   "idempotency_key": "e5f6a7b8-c9d0-4123-e456-123456789012",
   "signal_agent_segment_id": "meridian_competitor_visitors",
   "action": "deactivate",

--- a/docs/signals/specification.mdx
+++ b/docs/signals/specification.mdx
@@ -39,7 +39,7 @@ Signal agents MUST declare Signals Protocol support via `get_adcp_capabilities`:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/protocol/get-adcp-capabilities-response.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json",
   "adcp": {
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
@@ -93,7 +93,7 @@ The Signals Protocol defines two tasks. See task reference pages for complete re
 
 ### get_signals
 
-**Schema**: [`get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json) / [`get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json)
+**Schema**: [`get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json) / [`get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json)
 
 **Reference**: [`get_signals` task](/docs/signals/tasks/get_signals)
 
@@ -106,7 +106,7 @@ Discover signals matching campaign criteria.
 
 ### activate_signal
 
-**Schema**: [`activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json) / [`activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json)
+**Schema**: [`activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json) / [`activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json)
 
 **Reference**: [`activate_signal` task](/docs/signals/tasks/activate_signal)
 
@@ -194,9 +194,9 @@ The `activate_signal` request supports two destination types. The choice depends
 
 | Schema | Description |
 |--------|-------------|
-| [`signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json) | get_signals request |
-| [`signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json) | get_signals response |
-| [`signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json) | activate_signal request |
-| [`signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json) | activate_signal response |
-| [`core/deployment.json`](https://adcontextprotocol.org/schemas/latest/core/deployment.json) | Deployment target |
-| [`core/activation-key.json`](https://adcontextprotocol.org/schemas/latest/core/activation-key.json) | Activation key |
+| [`signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json) | get_signals request |
+| [`signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json) | get_signals response |
+| [`signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json) | activate_signal request |
+| [`signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json) | activate_signal response |
+| [`core/deployment.json`](https://adcontextprotocol.org/schemas/v3/core/deployment.json) | Deployment target |
+| [`core/activation-key.json`](https://adcontextprotocol.org/schemas/v3/core/activation-key.json) | Activation key |

--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -9,8 +9,8 @@ description: "activate_signal is the AdCP task for pushing audience segments to 
 
 **Response Time**: Minutes to days (asynchronous with potential human-in-the-loop)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/latest/signals/activate-signal-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json`](https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json)
 
 The `activate_signal` task handles the entire activation lifecycle, including:
 - Initiating the activation request

--- a/docs/signals/tasks/get_signals.mdx
+++ b/docs/signals/tasks/get_signals.mdx
@@ -9,8 +9,8 @@ description: "get_signals is the AdCP task for discovering audience and contextu
 
 **Response Time**: ~60 seconds (inference/RAG with back-end systems)
 
-**Request Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-request.json)
-**Response Schema**: [`https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/latest/signals/get-signals-response.json)
+**Request Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json)
+**Response Schema**: [`https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json`](https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json)
 
 The `get_signals` task returns both signal metadata and real-time deployment status across platforms, allowing agents to understand availability and guide the activation process.
 

--- a/docs/sponsored-intelligence/specification.mdx
+++ b/docs/sponsored-intelligence/specification.mdx
@@ -136,7 +136,7 @@ This enables hosts to show rich previews before session initiation.
 
 ### Session States
 
-**Schema**: [`enums/si-session-status.json`](https://adcontextprotocol.org/schemas/latest/enums/si-session-status.json)
+**Schema**: [`enums/si-session-status.json`](https://adcontextprotocol.org/schemas/v3/enums/si-session-status.json)
 
 SI sessions progress through the following states. Terminal states (`complete`, `terminated`) allow no further messages.
 
@@ -456,7 +456,7 @@ Brand agents MUST return errors in the `errors` array using the standard error s
 
 SI uses both standard AdCP error codes and SI-specific codes:
 
-**Standard AdCP error codes** (from [`enums/error-code.json`](https://adcontextprotocol.org/schemas/latest/enums/error-code.json)):
+**Standard AdCP error codes** (from [`enums/error-code.json`](https://adcontextprotocol.org/schemas/v3/enums/error-code.json)):
 
 | Code | Description |
 |------|-------------|

--- a/scripts/rewrite-dist-links.sh
+++ b/scripts/rewrite-dist-links.sh
@@ -18,6 +18,8 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
   exit 1
 fi
 
+MAJOR_VERSION="${VERSION%%.*}"
+
 DOCS_DIR="dist/docs/$VERSION"
 if [ ! -d "$DOCS_DIR" ]; then
   echo "Error: $DOCS_DIR does not exist" >&2
@@ -28,6 +30,10 @@ echo "Rewriting links in $DOCS_DIR for version $VERSION"
 
 # On macOS, sed -i requires an extension argument; on Linux it does not.
 # Use a portable approach via a temp file.
+#
+# Rewrites two families of unpinned references to the exact version:
+#   - /schemas/latest/  → /schemas/$VERSION/  (legacy; docs no longer use this)
+#   - /schemas/vN/       → /schemas/$VERSION/  (current; docs source pins to major alias)
 rewrite_file() {
   local file="$1"
   local tmp
@@ -40,6 +46,9 @@ rewrite_file() {
     -e "s|https://adcontextprotocol.org/schemas/latest/|https://adcontextprotocol.org/schemas/$VERSION/|g" \
     -e "s|](/schemas/latest/|](/schemas/$VERSION/|g" \
     -e "s|\`/schemas/latest/|\`/schemas/$VERSION/|g" \
+    -e "s|https://adcontextprotocol.org/schemas/v${MAJOR_VERSION}/|https://adcontextprotocol.org/schemas/$VERSION/|g" \
+    -e "s|](/schemas/v${MAJOR_VERSION}/|](/schemas/$VERSION/|g" \
+    -e "s|\`/schemas/v${MAJOR_VERSION}/|\`/schemas/$VERSION/|g" \
     "$file" > "$tmp"
 
   if ! diff -q "$file" "$tmp" > /dev/null 2>&1; then

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -16,33 +16,33 @@ import { logger } from '../../logger.js';
 import type { AddieTool } from '../types.js';
 import { ToolError } from '../tool-error.js';
 
-// Schema base URLs for different versions
+const SCHEMA_HOST = 'https://adcontextprotocol.org';
+
+// Schema base URLs for different versions. v3 is current; keep older aliases
+// so Addie can still answer historical questions.
 const SCHEMA_BASE_URLS: Record<string, string> = {
-  v2: 'https://adcontextprotocol.org/schemas/v2',
-  v3: 'https://adcontextprotocol.org/schemas/v3',
-  // Specific versions
-  '2.5': 'https://adcontextprotocol.org/schemas/v2.5',
-  '2.6': 'https://adcontextprotocol.org/schemas/v2.6',
-  '2.6.0': 'https://adcontextprotocol.org/schemas/2.6.0',
+  v2: `${SCHEMA_HOST}/schemas/v2`,
+  v3: `${SCHEMA_HOST}/schemas/v3`,
+  '2.5': `${SCHEMA_HOST}/schemas/v2.5`,
+  '2.6': `${SCHEMA_HOST}/schemas/v2.6`,
+  '2.6.0': `${SCHEMA_HOST}/schemas/2.6.0`,
 };
 
-// Common schemas available
-const COMMON_SCHEMAS = [
-  'core/format.json',
-  'core/product.json',
-  'core/media-buy.json',
-  'core/creative-manifest.json',
-  'core/property.json',
-  'core/targeting.json',
-  'core/pricing-option.json',
-  'enums/asset-content-type.json',
-  'enums/channels.json',
-];
+const DEFAULT_VERSION = 'v3';
 
 // Cache for fetched schemas (5 minute TTL, max 50 entries)
 const schemaCache = new Map<string, { schema: unknown; fetchedAt: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_CACHE_SIZE = 50;
+
+// Cache for the per-version schema registry (index.json). Separate from
+// schemaCache so expiration semantics match — registries are cheap and
+// refetched every 5 minutes.
+export type SchemaRegistry = {
+  paths: string[]; // flat list: ["core/product.json", "protocol/get-adcp-capabilities-response.json", ...]
+  byCategory: Map<string, string[]>; // "core" -> ["core/product.json", ...]
+};
+const registryCache = new Map<string, { registry: SchemaRegistry; fetchedAt: number }>();
 
 /**
  * Fetch a schema from the AdCP schema server
@@ -80,41 +80,189 @@ async function fetchSchema(schemaUrl: string): Promise<unknown> {
 }
 
 /**
- * Find the closest matching schema path from COMMON_SCHEMAS.
- * Returns the match if one is found, null otherwise.
+ * Walk the index.json tree and collect every `$ref` that points at a schema.
+ * Returns paths relative to the version root (e.g. "core/product.json",
+ * "protocol/get-adcp-capabilities-response.json").
+ *
+ * Uses a WeakSet to guard against cycles in case a future registry format
+ * ever includes self-referential nodes.
+ *
+ * Exported for testing.
  */
-function findClosestSchema(schemaPath: string): string | null {
-  const clean = schemaPath.replace(/^\//, '').replace(/\.json$/, '').toLowerCase();
-  // Exact match
-  if (COMMON_SCHEMAS.includes(schemaPath)) return schemaPath;
-  // Match by filename stem (e.g., "creative" matches "core/creative-manifest.json")
-  const stem = clean.split('/').pop() || clean;
-  const matches = COMMON_SCHEMAS.filter(s => {
-    const sStem = s.replace(/\.json$/, '').split('/').pop() || '';
-    return sStem === stem || sStem.startsWith(stem);
-  });
-  return matches.length === 1 ? matches[0] : null;
+export function extractRegistryPaths(index: unknown): string[] {
+  const found = new Set<string>();
+  const seen = new WeakSet<object>();
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    if (seen.has(node as object)) return;
+    seen.add(node as object);
+    const obj = node as Record<string, unknown>;
+    const ref = obj.$ref;
+    if (typeof ref === 'string') {
+      // $ref formats: "/schemas/3.0.0/core/product.json" or "/schemas/v3/core/product.json"
+      const match = ref.match(/^\/schemas\/[^/]+\/(.+\.json)$/);
+      if (match) found.add(match[1]);
+    }
+    for (const value of Object.values(obj)) visit(value);
+  };
+  visit(index);
+  return [...found].sort();
 }
 
 /**
- * Resolve and sanitize a schema path, applying fuzzy correction if needed.
- * Returns { resolved, corrected } where corrected is true if the path was auto-fixed.
+ * Fetch and cache the schema registry (index.json) for a given version alias.
  */
-function resolveSchemaPath(schemaPath: string): { resolved: string; corrected: boolean } {
-  if (COMMON_SCHEMAS.includes(schemaPath)) return { resolved: schemaPath, corrected: false };
-  const closest = findClosestSchema(schemaPath);
-  if (closest) {
-    logger.info({ requested: schemaPath, resolved: closest }, 'Auto-corrected schema path');
-    return { resolved: closest, corrected: true };
+async function fetchRegistry(version: string): Promise<SchemaRegistry> {
+  const cached = registryCache.get(version);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.registry;
   }
-  return { resolved: schemaPath, corrected: false };
+
+  const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
+  const indexUrl = `${baseUrl}/index.json`;
+  const index = await fetchSchema(indexUrl);
+  const paths = extractRegistryPaths(index);
+
+  const byCategory = new Map<string, string[]>();
+  for (const p of paths) {
+    const category = p.split('/')[0];
+    if (!byCategory.has(category)) byCategory.set(category, []);
+    byCategory.get(category)!.push(p);
+  }
+
+  const registry: SchemaRegistry = { paths, byCategory };
+  // Don't cache an empty registry — upstream likely returned malformed JSON
+  // or an index shape we don't recognize. Next call will retry instead of
+  // silently returning "no schemas" for the full TTL.
+  if (paths.length > 0) {
+    registryCache.set(version, { registry, fetchedAt: Date.now() });
+  } else {
+    logger.warn({ indexUrl }, 'Schema registry index returned zero paths; not caching');
+  }
+  return registry;
+}
+
+/**
+ * Tokenize a schema path for fuzzy matching. Splits on `/`, `-`, `_`, `.`
+ * and lowercases. "protocol/get-adcp-capabilities-response.json" →
+ * ["protocol", "get", "adcp", "capabilities", "response"].
+ */
+function tokenize(schemaPath: string): string[] {
+  return schemaPath
+    .replace(/\.json$/, '')
+    .toLowerCase()
+    .split(/[/\-_.]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Find the closest matching schema path in the registry.
+ * Strategy: exact match → same-filename match → best-overlap scoring.
+ * Only returns a match if the winner is meaningfully ahead of the runner-up,
+ * to avoid silently picking the wrong schema when the query is ambiguous.
+ *
+ * Exported for testing.
+ */
+export function findClosestSchema(schemaPath: string, registry: SchemaRegistry): string | null {
+  if (registry.paths.includes(schemaPath)) return schemaPath;
+
+  const clean = schemaPath.replace(/^\//, '');
+  const filename = clean.split('/').pop() || clean;
+
+  // Filename-only match (e.g., user omitted or guessed wrong category)
+  const filenameMatches = registry.paths.filter(p => p.endsWith('/' + filename));
+  if (filenameMatches.length === 1) return filenameMatches[0];
+
+  // Token-overlap scoring
+  const queryTokens = new Set(tokenize(clean));
+  if (queryTokens.size === 0) return null;
+
+  const scored = registry.paths.map(p => {
+    const pTokens = new Set(tokenize(p));
+    let overlap = 0;
+    for (const t of queryTokens) if (pTokens.has(t)) overlap++;
+    // Jaccard-like, but weighted toward query coverage to favor paths that
+    // contain all query tokens (e.g., "get capabilities response" fully
+    // covered by "protocol/get-adcp-capabilities-response").
+    const coverage = overlap / queryTokens.size;
+    const union = queryTokens.size + pTokens.size - overlap;
+    const jaccard = overlap / union;
+    return { path: p, score: coverage * 0.7 + jaccard * 0.3 };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  const [best, runnerUp] = scored;
+  if (!best || best.score < 0.5) return null;
+  if (runnerUp && best.score - runnerUp.score < 0.1) return null;
+  return best.path;
+}
+
+/**
+ * Format a "did you mean?" list for error messages when a schema path is wrong
+ * or unresolvable. Shows the top token-overlap candidates from the registry,
+ * or a category breakdown if we have no query signal.
+ */
+function formatCandidates(schemaPath: string, registry: SchemaRegistry | null): string {
+  if (!registry || registry.paths.length === 0) {
+    return 'Use `list_schemas` to see available schemas.';
+  }
+
+  const queryTokens = new Set(tokenize(schemaPath));
+  if (queryTokens.size === 0) {
+    return 'Use `list_schemas` to see available schemas.';
+  }
+
+  const ranked = registry.paths
+    .map(p => {
+      const pTokens = new Set(tokenize(p));
+      let overlap = 0;
+      for (const t of queryTokens) if (pTokens.has(t)) overlap++;
+      return { path: p, overlap };
+    })
+    .filter(x => x.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap)
+    .slice(0, 8);
+
+  if (ranked.length === 0) {
+    return 'Use `list_schemas` to see available schemas.';
+  }
+
+  return `Closest matches:\n${ranked.map(r => `- \`${r.path}\``).join('\n')}\n\nUse \`list_schemas\` to see the full registry.`;
+}
+
+/**
+ * Resolve a schema path, applying fuzzy correction via the registry if needed.
+ */
+async function resolveSchemaPath(
+  schemaPath: string,
+  version: string,
+): Promise<{ resolved: string; corrected: boolean; registry: SchemaRegistry | null }> {
+  let registry: SchemaRegistry | null = null;
+  try {
+    registry = await fetchRegistry(version);
+  } catch (error) {
+    // Registry fetch failed — still try the path as-is and let the schema
+    // fetch return a useful error.
+    logger.warn({ error, version }, 'Failed to fetch schema registry');
+    return { resolved: schemaPath, corrected: false, registry: null };
+  }
+
+  if (registry.paths.includes(schemaPath)) {
+    return { resolved: schemaPath, corrected: false, registry };
+  }
+  const closest = findClosestSchema(schemaPath, registry);
+  if (closest) {
+    logger.info({ requested: schemaPath, resolved: closest, version }, 'Auto-corrected schema path');
+    return { resolved: closest, corrected: true, registry };
+  }
+  return { resolved: schemaPath, corrected: false, registry };
 }
 
 /**
  * Build full schema URL from version and path
  */
 function buildSchemaUrl(version: string, schemaPath: string): string {
-  const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS['v2'];
+  const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
   // Remove leading slash and sanitize path
   let cleanPath = schemaPath.startsWith('/') ? schemaPath.slice(1) : schemaPath;
   // Prevent path traversal
@@ -210,7 +358,7 @@ export const SCHEMA_TOOLS: AddieTool[] = [
         version: {
           type: 'string',
           description:
-            'Schema version to use: "v2" (current stable), "v3" (upcoming), or specific like "2.6.0". Defaults to version in $schema or "v2".',
+            'Schema version to use: "v3" (current stable, default), "v2" (legacy), or specific like "2.6.0". Defaults to version in $schema or "v3".',
           enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
         },
       },
@@ -233,7 +381,7 @@ export const SCHEMA_TOOLS: AddieTool[] = [
         },
         version: {
           type: 'string',
-          description: 'Schema version: "v2" (current stable), "v3" (upcoming), or specific like "2.6.0"',
+          description: 'Schema version: "v3" (current stable, default), "v2" (legacy), or specific like "2.6.0"',
           enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
         },
         property: {
@@ -308,12 +456,13 @@ export function createSchemaToolHandlers(): Map<
     let schemaPath = input.schema_path as string | undefined;
     let version = input.version as string | undefined;
 
-    // Try to extract version and schema from $schema field
+    // Try to extract version and schema from $schema field. Accepts both
+    // major-alias form (`/schemas/v3/...`) and pinned-semver form
+    // (`/schemas/3.0.0/...`). The version must match a key in
+    // SCHEMA_BASE_URLS, which uses `v3` etc. — not bare `3`.
     if (jsonObj.$schema && typeof jsonObj.$schema === 'string') {
       const schemaUrl = jsonObj.$schema;
-      // Parse URL like https://adcontextprotocol.org/schemas/v2/core/format.json
-      // or https://schemas.adcontextprotocol.org/v3/format.json
-      const urlMatch = schemaUrl.match(/schemas(?:\.adcontextprotocol\.org)?\/(?:v?(\d+(?:\.\d+)?(?:\.\d+)?))\/(.+)$/);
+      const urlMatch = schemaUrl.match(/schemas(?:\.adcontextprotocol\.org)?\/(v\d+(?:\.\d+)?|\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)\/(.+)$/);
       if (urlMatch) {
         version = version || urlMatch[1];
         schemaPath = schemaPath || urlMatch[2];
@@ -324,10 +473,9 @@ export function createSchemaToolHandlers(): Map<
       return `Cannot determine schema. Please provide schema_path (e.g., "core/format.json") or include a $schema field in the JSON.`;
     }
 
-    const { resolved: resolvedPath } = resolveSchemaPath(schemaPath);
+    version = version || DEFAULT_VERSION;
+    const { resolved: resolvedPath, registry } = await resolveSchemaPath(schemaPath, version);
     schemaPath = resolvedPath;
-
-    version = version || 'v2';
     const schemaUrl = buildSchemaUrl(version, schemaPath);
 
     try {
@@ -349,16 +497,16 @@ ${errorList}
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new ToolError(`Failed to validate: ${message}
 
-Make sure the schema path is correct. Available schemas include:
-${COMMON_SCHEMAS.map((s) => `- ${s}`).join('\n')}`);
+${formatCandidates(schemaPath, registry)}`);
     }
   });
 
   handlers.set('get_schema', async (input) => {
-    const version = (input.version as string) || 'v2';
+    const version = (input.version as string) || DEFAULT_VERSION;
     const property = input.property as string | undefined;
 
-    const { resolved: schemaPath } = resolveSchemaPath(input.schema_path as string);
+    const requestedPath = input.schema_path as string;
+    const { resolved: schemaPath, registry } = await resolveSchemaPath(requestedPath, version);
     const schemaUrl = buildSchemaUrl(version, schemaPath);
 
     try {
@@ -415,47 +563,57 @@ ${truncated ? '\n**Note:** Schema truncated. Use the `property` parameter to foc
 
 **Schema URL attempted:** ${schemaUrl}
 
-Available schemas include:
-${COMMON_SCHEMAS.map((s) => `- ${s}`).join('\n')}`);
+${formatCandidates(requestedPath, registry)}`);
     }
   });
 
   handlers.set('list_schemas', async (input) => {
-    const version = (input.version as string) || 'v2';
-    const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS['v2'];
+    const version = (input.version as string) || DEFAULT_VERSION;
+    const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
+
+    let registry: SchemaRegistry | null = null;
+    try {
+      registry = await fetchRegistry(version);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new ToolError(`Failed to fetch schema registry from ${baseUrl}/index.json: ${message}`);
+    }
+
+    const categoryList = [...registry.byCategory.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([category, paths]) => {
+        const items = paths.map(p => `  - \`${p}\` → ${baseUrl}/${p}`).join('\n');
+        return `#### ${category}/ (${paths.length})\n${items}`;
+      })
+      .join('\n\n');
 
     return `## Available AdCP Schemas
 
-**Current Version:** v2 (2.6.x stable)
-**Upcoming Version:** v3 (in development)
+**Version:** ${version} (${baseUrl})
+**Total schemas:** ${registry.paths.length}
 
 ### Schema Versions
-| Version | URL | Status |
-|---------|-----|--------|
-| v2 | ${SCHEMA_BASE_URLS.v2} | Current stable |
-| v3 | ${SCHEMA_BASE_URLS.v3} | Development |
-| 2.6.0 | ${SCHEMA_BASE_URLS['2.6.0']} | Latest patch |
+| Version | URL | Notes |
+|---------|-----|-------|
+| v3 | ${SCHEMA_BASE_URLS.v3} | Current stable (3.x) |
+| v2 | ${SCHEMA_BASE_URLS.v2} | Legacy (2.x) |
 
 ### Key Differences: v2 vs v3
 ${VERSION_CHANGES['v2-to-v3'].map((change) => `- ${change}`).join('\n')}
 
-### Common Schemas (${version})
-${COMMON_SCHEMAS.map((s) => `- \`${s}\` → ${baseUrl}/${s}`).join('\n')}
+### Schemas by Category
+${categoryList}
 
-### Schema Categories
-- **core/** - Core data types (format, product, media-buy, creative-manifest, etc.)
-- **enums/** - Enumeration types (asset-content-type, channels, etc.)
-- **media-buy/** - Media buying task schemas (get-products, create-media-buy, etc.)
-- **creative/** - Creative agent task schemas
-- **signals/** - Signals agent task schemas
-
-**Tip:** Use \`get_schema\` with a schema path to see the full definition, or \`compare_schema_versions\` to see detailed differences between versions.`;
+**Tip:** Use \`get_schema\` with any path above to see the full definition, or \`compare_schema_versions\` to see detailed differences between versions.`;
   });
 
   handlers.set('compare_schema_versions', async (input) => {
-    const { resolved: schemaPath } = resolveSchemaPath(input.schema_path as string);
     const fromVersion = (input.from_version as string) || 'v2';
     const toVersion = (input.to_version as string) || 'v3';
+    const requestedPath = input.schema_path as string;
+    // Resolve against the "to" version's registry — that's where we most
+    // want the path to exist, and the registry also contains legacy schemas.
+    const { resolved: schemaPath, registry } = await resolveSchemaPath(requestedPath, toVersion);
 
     const fromUrl = buildSchemaUrl(fromVersion, schemaPath);
     const toUrl = buildSchemaUrl(toVersion, schemaPath);
@@ -474,8 +632,7 @@ Attempted URLs:
 - ${fromUrl}
 - ${toUrl}
 
-Available schemas include:
-${COMMON_SCHEMAS.map((s) => `- ${s}`).join('\n')}`;
+${formatCandidates(requestedPath, registry)}`;
       }
 
       // Build comparison report

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractRegistryPaths,
+  findClosestSchema,
+  type SchemaRegistry,
+} from '../../../src/addie/mcp/schema-tools.js';
+
+// Minimal index.json fixture mirroring the shape served at
+// /schemas/v3/index.json. Covers every ref format we care about.
+const indexFixture = {
+  schemas: {
+    core: {
+      schemas: {
+        product: { $ref: '/schemas/3.0.0/core/product.json' },
+        'media-buy': { $ref: '/schemas/3.0.0/core/media-buy.json' },
+        format: { $ref: '/schemas/v3/core/format.json' },
+      },
+    },
+    protocol: {
+      tasks: {
+        'get-adcp-capabilities': {
+          request: { $ref: '/schemas/3.0.0/protocol/get-adcp-capabilities-request.json' },
+          response: { $ref: '/schemas/3.0.0/protocol/get-adcp-capabilities-response.json' },
+        },
+      },
+    },
+    'media-buy': {
+      tasks: {
+        'create-media-buy': {
+          request: { $ref: '/schemas/3.0.0/media-buy/create-media-buy-request.json' },
+          response: { $ref: '/schemas/3.0.0/media-buy/create-media-buy-response.json' },
+        },
+      },
+    },
+  },
+};
+
+function registryFrom(index: unknown): SchemaRegistry {
+  const paths = extractRegistryPaths(index);
+  const byCategory = new Map<string, string[]>();
+  for (const p of paths) {
+    const cat = p.split('/')[0];
+    if (!byCategory.has(cat)) byCategory.set(cat, []);
+    byCategory.get(cat)!.push(p);
+  }
+  return { paths, byCategory };
+}
+
+describe('extractRegistryPaths', () => {
+  it('walks nested $ref structures and normalizes to version-relative paths', () => {
+    const paths = extractRegistryPaths(indexFixture);
+    expect(paths).toContain('core/product.json');
+    expect(paths).toContain('protocol/get-adcp-capabilities-response.json');
+    expect(paths).toContain('media-buy/create-media-buy-request.json');
+  });
+
+  it('handles both pinned-semver and alias $ref prefixes', () => {
+    const paths = extractRegistryPaths(indexFixture);
+    // /schemas/3.0.0/core/format.json and /schemas/v3/core/format.json
+    // both normalize to "core/format.json" — deduped.
+    expect(paths.filter(p => p === 'core/format.json')).toHaveLength(1);
+  });
+
+  it('returns empty list for empty or malformed input', () => {
+    expect(extractRegistryPaths(null)).toEqual([]);
+    expect(extractRegistryPaths({})).toEqual([]);
+    expect(extractRegistryPaths({ schemas: { core: {} } })).toEqual([]);
+  });
+
+  it('handles cycles without stack overflow', () => {
+    type Cyclic = { self?: Cyclic; $ref?: string };
+    const cyclic: Cyclic = { $ref: '/schemas/v3/core/product.json' };
+    cyclic.self = cyclic;
+    expect(extractRegistryPaths(cyclic)).toEqual(['core/product.json']);
+  });
+});
+
+describe('findClosestSchema', () => {
+  const registry = registryFrom(indexFixture);
+
+  it('returns exact match when path is valid', () => {
+    expect(findClosestSchema('core/product.json', registry)).toBe('core/product.json');
+  });
+
+  it('corrects the category when filename is unique', () => {
+    // User guessed "core/" but capabilities lives in "protocol/"
+    expect(
+      findClosestSchema('core/get-adcp-capabilities-response.json', registry),
+    ).toBe('protocol/get-adcp-capabilities-response.json');
+  });
+
+  it('auto-corrects the exact bug from the Addie 404 report', () => {
+    // This is the failure mode that triggered the fix: Addie tried
+    // "core/get-capabilities-response.json" (wrong category, missing "adcp"
+    // in the name). Token overlap should still surface the right schema.
+    const resolved = findClosestSchema('core/get-capabilities-response.json', registry);
+    expect(resolved).toBe('protocol/get-adcp-capabilities-response.json');
+  });
+
+  it('returns null when the query has no meaningful overlap', () => {
+    expect(findClosestSchema('completely/unrelated-thing.json', registry)).toBeNull();
+  });
+
+  it('returns null when multiple candidates tie too closely', () => {
+    // "create-media-buy" is ambiguous between request and response variants.
+    // Both score identically, so we should bail rather than silently pick one.
+    const resolved = findClosestSchema('media-buy/create-media-buy.json', registry);
+    expect(resolved).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two related schema-link bugs in one PR:

### 1. Addie 404s on schema lookup

Addie (MCP agent) had a hardcoded 9-item schema list in `server/src/addie/mcp/schema-tools.ts`. When the LLM guessed `core/get-capabilities-response.json`, fuzzy-match had nothing useful to match against and returned 404 — the real path is `protocol/get-adcp-capabilities-response.json`.

Now: the tool fetches `/schemas/{version}/index.json` from adcontextprotocol.org on first use (5-min cache), walks `$ref`s to extract every schema path (358 in live v3), and fuzzy-matches with token-overlap scoring. Error messages list "Closest matches" sourced from the live registry.

Live end-to-end verified: the exact bug case now resolves correctly and the resolved URL returns HTTP 200 from production.

### 2. Docs linked to `/schemas/latest/` instead of pinning

432 references across 89 docs files pointed at `latest`, which floats onto whatever is in dev. When v4 work begins, every v3 doc link would silently start serving v4 schemas. Mass-replaced with `/schemas/v3/`.

Also updated `scripts/rewrite-dist-links.sh` to pin major-version aliases to the exact release on dist snapshot (previously only rewrote `latest`), and added a CI lint in `check-schema-links.yml` that flags new `/schemas/latest/` in `docs/` outside release-notes.

## Review feedback addressed

- **Code review**: fixed `\$schema`-URL version parser to capture full `v3`/`3.0.0` alias (was stripping `v` prefix, silently fell through to default); added WeakSet cycle guard in `extractRegistryPaths`.
- **Security review**: skip-cache on empty-registry result so transient upstream garbage doesn't stick for 5 min.

## Test plan
- [x] 9/9 unit tests in `server/tests/unit/addie/schema-tools.test.ts` (includes exact 404 bug case + cycle guard + ambiguity bail-out)
- [x] Full server test suite (631 tests) passes via pre-commit hook
- [x] Typecheck clean
- [x] Live integration test against `https://adcontextprotocol.org/schemas/v3/index.json` (358 schemas extracted, fuzzy match resolves bug case, resolved URL returns 200)
- [x] CI stale-check simulated locally — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)