### PR TITLE
fix(compliance): add capability_discovery phase to governance_aware_seller

### DIFF
--- a/.changeset/fix-governance-aware-seller-empty-phases.md
+++ b/.changeset/fix-governance-aware-seller-empty-phases.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(compliance): add capability_discovery phase to governance_aware_seller storyboard
+
+The `governance_aware_seller` specialism declared `phases: []`, leaving the conformance runner with nothing to enumerate and emitting `__no_phases__` against any agent under test. It was the only specialism in `static/compliance/source/specialisms/` with an empty phases list — every peer (governance-spend-authority, signal-marketplace, brand-rights, all sales-*) declares at least a local `capability_discovery` phase even when most of the work is delegated through `requires_scenarios:`.
+
+This adds the standard `get_adcp_capabilities` capability_discovery phase, mirroring `governance-spend-authority/index.yaml`. The four governance scenarios (`governance_approved`, `governance_conditions`, `governance_denied`, `governance_denied_recovery`) continue to compose in via `requires_scenarios:`. Closes #2972.

--- a/static/compliance/source/specialisms/governance-aware-seller/index.yaml
+++ b/static/compliance/source/specialisms/governance-aware-seller/index.yaml
@@ -96,4 +96,40 @@ prerequisites:
     protocol.
   test_kit: "test-kits/acme-outdoor.yaml"
 
-phases: []
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent supports media buying before sending briefs or creating buys.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares the expected protocol support before
+          proceeding with domain-specific operations.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
+        sample_request:
+          context:
+            correlation_id: "governance_aware_seller--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "governance_aware_seller--get_capabilities"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
Closes #2972

## Summary

The `governance_aware_seller` specialism storyboard declared `phases: []`, which left the conformance runner with nothing to enumerate and surfaced a `__no_phases__` structural error against any agent under test — even ones passing every other media buy lifecycle scenario (the reporter saw 68/69, with this one as the only failure).

It is the **only** specialism in `static/compliance/source/specialisms/` with an empty phases list. Every peer (`governance-spend-authority`, `governance-delivery-monitor`, `signal-marketplace`, `brand-rights`, all `sales-*`) declares at least a local `capability_discovery` phase, even when they delegate the bulk of grading to scenarios via `requires_scenarios:`.

This PR transplants the canonical `capability_discovery` phase from `governance-spend-authority/index.yaml` (lines 99–135) into `governance-aware-seller/index.yaml`, with `correlation_id` rewritten to `governance_aware_seller--get_capabilities`. The four governance scenarios (`governance_approved`, `governance_conditions`, `governance_denied`, `governance_denied_recovery`) continue to compose in via the existing `requires_scenarios:` block — they're unchanged.

**Non-breaking justification:** purely additive — adds a new phase to a storyboard's `phases:` list, which was previously empty. No existing field is removed, renamed, or repurposed; no agent that already passed this storyboard could be broken by it (none could, since the runner crashed before any phase ran).

## Expert review

Two experts reviewed before this PR was opened:

- **ad-tech-protocol-expert**: confirmed Option 1 (transplant `capability_discovery`) is the canonical pattern. `requires_scenarios:` is a *composition* mechanism that runs alongside the parent, not a substitute for the parent's own phases. Inlining the four scenarios would duplicate work in `protocols/media-buy/scenarios/` and break the dedup the schema is designed for. Also flagged a likely runner-side defect: the `__no_phases__` string isn't in the schema's grading vocabulary, so the runner should ideally treat empty-phases-plus-non-empty-`requires_scenarios:` as a legal "scenario-only" specialism (or emit `not_applicable`) rather than crash. That follow-up belongs in `adcp-client`, not here.
- **code-reviewer**: thumbs up on the minimal fix. Confirmed YAML structure validates against `static/compliance/source/universal/storyboard-schema.yaml`, no correlation_id collisions exist anywhere in the corpus, no namespace clash between phase IDs and `requires_scenarios:` IDs, and `dist/compliance/3.0.0/...` is regenerated from `static/` via `scripts/build-compliance.cjs` (no hand-edit needed).

## Follow-up flagged for human attention

The runner-side defect is independent of this fix. Even with phases present, a non-claiming seller is supposed to grade `not_applicable` per the storyboard narrative — but if the runner crashes on `__no_phases__` *before* it reaches the not_applicable check, that path is dead. Worth a tracking issue against `adcp-client` to (a) validate the runner now skips this storyboard cleanly for sellers without `governance_aware`, and (b) replace `__no_phases__` with one of the documented skip codes.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvxD91VqfRoay9vdGymv1)_