### PR TITLE
fix(addie): audit and remove always-available tool duplicates from set arrays

### DIFF
--- a/.changeset/fix-tool-set-always-available-overlap.md
+++ b/.changeset/fix-tool-set-always-available-overlap.md
@@ -1,0 +1,24 @@
+---
+---
+
+fix(addie): remove always-available tools from set arrays to prevent hallucinations
+
+Audits every TOOL_SETS[x].tools array against ALWAYS_AVAILABLE_TOOLS and
+ALWAYS_AVAILABLE_ADMIN_TOOLS, removing 9 duplicates that caused Sonnet to
+hallucinate capability unavailability when a set was not routed (#2998):
+
+- Removed propose_content, get_my_content, set_outreach_preference from member.tools
+- Removed list_pending_content, approve_content, reject_content from content.tools
+- Removed get_github_issue from knowledge.tools
+- Removed list_escalations, resolve_escalation from admin.tools
+
+Updated descriptions for member and content sets to not claim ownership of
+always-available capabilities.
+
+Expanded ALWAYS_AVAILABLE_BLURBS with 7 new entries (get_escalation_status,
+propose_content, get_my_content, list_pending_content, approve_content,
+reject_content, set_outreach_preference) so the correction section in the
+unavailable-sets hint explicitly covers the reclaimed tools.
+
+Added a tools-array invariant test that will fail if a future edit re-introduces
+a duplicate, unioning both ALWAYS_AVAILABLE_TOOLS and ALWAYS_AVAILABLE_ADMIN_TOOLS.

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -97,8 +97,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'get_recent_news',
       'fetch_url',
       'read_slack_file',
-      // GitHub read tools — issues, PRs, RFCs, epics
-      'get_github_issue',
+      // GitHub read tools — list/search issues, PRs, RFCs, epics.
+      // NOTE: get_github_issue is intentionally NOT listed here — it lives in
+      // ALWAYS_AVAILABLE_TOOLS and is reachable regardless of routing. Keeping
+      // it here caused Sonnet to hallucinate that reading individual issues was
+      // unavailable when `knowledge` wasn't selected. See #2998.
       'list_github_issues',
       // Schema validation tools
       'validate_json',
@@ -110,7 +113,13 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   member: {
     name: 'member',
-    description: 'Manage member profile, working groups, committees, content proposals, and account settings. Includes listing working group documents.',
+    // NOTE: propose_content, get_my_content, and set_outreach_preference are
+    // intentionally NOT listed here — neither in the description nor the tools
+    // array. They live in ALWAYS_AVAILABLE_TOOLS and are reachable in every
+    // conversation. Duplicating them here caused Sonnet to hallucinate that
+    // content submission/retrieval and outreach preferences were unavailable
+    // when the router didn't pick `member`. See #2998.
+    description: 'Manage member profile, working groups, committees, and account settings. Includes listing working group documents and attaching assets to content.',
     tools: [
       'get_my_profile',
       'update_my_profile',
@@ -126,11 +135,8 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'get_my_council_interests',
       'list_perspectives',
       'create_working_group_post',
-      'propose_content',
       'attach_content_asset',
-      'get_my_content',
       'bookmark_resource',
-      'set_outreach_preference',
       'draft_social_posts',
       'list_committee_documents',
     ],
@@ -203,12 +209,16 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     // intentionally NOT listed here — neither in the description nor the tools
     // array. Duplicating it caused Addie to hallucinate "I can't file GitHub
     // issues" when the router didn't pick `content`.
-    description: 'Manage content workflows - propose news sources, handle content approvals, add or update committee documents (admin actions)',
+    //
+    // NOTE: list_pending_content, approve_content, and reject_content are also
+    // intentionally NOT listed here. They live in ALWAYS_AVAILABLE_TOOLS so
+    // content review is reachable in every conversation. Keeping them here
+    // (and saying "handle content approvals" in the description) caused Sonnet
+    // to hallucinate that approval tools were unavailable when `content` wasn't
+    // selected. See #2998.
+    description: 'Manage content workflows — propose news sources, add or update committee documents (admin actions)',
     tools: [
       'propose_news_source',
-      'list_pending_content',
-      'approve_content',
-      'reject_content',
       'add_committee_document',
       'update_committee_document',
       'delete_committee_document',
@@ -279,6 +289,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 
   admin: {
     name: 'admin',
+    // NOTE: list_escalations and resolve_escalation are intentionally NOT listed
+    // here — they live in ALWAYS_AVAILABLE_ADMIN_TOOLS and are reachable for
+    // admins regardless of routing. Duplicating them here caused Sonnet to
+    // hallucinate that escalation management was unavailable when `admin` wasn't
+    // selected. See #2998.
     description: 'Administrative operations - manage prospects, organizations, feeds, escalations, user roles, committee/working group leadership, event management (create/update events, manage registrations, invites, attendee lists), member insights and engagement analytics, community-wide engagement ranking (admin only)',
     tools: [
       // Event management (admin)
@@ -317,8 +332,6 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'check_domain_health',
       'manage_organization_domains',
       'update_org_member_role',
-      'list_escalations',
-      'resolve_escalation',
       'claim_prospect',
       'triage_prospect_domain',
       'suggest_prospects',
@@ -472,6 +485,13 @@ export function buildUnavailableSetsHint(selectedSets: string[], isAAOAdmin: boo
     create_github_issue: "filing an issue directly under the member's GitHub account (if connected)",
     get_github_issue: 'reading a GitHub issue or PR by number or URL',
     escalate_to_admin: 'handing the thread to a human admin',
+    get_escalation_status: 'checking the status of an escalation the member filed',
+    propose_content: 'submitting a content draft for publication',
+    get_my_content: 'viewing the member\'s own submitted content and proposals',
+    list_pending_content: 'listing content items awaiting review',
+    approve_content: 'approving a pending content item (admin)',
+    reject_content: 'rejecting a pending content item (admin)',
+    set_outreach_preference: 'opting out of proactive outreach messages',
   };
   const alwaysAvailableReminder = Object.entries(ALWAYS_AVAILABLE_BLURBS)
     .filter(([tool]) => ALWAYS_AVAILABLE_TOOLS.includes(tool))

--- a/server/tests/unit/addie/tool-sets.test.ts
+++ b/server/tests/unit/addie/tool-sets.test.ts
@@ -86,6 +86,29 @@ describe('getToolsForSets', () => {
       expect(TOOL_SETS.content.description).not.toMatch(/github issue/i);
     });
   });
+
+  describe('ALWAYS_AVAILABLE overlap invariant', () => {
+    it('no always-available tool (regular or admin) appears in any set tools array', () => {
+      // If a guaranteed tool is also in a set's tools array, that set's
+      // description will (by construction) describe that capability. When the
+      // set appears in the unavailable-sets hint, Sonnet reads the description
+      // and hallucinates that the capability is off — even though the tool is
+      // loaded via ALWAYS_AVAILABLE_TOOLS or ALWAYS_AVAILABLE_ADMIN_TOOLS.
+      // Keeping these arrays disjoint is the only way to prevent that class of
+      // hallucination. See #2998.
+      const always = new Set([...ALWAYS_AVAILABLE_TOOLS, ...ALWAYS_AVAILABLE_ADMIN_TOOLS]);
+      for (const [setName, set] of Object.entries(TOOL_SETS)) {
+        for (const tool of set.tools) {
+          expect(
+            always.has(tool),
+            `${setName}.tools contains "${tool}" which is also in ALWAYS_AVAILABLE_TOOLS or ALWAYS_AVAILABLE_ADMIN_TOOLS. ` +
+            `Remove it from the set's tools array — it is already guaranteed and duplicating it ` +
+            `causes Sonnet to hallucinate unavailability from set descriptions.`,
+          ).toBe(false);
+        }
+      }
+    });
+  });
 });
 
 describe('buildUnavailableSetsHint', () => {


### PR DESCRIPTION
Closes #2998

## Summary

PR #2979 fixed the specific Addie hallucination where `get_github_issue`/`draft_github_issue`/`create_github_issue` were duplicated between `ALWAYS_AVAILABLE_TOOLS` and a set's `tools` array. The same pattern existed in 9 other places. This PR completes the systematic audit.

**Root cause:** When a tool appears in both `ALWAYS_AVAILABLE_TOOLS` and a set's `tools` array, the set's description (by construction) describes that capability. When the set lands in the "Capabilities Not Available" hint, Sonnet reads the description and hallucinates the capability is off — even though the tool is loaded via `ALWAYS_AVAILABLE_TOOLS`.

## Changes

**`server/src/addie/tool-sets.ts`**
- `member.tools`: remove `propose_content`, `get_my_content`, `set_outreach_preference`
- `content.tools`: remove `list_pending_content`, `approve_content`, `reject_content`
- `knowledge.tools`: remove `get_github_issue`
- `admin.tools`: remove `list_escalations`, `resolve_escalation`
- Reword `member` and `content` descriptions to not claim ownership of always-available capabilities
- Expand `ALWAYS_AVAILABLE_BLURBS` with 7 new entries: `get_escalation_status`, `propose_content`, `get_my_content`, `list_pending_content`, `approve_content`, `reject_content`, `set_outreach_preference`

**`server/tests/unit/addie/tool-sets.test.ts`**
- Add tools-array invariant test: asserts no tool in `ALWAYS_AVAILABLE_TOOLS` ∪ `ALWAYS_AVAILABLE_ADMIN_TOOLS` appears in any set's `tools` array. Fails loudly with the exact set and tool name. This replaces the hand-auditing the issue requested as a "spreadsheet" — it's zero-maintenance and catches future regressions automatically.

## Non-breaking justification

All removed tools remain reachable in every conversation via `ALWAYS_AVAILABLE_TOOLS` / `ALWAYS_AVAILABLE_ADMIN_TOOLS`. Removing from set arrays is strictly a deduplication with no functional change to what tools Sonnet can call. `getToolsForSets` builds the final tool list as a `Set`, so ALWAYS_AVAILABLE already guarantees these tools are loaded regardless of routing.

## Expert consensus

prompt-engineer and adtech-product-expert reviewed; both approved. Key finding: `propose_content`/`get_my_content` is the highest-priority fix (content submission is the primary member workflow and the hallucination destroys trust at the moment a member is most invested).

Session: https://claude.ai/code/session_01Qyi4Qs9RU6WkxmMxQ3yjrv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyi4Qs9RU6WkxmMxQ3yjrv)_