### PR TITLE
feat(cost-cap): resolve real tier for authenticated callers (#2945 f/u)

### DIFF
--- a/.changeset/cost-cap-tier-upgrade.md
+++ b/.changeset/cost-cap-tier-upgrade.md
@@ -1,0 +1,26 @@
+---
+---
+
+Resolve real tier for authenticated callers of the Addie cost cap
+(#2945 follow-up; closes the deferred tier-upgrade path from
+#2790 / #2946 / #2950).
+
+Paying members were silently capped at `member_free` ($5/day) rather
+than their `member_paid` ceiling ($25/day) because every caller site
+hardcoded `tier: 'member_free'`. This lands a new async helper
+`resolveUserTierForScopeKey(userId)` in `claude-cost-tracker.ts` and
+wires it into every authenticated caller site (10 total across
+`bolt-app.ts`, `handler.ts`, `addie-chat.ts`, `tavus.ts`).
+
+**Resolution rule:**
+- Bare WorkOS id (`user_…`): DB probe against
+  `organization_memberships` + `organizations`. Active, non-canceled
+  subscription → `member_paid`. Otherwise → `member_free`.
+- Non-WorkOS scope keys (`slack:…`, `email:…`, `mcp:…`, `tavus:ip:…`,
+  `anon:…`): no lookup, stays `member_free`.
+- DB error: fail-closed to `member_free` so a transient outage can't
+  accidentally grant the $25/day ceiling to unverified callers.
+
+Tests cover the four cases (non-WorkOS bypass, active-sub promotion,
+no-sub fallback, DB-error fail-closed) via the `db/client.js` mock
+seam.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -30,7 +30,7 @@ import type { Router } from 'express';
 import { logger } from '../logger.js';
 import { captureEvent } from '../utils/posthog.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
-import { resolveUserTierForScopeKey } from './claude-cost-tracker.js';
+import { resolveUserTierFromDb } from './claude-cost-tracker.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
@@ -1530,7 +1530,7 @@ async function handleUserMessage({
   // Mapped WorkOS users resolve to member_paid when they have an
   // active subscription; Slack-fallback users stay at member_free.
   const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
+  const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
   const processOptions: import('./claude-client.js').ProcessMessageOptions = {
     requestContext: requestContextWithRouting,
     ...(routedTools.isAAOAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
@@ -2143,7 +2143,7 @@ async function handleAppMention({
   // namespaced Slack ID so unmapped users still get a bounded
   // daily Addie spend budget.
   const mentionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const mentionCostScopeTier = await resolveUserTierForScopeKey(mentionCostScopeUserId);
+  const mentionCostScopeTier = await resolveUserTierFromDb(mentionCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(mentionUseOpus ? { modelOverride: ModelConfig.precision } : {}),
@@ -3105,7 +3105,7 @@ async function handleDirectMessage(
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
   const dmCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const dmCostScopeTier = await resolveUserTierForScopeKey(dmCostScopeUserId);
+  const dmCostScopeTier = await resolveUserTierFromDb(dmCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...((routedTools.requiresPrecision || routedTools.requiresDepth) ? { modelOverride: ModelConfig.precision } : {}),
@@ -3487,7 +3487,7 @@ async function handleActiveThreadReply({
   // Admin users get higher iteration limit.
   // Cost cap scope follows the mention-handler pattern above.
   const threadCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const threadCostScopeTier = await resolveUserTierForScopeKey(threadCostScopeUserId);
+  const threadCostScopeTier = await resolveUserTierFromDb(threadCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(threadUseOpus ? { modelOverride: ModelConfig.precision } : {}),
@@ -4071,7 +4071,7 @@ async function handleChannelMessage({
     const effectiveModel = channelUseOpus ? ModelConfig.precision : AddieModelConfig.chat;
     // Cost cap scope follows the mention-handler pattern above.
     const channelCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-    const channelCostScopeTier = await resolveUserTierForScopeKey(channelCostScopeUserId);
+    const channelCostScopeTier = await resolveUserTierFromDb(channelCostScopeUserId);
     const processOptions = {
       ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
       ...(channelUseOpus ? { modelOverride: ModelConfig.precision } : {}),
@@ -4861,7 +4861,7 @@ async function handleReactionAdded({
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
   const reactionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${reactingUserId}`;
-  const reactionCostScopeTier = await resolveUserTierForScopeKey(reactionCostScopeUserId);
+  const reactionCostScopeTier = await resolveUserTierFromDb(reactionCostScopeUserId);
   const processOptions = {
     ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     requestContext,

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -30,6 +30,7 @@ import type { Router } from 'express';
 import { logger } from '../logger.js';
 import { captureEvent } from '../utils/posthog.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
+import { resolveUserTierForScopeKey } from './claude-cost-tracker.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
@@ -1526,7 +1527,10 @@ async function handleUserMessage({
   // (consistent with tool-rate-limiter's scope keys); fall back to a
   // `slack:${userId}` namespace when no mapping exists so the cap
   // still bounds an individual Slack user's Addie spend (#2790).
+  // Mapped WorkOS users resolve to member_paid when they have an
+  // active subscription; Slack-fallback users stay at member_free.
   const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+  const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
   const processOptions: import('./claude-client.js').ProcessMessageOptions = {
     requestContext: requestContextWithRouting,
     ...(routedTools.isAAOAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
@@ -1534,12 +1538,7 @@ async function handleUserMessage({
     ...((routedTools.requiresPrecision || routedTools.requiresDepth) && { modelOverride: ModelConfig.precision }),
     slackUserId: userId,
     threadId: thread.thread_id,
-    // Conservative tier resolution: member_free for all authenticated
-    // Slack users. Upgrading to member_paid for real subscribers is
-    // filed as a follow-up — the active-subscription lookup isn't
-    // already threaded here. AAO admins should never hit the cap in
-    // legitimate use; if they do, the follow-up covers elevating them.
-    costScope: { userId: costScopeUserId, tier: 'member_free' },
+    costScope: { userId: costScopeUserId, tier: costScopeTier },
   };
 
   // Process with Claude using streaming
@@ -2144,13 +2143,14 @@ async function handleAppMention({
   // namespaced Slack ID so unmapped users still get a bounded
   // daily Addie spend budget.
   const mentionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+  const mentionCostScopeTier = await resolveUserTierForScopeKey(mentionCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(mentionUseOpus ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: mentionCostScopeUserId, tier: 'member_free' as const },
+    costScope: { userId: mentionCostScopeUserId, tier: mentionCostScopeTier },
   };
 
   // Process with Claude
@@ -3105,13 +3105,14 @@ async function handleDirectMessage(
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
   const dmCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+  const dmCostScopeTier = await resolveUserTierForScopeKey(dmCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...((routedTools.requiresPrecision || routedTools.requiresDepth) ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: dmCostScopeUserId, tier: 'member_free' as const },
+    costScope: { userId: dmCostScopeUserId, tier: dmCostScopeTier },
   };
 
   // Process with Claude
@@ -3486,13 +3487,14 @@ async function handleActiveThreadReply({
   // Admin users get higher iteration limit.
   // Cost cap scope follows the mention-handler pattern above.
   const threadCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+  const threadCostScopeTier = await resolveUserTierForScopeKey(threadCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(threadUseOpus ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: threadCostScopeUserId, tier: 'member_free' as const },
+    costScope: { userId: threadCostScopeUserId, tier: threadCostScopeTier },
   };
 
   // Process with Claude
@@ -4069,13 +4071,14 @@ async function handleChannelMessage({
     const effectiveModel = channelUseOpus ? ModelConfig.precision : AddieModelConfig.chat;
     // Cost cap scope follows the mention-handler pattern above.
     const channelCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+    const channelCostScopeTier = await resolveUserTierForScopeKey(channelCostScopeUserId);
     const processOptions = {
       ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
       ...(channelUseOpus ? { modelOverride: ModelConfig.precision } : {}),
       requestContext,
       slackUserId: userId,
       threadId: thread.thread_id,
-      costScope: { userId: channelCostScopeUserId, tier: 'member_free' as const },
+      costScope: { userId: channelCostScopeUserId, tier: channelCostScopeTier },
     };
     const response = await claudeClient.processMessage(messageText, undefined, filteredTools, undefined, processOptions);
 
@@ -4858,12 +4861,13 @@ async function handleReactionAdded({
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
   const reactionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${reactingUserId}`;
+  const reactionCostScopeTier = await resolveUserTierForScopeKey(reactionCostScopeUserId);
   const processOptions = {
     ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     requestContext,
     slackUserId: reactingUserId,
     threadId: thread.thread_id,
-    costScope: { userId: reactionCostScopeUserId, tier: 'member_free' as const },
+    costScope: { userId: reactionCostScopeUserId, tier: reactionCostScopeTier },
   };
 
   // Process with Claude

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -272,12 +272,19 @@ export function resolveUserTier(opts: {
  * fall back to `member_free` so a transient outage doesn't accidentally
  * grant the $25/day ceiling to unverified callers.
  *
- * This is the async counterpart to the pure `resolveUserTier` above —
- * call this one when the caller only knows a scope-key userId and
- * needs the DB to tell it whether the user has an active subscription.
+ * The SQL predicate here (`subscription_status = 'active' AND
+ * subscription_canceled_at IS NULL`) matches `MEMBER_FILTER` in
+ * `db/org-filters.ts` — the two must stay in sync so admin views and
+ * the cap agree on who counts as a paying member. Trialing / past_due /
+ * comped-$0 states all correctly fall through to `member_free`; if
+ * future policy promotes any of those, update `MEMBER_FILTER` first.
+ *
+ * This is the async, DB-touching counterpart to the pure
+ * `resolveUserTier` above — the `FromDb` suffix is deliberate so a
+ * call site can tell at a glance that this one awaits the database.
  */
-export async function resolveUserTierForScopeKey(userId: string): Promise<UserTier> {
-  if (!userId.startsWith('user_')) return 'member_free';
+export async function resolveUserTierFromDb(userId: string | null | undefined): Promise<UserTier> {
+  if (!userId || !userId.startsWith('user_')) return 'member_free';
   try {
     const { rows } = await query<{ exists: 1 }>(
       `SELECT 1 AS exists

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -263,6 +263,43 @@ export function resolveUserTier(opts: {
 }
 
 /**
+ * Resolve the right tier for a scope-key userId by looking up the
+ * subscription status of a bare WorkOS user id. Non-WorkOS scope keys
+ * (`slack:...`, `email:...`, etc.) can't resolve a real subscription
+ * at call time, so they stay `member_free` regardless of the underlying
+ * person's membership — upgrading those paths would need the caller to
+ * have already mapped to a WorkOS id and passed *that* here. DB errors
+ * fall back to `member_free` so a transient outage doesn't accidentally
+ * grant the $25/day ceiling to unverified callers.
+ *
+ * This is the async counterpart to the pure `resolveUserTier` above —
+ * call this one when the caller only knows a scope-key userId and
+ * needs the DB to tell it whether the user has an active subscription.
+ */
+export async function resolveUserTierForScopeKey(userId: string): Promise<UserTier> {
+  if (!userId.startsWith('user_')) return 'member_free';
+  try {
+    const { rows } = await query<{ exists: 1 }>(
+      `SELECT 1 AS exists
+         FROM organization_memberships om
+         JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+        WHERE om.workos_user_id = $1
+          AND o.subscription_status = 'active'
+          AND o.subscription_canceled_at IS NULL
+        LIMIT 1`,
+      [userId],
+    );
+    return rows.length > 0 ? 'member_paid' : 'member_free';
+  } catch (err) {
+    logger.warn(
+      { err, userId },
+      'Failed to resolve user tier — defaulting to member_free',
+    );
+    return 'member_free';
+  }
+}
+
+/**
  * Test-only: swap the store implementation. Tests pass an
  * InMemoryStore so they don't need a DB connection.
  */

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -7,7 +7,7 @@
 import { logger } from '../logger.js';
 import { sendChannelMessage } from '../slack/client.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
-import { resolveUserTierForScopeKey } from './claude-cost-tracker.js';
+import { resolveUserTierFromDb } from './claude-cost-tracker.js';
 import {
   sanitizeInput,
   validateOutput,
@@ -603,7 +603,7 @@ export async function handleAssistantMessage(
     // daily Addie spend budget. Mapped WorkOS users resolve to
     // member_paid if they have an active subscription (#2945 f/u).
     const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
-    const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
+    const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
@@ -779,7 +779,7 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     // tier resolved from subscription status; fall back to a
     // namespaced Slack ID at member_free.
     const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
-    const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
+    const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -7,6 +7,7 @@
 import { logger } from '../logger.js';
 import { sendChannelMessage } from '../slack/client.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
+import { resolveUserTierForScopeKey } from './claude-cost-tracker.js';
 import {
   sanitizeInput,
   validateOutput,
@@ -599,12 +600,14 @@ export async function handleAssistantMessage(
     // Admin users get higher iteration limit for bulk operations.
     // Cost-cap scope (#2790): prefer WorkOS user ID; fall back to a
     // namespaced Slack ID so unmapped users still get a bounded
-    // daily Addie spend budget.
+    // daily Addie spend budget. Mapped WorkOS users resolve to
+    // member_paid if they have an active subscription (#2945 f/u).
     const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
+    const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
-      costScope: { userId: costScopeUserId, tier: 'member_free' },
+      costScope: { userId: costScopeUserId, tier: costScopeTier },
     };
 
     // Process with Claude
@@ -772,14 +775,15 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     const { tools: userTools, isAAOAdmin: userIsAdmin } = await createUserScopedTools(memberContext, event.user, event.thread_ts || event.ts, { isChannelMention: true });
 
     // Admin users get higher iteration limit for bulk operations.
-    // Cost-cap scope (#2790): prefer WorkOS user ID; fall back to a
-    // namespaced Slack ID so unmapped users still get a bounded
-    // daily Addie spend budget.
+    // Cost-cap scope (#2790 / #2945 f/u): prefer WorkOS user ID with
+    // tier resolved from subscription status; fall back to a
+    // namespaced Slack ID at member_free.
     const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
+    const costScopeTier = await resolveUserTierForScopeKey(costScopeUserId);
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
-      costScope: { userId: costScopeUserId, tier: 'member_free' },
+      costScope: { userId: costScopeUserId, tier: costScopeTier },
     };
 
     // Process with Claude

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -17,6 +17,7 @@ import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
+import { resolveUserTierForScopeKey } from "../addie/claude-cost-tracker.js";
 import {
   sanitizeInput,
   validateOutput,
@@ -781,6 +782,18 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       );
       const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth);
 
+      // Cost-cap scope (#2790). Authenticated callers key off the
+      // WorkOS user ID and resolve their tier from subscription
+      // status — paying members land on member_paid ($25/day),
+      // free accounts on member_free ($5/day). Anonymous callers key
+      // off a hashed IP; the client-generated `externalId` alone was
+      // a bypass vector (an attacker could rotate it to get a fresh
+      // budget per request). The per-IP 50 msg/day limiter above
+      // bounds rotation within a single host.
+      const authedTier = req.user?.id
+        ? await resolveUserTierForScopeKey(req.user.id)
+        : null;
+
       // Process with Claude
       let response;
       try {
@@ -789,22 +802,8 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
           requestContext,
           threadId: thread.thread_id,
           userDisplayName: displayName || undefined,
-          // Per-user Anthropic cost cap (#2790). Anonymous callers
-          // fall under a tighter $1/day ceiling; authenticated
-          // callers get $5/day as member_free. Upgrading to
-          // member_paid tier requires the subscription-status lookup
-          // (filed as follow-up) — until then, real paying members
-          // sit on member_free which is still plenty for normal
-          // conversational use.
-          // Cost-cap scope (#2790). Authenticated callers key off the
-          // WorkOS user ID directly. Anonymous callers key off a
-          // hashed IP — the client-generated `externalId` alone was a
-          // bypass vector (an attacker could rotate it to get a
-          // fresh budget per request). The per-IP 50 msg/day limiter
-          // above bounds rotation within a single host; a botnet
-          // defeats both, which is acknowledged in the module header.
-          ...(req.user?.id
-            ? { costScope: { userId: req.user.id, tier: 'member_free' as const } }
+          ...(req.user?.id && authedTier
+            ? { costScope: { userId: req.user.id, tier: authedTier } }
             : { costScope: { userId: `anon:${hashIp(req.ip)}`, tier: 'anonymous' as const } }),
         });
       } catch (error) {
@@ -1053,14 +1052,18 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       let response;
       const toolsUsed: string[] = [];
 
+      // Cost cap — see matching block in the non-streaming path.
+      const streamAuthedTier = req.user?.id
+        ? await resolveUserTierForScopeKey(req.user.id)
+        : null;
+
       for await (const event of claudeClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
         ...processOptions,
         requestContext,
         threadId: thread.thread_id,
         userDisplayName: displayName || undefined,
-        // Cost cap — see matching block in the non-streaming path.
-        ...(req.user?.id
-          ? { costScope: { userId: req.user.id, tier: 'member_free' as const } }
+        ...(req.user?.id && streamAuthedTier
+          ? { costScope: { userId: req.user.id, tier: streamAuthedTier } }
           : externalId
             ? { costScope: { userId: `anon:${externalId}`, tier: 'anonymous' as const } }
             : {}),

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -17,7 +17,7 @@ import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
-import { resolveUserTierForScopeKey } from "../addie/claude-cost-tracker.js";
+import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
   sanitizeInput,
   validateOutput,
@@ -782,16 +782,16 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       );
       const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth);
 
-      // Cost-cap scope (#2790). Authenticated callers key off the
-      // WorkOS user ID and resolve their tier from subscription
-      // status — paying members land on member_paid ($25/day),
-      // free accounts on member_free ($5/day). Anonymous callers key
-      // off a hashed IP; the client-generated `externalId` alone was
-      // a bypass vector (an attacker could rotate it to get a fresh
-      // budget per request). The per-IP 50 msg/day limiter above
-      // bounds rotation within a single host.
-      const authedTier = req.user?.id
-        ? await resolveUserTierForScopeKey(req.user.id)
+      // Cost-cap scope (#2790 / #2945 f/u). Authenticated callers key
+      // off the WorkOS user ID and resolve their tier from
+      // subscription status — paying members land on member_paid
+      // ($25/day), free accounts on member_free ($5). Anonymous
+      // callers key off a hashed IP; the client-generated
+      // `externalId` alone was a bypass vector (an attacker could
+      // rotate it to get a fresh budget per request). The per-IP 50
+      // msg/day limiter above bounds rotation within a single host.
+      const authedScope = req.user?.id
+        ? { userId: req.user.id, tier: await resolveUserTierFromDb(req.user.id) }
         : null;
 
       // Process with Claude
@@ -802,9 +802,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
           requestContext,
           threadId: thread.thread_id,
           userDisplayName: displayName || undefined,
-          ...(req.user?.id && authedTier
-            ? { costScope: { userId: req.user.id, tier: authedTier } }
-            : { costScope: { userId: `anon:${hashIp(req.ip)}`, tier: 'anonymous' as const } }),
+          costScope: authedScope ?? { userId: `anon:${hashIp(req.ip)}`, tier: 'anonymous' as const },
         });
       } catch (error) {
         // Provide user-friendly error message based on error type
@@ -1053,8 +1051,8 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       const toolsUsed: string[] = [];
 
       // Cost cap — see matching block in the non-streaming path.
-      const streamAuthedTier = req.user?.id
-        ? await resolveUserTierForScopeKey(req.user.id)
+      const streamAuthedScope = req.user?.id
+        ? { userId: req.user.id, tier: await resolveUserTierFromDb(req.user.id) }
         : null;
 
       for await (const event of claudeClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
@@ -1062,8 +1060,8 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         requestContext,
         threadId: thread.thread_id,
         userDisplayName: displayName || undefined,
-        ...(req.user?.id && streamAuthedTier
-          ? { costScope: { userId: req.user.id, tier: streamAuthedTier } }
+        ...(streamAuthedScope
+          ? { costScope: streamAuthedScope }
           : externalId
             ? { costScope: { userId: `anon:${externalId}`, tier: 'anonymous' as const } }
             : {}),

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createLogger } from "../logger.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
-import { resolveUserTierForScopeKey } from "../addie/claude-cost-tracker.js";
+import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
   initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS,
@@ -564,15 +564,17 @@ export function createTavusRouter() {
 
     let streamError = false;
     try {
-      // Cost cap (#2790 / #2950 / #2945 follow-up): voice sessions
-      // carry a thread.user_id resolved from session-init auth. When
-      // that resolves, charge the WorkOS user and honor their
+      // Cost cap (#2790 / #2945 f/u): voice sessions carry a
+      // thread.user_id resolved from session-init auth. When that
+      // resolves, charge the WorkOS user and honor their
       // subscription tier (member_paid vs member_free). If it
       // doesn't (misconfigured / abandoned thread, or a caller
       // reaching the LLM endpoint with the shared-secret but no
       // valid thread), bucket by IP under the anonymous tier so a
       // leaked TAVUS_LLM_SECRET still hits a bounded daily spend.
-      const voiceTier = voiceUserId ? await resolveUserTierForScopeKey(voiceUserId) : null;
+      const voiceScope = voiceUserId
+        ? { userId: voiceUserId, tier: await resolveUserTierFromDb(voiceUserId) }
+        : null;
 
       for await (const event of claudeClient.processMessageStream(
         currentMessage,
@@ -580,9 +582,7 @@ export function createTavusRouter() {
         voiceRequestTools,
         {
           requestContext,
-          ...(voiceUserId && voiceTier
-            ? { costScope: { userId: voiceUserId, tier: voiceTier } }
-            : { costScope: { userId: `tavus:ip:${req.ip ?? 'unknown'}`, tier: 'anonymous' as const } }),
+          costScope: voiceScope ?? { userId: `tavus:ip:${req.ip ?? 'unknown'}`, tier: 'anonymous' as const },
         }
       )) {
         if (connectionClosed) break;

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createLogger } from "../logger.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
+import { resolveUserTierForScopeKey } from "../addie/claude-cost-tracker.js";
 import {
   initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS,
@@ -563,22 +564,24 @@ export function createTavusRouter() {
 
     let streamError = false;
     try {
+      // Cost cap (#2790 / #2950 / #2945 follow-up): voice sessions
+      // carry a thread.user_id resolved from session-init auth. When
+      // that resolves, charge the WorkOS user and honor their
+      // subscription tier (member_paid vs member_free). If it
+      // doesn't (misconfigured / abandoned thread, or a caller
+      // reaching the LLM endpoint with the shared-secret but no
+      // valid thread), bucket by IP under the anonymous tier so a
+      // leaked TAVUS_LLM_SECRET still hits a bounded daily spend.
+      const voiceTier = voiceUserId ? await resolveUserTierForScopeKey(voiceUserId) : null;
+
       for await (const event of claudeClient.processMessageStream(
         currentMessage,
         threadContext,
         voiceRequestTools,
         {
           requestContext,
-          // Cost cap (#2790 / #2950): voice sessions carry a
-          // thread.user_id resolved from session-init auth. When
-          // that resolves, charge the WorkOS user at member_free.
-          // If it doesn't (misconfigured / abandoned thread, or a
-          // caller reaching the LLM endpoint with the shared-secret
-          // but no valid thread), bucket by IP under the anonymous
-          // tier so a leaked TAVUS_LLM_SECRET still hits a bounded
-          // daily spend rather than going uncapped.
-          ...(voiceUserId
-            ? { costScope: { userId: voiceUserId, tier: 'member_free' as const } }
+          ...(voiceUserId && voiceTier
+            ? { costScope: { userId: voiceUserId, tier: voiceTier } }
             : { costScope: { userId: `tavus:ip:${req.ip ?? 'unknown'}`, tier: 'anonymous' as const } }),
         }
       )) {

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * #2945 follow-up — `resolveUserTierForScopeKey` does a single-row
+ * probe to the DB to decide whether a bare WorkOS id should get the
+ * `member_paid` ($25/day) ceiling or stay at `member_free` ($5). The
+ * DB query is mocked per test so we can drive each branch without a
+ * Postgres connection.
+ */
+
+const queryMock = vi.fn();
+vi.mock('../../src/db/client.js', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  getPool: () => ({ query: queryMock }),
+}));
+
+// Import after the mock is installed so the module picks up the mocked
+// `query` reference instead of the real db/client.
+const { resolveUserTierForScopeKey } = await import('../../src/addie/claude-cost-tracker.js');
+
+beforeEach(() => {
+  queryMock.mockReset();
+});
+
+describe('resolveUserTierForScopeKey', () => {
+  it('returns member_free without hitting the DB for non-WorkOS scope keys', async () => {
+    // Anything that's not a bare WorkOS id (user_...) can't resolve a
+    // subscription at call time — slack:, email:, mcp:, tavus:ip:,
+    // anon: all skip the lookup and stay at member_free.
+    for (const key of ['slack:U12345', 'email:abc123', 'mcp:sub-1', 'tavus:ip:10.0.0.1', 'anon:hashedip']) {
+      const tier = await resolveUserTierForScopeKey(key);
+      expect(tier).toBe('member_free');
+    }
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns member_paid when the WorkOS user has an active, non-canceled subscription', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    expect(tier).toBe('member_paid');
+    expect(queryMock).toHaveBeenCalledOnce();
+    // The probe must filter on both active status AND not-canceled —
+    // otherwise a canceled org would still read as paid until grace
+    // period ends.
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("subscription_status = 'active'");
+    expect(sql).toContain('subscription_canceled_at IS NULL');
+  });
+
+  it('returns member_free when the WorkOS user has no active subscription (empty rows)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    expect(tier).toBe('member_free');
+  });
+
+  it('returns member_free when the DB query throws — fail-closed to the conservative tier', async () => {
+    // DB outage mid-conversation must not accidentally grant the
+    // $25/day ceiling to unverified callers. Fail-closed to
+    // member_free means legitimate members briefly see the lower cap
+    // during an outage but no-one gets an unearned bump.
+    queryMock.mockRejectedValueOnce(new Error('Connection refused'));
+    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    expect(tier).toBe('member_free');
+  });
+});

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 /**
- * #2945 follow-up — `resolveUserTierForScopeKey` does a single-row
+ * #2945 follow-up — `resolveUserTierFromDb` does a single-row
  * probe to the DB to decide whether a bare WorkOS id should get the
  * `member_paid` ($25/day) ceiling or stay at `member_free` ($5). The
  * DB query is mocked per test so we can drive each branch without a
@@ -16,27 +16,38 @@ vi.mock('../../src/db/client.js', () => ({
 
 // Import after the mock is installed so the module picks up the mocked
 // `query` reference instead of the real db/client.
-const { resolveUserTierForScopeKey } = await import('../../src/addie/claude-cost-tracker.js');
+const { resolveUserTierFromDb } = await import('../../src/addie/claude-cost-tracker.js');
 
 beforeEach(() => {
   queryMock.mockReset();
 });
 
-describe('resolveUserTierForScopeKey', () => {
+describe('resolveUserTierFromDb', () => {
   it('returns member_free without hitting the DB for non-WorkOS scope keys', async () => {
     // Anything that's not a bare WorkOS id (user_...) can't resolve a
     // subscription at call time — slack:, email:, mcp:, tavus:ip:,
     // anon: all skip the lookup and stay at member_free.
     for (const key of ['slack:U12345', 'email:abc123', 'mcp:sub-1', 'tavus:ip:10.0.0.1', 'anon:hashedip']) {
-      const tier = await resolveUserTierForScopeKey(key);
+      const tier = await resolveUserTierFromDb(key);
       expect(tier).toBe('member_free');
     }
     expect(queryMock).not.toHaveBeenCalled();
   });
 
+  it('returns member_free without throwing when given null / undefined / empty string', async () => {
+    // Signature is `string | null | undefined` — call sites use `??`
+    // fallbacks so nullish never reaches here in practice, but the
+    // exported helper must not TypeError on a stray null (a regression
+    // would silently default everyone to member_free without logging).
+    expect(await resolveUserTierFromDb(null)).toBe('member_free');
+    expect(await resolveUserTierFromDb(undefined)).toBe('member_free');
+    expect(await resolveUserTierFromDb('')).toBe('member_free');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
   it('returns member_paid when the WorkOS user has an active, non-canceled subscription', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
-    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_paid');
     expect(queryMock).toHaveBeenCalledOnce();
     // The probe must filter on both active status AND not-canceled —
@@ -49,7 +60,7 @@ describe('resolveUserTierForScopeKey', () => {
 
   it('returns member_free when the WorkOS user has no active subscription (empty rows)', async () => {
     queryMock.mockResolvedValueOnce({ rows: [] });
-    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_free');
   });
 
@@ -59,7 +70,7 @@ describe('resolveUserTierForScopeKey', () => {
     // member_free means legitimate members briefly see the lower cap
     // during an outage but no-one gets an unearned bump.
     queryMock.mockRejectedValueOnce(new Error('Connection refused'));
-    const tier = await resolveUserTierForScopeKey('user_01H2ABC');
+    const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_free');
   });
 });


### PR DESCRIPTION
## Summary
Closes the deferred tier-upgrade path from the cost-cap series (#2790 / #2946 / #2950 / #2961). Paying WorkOS members were silently capped at `member_free` (\$5/day) because every caller hardcoded that tier.

New async helper `resolveUserTierFromDb(userId)` in `claude-cost-tracker.ts`:
- Bare WorkOS id (`user_…`): DB probe against `organization_memberships` + `organizations`. Active, non-canceled subscription → `member_paid` (\$25/day). Otherwise → `member_free`.
- Non-WorkOS scope keys (`slack:…`, `email:…`, `mcp:…`, `tavus:ip:…`, `anon:…`) or null/undefined: no lookup, stays `member_free`.
- DB error: fail-closed to `member_free` so a transient outage can't accidentally grant \$25/day to unverified callers.

Wired into all 10 authenticated caller sites:
- `bolt-app.ts`: 6 (base handler, mention, DM, thread reply, proposed-channel, reaction)
- `handler.ts`: 2 (message, mention)
- `addie-chat.ts`: 2 (non-streaming, streaming)
- `tavus.ts`: 1 (voice stream)

SQL predicate (`subscription_status = 'active' AND subscription_canceled_at IS NULL`) matches `MEMBER_FILTER` in `db/org-filters.ts`; comment in the helper points at that as the canonical definition so future policy changes stay in lockstep.

**Expert-review fixes already folded in (commit 2):**
- **Must Fix** — added null/undefined/empty-string guard so a stray nullish input returns `member_free` instead of TypeErroring on `.startsWith`. Test pins the behavior.
- **Should Fix** — renamed `resolveUserTierForScopeKey` → `resolveUserTierFromDb` so the sync-vs-async / pure-vs-DB distinction is visible at every call site.
- **Should Fix** — cleaned up dead `authedTier && ...` branches in addie-chat / tavus; the DB helper never returns null, so the conditional implied a fallback path that could never fire.
- **Nit** — standardized cost-cap comment format to `#2790 / #2945 f/u` across all updated sites.

## Test plan
- [x] 5 unit tests for the helper (non-WorkOS bypass, nullish bypass, active-sub promotion, no-sub fallback, DB-error fail-closed)
- [x] \`npx tsc --project server/tsconfig.json --noEmit\` clean
- [x] \`npm run test:server-unit\` — 2024 passing (existing c2pa cert fixture is a pre-existing flake)
- [ ] **Post-deploy smoke** — verify admin addie-costs leaderboard shows paying members under `member_paid` tier on next real chat turn

Follow-ups deferred (reviewer flagged as a nit, fine for another PR): extract a `buildCostScope(memberContext, slackUserId)` helper for the 8 Slack sites that share the same 2-line prelude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)