### PR TITLE
docs(media-buy): bless pending_creatives + pending_start display collapsing

### DIFF
--- a/.changeset/docs-media-buy-pending-display-collapsing.md
+++ b/.changeset/docs-media-buy-pending-display-collapsing.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(media-buy): document blessed pattern for collapsing `pending_creatives` and `pending_start` in buyer UIs.
+
+Adds a `<Note>` block to the media-buy Lifecycle States section stating that buyer applications MAY render both pending states as a single `pending` label for display, but MUST preserve the raw status value on the wire (API responses, webhooks, persisted records, logs) so downstream gating keeps working. Reinforces the existing guidance to drive UI affordances from `valid_actions` rather than from the status value directly. Closes #2988. No schema change — docs guidance only.

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -270,6 +270,10 @@ Any non-terminal ──── update(canceled: true) ──▶ canceled (termina
 - **`rejected`**: Declined by the seller (terminal)
 - **`canceled`**: Terminated before natural completion. Check `cancellation.canceled_by` to determine whether the buyer or seller initiated.
 
+<Note>
+**Display collapsing.** `pending_creatives` and `pending_start` are granular to support downstream gating — conditional UI, task routing, readiness checks. Buyer applications MAY render both as a single `pending` label for end users, but MUST preserve the raw status value on the wire (API responses, webhooks, persisted records, logs) so logic that depends on the distinction keeps working. Treat the raw enum as the source of truth and derive display labels from it. Where possible, drive UI affordances from `valid_actions` rather than from the status value directly.
+</Note>
+
 **Effect on creatives**: A media buy reaching `rejected`, `canceled`, or `completed` releases its creative assignments but does not modify the creatives themselves. Assigned creatives remain in the library with their existing review status and are available for assignment to other media buys. See [creative state and assignment state](/docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate).
 
 **Order confirmation**: A successful `create_media_buy` response constitutes order confirmation. The response includes `confirmed_at` with the confirmation timestamp.


### PR DESCRIPTION
Closes #2988

## Summary

Adds a `<Note>` to the media-buy Lifecycle States section documenting the common buyer-UI pattern of collapsing `pending_creatives` and `pending_start` into a single `pending` display label. The spec was silent on this, so adapter authors (Scope3, per the issue) were guessing whether they were conformant. The note:

- Blesses the collapse for **display**: buyers MAY render both as a single `pending` label.
- Requires the raw enum value be preserved on the wire (API responses, webhooks, persisted records, logs) so downstream gating keeps working.
- Points buyers at `valid_actions` for UI affordances, reinforcing existing guidance on that page.

## Non-breaking justification

Docs-only addition to an existing section. No schema change, no task-reference change, no enum change — `static/schemas/source/enums/media-buy-status.json` is untouched. Existing clients are unaffected; the note describes an implementation pattern that is already in the wild.

## Expert consensus

`ad-tech-protocol-expert` and `docs-expert` reviewed in parallel and both recommended ship-with-edits against the original proposal. The edits (preserve raw on the wire; cross-reference `valid_actions`; drop the "conformance violation" framing) are incorporated. `code-reviewer` reviewed the diff and approved.

## Test plan

- [ ] Mintlify renders the `<Note>` cleanly (uses the same component pattern already in this file at line 36).
- [ ] No schema or task-reference change, so no schema/test impact.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6c21XFg9JHNSUDGgvGf1W)_