### PR TITLE
fix(server): distinguish WorkOS unavailable from not-connected in getGitHubConnectedAccount

### DIFF
--- a/.changeset/fix-github-connected-account-unavailable.md
+++ b/.changeset/fix-github-connected-account-unavailable.md
@@ -1,0 +1,32 @@
+---
+---
+
+**Fix: distinguish WorkOS unavailable from not-connected in getGitHubConnectedAccount**
+
+`getGitHubConnectedAccount` previously swallowed all non-404 WorkOS errors
+and returned `null`, causing the member-hub Connections card to show a
+"Connect GitHub" button during a WorkOS outage. Users who were already
+connected could inadvertently trigger double-consent or hit a 502 on the
+authorize endpoint.
+
+**Changed:**
+
+- `server/src/services/pipes.ts` — `getGitHubConnectedAccount` now returns a
+  discriminated union: `{ status: 'connected', login }`, `{ status: 'not_connected' }`,
+  or `{ status: 'unavailable', reason }`. Non-404 WorkOS errors map to
+  `unavailable` instead of collapsing into `null`.
+- `server/src/http.ts` — `GET /api/me/connected-accounts/github` returns HTTP
+  503 with `{ connected: false, unavailable: true }` when the status is
+  `unavailable`. Callers that do not handle 503 degrade to their existing
+  error branch (no regression).
+- `server/public/membership/hub.html` — `renderConnections` now renders a
+  "temporarily unavailable" message and omits the Connect button when the
+  API returns 503. This prevents users from triggering the authorize flow
+  during an outage.
+
+**Tests:** `server/tests/unit/pipes-connected-account.test.ts` — 5 new tests
+covering connected (with external_user_handle), connected (with external_handle
+fallback), not_connected (404), unavailable (5xx), and unavailable (network
+error without status code).
+
+Closes #2997.

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -1393,7 +1393,9 @@
             return;
           }
           if (engRes.status === 404) {
-            const github = githubRes.ok ? await githubRes.json() : { connected: false };
+            const github = githubRes.status === 503
+              ? { connected: false, unavailable: true }
+              : githubRes.ok ? await githubRes.json() : { connected: false };
             document.getElementById('hub-loading').innerHTML =
               '<div class="hub-empty-panel">' +
               '<div class="hub-kicker">My hub</div>' +
@@ -1417,7 +1419,9 @@
         const contentData = contentRes.ok ? await contentRes.json() : null;
         const perspectivesData = perspectivesRes.ok ? await perspectivesRes.json() : null;
         const journeyData = journeyRes.ok ? await journeyRes.json() : null;
-        const githubConnection = githubRes.ok ? await githubRes.json() : { connected: false };
+        const githubConnection = githubRes.status === 503
+          ? { connected: false, unavailable: true }
+          : githubRes.ok ? await githubRes.json() : { connected: false };
 
         renderHub({
           engagement: data,
@@ -2078,16 +2082,27 @@
       const rowStyle = 'display:flex; align-items:center; justify-content:space-between; gap:var(--space-4); flex-wrap:wrap;';
       const copyStyle = 'font-size:var(--text-sm); color:var(--color-text-secondary);';
       const statusStyle = 'font-size:var(--text-sm); color:#059669; font-weight:600;';
-      const githubRow = github.connected
-        ? `
+      const warnStyle = 'font-size:var(--text-sm); color:var(--color-text-secondary); font-style:italic;';
+      let githubRow;
+      if (github.connected) {
+        githubRow = `
           <div style="${rowStyle}">
             <div>
               <strong>GitHub</strong>
               <div style="${copyStyle}">Connected${github.login ? ` as <code>@${escapeHtml(github.login)}</code>` : ''}. Addie can file issues as you on <code>adcontextprotocol/adcp</code>.</div>
             </div>
             <span style="${statusStyle}">✓ Connected</span>
-          </div>`
-        : `
+          </div>`;
+      } else if (github.unavailable) {
+        githubRow = `
+          <div style="${rowStyle}">
+            <div>
+              <strong>GitHub</strong>
+              <div style="${warnStyle}">GitHub connection status is temporarily unavailable. Try again in a moment.</div>
+            </div>
+          </div>`;
+      } else {
+        githubRow = `
           <div style="${rowStyle}">
             <div>
               <strong>GitHub</strong>
@@ -2095,6 +2110,7 @@
             </div>
             <button type="button" class="btn btn-secondary" onclick="connectGitHub(this)">Connect GitHub</button>
           </div>`;
+      }
       return `${header}${githubRow}`;
     }
 

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -2074,14 +2074,14 @@
     // -------------------------------------------------------------------------
 
     function renderConnections(connections) {
-      const github = connections?.github || { connected: false };
+      const github = connections?.github ?? { connected: false };
       const header = `
         <div class="hub-card-header">
           <span class="hub-card-title">Connections</span>
         </div>`;
       const rowStyle = 'display:flex; align-items:center; justify-content:space-between; gap:var(--space-4); flex-wrap:wrap;';
       const copyStyle = 'font-size:var(--text-sm); color:var(--color-text-secondary);';
-      const statusStyle = 'font-size:var(--text-sm); color:#059669; font-weight:600;';
+      const statusStyle = 'font-size:var(--text-sm); color:var(--color-success-600); font-weight:600;';
       const warnStyle = 'font-size:var(--text-sm); color:var(--color-text-secondary); font-style:italic;';
       let githubRow;
       if (github.connected) {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7016,7 +7016,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       try {
         const account = await getGitHubConnectedAccount(req.user!.id);
         if (account.status === 'unavailable') {
-          return res.status(503).json({ connected: false, unavailable: true, reason: account.reason });
+          return res.status(503).json({ connected: false, unavailable: true });
         }
         if (account.status === 'not_connected') {
           return res.json({ connected: false });

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7015,7 +7015,10 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     this.app.get('/api/me/connected-accounts/github', requireAuth, async (req, res) => {
       try {
         const account = await getGitHubConnectedAccount(req.user!.id);
-        if (!account) {
+        if (account.status === 'unavailable') {
+          return res.status(503).json({ connected: false, unavailable: true, reason: account.reason });
+        }
+        if (account.status === 'not_connected') {
           return res.json({ connected: false });
         }
         return res.json({ connected: true, login: account.login ?? null });

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -55,7 +55,12 @@ export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: stri
   return data.url;
 }
 
-export async function getGitHubConnectedAccount(workosUserId: string): Promise<{ login?: string } | null> {
+export type ConnectedAccountResult =
+  | { status: 'connected'; login: string | undefined }
+  | { status: 'not_connected' }
+  | { status: 'unavailable'; reason: string };
+
+export async function getGitHubConnectedAccount(workosUserId: string): Promise<ConnectedAccountResult> {
   const workos = await getWorkos();
   try {
     const response = await workos.get(
@@ -68,11 +73,12 @@ export async function getGitHubConnectedAccount(workosUserId: string): Promise<{
       : typeof data?.external_handle === 'string'
         ? data.external_handle
         : undefined;
-    return { login: handle };
+    return { status: 'connected', login: handle };
   } catch (error) {
     const status = (error as { status?: number; code?: number })?.status ?? (error as { code?: number })?.code;
-    if (status === 404) return null;
+    if (status === 404) return { status: 'not_connected' };
+    const message = error instanceof Error ? error.message : String(error);
     logger.warn({ err: error, workosUserId }, 'Failed to look up Pipes connected account');
-    return null;
+    return { status: 'unavailable', reason: message };
   }
 }

--- a/server/tests/unit/pipes-connected-account.test.ts
+++ b/server/tests/unit/pipes-connected-account.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn();
+
+vi.mock('../../src/auth/workos-client.js', () => ({
+  workos: { get: mockGet },
+}));
+
+const { getGitHubConnectedAccount } = await import('../../src/services/pipes.js');
+
+describe('getGitHubConnectedAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns connected with login when WorkOS returns a connected account', async () => {
+    mockGet.mockResolvedValueOnce({ external_user_handle: 'octocat' });
+
+    const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result).toEqual({ status: 'connected', login: 'octocat' });
+  });
+
+  it('falls back to external_handle when external_user_handle is absent', async () => {
+    mockGet.mockResolvedValueOnce({ external_handle: 'octocat2' });
+
+    const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result).toEqual({ status: 'connected', login: 'octocat2' });
+  });
+
+  it('returns not_connected when WorkOS returns 404', async () => {
+    const err = Object.assign(new Error('Not Found'), { status: 404 });
+    mockGet.mockRejectedValueOnce(err);
+
+    const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result).toEqual({ status: 'not_connected' });
+  });
+
+  it('returns unavailable when WorkOS returns a 5xx error', async () => {
+    const err = Object.assign(new Error('Service Unavailable'), { status: 503 });
+    mockGet.mockRejectedValueOnce(err);
+
+    const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result.status).toBe('unavailable');
+  });
+
+  it('returns unavailable for network errors without a status code', async () => {
+    mockGet.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result.status).toBe('unavailable');
+  });
+});

--- a/server/tests/unit/pipes-connected-account.test.ts
+++ b/server/tests/unit/pipes-connected-account.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockGet = vi.fn();
 
+// vi.mock is hoisted before imports, so when pipes.ts lazily calls
+// import('../auth/workos-client.js') at runtime it gets this mock via
+// the module registry. Must remain a top-level vi.mock (not vi.doMock)
+// to preserve hoisting.
 vi.mock('../../src/auth/workos-client.js', () => ({
   workos: { get: mockGet },
 }));
@@ -45,6 +49,7 @@ describe('getGitHubConnectedAccount', () => {
     const result = await getGitHubConnectedAccount('user_123');
 
     expect(result.status).toBe('unavailable');
+    expect((result as { status: 'unavailable'; reason: string }).reason).toBeTruthy();
   });
 
   it('returns unavailable for network errors without a status code', async () => {
@@ -53,5 +58,6 @@ describe('getGitHubConnectedAccount', () => {
     const result = await getGitHubConnectedAccount('user_123');
 
     expect(result.status).toBe('unavailable');
+    expect((result as { status: 'unavailable'; reason: string }).reason).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #2997

## Summary

`getGitHubConnectedAccount` silently swallowed all non-404 WorkOS errors and returned `null`, causing the member-hub Connections card to render "Connect GitHub" during a WorkOS outage. A connected user who clicked the button would get double-consented by GitHub or hit a 502 on the authorize endpoint.

**Non-breaking justification:** All changes are confined to an internal server service and its single internal API consumer (`GET /api/me/connected-accounts/github`). The `not_connected` path still returns `{ connected: false }` — only the new `unavailable` branch changes, adding a 503 that callers treating any non-200 as an error fall back to their existing handler (no regression). No published AdCP protocol schema is touched.

## Changes

- **`server/src/services/pipes.ts`** — `getGitHubConnectedAccount` now returns a discriminated union `{ status: 'connected' | 'not_connected' | 'unavailable' }` instead of `{ login? } | null`. Non-404 WorkOS errors return `unavailable` (return, not throw — so the route's outer catch block never sees them as 500s).
- **`server/src/http.ts`** — Route returns HTTP 503 + `{ connected: false, unavailable: true }` when status is `unavailable`. `not_connected` still returns `{ connected: false }` with 200.
- **`server/public/membership/hub.html`** — `renderConnections` gains a third branch: when `github.unavailable` is true, shows "GitHub connection status is temporarily unavailable. Try again in a moment." and **omits the Connect button** entirely (prevents authorize-flow during outage). Both fetch-parse paths (workspace-joined and not-yet-joined) detect 503 before `res.ok`.
- **`server/tests/unit/pipes-connected-account.test.ts`** — 5 new vitest unit tests: connected (external_user_handle), connected (external_handle fallback), not_connected (404), unavailable (5xx), unavailable (network error with no status code).

## Expert consensus

internal-tools-strategist and dx-expert reviewed; both approved. Key notes incorporated: `unavailable` returns (not throws) to prevent outer catch serving 500; Connect button is absent (not just relabeled) during an outage.

Session: https://claude.ai/code/session_018jRAVqveiWaBF5wHGt2CUs

---
_Generated by [Claude Code](https://claude.ai/code/session_018jRAVqveiWaBF5wHGt2CUs)_