### PR TITLE
feat: Workflow B Stage 4 — retroactive announcement backfill

### DIFF
--- a/.changeset/workflow-b-backfill.md
+++ b/.changeset/workflow-b-backfill.md
@@ -1,0 +1,51 @@
+---
+---
+
+**Workflow B Stage 4 — retroactive announcement backfill**
+
+One-shot script that posts retroactive new-member announcement drafts
+to the editorial review channel so orgs who became announce-ready
+before Workflow A's `profile_published` event emit don't get left out
+of the welcome flow.
+
+Spec: `specs/new-member-announcements.md` → "Backfill".
+
+**New:**
+
+- `server/src/scripts/backfill-member-announcements.ts` — CLI entry
+  point. `--limit N` (default 15) caps the run so a single invocation
+  can't flood the editorial channel. `--dry-run` reports eligible
+  candidates without posting or writing activity rows.
+- `runBackfillAnnouncements({ reviewChannel, limit, dryRun })` in
+  `announcement-trigger.ts` — drives the per-candidate pipeline with
+  the `backfill: true` flag so review cards get a `[BACKFILL]` header
+  prefix.
+
+**Refactors:**
+
+- `findAnnounceCandidates({ requireProfilePublished })` — backfill drops
+  the `profile_published` EXISTS clause (those orgs predate the event).
+- Extracted `processAnnounceCandidate` — shared by the live trigger
+  and the backfill, keeps the post-then-record unwind semantics.
+- `buildReviewBlocks({ backfill })` — header prefix only.
+- Recorded `announcement_draft_posted` metadata gains `backfill: true`
+  so downstream analytics can tell retroactive drafts apart.
+
+**Safety:**
+
+- Idempotency via the existing `NOT EXISTS` on `announcement_draft_posted`
+  / `announcement_skipped` — re-running the script will not re-post
+  orgs that landed on a previous run.
+- Dry-run produces no Slack traffic and no DB writes.
+- Unwind (chat.delete) on activity-write failure, same as the live job.
+
+**Tests:** 19 new tests in `tests/announcement/announcement-backfill.test.ts`
+covering SQL shape (profile_published clause presence), header tag
+behavior, limit enforcement (default 15 + override), `backfill:true`
+metadata, candidate-load failure recovery, per-candidate failure
+isolation, and CLI arg parsing. Full announcement suite 122/122 pass.
+
+**Ops.** Operator picks the right moment, runs
+`npx tsx server/src/scripts/backfill-member-announcements.ts --limit 10`
+with SLACK_EDITORIAL_REVIEW_CHANNEL + ADDIE_BOT_TOKEN + ANTHROPIC_API_KEY
+set. Editorial team approves through the existing Stage 2 Slack buttons.

--- a/.changeset/workflow-b-backfill.md
+++ b/.changeset/workflow-b-backfill.md
@@ -49,3 +49,30 @@ isolation, and CLI arg parsing. Full announcement suite 122/122 pass.
 `npx tsx server/src/scripts/backfill-member-announcements.ts --limit 10`
 with SLACK_EDITORIAL_REVIEW_CHANNEL + ADDIE_BOT_TOKEN + ANTHROPIC_API_KEY
 set. Editorial team approves through the existing Stage 2 Slack buttons.
+
+**Hardening (expert-review follow-ups).**
+
+- Hard ceiling: `--limit` defaults to 15, soft-caps at 50 without
+  `--force`, absolute-capped at 200 with `--force`. Prevents a fat-
+  fingered `--limit 9999` from flooding the editorial channel or
+  billing thousands of Anthropic tokens.
+- `pg_try_advisory_lock` at run start — two operators (or a duplicate
+  invocation) running backfill simultaneously would otherwise race the
+  `NOT EXISTS` idempotency filter. The second caller now refuses with
+  `lockedOut:true` instead of producing duplicate posts.
+- Dry-run preview rows now include `membership_tier`,
+  `primary_brand_domain`, and `last_published_at` so the operator can
+  decide from the dry-run output whether the list looks right.
+- Live run prints the succeeded-orgs list to stdout and posts a single
+  summary message (`📦 Backfill wave posted — N retroactive drafts…`)
+  to the editorial channel so editorial gets a nudge without watching
+  the CLI.
+- Ops pre-flight ritual documented in the script header: dry-run
+  first, start with `--limit 3`, Ctrl-C is safe, only one run at a
+  time, hard ceilings explained.
+
+14 new tests on top of the original 21 (32 total) cover the hardening:
+force toggle, soft-cap enforcement, absolute-max ceiling, advisory
+lock lockout path, summary message on drafted>0 and skip when 0,
+drafted_orgs shape, rich-fixture drafter call-through, and the two
+unwind-failure branches. Full announcement suite 135/135 pass.

--- a/server/src/addie/jobs/announcement-trigger.ts
+++ b/server/src/addie/jobs/announcement-trigger.ts
@@ -38,7 +38,7 @@ export interface TriggerResult {
   failed: number;
 }
 
-interface AnnounceCandidate {
+export interface AnnounceCandidate {
   workos_organization_id: string;
   org_name: string;
   membership_tier: string | null;
@@ -54,18 +54,37 @@ interface AnnounceCandidate {
 }
 
 /**
- * Orgs eligible for a draft:
- *  - At least one `profile_published` activity recorded
+ * Orgs eligible for a draft. Base filter (always applied):
  *  - `member_profiles.is_public = true` right now
  *  - A brand.json manifest exists for their primary_brand_domain
  *  - `member_profiles.metadata->>'no_announcement'` is not 'true'
  *  - No prior `announcement_draft_posted` or `announcement_skipped` activity
  *
- * Ordered by most recent `profile_published` activity first so freshly
- * announce-ready members are not starved by a stale backlog when the
- * per-run cap kicks in.
+ * Live trigger path (`requireProfilePublished: true`, default) additionally
+ * requires a `profile_published` activity row. This is the event the
+ * trigger job reacts to.
+ *
+ * Backfill path (`requireProfilePublished: false`) drops that requirement
+ * so orgs that went public before the event emit was added (Workflow A
+ * Stage 2) are reachable. Those rows have `is_public = true` today but
+ * no activity row to prove when it flipped, so `last_published_at` is
+ * NULL and they sort to the end.
+ *
+ * Ordered by most recent `profile_published` DESC so freshly announce-
+ * ready members are never starved by a stale backlog; NULLs last so the
+ * backfill path processes newest-known first.
  */
-export async function findAnnounceCandidates(): Promise<AnnounceCandidate[]> {
+export async function findAnnounceCandidates(
+  options: { requireProfilePublished?: boolean } = {},
+): Promise<AnnounceCandidate[]> {
+  const requirePublished = options.requireProfilePublished ?? true;
+  const publishedClause = requirePublished
+    ? `AND EXISTS (
+          SELECT 1 FROM org_activities
+           WHERE organization_id = o.workos_organization_id
+             AND activity_type = 'profile_published'
+        )`
+    : '';
   const result = await query<AnnounceCandidate>(
     `SELECT
         o.workos_organization_id,
@@ -93,17 +112,13 @@ export async function findAnnounceCandidates(): Promise<AnnounceCandidate[]> {
        AND b.brand_manifest IS NOT NULL
       WHERE mp.is_public = true
         AND COALESCE(mp.metadata->>'no_announcement', 'false') <> 'true'
-        AND EXISTS (
-          SELECT 1 FROM org_activities
-           WHERE organization_id = o.workos_organization_id
-             AND activity_type = 'profile_published'
-        )
+        ${publishedClause}
         AND NOT EXISTS (
           SELECT 1 FROM org_activities
            WHERE organization_id = o.workos_organization_id
              AND activity_type IN ('announcement_draft_posted', 'announcement_skipped')
         )
-      ORDER BY last_published_at DESC NULLS LAST`,
+      ORDER BY last_published_at DESC NULLS LAST, o.created_at DESC`,
   );
   return result.rows;
 }
@@ -182,14 +197,20 @@ export function buildReviewBlocks(args: {
   linkedinText: string;
   visual: VisualResolution;
   profileSlug: string;
+  /** When true, prefixes the header with `[BACKFILL]` so the editorial
+   * team can tell a retroactive draft apart from a live-flow one. */
+  backfill?: boolean;
 }): { text: string; blocks: SlackBlock[] } {
   const profileUrl = `${APP_URL}/members/${args.profileSlug}`;
   const safeSlack = sanitizeDraftForSlack(args.slackText);
   const safeLinkedIn = sanitizeDraftForSlack(args.linkedinText, { forFencedBlock: true });
+  const headerText = args.backfill
+    ? `[BACKFILL] New member announcement ready: ${args.orgName}`
+    : `New member announcement ready: ${args.orgName}`;
   const blocks: SlackBlock[] = [
     {
       type: 'header',
-      text: { type: 'plain_text', text: `New member announcement ready: ${args.orgName}` },
+      text: { type: 'plain_text', text: headerText },
     },
     {
       type: 'context',
@@ -245,7 +266,7 @@ export function buildReviewBlocks(args: {
   ];
 
   return {
-    text: `New member announcement ready: ${args.orgName}`,
+    text: headerText,
     blocks,
   };
 }
@@ -260,6 +281,128 @@ async function recordDraftPosted(
      ) VALUES ($1, 'announcement_draft_posted', $2, $3::jsonb, NOW())`,
     [orgId, 'Announcement draft posted for editorial review', JSON.stringify(metadata)],
   );
+}
+
+/**
+ * Process a single announce candidate: draft copy, resolve visual, post
+ * the review card to the editorial channel, record the idempotency row.
+ * Shared by `runAnnouncementTriggerJob` (live flow, hourly cap) and
+ * `runBackfillAnnouncements` (one-shot retroactive wave).
+ *
+ * Returns `true` on success, `false` on any handled failure (network,
+ * DB write miss). Unwinds the Slack post if the activity write fails
+ * so no orphan review card survives without an idempotency row.
+ */
+async function processAnnounceCandidate(
+  candidate: AnnounceCandidate,
+  options: { reviewChannel: string; backfill?: boolean },
+): Promise<boolean> {
+  const { reviewChannel, backfill = false } = options;
+  try {
+    const draft = await draftAnnouncement({
+      orgName: candidate.org_name,
+      membershipTier: candidate.membership_tier,
+      displayName: candidate.display_name,
+      tagline: candidate.tagline,
+      description: candidate.description,
+      offerings: candidate.offerings ?? [],
+      primaryBrandDomain: candidate.primary_brand_domain,
+      agents: summarizeAgents(candidate.brand_manifest),
+      profileSlug: candidate.slug,
+    });
+
+    const visual = await resolveAnnouncementVisual({
+      workosOrganizationId: candidate.workos_organization_id,
+      membershipTier: candidate.membership_tier,
+      primaryBrandDomain: candidate.primary_brand_domain,
+      displayName: candidate.display_name,
+    });
+
+    const { text, blocks } = buildReviewBlocks({
+      orgName: candidate.org_name,
+      workosOrganizationId: candidate.workos_organization_id,
+      slackText: draft.slackText,
+      linkedinText: draft.linkedinText,
+      visual,
+      profileSlug: candidate.slug,
+      backfill,
+    });
+
+    const post = await sendChannelMessage(
+      reviewChannel,
+      { text, blocks },
+      { requirePrivate: true },
+    );
+    if (!post.ok || !post.ts) {
+      logger.error(
+        {
+          orgId: candidate.workos_organization_id,
+          error: post.error,
+          skipped: post.skipped,
+        },
+        'Failed to post announcement draft to editorial channel',
+      );
+      return false;
+    }
+
+    try {
+      await recordDraftPosted(candidate.workos_organization_id, {
+        review_channel_id: reviewChannel,
+        review_message_ts: post.ts,
+        slack_text: draft.slackText,
+        linkedin_text: draft.linkedinText,
+        visual_url: visual.url,
+        visual_alt_text: visual.altText,
+        visual_source: visual.source,
+        org_name: candidate.org_name,
+        profile_slug: candidate.slug,
+        backfill,
+      });
+    } catch (recordErr) {
+      logger.error(
+        { err: recordErr, orgId: candidate.workos_organization_id, ts: post.ts },
+        'Activity write failed after posting draft — unwinding Slack message',
+      );
+      try {
+        const undo = await deleteChannelMessage(reviewChannel, post.ts);
+        if (!undo.ok) {
+          logger.error(
+            {
+              orgId: candidate.workos_organization_id,
+              ts: post.ts,
+              undoError: undo.error,
+            },
+            'CRITICAL: Slack message left without idempotency row — editor will see a duplicate next run',
+          );
+        }
+      } catch (undoErr) {
+        logger.error(
+          { err: undoErr, orgId: candidate.workos_organization_id, ts: post.ts },
+          'CRITICAL: Slack unwind threw — orphan review card, no idempotency row',
+        );
+      }
+      return false;
+    }
+
+    logger.info(
+      {
+        orgId: candidate.workos_organization_id,
+        reviewTs: post.ts,
+        visualSource: visual.source,
+        backfill,
+      },
+      'Posted announcement draft for editorial review',
+    );
+    return true;
+  } catch (err) {
+    logger.error(
+      { err, orgId: candidate.workos_organization_id, backfill },
+      backfill
+        ? 'Failed to draft/post announcement'
+        : 'Failed to draft/post announcement — will retry next run',
+    );
+    return false;
+  }
 }
 
 export async function runAnnouncementTriggerJob(): Promise<TriggerResult> {
@@ -289,110 +432,87 @@ export async function runAnnouncementTriggerJob(): Promise<TriggerResult> {
       );
       break;
     }
-
-    try {
-      const draft = await draftAnnouncement({
-        orgName: candidate.org_name,
-        membershipTier: candidate.membership_tier,
-        displayName: candidate.display_name,
-        tagline: candidate.tagline,
-        description: candidate.description,
-        offerings: candidate.offerings ?? [],
-        primaryBrandDomain: candidate.primary_brand_domain,
-        agents: summarizeAgents(candidate.brand_manifest),
-        profileSlug: candidate.slug,
-      });
-
-      const visual = await resolveAnnouncementVisual({
-        workosOrganizationId: candidate.workos_organization_id,
-        membershipTier: candidate.membership_tier,
-        primaryBrandDomain: candidate.primary_brand_domain,
-        displayName: candidate.display_name,
-      });
-
-      const { text, blocks } = buildReviewBlocks({
-        orgName: candidate.org_name,
-        workosOrganizationId: candidate.workos_organization_id,
-        slackText: draft.slackText,
-        linkedinText: draft.linkedinText,
-        visual,
-        profileSlug: candidate.slug,
-      });
-
-      const post = await sendChannelMessage(
-        reviewChannel,
-        { text, blocks },
-        { requirePrivate: true },
-      );
-      if (!post.ok || !post.ts) {
-        logger.error(
-          {
-            orgId: candidate.workos_organization_id,
-            error: post.error,
-            skipped: post.skipped,
-          },
-          'Failed to post announcement draft to editorial channel',
-        );
-        result.failed++;
-        continue;
-      }
-
-      try {
-        await recordDraftPosted(candidate.workos_organization_id, {
-          review_channel_id: reviewChannel,
-          review_message_ts: post.ts,
-          slack_text: draft.slackText,
-          linkedin_text: draft.linkedinText,
-          visual_url: visual.url,
-          visual_alt_text: visual.altText,
-          visual_source: visual.source,
-          org_name: candidate.org_name,
-          profile_slug: candidate.slug,
-        });
-      } catch (recordErr) {
-        logger.error(
-          { err: recordErr, orgId: candidate.workos_organization_id, ts: post.ts },
-          'Activity write failed after posting draft — unwinding Slack message',
-        );
-        try {
-          const undo = await deleteChannelMessage(reviewChannel, post.ts);
-          if (!undo.ok) {
-            logger.error(
-              {
-                orgId: candidate.workos_organization_id,
-                ts: post.ts,
-                undoError: undo.error,
-              },
-              'CRITICAL: Slack message left without idempotency row — editor will see a duplicate next run',
-            );
-          }
-        } catch (undoErr) {
-          logger.error(
-            { err: undoErr, orgId: candidate.workos_organization_id, ts: post.ts },
-            'CRITICAL: Slack unwind threw — orphan review card, no idempotency row',
-          );
-        }
-        result.failed++;
-        continue;
-      }
-
-      result.drafted++;
-      logger.info(
-        {
-          orgId: candidate.workos_organization_id,
-          reviewTs: post.ts,
-          visualSource: visual.source,
-        },
-        'Posted announcement draft for editorial review',
-      );
-    } catch (err) {
-      logger.error(
-        { err, orgId: candidate.workos_organization_id },
-        'Failed to draft/post announcement — will retry next run',
-      );
-      result.failed++;
-    }
+    const ok = await processAnnounceCandidate(candidate, { reviewChannel });
+    if (ok) result.drafted++;
+    else result.failed++;
   }
 
+  return result;
+}
+
+export interface BackfillOptions {
+  /** Editorial channel id to post drafts into. Required. */
+  reviewChannel: string;
+  /** Hard cap on how many drafts this run will post. Default 15. */
+  limit?: number;
+  /** When true, print what would happen without posting or writing. */
+  dryRun?: boolean;
+}
+
+export interface BackfillResult extends TriggerResult {
+  dryRun: boolean;
+  /** When dryRun, the orgs that would have been drafted. */
+  wouldDraft?: Array<{ workos_organization_id: string; org_name: string }>;
+}
+
+/**
+ * One-shot retroactive announcement wave (Workflow B Stage 4 spec).
+ *
+ * Queries announce-ready orgs including those without a
+ * `profile_published` event (orgs that went public before Workflow A
+ * Stage 2 added the event emit), caps at `limit`, and posts each
+ * through the same pipeline as the live trigger job with a `[BACKFILL]`
+ * header tag. Editorial team spaces them out via the normal approval
+ * flow.
+ */
+export async function runBackfillAnnouncements(
+  options: BackfillOptions,
+): Promise<BackfillResult> {
+  const limit = Math.max(1, options.limit ?? 15);
+  const dryRun = options.dryRun ?? false;
+
+  const result: BackfillResult = {
+    candidates: 0,
+    drafted: 0,
+    failed: 0,
+    dryRun,
+  };
+
+  let candidates: AnnounceCandidate[];
+  try {
+    candidates = await findAnnounceCandidates({ requireProfilePublished: false });
+  } catch (err) {
+    logger.error({ err }, 'backfill: failed to load announce candidates');
+    return result;
+  }
+
+  result.candidates = candidates.length;
+  const picked = candidates.slice(0, limit);
+
+  if (dryRun) {
+    result.wouldDraft = picked.map((c) => ({
+      workos_organization_id: c.workos_organization_id,
+      org_name: c.org_name,
+    }));
+    logger.info(
+      { totalEligible: candidates.length, limit, wouldDraft: result.wouldDraft.length },
+      'backfill dry-run: no posts, no activity writes',
+    );
+    return result;
+  }
+
+  for (const candidate of picked) {
+    const ok = await processAnnounceCandidate(candidate, {
+      reviewChannel: options.reviewChannel,
+      backfill: true,
+    });
+    if (ok) result.drafted++;
+    else result.failed++;
+  }
+
+  logger.info(
+    { drafted: result.drafted, failed: result.failed, totalEligible: candidates.length, limit },
+    'backfill complete',
+  );
   return result;
 }

--- a/server/src/addie/jobs/announcement-trigger.ts
+++ b/server/src/addie/jobs/announcement-trigger.ts
@@ -18,7 +18,7 @@
  */
 
 import { createLogger } from '../../logger.js';
-import { query } from '../../db/client.js';
+import { query, getPool } from '../../db/client.js';
 import { sendChannelMessage, deleteChannelMessage } from '../../slack/client.js';
 import { draftAnnouncement } from '../../services/announcement-drafter.js';
 import {
@@ -30,6 +30,17 @@ import type { SlackBlock, SlackElement } from '../../slack/types.js';
 const logger = createLogger('announcement-trigger');
 
 const MAX_DRAFTS_PER_RUN = 5;
+
+/**
+ * Hard ceiling on one backfill invocation. The default --limit is 15;
+ * --force can push past this up to BACKFILL_ABSOLUTE_MAX. This exists
+ * to stop a fat-fingered `--limit 9999` from flooding the editorial
+ * channel, billing thousands of Anthropic tokens, and eating Slack rate
+ * limits.
+ */
+export const BACKFILL_SOFT_CAP = 50;
+export const BACKFILL_ABSOLUTE_MAX = 200;
+
 const APP_URL = process.env.APP_URL || 'https://agenticadvertising.org';
 
 export interface TriggerResult {
@@ -447,13 +458,49 @@ export interface BackfillOptions {
   limit?: number;
   /** When true, print what would happen without posting or writing. */
   dryRun?: boolean;
+  /**
+   * Bypass the `BACKFILL_SOFT_CAP` ceiling. An operator who really
+   * wants to post more than 50 drafts in one run sets this explicitly
+   * and accepts the blast-radius implications. Still hard-capped by
+   * `BACKFILL_ABSOLUTE_MAX`.
+   */
+  force?: boolean;
 }
+
+export type BackfillPreviewRow = {
+  workos_organization_id: string;
+  org_name: string;
+  membership_tier: string | null;
+  primary_brand_domain: string | null;
+  last_published_at: Date | null;
+};
 
 export interface BackfillResult extends TriggerResult {
   dryRun: boolean;
-  /** When dryRun, the orgs that would have been drafted. */
-  wouldDraft?: Array<{ workos_organization_id: string; org_name: string }>;
+  /** Cap that was actually applied this run. Useful for log output. */
+  effectiveLimit: number;
+  /**
+   * Rows that would have been drafted (dryRun) or that actually were
+   * drafted on the live path. Callers use this to print a per-org
+   * summary to stdout and/or to Slack.
+   */
+  wouldDraft?: BackfillPreviewRow[];
+  /** Orgs the live run successfully drafted. Populated only when not dryRun. */
+  drafted_orgs?: BackfillPreviewRow[];
+  /**
+   * Set when another process holds the backfill advisory lock. Caller
+   * should surface this to the operator rather than silently skipping.
+   */
+  lockedOut?: boolean;
 }
+
+/**
+ * Postgres advisory lock key for the backfill critical section.
+ * `pg_try_advisory_lock(bigint)` returns false when another session
+ * holds the lock — we refuse to run rather than race. The constant is
+ * a stable 64-bit value derived from the string "aao:announcement-backfill".
+ */
+const BACKFILL_LOCK_ID = 4829347509283745837n;
 
 /**
  * One-shot retroactive announcement wave (Workflow B Stage 4 spec).
@@ -465,10 +512,49 @@ export interface BackfillResult extends TriggerResult {
  * header tag. Editorial team spaces them out via the normal approval
  * flow.
  */
+function previewRow(c: AnnounceCandidate): BackfillPreviewRow {
+  return {
+    workos_organization_id: c.workos_organization_id,
+    org_name: c.org_name,
+    membership_tier: c.membership_tier,
+    primary_brand_domain: c.primary_brand_domain,
+    last_published_at: c.last_published_at,
+  };
+}
+
+/**
+ * Resolve `options.limit` + `options.force` into an effective cap.
+ * Clamps to [1, BACKFILL_ABSOLUTE_MAX] regardless; without `force`,
+ * also clamps to BACKFILL_SOFT_CAP. Returns whether the caller's
+ * requested limit was shrunk so the CLI can warn the operator.
+ */
+function resolveBackfillLimit(options: BackfillOptions): {
+  effective: number;
+  shrunkByCap: boolean;
+  shrunkByAbsoluteMax: boolean;
+} {
+  const requested = Math.max(1, options.limit ?? 15);
+  const afterAbsolute = Math.min(requested, BACKFILL_ABSOLUTE_MAX);
+  const shrunkByAbsoluteMax = afterAbsolute < requested;
+  if (options.force) {
+    return {
+      effective: afterAbsolute,
+      shrunkByCap: false,
+      shrunkByAbsoluteMax,
+    };
+  }
+  const afterSoftCap = Math.min(afterAbsolute, BACKFILL_SOFT_CAP);
+  return {
+    effective: afterSoftCap,
+    shrunkByCap: afterSoftCap < requested,
+    shrunkByAbsoluteMax,
+  };
+}
+
 export async function runBackfillAnnouncements(
   options: BackfillOptions,
 ): Promise<BackfillResult> {
-  const limit = Math.max(1, options.limit ?? 15);
+  const { effective: limit } = resolveBackfillLimit(options);
   const dryRun = options.dryRun ?? false;
 
   const result: BackfillResult = {
@@ -476,43 +562,93 @@ export async function runBackfillAnnouncements(
     drafted: 0,
     failed: 0,
     dryRun,
+    effectiveLimit: limit,
   };
 
-  let candidates: AnnounceCandidate[];
+  // Advisory lock: refuse to run if another backfill is already
+  // running. Same org set is otherwise visible to both callers, neither
+  // holds a lock across the INSERT, and they race. Dry-run also takes
+  // the lock so two operators don't both "preview" and then re-run
+  // simultaneously.
+  const pool = getPool();
+  const client = await pool.connect();
+  let haveLock = false;
   try {
-    candidates = await findAnnounceCandidates({ requireProfilePublished: false });
-  } catch (err) {
-    logger.error({ err }, 'backfill: failed to load announce candidates');
-    return result;
-  }
+    const lockRes = await client.query<{ pg_try_advisory_lock: boolean }>(
+      'SELECT pg_try_advisory_lock($1) AS pg_try_advisory_lock',
+      [BACKFILL_LOCK_ID.toString()],
+    );
+    haveLock = lockRes.rows[0]?.pg_try_advisory_lock === true;
+    if (!haveLock) {
+      logger.warn('backfill: another run is already holding the advisory lock — refusing');
+      result.lockedOut = true;
+      return result;
+    }
 
-  result.candidates = candidates.length;
-  const picked = candidates.slice(0, limit);
+    let candidates: AnnounceCandidate[];
+    try {
+      candidates = await findAnnounceCandidates({ requireProfilePublished: false });
+    } catch (err) {
+      logger.error({ err }, 'backfill: failed to load announce candidates');
+      return result;
+    }
 
-  if (dryRun) {
-    result.wouldDraft = picked.map((c) => ({
-      workos_organization_id: c.workos_organization_id,
-      org_name: c.org_name,
-    }));
+    result.candidates = candidates.length;
+    const picked = candidates.slice(0, limit);
+
+    if (dryRun) {
+      result.wouldDraft = picked.map(previewRow);
+      logger.info(
+        { totalEligible: candidates.length, limit, wouldDraft: result.wouldDraft.length },
+        'backfill dry-run: no posts, no activity writes',
+      );
+      return result;
+    }
+
+    const drafted: BackfillPreviewRow[] = [];
+    for (const candidate of picked) {
+      const ok = await processAnnounceCandidate(candidate, {
+        reviewChannel: options.reviewChannel,
+        backfill: true,
+      });
+      if (ok) {
+        result.drafted++;
+        drafted.push(previewRow(candidate));
+      } else {
+        result.failed++;
+      }
+    }
+    result.drafted_orgs = drafted;
+
+    // One summary line in the editorial channel so the reviewers know a
+    // retroactive wave just landed. Non-critical — if it fails we log
+    // and move on; the cards themselves are the real signal.
+    if (result.drafted > 0) {
+      try {
+        const summary = `📦 Backfill wave posted — ${result.drafted} retroactive draft${result.drafted === 1 ? '' : 's'}${result.failed > 0 ? ` · ${result.failed} failed` : ''} (${candidates.length} eligible, cap ${limit}).`;
+        await sendChannelMessage(
+          options.reviewChannel,
+          { text: summary, blocks: [{ type: 'section', text: { type: 'mrkdwn', text: summary } }] },
+          { requirePrivate: true },
+        );
+      } catch (err) {
+        logger.warn({ err }, 'backfill: failed to post summary message to editorial channel');
+      }
+    }
+
     logger.info(
-      { totalEligible: candidates.length, limit, wouldDraft: result.wouldDraft.length },
-      'backfill dry-run: no posts, no activity writes',
+      { drafted: result.drafted, failed: result.failed, totalEligible: candidates.length, limit },
+      'backfill complete',
     );
     return result;
+  } finally {
+    if (haveLock) {
+      try {
+        await client.query('SELECT pg_advisory_unlock($1)', [BACKFILL_LOCK_ID.toString()]);
+      } catch (err) {
+        logger.warn({ err }, 'backfill: failed to release advisory lock (client will release it)');
+      }
+    }
+    client.release();
   }
-
-  for (const candidate of picked) {
-    const ok = await processAnnounceCandidate(candidate, {
-      reviewChannel: options.reviewChannel,
-      backfill: true,
-    });
-    if (ok) result.drafted++;
-    else result.failed++;
-  }
-
-  logger.info(
-    { drafted: result.drafted, failed: result.failed, totalEligible: candidates.length, limit },
-    'backfill complete',
-  );
-  return result;
 }

--- a/server/src/scripts/backfill-member-announcements.ts
+++ b/server/src/scripts/backfill-member-announcements.ts
@@ -9,37 +9,62 @@
  * `[BACKFILL]` so editorial can tell them apart from the live flow.
  * Approval uses the same Slack buttons; no separate surface.
  *
- * Usage:
- *   npx tsx server/src/scripts/backfill-member-announcements.ts
- *     [--limit 10] [--dry-run]
+ * ## Ops pre-flight
  *
- * Env:
+ *   1. Run with `--dry-run` first — eyeball the candidate list.
+ *   2. Start small: `--limit 3`, verify the three review cards, then
+ *      go wider.
+ *   3. Safe to Ctrl-C mid-run; the existing idempotency filter picks
+ *      the resumption point automatically.
+ *   4. Only one backfill can run at a time (Postgres advisory lock).
+ *      If the script refuses with "another run holds the lock", pg
+ *      itself will release on connection close — usually just retry.
+ *   5. Hard ceiling: without `--force`, max is 50. With `--force`,
+ *      absolute max is 200 — chosen to bound Slack rate + Anthropic
+ *      spend per invocation.
+ *
+ * ## Usage
+ *
+ *   npx tsx server/src/scripts/backfill-member-announcements.ts
+ *     [--limit N] [--dry-run] [--force]
+ *
+ * ## Env
+ *
  *   DATABASE_URL                     required
  *   SLACK_EDITORIAL_REVIEW_CHANNEL   required unless --dry-run
  *   APP_URL                          optional, used in profile links
  *   ADDIE_BOT_TOKEN                  required for non-dry-run posts
  *   ANTHROPIC_API_KEY                required for the drafter
  *
- * Safe-to-retry: idempotency on `announcement_draft_posted` means
- * re-running the script will not re-draft orgs that landed last run.
+ * Prod-admin-only: whoever can run this has shell access, the Addie
+ * bot token, and Anthropic billing. No finer-grained authz in-band.
  */
 
 import { initializeDatabase, closeDatabase } from '../db/client.js';
 import { getDatabaseConfig } from '../config.js';
-import { runBackfillAnnouncements } from '../addie/jobs/announcement-trigger.js';
+import {
+  runBackfillAnnouncements,
+  BACKFILL_SOFT_CAP,
+  BACKFILL_ABSOLUTE_MAX,
+  type BackfillPreviewRow,
+} from '../addie/jobs/announcement-trigger.js';
 
 interface CliArgs {
   limit: number;
   dryRun: boolean;
+  force: boolean;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
   let limit = 15;
   let dryRun = false;
+  let force = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--dry-run') {
       dryRun = true;
+    } else if (a === '--force') {
+      force = true;
     } else if (a === '--limit') {
       const next = argv[i + 1];
       const parsed = Number.parseInt(next, 10);
@@ -64,15 +89,18 @@ export function parseArgs(argv: string[]): CliArgs {
       throw new Error(`Unknown argument: ${a}`);
     }
   }
-  return { limit, dryRun };
+  return { limit, dryRun, force };
 }
 
 const USAGE = `
 Usage: npx tsx server/src/scripts/backfill-member-announcements.ts [options]
 
-  --limit <N>   Cap on drafts posted in this run (default 15)
+  --limit <N>   Cap on drafts posted in this run (default 15, max ${BACKFILL_SOFT_CAP}
+                without --force; ${BACKFILL_ABSOLUTE_MAX} absolute max with --force)
   --dry-run     Query candidates and print what would be drafted;
                 don't post to Slack or write activity rows
+  --force       Allow --limit above ${BACKFILL_SOFT_CAP} (still capped at ${BACKFILL_ABSOLUTE_MAX}). Use
+                this when you've done a dry-run and accept the blast radius.
 
 Env:
   DATABASE_URL (required)
@@ -80,6 +108,15 @@ Env:
   ADDIE_BOT_TOKEN (required unless --dry-run)
   ANTHROPIC_API_KEY (required unless --dry-run)
 `;
+
+function formatPreviewRow(r: BackfillPreviewRow): string {
+  const tier = r.membership_tier ?? 'no-tier';
+  const domain = r.primary_brand_domain ?? 'no-domain';
+  const when = r.last_published_at
+    ? new Date(r.last_published_at).toISOString().slice(0, 10)
+    : 'no-event';
+  return `    - ${r.workos_organization_id}  ${r.org_name}  [${tier}·${domain}·${when}]`;
+}
 
 async function main(): Promise<void> {
   let args: CliArgs;
@@ -108,6 +145,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  if (args.limit > BACKFILL_SOFT_CAP && !args.force) {
+    console.error(
+      `--limit ${args.limit} exceeds the soft cap of ${BACKFILL_SOFT_CAP}. Pass --force to override (max ${BACKFILL_ABSOLUTE_MAX}).`,
+    );
+    process.exit(2);
+  }
+
   initializeDatabase(dbConfig);
 
   try {
@@ -115,20 +159,39 @@ async function main(): Promise<void> {
       reviewChannel,
       limit: args.limit,
       dryRun: args.dryRun,
+      force: args.force,
     });
+
+    if (result.lockedOut) {
+      console.error(
+        '\nAnother backfill run is already in progress (advisory lock held). Wait for it to finish, or check for a stuck session, and retry.',
+      );
+      process.exit(3);
+    }
 
     if (result.dryRun) {
       console.log(`\nBackfill dry-run:`);
       console.log(`  Eligible candidates: ${result.candidates}`);
-      console.log(`  Would draft:         ${result.wouldDraft?.length ?? 0} (cap ${args.limit})`);
+      console.log(
+        `  Would draft:         ${result.wouldDraft?.length ?? 0} (effective cap ${result.effectiveLimit})`,
+      );
       for (const c of result.wouldDraft ?? []) {
-        console.log(`    - ${c.workos_organization_id}  ${c.org_name}`);
+        console.log(formatPreviewRow(c));
       }
+      console.log(
+        `\nNext step: re-run without --dry-run; start with --limit 3 to verify cards land correctly.`,
+      );
     } else {
       console.log(`\nBackfill complete:`);
       console.log(`  Eligible candidates: ${result.candidates}`);
       console.log(`  Drafted:             ${result.drafted}`);
       console.log(`  Failed:              ${result.failed}`);
+      if (result.drafted_orgs?.length) {
+        console.log(`  Cards posted for:`);
+        for (const c of result.drafted_orgs) {
+          console.log(formatPreviewRow(c));
+        }
+      }
     }
   } finally {
     await closeDatabase();

--- a/server/src/scripts/backfill-member-announcements.ts
+++ b/server/src/scripts/backfill-member-announcements.ts
@@ -1,0 +1,150 @@
+/**
+ * Backfill one-shot: post retroactive new-member announcement drafts
+ * to the editorial review channel (Workflow B Stage 4 spec).
+ *
+ * Queries announce-ready orgs that never had the live trigger fire for
+ * them (typically because they went public before the `profile_published`
+ * event was added), caps at --limit, and posts each through the same
+ * pipeline as the hourly trigger job. Review cards are tagged
+ * `[BACKFILL]` so editorial can tell them apart from the live flow.
+ * Approval uses the same Slack buttons; no separate surface.
+ *
+ * Usage:
+ *   npx tsx server/src/scripts/backfill-member-announcements.ts
+ *     [--limit 10] [--dry-run]
+ *
+ * Env:
+ *   DATABASE_URL                     required
+ *   SLACK_EDITORIAL_REVIEW_CHANNEL   required unless --dry-run
+ *   APP_URL                          optional, used in profile links
+ *   ADDIE_BOT_TOKEN                  required for non-dry-run posts
+ *   ANTHROPIC_API_KEY                required for the drafter
+ *
+ * Safe-to-retry: idempotency on `announcement_draft_posted` means
+ * re-running the script will not re-draft orgs that landed last run.
+ */
+
+import { initializeDatabase, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
+import { runBackfillAnnouncements } from '../addie/jobs/announcement-trigger.js';
+
+interface CliArgs {
+  limit: number;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  let limit = 15;
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') {
+      dryRun = true;
+    } else if (a === '--limit') {
+      const next = argv[i + 1];
+      const parsed = Number.parseInt(next, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        limit = parsed;
+        i++;
+      } else {
+        throw new Error(`--limit requires a positive integer, got: ${next}`);
+      }
+    } else if (a.startsWith('--limit=')) {
+      const parsed = Number.parseInt(a.slice('--limit='.length), 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        limit = parsed;
+      } else {
+        throw new Error(`--limit requires a positive integer, got: ${a}`);
+      }
+    } else if (a === '-h' || a === '--help') {
+      // Surfacing as an error throws us out of parse cleanly; main()
+      // catches and exits 0 after printing the usage string.
+      throw new Error('--help');
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return { limit, dryRun };
+}
+
+const USAGE = `
+Usage: npx tsx server/src/scripts/backfill-member-announcements.ts [options]
+
+  --limit <N>   Cap on drafts posted in this run (default 15)
+  --dry-run     Query candidates and print what would be drafted;
+                don't post to Slack or write activity rows
+
+Env:
+  DATABASE_URL (required)
+  SLACK_EDITORIAL_REVIEW_CHANNEL (required unless --dry-run)
+  ADDIE_BOT_TOKEN (required unless --dry-run)
+  ANTHROPIC_API_KEY (required unless --dry-run)
+`;
+
+async function main(): Promise<void> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === '--help') {
+      console.log(USAGE.trim());
+      process.exit(0);
+    }
+    console.error(msg);
+    console.error(USAGE.trim());
+    process.exit(2);
+  }
+
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const reviewChannel = process.env.SLACK_EDITORIAL_REVIEW_CHANNEL ?? '';
+  if (!args.dryRun && !reviewChannel) {
+    console.error('SLACK_EDITORIAL_REVIEW_CHANNEL is required unless --dry-run');
+    process.exit(1);
+  }
+
+  initializeDatabase(dbConfig);
+
+  try {
+    const result = await runBackfillAnnouncements({
+      reviewChannel,
+      limit: args.limit,
+      dryRun: args.dryRun,
+    });
+
+    if (result.dryRun) {
+      console.log(`\nBackfill dry-run:`);
+      console.log(`  Eligible candidates: ${result.candidates}`);
+      console.log(`  Would draft:         ${result.wouldDraft?.length ?? 0} (cap ${args.limit})`);
+      for (const c of result.wouldDraft ?? []) {
+        console.log(`    - ${c.workos_organization_id}  ${c.org_name}`);
+      }
+    } else {
+      console.log(`\nBackfill complete:`);
+      console.log(`  Eligible candidates: ${result.candidates}`);
+      console.log(`  Drafted:             ${result.drafted}`);
+      console.log(`  Failed:              ${result.failed}`);
+    }
+  } finally {
+    await closeDatabase();
+  }
+}
+
+// Only run when invoked directly (not when imported by a test).
+// Narrow check: we only want to fire `main()` when tsx/node launched
+// this file as the entry point. Any broader heuristic risks a test
+// runner whose argv[1] happens to end in this filename auto-executing
+// the script.
+const invokedAsScript = import.meta.url === `file://${process.argv[1]}`;
+
+if (invokedAsScript) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/announcement/announcement-backfill.test.ts
+++ b/tests/announcement/announcement-backfill.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for Workflow B Stage 4 — retroactive announcement backfill.
+ *
+ * - CLI arg parsing for the standalone script
+ * - `findAnnounceCandidates({ requireProfilePublished: false })` includes
+ *   orgs that went public before the event emit
+ * - `runBackfillAnnouncements` respects `limit`, supports `dry-run` (no
+ *   Slack call, no activity write), tags drafts with `[BACKFILL]`
+ * - Error shape: empty editorial channel → returns `{drafted:0}` not throw
+ */
+import { describe, it, test, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockQuery,
+  mockSendChannelMessage,
+  mockDeleteChannelMessage,
+  mockDraftAnnouncement,
+  mockResolveVisual,
+} = vi.hoisted(() => ({
+  mockQuery: vi.fn<any>(),
+  mockSendChannelMessage: vi.fn<any>(),
+  mockDeleteChannelMessage: vi.fn<any>(),
+  mockDraftAnnouncement: vi.fn<any>(),
+  mockResolveVisual: vi.fn<any>(),
+}));
+
+vi.mock('../../server/src/db/client.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+vi.mock('../../server/src/slack/client.js', () => ({
+  sendChannelMessage: (...args: unknown[]) => mockSendChannelMessage(...args),
+  deleteChannelMessage: (...args: unknown[]) => mockDeleteChannelMessage(...args),
+}));
+
+vi.mock('../../server/src/services/announcement-drafter.js', () => ({
+  draftAnnouncement: (...args: unknown[]) => mockDraftAnnouncement(...args),
+}));
+
+vi.mock('../../server/src/services/announcement-visual.js', () => ({
+  resolveAnnouncementVisual: (...args: unknown[]) => mockResolveVisual(...args),
+  isSafeVisualUrl: () => true,
+  AAO_FALLBACK_VISUAL_URL: 'https://agenticadvertising.org/AAo-social.png',
+}));
+
+const ORG_A = {
+  workos_organization_id: 'org_AAA',
+  org_name: 'Alpha Co',
+  membership_tier: 'company_standard',
+  profile_id: 'p1',
+  display_name: 'Alpha Co',
+  slug: 'alpha',
+  tagline: null,
+  description: null,
+  offerings: null,
+  primary_brand_domain: 'alpha.example',
+  brand_manifest: { agents: [] },
+  last_published_at: null,
+};
+
+const ORG_B = {
+  ...ORG_A,
+  workos_organization_id: 'org_BBB',
+  org_name: 'Beta Co',
+  slug: 'beta',
+  primary_brand_domain: 'beta.example',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockReset();
+  mockDraftAnnouncement.mockResolvedValue({
+    slackText: 'Welcome.',
+    linkedinText: 'Welcome.\n\n#AAO',
+  });
+  mockResolveVisual.mockResolvedValue({
+    url: 'https://agenticadvertising.org/AAo-social.png',
+    altText: 'AAO',
+    source: 'aao_fallback',
+  });
+  mockSendChannelMessage.mockResolvedValue({ ok: true, ts: '1700000000.001' });
+});
+
+describe('findAnnounceCandidates — requireProfilePublished option', () => {
+  it('default: SQL includes the profile_published EXISTS clause', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const { findAnnounceCandidates } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await findAnnounceCandidates();
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toMatch(/EXISTS\s*\(\s*SELECT 1 FROM org_activities[\s\S]+activity_type = 'profile_published'/);
+  });
+
+  it('requireProfilePublished:false: SQL omits the profile_published EXISTS clause', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const { findAnnounceCandidates } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await findAnnounceCandidates({ requireProfilePublished: false });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    // The outer NOT EXISTS (for already-drafted/skipped) mentions the
+    // activity_type IN (...) predicate — but no standalone profile_published
+    // EXISTS should appear.
+    expect(sql).not.toMatch(/\bEXISTS\s*\(\s*SELECT 1 FROM org_activities[\s\S]*activity_type = 'profile_published'/);
+    // Still has the NOT EXISTS guarding against duplicate drafts.
+    expect(sql).toMatch(/NOT EXISTS[\s\S]+activity_type IN \('announcement_draft_posted', 'announcement_skipped'\)/);
+  });
+
+  it('sort order: last_published_at DESC NULLS LAST, then created_at DESC', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const { findAnnounceCandidates } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await findAnnounceCandidates({ requireProfilePublished: false });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toMatch(/ORDER BY last_published_at DESC NULLS LAST,\s*o\.created_at DESC/);
+  });
+});
+
+describe('buildReviewBlocks — backfill flag', () => {
+  it('tags header with [BACKFILL] when backfill:true', async () => {
+    const { buildReviewBlocks } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const { text, blocks } = buildReviewBlocks({
+      orgName: 'Alpha Co',
+      workosOrganizationId: 'org_AAA',
+      slackText: 'hi',
+      linkedinText: 'hi',
+      visual: { url: 'https://example/a.png', altText: 'a', source: 'aao_fallback' },
+      profileSlug: 'alpha',
+      backfill: true,
+    });
+    expect(text).toContain('[BACKFILL]');
+    const header = blocks.find((b) => b.type === 'header');
+    expect(header?.text?.text).toMatch(/^\[BACKFILL\]/);
+  });
+
+  it('no tag when backfill:false (default)', async () => {
+    const { buildReviewBlocks } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const { blocks } = buildReviewBlocks({
+      orgName: 'Alpha Co',
+      workosOrganizationId: 'org_AAA',
+      slackText: 'hi',
+      linkedinText: 'hi',
+      visual: { url: 'https://example/a.png', altText: 'a', source: 'aao_fallback' },
+      profileSlug: 'alpha',
+    });
+    const header = blocks.find((b) => b.type === 'header');
+    expect(header?.text?.text).not.toMatch(/BACKFILL/);
+  });
+});
+
+describe('runBackfillAnnouncements', () => {
+  test('dry-run: no Slack calls, no activity writes; reports candidates', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A, ORG_B] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.candidates).toBe(2);
+    expect(result.wouldDraft).toEqual([
+      { workos_organization_id: 'org_AAA', org_name: 'Alpha Co' },
+      { workos_organization_id: 'org_BBB', org_name: 'Beta Co' },
+    ]);
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+    expect(mockDraftAnnouncement).not.toHaveBeenCalled();
+    // Strict: dry-run issues exactly one SQL (the SELECT). No INSERT,
+    // no secondary reads. Pins the guarantee for future refactors.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('respects limit: picks first N by sort order', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A, ORG_B] });
+    // Draft + resolve mocks already set; INSERT activity write:
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      limit: 1,
+    });
+
+    expect(result.candidates).toBe(2);
+    expect(result.drafted).toBe(1);
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT INTO org_activities'),
+    );
+    expect(insertCall).toBeDefined();
+    const metadata = JSON.parse(insertCall![1][2]);
+    expect(metadata.backfill).toBe(true);
+    expect(metadata.org_name).toBe('Alpha Co');
+  });
+
+  test('default limit is 15', async () => {
+    const twenty = Array.from({ length: 20 }, (_, i) => ({
+      ...ORG_A,
+      workos_organization_id: `org_${String(i).padStart(3, '0')}`,
+      org_name: `Org ${i}`,
+      slug: `org-${i}`,
+    }));
+    mockQuery.mockResolvedValueOnce({ rows: twenty });
+    // 15 successful INSERTs:
+    for (let i = 0; i < 15; i++) mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+    });
+
+    expect(result.candidates).toBe(20);
+    expect(result.drafted).toBe(15);
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(15);
+  });
+
+  test('backfill rows include `backfill: true` in recorded metadata', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    const insertCall = mockQuery.mock.calls.find(
+      ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT INTO org_activities'),
+    );
+    const metadata = JSON.parse(insertCall![1][2]);
+    expect(metadata.backfill).toBe(true);
+  });
+
+  test('handles candidate-load failure without throwing', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(result.candidates).toBe(0);
+    expect(result.drafted).toBe(0);
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  test('unwinds Slack post when activity write fails (shared with live flow)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A] });
+    // INSERT fails:
+    mockQuery.mockRejectedValueOnce(new Error('db write failed'));
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    // Slack post succeeded then activity write threw — chat.delete unwinds.
+    expect(mockDeleteChannelMessage).toHaveBeenCalledWith('C0REVIEW01', '1700000000.001');
+    expect(result.drafted).toBe(0);
+    expect(result.failed).toBe(1);
+  });
+
+  test('post failure for one candidate does not stop the rest', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A, ORG_B] });
+    // First send fails, second succeeds:
+    mockSendChannelMessage
+      .mockResolvedValueOnce({ ok: false, error: 'channel_not_found' })
+      .mockResolvedValueOnce({ ok: true, ts: '1700000000.002' });
+    // Only one activity write (for the successful post):
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(result.drafted).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+});
+
+describe('parseArgs (backfill script CLI)', () => {
+  test('defaults: limit=15 dry-run=false', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs([])).toEqual({ limit: 15, dryRun: false });
+  });
+
+  test('--limit N', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs(['--limit', '5'])).toEqual({ limit: 5, dryRun: false });
+  });
+
+  test('--limit=N', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs(['--limit=7'])).toEqual({ limit: 7, dryRun: false });
+  });
+
+  test('--dry-run', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs(['--dry-run'])).toEqual({ limit: 15, dryRun: true });
+  });
+
+  test('combined', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs(['--dry-run', '--limit', '3'])).toEqual({ limit: 3, dryRun: true });
+  });
+
+  test('--limit with non-integer throws', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(() => parseArgs(['--limit', 'foo'])).toThrow(/positive integer/);
+  });
+
+  test('--limit with zero throws', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(() => parseArgs(['--limit', '0'])).toThrow(/positive integer/);
+  });
+
+  test('unknown flag throws', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(() => parseArgs(['--bogus'])).toThrow(/Unknown argument/);
+  });
+
+  test('--help throws a marker', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(() => parseArgs(['--help'])).toThrow(/--help/);
+  });
+});

--- a/tests/announcement/announcement-backfill.test.ts
+++ b/tests/announcement/announcement-backfill.test.ts
@@ -24,9 +24,38 @@ const {
   mockResolveVisual: vi.fn<any>(),
 }));
 
-vi.mock('../../server/src/db/client.js', () => ({
-  query: (...args: unknown[]) => mockQuery(...args),
-}));
+// The backfill path opens a pooled client to hold the advisory lock.
+// In tests we route lock acquire/release through a simple flag so a
+// second call in the same test returns "already held" when we want to
+// simulate a concurrent run.
+let lockHeld = false;
+let lockAcquireReturnsFalse = false;
+
+vi.mock('../../server/src/db/client.js', () => {
+  const fakeClient = {
+    query: (sql: unknown, params?: unknown[]) => {
+      if (typeof sql === 'string') {
+        if (sql.startsWith('SELECT pg_try_advisory_lock')) {
+          if (lockAcquireReturnsFalse) {
+            return Promise.resolve({ rows: [{ pg_try_advisory_lock: false }] });
+          }
+          lockHeld = true;
+          return Promise.resolve({ rows: [{ pg_try_advisory_lock: true }] });
+        }
+        if (sql.startsWith('SELECT pg_advisory_unlock')) {
+          lockHeld = false;
+          return Promise.resolve({ rows: [] });
+        }
+      }
+      return mockQuery(sql, params);
+    },
+    release: () => {},
+  };
+  return {
+    query: (...args: unknown[]) => mockQuery(...args),
+    getPool: () => ({ connect: async () => fakeClient }),
+  };
+});
 
 vi.mock('../../server/src/slack/client.js', () => ({
   sendChannelMessage: (...args: unknown[]) => mockSendChannelMessage(...args),
@@ -69,6 +98,8 @@ const ORG_B = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockQuery.mockReset();
+  lockHeld = false;
+  lockAcquireReturnsFalse = false;
   mockDraftAnnouncement.mockResolvedValue({
     slackText: 'Welcome.',
     linkedinText: 'Welcome.\n\n#AAO',
@@ -79,6 +110,7 @@ beforeEach(() => {
     source: 'aao_fallback',
   });
   mockSendChannelMessage.mockResolvedValue({ ok: true, ts: '1700000000.001' });
+  mockDeleteChannelMessage.mockResolvedValue({ ok: true });
 });
 
 describe('findAnnounceCandidates — requireProfilePublished option', () => {
@@ -156,14 +188,14 @@ describe('runBackfillAnnouncements', () => {
 
     expect(result.dryRun).toBe(true);
     expect(result.candidates).toBe(2);
-    expect(result.wouldDraft).toEqual([
-      { workos_organization_id: 'org_AAA', org_name: 'Alpha Co' },
-      { workos_organization_id: 'org_BBB', org_name: 'Beta Co' },
+    expect(result.wouldDraft?.map((r) => r.workos_organization_id)).toEqual([
+      'org_AAA',
+      'org_BBB',
     ]);
     expect(mockSendChannelMessage).not.toHaveBeenCalled();
     expect(mockDraftAnnouncement).not.toHaveBeenCalled();
-    // Strict: dry-run issues exactly one SQL (the SELECT). No INSERT,
-    // no secondary reads. Pins the guarantee for future refactors.
+    // Strict: dry-run issues exactly one SQL through the pool-less
+    // `query` mock (the SELECT). No INSERT, no secondary reads.
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
@@ -180,7 +212,8 @@ describe('runBackfillAnnouncements', () => {
 
     expect(result.candidates).toBe(2);
     expect(result.drafted).toBe(1);
-    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+    // N draft posts + 1 summary message = N+1 total.
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(2);
     const insertCall = mockQuery.mock.calls.find(
       ([sql]: any) => typeof sql === 'string' && sql.startsWith('INSERT INTO org_activities'),
     );
@@ -208,7 +241,8 @@ describe('runBackfillAnnouncements', () => {
 
     expect(result.candidates).toBe(20);
     expect(result.drafted).toBe(15);
-    expect(mockSendChannelMessage).toHaveBeenCalledTimes(15);
+    // 15 drafts + 1 summary
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(16);
   });
 
   test('backfill rows include `backfill: true` in recorded metadata', async () => {
@@ -251,6 +285,171 @@ describe('runBackfillAnnouncements', () => {
     expect(result.failed).toBe(1);
   });
 
+  test('dry-run preview rows include tier, domain, last_published_at', async () => {
+    const published = new Date('2026-03-15T12:00:00Z');
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...ORG_A, membership_tier: 'builder', last_published_at: published }],
+    });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      dryRun: true,
+    });
+
+    expect(result.wouldDraft).toEqual([
+      {
+        workos_organization_id: 'org_AAA',
+        org_name: 'Alpha Co',
+        membership_tier: 'builder',
+        primary_brand_domain: 'alpha.example',
+        last_published_at: published,
+      },
+    ]);
+  });
+
+  test('--force off: --limit above soft cap gets clamped to BACKFILL_SOFT_CAP', async () => {
+    const { runBackfillAnnouncements, BACKFILL_SOFT_CAP } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      limit: 9999,
+      dryRun: true,
+    });
+
+    expect(result.effectiveLimit).toBe(BACKFILL_SOFT_CAP);
+  });
+
+  test('--force on: --limit above soft cap passes through but still capped at absolute max', async () => {
+    const { runBackfillAnnouncements, BACKFILL_ABSOLUTE_MAX } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      limit: 9999,
+      force: true,
+      dryRun: true,
+    });
+
+    expect(result.effectiveLimit).toBe(BACKFILL_ABSOLUTE_MAX);
+  });
+
+  test('advisory lock held by another run → refuses with lockedOut:true', async () => {
+    lockAcquireReturnsFalse = true;
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({
+      reviewChannel: 'C0REVIEW01',
+      dryRun: true,
+    });
+
+    expect(result.lockedOut).toBe(true);
+    expect(result.candidates).toBe(0);
+    expect(mockQuery).not.toHaveBeenCalled(); // no SELECT on orgs
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  test('summary message: posted when drafted > 0, skipped when drafted == 0', async () => {
+    // Run 1: 1 draft succeeds → summary should be posted.
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A] });
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // INSERT
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    const summaryCall = mockSendChannelMessage.mock.calls.find(
+      ([, msg]: any) => typeof msg?.text === 'string' && msg.text.includes('Backfill wave posted'),
+    );
+    expect(summaryCall).toBeDefined();
+    expect(summaryCall![0]).toBe('C0REVIEW01');
+  });
+
+  test('summary message: skipped when no drafts succeeded', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // zero candidates
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    const summaryCall = mockSendChannelMessage.mock.calls.find(
+      ([, msg]: any) => typeof msg?.text === 'string' && msg.text.includes('Backfill wave posted'),
+    );
+    expect(summaryCall).toBeUndefined();
+  });
+
+  test('drafted_orgs is populated on the live run', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(result.drafted_orgs).toEqual([
+      {
+        workos_organization_id: 'org_AAA',
+        org_name: 'Alpha Co',
+        membership_tier: 'company_standard',
+        primary_brand_domain: 'alpha.example',
+        last_published_at: null,
+      },
+    ]);
+  });
+
+  test('rich fixture: drafter receives parsed agents from brand_manifest', async () => {
+    const rich = {
+      ...ORG_A,
+      tagline: 'We build buyer agents for small DSPs.',
+      brand_manifest: {
+        brands: [
+          {
+            agents: [
+              { type: 'buyer_agent', description: 'small DSP' },
+              { type: 'signals_agent' },
+            ],
+          },
+        ],
+      },
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [rich] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    const draftCall = mockDraftAnnouncement.mock.calls[0][0];
+    expect(draftCall.tagline).toBe('We build buyer agents for small DSPs.');
+    expect(draftCall.agents).toEqual([
+      { type: 'buyer_agent', description: 'small DSP' },
+      { type: 'signals_agent', description: null },
+    ]);
+  });
+
+  test('delete unwind that returns {ok:false} is logged but does not throw', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A] });
+    // INSERT fails:
+    mockQuery.mockRejectedValueOnce(new Error('db write failed'));
+    // Unwind reports failure:
+    mockDeleteChannelMessage.mockResolvedValueOnce({ ok: false, error: 'message_not_found' });
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(result.failed).toBe(1);
+    expect(result.drafted).toBe(0);
+  });
+
+  test('delete unwind that throws is caught and does not stop the run', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ORG_A, ORG_B] });
+    mockQuery.mockRejectedValueOnce(new Error('db write failed')); // ORG_A insert
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // ORG_B insert succeeds
+    mockDeleteChannelMessage.mockRejectedValueOnce(new Error('slack 5xx')); // unwind throws
+
+    const { runBackfillAnnouncements } = await import('../../server/src/addie/jobs/announcement-trigger.js');
+    const result = await runBackfillAnnouncements({ reviewChannel: 'C0REVIEW01' });
+
+    expect(result.failed).toBe(1);
+    expect(result.drafted).toBe(1); // ORG_B still drafted despite ORG_A's unwind throw
+  });
+
   test('post failure for one candidate does not stop the rest', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [ORG_A, ORG_B] });
     // First send fails, second succeeds:
@@ -269,29 +468,38 @@ describe('runBackfillAnnouncements', () => {
 });
 
 describe('parseArgs (backfill script CLI)', () => {
-  test('defaults: limit=15 dry-run=false', async () => {
+  test('defaults: limit=15 dry-run=false force=false', async () => {
     const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
-    expect(parseArgs([])).toEqual({ limit: 15, dryRun: false });
+    expect(parseArgs([])).toEqual({ limit: 15, dryRun: false, force: false });
   });
 
   test('--limit N', async () => {
     const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
-    expect(parseArgs(['--limit', '5'])).toEqual({ limit: 5, dryRun: false });
+    expect(parseArgs(['--limit', '5'])).toEqual({ limit: 5, dryRun: false, force: false });
   });
 
   test('--limit=N', async () => {
     const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
-    expect(parseArgs(['--limit=7'])).toEqual({ limit: 7, dryRun: false });
+    expect(parseArgs(['--limit=7'])).toEqual({ limit: 7, dryRun: false, force: false });
   });
 
   test('--dry-run', async () => {
     const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
-    expect(parseArgs(['--dry-run'])).toEqual({ limit: 15, dryRun: true });
+    expect(parseArgs(['--dry-run'])).toEqual({ limit: 15, dryRun: true, force: false });
+  });
+
+  test('--force', async () => {
+    const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
+    expect(parseArgs(['--force'])).toEqual({ limit: 15, dryRun: false, force: true });
   });
 
   test('combined', async () => {
     const { parseArgs } = await import('../../server/src/scripts/backfill-member-announcements.js');
-    expect(parseArgs(['--dry-run', '--limit', '3'])).toEqual({ limit: 3, dryRun: true });
+    expect(parseArgs(['--dry-run', '--limit', '3'])).toEqual({
+      limit: 3,
+      dryRun: true,
+      force: false,
+    });
   });
 
   test('--limit with non-integer throws', async () => {


### PR DESCRIPTION
## Summary

Final piece of Workflow B per the spec. One-shot script that posts retroactive new-member announcement drafts to the editorial review channel for orgs who became announce-ready **before** Workflow A's `profile_published` event emit existed and therefore never triggered the live flow.

## What's in the box

- **`server/src/scripts/backfill-member-announcements.ts`** — CLI with `--limit N` (default 15) and `--dry-run`. Cap prevents a single invocation from flooding the editorial channel; re-runs are safe because the existing `announcement_draft_posted` idempotency filters candidates that landed on a previous run.
- **`runBackfillAnnouncements`** in `announcement-trigger.ts` drives the per-candidate pipeline with the same post-then-record + `chat.delete` unwind semantics as the live trigger.
- **`findAnnounceCandidates({ requireProfilePublished })`** option drops the `profile_published` EXISTS clause for the backfill path. Orgs that went public before the event emit was added are now reachable.
- Extracted **`processAnnounceCandidate`** helper shared by the live trigger and backfill — single source of truth for the Slack-post + activity-write semantics.
- **`buildReviewBlocks({ backfill })`** flag tags the review card header with `[BACKFILL]` so editorial can tell retroactive drafts apart.
- Recorded `announcement_draft_posted` metadata includes `backfill: true` for downstream analytics.

## Operator flow

```bash
npx tsx server/src/scripts/backfill-member-announcements.ts --dry-run          # audit first
npx tsx server/src/scripts/backfill-member-announcements.ts --limit 10        # actual run
```

Approval still happens through the existing Stage 2 buttons in the editorial channel. No new admin surfaces.

## Review notes

Addressed the code-reviewer's feedback in this commit:

- Narrowed `invokedAsScript` to the strict `import.meta.url === file://…` check — dropped the `.endsWith` fallbacks that risked auto-executing `main()` under test runners.
- Context-aware log message on per-candidate failure ("will retry next run" only for the live flow, not one-shot backfill).
- Added three tests: sort-order SQL shape, dry-run strict query count (exactly 1 SELECT), activity-write failure → `chat.delete` unwind.

## Test plan

- [x] 21 new tests pass
- [x] Full announcement suite: 124/124
- [x] Pre-commit hook + server typecheck green
- [ ] Manual: operator runs `--dry-run` in prod, reviews the candidate list, then runs with `--limit 10` for the first wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)