### PR TITLE
ci: stop emailing PR authors about unreleased-schema warnings

### DIFF
--- a/.changeset/quiet-schema-link-warnings.md
+++ b/.changeset/quiet-schema-link-warnings.md
@@ -1,0 +1,7 @@
+---
+---
+
+Schema link check only comments on PRs for actionable errors. Warnings
+("schema exists in source but not yet released") now go to the workflow job
+summary instead of a PR comment — they self-resolve on the next release and
+were generating email noise on every schema-touching docs PR.

--- a/.github/workflows/check-schema-links.yml
+++ b/.github/workflows/check-schema-links.yml
@@ -169,21 +169,34 @@ jobs:
           COMMIT_MSG=$(git log -1 --format='%s' 2>/dev/null || echo "Unknown")
           COMMIT_INFO="**Commit**: [\`$COMMIT_SHA_SHORT\`](https://github.com/${{ github.repository }}/commit/$COMMIT_SHA) - $COMMIT_MSG"
           
-          if [ -n "$ERRORS" ] || [ -n "$WARNINGS" ]; then
+          # Warnings (unreleased-but-in-source schemas) are expected on pre-release
+          # docs PRs and self-resolve on the next release. Surface them on the job
+          # summary only — never as a PR comment — to avoid email noise. Errors
+          # still post a PR comment because they require author action.
+          if [ -n "$WARNINGS" ]; then
+            # Count top-level bullet entries (one per flagged URL).
+            WARNING_COUNT=$(echo -e "$WARNINGS" | grep -c '^- `' || true)
+            {
+              echo "## Schema Link Check — ${WARNING_COUNT} Warning(s)"
+              echo ""
+              echo "$COMMIT_INFO"
+              echo ""
+              echo "### ⚠️ Warnings (schema not yet released)"
+              echo ""
+              echo "These schemas exist in source but haven't been released yet. The links will work after the next version is published."
+              echo ""
+              echo -e "$WARNINGS"
+            } >> "$GITHUB_STEP_SUMMARY"
+            # Surface on the PR's Checks tab without emailing the author.
+            echo "::notice title=Schema link warnings::${WARNING_COUNT} schema link(s) reference unreleased schemas — see job summary"
+          fi
+
+          if [ -n "$ERRORS" ]; then
             echo "has_issues=true" >> $GITHUB_OUTPUT
             
-            COMMENT="## Schema Link Check Results\n\n$COMMIT_INFO\n\n"
-            
-            if [ -n "$ERRORS" ]; then
-              HAS_ERRORS="true"
-              COMMENT="$COMMENT### ❌ Errors (schema not found)\n\nThese schemas do not exist and the links will be broken:\n$ERRORS\n\n"
-            fi
-            
-            if [ -n "$WARNINGS" ]; then
-              COMMENT="$COMMENT### ⚠️ Warnings (schema not yet released)\n\nThese schemas exist in source but haven't been released yet. The links will be broken until the next version is published:\n$WARNINGS\n\n"
-              COMMENT="$COMMENT---\n\n**To fix**: Either:\n1. Wait for the next release and merge this PR after the release is published\n2. Use \`latest\` instead of a version alias if you need the link to work immediately (note: \`latest\` is the development version and may change)\n3. Coordinate with maintainers to cut a new release before merging"
-            fi
-            
+            HAS_ERRORS="true"
+            COMMENT="## Schema Link Check Results\n\n$COMMIT_INFO\n\n### ❌ Errors (schema not found)\n\nThese schemas do not exist and the links will be broken:\n$ERRORS\n"
+
             # Escape for GitHub Actions
             COMMENT=$(echo -e "$COMMENT" | sed 's/"/\\"/g')
             echo "comment<<EOF" >> $GITHUB_OUTPUT
@@ -191,7 +204,7 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "has_issues=false" >> $GITHUB_OUTPUT
-            echo "✅ All $TOTAL_URLS schema links are valid"
+            echo "✅ All $TOTAL_URLS schema links are valid (warnings, if any, on job summary)"
           fi
           
           echo "has_errors=$HAS_ERRORS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- `check-schema-links.yml` was posting a PR comment listing both actionable errors and benign warnings ("schema exists in source but not yet released"). Warnings fire on nearly every schema-touching docs PR and self-resolve on the next release, so this was generating email noise with no actionable path for authors.
- Warnings now go to the workflow job summary + a `::notice::` annotation on the Checks tab — visible from the PR page, no email.
- Errors still post a PR comment (they require author action).
- Existing cleanup step already runs on `has_issues == 'false'`, which now covers both "clean" and "warnings-only" runs, so stale error comments get deleted when errors are resolved.

Reviewed by `code-reviewer`, `dx-expert`, and `docs-expert` agents — all ship-it. The `::notice::` + warning count in the summary heading were added per the dx-expert's suggestion.

Followup (separate PR, not scoped here): `check-dist-links.yml` and `broken-links.yml` don't PR-comment at all — they rely on `::error::` annotations. If the spam complaints persist even for actual errors, this workflow could move to that pattern too.

## Test plan

- [ ] Merge a docs PR that references an unreleased schema — verify: no PR comment posted, warning visible on Checks tab annotation, full list in job summary.
- [ ] Merge a docs PR that references a truly missing schema — verify: PR comment still posted with errors, workflow fails.
- [ ] A PR that had an error comment, then pushes a fix leaving only warnings — verify: stale error comment gets deleted by the cleanup step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)