### PR TITLE
spec(media-buy): get_media_buys MUST return all account-owned buys

### DIFF
--- a/.changeset/get-media-buys-account-ownership-scope.md
+++ b/.changeset/get-media-buys-account-ownership-scope.md
@@ -1,0 +1,21 @@
+---
+---
+
+spec(media-buy): `get_media_buys` MUST return all account-owned buys regardless of creation surface
+
+Tightens the scope of `get_media_buys`, `get_media_buy_delivery`, and `update_media_buy` to be bounded by account ownership, not by the surface through which a buy was created. A sales agent MUST NOT partition its inventory into "AdCP-created" and "non-AdCP" subsets for account-scoped tasks, and MUST NOT refuse reporting or updates on the basis that a buy was booked directly in the ad server, via legacy APIs, or via manual trafficking.
+
+Closes #2963. Rationale:
+
+- **Adoption**: enterprises with large existing ad-server state (10K+ GAM campaigns) can't rebuild from zero through AdCP to adopt the protocol.
+- **Attestation**: brownfield Tier-2 conformance (#2965) depends on the compliance engine being able to `get_media_buys` → discover a live campaign → `update_media_buy` with a verification `reporting_webhook`. If pre-existing campaigns are invisible, that path collapses.
+- **Honesty**: AdCP is a protocol onto the seller's ad operations, not a shadow ledger beside them.
+
+Normative changes:
+
+- `docs/media-buy/task-reference/get_media_buys.mdx`: new "Scope of Results" section.
+- `docs/media-buy/task-reference/update_media_buy.mdx`: new "Scope" section; updates operate on any `media_buy_id` returned by `get_media_buys`.
+- `docs/media-buy/task-reference/get_media_buy_delivery.mdx`: new "Scope" section; delivery reporting covers any returned buy.
+- `docs/media-buy/specification.mdx`: new "Account Ownership vs. Creation Surface" core concept; cross-referenced from the `get_media_buys`, `update_media_buy`, and `get_media_buy_delivery` requirements lists.
+
+Business constraints on specific operations remain expressible via `valid_actions` — the seller omits the action rather than hiding the buy.

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -74,11 +74,22 @@ Every media buy request involves three entities:
 
 ### Identifiers
 
-- **`media_buy_id`**: Unique identifier for a media buy. Sales agents MUST return this on successful creation. Orchestrators MUST use this for all subsequent operations on the media buy.
+- **`media_buy_id`**: Unique identifier for a media buy. Sales agents MUST return this on successful creation. Orchestrators MUST use this for all subsequent operations on the media buy. A `media_buy_id` is a stable handle to any order in the seller's ad server that the authenticated account owns — not only orders originally booked via AdCP.
 
 - **`package_id`**: Unique identifier for a package within a media buy. Sales agents MUST return this for each package created.
 
 - **`idempotency_key`**: Client-generated unique key for safe retries. Sales agents that receive a duplicate key for the same account MUST return the original response rather than re-executing.
+
+### Account Ownership vs. Creation Surface
+
+AdCP is a protocol onto the seller's ad operations, not a shadow ledger beside them. Account-scoped tasks (`get_media_buys`, `get_media_buy_delivery`, `update_media_buy`, creative sync where applicable) are scoped by **account ownership**, not by the surface through which a resource was created. A sales agent MUST NOT partition its own inventory into "AdCP-managed" and "non-AdCP" subsets for the purpose of these tasks.
+
+Concretely:
+
+- `get_media_buys` MUST return every media buy owned by the authenticated account — whether created via `create_media_buy`, via the seller's native APIs or UI, via manual trafficking, or via legacy/third-party systems — subject only to the declared `status_filter` and pagination.
+- Any `media_buy_id` returned by `get_media_buys` MUST be a valid argument to `get_media_buy_delivery` and to `update_media_buy` for every action listed in its `valid_actions`.
+- A sales agent MUST NOT mark a buy read-only, hide it, or return `MEDIA_BUY_NOT_FOUND` on the basis that it was not originally booked through AdCP.
+- When a specific action is unavailable for business reasons (contractual obligations, platform constraints, policy), the sales agent expresses that by omitting the action from `valid_actions`, not by refusing the buy from account-scoped listings.
 
 ### Asynchronous Operations
 
@@ -258,6 +269,7 @@ Modify an existing media buy's budget, targeting, or settings.
 
 **Requirements:**
 - Orchestrators MUST include `media_buy_id`
+- Sales agents MUST accept any `media_buy_id` returned by `get_media_buys` for the authenticated account and MUST NOT refuse updates on the basis that the buy was originally created outside AdCP. Business constraints on specific operations are expressed by omitting them from `valid_actions`. See [Account Ownership vs. Creation Surface](#account-ownership-vs-creation-surface).
 - Sales agents MUST apply PATCH semantics: only specified fields are updated; omitted fields remain unchanged
 - When a buyer attempts to cancel a media buy already in `canceled` (`canceled: true` on a `canceled` buy), sales agents MUST reject with `NOT_CANCELLABLE`
 - All other updates to media buys in terminal states (`completed`, `rejected`, `canceled`) — including `canceled: true` attempts against `completed` or `rejected` buys — MUST be rejected with `INVALID_STATE`
@@ -310,6 +322,7 @@ Retrieve operational media buy state, including package status, creative approva
 **Requirements:**
 - Orchestrators MAY filter by `account_id`, `media_buy_ids`, and `status_filter`
 - Orchestrators SHOULD use cursor pagination (`pagination.max_results` / `pagination.cursor`) for broad scope queries
+- Sales agents MUST return every media buy owned by the authenticated account that matches the declared filter set, regardless of how the buy was created (AdCP, seller's native APIs/UI, manual trafficking, legacy systems). See [Account Ownership vs. Creation Surface](#account-ownership-vs-creation-surface).
 - Sales agents MUST return current media buy status and package-level operational state for each matched media buy
 - Sales agents SHOULD include `valid_actions` for each media buy, listing the actions the buyer can perform in the current state. This eliminates the need for agents to internalize the state machine. Expected mapping:
 
@@ -341,6 +354,7 @@ Track performance metrics and campaign delivery.
 
 **Requirements:**
 - Orchestrators MUST include `media_buy_id`
+- Sales agents MUST accept any `media_buy_id` returned by `get_media_buys` for the authenticated account, regardless of creation surface. See [Account Ownership vs. Creation Surface](#account-ownership-vs-creation-surface).
 - Sales agents MUST return delivery metrics at the package level
 - Sales agents SHOULD include dimensional breakdowns when requested
 - Sales agents MUST include `as_of` timestamp indicating data freshness

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -10,6 +10,10 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 **Response Time**: ~60 seconds (reporting query)
 
+## Scope
+
+`get_media_buy_delivery` works on any `media_buy_id` returned by [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys), regardless of how the underlying campaign was created. Sales agents MUST NOT refuse delivery reporting — or narrow its coverage — on the basis that the buy originated outside AdCP. If delivery data for a buy is genuinely unavailable (e.g., the ad server has not yet reported a flight), the seller returns the buy in `media_buy_deliveries` with zero or partial metrics; the seller does not omit it and does not return `MEDIA_BUY_NOT_FOUND` for an account-owned buy.
+
 **Request Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json)
 **Response Schema**: [`/schemas/v3/media-buy/get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
 

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -10,6 +10,12 @@ Retrieve the current operational state of media buys: configuration, creative ap
 
 **Response Time**: ~1 second
 
+## Scope of Results
+
+Sales agents MUST return every media buy owned by the authenticated account, regardless of how the buy was created — via AdCP `create_media_buy`, via the seller's own APIs, via manual trafficking, via legacy or third-party systems. Scope is **account ownership**, not creation surface. A `media_buy_id` returned here identifies any order in the seller's ad server accessible to the authenticated caller.
+
+Any media buy returned by `get_media_buys` MUST be reachable by every task in its `valid_actions`. Sales agents MUST NOT mark a buy read-only, hide it, or refuse updates on the basis that it was not originally created via AdCP. If an action is unavailable for business reasons, the seller SHOULD omit it from `valid_actions` rather than returning a buy that cannot be operated on.
+
 **Request Schema**: [`/schemas/v3/media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-request.json)
 **Response Schema**: [`/schemas/v3/media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-response.json)
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -10,6 +10,10 @@ Modify an existing media buy using PATCH semantics. Supports campaign-level and 
 
 **Response Time**: Instant to days (status: `completed`, `working` < 120s, or `submitted` for manual review)
 
+## Scope
+
+`update_media_buy` operates on any `media_buy_id` returned by [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys), not just buys created via `create_media_buy`. Sales agents MUST NOT refuse updates on the basis that a buy was originally created outside AdCP (direct ad-server entry, legacy APIs, manual trafficking). Creation surface is not a supported axis of authorization; account ownership is. When a specific action is unsupported for a given buy for business reasons (contractual obligations, platform constraints), the seller MUST omit that action from `valid_actions` on the buy rather than silently rejecting the corresponding update.
+
 **PATCH Semantics**: Only specified fields are updated; omitted fields remain unchanged.
 
 **Request Schema**: [`/schemas/v3/media-buy/update-media-buy-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/update-media-buy-request.json)


### PR DESCRIPTION
## Summary

Tightens the scope of `get_media_buys`, `get_media_buy_delivery`, and `update_media_buy` so account-scoped tasks are bounded by **account ownership**, not by the surface through which a buy was created. Sales agents MUST NOT partition their inventory into "AdCP-created" and "non-AdCP" subsets for these tasks, and MUST NOT refuse reporting or updates on the basis that a buy was booked directly in the ad server, via legacy APIs, or via manual trafficking.

Closes #2963.

## Why

The spec was previously silent on this. Nothing forbid "AdCP only returns what AdCP created" — an interpretation compatible with the letter of the spec but fatal in practice:

- **Adoption**: an agency with 10,000 GAM campaigns adding an AdCP agent needs all 10,000 addressable, not just the ones rebuilt through AdCP.
- **Attestation**: brownfield Tier-2 conformance (#2965) requires the compliance engine to `get_media_buys` → discover a live campaign → `update_media_buy` with a verification `reporting_webhook`. Partitioning by creation surface collapses Path B.
- **Honesty**: AdCP as a protocol onto the seller's ad operations is the premise of the whole spec — not a shadow ledger beside it.

## Changes

- `docs/media-buy/task-reference/get_media_buys.mdx` — new **Scope of Results** section: sales agents MUST return every account-owned buy regardless of creation surface; MUST NOT mark a buy read-only on that basis. Business constraints expressed via `valid_actions`, not by hiding buys.
- `docs/media-buy/task-reference/update_media_buy.mdx` — new **Scope** section: operates on any `media_buy_id` returned by `get_media_buys`; creation surface is not a supported axis of authorization.
- `docs/media-buy/task-reference/get_media_buy_delivery.mdx` — new **Scope** section: delivery reporting covers any buy returned by `get_media_buys`; sellers return zero/partial metrics rather than `MEDIA_BUY_NOT_FOUND` for account-owned buys.
- `docs/media-buy/specification.mdx` — new **Account Ownership vs. Creation Surface** core concept, cross-referenced from the `get_media_buys`, `update_media_buy`, and `get_media_buy_delivery` requirements lists. Updates the `media_buy_id` definition to call out that it identifies any ad-server order the account owns.

## Test plan

- [ ] Docs build cleanly (verified by pre-commit docs validation)
- [ ] Cross-references to `#account-ownership-vs-creation-surface` resolve on the specification page
- [ ] Review by ad-tech-protocol-expert for normative language and MUST/SHOULD placement
- [ ] Confirm no schema changes needed — this is normative tightening on existing fields, not new shape

## Follow-ups

Part of a 3-issue series on brownfield conformance:
- **#2963** (this PR) — account-ownership scope
- **#2964** — `get_agent_capabilities` + `attestation_verifier` scope + RBAC error codes
- **#2965** — Tier-2 Production Verified via continuous delivery observability (depends on both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)