### PR TITLE
refactor(server): lazy-init WorkOS client via getWorkos() factory

### DIFF
--- a/.changeset/workos-lazy-init-factory.md
+++ b/.changeset/workos-lazy-init-factory.md
@@ -1,0 +1,4 @@
+---
+---
+
+Refactor `workos-client.ts` to a lazy-init factory (`getWorkos()`), removing the module-load throw that broke test suites. Converts all dynamic-import workarounds back to static imports.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -78,7 +78,7 @@ import {
   type BillingProduct,
 } from '../../billing/stripe-client.js';
 import { mergeOrganizations, previewMerge, type StripeCustomerResolution } from '../../db/org-merge-db.js';
-import { workos } from '../../auth/workos-client.js';
+import { getWorkos } from '../../auth/workos-client.js';
 import { DomainDataState } from '@workos-inc/node';
 import { processInteraction, type InteractionContext } from '../services/interaction-analyzer.js';
 import {
@@ -4896,6 +4896,7 @@ Use add_committee_leader to assign a leader.`;
 
   // Merge organizations
   handlers.set('merge_organizations', async (input) => {
+    const workos = getWorkos();
 
     const primaryOrgId = input.primary_org_id as string;
     const secondaryOrgId = input.secondary_org_id as string;
@@ -5244,7 +5245,10 @@ Use add_committee_leader to assign a leader.`;
       return '❌ organization_id is required. Use lookup_organization to find the org ID first.';
     }
 
-    if (!workos) {
+    let workos: ReturnType<typeof getWorkos>;
+    try {
+      workos = getWorkos();
+    } catch {
       return '❌ WorkOS is not configured. Domain management requires WorkOS to be set up.';
     }
 
@@ -5539,7 +5543,10 @@ Use add_committee_leader to assign a leader.`;
       return '❌ role must be "member", "admin", or "owner".';
     }
 
-    if (!workos) {
+    let workos: ReturnType<typeof getWorkos>;
+    try {
+      workos = getWorkos();
+    } catch {
       return '❌ WorkOS is not configured.';
     }
 

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -14,7 +14,7 @@ import { AddieDatabase } from '../db/addie-db.js';
 import { JoinRequestDatabase } from '../db/join-request-db.js';
 import { OrgKnowledgeDatabase } from '../db/org-knowledge-db.js';
 import { getThreadService } from './thread-service.js';
-import { workos } from '../auth/workos-client.js';
+import { getWorkos } from '../auth/workos-client.js';
 import { isDevModeEnabled, DEV_USERS } from '../middleware/auth.js';
 import { logger } from '../logger.js';
 import { getPool, query } from '../db/client.js';
@@ -370,7 +370,7 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
     // Step 3: Get WorkOS user info
     let workosUser;
     try {
-      workosUser = await workos.userManagement.getUser(slackMapping.workos_user_id);
+      workosUser = await getWorkos().userManagement.getUser(slackMapping.workos_user_id);
       context.workos_user = {
         workos_user_id: workosUser.id,
         email: workosUser.email,
@@ -387,7 +387,7 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
     let userRole: string = 'member';
     let userJoinedAt: Date | null = null;
     try {
-      const memberships = await workos.userManagement.listOrganizationMemberships({
+      const memberships = await getWorkos().userManagement.listOrganizationMemberships({
         userId: slackMapping.workos_user_id,
       });
 
@@ -413,7 +413,7 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
     // Step 4b: Get org member count from WorkOS
     let memberCount = 0;
     try {
-      const orgMemberships = await workos.userManagement.listOrganizationMemberships({
+      const orgMemberships = await getWorkos().userManagement.listOrganizationMemberships({
         organizationId: organizationId,
       });
       memberCount = orgMemberships.data?.length || 0;
@@ -902,7 +902,7 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
     // Step 1: Get WorkOS user info
     let workosUser;
     try {
-      workosUser = await workos.userManagement.getUser(workosUserId);
+      workosUser = await getWorkos().userManagement.getUser(workosUserId);
       context.workos_user = {
         workos_user_id: workosUser.id,
         email: workosUser.email,
@@ -948,7 +948,7 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
     let userRole: string = 'member';
     let userJoinedAt: Date | null = null;
     try {
-      const memberships = await workos.userManagement.listOrganizationMemberships({
+      const memberships = await getWorkos().userManagement.listOrganizationMemberships({
         userId: workosUserId,
       });
 
@@ -973,7 +973,7 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
     // Step 4: Get org member count from WorkOS
     let memberCount = 0;
     try {
-      const orgMemberships = await workos.userManagement.listOrganizationMemberships({
+      const orgMemberships = await getWorkos().userManagement.listOrganizationMemberships({
         organizationId: organizationId,
       });
       memberCount = orgMemberships.data?.length || 0;

--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -4,28 +4,30 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('workos-client');
 
-if (!process.env.WORKOS_API_KEY) {
-  throw new Error('WORKOS_API_KEY environment variable is required');
-}
+let _workos: WorkOS | null = null;
+let _clientId = '';
 
-if (!process.env.WORKOS_CLIENT_ID) {
-  throw new Error('WORKOS_CLIENT_ID environment variable is required');
+/** Returns the shared WorkOS client. Constructed on first call; WORKOS_API_KEY and WORKOS_CLIENT_ID must be set by then. */
+export function getWorkos(): WorkOS {
+  if (!_workos) {
+    if (!process.env.WORKOS_API_KEY) throw new Error('WORKOS_API_KEY environment variable is required');
+    if (!process.env.WORKOS_CLIENT_ID) throw new Error('WORKOS_CLIENT_ID environment variable is required');
+    _clientId = process.env.WORKOS_CLIENT_ID;
+    _workos = new WorkOS(process.env.WORKOS_API_KEY, { clientId: _clientId });
+  }
+  return _workos;
 }
-
-export const workos = new WorkOS(process.env.WORKOS_API_KEY, {
-  clientId: process.env.WORKOS_CLIENT_ID!,
-});
-export const clientId = process.env.WORKOS_CLIENT_ID!;
 
 /**
  * Get the authorization URL to redirect users to WorkOS for authentication
  */
 export function getAuthorizationUrl(state?: string): string {
+  const workos = getWorkos();
   const redirectUri = process.env.WORKOS_REDIRECT_URI || 'http://localhost:3000/auth/callback';
 
   return workos.userManagement.getAuthorizationUrl({
     provider: 'authkit',
-    clientId,
+    clientId: _clientId,
     redirectUri,
     state,
   });
@@ -38,13 +40,14 @@ export async function authenticateWithCode(code: string): Promise<{
   user: WorkOSUser;
   sealedSession: string;
 }> {
+  const workos = getWorkos();
   const redirectUri = process.env.WORKOS_REDIRECT_URI || 'http://localhost:3000/auth/callback';
 
   logger.debug('Authenticating with authorization code');
 
   const { user, sealedSession } =
     await workos.userManagement.authenticateWithCode({
-      clientId,
+      clientId: _clientId,
       code,
       session: {
         sealSession: true,
@@ -72,6 +75,7 @@ export async function authenticateWithCode(code: string): Promise<{
  * Get user info from access token
  */
 export async function getUser(accessToken: string): Promise<WorkOSUser> {
+  const workos = getWorkos();
   const user = await workos.userManagement.getUser(accessToken);
 
   return {
@@ -95,6 +99,8 @@ export async function loadSealedSession(sessionData: string): Promise<{
 }> {
   try {
     logger.debug('Validating sealed session');
+
+    const workos = getWorkos();
 
     // Use WorkOS's authenticateWithSessionCookie to validate and unseal
     // Note: clientId is configured in the WorkOS instance, not passed here
@@ -136,8 +142,9 @@ export async function refreshToken(refreshToken: string): Promise<{
   accessToken: string;
   refreshToken: string;
 }> {
+  const workos = getWorkos();
   const response = await workos.userManagement.authenticateWithRefreshToken({
-    clientId,
+    clientId: _clientId,
     refreshToken,
     session: {
       sealSession: true,
@@ -160,10 +167,11 @@ export async function authenticateWithCodeForTokens(code: string): Promise<{
   refreshToken: string;
   user: WorkOSUser;
 }> {
+  const workos = getWorkos();
   logger.debug('Authenticating with code for tokens (MCP flow)');
 
   const result = await workos.userManagement.authenticateWithCode({
-    clientId,
+    clientId: _clientId,
     code,
   });
 
@@ -192,8 +200,9 @@ export async function refreshTokenRaw(refreshTokenValue: string): Promise<{
   accessToken: string;
   refreshToken: string;
 }> {
+  const workos = getWorkos();
   const response = await workos.userManagement.authenticateWithRefreshToken({
-    clientId,
+    clientId: _clientId,
     refreshToken: refreshTokenValue,
   });
 
@@ -210,6 +219,7 @@ export async function refreshTokenRaw(refreshTokenValue: string): Promise<{
  * happens only via explicit OAuth login.
  */
 export async function findOrCreateUserByEmail(email: string): Promise<WorkOSUser> {
+  const workos = getWorkos();
   const normalized = email.trim().toLowerCase();
 
   const toUser = (u: {

--- a/server/src/mcp/oauth-provider.ts
+++ b/server/src/mcp/oauth-provider.ts
@@ -19,6 +19,7 @@ import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.
 import { decodeJwt } from 'jose';
 import { createLogger } from '../logger.js';
 import { verifyWorkOSJWT } from '../auth/workos-jwt.js';
+import { getAuthorizationUrl, refreshTokenRaw, authenticateWithCodeForTokens } from '../auth/workos-client.js';
 import * as mcpClientsDb from '../db/mcp-clients-db.js';
 import * as mcpOAuthStateDb from '../db/mcp-oauth-state-db.js';
 
@@ -129,7 +130,6 @@ class MCPOAuthProvider implements OAuthServerProvider {
     });
 
     // Redirect to AuthKit via WorkOS SDK (reuses existing WORKOS_REDIRECT_URI)
-    const { getAuthorizationUrl } = await import('../auth/workos-client.js');
     const workosState = JSON.stringify({ mcp_pending_id: pendingId });
     const authUrl = getAuthorizationUrl(workosState);
 
@@ -188,7 +188,6 @@ class MCPOAuthProvider implements OAuthServerProvider {
     _scopes?: string[],
     _resource?: URL,
   ): Promise<OAuthTokens> {
-    const { refreshTokenRaw } = await import('../auth/workos-client.js');
     const result = await refreshTokenRaw(refreshTokenValue);
     return {
       access_token: result.accessToken,
@@ -241,9 +240,8 @@ export async function handleMCPOAuthCallback(
   }
 
   // Exchange WorkOS code for tokens
-  let authResult: Awaited<ReturnType<typeof import('../auth/workos-client.js').authenticateWithCodeForTokens>>;
+  let authResult: Awaited<ReturnType<typeof authenticateWithCodeForTokens>>;
   try {
-    const { authenticateWithCodeForTokens } = await import('../auth/workos-client.js');
     authResult = await authenticateWithCodeForTokens(workosCode);
   } catch (err) {
     logger.error({ err, mcpPendingId }, 'MCP OAuth: Failed to exchange WorkOS code');

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -6,7 +6,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { query, getPool } from '../db/client.js';
 import { mergeUsers } from '../db/user-merge-db.js';
 import { sendEmailLinkVerification } from '../notifications/email.js';
-import { workos } from '../auth/workos-client.js';
+import { getWorkos } from '../auth/workos-client.js';
 import { CachedPostgresStore } from '../middleware/pg-rate-limit-store.js';
 
 const logger = createLogger('account-linking');
@@ -278,7 +278,7 @@ export function createAccountLinkingRouter(): Router {
       // If WorkOS rejects the update the outer catch handles the error;
       // the DB change is already committed, and the user.updated webhook
       // will re-sync on the next WorkOS event if needed.
-      await workos.userManagement.updateUser({ userId, email: aliasEmail });
+      await getWorkos().userManagement.updateUser({ userId, email: aliasEmail });
 
       logger.info(
         { userId, oldPrimary, newPrimary: aliasEmail },

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -410,7 +410,7 @@ export function handleEmailLinkVerification(app: {
             tokenRecord.primary_workos_user_id,
             tokenRecord.target_workos_user_id,
             tokenRecord.primary_workos_user_id,
-            workos
+            getWorkos()
           );
         }
 

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -22,6 +22,7 @@ import { ModelConfig } from "../config/models.js";
 import { AddieRouter, type RoutingContext } from "../addie/router.js";
 import { sanitizeInput } from "../addie/security.js";
 import { runSlackHistoryBackfill } from "../addie/jobs/slack-history-backfill.js";
+import { getWorkos } from "../auth/workos-client.js";
 import {
   resolveSlackUserDisplayName,
   resolveSlackUserDisplayNames,
@@ -1423,7 +1424,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
         targetUserId = slack_user_id as string;
       } else {
         // Look up WorkOS user by ID or email
-        const { workos } = await import("../auth/workos-client.js");
+        const workos = getWorkos();
 
         let workosUserId: string;
 
@@ -1431,7 +1432,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
           workosUserId = user_id as string;
         } else if (email) {
           // Look up user by email
-          const users = await workos!.userManagement.listUsers({
+          const users = await workos.userManagement.listUsers({
             email: email as string,
           });
 

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -35,6 +35,7 @@ import {
   refreshReviewCardForOrg,
 } from "../../addie/jobs/announcement-handlers.js";
 import { WorkOS } from "@workos-inc/node";
+import { getWorkos } from "../../auth/workos-client.js";
 import {
   MEMBER_FILTER_ALIASED,
   NOT_MEMBER_ALIASED,
@@ -2157,15 +2158,7 @@ export function setupAccountRoutes(
           });
         }
 
-        // Dynamic import of WorkOS client since it may not be available in all environments
-        const { workos } = await import("../../auth/workos-client.js");
-
-        if (!workos) {
-          return res.status(503).json({
-            error: "Service unavailable",
-            message: "WorkOS client not configured",
-          });
-        }
+        const workos = getWorkos();
 
         const results: {
           user_id: string;
@@ -2327,10 +2320,7 @@ export function setupAccountRoutes(
 
         // If membership ID is missing locally, look it up from WorkOS and backfill
         if (!membership.workos_membership_id) {
-          const { workos: workosClient } = await import("../../auth/workos-client.js");
-          if (!workosClient) {
-            return res.status(500).json({ error: "WorkOS client not configured" });
-          }
+          const workosClient = getWorkos();
           try {
             const memberships = await workosClient.userManagement.listOrganizationMemberships({
               userId,
@@ -2389,10 +2379,7 @@ export function setupAccountRoutes(
         }
 
         // Update role via WorkOS API
-        const { workos } = await import("../../auth/workos-client.js");
-        if (!workos) {
-          return res.status(500).json({ error: "WorkOS client not configured" });
-        }
+        const workos = getWorkos();
 
         // Verify membership belongs to the specified organization via WorkOS
         let existingMembership;

--- a/server/src/routes/admin/cleanup.ts
+++ b/server/src/routes/admin/cleanup.ts
@@ -13,7 +13,7 @@ import {
 import { isLushaConfigured } from "../../services/lusha.js";
 import { mergeOrganizations, previewMerge, StripeCustomerResolution } from "../../db/org-merge-db.js";
 import { getPool } from "../../db/client.js";
-import { workos } from "../../auth/workos-client.js";
+import { getWorkos } from "../../auth/workos-client.js";
 
 const logger = createLogger("admin-cleanup");
 
@@ -304,7 +304,7 @@ export function setupCleanupRoutes(apiRouter: Router): void {
         primary_org_id,
         secondary_org_id,
         userId,
-        workos,
+        getWorkos(),
         stripe_customer_resolution ? { stripeCustomerResolution: stripe_customer_resolution } : undefined
       );
 

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -21,7 +21,7 @@
 import { Router, Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { getPool } from '../db/client.js';
-import { workos } from '../auth/workos-client.js';
+import { getWorkos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { tryAutoLinkWebsiteUserToSlack } from '../slack/sync.js';
 import { triageAndNotify } from '../services/prospect-triage.js';
@@ -96,7 +96,7 @@ async function upsertMembership(
   let userData = user;
   if (!userData) {
     try {
-      const workosUser = await workos.userManagement.getUser(membership.user_id);
+      const workosUser = await getWorkos().userManagement.getUser(membership.user_id);
       userData = {
         id: workosUser.id,
         email: workosUser.email,
@@ -140,7 +140,7 @@ async function upsertMembership(
   // If the DB promoted this member to owner, sync the change to WorkOS
   if (assigned_role === 'owner' && role === 'member') {
     try {
-      await workos.userManagement.updateOrganizationMembership(membership.id, {
+      await getWorkos().userManagement.updateOrganizationMembership(membership.id, {
         roleSlug: 'owner',
       });
       logger.info({
@@ -189,19 +189,19 @@ async function deleteMembership(membership: OrganizationMembershipData): Promise
       // Promote in WorkOS first, then mirror locally
       let promotedInWorkos = false;
       if (target.workos_membership_id) {
-        await workos.userManagement.updateOrganizationMembership(
+        await getWorkos().userManagement.updateOrganizationMembership(
           target.workos_membership_id,
           { roleSlug: 'owner' }
         );
         promotedInWorkos = true;
       } else {
         // No cached membership ID — look it up from WorkOS
-        const memberships = await workos.userManagement.listOrganizationMemberships({
+        const memberships = await getWorkos().userManagement.listOrganizationMemberships({
           organizationId: membership.organization_id,
           userId: target.workos_user_id,
         });
         if (memberships.data.length > 0) {
-          await workos.userManagement.updateOrganizationMembership(
+          await getWorkos().userManagement.updateOrganizationMembership(
             memberships.data[0].id,
             { roleSlug: 'owner' }
           );
@@ -686,7 +686,7 @@ export function createWorkOSWebhooksRouter(): Router {
         }
 
         try {
-          await workos.webhooks.constructEvent({
+          await getWorkos().webhooks.constructEvent({
             payload: req.body,
             sigHeader,
             secret: WORKOS_WEBHOOK_SECRET,
@@ -707,7 +707,7 @@ export function createWorkOSWebhooksRouter(): Router {
             if (membership.status === 'active') {
               let workosUser: any;
               try {
-                workosUser = await workos.userManagement.getUser(membership.user_id);
+                workosUser = await getWorkos().userManagement.getUser(membership.user_id);
               } catch (error) {
                 logger.debug({ error, userId: membership.user_id }, 'Could not fetch user for auto-link on membership');
               }
@@ -944,7 +944,7 @@ export async function backfillOrganizationMemberships(): Promise<{
           // Fetch users for this org from WorkOS
           let after: string | undefined;
           do {
-            const usersResponse = await workos.userManagement.listUsers({
+            const usersResponse = await getWorkos().userManagement.listUsers({
               organizationId: org.workos_organization_id,
               limit: 100,
               after,
@@ -953,7 +953,7 @@ export async function backfillOrganizationMemberships(): Promise<{
             for (const user of usersResponse.data) {
               try {
                 // Get the membership ID for this user in this org
-                const membershipsResponse = await workos.userManagement.listOrganizationMemberships({
+                const membershipsResponse = await getWorkos().userManagement.listOrganizationMemberships({
                   userId: user.id,
                 });
 
@@ -1102,7 +1102,7 @@ export async function backfillUsers(): Promise<{
     try {
       let after: string | undefined;
       do {
-        const usersResponse = await workos.userManagement.listUsers({
+        const usersResponse = await getWorkos().userManagement.listUsers({
           limit: 100,
           after,
         });
@@ -1141,7 +1141,7 @@ export async function backfillUsers(): Promise<{
         try {
           let orgAfter: string | undefined;
           do {
-            const usersResponse = await workos.userManagement.listUsers({
+            const usersResponse = await getWorkos().userManagement.listUsers({
               organizationId: org.workos_organization_id,
               limit: 100,
               after: orgAfter,
@@ -1186,7 +1186,7 @@ export async function backfillUsers(): Promise<{
       for (const row of candidates) {
         try {
           // Confirm the user is actually gone from WorkOS before deleting
-          await workos.userManagement.getUser(row.workos_user_id);
+          await getWorkos().userManagement.getUser(row.workos_user_id);
           // User still exists in WorkOS — skip deletion
           result.usersSkipped++;
         } catch (getErr: any) {
@@ -1266,7 +1266,7 @@ export async function backfillOrganizationDomains(): Promise<{
 
       await Promise.all(batch.map(async (org) => {
         try {
-          const workosOrg = await workos.organizations.getOrganization(org.workos_organization_id);
+          const workosOrg = await getWorkos().organizations.getOrganization(org.workos_organization_id);
 
           // Map WorkOS SDK response to the shape syncOrganizationDomains expects
           const orgData: OrganizationData = {

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -1,16 +1,9 @@
 import { createLogger } from '../logger.js';
+import { getWorkos } from '../auth/workos-client.js';
 
 const logger = createLogger('pipes');
 
 const GITHUB_PROVIDER = 'github';
-
-// Lazy-load the WorkOS client so importing this module doesn't trip the
-// `WORKOS_API_KEY` check at module-load time (tests transitively import pipes
-// via member-tools.ts and don't all set WorkOS env).
-async function getWorkos() {
-  const mod = await import('../auth/workos-client.js');
-  return mod.workos;
-}
 
 export type PipesTokenResult =
   | { status: 'ok'; accessToken: string; scopes: string[]; missingScopes: string[] }
@@ -18,7 +11,7 @@ export type PipesTokenResult =
   | { status: 'needs_reauthorization'; missingScopes: string[] };
 
 export async function getGitHubAccessToken(workosUserId: string): Promise<PipesTokenResult> {
-  const workos = await getWorkos();
+  const workos = getWorkos();
   const result = await workos.pipes.getAccessToken({
     provider: GITHUB_PROVIDER,
     userId: workosUserId,
@@ -41,7 +34,7 @@ export async function getGitHubAccessToken(workosUserId: string): Promise<PipesT
 }
 
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
-  const workos = await getWorkos();
+  const workos = getWorkos();
   const response = await workos.post<{ user_id: string; return_to: string }>(
     `/data-integrations/${GITHUB_PROVIDER}/authorize`,
     { user_id: workosUserId, return_to: returnTo },
@@ -61,7 +54,7 @@ export type ConnectedAccountResult =
   | { status: 'unavailable'; reason: string };
 
 export async function getGitHubConnectedAccount(workosUserId: string): Promise<ConnectedAccountResult> {
-  const workos = await getWorkos();
+  const workos = getWorkos();
   try {
     const response = await workos.get(
       `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,

--- a/server/src/slack/sync.ts
+++ b/server/src/slack/sync.ts
@@ -15,7 +15,7 @@ import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { invalidateMemberContextCache } from '../addie/index.js';
 import { invalidateAdminStatusCache, invalidateWebAdminStatusCache } from '../addie/mcp/admin-tools.js';
 import { getPool } from '../db/client.js';
-import { workos } from '../auth/workos-client.js';
+import { getWorkos } from '../auth/workos-client.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
 import type { SyncSlackUsersResult } from './types.js';
 
@@ -27,8 +27,8 @@ const workingGroupDb = new WorkingGroupDatabase();
  * the first member gets 'owner' to prevent ownerless orgs.
  */
 async function roleForNewMember(orgId: string): Promise<'owner' | 'member'> {
-  if (!workos) return 'member';
   try {
+    const workos = getWorkos();
     const memberships = await workos.userManagement.listOrganizationMemberships({
       organizationId: orgId,
       statuses: ['active', 'inactive', 'pending'],
@@ -673,7 +673,7 @@ export async function checkAndAssignOrganizationByDomain(
       'Adding user to organization based on email domain'
     );
 
-    await workos.userManagement.createOrganizationMembership({
+    await getWorkos().userManagement.createOrganizationMembership({
       userId: workosUserId,
       organizationId: targetOrgId,
       roleSlug: role,
@@ -857,7 +857,7 @@ export async function autoAddVerifiedDomainUsersAsMembers(): Promise<{
     try {
       let after: string | undefined;
       do {
-        const memberships = await workos.userManagement.listOrganizationMemberships({
+        const memberships = await getWorkos().userManagement.listOrganizationMemberships({
           organizationId: orgId,
           statuses: ['active', 'inactive', 'pending'],
           limit: 100,
@@ -888,7 +888,7 @@ export async function autoAddVerifiedDomainUsersAsMembers(): Promise<{
       const role = hasAdmin ? 'member' : 'owner';
 
       try {
-        await workos.userManagement.createOrganizationMembership({
+        await getWorkos().userManagement.createOrganizationMembership({
           userId: user.workos_user_id,
           organizationId: orgId,
           roleSlug: role,

--- a/server/tests/unit/pipes-connected-account.test.ts
+++ b/server/tests/unit/pipes-connected-account.test.ts
@@ -1,13 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockGet = vi.fn();
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
 
-// vi.mock is hoisted before imports, so when pipes.ts lazily calls
-// import('../auth/workos-client.js') at runtime it gets this mock via
-// the module registry. Must remain a top-level vi.mock (not vi.doMock)
-// to preserve hoisting.
 vi.mock('../../src/auth/workos-client.js', () => ({
-  workos: { get: mockGet },
+  getWorkos: () => ({ get: mockGet }),
 }));
 
 const { getGitHubConnectedAccount } = await import('../../src/services/pipes.js');

--- a/server/tests/unit/set-primary-email.test.ts
+++ b/server/tests/unit/set-primary-email.test.ts
@@ -34,7 +34,7 @@ describe('Set primary email endpoint', () => {
   });
 
   it('updates WorkOS as source of truth', () => {
-    expect(source).toMatch(/workos\.userManagement\.updateUser/);
+    expect(source).toMatch(/getWorkos\(\)\.userManagement\.updateUser/);
   });
 
   it('swaps emails in a transaction', () => {
@@ -55,7 +55,7 @@ describe('Set primary email endpoint', () => {
 
   it('does WorkOS update after DB transaction to avoid holding connections during network calls', () => {
     const commitIdx = source.indexOf("'COMMIT'");
-    const workosIdx = source.indexOf('workos.userManagement.updateUser');
+    const workosIdx = source.indexOf('getWorkos().userManagement.updateUser');
     expect(workosIdx).toBeGreaterThan(commitIdx);
   });
 


### PR DESCRIPTION
Closes #2996

## Summary

`server/src/auth/workos-client.ts` threw at module load if `WORKOS_API_KEY` was unset. PR #2967 worked around this with `await import()` in `pipes.ts`, but the pattern was spreading to `oauth-provider.ts`, `addie-admin.ts`, and `accounts.ts`, adding an async hop per call and hiding the dependency from static analysis.

This PR fixes the root cause: replace the eager `export const workos` with a `getWorkos()` factory that constructs and caches the client on first call, throwing only when called without the env vars set. All 11 call sites are updated; two dead `if (!workos)` guards (in `admin-tools.ts` and `sync.ts`) are replaced with the surrounding try/catch.

**Files changed:**
- `server/src/auth/workos-client.ts` — factory (core fix)
- `server/src/services/pipes.ts` — static import restored, `await` removed (acceptance criteria)
- `server/src/mcp/oauth-provider.ts` — 3 dynamic imports → static
- `server/src/routes/addie-admin.ts` — dynamic import → static
- `server/src/routes/admin/accounts.ts` — 3 dynamic imports → static
- `server/src/slack/sync.ts` — dead `if (!workos)` guard folded into try/catch
- `server/src/addie/mcp/admin-tools.ts` — 2 dead guards replaced; `merge_organizations` handler gets early `const workos = getWorkos()`
- `server/src/addie/member-context.ts`, `server/src/routes/account-linking.ts`, `server/src/routes/workos-webhooks.ts`, `server/src/routes/admin/cleanup.ts` — static import update

**Non-breaking justification:** all changes are internal server module wiring; no public AdCP protocol surface (schemas, task definitions, exported API types) is touched. Existing callers of the named-function exports (`getAuthorizationUrl`, `authenticateWithCode`, etc.) are unaffected.

**Expert consensus:** ad-tech-protocol-expert not applicable (no protocol surface). code-reviewer and dx-expert both reviewed; both approved Option 1 (factory). Blockers they identified — the dead guards in `sync.ts` and `admin-tools.ts` and the spreading dynamic-import pattern in `oauth-provider.ts` and `accounts.ts` — are all resolved in this PR.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmLeVRhhYqBS7LF3oU7uDh)_