### PR TITLE
feat(admin): surface Gemini illustration cap on admin dashboard (#2796)

### DIFF
--- a/.changeset/gemini-illustration-cap-ops-metric.md
+++ b/.changeset/gemini-illustration-cap-ops-metric.md
@@ -1,0 +1,25 @@
+---
+---
+
+Surface Gemini illustration-generation activity against the workspace
+cap on the admin dashboard (closes #2796 ops metric requirement).
+
+The workspace cap (50/day) and per-user co-author aggregation for
+`generate_perspective_illustration` were already enforced in
+`tool-rate-limiter.ts` (`WORKSPACE_CAPS`) and
+`illustration-db.ts:countMonthlyGenerations`. What was missing from
+#2796's acceptance criteria was ops visibility — a dashboard metric
+for "illustration generations today" so operators can see cap status
+without reading Gemini's billing console.
+
+Changes:
+- Exported `WORKSPACE_CAPS` from `tool-rate-limiter.ts` so the stats
+  endpoint reads the configured cap value instead of hard-coding it.
+- `/api/admin/stats` now includes `illustrations_generated_24h`,
+  `illustrations_generated_7d`, `illustrations_cap_24h`, and
+  `illustrations_cap_remaining` fields.
+- Added a card to `admin.html`: "Gemini Illustrations (24h cost cap)"
+  rendering generated / cap / remaining / 7d trend.
+
+No new enforcement — this is pure visibility over the already-active
+cap.

--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -603,6 +603,16 @@
             <span id="addieRating">-</span> avg rating
           </div>
         </div>
+
+        <div class="insight-box">
+          <div class="insight-label">Gemini Illustrations (24h cost cap)</div>
+          <div class="insight-text">
+            <span id="illustrationsGenerated24h">-</span> /
+            <span id="illustrationsCap24h">-</span> generated
+            · <span id="illustrationsCapRemaining">-</span> remaining
+            · <span id="illustrationsGenerated7d">-</span> over 7 days
+          </div>
+        </div>
       </div>
 
       <!-- GOAL 2: FUNNEL -->
@@ -820,6 +830,12 @@
           const addieTrend = calculateTrend(trends.addie_threads.current, trends.addie_threads.previous);
           document.getElementById('addieTrend').textContent = addieTrend.text;
         }
+
+        // Gemini illustration cap (#2796)
+        document.getElementById('illustrationsGenerated24h').textContent = formatNumber(stats.illustrations_generated_24h);
+        document.getElementById('illustrationsCap24h').textContent = formatNumber(stats.illustrations_cap_24h);
+        document.getElementById('illustrationsCapRemaining').textContent = formatNumber(stats.illustrations_cap_remaining);
+        document.getElementById('illustrationsGenerated7d').textContent = formatNumber(stats.illustrations_generated_7d);
 
         // FUNNEL
         document.getElementById('totalOrgs').textContent = formatNumber(stats.total_orgs);

--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -605,10 +605,10 @@
         </div>
 
         <div class="insight-box">
-          <div class="insight-label">Gemini Illustrations (24h cost cap)</div>
+          <div class="insight-label">Gemini Illustrations (daily cost cap)</div>
           <div class="insight-text">
             <span id="illustrationsGenerated24h">-</span> /
-            <span id="illustrationsCap24h">-</span> generated
+            <span id="illustrationsCapDaily">-</span> generated
             · <span id="illustrationsCapRemaining">-</span> remaining
             · <span id="illustrationsGenerated7d">-</span> over 7 days
           </div>
@@ -833,7 +833,7 @@
 
         // Gemini illustration cap (#2796)
         document.getElementById('illustrationsGenerated24h').textContent = formatNumber(stats.illustrations_generated_24h);
-        document.getElementById('illustrationsCap24h').textContent = formatNumber(stats.illustrations_cap_24h);
+        document.getElementById('illustrationsCapDaily').textContent = formatNumber(stats.illustrations_cap_daily);
         document.getElementById('illustrationsCapRemaining').textContent = formatNumber(stats.illustrations_cap_remaining);
         document.getElementById('illustrationsGenerated7d').textContent = formatNumber(stats.illustrations_generated_7d);
 

--- a/server/src/addie/mcp/tool-rate-limiter.ts
+++ b/server/src/addie/mcp/tool-rate-limiter.ts
@@ -67,9 +67,8 @@ const GLOBAL_CAP: ToolRateLimitConfig = { windowMs: 10 * 60 * 1000, max: 200 };
  * defensible cost ceiling, or where an attacker rotates through
  * compromised user sessions to stay under individual caps.
  *
- * Exported so admin observability (#2796 ops metric) can read the cap
- * value instead of hard-coding it — single source of truth for the
- * ceiling.
+ * Exported so admin stats can read the configured cap — single
+ * source of truth for the ceiling. Part of the admin API contract.
  */
 export const WORKSPACE_CAPS: Record<string, ToolRateLimitConfig> = {
   // Gemini generation — most expensive tool in the Addie surface.

--- a/server/src/addie/mcp/tool-rate-limiter.ts
+++ b/server/src/addie/mcp/tool-rate-limiter.ts
@@ -66,8 +66,12 @@ const GLOBAL_CAP: ToolRateLimitConfig = { windowMs: 10 * 60 * 1000, max: 200 };
  * multi-member workspace collectively drives the tool past a
  * defensible cost ceiling, or where an attacker rotates through
  * compromised user sessions to stay under individual caps.
+ *
+ * Exported so admin observability (#2796 ops metric) can read the cap
+ * value instead of hard-coding it — single source of truth for the
+ * ceiling.
  */
-const WORKSPACE_CAPS: Record<string, ToolRateLimitConfig> = {
+export const WORKSPACE_CAPS: Record<string, ToolRateLimitConfig> = {
   // Gemini generation — most expensive tool in the Addie surface.
   // 50/day across the whole workspace keeps monthly spend bounded
   // (~1500 generations/mo max). The per-user 5/month quota + per-user

--- a/server/src/routes/admin/stats.ts
+++ b/server/src/routes/admin/stats.ts
@@ -272,18 +272,28 @@ export function setupStatsRoutes(apiRouter: Router): void {
           FROM addie_threads
         `),
 
-        // Gemini illustration generation — rolling 24h window matches
-        // the enforced workspace cap in tool-rate-limiter's
-        // WORKSPACE_CAPS. Counting `perspective_illustrations` directly
-        // (not the rate-limiter's scope_key events) because the
-        // illustrations table is the source of truth for what actually
-        // got persisted; tool-rate-limit events fire on *attempts*
-        // including rejected-by-cap ones. (#2796 ops metric)
+        // Gemini illustration generation — rolling 24h window aligned
+        // with the enforced workspace cap in tool-rate-limiter's
+        // WORKSPACE_CAPS. Counts persisted rows (one Gemini call = one
+        // row) excluding `status='pending'`, which represents a
+        // pre-call placeholder insert without a paid generation.
+        // `rejected` rows are included because rejection happens after
+        // the paid generation — the dollars were spent.
+        //
+        // NOTE: this is an ops approximation of the enforcement
+        // counter, not the counter itself. The rate-limiter counts
+        // attempts (including cap-rejected ones) in
+        // `addie_tool_rate_limit_events`, while we count persists in
+        // `perspective_illustrations`. Bursts of cap-rejected attempts
+        // in the enforcement window won't show up here. Good enough
+        // for "what did we spend today" but not for "how close is the
+        // next generation to being blocked." (#2796)
         pool.query(`
           SELECT
             COUNT(CASE WHEN created_at > NOW() - INTERVAL '24 hours' THEN 1 END) as generated_24h,
             COUNT(CASE WHEN created_at > NOW() - INTERVAL '7 days' THEN 1 END)  as generated_7d
           FROM perspective_illustrations
+          WHERE status != 'pending'
         `),
       ]);
 
@@ -356,10 +366,13 @@ export function setupStatsRoutes(apiRouter: Router): void {
         addie_positive_ratings: parseInt(ratings.positive_ratings) || 0,
         addie_negative_ratings: parseInt(ratings.negative_ratings) || 0,
 
-        // Gemini illustration cap observability (#2796).
+        // Gemini illustration cap observability (#2796). The `_daily`
+        // suffix on `cap_daily` marks it as a scalar ceiling (not a
+        // count over 24h, which would parallel the `_24h` suffixes
+        // above).
         illustrations_generated_24h: illustrationsGenerated24h,
         illustrations_generated_7d: parseInt(illustrations.generated_7d) || 0,
-        illustrations_cap_24h: illustrationCap,
+        illustrations_cap_daily: illustrationCap,
         illustrations_cap_remaining: illustrationsCapRemaining,
 
         // User stats (community points tiers)

--- a/server/src/routes/admin/stats.ts
+++ b/server/src/routes/admin/stats.ts
@@ -24,6 +24,7 @@ import {
   ENGAGED_FILTER,
   REGISTERED_FILTER,
 } from "../../db/org-filters.js";
+import { WORKSPACE_CAPS } from "../../addie/mcp/tool-rate-limiter.js";
 
 const memberSearchAnalyticsDb = new MemberSearchAnalyticsDatabase();
 const memberDb = new MemberDatabase();
@@ -63,6 +64,7 @@ export function setupStatsRoutes(apiRouter: Router): void {
         slackByWeek,
         engagementTrends,
         addieTrends,
+        illustrationStats,
       ] = await Promise.all([
         // Member counts from organizations
         pool.query(`
@@ -269,6 +271,20 @@ export function setupStatsRoutes(apiRouter: Router): void {
             COUNT(CASE WHEN started_at >= CURRENT_DATE - INTERVAL '60 days' AND started_at < CURRENT_DATE - INTERVAL '30 days' THEN 1 END) as threads_previous
           FROM addie_threads
         `),
+
+        // Gemini illustration generation — rolling 24h window matches
+        // the enforced workspace cap in tool-rate-limiter's
+        // WORKSPACE_CAPS. Counting `perspective_illustrations` directly
+        // (not the rate-limiter's scope_key events) because the
+        // illustrations table is the source of truth for what actually
+        // got persisted; tool-rate-limit events fire on *attempts*
+        // including rejected-by-cap ones. (#2796 ops metric)
+        pool.query(`
+          SELECT
+            COUNT(CASE WHEN created_at > NOW() - INTERVAL '24 hours' THEN 1 END) as generated_24h,
+            COUNT(CASE WHEN created_at > NOW() - INTERVAL '7 days' THEN 1 END)  as generated_7d
+          FROM perspective_illustrations
+        `),
       ]);
 
       const members = memberStats.rows[0] || {};
@@ -282,6 +298,14 @@ export function setupStatsRoutes(apiRouter: Router): void {
       const bookings = recentBookings.rows[0] || {};
       const engagement = engagementTrends.rows[0] || {};
       const addieT = addieTrends.rows[0] || {};
+      const illustrations = illustrationStats.rows[0] || {};
+
+      // Gemini cap is enforced in tool-rate-limiter.ts; read the
+      // configured value here rather than hard-coding so the metric
+      // and the enforcement stay in sync.
+      const illustrationCap = WORKSPACE_CAPS.generate_perspective_illustration?.max ?? 0;
+      const illustrationsGenerated24h = parseInt(illustrations.generated_24h) || 0;
+      const illustrationsCapRemaining = Math.max(0, illustrationCap - illustrationsGenerated24h);
 
       res.json({
         // Member stats
@@ -331,6 +355,12 @@ export function setupStatsRoutes(apiRouter: Router): void {
         addie_avg_rating: (parseFloat(ratings.avg_rating) || 0).toFixed(1),
         addie_positive_ratings: parseInt(ratings.positive_ratings) || 0,
         addie_negative_ratings: parseInt(ratings.negative_ratings) || 0,
+
+        // Gemini illustration cap observability (#2796).
+        illustrations_generated_24h: illustrationsGenerated24h,
+        illustrations_generated_7d: parseInt(illustrations.generated_7d) || 0,
+        illustrations_cap_24h: illustrationCap,
+        illustrations_cap_remaining: illustrationsCapRemaining,
 
         // User stats (community points tiers)
         total_users: parseInt(users.total_users) || 0,


### PR DESCRIPTION
## Summary
Closes #2796. Enforcement pieces (workspace-level 50/day cap + co-author-aggregated per-user quota) were already shipped — the one acceptance criterion missing was ops visibility. This adds the dashboard metric.

**Found during exploration:**
- `tool-rate-limiter.ts:70` already has `WORKSPACE_CAPS[generate_perspective_illustration] = 50/day` (singleton counter).
- `illustration-db.ts:135` `countMonthlyGenerations` already joins `content_authors` and counts across all perspectives the user is a co-author on — co-authors share the 5/month pool, don't get 5 each.

**Added in this PR (ops visibility only):**
- Exported `WORKSPACE_CAPS` from `tool-rate-limiter.ts` so the stats endpoint reads the configured cap instead of hard-coding it. Single source of truth for the ceiling.
- `/api/admin/stats` now returns `illustrations_generated_24h`, `illustrations_generated_7d`, `illustrations_cap_24h`, `illustrations_cap_remaining`.
- New insight card on `admin.html`: *\"Gemini Illustrations (24h cost cap): N / 50 generated · X remaining · M over 7 days\"*.

Counts come from `perspective_illustrations` (source of truth for persisted generations), not the rate-limiter's scope_key events — those fire on attempts including cap-rejected ones, so they'd overstate actual spend.

No enforcement changes.

## Test plan
- [x] \`npx tsc --project server/tsconfig.json --noEmit\` clean
- [x] \`npm run test:server-unit\` — 2035 pass (no regressions)
- [ ] Post-deploy: verify the card renders on /admin with live stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)