### PR TITLE
feat(addie): file GitHub issues as the member via WorkOS Pipes

### DIFF
--- a/.changeset/test-create-github-issue.md
+++ b/.changeset/test-create-github-issue.md
@@ -1,0 +1,4 @@
+---
+---
+
+Let Addie file GitHub issues as the member via WorkOS Pipes instead of a bot token. `create_github_issue` now pulls a per-user GitHub access token from Pipes; if the user hasn't connected yet (or scopes changed) it returns a Connect URL alongside the `draft_github_issue` fallback. Member hub gains a Connections card with a "Connect GitHub" button backed by new `/api/me/connected-accounts/github` routes.

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -1354,7 +1354,24 @@
       window.location.href = '/auth/login?return_to=/member-hub';
     }
 
-    document.addEventListener('DOMContentLoaded', loadHub);
+    document.addEventListener('DOMContentLoaded', () => {
+      loadHub();
+      maybeShowConnectedToast();
+    });
+
+    function maybeShowConnectedToast() {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('connected') !== 'github') return;
+      const toast = document.createElement('div');
+      toast.textContent = 'GitHub connected. Ask Addie to file your issue now.';
+      toast.style.cssText = 'position:fixed; top:var(--space-4); right:var(--space-4); background:#059669; color:#fff; padding:var(--space-3) var(--space-4); border-radius:var(--radius-md); box-shadow:0 4px 12px rgba(0,0,0,0.15); z-index:9999; font-size:var(--text-sm); font-weight:500; max-width:340px;';
+      document.body.appendChild(toast);
+      setTimeout(() => toast.style.opacity = '0', 4500);
+      setTimeout(() => toast.remove(), 5000);
+      params.delete('connected');
+      const newSearch = params.toString();
+      window.history.replaceState({}, '', window.location.pathname + (newSearch ? '?' + newSearch : ''));
+    }
 
     async function loadHub() {
       try {
@@ -1376,6 +1393,7 @@
             return;
           }
           if (engRes.status === 404) {
+            const github = githubRes.ok ? await githubRes.json() : { connected: false };
             document.getElementById('hub-loading').innerHTML =
               '<div class="hub-empty-panel">' +
               '<div class="hub-kicker">My hub</div>' +
@@ -1385,7 +1403,8 @@
               '<a href="/membership" class="btn btn-primary">Explore membership</a>' +
               '<a href="/community" class="btn btn-secondary">Browse community</a>' +
               '</div>' +
-              '</div>';
+              '</div>' +
+              '<div class="hub-card" style="max-width:720px; margin:var(--space-6) auto 0;">' + renderConnections({ github }) + '</div>';
             return;
           }
           throw new Error('Failed to load engagement data');

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -1358,7 +1358,7 @@
 
     async function loadHub() {
       try {
-        const [engRes, meRes, communityRes, certRes, tracksRes, contentRes, perspectivesRes, journeyRes] = await Promise.all([
+        const [engRes, meRes, communityRes, certRes, tracksRes, contentRes, perspectivesRes, journeyRes, githubRes] = await Promise.all([
           fetch('/api/me/engagement'),
           fetch('/api/me', { credentials: 'include' }),
           fetch('/api/me/community/hub', { credentials: 'include' }),
@@ -1367,6 +1367,7 @@
           fetch('/api/me/content?limit=6', { credentials: 'include' }),
           fetch('/api/perspectives?authored=true&limit=6', { credentials: 'include' }),
           fetch('/api/me/journey', { credentials: 'include' }),
+          fetch('/api/me/connected-accounts/github', { credentials: 'include' }),
         ]);
 
         if (!engRes.ok) {
@@ -1397,6 +1398,7 @@
         const contentData = contentRes.ok ? await contentRes.json() : null;
         const perspectivesData = perspectivesRes.ok ? await perspectivesRes.json() : null;
         const journeyData = journeyRes.ok ? await journeyRes.json() : null;
+        const githubConnection = githubRes.ok ? await githubRes.json() : { connected: false };
 
         renderHub({
           engagement: data,
@@ -1407,6 +1409,7 @@
           contentItems: contentData?.items || [],
           latestPerspectives: Array.isArray(perspectivesData) ? perspectivesData : [],
           journey: journeyData,
+          connections: { github: githubConnection },
         });
 
         // Check marketing opt-in status (non-blocking)
@@ -1511,6 +1514,7 @@
         contentItems,
         latestPerspectives,
         journey,
+        connections,
       } = payload;
       const {
         organization_name,
@@ -1604,6 +1608,10 @@
         <div class="hub-grid">
           <div class="hub-card">${renderProfileCard(profile, profileCompleteness)}</div>
           <div class="hub-card">${renderContentStudio(contentItems)}</div>
+        </div>
+
+        <div class="hub-grid hub-grid--single">
+          <div class="hub-card">${renderConnections(connections)}</div>
         </div>
 
         <div class="hub-grid hub-grid--single">
@@ -2041,6 +2049,57 @@
     }
 
     // -------------------------------------------------------------------------
+
+    function renderConnections(connections) {
+      const github = connections?.github || { connected: false };
+      const header = `
+        <div class="hub-card-header">
+          <span class="hub-card-title">Connections</span>
+        </div>`;
+      const rowStyle = 'display:flex; align-items:center; justify-content:space-between; gap:var(--space-4); flex-wrap:wrap;';
+      const copyStyle = 'font-size:var(--text-sm); color:var(--color-text-secondary);';
+      const statusStyle = 'font-size:var(--text-sm); color:#059669; font-weight:600;';
+      const githubRow = github.connected
+        ? `
+          <div style="${rowStyle}">
+            <div>
+              <strong>GitHub</strong>
+              <div style="${copyStyle}">Connected${github.login ? ` as <code>@${escapeHtml(github.login)}</code>` : ''}. Addie can file issues as you on <code>adcontextprotocol/adcp</code>.</div>
+            </div>
+            <span style="${statusStyle}">✓ Connected</span>
+          </div>`
+        : `
+          <div style="${rowStyle}">
+            <div>
+              <strong>GitHub</strong>
+              <div style="${copyStyle}">Connect GitHub so Addie can file issues on <code>adcontextprotocol/adcp</code> under your account.</div>
+            </div>
+            <button type="button" class="btn btn-secondary" onclick="connectGitHub(this)">Connect GitHub</button>
+          </div>`;
+      return `${header}${githubRow}`;
+    }
+
+    async function connectGitHub(btn) {
+      const original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Opening...';
+      try {
+        const res = await fetch('/api/me/connected-accounts/github/authorize', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ return_to: '/member-hub?connected=github' }),
+        });
+        if (!res.ok) throw new Error('Failed to start GitHub connection');
+        const { url } = await res.json();
+        window.location.href = url;
+      } catch (err) {
+        console.error(err);
+        btn.disabled = false;
+        btn.textContent = original;
+        alert('Could not start GitHub connection. Please try again in a moment.');
+      }
+    }
 
     function renderProfileCard(profile, profileCompleteness) {
       const hdr = `

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -1175,14 +1175,13 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'create_github_issue',
     description:
-      'File a GitHub issue authored by the logged-in user via their WorkOS Pipes GitHub connection. Use after showing the user a draft and getting their confirmation. If the user has not yet connected GitHub, the tool returns a message with a one-time Connect link AND reminds them they can ask for `draft_github_issue` instead — include that full message in your reply. All issues go to the "adcp" repository.',
+      'File a GitHub issue on adcontextprotocol/adcp authored by the logged-in user via their WorkOS Pipes GitHub connection. Use after showing the user a draft and getting their confirmation. If the user has not yet connected GitHub, the tool returns a message with a one-time Connect link AND reminds them they can ask for `draft_github_issue` instead — include that full message in your reply.',
     usage_hints: 'use after draft_github_issue when the user confirms they want the issue created. If the tool result asks the user to connect GitHub, show the full Connect link — do not silently fall back.',
     input_schema: {
       type: 'object',
       properties: {
         title: { type: 'string', description: 'Issue title' },
         body: { type: 'string', description: 'Issue body (no PII - GitHub is public)' },
-        repo: { type: 'string', description: 'Repo name (default: "adcp")' },
       },
       required: ['title', 'body'],
     },
@@ -4634,14 +4633,13 @@ export function createMemberToolHandlers(
   handlers.set('create_github_issue', async (input) => {
     const workosUserId = memberContext?.workos_user?.workos_user_id;
     if (!workosUserId) {
-      return 'You need to be logged in to create GitHub issues. Please log in at https://agenticadvertising.org/dashboard first.';
+      return 'You need to be logged in to create GitHub issues. Please log in at https://agenticadvertising.org/auth/login first.';
     }
 
     const title = input.title as string;
     const body = input.body as string;
     const org = 'adcontextprotocol';
-    const ALLOWED_REPOS = new Set(['adcp']);
-    const repo = ALLOWED_REPOS.has(input.repo as string) ? (input.repo as string) : 'adcp';
+    const repo = 'adcp';
 
     let tokenResult: Awaited<ReturnType<typeof getGitHubAccessToken>>;
     try {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -66,6 +66,7 @@ import { sendIntroductionEmail } from '../../notifications/email.js';
 import { v4 as uuidv4 } from 'uuid';
 import * as relationshipDb from '../../db/relationship-db.js';
 import * as personEvents from '../../db/person-events-db.js';
+import { getGitHubAccessToken, getGitHubAuthorizeUrl } from '../../services/pipes.js';
 
 const memberDb = new MemberDatabase();
 const agentContextDb = new AgentContextDatabase();
@@ -1174,8 +1175,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'create_github_issue',
     description:
-      'Create a GitHub issue directly via the API. Use this after showing the user a draft and getting their confirmation. Requires GITHUB_TOKEN to be configured. Attribution is added automatically. All issues go to the "adcp" repository.',
-    usage_hints: 'use after draft_github_issue when user confirms they want the issue created, or when user explicitly asks to create an issue directly',
+      'File a GitHub issue authored by the logged-in user via their WorkOS Pipes GitHub connection. Use after showing the user a draft and getting their confirmation. If the user has not yet connected GitHub, the tool returns a message with a one-time Connect link AND reminds them they can ask for `draft_github_issue` instead — include that full message in your reply. All issues go to the "adcp" repository.',
+    usage_hints: 'use after draft_github_issue when the user confirms they want the issue created. If the tool result asks the user to connect GitHub, show the full Connect link — do not silently fall back.',
     input_schema: {
       type: 'object',
       properties: {
@@ -4631,13 +4632,9 @@ export function createMemberToolHandlers(
   });
 
   handlers.set('create_github_issue', async (input) => {
-    if (!memberContext?.workos_user?.workos_user_id) {
+    const workosUserId = memberContext?.workos_user?.workos_user_id;
+    if (!workosUserId) {
       return 'You need to be logged in to create GitHub issues. Please log in at https://agenticadvertising.org/dashboard first.';
-    }
-
-    const token = process.env.GITHUB_TOKEN;
-    if (!token) {
-      return 'GitHub issue creation is not configured (GITHUB_TOKEN not set). Use draft_github_issue to generate a link instead.';
     }
 
     const title = input.title as string;
@@ -4646,18 +4643,39 @@ export function createMemberToolHandlers(
     const ALLOWED_REPOS = new Set(['adcp']);
     const repo = ALLOWED_REPOS.has(input.repo as string) ? (input.repo as string) : 'adcp';
 
-    // Add attribution
-    const userDisplayName = memberContext?.slack_user?.display_name
-      ?? (memberContext?.workos_user?.first_name
-        ? `${memberContext.workos_user.first_name} ${memberContext.workos_user.last_name || ''}`.trim()
-        : undefined);
-    const orgName = memberContext?.organization?.name;
-    const attribution = userDisplayName
-      ? `\n\n---\n*Filed by Addie on behalf of ${userDisplayName}${orgName ? ` (${orgName})` : ''}*`
-      : '\n\n---\n*Filed by Addie*';
+    let tokenResult: Awaited<ReturnType<typeof getGitHubAccessToken>>;
+    try {
+      tokenResult = await getGitHubAccessToken(workosUserId);
+    } catch (error) {
+      logger.error({ err: error }, 'create_github_issue: Pipes getAccessToken failed');
+      return 'GitHub connection is unavailable right now. Use `draft_github_issue` to generate a pre-filled link you can submit yourself.';
+    }
+
+    if (tokenResult.status !== 'ok') {
+      const baseUrl = (process.env.BASE_URL || 'https://agenticadvertising.org').replace(/\/$/, '');
+      const returnTo = `${baseUrl}/member-hub?connected=github`;
+      let authorizeUrl: string;
+      try {
+        authorizeUrl = await getGitHubAuthorizeUrl(workosUserId, returnTo);
+      } catch (error) {
+        logger.error({ err: error }, 'create_github_issue: Failed to build Pipes authorize URL');
+        return 'GitHub connection is unavailable right now. Use `draft_github_issue` to generate a pre-filled link you can submit yourself.';
+      }
+
+      const reason = tokenResult.status === 'needs_reauthorization'
+        ? "Your GitHub connection needs to be re-authorized (the scopes we need changed)."
+        : "You haven't connected GitHub yet, so I can't file this as you directly.";
+      return [
+        reason,
+        '',
+        `**Two options:**`,
+        `1. **[Connect GitHub](${authorizeUrl})** — takes ~10 seconds, then I'll file the issue authored by your GitHub account.`,
+        `2. Ask me to use \`draft_github_issue\` instead and I'll give you a pre-filled link you submit yourself.`,
+      ].join('\n');
+    }
 
     const ghHeaders = {
-      'Authorization': `Bearer ${token}`,
+      'Authorization': `Bearer ${tokenResult.accessToken}`,
       'Content-Type': 'application/json',
       'Accept': 'application/vnd.github.v3+json',
     };
@@ -4669,7 +4687,7 @@ export function createMemberToolHandlers(
         headers: ghHeaders,
         body: JSON.stringify({
           title,
-          body: body + attribution,
+          body,
           labels: ['community-reported'],
         }),
       });
@@ -4677,12 +4695,11 @@ export function createMemberToolHandlers(
       if (!response.ok) {
         const errorText = await response.text();
         logger.error({ status: response.status, repo }, 'create_github_issue: GitHub API error');
-        // Retry without labels only if the 422 is specifically about labels
         if (response.status === 422 && errorText.includes('label')) {
           const retryResponse = await fetch(apiUrl, {
             method: 'POST',
             headers: ghHeaders,
-            body: JSON.stringify({ title, body: body + attribution }),
+            body: JSON.stringify({ title, body }),
           });
           if (retryResponse.ok) {
             const issue = await retryResponse.json() as { html_url: string; number: number };

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7008,8 +7008,13 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       try {
         const host = req.get('host') || '';
         const protocol = req.protocol === 'http' && !host.startsWith('localhost') ? 'https' : req.protocol;
-        const requested = typeof req.body?.return_to === 'string' ? req.body.return_to : '/member-hub?connected=github';
-        const safeReturn = requested.startsWith('/') && !requested.startsWith('//') ? requested : '/member-hub?connected=github';
+        const DEFAULT_RETURN = '/member-hub?connected=github';
+        const requested = typeof req.body?.return_to === 'string' ? req.body.return_to : DEFAULT_RETURN;
+        const isSafeReturn = requested.startsWith('/')
+          && !requested.startsWith('//')
+          && !requested.includes('\\')
+          && !/[\r\n\t]/.test(requested);
+        const safeReturn = isSafeReturn ? requested : DEFAULT_RETURN;
         const returnTo = `${protocol}://${host}${safeReturn}`;
         const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
         res.json({ url });

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -31,6 +31,7 @@ import Stripe from "stripe";
 import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { ensureMemberProfilePublished } from "./services/member-profile-autopublish.js";
+import { getGitHubConnectedAccount, getGitHubAuthorizeUrl } from "./services/pipes.js";
 import { BrandDatabase, resolveBrandFromJson } from "./db/brand-db.js";
 import { CatalogEventsDatabase } from "./db/catalog-events-db.js";
 import { AgentInventoryProfilesDatabase } from "./db/agent-inventory-profiles-db.js";
@@ -6985,6 +6986,36 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         res.status(500).json({
           error: 'Failed to get agreement history',
         });
+      }
+    });
+
+    // GET /api/me/connected-accounts/github - Report whether the user has linked their GitHub via WorkOS Pipes
+    this.app.get('/api/me/connected-accounts/github', requireAuth, async (req, res) => {
+      try {
+        const account = await getGitHubConnectedAccount(req.user!.id);
+        if (!account) {
+          return res.json({ connected: false });
+        }
+        return res.json({ connected: true, login: account.login ?? null });
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to look up GitHub connected account');
+        res.status(500).json({ error: 'Failed to look up connection status' });
+      }
+    });
+
+    // POST /api/me/connected-accounts/github/authorize - Mint a WorkOS Pipes authorize URL for GitHub
+    this.app.post('/api/me/connected-accounts/github/authorize', requireAuth, async (req, res) => {
+      try {
+        const host = req.get('host') || '';
+        const protocol = req.protocol === 'http' && !host.startsWith('localhost') ? 'https' : req.protocol;
+        const requested = typeof req.body?.return_to === 'string' ? req.body.return_to : '/member-hub?connected=github';
+        const safeReturn = requested.startsWith('/') && !requested.startsWith('//') ? requested : '/member-hub?connected=github';
+        const returnTo = `${protocol}://${host}${safeReturn}`;
+        const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
+        res.json({ url });
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to mint GitHub authorize URL');
+        res.status(502).json({ error: 'Failed to start GitHub connection' });
       }
     });
 

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -1,9 +1,16 @@
-import { workos } from '../auth/workos-client.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('pipes');
 
 const GITHUB_PROVIDER = 'github';
+
+// Lazy-load the WorkOS client so importing this module doesn't trip the
+// `WORKOS_API_KEY` check at module-load time (tests transitively import pipes
+// via member-tools.ts and don't all set WorkOS env).
+async function getWorkos() {
+  const mod = await import('../auth/workos-client.js');
+  return mod.workos;
+}
 
 export type PipesTokenResult =
   | { status: 'ok'; accessToken: string; scopes: string[]; missingScopes: string[] }
@@ -11,6 +18,7 @@ export type PipesTokenResult =
   | { status: 'needs_reauthorization'; missingScopes: string[] };
 
 export async function getGitHubAccessToken(workosUserId: string): Promise<PipesTokenResult> {
+  const workos = await getWorkos();
   const result = await workos.pipes.getAccessToken({
     provider: GITHUB_PROVIDER,
     userId: workosUserId,
@@ -33,6 +41,7 @@ export async function getGitHubAccessToken(workosUserId: string): Promise<PipesT
 }
 
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
+  const workos = await getWorkos();
   const response = await workos.post<{ user_id: string; return_to: string }>(
     `/data-integrations/${GITHUB_PROVIDER}/authorize`,
     { user_id: workosUserId, return_to: returnTo },
@@ -47,6 +56,7 @@ export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: stri
 }
 
 export async function getGitHubConnectedAccount(workosUserId: string): Promise<{ login?: string } | null> {
+  const workos = await getWorkos();
   try {
     const response = await workos.get(
       `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -1,0 +1,68 @@
+import { workos } from '../auth/workos-client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('pipes');
+
+const GITHUB_PROVIDER = 'github';
+
+export type PipesTokenResult =
+  | { status: 'ok'; accessToken: string; scopes: string[]; missingScopes: string[] }
+  | { status: 'not_connected' }
+  | { status: 'needs_reauthorization'; missingScopes: string[] };
+
+export async function getGitHubAccessToken(workosUserId: string): Promise<PipesTokenResult> {
+  const result = await workos.pipes.getAccessToken({
+    provider: GITHUB_PROVIDER,
+    userId: workosUserId,
+  });
+
+  if (result.active) {
+    return {
+      status: 'ok',
+      accessToken: result.accessToken.accessToken,
+      scopes: result.accessToken.scopes,
+      missingScopes: result.accessToken.missingScopes,
+    };
+  }
+
+  if (result.error === 'not_installed') {
+    return { status: 'not_connected' };
+  }
+
+  return { status: 'needs_reauthorization', missingScopes: [] };
+}
+
+export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
+  const response = await workos.post<{ user_id: string; return_to: string }>(
+    `/data-integrations/${GITHUB_PROVIDER}/authorize`,
+    { user_id: workosUserId, return_to: returnTo },
+    {},
+  );
+  const data = (response && typeof response === 'object' && 'data' in response ? response.data : response) as { url?: string };
+  if (!data?.url) {
+    logger.error({ workosUserId, response }, 'Pipes authorize response missing url');
+    throw new Error('Pipes authorize response missing url');
+  }
+  return data.url;
+}
+
+export async function getGitHubConnectedAccount(workosUserId: string): Promise<{ login?: string } | null> {
+  try {
+    const response = await workos.get(
+      `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,
+      {},
+    );
+    const data = (response && typeof response === 'object' && 'data' in response ? response.data : response) as Record<string, unknown>;
+    const handle = typeof data?.external_user_handle === 'string'
+      ? data.external_user_handle
+      : typeof data?.external_handle === 'string'
+        ? data.external_handle
+        : undefined;
+    return { login: handle };
+  } catch (error) {
+    const status = (error as { status?: number; code?: number })?.status ?? (error as { code?: number })?.code;
+    if (status === 404) return null;
+    logger.warn({ err: error, workosUserId }, 'Failed to look up Pipes connected account');
+    return null;
+  }
+}

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -5,11 +5,17 @@
  * without external dependencies (API calls, database, etc.)
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemberContext } from '../../server/src/addie/member-context.js';
+
+vi.mock('../../server/src/services/pipes.js', () => ({
+  getGitHubAccessToken: vi.fn(),
+  getGitHubAuthorizeUrl: vi.fn(),
+}));
 
 // Import the tool definitions directly (no side effects)
 import { MEMBER_TOOLS, createMemberToolHandlers, extractAdcpVersion } from '../../server/src/addie/mcp/member-tools.js';
+import { getGitHubAccessToken, getGitHubAuthorizeUrl } from '../../server/src/services/pipes.js';
 
 describe('MEMBER_TOOLS definitions', () => {
   it('exports an array of tools', () => {
@@ -274,6 +280,202 @@ describe('createMemberToolHandlers', () => {
 
       expect(result).toContain('too long for a pre-filled URL');
       expect(result).toContain('create the issue manually');
+    });
+  });
+
+  describe('create_github_issue handler', () => {
+    const loggedInContext = {
+      is_mapped: true,
+      is_member: true,
+      slack_linked: false,
+      workos_user: {
+        workos_user_id: 'user_abc',
+        email: 'jane@example.com',
+        first_name: 'Jane',
+        last_name: 'Doe',
+      },
+      organization: { name: 'Acme Corp' },
+    } as unknown as MemberContext;
+
+    let fetchMock: ReturnType<typeof vi.fn>;
+    const getTokenMock = vi.mocked(getGitHubAccessToken);
+    const getAuthorizeUrlMock = vi.mocked(getGitHubAuthorizeUrl);
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      getTokenMock.mockReset();
+      getAuthorizeUrlMock.mockReset();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('requires a logged-in user', async () => {
+      const handlers = createMemberToolHandlers(null);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('logged in');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getTokenMock).not.toHaveBeenCalled();
+    });
+
+    it("returns Connect URL when user hasn't connected GitHub", async () => {
+      getTokenMock.mockResolvedValue({ status: 'not_connected' });
+      getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/abc');
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(getTokenMock).toHaveBeenCalledWith('user_abc');
+      expect(getAuthorizeUrlMock).toHaveBeenCalledWith('user_abc', expect.stringContaining('/member-hub'));
+      expect(result).toContain('haven\'t connected GitHub');
+      expect(result).toContain('[Connect GitHub](https://workos.example/pipes/authorize/abc)');
+      expect(result).toContain('draft_github_issue');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns Connect URL when connection needs reauthorization', async () => {
+      getTokenMock.mockResolvedValue({ status: 'needs_reauthorization', missingScopes: ['public_repo'] });
+      getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/xyz');
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('needs to be re-authorized');
+      expect(result).toContain('https://workos.example/pipes/authorize/xyz');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('gracefully degrades when Pipes getAccessToken throws', async () => {
+      getTokenMock.mockRejectedValue(new Error('workos api down'));
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('unavailable');
+      expect(result).toContain('draft_github_issue');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('gracefully degrades when Pipes authorize URL lookup fails', async () => {
+      getTokenMock.mockResolvedValue({ status: 'not_connected' });
+      getAuthorizeUrlMock.mockRejectedValue(new Error('workos unavailable'));
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('unavailable');
+      expect(result).toContain('draft_github_issue');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('creates an issue via the GitHub API using the Pipes user token', async () => {
+      getTokenMock.mockResolvedValue({ status: 'ok', accessToken: 'gho_pipes_token', scopes: ['public_repo'], missingScopes: [] });
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({ html_url: 'https://github.com/adcontextprotocol/adcp/issues/4242', number: 4242 }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'Bug report', body: 'Something broke.' });
+
+      expect(result).toContain('#4242');
+      expect(result).toContain('https://github.com/adcontextprotocol/adcp/issues/4242');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.github.com/repos/adcontextprotocol/adcp/issues');
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer gho_pipes_token');
+      const payload = JSON.parse(init.body as string) as { title: string; body: string; labels: string[] };
+      expect(payload.title).toBe('Bug report');
+      expect(payload.body).toBe('Something broke.');
+      expect(payload.body).not.toContain('Filed by Addie');
+      expect(payload.labels).toEqual(['community-reported']);
+    });
+
+    it('rejects unknown repos and defaults to adcp', async () => {
+      getTokenMock.mockResolvedValue({ status: 'ok', accessToken: 'gho_pipes_token', scopes: [], missingScopes: [] });
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({ html_url: 'https://github.com/adcontextprotocol/adcp/issues/1', number: 1 }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      await handler({ title: 'T', body: 'B', repo: 'adcp-client' });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.github.com/repos/adcontextprotocol/adcp/issues');
+    });
+
+    it('retries without labels when GitHub rejects an unknown label', async () => {
+      getTokenMock.mockResolvedValue({ status: 'ok', accessToken: 'gho_pipes_token', scopes: [], missingScopes: [] });
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response('validation failed: label does not exist', { status: 422 }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ html_url: 'https://github.com/adcontextprotocol/adcp/issues/77', number: 77 }),
+            { status: 201, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('#77');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const retryBody = JSON.parse((fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string);
+      expect(retryBody).not.toHaveProperty('labels');
+    });
+
+    it('returns a fallback message on non-ok responses', async () => {
+      getTokenMock.mockResolvedValue({ status: 'ok', accessToken: 'gho_pipes_token', scopes: [], missingScopes: [] });
+      fetchMock.mockResolvedValue(new Response('server error', { status: 500 }));
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('500');
+      expect(result).toContain('draft_github_issue');
+    });
+
+    it('returns a network-error message when fetch throws', async () => {
+      getTokenMock.mockResolvedValue({ status: 'ok', accessToken: 'gho_pipes_token', scopes: [], missingScopes: [] });
+      fetchMock.mockRejectedValue(new Error('connection refused'));
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('network error');
+      expect(result).toContain('draft_github_issue');
     });
   });
 


### PR DESCRIPTION
## Summary

- `create_github_issue` now pulls a per-user GitHub token from WorkOS Pipes instead of a shared bot `GITHUB_TOKEN`, so issues are authored by the actual member on `adcontextprotocol/adcp`.
- When a user hasn't connected GitHub yet (or scopes drifted), the tool returns a one-click Connect link *and* offers `draft_github_issue` as a fallback.
- Member hub gains a **Connections** card backed by new `GET /api/me/connected-accounts/github` and `POST /api/me/connected-accounts/github/authorize` routes.
- Removed the `Filed by Addie on behalf of …` attribution footer — the issue is now authored by the user's real GitHub account, so an attribution line is redundant.

## Prereqs before this works in prod

Already done by @bokelley:
- WorkOS Pipes GitHub provider is enabled with scopes `public_repo` + `read:user`.
- GitHub OAuth app's callback URL is registered to the WorkOS-hosted redirect URI.

Not needed anymore: `GITHUB_TOKEN` in Fly secrets (safe to leave unset — the code no longer reads it).

## Test plan

- [x] Unit tests (`tests/addie/member-tools.test.ts` — 53 pass, 8 covering `create_github_issue`): connected-token happy path, not-connected → Connect URL + draft fallback, needs-reauthorization, Pipes getAccessToken throw, authorize URL throw, 422 label retry, non-ok response, network error, rejected repo defaulting.
- [x] Typecheck clean.
- [x] Local end-to-end smoke: `/api/me/connected-accounts/github` returns `{connected: false}` as expected; hub renders the Connections card; Addie via `/api/addie/chat` degrades correctly when Pipes is unavailable.
- [ ] **Prod verification after merge**: log in, click Connect GitHub on member hub, ask Addie to file a test issue on `adcontextprotocol/adcp`, confirm authorship is your GitHub account. (Local end-to-end was blocked by GitHub OAuth App redirect URI scoping — easiest to verify once deployed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)