### PR TITLE
feat(server): accept OAuth user JWTs at /api/*

### DIFF
--- a/.changeset/rest-api-oauth-sso.md
+++ b/.changeset/rest-api-oauth-sso.md
@@ -1,0 +1,34 @@
+---
+---
+
+Accept OAuth-issued user JWTs at `/api/*`, closing the gap between what the OpenAPI spec advertised and what the server enforced.
+
+The MCP OAuth flow (`mcpAuthRouter` at `/authorize` → AuthKit → `/token`) already issued WorkOS-signed JWTs and verified them on `/mcp`. REST's `requireAuth` only accepted sealed-session cookies and `sk_...` organization API keys — so an agent client that SSO'd a user had no way to call the REST API on that user's behalf, even though the spec said `bearerAuth` was accepted.
+
+**What's new**
+
+- `requireAuth` accepts WorkOS-signed user JWTs via `Authorization: Bearer <jwt>`. Same verifier the MCP OAuth flow uses (WorkOS JWKS). Subject must correspond to a real local user. Machine-to-machine tokens (`client_credentials`) are rejected here — server-to-server callers continue to use `sk_...` keys.
+- RFC 9728 protected-resource metadata is now published at `GET /.well-known/oauth-protected-resource/api`, pointing at the same authorization server as `/mcp`. A single user SSO grants both surfaces.
+- `scripts/generate-openapi.ts` now registers the `bearerAuth` and `oauth2` security schemes on the registry (passing them via `generateDocument` options was silently dropped by `OpenApiGeneratorV31`). The checked-in spec had `security: [{ bearerAuth: [] }]` on 24 endpoints referencing a scheme the spec never defined — codegen would have broken. Each protected endpoint now lists both schemes as alternatives.
+- `docs/registry/index.mdx` gains an "Option B: User SSO via OAuth 2.1" section covering the discovery endpoints and flow.
+
+**Incidental fix — MCP OAuth user upsert**
+
+`handleMCPOAuthCallback` did not upsert the authenticated user into the local `users` table, while the cookie-based `/auth/callback` path did. MCP tool handlers never noticed because they read claims straight off `req.mcpAuth`. REST `requireAuth` verifies the JWT subject corresponds to a real local user, so users who first arrived via MCP were rejected at `/api/*`. The callback now performs the same upsert the cookie path does (`server/src/mcp/oauth-provider.ts`).
+
+**Security hardening from review**
+
+- **Application pinning.** `verifyWorkOSJWT` now rejects tokens whose `azp` or `client_id` claim is not our own `WORKOS_CLIENT_ID`. Without this, a sibling application in the same WorkOS tenant could mint tokens that pass signature verification against the shared JWKS.
+- **Positive cache on the JWT branch.** `validateWorkOSBearerJWT` caches successful validations keyed on SHA-256 of the token, TTL `min(60s, remaining token exp)`. Removes the per-request DB round-trip that would otherwise amplify DoS surface vs the cookie path (which has an equivalent cache).
+- **Trust scoping.** Dropped the auto-`isMember = true` assignment from the JWT's `org_id` claim — the claim reflects the AuthKit-selected org, not AAO membership. Downstream `enrichUserWithMembership` resolves real standing via the DB.
+- **Error surface.** MCP `InvalidTokenError` now returns a fixed `"Invalid or expired token"` message instead of echoing `jose` internals. Real error is logged server-side.
+- **Test coverage.** `__setJWKSForTesting` hook lets us exercise `verifyWorkOSJWT` with locally-generated key pairs — added coverage for happy path, expired tokens, signature-from-unknown-key, `azp`/`client_id` mismatch, missing application id, and M2M detection.
+
+**Scope of writes**
+
+User JWTs get the same access as organization API keys — writes included. MCP tool handlers already allowed OAuth users to mutate registry state; restricting REST to reads would have been arbitrary inconsistency.
+
+**Files**
+
+- New: `server/src/auth/workos-jwt.ts` (shared verifier), `server/tests/unit/workos-jwt.test.ts`
+- Changed: `server/src/middleware/auth.ts`, `server/src/mcp/oauth-provider.ts`, `server/src/http.ts`, `server/src/mcp/index.ts`, `server/src/routes/registry-api.ts`, `scripts/generate-openapi.ts`, `static/openapi/registry.yaml`, `docs/registry/index.mdx`

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -218,20 +218,38 @@ These controls are enforced by the hosted AgenticAdvertising.org registry. Self-
 
 ## Authentication
 
-Public endpoints (resolution, discovery, search) require no authentication. Write endpoints require a Bearer token issued to an AgenticAdvertising.org member organization.
+Public endpoints (resolution, discovery, search) require no authentication. Write endpoints accept either an **organization API key** (server-to-server) or a **user JWT** obtained via OAuth 2.1 (interactive / agent clients). Both are sent in the `Authorization: Bearer ...` header.
 
-### Obtaining an API key
+### Option A: Organization API key
+
+Long-lived, org-scoped. Best for server-to-server integrations where no user is present.
 
 1. Sign in at [agenticadvertising.org/dashboard/api-keys](https://agenticadvertising.org/dashboard/api-keys)
 2. Click **Create key** and copy the generated key
-
-### Using the API key
 
 Pass the key in the `Authorization` header:
 
 ```
 Authorization: Bearer sk_...
 ```
+
+### Option B: User SSO via OAuth 2.1
+
+Short-lived, user-scoped. Best for agent clients (MCP, AI assistants, custom apps) where a human is signing in. A single token works against both `/mcp` and the REST API.
+
+Discovery follows [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) and [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728):
+
+- Authorization server metadata: `GET /.well-known/oauth-authorization-server`
+- Protected-resource metadata (REST API): `GET /.well-known/oauth-protected-resource/api`
+- Protected-resource metadata (MCP): `GET /.well-known/oauth-protected-resource/mcp`
+
+The flow is authorization code with PKCE. Dynamic client registration ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)) is available at `/register`. Users authenticate via AuthKit; the token is a WorkOS-signed JWT.
+
+```
+Authorization: Bearer <jwt>
+```
+
+A valid user JWT proves identity, not entitlement. Endpoints gated on organization membership or admin role (most write endpoints) still return `403` if the authenticated user lacks the required standing.
 
 ### Authenticated endpoints
 

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -19,6 +19,38 @@ import { registry } from "../server/src/schemas/registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Register security schemes. These must be registered on the registry —
+// passing them via the generateDocument `components` option is silently
+// dropped by OpenApiGeneratorV31, which emits only registered components.
+registry.registerComponent("securitySchemes", "bearerAuth", {
+  type: "http",
+  scheme: "bearer",
+  description: [
+    "Bearer token in the `Authorization` header. Two token types are accepted:",
+    "",
+    "- **Organization API key** (`sk_...`) issued via the dashboard. Org-scoped, long-lived, for server-to-server use.",
+    "- **User JWT** obtained via the OAuth 2.1 authorization code flow with PKCE. User-scoped, short-lived. Discover the authorization server at `/.well-known/oauth-authorization-server` and the protected-resource metadata at `/.well-known/oauth-protected-resource/api`.",
+  ].join("\n"),
+});
+
+registry.registerComponent("securitySchemes", "oauth2", {
+  type: "oauth2",
+  description:
+    "OAuth 2.1 authorization code flow with PKCE. Users authenticate via AuthKit and clients receive a Bearer JWT that authorizes both the MCP endpoint and this REST API. Dynamic client registration is supported at `/register`.",
+  flows: {
+    authorizationCode: {
+      authorizationUrl: "https://agenticadvertising.org/authorize",
+      tokenUrl: "https://agenticadvertising.org/token",
+      refreshUrl: "https://agenticadvertising.org/token",
+      scopes: {
+        openid: "User identifier",
+        profile: "User profile information",
+        email: "User email address",
+      },
+    },
+  },
+});
+
 const generator = new OpenApiGeneratorV31(registry.definitions);
 
 const doc = generator.generateDocument({
@@ -31,7 +63,8 @@ const doc = generator.generateDocument({
       "AdCP ecosystem.",
       "",
       "Most endpoints are public and require no authentication. Endpoints marked",
-      "with a lock icon require a Bearer token — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).",
+      "with a lock icon accept either an organization API key or a user JWT",
+      "obtained via the OAuth 2.1 flow — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).",
       "",
       "**Base URL:** `https://agenticadvertising.org`",
     ].join("\n"),
@@ -48,15 +81,6 @@ const doc = generator.generateDocument({
     },
   ],
   security: [],
-  components: {
-    securitySchemes: {
-      bearerAuth: {
-        type: "http",
-        scheme: "bearer",
-        description: "API key issued to an AgenticAdvertising.org member organization.",
-      },
-    },
-  },
 });
 
 // Tag descriptions for the generated spec

--- a/scripts/rest-oauth-test.mjs
+++ b/scripts/rest-oauth-test.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * REST API OAuth test script
+ *
+ * Proves that a single OAuth-issued user JWT works against both
+ * the MCP endpoint AND the REST API on the same server. Flow:
+ *
+ * 1. Discovers PRM at /.well-known/oauth-protected-resource/api
+ * 2. Discovers AS metadata
+ * 3. Registers a dynamic client (RFC 7591)
+ * 4. Opens browser for authorization (AuthKit)
+ * 5. Captures the callback, exchanges code for token
+ * 6. Calls REST API with the bearer token — both a read and a write
+ *
+ * Usage: node scripts/rest-oauth-test.mjs [port]
+ */
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
+
+const PORT = process.argv[2] || '55020';
+const BASE_URL = `http://localhost:${PORT}`;
+const CALLBACK_PORT = 8789;
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/callback`;
+
+function base64url(buf) {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function main() {
+  console.log(`\n🔑 REST OAuth Test — ${BASE_URL}/api\n`);
+
+  // Step 1: Discover PRM for /api
+  console.log('1️⃣  Fetching Protected Resource Metadata for /api...');
+  const prmRes = await fetch(`${BASE_URL}/.well-known/oauth-protected-resource/api`);
+  if (!prmRes.ok) {
+    throw new Error(`PRM fetch failed: ${prmRes.status} ${await prmRes.text()}`);
+  }
+  const prm = await prmRes.json();
+  console.log(`   Resource: ${prm.resource}`);
+  console.log(`   Auth server: ${prm.authorization_servers[0]}`);
+  console.log(`   Bearer methods: ${prm.bearer_methods_supported?.join(', ')}`);
+
+  // Step 2: Discover AS metadata
+  const asUrl = prm.authorization_servers[0];
+  console.log('\n2️⃣  Fetching AS Metadata...');
+  const asRes = await fetch(`${asUrl}/.well-known/oauth-authorization-server`);
+  const as = await asRes.json();
+  console.log(`   Token endpoint: ${as.token_endpoint}`);
+  console.log(`   Registration: ${as.registration_endpoint}`);
+
+  // Step 3: Dynamic client registration
+  console.log('\n3️⃣  Registering dynamic client...');
+  const regRes = await fetch(as.registration_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_name: 'REST OAuth Test Script',
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    }),
+  });
+  const client = await regRes.json();
+  if (!client.client_id) {
+    console.error('   ❌ Registration failed:', JSON.stringify(client));
+    process.exit(1);
+  }
+  console.log(`   Client ID: ${client.client_id}`);
+
+  // Step 4: PKCE + authorization URL
+  const codeVerifier = base64url(crypto.randomBytes(32));
+  const codeChallenge = base64url(crypto.createHash('sha256').update(codeVerifier).digest());
+  const state = base64url(crypto.randomBytes(16));
+
+  const authUrl = new URL(as.authorization_endpoint);
+  authUrl.searchParams.set('client_id', client.client_id);
+  authUrl.searchParams.set('redirect_uri', REDIRECT_URI);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('scope', 'openid profile email');
+  authUrl.searchParams.set('code_challenge', codeChallenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+  authUrl.searchParams.set('state', state);
+
+  // Step 5: Start callback server and open browser
+  console.log('\n4️⃣  Starting callback server and opening browser...');
+
+  const tokenPromise = new Promise((resolve, reject) => {
+    const server = http.createServer(async (req, res) => {
+      const url = new URL(req.url, `http://localhost:${CALLBACK_PORT}`);
+      if (url.pathname !== '/callback') {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const code = url.searchParams.get('code');
+      const returnedState = url.searchParams.get('state');
+      const error = url.searchParams.get('error');
+
+      if (error) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(`Auth Error: ${error}\n${url.searchParams.get('error_description')}`);
+        server.close();
+        reject(new Error(error));
+        return;
+      }
+
+      if (returnedState !== state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<h2>❌ State mismatch</h2>');
+        server.close();
+        reject(new Error('State mismatch'));
+        return;
+      }
+
+      console.log('\n5️⃣  Exchanging authorization code for token...');
+      const tokenRes = await fetch(as.token_endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: REDIRECT_URI,
+          client_id: client.client_id,
+          code_verifier: codeVerifier,
+        }),
+      });
+      const tokenData = await tokenRes.json();
+
+      if (tokenData.error) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<h2>❌ Token Error: ${tokenData.error}</h2>`);
+        server.close();
+        reject(new Error(tokenData.error));
+        return;
+      }
+
+      console.log(`   ✅ Got access token (${tokenData.access_token.substring(0, 20)}...)`);
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<h2>✅ Auth complete!</h2><p>You can close this tab.</p>');
+      server.close();
+      resolve(tokenData);
+    });
+
+    server.listen(CALLBACK_PORT, () => {
+      console.log(`   Callback server on http://localhost:${CALLBACK_PORT}`);
+      console.log(`   Opening browser...\n`);
+      try {
+        execSync(`open "${authUrl.toString()}"`);
+      } catch {
+        console.log(`   ⚠️  Could not open browser. Open this URL manually:\n   ${authUrl.toString()}\n`);
+      }
+    });
+
+    setTimeout(() => {
+      server.close();
+      reject(new Error('Timeout waiting for callback'));
+    }, 120000);
+  });
+
+  const tokenData = await tokenPromise;
+  const bearer = { Authorization: `Bearer ${tokenData.access_token}` };
+
+  // Step 6a: REST read — hit /api/me/member-profile (requireAuth-gated read)
+  console.log('\n6️⃣  Calling REST read (/api/me/member-profile) with bearer token...');
+  const meRes = await fetch(`${BASE_URL}/api/me/member-profile`, { headers: bearer });
+  console.log(`   Status: ${meRes.status}`);
+  if (meRes.ok) {
+    const me = await meRes.json();
+    console.log(`   ✅ Read succeeded — user identified:`);
+    console.log('   ' + JSON.stringify(me, null, 2).split('\n').join('\n   '));
+  } else {
+    const body = await meRes.text();
+    console.log(`   ⚠️  Read returned non-200. Body: ${body.slice(0, 300)}`);
+  }
+
+  // Step 6b: REST write — save a test brand
+  console.log('\n7️⃣  Calling REST write (POST /api/brands/save) with bearer token...');
+  const testDomain = `rest-oauth-test-${Date.now()}.example`;
+  const saveRes = await fetch(`${BASE_URL}/api/brands/save`, {
+    method: 'POST',
+    headers: { ...bearer, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain: testDomain, brand_name: 'REST OAuth Test Brand' }),
+  });
+  console.log(`   Status: ${saveRes.status}`);
+  const saveBody = await saveRes.text();
+  console.log(`   Body: ${saveBody.slice(0, 400)}`);
+
+  if (saveRes.ok) {
+    console.log('\n✅ End-to-end SSO → REST write confirmed.\n');
+  } else {
+    console.log('\n❌ Write failed — investigate.\n');
+    process.exit(1);
+  }
+
+  console.log(`Token (for manual testing):\n${tokenData.access_token}\n`);
+}
+
+main().catch((err) => {
+  // Dev-only smoke script. The error path is reached only when the
+  // developer runs this against their own local server, so the
+  // user-controlled source is the developer themselves. JSON-encode
+  // the message anyway — CodeQL expects a recognized sanitizer, not
+  // a hand-rolled control-char regex.
+  const safeMessage = JSON.stringify(String(err.message));
+  console.error('\n❌ Error:', safeMessage);
+  process.exit(1);
+});

--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -158,6 +158,7 @@ export async function refreshToken(refreshToken: string): Promise<{
 export async function authenticateWithCodeForTokens(code: string): Promise<{
   accessToken: string;
   refreshToken: string;
+  user: WorkOSUser;
 }> {
   logger.debug('Authenticating with code for tokens (MCP flow)');
 
@@ -171,6 +172,15 @@ export async function authenticateWithCodeForTokens(code: string): Promise<{
   return {
     accessToken: result.accessToken,
     refreshToken: result.refreshToken,
+    user: {
+      id: result.user.id,
+      email: result.user.email,
+      firstName: result.user.firstName ?? undefined,
+      lastName: result.user.lastName ?? undefined,
+      emailVerified: result.user.emailVerified,
+      createdAt: result.user.createdAt,
+      updatedAt: result.user.updatedAt,
+    },
   };
 }
 

--- a/server/src/auth/workos-jwt.ts
+++ b/server/src/auth/workos-jwt.ts
@@ -1,0 +1,126 @@
+/**
+ * WorkOS JWT verification — shared between MCP OAuth and REST API auth.
+ *
+ * WorkOS signs all user-management access tokens with the JWKS exposed at
+ * `https://api.workos.com/sso/jwks/<client_id>`. Both the MCP OAuth provider
+ * and the REST requireAuth middleware use the same verifier so a single
+ * token issued by the MCP OAuth flow works across both surfaces.
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('workos-jwt');
+
+/**
+ * Read `WORKOS_CLIENT_ID` at call time rather than at module import.
+ * Vitest can evaluate `workos-jwt.ts` before a test file has had a
+ * chance to set the env var, so capturing the value in a module-level
+ * constant leaves tests with a stale `undefined`.
+ */
+function workosClientId(): string | undefined {
+  return process.env.WORKOS_CLIENT_ID;
+}
+
+/**
+ * Resolver used to verify tokens. `createRemoteJWKSet` returns one of
+ * these; we widen the type here so tests can swap in a static-key
+ * resolver built with `jose.generateKeyPair`, without having to stand
+ * up an HTTP server to host a JWKS endpoint.
+ */
+type KeyResolver = Parameters<typeof jwtVerify>[1];
+
+export interface VerifiedWorkOSToken {
+  sub: string;
+  clientId: string;
+  email?: string;
+  orgId?: string;
+  isM2M: boolean;
+  scopes: string[];
+  expiresAt?: number;
+  payload: JWTPayload;
+}
+
+let jwks: KeyResolver | null = null;
+
+function getJWKS(): KeyResolver {
+  if (!jwks) {
+    const clientId = workosClientId();
+    if (!clientId) {
+      throw new Error('WORKOS_CLIENT_ID is required for JWT verification');
+    }
+    const jwksUrl = new URL(`https://api.workos.com/sso/jwks/${clientId}`);
+    jwks = createRemoteJWKSet(jwksUrl);
+    logger.info({ jwksUrl: jwksUrl.toString() }, 'WorkOS JWKS configured');
+  }
+  return jwks;
+}
+
+/**
+ * Test-only hook: swap in a local key resolver (e.g. one built from a
+ * `jose.generateKeyPair` public key) so `verifyWorkOSJWT` can be
+ * exercised end-to-end without reaching out to WorkOS. Pass `null` to
+ * reset to the production resolver.
+ */
+export function __setJWKSForTesting(resolver: KeyResolver | null): void {
+  jwks = resolver;
+}
+
+/**
+ * Quick heuristic — does this string look like a compact JWT?
+ * Three base64url-ish segments separated by dots. Used to distinguish
+ * JWTs from opaque API keys without attempting signature verification.
+ */
+export function looksLikeJWT(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  return parts.every((p) => p.length > 0 && /^[A-Za-z0-9_-]+$/.test(p));
+}
+
+/**
+ * Verify a WorkOS-signed JWT. Throws on any verification failure
+ * (bad signature, expired, wrong application, malformed). On success,
+ * returns the extracted claims the app cares about.
+ *
+ * WorkOS user tokens don't include a stable `iss` or `aud`, but they
+ * do carry the application identifier — as `azp` (OIDC) and/or
+ * `client_id` (RFC 9068). We reject any token whose application
+ * identifier is not our own `WORKOS_CLIENT_ID`; otherwise a sibling
+ * application in the same WorkOS tenant could mint tokens that pass
+ * signature verification against our shared JWKS.
+ */
+export async function verifyWorkOSJWT(token: string): Promise<VerifiedWorkOSToken> {
+  const jwksInstance = getJWKS();
+
+  const { payload } = await jwtVerify(token, jwksInstance);
+
+  const azp = typeof payload.azp === 'string' ? payload.azp : undefined;
+  const clientIdClaim =
+    typeof payload.client_id === 'string' ? payload.client_id : undefined;
+  const applicationId = azp ?? clientIdClaim;
+  if (!applicationId || applicationId !== workosClientId()) {
+    throw new Error(
+      `Token application id ("${applicationId ?? 'missing'}") does not match this application`,
+    );
+  }
+
+  const sub = typeof payload.sub === 'string' ? payload.sub : '';
+  const isM2M =
+    payload.grant_type === 'client_credentials' || sub.startsWith('client_');
+
+  const scopes =
+    typeof payload.scope === 'string'
+      ? payload.scope.split(' ').filter(Boolean)
+      : [];
+
+  return {
+    sub,
+    clientId: applicationId,
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    orgId: typeof payload.org_id === 'string' ? payload.org_id : undefined,
+    isM2M,
+    scopes,
+    expiresAt: typeof payload.exp === 'number' ? payload.exp : undefined,
+    payload,
+  };
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "url";
 import { WorkOS, DomainDataState } from "@workos-inc/node";
 import { AgentService } from "./agent-service.js";
 import { AgentValidator } from "./validator.js";
-import { configureMCPRoutes, initializeMCPServer, isMCPServerReady } from "./mcp/index.js";
+import { configureMCPRoutes, isMCPServerReady, resolveMCPServerURL } from "./mcp/index.js";
 import { HealthChecker } from "./health.js";
 import { notifySystemError } from "./addie/error-notifier.js";
 import { CrawlerService } from "./crawler.js";
@@ -554,6 +554,20 @@ export class HTTPServer {
     this.app.get('/.well-known/openapi.yaml', (_req, res) => {
       res.setHeader('Cache-Control', 'public, max-age=3600');
       res.redirect(302, '/openapi/registry.yaml');
+    });
+
+    // RFC 9728 protected-resource metadata for the REST API. Points at the same
+    // OAuth 2.1 authorization server that the MCP endpoint uses, so a single
+    // SSO'd token issued via mcpAuthRouter works against /api/* too.
+    this.app.get('/.well-known/oauth-protected-resource/api', (_req, res) => {
+      const issuer = resolveMCPServerURL();
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.json({
+        resource: `${issuer}/api`,
+        authorization_servers: [issuer],
+        bearer_methods_supported: ['header'],
+        scopes_supported: ['openid', 'profile', 'email'],
+      });
     });
 
     // Serve other static files (robots.txt, images, etc.)

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -11,7 +11,7 @@
  */
 
 export { createUnifiedMCPServer, initializeMCPServer, isMCPServerReady, getAllTools } from './server.js';
-export { configureMCPRoutes } from './routes.js';
+export { configureMCPRoutes, resolveMCPServerURL } from './routes.js';
 export { createOAuthProvider, handleMCPOAuthCallback, MCP_AUTH_ENABLED } from './oauth-provider.js';
 export {
   authInfoToMCPAuthContext,

--- a/server/src/mcp/oauth-provider.ts
+++ b/server/src/mcp/oauth-provider.ts
@@ -16,14 +16,13 @@ import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/serv
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { OAuthClientInformationFull, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
-import { createRemoteJWKSet, jwtVerify, decodeJwt } from 'jose';
+import { decodeJwt } from 'jose';
 import { createLogger } from '../logger.js';
+import { verifyWorkOSJWT } from '../auth/workos-jwt.js';
 import * as mcpClientsDb from '../db/mcp-clients-db.js';
 import * as mcpOAuthStateDb from '../db/mcp-oauth-state-db.js';
 
 const logger = createLogger('mcp-oauth');
-
-const WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID;
 
 /**
  * Whether MCP auth is enabled.
@@ -40,61 +39,26 @@ cleanupTimer.unref();
 // JWT verification
 // ---------------------------------------------------------------------------
 
-let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
-
-function getJWKS() {
-  if (!jwks) {
-    if (!WORKOS_CLIENT_ID) {
-      throw new Error('WORKOS_CLIENT_ID is required for MCP token verification');
-    }
-    // WorkOS serves JWKS at this endpoint for all user management tokens
-    const jwksUrl = new URL(`https://api.workos.com/sso/jwks/${WORKOS_CLIENT_ID}`);
-    jwks = createRemoteJWKSet(jwksUrl);
-    logger.info({ jwksUrl: jwksUrl.toString() }, 'MCP OAuth: JWKS configured');
-  }
-  return jwks;
-}
-
 async function verifyAccessTokenJWT(token: string): Promise<AuthInfo> {
-  const jwksInstance = getJWKS();
-
-  // WorkOS user tokens don't include `aud` or a stable `iss`.
-  // Signature verification via JWKS plus expiration is sufficient.
-  let payload: Awaited<ReturnType<typeof jwtVerify>>['payload'];
+  let verified: Awaited<ReturnType<typeof verifyWorkOSJWT>>;
   try {
-    const result = await jwtVerify(token, jwksInstance);
-    payload = result.payload;
+    verified = await verifyWorkOSJWT(token);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Token verification failed';
     logger.warn({ err }, 'MCP OAuth: Token verification failed');
-    throw new InvalidTokenError(message);
+    throw new InvalidTokenError('Invalid or expired token');
   }
-
-  const isM2M =
-    payload.grant_type === 'client_credentials' ||
-    (typeof payload.sub === 'string' && payload.sub.startsWith('client_'));
-
-  const clientId =
-    (payload.azp as string) ||
-    (typeof payload.aud === 'string' ? payload.aud : payload.aud?.[0]) ||
-    'unknown';
-
-  const scopes =
-    typeof payload.scope === 'string'
-      ? payload.scope.split(' ').filter(Boolean)
-      : [];
 
   return {
     token,
-    clientId,
-    scopes,
-    expiresAt: payload.exp,
+    clientId: verified.clientId,
+    scopes: verified.scopes,
+    expiresAt: verified.expiresAt,
     extra: {
-      sub: payload.sub,
-      orgId: payload.org_id,
-      isM2M,
-      email: payload.email,
-      payload,
+      sub: verified.sub,
+      orgId: verified.orgId,
+      isM2M: verified.isM2M,
+      email: verified.email,
+      payload: verified.payload,
     },
   };
 }
@@ -277,7 +241,7 @@ export async function handleMCPOAuthCallback(
   }
 
   // Exchange WorkOS code for tokens
-  let authResult: { accessToken: string; refreshToken: string };
+  let authResult: Awaited<ReturnType<typeof import('../auth/workos-client.js').authenticateWithCodeForTokens>>;
   try {
     const { authenticateWithCodeForTokens } = await import('../auth/workos-client.js');
     authResult = await authenticateWithCodeForTokens(workosCode);
@@ -289,6 +253,36 @@ export async function handleMCPOAuthCallback(
     if (pending.state) errorUrl.searchParams.set('state', pending.state);
     res.redirect(errorUrl.toString());
     return;
+  }
+
+  // Upsert the user into our local table so downstream code (REST requireAuth,
+  // /api/me/*, dashboard queries) can find them by workos_user_id. The
+  // cookie-based /auth/callback path does the same upsert; without it,
+  // users who first arrive via the MCP OAuth flow don't exist locally and
+  // REST auth rejects their JWT.
+  //
+  // On failure we log and continue — we still issue the OAuth code so /mcp
+  // works. The user will see a 401 the first time they call /api/*, with a
+  // corresponding warn log ("Bearer JWT verified but user not found in
+  // local DB"). A retry (re-SSO) recovers; a persistent failure indicates
+  // a DB problem that operators need to investigate, not a per-user issue.
+  try {
+    const { getPool } = await import('../db/client.js');
+    const { user } = authResult;
+    await getPool().query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified, workos_created_at, workos_updated_at, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+       ON CONFLICT (workos_user_id) DO UPDATE SET
+         email = EXCLUDED.email,
+         first_name = COALESCE(NULLIF(TRIM(users.first_name), ''), EXCLUDED.first_name),
+         last_name = COALESCE(NULLIF(TRIM(users.last_name), ''), EXCLUDED.last_name),
+         email_verified = EXCLUDED.email_verified,
+         workos_updated_at = EXCLUDED.workos_updated_at,
+         updated_at = NOW()`,
+      [user.id, user.email, user.firstName, user.lastName, user.emailVerified, user.createdAt, user.updatedAt],
+    );
+  } catch (upsertErr) {
+    logger.error({ err: upsertErr }, 'MCP OAuth: Failed to upsert user on callback');
   }
 
   // Generate local authorization code

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../logger.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
 import { bansDb } from '../db/bans-db.js';
 import { isWorkOSApiKeyFormat } from './api-key-format.js';
+import { verifyWorkOSJWT, looksLikeJWT } from '../auth/workos-jwt.js';
 import { storeRefreshedSession, getRefreshedSession, cleanExpiredRefreshes } from '../db/session-refresh-db.js';
 import { getPool } from '../db/client.js';
 
@@ -79,6 +80,9 @@ setInterval(() => {
   }
   for (const [key, ts] of deadSessionCache.entries()) {
     if (now - ts > DEAD_SESSION_TTL_MS) deadSessionCache.delete(key);
+  }
+  for (const [key, value] of bearerJwtCache.entries()) {
+    if (value.expiresAt < now) bearerJwtCache.delete(key);
   }
 }, 5 * 60 * 1000);
 
@@ -245,6 +249,122 @@ export async function validateWorkOSApiKey(req: Request): Promise<ValidatedApiKe
  */
 function apiKeyHasPermission(apiKey: ValidatedApiKey, permission: string): boolean {
   return apiKey.permissions.includes(permission);
+}
+
+/**
+ * Validated OAuth bearer token — a WorkOS-signed JWT issued via the
+ * OAuth 2.1 flow brokered by mcpAuthRouter. Callers end up here when
+ * a user SSO'd through AuthKit from an agent/MCP client.
+ */
+export interface ValidatedBearerJWT {
+  user: WorkOSUser;
+  rawToken: string;
+  orgId?: string;
+}
+
+/**
+ * Short-lived positive cache for successfully-validated bearer JWTs.
+ * Keyed on SHA-256 of the raw token; value includes the synthesized user
+ * and an expiry that is the minimum of (token exp, now + BEARER_JWT_CACHE_TTL_MS).
+ *
+ * Without this, every REST request with a Bearer JWT incurs a DB round-trip
+ * for the local-user lookup — the cookie path has an equivalent cache
+ * (`sessionCache`) and its absence here creates a DoS amplifier.
+ */
+interface CachedBearerJWT {
+  user: WorkOSUser;
+  orgId?: string;
+  expiresAt: number;
+}
+const bearerJwtCache = new Map<string, CachedBearerJWT>();
+const BEARER_JWT_CACHE_TTL_MS = 60 * 1000;
+const BEARER_JWT_CACHE_MAX_SIZE = 10_000;
+
+function hashBearerToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Validate a WorkOS-signed user JWT from the Authorization header.
+ * Returns null if the header is missing, points at a different token
+ * type (API key, admin key), or fails verification.
+ *
+ * On success the returned `user` mirrors the shape produced by the
+ * sealed-session path — real WorkOS user id, real email, names resolved
+ * from the local users table. Machine-to-machine tokens (client_credentials)
+ * are not accepted here; those callers should use WorkOS API keys.
+ *
+ * `isMember` is intentionally NOT set from the JWT's `org_id` claim —
+ * that claim reflects the org the user selected during AuthKit, not
+ * whether the org holds an active AAO membership. Downstream
+ * `enrichUserWithMembership` resolves real membership via the DB.
+ */
+export async function validateWorkOSBearerJWT(req: Request): Promise<ValidatedBearerJWT | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  if (isWorkOSApiKeyFormat(token)) return null; // handled by validateWorkOSApiKey
+  if (ADMIN_API_KEY && token === ADMIN_API_KEY) return null; // handled by hasValidAdminApiKey
+  if (!looksLikeJWT(token)) return null;
+
+  const cacheKey = hashBearerToken(token);
+  const now = Date.now();
+  const cached = bearerJwtCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return { user: cached.user, rawToken: token, orgId: cached.orgId };
+  }
+
+  let verified: Awaited<ReturnType<typeof verifyWorkOSJWT>>;
+  try {
+    verified = await verifyWorkOSJWT(token);
+  } catch (err) {
+    logger.debug({ err }, 'Bearer JWT verification failed');
+    return null;
+  }
+
+  if (verified.isM2M || !verified.sub) return null;
+
+  // Confirm the subject corresponds to a real local user. This catches
+  // tokens from WorkOS accounts that have been deleted or never synced,
+  // and gives us names for the synthesized WorkOSUser.
+  const pool = getPool();
+  const localUser = await pool.query<{
+    first_name: string | null;
+    last_name: string | null;
+    email: string | null;
+  }>(
+    `SELECT first_name, last_name, email FROM users WHERE workos_user_id = $1`,
+    [verified.sub],
+  );
+  if (localUser.rowCount === 0) {
+    logger.warn({ sub: verified.sub }, 'Bearer JWT verified but user not found in local DB');
+    return null;
+  }
+
+  const row = localUser.rows[0];
+  const email = verified.email ?? row.email ?? '';
+  const user: WorkOSUser = {
+    id: verified.sub,
+    email,
+    firstName: row.first_name?.trim() || undefined,
+    lastName: row.last_name?.trim() || undefined,
+    emailVerified: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const tokenExpMs = verified.expiresAt ? verified.expiresAt * 1000 : Infinity;
+  const cacheUntil = Math.min(now + BEARER_JWT_CACHE_TTL_MS, tokenExpMs);
+  if (cacheUntil > now) {
+    if (bearerJwtCache.size >= BEARER_JWT_CACHE_MAX_SIZE) {
+      const oldest = bearerJwtCache.keys().next().value;
+      if (oldest) bearerJwtCache.delete(oldest);
+    }
+    bearerJwtCache.set(cacheKey, { user, orgId: verified.orgId, expiresAt: cacheUntil });
+  }
+
+  return { user, rawToken: token, orgId: verified.orgId };
 }
 
 // Dev mode: bypass auth with mock users for local testing
@@ -516,6 +636,30 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     if (apiKeyBan) {
       logger.info({ apiKeyId: apiKey.id, banId: apiKeyBan.id }, 'API key request blocked by platform ban');
       return sendBanResponse(res, apiKeyBan);
+    }
+
+    return next();
+  }
+
+  // Check for OAuth-issued user JWT (user SSO'd via AuthKit through the
+  // MCP OAuth flow and is now calling the REST API with that token).
+  const jwtAuth = await validateWorkOSBearerJWT(req);
+  if (jwtAuth) {
+    logger.debug({ path: req.path, userId: jwtAuth.user.id }, 'Authenticated via OAuth user JWT');
+    req.user = jwtAuth.user;
+    req.accessToken = jwtAuth.rawToken;
+
+    try {
+      const userBan = await checkPlatformBan(
+        `user:${jwtAuth.user.id}`,
+        () => bansDb.checkPlatformBan(jwtAuth.user.id),
+      );
+      if (userBan) {
+        logger.info({ userId: jwtAuth.user.id, banId: userBan.id }, 'User request blocked by platform ban');
+        return sendBanResponse(res, userBan);
+      }
+    } catch (banError) {
+      logger.warn({ err: banError, userId: jwtAuth.user.id, path: req.path }, 'Ban check failed — allowing request through');
     }
 
     return next();

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -235,7 +235,7 @@ registry.registerPath({
   description:
     "Save or update a brand in the registry. Requires authentication. For existing brands, creates a revision-tracked edit. For new brands, creates the brand directly. Cannot edit authoritative brands managed via brand.json.",
   tags: ["Brand Resolution"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -434,7 +434,7 @@ registry.registerPath({
   description:
     "Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.",
   tags: ["Property Resolution"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -1013,7 +1013,7 @@ registry.registerPath({
   description:
     "Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.",
   tags: ["Policy Registry"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -1076,7 +1076,7 @@ registry.registerPath({
   description:
     "Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.\n\nType filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.",
   tags: ["Change Feed"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     query: z.object({
       cursor: z.string().uuid().optional().openapi({ description: "Resume after this event ID" }),
@@ -1129,7 +1129,7 @@ registry.registerPath({
   description:
     "Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.",
   tags: ["Agent Discovery"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     query: z.object({
       channels: z.string().optional().openapi({ description: "Comma-separated channel filter", example: "ctv,olv" }),
@@ -1186,7 +1186,7 @@ registry.registerPath({
   description:
     "Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
   tags: ["Agent Discovery"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -1234,7 +1234,7 @@ registry.registerPath({
   description:
     "Trigger an immediate re-crawl of a domain's brand.json. The crawl runs asynchronously — returns 202 immediately.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour (shared with adagents.json crawl requests).",
   tags: ["Brand Discovery"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -1304,7 +1304,7 @@ registry.registerPath({
   description:
     "Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.\n\n**Members only** — requires authentication and an active membership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL", example: "https%3A%2F%2Fexample.com%2Fmcp" }),
@@ -1339,7 +1339,7 @@ registry.registerPath({
   description:
     "Returns per-storyboard test results for multiple agents in a single request.\n\n**Members only** — requires authentication and an active membership. Maximum 100 agent URLs per request.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -1415,7 +1415,7 @@ registry.registerPath({
   description:
     "Set the lifecycle stage for an agent. Requires authentication and ownership of the agent.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1447,7 +1447,7 @@ registry.registerPath({
   description:
     "Opt an agent in or out of public compliance reporting. Requires authentication and ownership of the agent.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1481,7 +1481,7 @@ registry.registerPath({
   description:
     "Returns the monitoring configuration for an agent. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1504,7 +1504,7 @@ registry.registerPath({
   description:
     "Pause or resume automated compliance monitoring for an agent. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1536,7 +1536,7 @@ registry.registerPath({
   description:
     "Set the check interval for automated compliance monitoring (6–168 hours). Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1568,7 +1568,7 @@ registry.registerPath({
   description:
     "Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1609,7 +1609,7 @@ registry.registerPath({
   description:
     "Returns whether an agent has stored authentication credentials and OAuth token status. Requires authentication.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1631,7 +1631,7 @@ registry.registerPath({
   description:
     "Store authentication credentials for an agent. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1675,7 +1675,7 @@ registry.registerPath({
   description:
     "Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1728,7 +1728,7 @@ registry.registerPath({
   description:
     "Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1776,7 +1776,7 @@ registry.registerPath({
   description:
     "Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -1941,7 +1941,7 @@ registry.registerPath({
   description:
     "Create or update a hosted brand.json for a domain owned by the authenticated user's organization. Returns the hosted URL and a pointer snippet for DNS setup.",
   tags: ["Brand Resolution"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     body: {
       content: {
@@ -2085,7 +2085,7 @@ registry.registerPath({
   description:
     "Execute a single storyboard step against an agent. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -2151,7 +2151,7 @@ registry.registerPath({
   description:
     "Execute all steps of a storyboard against an agent and record the compliance result. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
@@ -2199,7 +2199,7 @@ registry.registerPath({
   description:
     "Run a storyboard against both the target agent and the public reference agent, returning side-by-side results. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),

--- a/server/tests/unit/workos-jwt.test.ts
+++ b/server/tests/unit/workos-jwt.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SignJWT, generateKeyPair, exportJWK, type KeyLike } from 'jose';
+import {
+  looksLikeJWT,
+  verifyWorkOSJWT,
+  __setJWKSForTesting,
+} from '../../src/auth/workos-jwt.js';
+
+// WORKOS_CLIENT_ID must be set before workos-jwt.ts is imported for the
+// module's `WORKOS_CLIENT_ID` constant to pick it up. Vitest evaluates
+// top-level test code after module imports, so we set it at module load.
+process.env.WORKOS_CLIENT_ID ??= 'client_01TESTAZPVALUE';
+const EXPECTED_AZP = process.env.WORKOS_CLIENT_ID!;
+
+describe('looksLikeJWT', () => {
+  it('accepts compact JWT format (three base64url segments)', () => {
+    // Three arbitrary base64url-safe segments — this heuristic only checks
+    // structure, not signature, so the payload content is irrelevant.
+    expect(looksLikeJWT('aaa_bbb-ccc.ddd_eee-fff.ggg_hhh-iii')).toBe(true);
+  });
+
+  it('rejects WorkOS API key formats', () => {
+    expect(looksLikeJWT('sk_fake_example_key_for_testing_only')).toBe(false);
+    expect(looksLikeJWT('wos_api_key_abc123')).toBe(false);
+  });
+
+  it('rejects strings with the wrong number of segments', () => {
+    expect(looksLikeJWT('header.payload')).toBe(false);
+    expect(looksLikeJWT('one-segment')).toBe(false);
+    expect(looksLikeJWT('a.b.c.d')).toBe(false);
+  });
+
+  it('rejects strings with empty segments', () => {
+    expect(looksLikeJWT('..')).toBe(false);
+    expect(looksLikeJWT('a..c')).toBe(false);
+    expect(looksLikeJWT('.b.c')).toBe(false);
+  });
+
+  it('rejects segments with non-base64url characters', () => {
+    expect(looksLikeJWT('header.payload.signature with spaces')).toBe(false);
+    expect(looksLikeJWT('header.pay+load.sig')).toBe(false);
+    expect(looksLikeJWT('header.payload.sig/nature')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(looksLikeJWT('')).toBe(false);
+  });
+});
+
+describe('verifyWorkOSJWT', () => {
+  let privateKey: KeyLike;
+  let publicKey: KeyLike;
+
+  beforeAll(async () => {
+    const kp = await generateKeyPair('RS256');
+    privateKey = kp.privateKey;
+    publicKey = kp.publicKey;
+    const jwk = await exportJWK(publicKey);
+    // Swap in a static-key resolver that matches any `alg: RS256` kid.
+    __setJWKSForTesting(async () => ({ ...jwk, alg: 'RS256' }));
+  });
+
+  afterAll(() => {
+    __setJWKSForTesting(null);
+  });
+
+  async function mint(claims: Record<string, unknown>, expiresIn: string | number = '5m'): Promise<string> {
+    return new SignJWT(claims)
+      .setProtectedHeader({ alg: 'RS256' })
+      .setSubject(claims.sub as string | undefined ?? 'user_01TEST')
+      .setIssuedAt()
+      .setExpirationTime(expiresIn)
+      .sign(privateKey);
+  }
+
+  it('accepts a valid user token and extracts claims', async () => {
+    const token = await mint({
+      sub: 'user_01ABC',
+      azp: EXPECTED_AZP,
+      org_id: 'org_01XYZ',
+      email: 'test@example.com',
+      scope: 'openid profile email',
+    });
+    const result = await verifyWorkOSJWT(token);
+    expect(result.sub).toBe('user_01ABC');
+    expect(result.clientId).toBe(EXPECTED_AZP);
+    expect(result.orgId).toBe('org_01XYZ');
+    expect(result.email).toBe('test@example.com');
+    expect(result.isM2M).toBe(false);
+    expect(result.scopes).toEqual(['openid', 'profile', 'email']);
+  });
+
+  it('accepts a token identified via client_id (RFC 9068 style)', async () => {
+    const token = await mint({
+      sub: 'user_01ABC',
+      client_id: EXPECTED_AZP,
+    });
+    const result = await verifyWorkOSJWT(token);
+    expect(result.clientId).toBe(EXPECTED_AZP);
+  });
+
+  it('rejects a token whose azp does not match WORKOS_CLIENT_ID', async () => {
+    const token = await mint({
+      sub: 'user_01ABC',
+      azp: 'client_01DIFFERENT_APP',
+    });
+    await expect(verifyWorkOSJWT(token)).rejects.toThrow(/application id/);
+  });
+
+  it('rejects a token whose client_id does not match WORKOS_CLIENT_ID', async () => {
+    const token = await mint({
+      sub: 'user_01ABC',
+      client_id: 'client_01DIFFERENT_APP',
+    });
+    await expect(verifyWorkOSJWT(token)).rejects.toThrow(/application id/);
+  });
+
+  it('rejects a token with no azp and no client_id', async () => {
+    const token = await mint({ sub: 'user_01ABC' });
+    await expect(verifyWorkOSJWT(token)).rejects.toThrow(/application id/);
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await mint({ sub: 'user_01ABC', azp: EXPECTED_AZP }, '-1s');
+    await expect(verifyWorkOSJWT(token)).rejects.toThrow();
+  });
+
+  it('rejects a token signed by an unknown key', async () => {
+    const other = await generateKeyPair('RS256');
+    const token = await new SignJWT({ sub: 'user_01ABC', azp: EXPECTED_AZP })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setExpirationTime('5m')
+      .sign(other.privateKey);
+    await expect(verifyWorkOSJWT(token)).rejects.toThrow();
+  });
+
+  it('flags M2M tokens (client_credentials)', async () => {
+    const token = await mint({
+      sub: 'client_01APP',
+      azp: EXPECTED_AZP,
+      grant_type: 'client_credentials',
+    });
+    const result = await verifyWorkOSJWT(token);
+    expect(result.isM2M).toBe(true);
+  });
+
+  it('flags M2M tokens when sub starts with client_', async () => {
+    const token = await mint({ sub: 'client_01APP', azp: EXPECTED_AZP });
+    const result = await verifyWorkOSJWT(token);
+    expect(result.isM2M).toBe(true);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -7,7 +7,8 @@ info:
     AdCP ecosystem.
 
     Most endpoints are public and require no authentication. Endpoints marked
-    with a lock icon require a Bearer token — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
+    with a lock icon accept either an organization API key or a user JWT
+    obtained via the OAuth 2.1 flow — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
 
     **Base URL:** `https://agenticadvertising.org`
   version: 1.0.0
@@ -19,6 +20,27 @@ servers:
     description: Production
 security: []
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |-
+        Bearer token in the `Authorization` header. Two token types are accepted:
+
+        - **Organization API key** (`sk_...`) issued via the dashboard. Org-scoped, long-lived, for server-to-server use.
+        - **User JWT** obtained via the OAuth 2.1 authorization code flow with PKCE. User-scoped, short-lived. Discover the authorization server at `/.well-known/oauth-authorization-server` and the protected-resource metadata at `/.well-known/oauth-protected-resource/api`.
+    oauth2:
+      type: oauth2
+      description: OAuth 2.1 authorization code flow with PKCE. Users authenticate via AuthKit and clients receive a Bearer JWT that authorizes both the MCP endpoint and this REST API. Dynamic client registration is supported at `/register`.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://agenticadvertising.org/authorize
+          tokenUrl: https://agenticadvertising.org/token
+          refreshUrl: https://agenticadvertising.org/token
+          scopes:
+            openid: User identifier
+            profile: User profile information
+            email: User email address
   schemas:
     ResolvedBrand:
       type: object
@@ -1135,6 +1157,8 @@ components:
             - testing
             - production
             - deprecated
+        compliance_opt_out:
+          type: boolean
         tracks:
           type: object
           additionalProperties:
@@ -1351,6 +1375,7 @@ components:
             - bearer
             - basic
             - oauth
+            - oauth_client_credentials
             - null
         has_oauth_token:
           type: boolean
@@ -1360,6 +1385,8 @@ components:
           type:
             - string
             - "null"
+        has_oauth_client_credentials:
+          type: boolean
       required:
         - has_auth
         - agent_context_id
@@ -1367,6 +1394,39 @@ components:
         - has_oauth_token
         - has_valid_oauth
         - oauth_token_expires_at
+        - has_oauth_client_credentials
+    CredentialSaveValidationError:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          enum:
+            - invalid_blob_shape
+            - missing_field
+            - invalid_field_type
+            - field_too_long
+            - invalid_url
+            - invalid_env_reference
+            - invalid_auth_method_value
+          description: Stable rejection tag. UI maps this to operator-friendly prose.
+        field:
+          type: string
+          enum:
+            - oauth_client_credentials
+            - token_endpoint
+            - client_id
+            - client_secret
+            - scope
+            - resource
+            - audience
+            - auth_method
+          description: Field the UI should scroll to + highlight.
+      required:
+        - error
+        - code
+        - field
     StoryboardSummary:
       type: object
       properties:
@@ -1693,6 +1753,7 @@ paths:
         - Brand Resolution
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -2106,6 +2167,7 @@ paths:
         - Property Resolution
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -3474,6 +3536,7 @@ paths:
         - Policy Registry
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -3645,6 +3708,7 @@ paths:
         - Change Feed
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -3760,6 +3824,7 @@ paths:
         - Agent Discovery
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -3958,6 +4023,7 @@ paths:
         - Agent Discovery
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -4026,6 +4092,7 @@ paths:
         - Brand Discovery
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -4132,6 +4199,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4208,6 +4276,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -4348,6 +4417,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4411,6 +4481,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4469,6 +4540,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4517,6 +4589,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4575,6 +4648,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4635,6 +4709,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4713,6 +4788,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4755,6 +4831,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -4823,6 +4900,217 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials:
+    put:
+      operationId: saveAgentOAuthClientCredentials
+      summary: Save OAuth 2.0 client-credentials for an agent
+      description: Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token_endpoint:
+                  type: string
+                  maxLength: 2048
+                  description: Token endpoint URL (HTTPS required; localhost allowed in dev).
+                client_id:
+                  type: string
+                  maxLength: 2048
+                  description: OAuth client ID. May be a `$ENV:VAR_NAME` reference.
+                client_secret:
+                  type: string
+                  maxLength: 8192
+                  description: OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest.
+                scope:
+                  type: string
+                  maxLength: 1024
+                  description: Space-separated OAuth scope values.
+                resource:
+                  type: string
+                  maxLength: 2048
+                  description: RFC 8707 resource indicator.
+                audience:
+                  type: string
+                  maxLength: 2048
+                  description: Audience parameter for audience-validating authorization servers.
+                auth_method:
+                  type: string
+                  enum:
+                    - basic
+                    - body
+                  description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic."
+              required:
+                - token_endpoint
+                - client_id
+                - client_secret
+      responses:
+        "200":
+          description: Credentials saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                    enum:
+                      - true
+                  agent_context_id:
+                    type: string
+                  auth_type:
+                    type: string
+                    enum:
+                      - oauth_client_credentials
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+                  - auth_type
+        "400":
+          description: Invalid parameters — response carries `code` and `field` pointing to the rejection cause.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialSaveValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials/test:
+    post:
+      operationId: testAgentOAuthClientCredentials
+      summary: Dry-run the saved OAuth 2.0 client-credentials config
+      description: Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it)."
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      latency_ms:
+                        type: integer
+                    required:
+                      - ok
+                      - latency_ms
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - false
+                      latency_ms:
+                        type: integer
+                      error:
+                        type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - oauth
+                              - malformed
+                              - network
+                            description: "Category of failure: `oauth` = AS returned a typed error (e.g. invalid_client), `malformed` = AS returned an unexpected 2xx payload, `network` = couldn't reach the AS."
+                          message:
+                            type: string
+                          oauth_error:
+                            type: string
+                            description: RFC 6749 `error` field when kind=oauth.
+                          oauth_error_description:
+                            type: string
+                            description: RFC 6749 `error_description` field when kind=oauth.
+                          http_status:
+                            type: integer
+                            description: Status code when the AS returned a non-2xx.
+                        required:
+                          - kind
+                          - message
+                    required:
+                      - ok
+                      - latency_ms
+                      - error
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No saved client-credentials config for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/agents/{encodedUrl}/applicable-storyboards:
     get:
       operationId: getApplicableStoryboards
@@ -4832,6 +5120,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -5112,6 +5401,7 @@ paths:
         - Brand Resolution
       security:
         - bearerAuth: []
+        - oauth2: []
       requestBody:
         content:
           application/json:
@@ -5390,6 +5680,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -5512,6 +5803,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string
@@ -5605,6 +5897,7 @@ paths:
         - Agent Compliance
       security:
         - bearerAuth: []
+        - oauth2: []
       parameters:
         - schema:
             type: string


### PR DESCRIPTION
## Summary

- Teaches `requireAuth` to accept WorkOS-signed user JWTs (same tokens `mcpAuthRouter` already issues at `/mcp`). A user who SSO's via an agent client can now call the REST API on that user's behalf — closing the gap between what the OpenAPI spec advertised and what the server enforced.
- Publishes RFC 9728 protected-resource metadata at `GET /.well-known/oauth-protected-resource/api` pointing at the same authorization server as `/mcp`. One user SSO grants both surfaces.
- Fixes a silently-broken OpenAPI spec: `bearerAuth` was referenced on 24 endpoints but never defined in `components.securitySchemes` because `OpenApiGeneratorV31` drops schemes passed via `generateDocument` options — they must be registered via `registry.registerComponent`. Both `bearerAuth` and `oauth2` are now declared.
- Incidental fix: `handleMCPOAuthCallback` now upserts the authenticated user into the local `users` table, matching the cookie-based `/auth/callback` path. MCP handlers didn't notice the gap because they read claims from `req.mcpAuth`, but REST `requireAuth` rejects JWTs whose subject isn't in the local DB.

## Security hardening (from review)

- `verifyWorkOSJWT` rejects tokens whose `azp`/`client_id` claim doesn't match `WORKOS_CLIENT_ID` — a sibling application in the same WorkOS tenant would otherwise mint tokens that pass signature verification against the shared JWKS.
- Short-lived positive cache on the JWT branch (keyed on SHA-256, TTL `min(60s, remaining exp)`) — removes the per-request DB round-trip that would otherwise amplify DoS surface vs the cookie path.
- Dropped the auto-`isMember = true` assignment from the JWT's `org_id` claim — the claim reflects the AuthKit-selected org, not AAO membership tier. Downstream `enrichUserWithMembership` resolves real standing via the DB.
- MCP `InvalidTokenError` now returns a fixed `\"Invalid or expired token\"` instead of echoing `jose` internals.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Full unit suite (`npm run test:unit`) — 686/686 pass
- [x] New `server/tests/unit/workos-jwt.test.ts` — 15 tests covering happy path, `azp`/`client_id` pinning, expired token, unknown-key signature, and M2M detection (uses `jose.generateKeyPair` via `__setJWKSForTesting` hook)
- [x] End-to-end manual test against a local server with real WorkOS creds — full OAuth DCR → AuthKit login → token → REST read (`/api/me/member-profile`) and REST write (`POST /api/brands/save`) both returned 200
- [x] Negative cases (no auth / garbage bearer / malformed JWT) → 401
- [x] Cache behavior verified — follow-up requests with the same JWT don't re-query the DB
- [x] Rebased onto main (includes the recent org-resolution helper from #2956 — the two paths coexist cleanly; my strict `requireAuth` JWT branch handles identity, `resolveCallerOrgId` handles looser org-resolution for optional-auth routes)
- [x] Reusable smoke script: `scripts/rest-oauth-test.mjs` walks the full flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)