### PR TITLE
chore: rename Community & Events WG to Community & Marketing

### DIFF
--- a/.changeset/wg-community-marketing-rename.md
+++ b/.changeset/wg-community-marketing-rename.md
@@ -1,0 +1,4 @@
+---
+---
+
+Rename the Community & Events WG to "Community & Marketing" with an expanded description covering events, marketing, content, education, and thought leadership — matching the scope of the active `#wg-community-events-mktg-education` channel. Also update Creative's description to avoid word collision with the separate Governance WG: "governance" → "review and approvals". Both are one-line display changes in migration 425.

--- a/server/src/db/migrations/425_wg_community_marketing_rename.sql
+++ b/server/src/db/migrations/425_wg_community_marketing_rename.sql
@@ -1,0 +1,16 @@
+-- Address feedback on the WG consolidation:
+--   - "Community & Events" undersells the group's scope (marketing, content,
+--     PMM, education are equally active). Rename to "Community & Marketing"
+--     and expand the description to list every stream.
+--   - Creative's description used "governance" which collides with the
+--     separate Governance WG. Swap to "review & approvals", which is what
+--     creative governance actually means.
+
+UPDATE working_groups SET
+  name = 'Community & Marketing',
+  description = 'Community building, events, marketing, content, education, and thought leadership.'
+WHERE slug = 'events-thought-leadership-wg';
+
+UPDATE working_groups SET
+  description = 'Creative lifecycle, generative creative, review and approvals.'
+WHERE slug = 'creative-wg';


### PR DESCRIPTION
## Summary

Addresses feedback from the #2243 rollout announcement:

- **Christina** pointed out the "Community & Events" name undersells the scope — marketing, PMM, content, and education are equally active streams in `#wg-community-events-mktg-education`. Renames to **"Community & Marketing"** with an expanded description.
- **Pia** pointed out "governance" in Creative's description collides with the separate Governance WG. Swaps for **"review and approvals"**, which is what creative governance actually means.

Both are one-line display-only changes in migration 425. No slug changes, no impact on URLs, members, or data.

## Test plan

- [x] Migration validates as a plain UPDATE on existing rows
- [x] Typecheck clean (after updating stale node_modules)
- [x] No schema change, no behavior change beyond display text

🤖 Generated with [Claude Code](https://claude.com/claude-code)