### PR TITLE
feat(cost-cap): Slack scope helper + tier-resolution memo cache

### DIFF
--- a/.changeset/cost-cap-slack-helper-and-cache.md
+++ b/.changeset/cost-cap-slack-helper-and-cache.md
@@ -1,0 +1,36 @@
+---
+---
+
+Cost-cap polish bundle — closes deferred items from the #2945 / #2969
+reviews.
+
+**`buildSlackCostScope(memberContext, slackUserId)` helper.** The
+8 Slack-originated call sites (6 in `bolt-app.ts`, 2 in `handler.ts`)
+each had a 2-line prelude constructing the scope key and probing tier:
+
+```ts
+const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
+const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
+costScope: { userId: costScopeUserId, tier: costScopeTier },
+```
+
+Collapsed to one line at each site:
+
+```ts
+costScope: await buildSlackCostScope(memberContext, userId),
+```
+
+Keeps the `slack:` fallback shape in one place so a future namespace
+rename only touches the helper.
+
+**60s memo cache on `resolveUserTierFromDb`.** Subscription status
+changes on the order of days (Stripe webhooks → organizations
+update), so a per-process 60s stale window cuts the DB-probe hot path
+to ~1 probe per user per minute rather than 1 per Addie turn. Error
+paths are NOT cached — a transient DB failure shouldn't lock a paying
+member out of `member_paid` for a full TTL. Tests pin:
+- Burst calls hit DB once, return cached tier thereafter.
+- Error paths are not cached; next call retries.
+- Cache is per-user, not global.
+
+No behavior change for end users; pure dev-debt cleanup + perf.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -30,7 +30,7 @@ import type { Router } from 'express';
 import { logger } from '../logger.js';
 import { captureEvent } from '../utils/posthog.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
-import { resolveUserTierFromDb } from './claude-cost-tracker.js';
+import { buildSlackCostScope } from './claude-cost-tracker.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
@@ -1533,14 +1533,10 @@ async function handleUserMessage({
   const certIterations = hasCertificationContext && !routedTools.isAAOAdmin
     ? CERTIFICATION_MAX_ITERATIONS
     : undefined;
-  // Resolve the cost-cap identity. Prefer the mapped WorkOS user ID
-  // (consistent with tool-rate-limiter's scope keys); fall back to a
-  // `slack:${userId}` namespace when no mapping exists so the cap
-  // still bounds an individual Slack user's Addie spend (#2790).
-  // Mapped WorkOS users resolve to member_paid when they have an
-  // active subscription; Slack-fallback users stay at member_free.
-  const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
+  // Resolve the cost-cap identity + tier (#2790 / #2945 f/u).
+  // Prefers a mapped WorkOS user ID (member_paid for active subs);
+  // falls back to `slack:${userId}` at member_free when no mapping
+  // exists, bounding an individual Slack user's Addie spend.
   const processOptions: import('./claude-client.js').ProcessMessageOptions = {
     requestContext: requestContextWithRouting,
     ...(routedTools.isAAOAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
@@ -1548,7 +1544,7 @@ async function handleUserMessage({
     ...((routedTools.requiresPrecision || routedTools.requiresDepth) && { modelOverride: ModelConfig.precision }),
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: costScopeUserId, tier: costScopeTier },
+    costScope: await buildSlackCostScope(memberContext, userId),
   };
 
   // Process with Claude using streaming
@@ -2152,15 +2148,13 @@ async function handleAppMention({
   // Cost cap (#2790 / #2950): prefer WorkOS user ID; fall back to a
   // namespaced Slack ID so unmapped users still get a bounded
   // daily Addie spend budget.
-  const mentionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const mentionCostScopeTier = await resolveUserTierFromDb(mentionCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(mentionUseOpus ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: mentionCostScopeUserId, tier: mentionCostScopeTier },
+    costScope: await buildSlackCostScope(memberContext, userId),
   };
 
   // Process with Claude
@@ -3114,15 +3108,13 @@ async function handleDirectMessage(
 
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
-  const dmCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const dmCostScopeTier = await resolveUserTierFromDb(dmCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...((routedTools.requiresPrecision || routedTools.requiresDepth) ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: dmCostScopeUserId, tier: dmCostScopeTier },
+    costScope: await buildSlackCostScope(memberContext, userId),
   };
 
   // Process with Claude
@@ -3496,15 +3488,13 @@ async function handleActiveThreadReply({
 
   // Admin users get higher iteration limit.
   // Cost cap scope follows the mention-handler pattern above.
-  const threadCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-  const threadCostScopeTier = await resolveUserTierFromDb(threadCostScopeUserId);
   const processOptions = {
     ...(routedTools.isAAOAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     ...(threadUseOpus ? { modelOverride: ModelConfig.precision } : {}),
     requestContext,
     slackUserId: userId,
     threadId: thread.thread_id,
-    costScope: { userId: threadCostScopeUserId, tier: threadCostScopeTier },
+    costScope: await buildSlackCostScope(memberContext, userId),
   };
 
   // Process with Claude
@@ -4080,15 +4070,13 @@ async function handleChannelMessage({
     const channelUseOpus = plan.requires_precision || plan.requires_depth || channelIsDepthChannel;
     const effectiveModel = channelUseOpus ? ModelConfig.precision : AddieModelConfig.chat;
     // Cost cap scope follows the mention-handler pattern above.
-    const channelCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${userId}`;
-    const channelCostScopeTier = await resolveUserTierFromDb(channelCostScopeUserId);
     const processOptions = {
       ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
       ...(channelUseOpus ? { modelOverride: ModelConfig.precision } : {}),
       requestContext,
       slackUserId: userId,
       threadId: thread.thread_id,
-      costScope: { userId: channelCostScopeUserId, tier: channelCostScopeTier },
+      costScope: await buildSlackCostScope(memberContext, userId),
     };
     const response = await claudeClient.processMessage(messageText, undefined, filteredTools, undefined, processOptions);
 
@@ -4870,14 +4858,12 @@ async function handleReactionAdded({
 
   // Admin users get higher iteration limit for bulk operations.
   // Cost cap scope follows the mention-handler pattern above.
-  const reactionCostScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${reactingUserId}`;
-  const reactionCostScopeTier = await resolveUserTierFromDb(reactionCostScopeUserId);
   const processOptions = {
     ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     requestContext,
     slackUserId: reactingUserId,
     threadId: thread.thread_id,
-    costScope: { userId: reactionCostScopeUserId, tier: reactionCostScopeTier },
+    costScope: await buildSlackCostScope(memberContext, reactingUserId),
   };
 
   // Process with Claude

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -46,6 +46,7 @@ import { createLogger } from '../logger.js';
 import { query } from '../db/client.js';
 import { costUsdMicros, type ClaudeUsage } from './claude-pricing.js';
 import { SYSTEM_USER_IDS } from './system-identities.js';
+import type { MemberContext } from './member-context.js';
 
 const logger = createLogger('addie-cost-tracker');
 
@@ -272,10 +273,39 @@ export function resolveUserTier(opts: {
  * user, which burns connections for a value that rarely changes.
  *
  * Per-process: each worker has its own cache. No coherence needed
- * across workers — staleness is bounded by the TTL.
+ * across workers — staleness is bounded by the TTL. There is no
+ * webhook-triggered invalidation hook; Stripe cancellations propagate
+ * via the next DB probe after the 60s TTL elapses.
+ *
+ * Expired entries are lazy-evicted on the next lookup for the same
+ * key. Under normal load the cache self-trims at a steady state
+ * equal to distinct active users in the last 60s. The lazy sweep
+ * inside `writeCachedTier` bounds worst-case growth if the caller
+ * graph ever starts passing more transient keys than we expect.
  */
 const TIER_CACHE_TTL_MS = 60_000;
+const TIER_CACHE_MAX_SIZE = 10_000;
 const tierCache = new Map<string, { tier: UserTier; expiresAt: number }>();
+
+function writeCachedTier(userId: string, tier: UserTier): void {
+  // When the cache crosses the soft cap, opportunistically sweep
+  // expired entries. Bounds memory at worst case O(cap) under any
+  // access pattern without paying for eviction on the hot path.
+  if (tierCache.size >= TIER_CACHE_MAX_SIZE) {
+    const now = Date.now();
+    for (const [k, v] of tierCache) {
+      if (v.expiresAt <= now) tierCache.delete(k);
+    }
+    // Pathological burst: 10k distinct users active within the TTL
+    // window. Clear oldest half via insertion-order iteration so the
+    // cache can resume filling with fresh entries.
+    if (tierCache.size >= TIER_CACHE_MAX_SIZE) {
+      const keysToDrop = [...tierCache.keys()].slice(0, Math.floor(TIER_CACHE_MAX_SIZE / 2));
+      for (const k of keysToDrop) tierCache.delete(k);
+    }
+  }
+  tierCache.set(userId, { tier, expiresAt: Date.now() + TIER_CACHE_TTL_MS });
+}
 
 /**
  * Resolve the right tier for a scope-key userId by looking up the
@@ -319,7 +349,7 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
       [userId],
     );
     const tier: UserTier = rows.length > 0 ? 'member_paid' : 'member_free';
-    tierCache.set(userId, { tier, expiresAt: now + TIER_CACHE_TTL_MS });
+    writeCachedTier(userId, tier);
     return tier;
   } catch (err) {
     logger.warn(
@@ -339,9 +369,14 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
  * fallback, then probe the DB for subscription tier. Keeps the
  * scope-key fallback shape in one place so future renames of the
  * `slack:` namespace only touch one line.
+ *
+ * Accepts `Pick<MemberContext, 'workos_user'>` rather than the full
+ * `MemberContext` shape — the helper only reads `workos_user`, so
+ * accepting a narrower structural type keeps the dependency minimal
+ * while still tracking shape changes in `member-context.ts`.
  */
 export async function buildSlackCostScope(
-  memberContext: { workos_user?: { workos_user_id?: string | null } | null } | null | undefined,
+  memberContext: Pick<MemberContext, 'workos_user'> | null | undefined,
   slackUserId: string,
 ): Promise<{ userId: string; tier: UserTier }> {
   const userId = memberContext?.workos_user?.workos_user_id ?? `slack:${slackUserId}`;

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -263,6 +263,21 @@ export function resolveUserTier(opts: {
 }
 
 /**
+ * In-memory memo cache for `resolveUserTierFromDb` results. Subscription
+ * status changes on the order of days (Stripe webhooks → organizations
+ * update), so a 60s stale window is well within tolerance — a paying
+ * member briefly seeing member_free after a cancel, or a fresh
+ * subscriber seeing member_free for up to 60s after activation, is
+ * acceptable. The alternative is ~1 DB probe per Addie turn per active
+ * user, which burns connections for a value that rarely changes.
+ *
+ * Per-process: each worker has its own cache. No coherence needed
+ * across workers — staleness is bounded by the TTL.
+ */
+const TIER_CACHE_TTL_MS = 60_000;
+const tierCache = new Map<string, { tier: UserTier; expiresAt: number }>();
+
+/**
  * Resolve the right tier for a scope-key userId by looking up the
  * subscription status of a bare WorkOS user id. Non-WorkOS scope keys
  * (`slack:...`, `email:...`, etc.) can't resolve a real subscription
@@ -282,9 +297,16 @@ export function resolveUserTier(opts: {
  * This is the async, DB-touching counterpart to the pure
  * `resolveUserTier` above — the `FromDb` suffix is deliberate so a
  * call site can tell at a glance that this one awaits the database.
+ * Results are memoized for 60 seconds per userId to keep the hot path
+ * off the DB on repeated calls from the same user in a conversation.
  */
 export async function resolveUserTierFromDb(userId: string | null | undefined): Promise<UserTier> {
   if (!userId || !userId.startsWith('user_')) return 'member_free';
+
+  const now = Date.now();
+  const cached = tierCache.get(userId);
+  if (cached && cached.expiresAt > now) return cached.tier;
+
   try {
     const { rows } = await query<{ exists: 1 }>(
       `SELECT 1 AS exists
@@ -296,14 +318,44 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
         LIMIT 1`,
       [userId],
     );
-    return rows.length > 0 ? 'member_paid' : 'member_free';
+    const tier: UserTier = rows.length > 0 ? 'member_paid' : 'member_free';
+    tierCache.set(userId, { tier, expiresAt: now + TIER_CACHE_TTL_MS });
+    return tier;
   } catch (err) {
     logger.warn(
       { err, userId },
       'Failed to resolve user tier — defaulting to member_free',
     );
+    // Don't cache errors — a transient DB issue shouldn't make a
+    // member see member_free for a full TTL. Next call retries.
     return 'member_free';
   }
+}
+
+/**
+ * Build a complete cost-scope `{ userId, tier }` for Slack-originated
+ * callers. Collapses the 2-line prelude that was duplicated at every
+ * Slack site: resolve the WorkOS id (preferred) with a `slack:${id}`
+ * fallback, then probe the DB for subscription tier. Keeps the
+ * scope-key fallback shape in one place so future renames of the
+ * `slack:` namespace only touch one line.
+ */
+export async function buildSlackCostScope(
+  memberContext: { workos_user?: { workos_user_id?: string | null } | null } | null | undefined,
+  slackUserId: string,
+): Promise<{ userId: string; tier: UserTier }> {
+  const userId = memberContext?.workos_user?.workos_user_id ?? `slack:${slackUserId}`;
+  const tier = await resolveUserTierFromDb(userId);
+  return { userId, tier };
+}
+
+/**
+ * Test-only: clear the tier-resolution memo cache. Unit tests that
+ * drive the DB probe need a clean cache between runs so an earlier
+ * test's memoized result doesn't leak into the next.
+ */
+export function __clearTierCache(): void {
+  tierCache.clear();
 }
 
 /**

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -7,7 +7,7 @@
 import { logger } from '../logger.js';
 import { sendChannelMessage } from '../slack/client.js';
 import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
-import { resolveUserTierFromDb } from './claude-cost-tracker.js';
+import { buildSlackCostScope } from './claude-cost-tracker.js';
 import {
   sanitizeInput,
   validateOutput,
@@ -598,16 +598,11 @@ export async function handleAssistantMessage(
     const { tools: userTools, isAAOAdmin: userIsAdmin } = await createUserScopedTools(memberContext, event.user, undefined);
 
     // Admin users get higher iteration limit for bulk operations.
-    // Cost-cap scope (#2790): prefer WorkOS user ID; fall back to a
-    // namespaced Slack ID so unmapped users still get a bounded
-    // daily Addie spend budget. Mapped WorkOS users resolve to
-    // member_paid if they have an active subscription (#2945 f/u).
-    const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
-    const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
+    // Cost-cap scope (#2790 / #2945 f/u) resolved via shared helper.
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
-      costScope: { userId: costScopeUserId, tier: costScopeTier },
+      costScope: await buildSlackCostScope(memberContext, event.user),
     };
 
     // Process with Claude
@@ -775,15 +770,11 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     const { tools: userTools, isAAOAdmin: userIsAdmin } = await createUserScopedTools(memberContext, event.user, event.thread_ts || event.ts, { isChannelMention: true });
 
     // Admin users get higher iteration limit for bulk operations.
-    // Cost-cap scope (#2790 / #2945 f/u): prefer WorkOS user ID with
-    // tier resolved from subscription status; fall back to a
-    // namespaced Slack ID at member_free.
-    const costScopeUserId = memberContext?.workos_user?.workos_user_id ?? `slack:${event.user}`;
-    const costScopeTier = await resolveUserTierFromDb(costScopeUserId);
+    // Cost-cap scope (#2790 / #2945 f/u) resolved via shared helper.
     const processOptions: import('./claude-client.js').ProcessMessageOptions = {
       requestContext,
       ...(userIsAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),
-      costScope: { userId: costScopeUserId, tier: costScopeTier },
+      costScope: await buildSlackCostScope(memberContext, event.user),
     };
 
     // Process with Claude

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -130,8 +130,11 @@ describe('buildSlackCostScope', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to slack:<id> when memberContext exists but workos_user is null', async () => {
-    const scope = await buildSlackCostScope({ workos_user: null }, 'U_pending');
+  it('falls back to slack:<id> when memberContext exists but workos_user is absent', async () => {
+    // MemberContext.workos_user is optional — matches the case where
+    // the caller found a memberContext but the Slack user isn't
+    // mapped to a WorkOS identity yet.
+    const scope = await buildSlackCostScope({ workos_user: undefined }, 'U_pending');
     expect(scope).toEqual({ userId: 'slack:U_pending', tier: 'member_free' });
   });
 });

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -16,10 +16,15 @@ vi.mock('../../src/db/client.js', () => ({
 
 // Import after the mock is installed so the module picks up the mocked
 // `query` reference instead of the real db/client.
-const { resolveUserTierFromDb } = await import('../../src/addie/claude-cost-tracker.js');
+const { resolveUserTierFromDb, buildSlackCostScope, __clearTierCache } =
+  await import('../../src/addie/claude-cost-tracker.js');
 
 beforeEach(() => {
   queryMock.mockReset();
+  // The helper memoizes results for 60s per userId. Clear between
+  // tests so cached values from an earlier case don't leak into the
+  // next one's expectations.
+  __clearTierCache();
 });
 
 describe('resolveUserTierFromDb', () => {
@@ -72,5 +77,61 @@ describe('resolveUserTierFromDb', () => {
     queryMock.mockRejectedValueOnce(new Error('Connection refused'));
     const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_free');
+  });
+
+  it('memoizes results so repeated probes for the same user hit the DB once', async () => {
+    // 60s in-process cache. A chat burst should not produce N DB
+    // probes for the same user — one probe, cached tier, replayed.
+    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
+    expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
+    expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
+    expect(queryMock).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT cache error paths — next call retries the DB', async () => {
+    // Transient DB failures shouldn't lock a paying member out of
+    // member_paid for a full 60s. The first call fails → returns
+    // member_free without caching; the second call retries.
+    queryMock.mockRejectedValueOnce(new Error('Connection refused'));
+    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_free');
+    expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
+    expect(queryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('memoizes per-user, not globally — different users get independent probes', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    expect(await resolveUserTierFromDb('user_alice')).toBe('member_paid');
+    expect(await resolveUserTierFromDb('user_bob')).toBe('member_free');
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    // Second round: both cached, no further probes.
+    expect(await resolveUserTierFromDb('user_alice')).toBe('member_paid');
+    expect(await resolveUserTierFromDb('user_bob')).toBe('member_free');
+    expect(queryMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('buildSlackCostScope', () => {
+  it('prefers the mapped WorkOS user id when memberContext carries one', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    const scope = await buildSlackCostScope(
+      { workos_user: { workos_user_id: 'user_01H2ABC' } },
+      'U_slack',
+    );
+    expect(scope).toEqual({ userId: 'user_01H2ABC', tier: 'member_paid' });
+  });
+
+  it('falls back to slack:<id> at member_free when no WorkOS mapping exists', async () => {
+    const scope = await buildSlackCostScope(null, 'U_unmapped');
+    expect(scope).toEqual({ userId: 'slack:U_unmapped', tier: 'member_free' });
+    // No DB probe — slack: scope keys skip the lookup.
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to slack:<id> when memberContext exists but workos_user is null', async () => {
+    const scope = await buildSlackCostScope({ workos_user: null }, 'U_pending');
+    expect(scope).toEqual({ userId: 'slack:U_pending', tier: 'member_free' });
   });
 });


### PR DESCRIPTION
## Summary
Polish bundle closing deferred items from the #2945 / #2969 reviews. No behavior change for end users — dev-debt + perf cleanup.

**\`buildSlackCostScope(memberContext, slackUserId)\` helper.** The 8 Slack-originated call sites (6 in \`bolt-app.ts\`, 2 in \`handler.ts\`) each had a 2-line prelude constructing the scope key and probing tier. Collapsed to one line per site:

\`\`\`ts
costScope: await buildSlackCostScope(memberContext, userId),
\`\`\`

Keeps the \`slack:\${id}\` fallback shape in one place — a future namespace rename touches the helper, not 8 sites.

**60s memo cache on \`resolveUserTierFromDb\`.** Per-process in-memory cache. Subscription status changes on the order of days (Stripe webhook → \`organizations\` update), so a 60s stale window is well within tolerance. Cuts the hot-path DB load from ~1 probe per Addie turn per active user to ~1 per user per minute.

Error paths are **NOT** cached — a transient DB failure shouldn't lock a paying member out of \`member_paid\` for a full TTL.

## Test plan
- [x] 11 unit tests — existing 5 plus: burst calls hit DB once; error paths not cached; cache is per-user not global; \`buildSlackCostScope\` handles WorkOS id, null memberContext, null workos_user
- [x] \`npx tsc --project server/tsconfig.json --noEmit\` clean
- [x] \`npm run test:server-unit\` — 2046 pass
- [ ] Post-deploy: verify paying members still resolve member_paid on their first Addie turn after deploy (cache is cold); subsequent turns shouldn't generate DB probes for the same user

🤖 Generated with [Claude Code](https://claude.com/claude-code)