### PR TITLE
fix(addie): keep github issue tools reachable across Slack routing

### DIFF
--- a/.changeset/addie-always-available-gh-tools.md
+++ b/.changeset/addie-always-available-gh-tools.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stop Addie from hallucinating that GitHub issue filing is unavailable in Slack threads. `create_github_issue` joins `draft_github_issue` in `ALWAYS_AVAILABLE_TOOLS`, the content tool-set description no longer claims ownership of GitHub issuing, and the unavailable-sets hint now explicitly enumerates always-available escape hatches. Also tightens `draft_github_issue` so Addie can't invent non-existent repo names, and points the Connect-GitHub fallback at the actual `/member-hub` page.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -4574,7 +4574,7 @@ export function createMemberToolHandlers(
   // ============================================
   handlers.set('draft_github_issue', async (input) => {
     const title = input.title as string;
-    const body = input.body as string;
+    let body = input.body as string;
     const labels = (input.labels as string[]) || [];
 
     // GitHub organization
@@ -4585,10 +4585,15 @@ export function createMemberToolHandlers(
     // context (e.g. "creative-agent") and produce 404 links.
     const ALLOWED_REPOS = new Set(['adcp', 'adcp-client', 'adcp-client-python', 'adcp-go']);
     const requestedRepo = (input.repo as string) || 'adcp';
+    let repo = requestedRepo;
     if (!ALLOWED_REPOS.has(requestedRepo)) {
-      return `\`${requestedRepo}\` is not a recognized AdCP repository. Allowed: ${Array.from(ALLOWED_REPOS).map(r => `\`${r}\``).join(', ')}. If you're not sure which repo this belongs to, use \`adcp\` and note the subproject in the issue body — maintainers can re-route it.`;
+      // Don't reject — file against `adcp` and prepend a subproject note to the
+      // body so the maintainer can re-route if needed. The handler's string
+      // return would otherwise land verbatim in Addie's reply ("not a
+      // recognized repo") which looks like a 404 to the user.
+      body = `> **Subproject:** \`${requestedRepo}\` (routed to adcp by default — maintainer can move if needed)\n\n${body}`;
+      repo = 'adcp';
     }
-    const repo = requestedRepo;
 
     // Build the pre-filled GitHub issue URL
     // GitHub supports: title, body, labels (comma-separated)
@@ -4670,15 +4675,19 @@ export function createMemberToolHandlers(
         return `GitHub connection is unavailable right now. Use \`draft_github_issue\` to generate a pre-filled link you can submit yourself. (Manage connections at ${manageConnectionsUrl}.)`;
       }
 
-      const reason = tokenResult.status === 'needs_reauthorization'
-        ? "Your GitHub connection needs to be re-authorized (the scopes we need changed)."
-        : "You haven't connected GitHub yet, so I can't file this as you directly.";
+      if (tokenResult.status === 'needs_reauthorization') {
+        return [
+          `Your GitHub connection needs a quick re-authorization (the scopes we need changed).`,
+          '',
+          `**[Reconnect GitHub](${authorizeUrl})** — takes under a minute. Or ask me to use \`draft_github_issue\` and I'll give you a pre-filled link to submit yourself.`,
+          '',
+          `Manage connections any time at ${manageConnectionsUrl}.`,
+        ].join('\n');
+      }
       return [
-        reason,
+        `**[Connect GitHub](${authorizeUrl})** — one click and I'll file this under your GitHub account.`,
         '',
-        `**Two options:**`,
-        `1. **[Connect GitHub](${authorizeUrl})** — takes under a minute, then I'll file the issue authored by your GitHub account. You can also manage connections any time at ${manageConnectionsUrl}.`,
-        `2. Ask me to use \`draft_github_issue\` instead and I'll give you a pre-filled link you submit yourself.`,
+        `Or ask me to use \`draft_github_issue\` and I'll give you a pre-filled link instead.`,
       ].join('\n');
     }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -4575,11 +4575,20 @@ export function createMemberToolHandlers(
   handlers.set('draft_github_issue', async (input) => {
     const title = input.title as string;
     const body = input.body as string;
-    const repo = (input.repo as string) || 'adcp';
     const labels = (input.labels as string[]) || [];
 
     // GitHub organization
     const org = 'adcontextprotocol';
+
+    // Only accept repos that actually exist under the adcontextprotocol org.
+    // Without this guard Addie will happily invent repo names from conversation
+    // context (e.g. "creative-agent") and produce 404 links.
+    const ALLOWED_REPOS = new Set(['adcp', 'adcp-client', 'adcp-client-python', 'adcp-go']);
+    const requestedRepo = (input.repo as string) || 'adcp';
+    if (!ALLOWED_REPOS.has(requestedRepo)) {
+      return `\`${requestedRepo}\` is not a recognized AdCP repository. Allowed: ${Array.from(ALLOWED_REPOS).map(r => `\`${r}\``).join(', ')}. If you're not sure which repo this belongs to, use \`adcp\` and note the subproject in the issue body — maintainers can re-route it.`;
+    }
+    const repo = requestedRepo;
 
     // Build the pre-filled GitHub issue URL
     // GitHub supports: title, body, labels (comma-separated)
@@ -4640,23 +4649,25 @@ export function createMemberToolHandlers(
     const org = 'adcontextprotocol';
     const repo = 'adcp';
 
+    const baseUrl = (process.env.BASE_URL || 'https://agenticadvertising.org').replace(/\/$/, '');
+    const manageConnectionsUrl = `${baseUrl}/member-hub`;
+
     let tokenResult: Awaited<ReturnType<typeof getGitHubAccessToken>>;
     try {
       tokenResult = await getGitHubAccessToken(workosUserId);
     } catch (error) {
       logger.error({ err: error }, 'create_github_issue: Pipes getAccessToken failed');
-      return 'GitHub connection is unavailable right now. Use `draft_github_issue` to generate a pre-filled link you can submit yourself.';
+      return `GitHub connection is unavailable right now. Use \`draft_github_issue\` to generate a pre-filled link you can submit yourself. (Manage connections at ${manageConnectionsUrl}.)`;
     }
 
     if (tokenResult.status !== 'ok') {
-      const baseUrl = (process.env.BASE_URL || 'https://agenticadvertising.org').replace(/\/$/, '');
       const returnTo = `${baseUrl}/member-hub?connected=github`;
       let authorizeUrl: string;
       try {
         authorizeUrl = await getGitHubAuthorizeUrl(workosUserId, returnTo);
       } catch (error) {
         logger.error({ err: error }, 'create_github_issue: Failed to build Pipes authorize URL');
-        return 'GitHub connection is unavailable right now. Use `draft_github_issue` to generate a pre-filled link you can submit yourself.';
+        return `GitHub connection is unavailable right now. Use \`draft_github_issue\` to generate a pre-filled link you can submit yourself. (Manage connections at ${manageConnectionsUrl}.)`;
       }
 
       const reason = tokenResult.status === 'needs_reauthorization'
@@ -4666,7 +4677,7 @@ export function createMemberToolHandlers(
         reason,
         '',
         `**Two options:**`,
-        `1. **[Connect GitHub](${authorizeUrl})** — takes ~10 seconds, then I'll file the issue authored by your GitHub account.`,
+        `1. **[Connect GitHub](${authorizeUrl})** — takes under a minute, then I'll file the issue authored by your GitHub account. You can also manage connections any time at ${manageConnectionsUrl}.`,
         `2. Ask me to use \`draft_github_issue\` instead and I'll give you a pre-filled link you submit yourself.`,
       ].join('\n');
     }

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -199,14 +199,12 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   content: {
     name: 'content',
-    // NOTE: GitHub issue filing (draft_github_issue / create_github_issue) is in
-    // ALWAYS_AVAILABLE_TOOLS and is never restricted to the content set. Do not
-    // re-add it to this description — doing so would cause the "unavailable
-    // sets" hint to claim GitHub issuing is off when it isn't.
+    // NOTE: GitHub issue filing lives in ALWAYS_AVAILABLE_TOOLS and is
+    // intentionally NOT listed here — neither in the description nor the tools
+    // array. Duplicating it caused Addie to hallucinate "I can't file GitHub
+    // issues" when the router didn't pick `content`.
     description: 'Manage content workflows - propose news sources, handle content approvals, add or update committee documents (admin actions)',
     tools: [
-      'draft_github_issue',
-      'create_github_issue',
       'propose_news_source',
       'list_pending_content',
       'approve_content',
@@ -466,13 +464,18 @@ export function buildUnavailableSetsHint(selectedSets: string[], isAAOAdmin: boo
   // with an always-available capability (e.g., GitHub issue filing) and
   // hallucinates that the capability is off. Keep this list tight — only the
   // tools users explicitly ask for by name.
-  const alwaysAvailableReminder = [
-    'draft_github_issue — filing bugs / feature requests as a pre-filled GitHub link',
-    'create_github_issue — filing an issue directly under the member\'s GitHub account (if connected)',
-    'get_github_issue — reading a GitHub issue or PR by number or URL',
-    'escalate_to_admin — handing the thread to a human admin',
-    'get_account_link — linking / signing-in flows',
-  ];
+  //
+  // NOTE: each key MUST exist in ALWAYS_AVAILABLE_TOOLS. A test enforces this
+  // so a renamed/removed tool can't silently rot into a lying hint.
+  const ALWAYS_AVAILABLE_BLURBS: Record<string, string> = {
+    draft_github_issue: 'filing bugs / feature requests as a pre-filled GitHub link',
+    create_github_issue: "filing an issue directly under the member's GitHub account (if connected)",
+    get_github_issue: 'reading a GitHub issue or PR by number or URL',
+    escalate_to_admin: 'handing the thread to a human admin',
+  };
+  const alwaysAvailableReminder = Object.entries(ALWAYS_AVAILABLE_BLURBS)
+    .filter(([tool]) => ALWAYS_AVAILABLE_TOOLS.includes(tool))
+    .map(([tool, blurb]) => `${tool} — ${blurb}`);
 
   return `
 ## Capabilities Not Available in This Conversation
@@ -483,7 +486,7 @@ ${hints.join('\n')}
 
 ## Capabilities That ARE Always Available
 
-Regardless of the above, these tools are ALWAYS available to you. Never tell the user you can't do one of these:
+These tools are callable in every conversation. If you're about to tell the user you can't do one of these, call it instead:
 ${alwaysAvailableReminder.map(l => `- ${l}`).join('\n')}
 `;
 }

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -39,6 +39,7 @@ export const ALWAYS_AVAILABLE_TOOLS = [
   'set_outreach_preference', // Users can always opt out of proactive outreach
   'search_image_library', // Illustrations to enrich explanations — not topic-dependent
   'draft_github_issue',  // Bug reports & feature requests should always be possible
+  'create_github_issue', // Paired with draft — if a member wants it filed directly, keep it reachable
   'get_github_issue',    // Users paste GitHub links in any conversation; reading should never be routed away
   // Content submission is a first-class action — a member sharing a draft in
   // any channel (editorial, admin, DM) should land in pending_review, not an
@@ -198,7 +199,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   content: {
     name: 'content',
-    description: 'Manage content workflows - draft GitHub issues, propose news sources, handle content approvals, add or update committee documents (admin actions)',
+    // NOTE: GitHub issue filing (draft_github_issue / create_github_issue) is in
+    // ALWAYS_AVAILABLE_TOOLS and is never restricted to the content set. Do not
+    // re-add it to this description — doing so would cause the "unavailable
+    // sets" hint to claim GitHub issuing is off when it isn't.
+    description: 'Manage content workflows - propose news sources, handle content approvals, add or update committee documents (admin actions)',
     tools: [
       'draft_github_issue',
       'create_github_issue',
@@ -456,12 +461,30 @@ export function buildUnavailableSetsHint(selectedSets: string[], isAAOAdmin: boo
     return `- **${setName}**: ${set.description}`;
   });
 
+  // Remind Claude which escape-hatch tools bypass set routing. Without this,
+  // the model sometimes reads an unavailable-set description that overlaps
+  // with an always-available capability (e.g., GitHub issue filing) and
+  // hallucinates that the capability is off. Keep this list tight — only the
+  // tools users explicitly ask for by name.
+  const alwaysAvailableReminder = [
+    'draft_github_issue — filing bugs / feature requests as a pre-filled GitHub link',
+    'create_github_issue — filing an issue directly under the member\'s GitHub account (if connected)',
+    'get_github_issue — reading a GitHub issue or PR by number or URL',
+    'escalate_to_admin — handing the thread to a human admin',
+    'get_account_link — linking / signing-in flows',
+  ];
+
   return `
 ## Capabilities Not Available in This Conversation
 
 The following capabilities are not available right now. If the user asks for something in these areas, explain what you can't help with in plain, natural language and suggest an alternative (e.g., direct them to the right person, page, or channel). Do NOT use technical terms like "tool sets", "not loaded", or "tool categories" — describe capabilities naturally (e.g., "I don't have access to scheduling features right now" rather than "meeting tools aren't loaded").
 
 ${hints.join('\n')}
+
+## Capabilities That ARE Always Available
+
+Regardless of the above, these tools are ALWAYS available to you. Never tell the user you can't do one of these:
+${alwaysAvailableReminder.map(l => `- ${l}`).join('\n')}
 `;
 }
 

--- a/server/tests/unit/addie/tool-sets.test.ts
+++ b/server/tests/unit/addie/tool-sets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getToolsForSets, ALWAYS_AVAILABLE_ADMIN_TOOLS, TOOL_SETS, buildUnavailableSetsHint } from '../../../src/addie/tool-sets.js';
+import { getToolsForSets, ALWAYS_AVAILABLE_TOOLS, ALWAYS_AVAILABLE_ADMIN_TOOLS, TOOL_SETS, buildUnavailableSetsHint } from '../../../src/addie/tool-sets.js';
 
 describe('getToolsForSets', () => {
   describe('admin always-available tools', () => {
@@ -106,5 +106,20 @@ describe('buildUnavailableSetsHint', () => {
     const hint = buildUnavailableSetsHint(['knowledge'], false);
     const contentSection = hint.match(/- \*\*content\*\*:[^\n]*/)?.[0] ?? '';
     expect(contentSection).not.toMatch(/github issue/i);
+  });
+
+  it('never advertises tools that are not actually in ALWAYS_AVAILABLE_TOOLS (drift guard)', () => {
+    const hint = buildUnavailableSetsHint(['knowledge'], false);
+    // Extract tool names from the "Always Available" section: lines of the
+    // form `- <tool_name> — blurb`.
+    const section = hint.split('## Capabilities That ARE Always Available')[1] ?? '';
+    const advertised = [...section.matchAll(/^- (\w+) — /gm)].map((m) => m[1]);
+    expect(advertised.length).toBeGreaterThan(0);
+    for (const tool of advertised) {
+      expect(
+        ALWAYS_AVAILABLE_TOOLS,
+        `Hint advertised "${tool}" as always-available but it is not in ALWAYS_AVAILABLE_TOOLS`,
+      ).toContain(tool);
+    }
   });
 });

--- a/server/tests/unit/addie/tool-sets.test.ts
+++ b/server/tests/unit/addie/tool-sets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getToolsForSets, ALWAYS_AVAILABLE_ADMIN_TOOLS, TOOL_SETS } from '../../../src/addie/tool-sets.js';
+import { getToolsForSets, ALWAYS_AVAILABLE_ADMIN_TOOLS, TOOL_SETS, buildUnavailableSetsHint } from '../../../src/addie/tool-sets.js';
 
 describe('getToolsForSets', () => {
   describe('admin always-available tools', () => {
@@ -61,5 +61,50 @@ describe('getToolsForSets', () => {
       const tools = getToolsForSets(['knowledge'], false, true);
       expect(tools).toContain('search_docs');
     });
+  });
+
+  describe('github issue tools always available', () => {
+    it('includes draft_github_issue regardless of routed sets', () => {
+      const tools = getToolsForSets(['knowledge'], false, false);
+      expect(tools).toContain('draft_github_issue');
+    });
+
+    it('includes create_github_issue regardless of routed sets', () => {
+      const tools = getToolsForSets(['knowledge'], false, false);
+      expect(tools).toContain('create_github_issue');
+    });
+
+    it('includes github issue tools in public channels', () => {
+      const tools = getToolsForSets([], false, true);
+      expect(tools).toContain('draft_github_issue');
+      expect(tools).toContain('create_github_issue');
+    });
+  });
+
+  describe('content set description does not claim ownership of github issuing', () => {
+    it('omits "draft GitHub issues" from the description', () => {
+      expect(TOOL_SETS.content.description).not.toMatch(/github issue/i);
+    });
+  });
+});
+
+describe('buildUnavailableSetsHint', () => {
+  it('returns empty when all sets are selected', () => {
+    const allSets = Object.keys(TOOL_SETS);
+    expect(buildUnavailableSetsHint(allSets, true)).toBe('');
+  });
+
+  it('lists an always-available escape-hatch section when sets are unavailable', () => {
+    const hint = buildUnavailableSetsHint(['knowledge'], false);
+    expect(hint).toContain('Always Available');
+    expect(hint).toContain('draft_github_issue');
+    expect(hint).toContain('create_github_issue');
+    expect(hint).toContain('escalate_to_admin');
+  });
+
+  it('never describes the content set as owning GitHub issue filing', () => {
+    const hint = buildUnavailableSetsHint(['knowledge'], false);
+    const contentSection = hint.match(/- \*\*content\*\*:[^\n]*/)?.[0] ?? '';
+    expect(contentSection).not.toMatch(/github issue/i);
   });
 });

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -281,6 +281,36 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('too long for a pre-filled URL');
       expect(result).toContain('create the issue manually');
     });
+
+    it('accepts adcp-client as a valid repo', async () => {
+      const handlers = createMemberToolHandlers(null);
+      const handler = handlers.get('draft_github_issue')!;
+
+      const result = await handler({
+        title: 'T',
+        body: 'B',
+        repo: 'adcp-client',
+      });
+
+      expect(result).toContain('github.com/adcontextprotocol/adcp-client/issues/new');
+    });
+
+    it('rejects invented repo names and names the allowed list', async () => {
+      const handlers = createMemberToolHandlers(null);
+      const handler = handlers.get('draft_github_issue')!;
+
+      const result = await handler({
+        title: 'T',
+        body: 'B',
+        repo: 'creative-agent',
+      });
+
+      expect(result).toContain('creative-agent');
+      expect(result).toContain('not a recognized AdCP repository');
+      expect(result).toContain('adcp');
+      expect(result).toContain('adcp-client');
+      expect(result).toContain('adcp-go');
+    });
   });
 
   describe('create_github_issue handler', () => {

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -295,21 +295,21 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('github.com/adcontextprotocol/adcp-client/issues/new');
     });
 
-    it('rejects invented repo names and names the allowed list', async () => {
+    it('routes invented repo names to adcp with a subproject note in the body', async () => {
       const handlers = createMemberToolHandlers(null);
       const handler = handlers.get('draft_github_issue')!;
 
       const result = await handler({
         title: 'T',
-        body: 'B',
+        body: 'Original body',
         repo: 'creative-agent',
       });
 
+      expect(result).toContain('github.com/adcontextprotocol/adcp/issues/new');
+      expect(result).not.toContain('github.com/adcontextprotocol/creative-agent');
+      expect(result).toContain('Subproject');
       expect(result).toContain('creative-agent');
-      expect(result).toContain('not a recognized AdCP repository');
-      expect(result).toContain('adcp');
-      expect(result).toContain('adcp-client');
-      expect(result).toContain('adcp-go');
+      expect(result).toContain('Original body');
     });
   });
 
@@ -353,7 +353,7 @@ describe('createMemberToolHandlers', () => {
       expect(getTokenMock).not.toHaveBeenCalled();
     });
 
-    it("returns Connect URL when user hasn't connected GitHub", async () => {
+    it("leads with the Connect offer when user hasn't connected GitHub", async () => {
       getTokenMock.mockResolvedValue({ status: 'not_connected' });
       getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/abc');
 
@@ -364,13 +364,15 @@ describe('createMemberToolHandlers', () => {
 
       expect(getTokenMock).toHaveBeenCalledWith('user_abc');
       expect(getAuthorizeUrlMock).toHaveBeenCalledWith('user_abc', expect.stringContaining('/member-hub'));
-      expect(result).toContain('haven\'t connected GitHub');
       expect(result).toContain('[Connect GitHub](https://workos.example/pipes/authorize/abc)');
       expect(result).toContain('draft_github_issue');
+      // Lead line should be the offer, not the failure reason.
+      const firstLine = result.split('\n')[0];
+      expect(firstLine).toContain('Connect GitHub');
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('returns Connect URL when connection needs reauthorization', async () => {
+    it('returns Reconnect URL when connection needs reauthorization', async () => {
       getTokenMock.mockResolvedValue({ status: 'needs_reauthorization', missingScopes: ['public_repo'] });
       getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/xyz');
 
@@ -379,8 +381,8 @@ describe('createMemberToolHandlers', () => {
 
       const result = await handler({ title: 'T', body: 'B' });
 
-      expect(result).toContain('needs to be re-authorized');
-      expect(result).toContain('https://workos.example/pipes/authorize/xyz');
+      expect(result).toContain('re-authorization');
+      expect(result).toContain('[Reconnect GitHub](https://workos.example/pipes/authorize/xyz)');
       expect(fetchMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

In Slack, Addie was telling users *"I don't have GitHub issue tools available in this conversation"* — even though `draft_github_issue` has always been in `ALWAYS_AVAILABLE_TOOLS`. Root cause: the "unavailable tool sets" hint described the `content` set as *\"draft GitHub issues, propose news sources, …\"*. Claude read that and hallucinated unavailability.

Changes:
- `create_github_issue` joins `draft_github_issue` in `ALWAYS_AVAILABLE_TOOLS` (they're a pair).
- `content` set description no longer claims ownership of GitHub issuing.
- `buildUnavailableSetsHint` now appends an explicit "Capabilities That ARE Always Available" section so the model can't conflate set-scoped descriptions with per-tool availability.
- `draft_github_issue` enforces a repo allowlist (`adcp`, `adcp-client`, `adcp-client-python`, `adcp-go`) — Addie was inventing repo names like `creative-agent` from conversation context.
- `create_github_issue` unavailable/connect responses now point at the canonical `/member-hub` (Addie was hallucinating `/account`).

## Test plan

- [x] 72 unit tests pass (55 `tests/addie/member-tools.test.ts` + 17 `server/tests/unit/addie/tool-sets.test.ts`). Added coverage for always-available github tools, content description, `buildUnavailableSetsHint`, repo allowlist accept/reject.
- [x] Typecheck clean.
- [x] Live battery of 8 prompts against a local docker build confirmed:
  - Casual bug reports → `draft_github_issue` (safe default even when user says "create").
  - Explicit `create_github_issue` ask → unavailable-fallback now names `/member-hub` correctly.
  - User-supplied `creative-agent` repo → rejected, Addie falls back to `adcp` and notes the subproject in the body.
  - Vague "file this in github" → asks for clarification.
- [ ] Post-deploy: confirm the Slack `wg-builders` scenario in the screenshot no longer produces "I don't have GitHub issue tools" — easiest check is a new Slack message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)