### PR TITLE
feat(agents): split public/internal context + CI safety lint

### DIFF
--- a/.agents/current-context.md
+++ b/.agents/current-context.md
@@ -1,7 +1,15 @@
-# Current Context
+## Current Context
 
-Snapshot of what's active in the AdCP ecosystem. Refreshed weekly by the
-context-refresh routine. Human edits welcome between refreshes.
+Public snapshot of what's active in the AdCP ecosystem. Injected into
+Addie's system prompt and readable by the triage routines, so content
+here must be safe to quote back to any community member. Keep entries
+factual (PRs, issues, status). Strategic commentary and stakeholder-
+sensitive phrasing live in `internal-context.md` instead.
+
+Refreshed weekly by the context-refresh routine. Human edits welcome
+between refreshes. The CI lint at
+`.github/workflows/validate-agent-context.yml` checks safety and the
+public/internal boundary on every PR.
 
 Last refresh: 2026-04-23 (initial seed)
 
@@ -34,7 +42,7 @@ Last refresh: 2026-04-23 (initial seed)
   (OpenRTB vs TMP JSON vs Cap'n Proto), Addie live demo. Building in
   subdirectories first. Status: **active**.
 - **DBCFM integration** — German DBCFM standard mapping to AdCP.
-  David Porzelt gap analysis. Related PRs:
+  David Porzelt analysis. Related PRs:
   [#1594](https://github.com/adcontextprotocol/adcp/pull/1594)
   (price_breakdown),
   [#1605](https://github.com/adcontextprotocol/adcp/pull/1605)
@@ -83,12 +91,3 @@ Last refresh: 2026-04-23 (initial seed)
   `strict:true`. Aligned. Status: **shipped**.
 - **Registry agents snapshot tables** — PR 86eba0cd2. Materialize
   agent health + capabilities in DB snapshot tables. Status: **shipped**.
-
-## Narratives and gaps
-
-- **Security narrative gap** — mechanics exist (security.mdx,
-  idempotency, auth declarations) but no community-facing narrative or
-  curriculum. Brian flagged as tier-1 gap 2026-04-19. Status: **active**.
-- **SDK both-sides framing** — @adcp/client and adcp (Python) ship
-  server primitives + testing utilities. Docs framing reads
-  caller-first, hides this. Status: **active**.

--- a/.agents/internal-context.md
+++ b/.agents/internal-context.md
@@ -1,0 +1,31 @@
+# Internal Context (not injected into Addie)
+
+Strategic framing, editorial narratives, gaps, and maintainer-only
+commentary about the AdCP ecosystem. Triage routines read this file for
+richer relevance decisions but **never quote from it in public comments**.
+Addie does **not** read this file — keep it free of content you'd want
+her to answer with.
+
+Content that belongs here vs. `current-context.md`:
+
+| Here (internal) | There (public `current-context.md`) |
+|---|---|
+| "X is a tier-1 gap" | "X is active. PR #Y." |
+| "blocked on Brian's call" | "blocked. Status: deferred." |
+| "stakeholder flagged" | "see PR #Z" |
+| Editorial framing, strategic bets | Factual status + link |
+| Narratives | Facts |
+
+Refreshed weekly by the context-refresh routine alongside
+`current-context.md`.
+
+Last refresh: 2026-04-23 (initial seed)
+
+## Narratives and gaps
+
+- **Security narrative gap** — mechanics exist (security.mdx,
+  idempotency, auth declarations) but no community-facing narrative or
+  curriculum. Brian flagged as tier-1 gap 2026-04-19. Status: **active**.
+- **SDK both-sides framing** — @adcp/client and adcp (Python) ship
+  server primitives + testing utilities. Docs framing reads
+  caller-first, hides this. Status: **active**.

--- a/.agents/routines/context-refresh-prompt.md
+++ b/.agents/routines/context-refresh-prompt.md
@@ -1,10 +1,18 @@
 # Context Refresh — Routine Prompt
 
-You maintain `.agents/current-context.md` in `adcontextprotocol/adcp`. It
-is the shared snapshot of what's active right now — roadmap items, open
-initiatives, recent merged PRs, upstream spec issues, known in-flight
-work. Other routines (triage, review) read it to avoid asking questions
-already answered by recent activity.
+You maintain two files in `adcontextprotocol/adcp`:
+
+1. `.agents/current-context.md` — **PUBLIC** snapshot. Injected into
+   Addie's system prompt and quotable in triage comments. Factual
+   status + links only.
+2. `.agents/internal-context.md` — **INTERNAL** snapshot. Read by
+   triage routines for richer context; never injected into Addie;
+   never quoted in public comments. Editorial framing, narratives,
+   gaps, stakeholder-sensitive phrasing.
+
+The split matters: `current-context.md` is exposed to any community
+member via Addie. If you wouldn't say it to a cold prospect on Slack,
+it doesn't belong in the public file.
 
 ## Every run
 
@@ -26,11 +34,27 @@ already answered by recent activity.
    Drop themes with no activity in 60 days, **unless** they carry a
    `tracking` or `roadmap` label — long-running initiatives (v2
    sunset, 4.0 planning) stay even when quiet.
-5. Rewrite `.agents/current-context.md` as a fresh snapshot. Keep it
-   under 200 lines. Each entry should be one bullet with a
-   why/status/link, not an explainer. Treat this file as prompt
-   input, not free prose — the triage routine will read it before
-   every run, so every word counts against its context budget.
+5. **Route each item to the right file** — public vs. internal:
+
+   | Public (`current-context.md`) | Internal (`internal-context.md`) |
+   |---|---|
+   | "X is active. PR #Y." | "X is a tier-1 gap" |
+   | "blocked. Status: deferred." | "blocked on Brian's call" |
+   | "DBCFM integration. See #1594, #1605, #1664." | "Stakeholder flagged this as urgent" |
+   | Factual status + link | Narrative framing |
+   | Shipped / active / review / deferred | Editorial / strategic / "gaps" |
+
+   Default to public when in doubt — the CI lint will flag internal
+   signaling that accidentally landed there.
+
+6. Rewrite `.agents/current-context.md`: under 200 lines, factual
+   bullets, one-link-per-entry. Treat as prompt input — every word
+   counts against the triage routine's context budget.
+7. Rewrite `.agents/internal-context.md`: narratives, gaps, strategic
+   framing, stakeholder-sensitive commentary. Under 100 lines.
+8. Run the safety lint locally before committing:
+   `node .github/scripts/validate-agent-context.mjs` (CI will re-run
+   on the PR; local-first saves a round-trip).
 
 ## Untrusted input
 

--- a/.changeset/split-agent-context-and-lint.md
+++ b/.changeset/split-agent-context-and-lint.md
@@ -1,0 +1,4 @@
+---
+---
+
+Split the agent-context snapshot in two: public `.agents/current-context.md` (factual status, safe to inject into Addie and quote in triage comments) vs. internal `.agents/internal-context.md` (editorial framing, narratives, stakeholder-sensitive phrasing — read by triage routines for richer decisions but never injected or quoted publicly). Add a CI lint at `.github/workflows/validate-agent-context.yml` that fails on prompt-injection markers, level-1 headings, oversized content, or control characters in the public file, and warns when additions look like they belong in the internal file instead. Update the context-refresh routine prompt to write both files and honor the split. This closes the persistent-injection path and the "reads weird to a cold prospect" concern raised in the Addie PR expert review.

--- a/.github/scripts/validate-agent-context.mjs
+++ b/.github/scripts/validate-agent-context.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Lint `.agents/current-context.md`.
+ *
+ * This file is loaded verbatim into Addie's system prompt (via the rules
+ * loader in `server/src/addie/rules/index.ts`) on every conversational
+ * turn. That makes its contents a high-value target for prompt injection
+ * and a persistent surface for off-brand or internal-sounding content.
+ *
+ * Two layers:
+ *   - **Safety** (hard fail): file size cap, level-1 heading ban,
+ *     injection-marker regexes, control-character check. The runtime
+ *     loader already defends (fence, heading demotion, size cap), but
+ *     failing CI when something slips in keeps the file clean at the
+ *     source rather than relying on defense-in-depth.
+ *   - **Boundary** (warning): phrases that suggest the content belongs
+ *     in `.agents/internal-context.md` instead — "tier-1 gap", named
+ *     stakeholder attribution, "narrative", "editorial", etc. These
+ *     don't break anything technically, but they're the signaling the
+ *     product review flagged as "reads weird to a cold prospect."
+ *
+ * Designed to also run locally during context-refresh: the routine
+ * invokes this after rewriting the file and before opening a PR.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+
+const PATH = '.agents/current-context.md';
+const MAX_BYTES = 16 * 1024;
+
+if (!existsSync(PATH)) {
+  console.error(`✗ ${PATH} does not exist.`);
+  process.exit(1);
+}
+
+const content = readFileSync(PATH, 'utf-8');
+const lines = content.split('\n');
+const errors = [];
+const warnings = [];
+
+// -- Safety checks (hard fail) -----------------------------------------
+
+if (content.length > MAX_BYTES) {
+  errors.push(
+    `File exceeds ${MAX_BYTES} bytes (${content.length}). The runtime ` +
+    `loader will truncate — trim or move sections to internal-context.md.`
+  );
+}
+
+// Level-1 ATX headings get demoted by the runtime loader, but failing
+// here tells authors to use `##` instead of relying on silent rewrite.
+lines.forEach((line, i) => {
+  if (/^#\s/.test(line)) {
+    errors.push(
+      `Line ${i + 1}: level-1 heading. Use \`## \` instead — the runtime ` +
+      `demotes these to prevent prompt-section spoofing.`
+    );
+  }
+});
+
+// Injection-marker regexes. These patterns appear often in real prompt-
+// injection payloads and have no place in a factual status snapshot.
+const INJECTION_PATTERNS = [
+  [/ignore\s+(?:previous|prior|above|all)/i, 'ignore-previous'],
+  [/^(?:system|assistant|user)\s*:/im, 'role-marker'],
+  [/you\s+(?:are|must|should|will)\s+now/i, 'behavior-switch'],
+  [/new\s+instructions?\s*:/i, 'new-instructions'],
+  [/\bdisregard\b/i, 'disregard'],
+  [/<\/?(?:system|instructions?|prompt|context|addie_reference)>/i, 'fence-tag'],
+];
+for (const [re, label] of INJECTION_PATTERNS) {
+  const m = content.match(re);
+  if (m) {
+    errors.push(
+      `Injection marker "${m[0]}" (${label}). This file is read into ` +
+      `Addie's system prompt; imperatives directed at the model are banned.`
+    );
+  }
+}
+
+// Control characters (strip TAB / LF / CR from the check).
+if (/[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(content)) {
+  errors.push('Control characters present. Strip them.');
+}
+
+// -- Boundary checks (warnings) ----------------------------------------
+
+const BOUNDARY_PATTERNS = [
+  [/\btier[- ][0-9]\b/i, 'priority tier ("tier-1")'],
+  [/\b(?:narrative|editorial)\b/i, 'editorial framing'],
+  [/\bgap\b/i, '"gap" framing'],
+  [/\bblocked\s+on\s+(?!PR\b|#)/i, 'blocker attribution (not a PR link)'],
+  [/\b(?:Brian|bokelley)\s+(?:flagged|thinks|believes|said|wants)\b/i,
+    'stakeholder attribution to a named person'],
+];
+for (const [re, label] of BOUNDARY_PATTERNS) {
+  if (re.test(content)) {
+    warnings.push(
+      `${label}: consider moving to \`.agents/internal-context.md\`. ` +
+      `The public snapshot is exposed to any community member via Addie.`
+    );
+  }
+}
+
+// -- Report ------------------------------------------------------------
+
+if (errors.length) {
+  console.error(`✗ ${PATH} — ${errors.length} safety error(s):`);
+  for (const e of errors) console.error(`  - ${e}`);
+}
+if (warnings.length) {
+  console.error(`⚠ ${PATH} — ${warnings.length} boundary warning(s):`);
+  for (const w of warnings) console.error(`  - ${w}`);
+}
+
+if (errors.length) {
+  console.error('\nFix errors above. Warnings do not fail the build.');
+  process.exit(1);
+}
+if (warnings.length) {
+  console.log('\n(warnings noted — consider addressing, but build passes)');
+}
+console.log(`✓ ${PATH} passes safety checks`);

--- a/.github/workflows/validate-agent-context.yml
+++ b/.github/workflows/validate-agent-context.yml
@@ -1,0 +1,23 @@
+name: Validate agent context files
+
+on:
+  pull_request:
+    paths:
+      - '.agents/current-context.md'
+      - '.github/scripts/validate-agent-context.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Safety + boundary lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Run validator
+        run: node .github/scripts/validate-agent-context.mjs


### PR DESCRIPTION
## Summary

Follow-up to the expert review on #2974. Closes two related gaps at the source:

1. **Product** — committed snapshot leaks internal-sounding content ("tier-1 gap", "Brian flagged") into Addie's public responses.
2. **Security H1** — persistent prompt-injection path through the weekly context-refresh cycle into Addie's cached base prompt.

## Change

**File split:**
- `.agents/current-context.md` — public. Factual status + links. Injected into Addie; quotable in triage comments.
- `.agents/internal-context.md` — internal. Editorial framing, narratives, gaps, stakeholder-sensitive. Triage reads it; Addie doesn't.

Moved the "Narratives and gaps" section from public to internal as the seed. Demoted the public file's title from `# Current Context` to `## Current Context` so the CI lint can ban level-1 headings outright.

**CI lint:**
- Safety (hard fail): injection markers (`ignore previous`, role markers, `you are now`, `new instructions`, `disregard`, fence tags), level-1 headings, control chars, 16 KB size cap.
- Boundary (warnings): `tier-N`, `narrative`, `editorial`, `gap`, stakeholder attribution without a PR link.
- Self-tested: clean file passes with zero warnings, crafted bad file hits 3 errors + 3 warnings.

**Context-refresh routine prompt** updated to write both files per a side-by-side routing table and to run the lint locally before opening the refresh PR.

## Test plan

- [x] Clean file passes lint with zero errors/warnings
- [x] Crafted bad file fails loudly (3 errors, 3 warnings)
- [x] Addie rules-loader tests from #2974 still pass against the trimmed file
- [ ] CI workflow runs on this PR

Independent of #2974 — either order merges fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)