### PR TITLE
feat: Workflow B Stage 3 — admin "Mark posted to LinkedIn" action

### DIFF
--- a/.changeset/workflow-b-admin-mark-linkedin.md
+++ b/.changeset/workflow-b-admin-mark-linkedin.md
@@ -1,0 +1,43 @@
+---
+---
+
+**Workflow B Stage 3 — admin "Mark posted to LinkedIn" action**
+
+Closes the Workflow B loop: admins who post to LinkedIn *outside* Slack
+can now click "Mark posted to LinkedIn" on the admin account detail page
+and record the same `announcement_published` (channel=linkedin) row that
+the Slack button writes.
+
+**Shared critical section.** `markLinkedInPosted(orgId, actor)` is
+extracted from the Slack Bolt handler (Stage 2) and called by both the
+handler and the new HTTP route. Both paths hold the same advisory lock
+keyed on `(orgId, 'mark_linkedin')` so admin double-clicks, Slack
+retries, and cross-surface races converge on a single INSERT.
+
+**Actor identity.** Metadata now discriminates the actor source — Stage
+2 rows write `marked_by_slack_user_id` + `marked_via: 'slack'`; Stage 3
+rows write `marked_by_workos_user_id` + `marked_via: 'admin'`. The review
+card render path shows a clickable `<@U…>` mention for Slack-originated
+marks and a plain-text "an AAO admin" for admin-UI marks (Slack can't
+resolve WorkOS ids; leaking internal ids into a shared channel isn't
+something we want). Legacy rows (no `marked_via`) are treated as
+Slack-originated for back-compat.
+
+The `announcement_skipped` and `announcement_published (slack)` rows
+follow the same shape going forward: `skipper_slack_user_id` /
+`approver_slack_user_id` with a matching `_via` field.
+
+**Changes:**
+
+- `server/src/addie/jobs/announcement-handlers.ts` — extracts the shared
+  `markLinkedInPosted`; refactors `AnnouncementState` to carry tagged
+  `StoredActor` objects instead of raw Slack user ids; adds
+  `renderActorMention` helper; exports `loadDraftAndState`.
+- `server/src/routes/admin/accounts.ts` — adds `POST /api/admin/accounts/:orgId/announcement/linkedin`; extends the account detail GET response with an `announcement` object.
+- `server/public/admin-account-detail.html` — new "New-member
+  announcement" collapsible card. Shows current state and surfaces
+  the Mark-LI button when `slack_posted && !linkedin_posted && !skipped`.
+
+6 new shared-function tests cover admin actor, Slack actor, legacy row
+back-compat, and the three refuse paths. 86/86 announcement tests pass;
+server typecheck clean.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -1865,40 +1865,81 @@
       // shared advisory-lock path.
       const canMarkLinkedin = a.slack_posted && !a.linkedin_posted && !a.skipped;
       const button = canMarkLinkedin
-        ? `<button class="btn btn-primary btn-sm" id="markLinkedInBtn" onclick="markAnnouncementLinkedIn()" style="margin-top: var(--space-3);">Mark posted to LinkedIn</button>`
+        ? `<button class="btn btn-primary btn-sm" id="markLinkedInBtn" onclick="markAnnouncementLinkedIn()" aria-busy="false" style="margin-top: var(--space-3);">Mark posted to LinkedIn</button>`
         : '';
 
       content.innerHTML = `
-        <div style="display: flex; flex-direction: column; gap: var(--space-2); font-size: var(--text-sm);">
+        <div aria-live="polite" style="display: flex; flex-direction: column; gap: var(--space-2); font-size: var(--text-sm);">
           ${rows.join('')}
         </div>
         ${button}
+        <div id="announcementMessage" role="status" style="display: none; margin-top: var(--space-3); padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); font-size: var(--text-sm);"></div>
       `;
+    }
+
+    function showAnnouncementMessage(text, kind) {
+      const box = document.getElementById('announcementMessage');
+      if (!box) return;
+      // `kind` is 'error' | 'info'. Inline messages (vs alert) keep the
+      // context next to the action so an admin can read the server's
+      // 409 `refused` reason without the modal stealing focus.
+      const colors = kind === 'error'
+        ? { bg: 'var(--color-red-50, #fef2f2)', fg: 'var(--color-red-700, #b91c1c)' }
+        : { bg: 'var(--color-gray-100)', fg: 'var(--color-text-secondary)' };
+      box.style.background = colors.bg;
+      box.style.color = colors.fg;
+      box.style.display = '';
+      box.textContent = text;
     }
 
     async function markAnnouncementLinkedIn() {
       const btn = document.getElementById('markLinkedInBtn');
       if (!btn) return;
       btn.disabled = true;
+      btn.setAttribute('aria-busy', 'true');
       btn.textContent = 'Marking…';
       try {
         const response = await manageFetch(`/api/admin/accounts/${accountId}/announcement/linkedin`, {
           method: 'POST',
         });
+        const body = await response.json().catch(() => ({}));
         if (!response.ok) {
-          const body = await response.json().catch(() => ({}));
-          alert(body.message || body.error || `Failed (${response.status})`);
+          // Log to console so an admin on a support call can screenshot
+          // DevTools with status + body rather than an ephemeral alert.
+          console.error('markAnnouncementLinkedIn failed', response.status, body);
+          showAnnouncementMessage(
+            body.message || body.error || `Failed (${response.status})`,
+            'error',
+          );
           btn.disabled = false;
+          btn.setAttribute('aria-busy', 'false');
           btn.textContent = 'Mark posted to LinkedIn';
           return;
         }
-        // Re-fetch the account so the announcement section reflects the
-        // new state (and hides the button).
-        await loadAccount();
+        // Optimistic patch so the status line flips immediately. The
+        // subsequent loadAccount() reconciles with the server.
+        if (accountData.announcement) {
+          accountData.announcement.linkedin_posted = true;
+          accountData.announcement.linkedin_marked_at = new Date().toISOString();
+          accountData.announcement.linkedin_marker_label = 'an AAO admin';
+        }
+        renderAnnouncement();
+        if (body.already_done) {
+          showAnnouncementMessage(
+            body.message || 'Already recorded — no duplicate row created.',
+            'info',
+          );
+        }
+        // Background reconcile — no await; the optimistic render already
+        // updated the visible state.
+        loadAccount().catch((err) => {
+          console.error('Account refetch after markAnnouncementLinkedIn failed', err);
+        });
       } catch (err) {
         console.error('markAnnouncementLinkedIn failed', err);
-        alert('Failed to mark LinkedIn posted. Please retry.');
+        showAnnouncementMessage('Network error — please retry.', 'error');
         btn.disabled = false;
+        btn.setAttribute('aria-busy', 'false');
         btn.textContent = 'Mark posted to LinkedIn';
       }
     }

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -895,6 +895,14 @@
             </div>
           </div>
 
+          <!-- New-member announcement state (Workflow B) -->
+          <div class="card" id="announcementCard" style="display: none;">
+            <h2 class="collapsible" onclick="toggleSection(this)">New-member announcement</h2>
+            <div class="collapsible-content" id="announcementContent">
+              <div class="empty-state">Loading...</div>
+            </div>
+          </div>
+
           <!-- Users (Members + Slack-only) -->
           <div class="card">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -1811,8 +1819,88 @@
       // Billing (Stripe link, sync, payment history, delete workspace)
       renderBillingCard();
 
+      // New-member announcement state (Workflow B)
+      renderAnnouncement();
+
       // Populate team dropdowns
       populateTeamDropdowns();
+    }
+
+    function renderAnnouncement() {
+      const a = accountData.announcement;
+      const card = document.getElementById('announcementCard');
+      const content = document.getElementById('announcementContent');
+      if (!a) {
+        card.style.display = 'none';
+        return;
+      }
+      card.style.display = '';
+
+      // `_label` strings come from the server and are either a literal
+      // `<@U…>` Slack mention or a plain-text fallback like "an AAO
+      // admin". We treat both as already-formatted display text — the
+      // server is trusted since it assembled them from typed columns,
+      // not free-form draft content.
+      const byLabel = (label) => label ? ` by ${escapeHtml(label)}` : '';
+      const rows = [];
+      if (a.skipped) {
+        rows.push(`<div>⊘ <strong>Skipped</strong>${byLabel(a.skipper_label)}${a.skipped_at ? ` on ${escapeHtml(new Date(a.skipped_at).toLocaleString())}` : ''}</div>`);
+      } else {
+        rows.push(
+          a.slack_posted
+            ? `<div>✓ <strong>Slack posted</strong>${byLabel(a.slack_approver_label)}${a.slack_channel_id ? ` to <code>${escapeHtml(a.slack_channel_id)}</code>` : ''}</div>`
+            : `<div>⏳ Slack pending</div>`,
+        );
+        rows.push(
+          a.linkedin_posted
+            ? `<div>✓ <strong>LinkedIn posted</strong>${byLabel(a.linkedin_marker_label)}${a.linkedin_marked_at ? ` on ${escapeHtml(new Date(a.linkedin_marked_at).toLocaleString())}` : ''}</div>`
+            : `<div>⏳ LinkedIn pending</div>`,
+        );
+      }
+
+      // `Mark posted to LinkedIn` is only offered when Slack is done,
+      // LinkedIn hasn't been marked, and the draft wasn't skipped. The
+      // same button exists in the editorial-review Slack card; clicking
+      // either converges on one `announcement_published` row through the
+      // shared advisory-lock path.
+      const canMarkLinkedin = a.slack_posted && !a.linkedin_posted && !a.skipped;
+      const button = canMarkLinkedin
+        ? `<button class="btn btn-primary btn-sm" id="markLinkedInBtn" onclick="markAnnouncementLinkedIn()" style="margin-top: var(--space-3);">Mark posted to LinkedIn</button>`
+        : '';
+
+      content.innerHTML = `
+        <div style="display: flex; flex-direction: column; gap: var(--space-2); font-size: var(--text-sm);">
+          ${rows.join('')}
+        </div>
+        ${button}
+      `;
+    }
+
+    async function markAnnouncementLinkedIn() {
+      const btn = document.getElementById('markLinkedInBtn');
+      if (!btn) return;
+      btn.disabled = true;
+      btn.textContent = 'Marking…';
+      try {
+        const response = await manageFetch(`/api/admin/accounts/${accountId}/announcement/linkedin`, {
+          method: 'POST',
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          alert(body.message || body.error || `Failed (${response.status})`);
+          btn.disabled = false;
+          btn.textContent = 'Mark posted to LinkedIn';
+          return;
+        }
+        // Re-fetch the account so the announcement section reflects the
+        // new state (and hides the button).
+        await loadAccount();
+      } catch (err) {
+        console.error('markAnnouncementLinkedIn failed', err);
+        alert('Failed to mark LinkedIn posted. Please retry.');
+        btn.disabled = false;
+        btn.textContent = 'Mark posted to LinkedIn';
+      }
     }
 
     function renderOwner() {

--- a/server/src/addie/jobs/announcement-handlers.ts
+++ b/server/src/addie/jobs/announcement-handlers.ts
@@ -38,7 +38,11 @@
 
 import { createLogger } from '../../logger.js';
 import { query, getPool } from '../../db/client.js';
-import { sendChannelMessage, deleteChannelMessage } from '../../slack/client.js';
+import {
+  sendChannelMessage,
+  deleteChannelMessage,
+  updateChannelMessage,
+} from '../../slack/client.js';
 import { getAnnouncementChannel } from '../../db/system-settings-db.js';
 import { sanitizeDraftForSlack } from './announcement-trigger.js';
 import { isSafeVisualUrl } from '../../services/announcement-visual.js';
@@ -874,6 +878,49 @@ export async function markLinkedInPosted(
       },
     };
   });
+}
+
+/**
+ * Refresh the editorial review card in Slack to reflect a state change
+ * that happened outside of Slack (admin-UI click, background job).
+ *
+ * Bolt handlers already update the card via `client.chat.update` because
+ * they have the clicked message's channel + ts in the action body. The
+ * HTTP path has neither, so it loads them from the `announcement_draft_posted`
+ * activity metadata written by the Stage 1 trigger job. If the draft row
+ * or its review ts is missing (legacy pre-Stage-2 row, manual cleanup,
+ * etc.) the refresh is a silent no-op — the web UI already reflects the
+ * new state.
+ *
+ * Fire-and-forget from the caller's perspective: we log failures but
+ * don't surface them, because the authoritative state is already in the
+ * DB and the next Slack click will repaint from it.
+ */
+export async function refreshReviewCardForOrg(orgId: string): Promise<void> {
+  let loaded;
+  try {
+    loaded = await loadDraftAndState(orgId);
+  } catch (err) {
+    logger.warn({ err, orgId }, 'refreshReviewCardForOrg: loadDraftAndState failed');
+    return;
+  }
+  if (!loaded) return;
+  const { draft, state } = loaded;
+  const channel = draft.review_channel_id;
+  const ts = draft.review_message_ts;
+  if (!channel || !ts) return;
+  const rendered = renderReviewCard({ orgId, draft, state });
+  try {
+    const out = await updateChannelMessage(channel, ts, rendered);
+    if (!out.ok) {
+      logger.warn(
+        { orgId, channel, ts, error: out.error },
+        'refreshReviewCardForOrg: Slack chat.update failed',
+      );
+    }
+  } catch (err) {
+    logger.warn({ err, orgId, channel, ts }, 'refreshReviewCardForOrg: threw');
+  }
 }
 
 /**

--- a/server/src/addie/jobs/announcement-handlers.ts
+++ b/server/src/addie/jobs/announcement-handlers.ts
@@ -78,14 +78,106 @@ export interface DraftMetadata {
   profile_slug?: string;
 }
 
+/**
+ * Identifier shape for an actor who marked an announcement step. Stage 2
+ * (Slack button) carries a Slack user id; Stage 3 (admin HTTP) carries a
+ * WorkOS user id. We keep a tagged string rather than a plain id so
+ * downstream renderers can format it correctly (Slack `<@U…>` mention
+ * vs. plain WorkOS user id text).
+ */
+export type ActionActor =
+  | { source: 'slack'; slackUserId: string }
+  | { source: 'admin'; workosUserId: string };
+
+/** Actor as loaded from stored metadata (either channel may be null). */
+export interface StoredActor {
+  slackUserId: string | null;
+  workosUserId: string | null;
+  source: 'slack' | 'admin' | null;
+}
+
 export interface AnnouncementState {
   slackTs: string | null;
-  slackApproverUserId: string | null;
+  slackApprover: StoredActor;
   slackAnnouncementChannelId: string | null;
-  linkedinMarkerUserId: string | null;
+  linkedinMarker: StoredActor;
   linkedinMarkedAt: Date | null;
-  skipperUserId: string | null;
+  skipper: StoredActor;
   skippedAt: Date | null;
+}
+
+function emptyActor(): StoredActor {
+  return { slackUserId: null, workosUserId: null, source: null };
+}
+
+/** Coerce a loaded metadata row into a `StoredActor`. */
+function actorFromMetadata(m: Record<string, unknown>): StoredActor {
+  const source: 'slack' | 'admin' | null =
+    m.marked_via === 'slack' || m.marked_via === 'admin'
+      ? (m.marked_via as 'slack' | 'admin')
+      : null;
+  const slackUserId =
+    typeof m.marked_by_slack_user_id === 'string'
+      ? m.marked_by_slack_user_id
+      : typeof m.marked_by_user_id === 'string' && source !== 'admin'
+        ? m.marked_by_user_id
+        : null;
+  const workosUserId =
+    typeof m.marked_by_workos_user_id === 'string' ? m.marked_by_workos_user_id : null;
+  return { slackUserId, workosUserId, source };
+}
+
+/** Same pattern for the approver (Stage 2 metadata uses `approver_user_id`). */
+function approverFromMetadata(m: Record<string, unknown>): StoredActor {
+  const source: 'slack' | 'admin' | null =
+    m.approver_via === 'slack' || m.approver_via === 'admin'
+      ? (m.approver_via as 'slack' | 'admin')
+      : null;
+  const slackUserId =
+    typeof m.approver_slack_user_id === 'string'
+      ? m.approver_slack_user_id
+      : typeof m.approver_user_id === 'string' && source !== 'admin'
+        ? m.approver_user_id
+        : null;
+  const workosUserId =
+    typeof m.approver_workos_user_id === 'string' ? m.approver_workos_user_id : null;
+  return { slackUserId, workosUserId, source };
+}
+
+/**
+ * Render an actor as a mention suitable for the Slack review card. Slack
+ * users render as clickable `<@U…>` mentions; WorkOS-only actors
+ * (admin-UI click) render as plain text since Slack can't resolve them.
+ * Returns an empty string when no id is available.
+ */
+export function renderActorMention(actor: StoredActor): string {
+  if (actor.slackUserId) return `<@${actor.slackUserId}>`;
+  if (actor.workosUserId) return 'an AAO admin';
+  return '';
+}
+
+function actorToState(actor: ActionActor): StoredActor {
+  if (actor.source === 'slack') {
+    return { slackUserId: actor.slackUserId, workosUserId: null, source: 'slack' };
+  }
+  return { slackUserId: null, workosUserId: actor.workosUserId, source: 'admin' };
+}
+
+/** Skipper variant — same shape, different metadata key. */
+function skipperFromMetadata(m: Record<string, unknown>): StoredActor {
+  const source: 'slack' | 'admin' | null =
+    m.skipper_via === 'slack' || m.skipper_via === 'admin'
+      ? (m.skipper_via as 'slack' | 'admin')
+      : null;
+  const slackUserId =
+    typeof m.skipper_slack_user_id === 'string'
+      ? m.skipper_slack_user_id
+      : typeof m.skipper_user_id === 'string' && source !== 'admin'
+        ? m.skipper_user_id
+        : null;
+  const workosUserId =
+    typeof m.skipper_workos_user_id === 'string' ? m.skipper_workos_user_id : null;
+  return { slackUserId, workosUserId, source };
 }
 
 interface LoadedDraft {
@@ -136,11 +228,11 @@ async function loadDraftAndStateWith(
 
   const state: AnnouncementState = {
     slackTs: null,
-    slackApproverUserId: null,
+    slackApprover: emptyActor(),
     slackAnnouncementChannelId: null,
-    linkedinMarkerUserId: null,
+    linkedinMarker: emptyActor(),
     linkedinMarkedAt: null,
-    skipperUserId: null,
+    skipper: emptyActor(),
     skippedAt: null,
   };
 
@@ -149,22 +241,17 @@ async function loadDraftAndStateWith(
       const channel = typeof row.metadata?.channel === 'string' ? row.metadata.channel : null;
       if (channel === 'slack') {
         state.slackTs = typeof row.metadata.slack_ts === 'string' ? row.metadata.slack_ts : null;
-        state.slackApproverUserId =
-          typeof row.metadata.approver_user_id === 'string' ? row.metadata.approver_user_id : null;
+        state.slackApprover = approverFromMetadata(row.metadata);
         state.slackAnnouncementChannelId =
           typeof row.metadata.announcement_channel_id === 'string'
             ? row.metadata.announcement_channel_id
             : null;
       } else if (channel === 'linkedin') {
-        state.linkedinMarkerUserId =
-          typeof row.metadata.marked_by_user_id === 'string'
-            ? row.metadata.marked_by_user_id
-            : null;
+        state.linkedinMarker = actorFromMetadata(row.metadata);
         state.linkedinMarkedAt = row.activity_date;
       }
     } else if (row.activity_type === 'announcement_skipped') {
-      state.skipperUserId =
-        typeof row.metadata?.skipper_user_id === 'string' ? row.metadata.skipper_user_id : null;
+      state.skipper = skipperFromMetadata(row.metadata);
       state.skippedAt = row.activity_date;
     }
   }
@@ -231,19 +318,29 @@ export function renderReviewCard(args: {
     },
   ];
 
+  const skipped = Boolean(
+    state.skipper.slackUserId || state.skipper.workosUserId,
+  );
+  const linkedinDone = Boolean(
+    state.linkedinMarker.slackUserId || state.linkedinMarker.workosUserId,
+  );
+
   // Status line derived from state.
   const statusParts: string[] = [];
-  if (state.skipperUserId) {
-    statusParts.push(`⊘ Skipped by <@${state.skipperUserId}>`);
+  if (skipped) {
+    const mention = renderActorMention(state.skipper);
+    statusParts.push(`⊘ Skipped${mention ? ` by ${mention}` : ''}`);
   } else {
+    const approverMention = renderActorMention(state.slackApprover);
     statusParts.push(
       state.slackTs
-        ? `✓ Slack posted${state.slackApproverUserId ? ` by <@${state.slackApproverUserId}>` : ''}`
+        ? `✓ Slack posted${approverMention ? ` by ${approverMention}` : ''}`
         : '⏳ Slack pending',
     );
+    const markerMention = renderActorMention(state.linkedinMarker);
     statusParts.push(
-      state.linkedinMarkerUserId
-        ? `✓ LinkedIn posted by <@${state.linkedinMarkerUserId}>`
+      linkedinDone
+        ? `✓ LinkedIn posted${markerMention ? ` by ${markerMention}` : ''}`
         : '⏳ LinkedIn pending',
     );
   }
@@ -256,7 +353,7 @@ export function renderReviewCard(args: {
 
   // Actions derived from state. Terminal states (skipped, or both
   // channels posted) have no actions.
-  if (!state.skipperUserId && !(state.slackTs && state.linkedinMarkerUserId)) {
+  if (!skipped && !(state.slackTs && linkedinDone)) {
     const actionElements: SlackElement[] = [];
     if (!state.slackTs) {
       actionElements.push({
@@ -267,7 +364,7 @@ export function renderReviewCard(args: {
         style: 'primary',
       });
     }
-    if (!state.linkedinMarkerUserId) {
+    if (!linkedinDone) {
       actionElements.push({
         type: 'button',
         text: { type: 'plain_text', text: 'Mark posted to LinkedIn' },
@@ -275,7 +372,7 @@ export function renderReviewCard(args: {
         value: orgId,
       });
     }
-    if (!state.slackTs && !state.linkedinMarkerUserId) {
+    if (!state.slackTs && !linkedinDone) {
       actionElements.push({
         type: 'button',
         text: { type: 'plain_text', text: 'Skip' },
@@ -544,7 +641,7 @@ export async function handleAnnouncementApproveSlack(args: HandlerArgs): Promise
       const { draft } = loaded;
       const { state } = loaded;
 
-      if (state.skipperUserId) {
+      if (state.skipper.slackUserId || state.skipper.workosUserId) {
         return { kind: 'terminal', draft, state, notice: 'This announcement was already skipped.' };
       }
       if (state.slackTs) {
@@ -585,7 +682,8 @@ export async function handleAnnouncementApproveSlack(args: HandlerArgs): Promise
               announcement_channel_id: channelSetting.channel_id,
               announcement_channel_name: channelSetting.channel_name,
               slack_ts: post.ts,
-              approver_user_id: userId,
+              approver_slack_user_id: userId,
+              approver_via: 'slack',
             }),
           ],
         );
@@ -624,7 +722,7 @@ export async function handleAnnouncementApproveSlack(args: HandlerArgs): Promise
         state: {
           ...state,
           slackTs: post.ts,
-          slackApproverUserId: userId,
+          slackApprover: actorToState({ source: 'slack', slackUserId: userId }),
           slackAnnouncementChannelId: channelSetting.channel_id,
         },
       };
@@ -706,11 +804,80 @@ type SimpleOutcome =
   | { kind: 'recorded'; draft: DraftMetadata; state: AnnouncementState };
 
 /**
- * `Mark posted to LinkedIn`
+ * Record that the LinkedIn post for this org has been made externally.
+ * Shared by the Slack Bolt button handler (Stage 2) and the admin-UI
+ * HTTP route (Stage 3).
  *
- * Record that an admin has manually posted the draft to LinkedIn.
- * LinkedIn posting is external to AAO — this click closes the loop so
- * the admin backlog view can compute "fully announced".
+ * The critical section — load state, guard against skipped-or-already-
+ * marked, INSERT the `announcement_published` row — runs inside a
+ * transaction holding a Postgres advisory lock keyed on (orgId,
+ * 'mark_linkedin'). Concurrent calls (two rapid clicks, Slack 3s-ack
+ * retries, admin double-click) serialize on the lock and resolve
+ * deterministically to a single INSERT.
+ *
+ * Actor identity is recorded with `marked_via: 'slack' | 'admin'` plus
+ * the id shape appropriate to the path (`marked_by_slack_user_id` or
+ * `marked_by_workos_user_id`). This lets the read path render Slack
+ * mentions for Slack-originated marks and plain-text admins for admin
+ * UI marks without a cross-directory lookup.
+ */
+export async function markLinkedInPosted(
+  orgId: string,
+  actor: ActionActor,
+): Promise<SimpleOutcome> {
+  return withOrgActionLock<SimpleOutcome>(orgId, 'mark_linkedin', async (q) => {
+    const loaded = await loadDraftAndStateWith(q, orgId);
+    if (!loaded) return { kind: 'no_draft' };
+    const { draft, state } = loaded;
+
+    if (state.skipper.slackUserId || state.skipper.workosUserId) {
+      return {
+        kind: 'refuse',
+        draft,
+        state,
+        notice: 'This announcement was already skipped.',
+      };
+    }
+    if (state.linkedinMarker.slackUserId || state.linkedinMarker.workosUserId) {
+      return {
+        kind: 'already_done',
+        draft,
+        state,
+        notice: 'LinkedIn post was already marked.',
+      };
+    }
+
+    const metadata: Record<string, unknown> = {
+      channel: 'linkedin',
+      marked_via: actor.source,
+    };
+    if (actor.source === 'slack') {
+      metadata.marked_by_slack_user_id = actor.slackUserId;
+    } else {
+      metadata.marked_by_workos_user_id = actor.workosUserId;
+    }
+
+    await q(
+      `INSERT INTO org_activities (
+          organization_id, activity_type, description, metadata, activity_date
+       ) VALUES ($1, 'announcement_published', $2, $3::jsonb, NOW())`,
+      [orgId, 'Announcement marked as posted to LinkedIn', JSON.stringify(metadata)],
+    );
+
+    return {
+      kind: 'recorded',
+      draft,
+      state: {
+        ...state,
+        linkedinMarker: actorToState(actor),
+        linkedinMarkedAt: new Date(),
+      },
+    };
+  });
+}
+
+/**
+ * `Mark posted to LinkedIn` — Slack Bolt handler.
  */
 export async function handleAnnouncementMarkLinkedIn(args: HandlerArgs): Promise<void> {
   const { ack, body, client } = args;
@@ -727,48 +894,7 @@ export async function handleAnnouncementMarkLinkedIn(args: HandlerArgs): Promise
 
   let outcome: SimpleOutcome;
   try {
-    outcome = await withOrgActionLock<SimpleOutcome>(orgId, 'mark_linkedin', async (q) => {
-      const loaded = await loadDraftAndStateWith(q, orgId);
-      if (!loaded) return { kind: 'no_draft' };
-      const { draft, state } = loaded;
-
-      if (state.skipperUserId) {
-        return {
-          kind: 'refuse',
-          draft,
-          state,
-          notice: 'This announcement was already skipped.',
-        };
-      }
-      if (state.linkedinMarkerUserId) {
-        return {
-          kind: 'already_done',
-          draft,
-          state,
-          notice: 'LinkedIn post was already marked.',
-        };
-      }
-
-      await q(
-        `INSERT INTO org_activities (
-            organization_id, activity_type, description, metadata, activity_date
-         ) VALUES ($1, 'announcement_published', $2, $3::jsonb, NOW())`,
-        [
-          orgId,
-          'Announcement marked as posted to LinkedIn',
-          JSON.stringify({
-            channel: 'linkedin',
-            marked_by_user_id: userId,
-          }),
-        ],
-      );
-
-      return {
-        kind: 'recorded',
-        draft,
-        state: { ...state, linkedinMarkerUserId: userId, linkedinMarkedAt: new Date() },
-      };
-    });
+    outcome = await markLinkedInPosted(orgId, { source: 'slack', slackUserId: userId });
   } catch (err) {
     logger.error({ err, orgId, userId }, 'mark_linkedin critical section threw');
     await tellUser(client, channelId, userId, 'Failed to record the LinkedIn post. Please retry.');
@@ -824,7 +950,7 @@ export async function handleAnnouncementSkip(args: HandlerArgs): Promise<void> {
       if (!loaded) return { kind: 'no_draft' };
       const { draft, state } = loaded;
 
-      if (state.skipperUserId) {
+      if (state.skipper.slackUserId || state.skipper.workosUserId) {
         return {
           kind: 'already_done',
           draft,
@@ -832,7 +958,11 @@ export async function handleAnnouncementSkip(args: HandlerArgs): Promise<void> {
           notice: 'This announcement was already skipped.',
         };
       }
-      if (state.slackTs || state.linkedinMarkerUserId) {
+      if (
+        state.slackTs ||
+        state.linkedinMarker.slackUserId ||
+        state.linkedinMarker.workosUserId
+      ) {
         return {
           kind: 'refuse',
           draft,
@@ -846,13 +976,21 @@ export async function handleAnnouncementSkip(args: HandlerArgs): Promise<void> {
         `INSERT INTO org_activities (
             organization_id, activity_type, description, metadata, activity_date
          ) VALUES ($1, 'announcement_skipped', $2, $3::jsonb, NOW())`,
-        [orgId, 'Announcement skipped', JSON.stringify({ skipper_user_id: userId })],
+        [
+          orgId,
+          'Announcement skipped',
+          JSON.stringify({ skipper_slack_user_id: userId, skipper_via: 'slack' }),
+        ],
       );
 
       return {
         kind: 'recorded',
         draft,
-        state: { ...state, skipperUserId: userId, skippedAt: new Date() },
+        state: {
+          ...state,
+          skipper: actorToState({ source: 'slack', slackUserId: userId }),
+          skippedAt: new Date(),
+        },
       };
     });
   } catch (err) {

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -32,6 +32,7 @@ import { createProspect, updateProspect } from "../../services/prospect.js";
 import {
   loadDraftAndState,
   markLinkedInPosted,
+  refreshReviewCardForOrg,
 } from "../../addie/jobs/announcement-handlers.js";
 import { WorkOS } from "@workos-inc/node";
 import {
@@ -1720,6 +1721,10 @@ export function setupAccountRoutes(
           workosUserId,
         });
 
+        // Uniform response shape across all success branches makes the
+        // admin-UI handler branch on `already_done` without checking for
+        // missing fields. `message` is absent on a fresh record because
+        // there's no "something was already true" to report.
         switch (outcome.kind) {
           case "no_draft":
             return res.status(404).json({
@@ -1733,13 +1738,25 @@ export function setupAccountRoutes(
               message: outcome.notice,
             });
           case "already_done":
+            // State already at the target — refresh the editorial Slack
+            // card anyway so it doesn't linger on a stale state.
+            void refreshReviewCardForOrg(orgId);
             return res.status(200).json({
               success: true,
               already_done: true,
               message: outcome.notice,
             });
           case "recorded":
-            return res.status(200).json({ success: true });
+            // Fire-and-forget Slack refresh so the in-Slack review card
+            // shows the new state. We don't await — the HTTP response
+            // should complete fast, and any refresh failure is already
+            // logged; the DB is the authoritative source.
+            void refreshReviewCardForOrg(orgId);
+            return res.status(200).json({
+              success: true,
+              already_done: false,
+              message: "LinkedIn post recorded.",
+            });
         }
       } catch (error) {
         logger.error(

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -29,6 +29,10 @@ import {
 } from "../../db/membership-invites-db.js";
 import { sendMembershipInviteEmail } from "../../notifications/email.js";
 import { createProspect, updateProspect } from "../../services/prospect.js";
+import {
+  loadDraftAndState,
+  markLinkedInPosted,
+} from "../../addie/jobs/announcement-handlers.js";
 import { WorkOS } from "@workos-inc/node";
 import {
   MEMBER_FILTER_ALIASED,
@@ -388,6 +392,7 @@ export function setupAccountRoutes(
           similarOrgsResult,
           pendingSlackUsersResult,
           subsidiariesResult,
+          announcementLoaded,
         ] = await Promise.all([
           // Working groups
           pool.query(
@@ -644,6 +649,14 @@ export function setupAccountRoutes(
                 [org.email_domain, orgId]
               )
             : Promise.resolve({ rows: [] }),
+
+          // Workflow B announcement state: returns null when no draft has
+          // been posted yet. Non-blocking — if the fetch errors we still
+          // render the rest of the account page.
+          loadDraftAndState(orgId).catch((err: unknown) => {
+            logger.warn({ err, orgId }, "loadDraftAndState failed for account detail");
+            return null;
+          }),
         ]);
 
         // Brand-aware similar org detection via aliases and hierarchy
@@ -881,6 +894,39 @@ export function setupAccountRoutes(
           // Pending Slack users (discovered via domain but not yet linked/members)
           pending_slack_users: pendingSlackUsersResult.rows,
           pending_slack_count: pendingSlackUsersResult.rows.length,
+
+          // Workflow B announcement state. `null` = no draft has been
+          // posted yet. Admin UI renders a `Mark posted to LinkedIn`
+          // action when `slack_posted && !linkedin_posted && !skipped`.
+          // Actors are collapsed to a single `_label` string suitable
+          // for display; internal ids stay server-side.
+          announcement: announcementLoaded
+            ? (() => {
+                const s = announcementLoaded.state;
+                const actorLabel = (actor: typeof s.slackApprover): string | null => {
+                  if (actor.source === "admin" && actor.workosUserId) return "an AAO admin";
+                  if (actor.slackUserId) return `<@${actor.slackUserId}>`;
+                  if (actor.workosUserId) return "an AAO admin";
+                  return null;
+                };
+                return {
+                  slack_posted: Boolean(s.slackTs),
+                  slack_ts: s.slackTs,
+                  slack_channel_id: s.slackAnnouncementChannelId,
+                  slack_approver_label: actorLabel(s.slackApprover),
+                  linkedin_posted: Boolean(
+                    s.linkedinMarker.slackUserId || s.linkedinMarker.workosUserId,
+                  ),
+                  linkedin_marked_at: s.linkedinMarkedAt?.toISOString() ?? null,
+                  linkedin_marker_label: actorLabel(s.linkedinMarker),
+                  skipped: Boolean(s.skipper.slackUserId || s.skipper.workosUserId),
+                  skipped_at: s.skippedAt?.toISOString() ?? null,
+                  skipper_label: actorLabel(s.skipper),
+                  org_name: announcementLoaded.draft.org_name ?? null,
+                  profile_slug: announcementLoaded.draft.profile_slug ?? null,
+                };
+              })()
+            : null,
 
           owner: owner
             ? {
@@ -1638,6 +1684,72 @@ export function setupAccountRoutes(
       });
     }
   });
+
+  // POST /api/admin/accounts/:orgId/announcement/linkedin
+  // Admin-UI counterpart to the `Mark posted to LinkedIn` Slack button.
+  // Idempotent — the shared `markLinkedInPosted` holds a Postgres advisory
+  // lock keyed on (orgId, 'mark_linkedin') so this endpoint, the Bolt
+  // handler, and concurrent double-submits all converge on one row.
+  apiRouter.post(
+    "/accounts/:orgId/announcement/linkedin",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const { orgId } = req.params;
+        if (!/^org_[A-Z0-9]+$/.test(orgId)) {
+          return res.status(400).json({ error: "Invalid organization id" });
+        }
+        const workosUserId = req.user?.id;
+        if (!workosUserId) {
+          return res.status(401).json({ error: "Unauthenticated" });
+        }
+        // Reject the static `ADMIN_API_KEY` auth path (id = 'admin_api_key')
+        // — this endpoint records the caller into the audit trail and a
+        // shared static key can't stand in for an individual admin.
+        if (workosUserId === "admin_api_key") {
+          return res.status(403).json({
+            error: "admin_api_key_not_allowed",
+            message:
+              "This action must be performed by a signed-in admin, not the static API key.",
+          });
+        }
+
+        const outcome = await markLinkedInPosted(orgId, {
+          source: "admin",
+          workosUserId,
+        });
+
+        switch (outcome.kind) {
+          case "no_draft":
+            return res.status(404).json({
+              error: "no_draft",
+              message:
+                "No announcement draft has been posted for this org yet.",
+            });
+          case "refuse":
+            return res.status(409).json({
+              error: "refused",
+              message: outcome.notice,
+            });
+          case "already_done":
+            return res.status(200).json({
+              success: true,
+              already_done: true,
+              message: outcome.notice,
+            });
+          case "recorded":
+            return res.status(200).json({ success: true });
+        }
+      } catch (error) {
+        logger.error(
+          { err: error, orgId: req.params.orgId },
+          "Error marking announcement LinkedIn posted"
+        );
+        return res.status(500).json({ error: "Internal server error" });
+      }
+    }
+  );
 
   // POST /api/admin/accounts/:orgId/activities/:activityId/complete - Mark a task complete
   apiRouter.post(

--- a/server/src/slack/client.ts
+++ b/server/src/slack/client.ts
@@ -518,6 +518,33 @@ export async function sendChannelMessage(
 }
 
 /**
+ * Update (edit in place) a previously posted channel message.
+ * Wraps Slack's `chat.update`. Used when non-Bolt code paths need to
+ * refresh a message whose `ts` we already know — e.g. admin-UI actions
+ * that mirror a Bolt button and need to refresh the original review
+ * card so the in-Slack state doesn't drift from the web state.
+ */
+export async function updateChannelMessage(
+  channelId: string,
+  ts: string,
+  message: SlackBlockMessage,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await slackPostRequest<Record<string, unknown>>('chat.update', {
+      channel: channelId,
+      ts,
+      text: message.text,
+      blocks: message.blocks,
+    });
+    return { ok: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error({ error, channelId, ts }, 'Failed to update Slack channel message');
+    return { ok: false, error: errorMessage };
+  }
+}
+
+/**
  * Delete a posted channel message. Used to unwind a post when a
  * subsequent write (e.g. activity row) fails and would otherwise leave
  * an orphan message in a review channel with no idempotency record.

--- a/tests/announcement/announcement-admin-route.test.ts
+++ b/tests/announcement/announcement-admin-route.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Integration-style tests for the admin "Mark posted to LinkedIn" HTTP
+ * route. Exercises the middleware chain, orgId regex, ADMIN_API_KEY
+ * guard, outcome→status code mapping, and the Slack-refresh fire-and-
+ * forget — all the wiring that the shared-function unit tests can't
+ * cover because they call `markLinkedInPosted` directly.
+ *
+ * Uses a bare Express app with `setupAccountRoutes`; auth middleware
+ * and `markLinkedInPosted` / `refreshReviewCardForOrg` are mocked at
+ * module boundaries. No DB, no real Slack.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import { Router } from 'express';
+import request from 'supertest';
+
+// Route module transitively imports workos-client which throws on
+// module load if this isn't set. Any value works — the client is never
+// called in these tests because we mock the admin-tools boundary.
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const {
+  mockMarkLinkedInPosted,
+  mockRefreshReviewCardForOrg,
+  mockLoadDraftAndState,
+  mockCurrentUser,
+} = vi.hoisted(() => ({
+  mockMarkLinkedInPosted: vi.fn<any>(),
+  mockRefreshReviewCardForOrg: vi.fn<any>(),
+  mockLoadDraftAndState: vi.fn<any>(),
+  mockCurrentUser: { id: 'user_wk_admin01', email: 'admin@example.com', is_admin: true },
+}));
+
+vi.mock('../../server/src/addie/jobs/announcement-handlers.js', () => ({
+  markLinkedInPosted: (...args: unknown[]) => mockMarkLinkedInPosted(...args),
+  refreshReviewCardForOrg: (...args: unknown[]) => mockRefreshReviewCardForOrg(...args),
+  loadDraftAndState: (...args: unknown[]) => mockLoadDraftAndState(...args),
+}));
+
+vi.mock('../../server/src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = mockCurrentUser;
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Everything else the route module imports but doesn't need for these
+// tests — we stub with enough to make module init a no-op.
+vi.mock('../../server/src/db/client.js', () => ({
+  getPool: () => ({ query: vi.fn() }),
+}));
+vi.mock('../../server/src/billing/stripe-client.js', () => ({
+  getPendingInvoices: vi.fn(),
+  createCheckoutSession: vi.fn(),
+  getProductsForCustomer: vi.fn(),
+}));
+
+async function buildApp() {
+  const { setupAccountRoutes } = await import('../../server/src/routes/admin/accounts.js');
+  const app = express();
+  app.use(express.json());
+  const pageRouter = Router();
+  const apiRouter = Router();
+  setupAccountRoutes(pageRouter, apiRouter);
+  app.use('/api/admin', apiRouter);
+  return app;
+}
+
+const ORG_ID = 'org_ACME123';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCurrentUser.id = 'user_wk_admin01';
+  mockRefreshReviewCardForOrg.mockResolvedValue(undefined);
+});
+
+describe('POST /api/admin/accounts/:orgId/announcement/linkedin', () => {
+  it('400 on malformed orgId', async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post('/api/admin/accounts/not-an-org/announcement/linkedin')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid organization id');
+    expect(mockMarkLinkedInPosted).not.toHaveBeenCalled();
+  });
+
+  it('403 when the caller is the static ADMIN_API_KEY', async () => {
+    mockCurrentUser.id = 'admin_api_key';
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('admin_api_key_not_allowed');
+    expect(mockMarkLinkedInPosted).not.toHaveBeenCalled();
+  });
+
+  it('404 when markLinkedInPosted returns no_draft', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({ kind: 'no_draft' });
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('no_draft');
+  });
+
+  it('409 when markLinkedInPosted refuses', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({
+      kind: 'refuse',
+      draft: {},
+      state: {},
+      notice: 'This announcement was already skipped.',
+    });
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('refused');
+    expect(res.body.message).toMatch(/already skipped/);
+  });
+
+  it('200 + already_done:true when the row already exists', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({
+      kind: 'already_done',
+      draft: {},
+      state: {},
+      notice: 'LinkedIn post was already marked.',
+    });
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, already_done: true });
+    expect(res.body.message).toMatch(/already marked/);
+  });
+
+  it('200 + already_done:false when a fresh record was written', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({
+      kind: 'recorded',
+      draft: {},
+      state: {},
+    });
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, already_done: false });
+  });
+
+  it('calls refreshReviewCardForOrg fire-and-forget on success paths', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({ kind: 'recorded', draft: {}, state: {} });
+    const app = await buildApp();
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(mockRefreshReviewCardForOrg).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it('does NOT call refreshReviewCardForOrg on error paths', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({ kind: 'no_draft' });
+    const app = await buildApp();
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(mockRefreshReviewCardForOrg).not.toHaveBeenCalled();
+  });
+
+  it('passes the admin actor shape to markLinkedInPosted', async () => {
+    mockMarkLinkedInPosted.mockResolvedValueOnce({ kind: 'recorded', draft: {}, state: {} });
+    const app = await buildApp();
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(mockMarkLinkedInPosted).toHaveBeenCalledWith(ORG_ID, {
+      source: 'admin',
+      workosUserId: 'user_wk_admin01',
+    });
+  });
+
+  it('returns 500 when markLinkedInPosted throws', async () => {
+    mockMarkLinkedInPosted.mockRejectedValueOnce(new Error('db down'));
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)
+      .send({});
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/announcement/announcement-handlers.test.ts
+++ b/tests/announcement/announcement-handlers.test.ts
@@ -88,6 +88,30 @@ function buildClient() {
   };
 }
 
+function emptyActor() {
+  return { slackUserId: null, workosUserId: null, source: null };
+}
+
+function slackActor(slackUserId: string) {
+  return { slackUserId, workosUserId: null, source: 'slack' as const };
+}
+
+function adminActor(workosUserId: string) {
+  return { slackUserId: null, workosUserId, source: 'admin' as const };
+}
+
+function blankState() {
+  return {
+    slackTs: null,
+    slackApprover: emptyActor(),
+    slackAnnouncementChannelId: null,
+    linkedinMarker: emptyActor(),
+    linkedinMarkedAt: null,
+    skipper: emptyActor(),
+    skippedAt: null,
+  };
+}
+
 /**
  * Queue up `mockQuery` results in the order the handler reads them:
  *   1) draft row  2) published/skipped activity rows  3) any writes
@@ -110,6 +134,10 @@ function queueDbReads(opts: {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset mockQuery specifically so the `mockResolvedValueOnce` queue
+  // from a previous test doesn't carry over. `clearAllMocks` clears
+  // call history but not queued implementations.
+  mockQuery.mockReset();
   mockIsSlackUserAAOAdmin.mockResolvedValue(true);
   mockGetAnnouncementChannel.mockResolvedValue({
     channel_id: ANNOUNCE_CHANNEL,
@@ -125,15 +153,7 @@ describe('renderReviewCard', () => {
     const { blocks, text } = renderReviewCard({
       orgId: ORG_ID,
       draft: DRAFT_METADATA,
-      state: {
-        slackTs: null,
-        slackApproverUserId: null,
-        slackAnnouncementChannelId: null,
-        linkedinMarkerUserId: null,
-        linkedinMarkedAt: null,
-        skipperUserId: null,
-        skippedAt: null,
-      },
+      state: blankState(),
     });
     expect(text).toContain('Acme Ad Tech');
     const status = blocks.find((b) => b.type === 'context' && b.elements?.[0]?.text?.includes('pending'));
@@ -154,13 +174,10 @@ describe('renderReviewCard', () => {
       orgId: ORG_ID,
       draft: DRAFT_METADATA,
       state: {
+        ...blankState(),
         slackTs: POSTED_TS,
-        slackApproverUserId: ADMIN_USER,
+        slackApprover: slackActor(ADMIN_USER),
         slackAnnouncementChannelId: ANNOUNCE_CHANNEL,
-        linkedinMarkerUserId: null,
-        linkedinMarkedAt: null,
-        skipperUserId: null,
-        skippedAt: null,
       },
     });
     const statusBlock = blocks.find(
@@ -179,13 +196,12 @@ describe('renderReviewCard', () => {
       orgId: ORG_ID,
       draft: DRAFT_METADATA,
       state: {
+        ...blankState(),
         slackTs: POSTED_TS,
-        slackApproverUserId: ADMIN_USER,
+        slackApprover: slackActor(ADMIN_USER),
         slackAnnouncementChannelId: ANNOUNCE_CHANNEL,
-        linkedinMarkerUserId: 'U0LIPOSTER',
+        linkedinMarker: slackActor('U0LIPOSTER'),
         linkedinMarkedAt: new Date(),
-        skipperUserId: null,
-        skippedAt: null,
       },
     });
     expect(blocks.find((b) => b.type === 'actions')).toBeUndefined();
@@ -195,18 +211,37 @@ describe('renderReviewCard', () => {
     expect(statusBlock?.elements?.[0]?.text).toContain('✓ LinkedIn posted by <@U0LIPOSTER>');
   });
 
+  it('admin-source actor renders as plain "an AAO admin" text, not a slack mention', async () => {
+    const { renderReviewCard } = await loadModule();
+    const { blocks } = renderReviewCard({
+      orgId: ORG_ID,
+      draft: DRAFT_METADATA,
+      state: {
+        ...blankState(),
+        slackTs: POSTED_TS,
+        slackApprover: slackActor(ADMIN_USER),
+        slackAnnouncementChannelId: ANNOUNCE_CHANNEL,
+        linkedinMarker: adminActor('user_workos_123'),
+        linkedinMarkedAt: new Date(),
+      },
+    });
+    const statusBlock = blocks.find(
+      (b) => b.type === 'context' && b.elements?.[0]?.text?.includes('✓ Slack posted'),
+    );
+    expect(statusBlock?.elements?.[0]?.text).toContain('✓ LinkedIn posted by an AAO admin');
+    // Must NOT mention the workos id directly — Slack can't resolve it
+    // and we don't want to leak internal ids into a shared channel.
+    expect(statusBlock?.elements?.[0]?.text).not.toContain('user_workos_123');
+  });
+
   it('skipped: shows skipper, no actions', async () => {
     const { renderReviewCard } = await loadModule();
     const { blocks } = renderReviewCard({
       orgId: ORG_ID,
       draft: DRAFT_METADATA,
       state: {
-        slackTs: null,
-        slackApproverUserId: null,
-        slackAnnouncementChannelId: null,
-        linkedinMarkerUserId: null,
-        linkedinMarkedAt: null,
-        skipperUserId: ADMIN_USER,
+        ...blankState(),
+        skipper: slackActor(ADMIN_USER),
         skippedAt: new Date(),
       },
     });
@@ -226,15 +261,7 @@ describe('renderReviewCard', () => {
         slack_text: 'ping <!channel> and <@U123>',
         linkedin_text: 'shell `rm -rf` #AAO',
       },
-      state: {
-        slackTs: null,
-        slackApproverUserId: null,
-        slackAnnouncementChannelId: null,
-        linkedinMarkerUserId: null,
-        linkedinMarkedAt: null,
-        skipperUserId: null,
-        skippedAt: null,
-      },
+      state: blankState(),
     });
     const slackBlock = blocks.find((b) => b.type === 'section' && b.text?.text?.includes('Slack draft'));
     expect(slackBlock?.text?.text).not.toMatch(/<!channel>/);
@@ -331,7 +358,8 @@ describe('handleAnnouncementApproveSlack', () => {
     const metadata = JSON.parse(insertCall![1][2]);
     expect(metadata.channel).toBe('slack');
     expect(metadata.slack_ts).toBe(POSTED_TS);
-    expect(metadata.approver_user_id).toBe(ADMIN_USER);
+    expect(metadata.approver_slack_user_id).toBe(ADMIN_USER);
+    expect(metadata.approver_via).toBe('slack');
     expect(client.chat.update).toHaveBeenCalledTimes(1);
   });
 
@@ -535,6 +563,134 @@ describe('handleAnnouncementApproveSlack', () => {
   });
 });
 
+describe('markLinkedInPosted (shared)', () => {
+  const WORKOS_USER = 'user_wk_01HZ';
+
+  test('admin actor: writes marked_by_workos_user_id + marked_via=admin', async () => {
+    queueDbReads({});
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'admin',
+      workosUserId: WORKOS_USER,
+    });
+
+    expect(outcome.kind).toBe('recorded');
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT INTO org_activities'),
+    );
+    const metadata = JSON.parse(insertCall![1][2]);
+    expect(metadata.channel).toBe('linkedin');
+    expect(metadata.marked_via).toBe('admin');
+    expect(metadata.marked_by_workos_user_id).toBe(WORKOS_USER);
+    expect(metadata.marked_by_slack_user_id).toBeUndefined();
+  });
+
+  test('slack actor: writes marked_by_slack_user_id + marked_via=slack', async () => {
+    queueDbReads({});
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'slack',
+      slackUserId: ADMIN_USER,
+    });
+
+    expect(outcome.kind).toBe('recorded');
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT INTO org_activities'),
+    );
+    const metadata = JSON.parse(insertCall![1][2]);
+    expect(metadata.marked_via).toBe('slack');
+    expect(metadata.marked_by_slack_user_id).toBe(ADMIN_USER);
+    expect(metadata.marked_by_workos_user_id).toBeUndefined();
+  });
+
+  test('no draft → kind=no_draft, no INSERT', async () => {
+    queueDbReads({ draft: null });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'admin',
+      workosUserId: WORKOS_USER,
+    });
+
+    expect(outcome.kind).toBe('no_draft');
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT'),
+    );
+    expect(insertCall).toBeUndefined();
+  });
+
+  test('already skipped → kind=refuse, no INSERT', async () => {
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_skipped',
+          activity_date: new Date(),
+          metadata: { skipper_slack_user_id: 'U0OTHERA', skipper_via: 'slack' },
+        },
+      ],
+    });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'admin',
+      workosUserId: WORKOS_USER,
+    });
+
+    expect(outcome.kind).toBe('refuse');
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT'),
+    );
+    expect(insertCall).toBeUndefined();
+  });
+
+  test('already marked → kind=already_done, no INSERT', async () => {
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: { channel: 'linkedin', marked_by_slack_user_id: 'U0PRIOR', marked_via: 'slack' },
+        },
+      ],
+    });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'admin',
+      workosUserId: WORKOS_USER,
+    });
+
+    expect(outcome.kind).toBe('already_done');
+  });
+
+  test('legacy row with marked_by_user_id (no marked_via) is treated as already-done', async () => {
+    // Stage 2 rows written before the Stage 3 migration used `marked_by_user_id`
+    // without a `marked_via`. The loader must recognize those so an admin
+    // re-clicking after the fact doesn't double-insert.
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: { channel: 'linkedin', marked_by_user_id: 'U0LEGACY' },
+        },
+      ],
+    });
+
+    const { markLinkedInPosted } = await loadModule();
+    const outcome = await markLinkedInPosted(ORG_ID, {
+      source: 'admin',
+      workosUserId: WORKOS_USER,
+    });
+
+    expect(outcome.kind).toBe('already_done');
+  });
+});
+
 describe('handleAnnouncementMarkLinkedIn', () => {
   test('happy path: inserts linkedin row + refreshes card', async () => {
     queueDbReads({});
@@ -554,7 +710,8 @@ describe('handleAnnouncementMarkLinkedIn', () => {
     expect(insertCall).toBeDefined();
     const metadata = JSON.parse(insertCall![1][2]);
     expect(metadata.channel).toBe('linkedin');
-    expect(metadata.marked_by_user_id).toBe(ADMIN_USER);
+    expect(metadata.marked_by_slack_user_id).toBe(ADMIN_USER);
+    expect(metadata.marked_via).toBe('slack');
     expect(client.chat.update).toHaveBeenCalled();
   });
 
@@ -661,7 +818,8 @@ describe('handleAnnouncementSkip', () => {
     );
     expect(insertCall).toBeDefined();
     const metadata = JSON.parse(insertCall![1][2]);
-    expect(metadata.skipper_user_id).toBe(ADMIN_USER);
+    expect(metadata.skipper_slack_user_id).toBe(ADMIN_USER);
+    expect(metadata.skipper_via).toBe('slack');
     expect(client.chat.update).toHaveBeenCalled();
   });
 

--- a/tests/announcement/announcement-handlers.test.ts
+++ b/tests/announcement/announcement-handlers.test.ts
@@ -4,12 +4,14 @@ const {
   mockQuery,
   mockSendChannelMessage,
   mockDeleteChannelMessage,
+  mockUpdateChannelMessage,
   mockGetAnnouncementChannel,
   mockIsSlackUserAAOAdmin,
 } = vi.hoisted(() => ({
   mockQuery: vi.fn<any>(),
   mockSendChannelMessage: vi.fn<any>(),
   mockDeleteChannelMessage: vi.fn<any>(),
+  mockUpdateChannelMessage: vi.fn<any>(),
   mockGetAnnouncementChannel: vi.fn<any>(),
   mockIsSlackUserAAOAdmin: vi.fn<any>(),
 }));
@@ -37,6 +39,7 @@ vi.mock('../../server/src/db/client.js', () => {
 vi.mock('../../server/src/slack/client.js', () => ({
   sendChannelMessage: (...args: unknown[]) => mockSendChannelMessage(...args),
   deleteChannelMessage: (...args: unknown[]) => mockDeleteChannelMessage(...args),
+  updateChannelMessage: (...args: unknown[]) => mockUpdateChannelMessage(...args),
 }));
 
 vi.mock('../../server/src/db/system-settings-db.js', () => ({
@@ -145,6 +148,7 @@ beforeEach(() => {
   });
   mockSendChannelMessage.mockResolvedValue({ ok: true, ts: POSTED_TS });
   mockDeleteChannelMessage.mockResolvedValue({ ok: true });
+  mockUpdateChannelMessage.mockResolvedValue({ ok: true });
 });
 
 describe('renderReviewCard', () => {
@@ -560,6 +564,138 @@ describe('handleAnnouncementApproveSlack', () => {
     expect(client.chat.postEphemeral).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/channel_not_found/) }),
     );
+  });
+});
+
+describe('legacy-row back-compat (Stage 2 rows without _via)', () => {
+  it('legacy approver_user_id renders as Slack mention in review card', async () => {
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: {
+            channel: 'slack',
+            slack_ts: POSTED_TS,
+            approver_user_id: 'U0LEGACYAPP',
+          },
+        },
+      ],
+    });
+    const { loadDraftAndState, renderReviewCard } = await loadModule();
+    const loaded = await loadDraftAndState(ORG_ID);
+    expect(loaded).not.toBeNull();
+    const { blocks } = renderReviewCard({
+      orgId: ORG_ID,
+      draft: loaded!.draft,
+      state: loaded!.state,
+    });
+    const statusBlock = blocks.find(
+      (b) => b.type === 'context' && b.elements?.[0]?.text?.includes('✓ Slack posted'),
+    );
+    expect(statusBlock?.elements?.[0]?.text).toContain('<@U0LEGACYAPP>');
+  });
+
+  it('legacy skipper_user_id renders as Slack mention in review card', async () => {
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_skipped',
+          activity_date: new Date(),
+          metadata: { skipper_user_id: 'U0LEGACYSKIP' },
+        },
+      ],
+    });
+    const { loadDraftAndState, renderReviewCard } = await loadModule();
+    const loaded = await loadDraftAndState(ORG_ID);
+    const { blocks } = renderReviewCard({
+      orgId: ORG_ID,
+      draft: loaded!.draft,
+      state: loaded!.state,
+    });
+    const statusBlock = blocks.find(
+      (b) => b.type === 'context' && b.elements?.[0]?.text?.includes('⊘'),
+    );
+    expect(statusBlock?.elements?.[0]?.text).toContain('<@U0LEGACYSKIP>');
+  });
+
+  it('invariant: marked_via=admin + marked_by_user_id does NOT populate slackUserId', async () => {
+    // The `source !== 'admin'` guard in actorFromMetadata must take
+    // precedence so a future row that happens to carry both fields is
+    // interpreted as admin-sourced, not Slack-sourced.
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: {
+            channel: 'linkedin',
+            marked_via: 'admin',
+            marked_by_workos_user_id: 'user_wk_01HZ',
+            // Legacy shape accidentally present:
+            marked_by_user_id: 'U0NOTSLACK',
+          },
+        },
+      ],
+    });
+    const { loadDraftAndState } = await loadModule();
+    const loaded = await loadDraftAndState(ORG_ID);
+    expect(loaded!.state.linkedinMarker.source).toBe('admin');
+    expect(loaded!.state.linkedinMarker.slackUserId).toBeNull();
+    expect(loaded!.state.linkedinMarker.workosUserId).toBe('user_wk_01HZ');
+  });
+});
+
+describe('refreshReviewCardForOrg', () => {
+  it('loads draft + state then calls chat.update with the rebuilt card', async () => {
+    queueDbReads({
+      activityRows: [
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: { channel: 'slack', slack_ts: POSTED_TS, approver_slack_user_id: 'U0SL', approver_via: 'slack' },
+        },
+        {
+          activity_type: 'announcement_published',
+          activity_date: new Date(),
+          metadata: { channel: 'linkedin', marked_via: 'admin', marked_by_workos_user_id: 'user_wk_42' },
+        },
+      ],
+    });
+
+    const { refreshReviewCardForOrg } = await loadModule();
+    await refreshReviewCardForOrg(ORG_ID);
+
+    expect(mockUpdateChannelMessage).toHaveBeenCalledTimes(1);
+    const [channel, ts, message] = mockUpdateChannelMessage.mock.calls[0];
+    expect(channel).toBe(REVIEW_CHANNEL);
+    expect(ts).toBe(REVIEW_TS);
+    // Both channels are done — no actions block in the terminal state.
+    const actions = message.blocks?.find((b: any) => b.type === 'actions');
+    expect(actions).toBeUndefined();
+  });
+
+  it('no-ops silently when no draft row exists', async () => {
+    queueDbReads({ draft: null });
+    const { refreshReviewCardForOrg } = await loadModule();
+    await refreshReviewCardForOrg(ORG_ID);
+    expect(mockUpdateChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('no-ops silently when the stored review_message_ts is missing', async () => {
+    queueDbReads({
+      draft: { ...DRAFT_METADATA, review_message_ts: null as unknown as string },
+    });
+    const { refreshReviewCardForOrg } = await loadModule();
+    await refreshReviewCardForOrg(ORG_ID);
+    expect(mockUpdateChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('swallows chat.update errors — caller does not need to worry about them', async () => {
+    queueDbReads({});
+    mockUpdateChannelMessage.mockResolvedValueOnce({ ok: false, error: 'message_not_found' });
+    const { refreshReviewCardForOrg } = await loadModule();
+    await expect(refreshReviewCardForOrg(ORG_ID)).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the Workflow B loop. Admins who post to LinkedIn outside Slack can now record the LinkedIn post from the admin account detail page — parallel surface to the Stage 2 (#2975) Slack button.

- Extracts `markLinkedInPosted(orgId, actor)` so both surfaces share one critical section under a pg advisory lock keyed on `(orgId, 'mark_linkedin')`. Cross-surface double-submits serialize and converge on one `announcement_published` row.
- Refactors `AnnouncementState` to carry tagged `StoredActor` objects (slack / admin / legacy-null). Metadata writes `marked_by_slack_user_id` + `marked_via: 'slack'` from the Slack path, `marked_by_workos_user_id` + `marked_via: 'admin'` from the admin path. Loader reads legacy Stage-2 rows (`marked_by_user_id` without `_via`) as Slack-originated for back-compat.
- `POST /api/admin/accounts/:orgId/announcement/linkedin` — `requireAuth + requireAdmin`. Rejects the static `ADMIN_API_KEY` auth path so the audit trail reflects a real admin, not a shared key.
- `GET /api/admin/accounts/:orgId` gains a flat `announcement` object with display-ready `*_label` strings; internal user ids stay server-side.
- New card on `admin-account-detail.html` shows current state and surfaces the Mark-LI button when `slack_posted && !linkedin_posted && !skipped`. Refetches after success.
- Review-card render shows `<@U…>` mentions for Slack-origin marks and "an AAO admin" for admin-UI marks (Slack can't resolve WorkOS ids — we don't want to leak those into a shared channel).

## Ordering note

Consistent with Stage 2 behavior: neither the Slack button nor this HTTP endpoint enforces "Slack must be posted first" — admins can mark LinkedIn standalone if that matches reality. The UI gates the button on `slack_posted`, but a direct POST is an allowed admin override.

## Addresses review feedback

Two fixes landed after the code-reviewer + security-reviewer pass:
- Reject `ADMIN_API_KEY` callers on the new endpoint — closes the audit hole where the static key would stamp `'admin_api_key'` as the marker id.
- Flatten the API response to `*_label` display strings instead of exposing raw `StoredActor` objects to the client.

## Test plan

- [x] 6 new shared-function tests cover admin/slack actor discrimination + legacy-row back-compat + all five outcome branches
- [x] 86/86 announcement suite pass
- [x] Pre-commit hook: 732 tests + typecheck green
- [ ] Manual smoke test in prod: post a live draft, click Mark-LI on the admin UI, verify the `announcement_published` row + the refreshed card state in both admin UI and (if Slack draft still visible) editorial review channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)