### PR TITLE
feat(agents): triage runs pre-PR expert review on diff

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -424,6 +424,43 @@ A single cohesive PR of 200 non-breaking lines is easier to review
 than three PRs of 60 lines with dependencies and cross-links. The
 bot's job is to reduce maintainer clicks, not multiply them.
 
+## Pre-PR expert review — mandatory before `gh pr create`
+
+After the branch is pushed but **before** opening the PR, run a
+second expert pass on the actual diff. The Step 4 synthesis
+reviewed the plan; this step reviews the code. They catch
+different things — protocol drift, broken tests, overlong files,
+wrong PR target, typos — before a human reviewer sees anything.
+
+1. Capture the diff: `git diff main...HEAD`.
+2. Spawn 2 experts **in parallel** via Task:
+   - `code-reviewer` — always
+   - The domain expert matching the bucket (same one from
+     Step 4; for cross-cutting diffs, pick the bucket the diff
+     primarily touches)
+3. Pass each expert: the diff + 2–3 sentences of intent ("Issue
+   #N asks for X; this PR does Y by touching Z"). Ask them to
+   classify each finding as **blocker**, **nit**, or **out of
+   scope**.
+4. **Fix blockers.** Re-run only the experts that flagged
+   blockers on the updated diff. Cap at **2 review→fix
+   iterations.** If blockers persist after two passes, abandon
+   the PR and Flag for human review instead.
+5. Surface nits in the PR body; don't fix them.
+6. If experts disagree on a blocker, do **not** resolve it
+   yourself — Flag for human review with both positions.
+7. Record both sign-offs in the PR body:
+
+   ```
+   **Pre-PR review:**
+   - code-reviewer: approved (1 nit noted)
+   - ad-tech-protocol-expert: approved — non-breaking per spec
+   ```
+
+**Never skip this step**, not even for one-line typo fixes.
+Cost is ~90 seconds of Task calls; benefit is two perspectives
+have read the diff before a human reviewer does.
+
 ## PR constraints
 
 - Branch: `claude/issue-<N>-<short-slug>`
@@ -436,11 +473,10 @@ bot's job is to reduce maintainer clicks, not multiply them.
   - **Non-breaking justification:** one line naming why the change
     is non-breaking per the definition above (e.g., "adds optional
     field X; existing clients unaffected")
-  - Expert consensus note: "ad-tech-protocol-expert and
-    code-reviewer reviewed; both approved."
+  - **Pre-PR review** block (from the step above) with both
+    experts' one-line sign-off
   - `Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}`
 - Include a changeset file
-- Run code-reviewer **on your own diff** before pushing; fix blockers
 - Run any relevant repo checks (tests for MDX if MDX touched, schema
   validation if JSON schemas touched)
 - **Never edit:** `.github/**`, `.agents/**`, `.claude/**`,

--- a/.changeset/triage-pre-pr-review.md
+++ b/.changeset/triage-pre-pr-review.md
@@ -1,0 +1,4 @@
+---
+---
+
+Triage routine now runs a mandatory pre-PR expert review on the diff (code-reviewer + domain expert in parallel) before opening the PR, capped at 2 review→fix iterations. Sign-offs recorded in the PR body.


### PR DESCRIPTION
## Summary

Triage routine now runs a mandatory **pre-PR expert review** on the actual diff (not just the plan) before opening the PR. Spawns `code-reviewer` + the matching domain expert in parallel, classifies findings as blocker/nit/out-of-scope, fixes blockers in up to 2 iterations, records sign-offs in the PR body.

Paired with flipping all 5 routines (4 triage + 1 context-refresh) from `claude-opus-4-7[1m]` → `claude-sonnet-4-6`. The stream-idle timeouts we've been hitting on multi-step sessions (issues #2987, python#263) suggest the orchestrator was the bottleneck; Sonnet is 3-5x faster per step and the deep thinking stays in Opus-backed Task subagents.

## Changes

- `.agents/routines/triage-prompt.md` — new `## Pre-PR expert review` section between "Bundling" and "PR constraints"
- PR constraints body now requires the **Pre-PR review** block (replaces the weaker "expert-consensus note")
- Routine model config flipped to Sonnet for all 5 triggers (done via RemoteTrigger API)

Sibling PRs to follow on adcp-client, adcp-client-python, adcp-go.

## Test plan
- [ ] CI green
- [ ] Fire one triage run after merge; confirm the pre-PR review block appears in the resulting draft PR body
- [ ] Confirm session completes without stream-timeout on Sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)