### PR TITLE
feat(agents): switch triage nudge prefix to @claude-triage

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -90,18 +90,18 @@ summary. This is the dedup lock — it costs one API call per issue.
 
 If the event context (the text the routine receives) contains a
 `MANUAL NUDGE:` line, a repo member explicitly requested triage via
-a `/claude-triage` comment. **Skip the already-engaged check.** The
+a `@claude-triage` comment. **Skip the already-engaged check.** The
 nudge *is* the explicit request for help — proceed with full triage
 regardless of assignees, open PRs, or recent comments.
 
-If the comment text includes a modifier after `/claude-triage`, use
+If the comment text includes a modifier after `@claude-triage`, use
 it to bias the decision:
 
-- `/claude-triage execute` — lean toward Execute on borderline
+- `@claude-triage execute` — lean toward Execute on borderline
   non-breaking changes
-- `/claude-triage clarify` — force a clarifying-question comment
+- `@claude-triage clarify` — force a clarifying-question comment
   even if you'd otherwise act
-- `/claude-triage defer` — force defer and stop
+- `@claude-triage defer` — force defer and stop
 
 Without a modifier, use standard four-outcome logic.
 

--- a/.changeset/nudge-at-mention.md
+++ b/.changeset/nudge-at-mention.md
@@ -1,0 +1,4 @@
+---
+---
+
+Switch the manual triage nudge from `/claude-triage` to `@claude-triage`. GitHub's native `/` autocomplete menu pops up when you type `/` in a comment (Alerts, Code block, Details…) and our non-registered slash command collides with it visually. `@` prefix avoids the menu, matches the `@dependabot` / `@claude` conventions users already recognize, and reads more naturally as "get this agent's attention." Bridge workflow filter and triage-prompt modifier docs updated.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -3,7 +3,7 @@ name: Claude Issue Triage Bridge
 # Bridges GitHub events to a Claude Code routine's /fire endpoint.
 # Two entry points:
 #   1. `issues.opened` / `issues.reopened` — automatic triage on new issues.
-#   2. `issue_comment.created` with `/claude-triage` in the body — manual
+#   2. `issue_comment.created` with `@claude-triage` in the body — manual
 #      nudge from a repo member, useful when you want the routine to
 #      (re-)look at a specific issue on demand.
 #
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     # Skip bots always. For comment events: only repo members can nudge,
-    # and the comment body must contain `/claude-triage`.
+    # and the comment body must contain `@claude-triage`.
     if: >-
       github.event.issue.user.type != 'Bot' &&
       !endsWith(github.event.issue.user.login, '[bot]') &&
@@ -44,7 +44,7 @@ jobs:
         github.event_name == 'issues' ||
         (
           github.event_name == 'issue_comment' &&
-          contains(github.event.comment.body, '/claude-triage') &&
+          contains(github.event.comment.body, '@claude-triage') &&
           (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
@@ -89,7 +89,7 @@ jobs:
           # The already-engaged check should pass this through; the nudge IS
           # the explicit request.
           if [ "$EVENT_NAME" = "issue_comment" ]; then
-            nudge_note="MANUAL NUDGE: @${COMMENT_AUTHOR} requested triage via /claude-triage. Comment body (trimmed): \"${COMMENT_BODY_SAFE}\". Treat this as an explicit request; do NOT silent-defer on already-engaged signals — the nudge overrides."
+            nudge_note="MANUAL NUDGE: @${COMMENT_AUTHOR} requested triage via @claude-triage. Comment body (trimmed): \"${COMMENT_BODY_SAFE}\". Treat this as an explicit request; do NOT silent-defer on already-engaged signals — the nudge overrides."
           else
             nudge_note=""
           fi


### PR DESCRIPTION
## Summary

GitHub's native slash menu (Alerts / Code block / Details…) popped up whenever a user typed `/` in a comment, colliding visually with our non-registered `/claude-triage` command. `@` prefix fixes it.

- Bridge workflow filter: `contains(comment.body, '@claude-triage')`
- Prompt modifier examples: `@claude-triage execute` / `clarify` / `defer`
- Same for all 3 sibling repos (separate PRs, same change)

## Why `@` and not something else

- Matches `@dependabot` / `@claude` patterns users already recognize on GitHub
- No collision with GitHub's `/` autocomplete
- Reads naturally as "get the agent's attention"

🤖 Generated with [Claude Code](https://claude.com/claude-code)