### PR TITLE
spec(media-buy): close empty-valid_actions loophole + specify where partitioning belongs

### DIFF
--- a/.changeset/post-2993-valid-actions-and-partitioning.md
+++ b/.changeset/post-2993-valid-actions-and-partitioning.md
@@ -1,0 +1,16 @@
+---
+---
+
+spec(media-buy): close the empty-`valid_actions` loophole and specify where partitioning belongs
+
+Post-#2993 follow-up tightening, surfaced by expert review of the Tier-2 conformance PR (#2965). The merged #2993 rules say a seller MUST return every account-owned buy and MUST NOT mark non-AdCP buys read-only — but they also say an action MAY be omitted from `valid_actions` for "business reasons." Those two clauses combined let a seller technically comply by returning non-AdCP buys with a systematically empty `valid_actions`, which is indistinguishable from hiding the buy and defeats the normative intent.
+
+Two clarifications:
+
+1. **Creation surface is never a business reason.** Sales agents MUST NOT omit an action from `valid_actions` — or return `INVALID_STATE` on an otherwise-valid update — solely because the buy was created outside AdCP. `valid_actions` omissions are legitimate only when grounded in contractual, platform, or policy constraints that would apply equally to an AdCP-created buy in the same state. A systematically-empty `valid_actions` set on non-AdCP buys is non-conformant.
+
+2. **Partitioning belongs at the account boundary.** When a seller has a legitimate reason to keep a set of buys outside a caller's operational reach (child-seller models, NDA-scoped PMP deals, sandbox-vs-prod separation, tenant-level privacy partitions), the correct mechanism is expressing that as a separate account the caller is not authorized to reference — not filtering a subset of the caller's authorized account. Within-account filtering reintroduces the shadow-ledger problem #2963 forbade.
+
+Updated: `docs/media-buy/specification.mdx` (new "Partitioning belongs at the account boundary" subsection under Account Ownership vs. Creation Surface; strengthened MUST NOTs), `docs/media-buy/task-reference/get_media_buys.mdx`, `docs/media-buy/task-reference/update_media_buy.mdx`.
+
+No schema changes. Closes the gap flagged on PRs #2994 and #3001 reviews.

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -90,6 +90,16 @@ Concretely:
 - Any `media_buy_id` returned by `get_media_buys` MUST be a valid argument to `get_media_buy_delivery` and to `update_media_buy` for every action listed in its `valid_actions`.
 - A sales agent MUST NOT mark a buy read-only, hide it, or return `MEDIA_BUY_NOT_FOUND` on the basis that it was not originally booked through AdCP.
 - When a specific action is unavailable for business reasons (contractual obligations, platform constraints, policy), the sales agent expresses that by omitting the action from `valid_actions`, not by refusing the buy from account-scoped listings.
+- **Creation surface is never a business reason.** Sales agents MUST NOT omit an action from `valid_actions` — or return `INVALID_STATE` on an otherwise-valid update — solely because the buy was created outside AdCP. `valid_actions` omissions are legitimate only when grounded in actual contractual, platform, or policy constraints that would apply equally to an AdCP-created buy in the same state. A seller that returns non-AdCP buys with a systematically empty `valid_actions` is non-conformant, because that behavior is indistinguishable from hiding the buy and defeats the normative intent of the rules above.
+
+#### Partitioning belongs at the account boundary
+
+When a seller has a legitimate reason to keep a set of buys outside a caller's operational reach — child-seller models, NDA-scoped PMP deals, sandbox-vs-production separation, tenant-level privacy partitions — the correct mechanism is **account partitioning**, not within-account filtering:
+
+- Expose the hidden subset as a separate account (or sub-account) the caller is not authorized to reference.
+- Within any account the caller *is* authorized on, return the full set of buys that account owns per the rules above.
+
+The account boundary is the AdCP primitive for access partitioning; `get_agent_capabilities` is the introspection surface for the scope granted on a given account. Callers can see what they can see; what they cannot see lives behind an account reference they do not hold. Within-account filtering — returning only a subset of an account's buys to a caller who is authorized on that account — reintroduces the shadow-ledger problem this rule forbids.
 
 ### Asynchronous Operations
 

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -14,7 +14,9 @@ Retrieve the current operational state of media buys: configuration, creative ap
 
 Sales agents MUST return every media buy owned by the authenticated account, regardless of how the buy was created — via AdCP `create_media_buy`, via the seller's own APIs, via manual trafficking, via legacy or third-party systems. Scope is **account ownership**, not creation surface. A `media_buy_id` returned here identifies any order in the seller's ad server accessible to the authenticated caller.
 
-Any media buy returned by `get_media_buys` MUST be reachable by every task in its `valid_actions`. Sales agents MUST NOT mark a buy read-only, hide it, or refuse updates on the basis that it was not originally created via AdCP. If an action is unavailable for business reasons, the seller SHOULD omit it from `valid_actions` rather than returning a buy that cannot be operated on.
+Any media buy returned by `get_media_buys` MUST be reachable by every task in its `valid_actions`. Sales agents MUST NOT mark a buy read-only, hide it, or refuse updates on the basis that it was not originally created via AdCP. When an action is unavailable for business reasons (contractual obligations, platform constraints, policy), the seller MUST omit only that action from `valid_actions` — never the whole set, and never merely because the buy was created outside AdCP. A seller that returns non-AdCP buys with a systematically empty `valid_actions` is non-conformant; that pattern is indistinguishable from hiding the buy.
+
+Sellers that need to partition inventory away from a caller MUST do so at the **account boundary**, not within-account. See [Account Ownership vs. Creation Surface](/docs/media-buy/specification#account-ownership-vs-creation-surface).
 
 **Request Schema**: [`/schemas/v3/media-buy/get-media-buys-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-request.json)
 **Response Schema**: [`/schemas/v3/media-buy/get-media-buys-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buys-response.json)

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -12,7 +12,9 @@ Modify an existing media buy using PATCH semantics. Supports campaign-level and 
 
 ## Scope
 
-`update_media_buy` operates on any `media_buy_id` returned by [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys), not just buys created via `create_media_buy`. Sales agents MUST NOT refuse updates on the basis that a buy was originally created outside AdCP (direct ad-server entry, legacy APIs, manual trafficking). Creation surface is not a supported axis of authorization; account ownership is. When a specific action is unsupported for a given buy for business reasons (contractual obligations, platform constraints), the seller MUST omit that action from `valid_actions` on the buy rather than silently rejecting the corresponding update.
+`update_media_buy` operates on any `media_buy_id` returned by [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys), not just buys created via `create_media_buy`. Sales agents MUST NOT refuse updates on the basis that a buy was originally created outside AdCP (direct ad-server entry, legacy APIs, manual trafficking). Creation surface is not a supported axis of authorization; account ownership is.
+
+When a specific action is unsupported for a given buy for business reasons (contractual obligations, platform constraints, policy), the seller MUST omit only that action from `valid_actions` on the buy rather than silently rejecting the corresponding update. **Creation surface is not a business reason.** Sellers MUST NOT return `INVALID_STATE` on an otherwise-valid update against a non-AdCP-created buy, and MUST NOT return a buy with systematically empty `valid_actions` simply because it was booked outside AdCP — that pattern is indistinguishable from hiding the buy and violates the [Account Ownership vs. Creation Surface](/docs/media-buy/specification#account-ownership-vs-creation-surface) rule.
 
 **PATCH Semantics**: Only specified fields are updated; omitted fields remain unchanged.
 


### PR DESCRIPTION
## Summary

Post-#2993 follow-up tightening, surfaced by expert review of the stacked Tier-2 conformance PR (#3001). The merged #2993 rules create a loophole at their boundary that a seller could technically comply with while violating the intent. Two small tightenings close it.

## The loophole

#2993 (merged) says:

1. Sales agents MUST return every account-owned buy regardless of creation surface.
2. Sales agents MUST NOT mark a buy read-only simply because it was created outside AdCP.
3. Business constraints on specific actions are expressed by **omitting those actions from `valid_actions`**.

Rules 1 + 2 forbid hiding the buy. Rule 3 says "omit the action you can't support." But taken together, a seller can comply with rules 1 and 2 by returning non-AdCP buys with a *systematically empty* `valid_actions` set — which is indistinguishable from hiding the buy and defeats the normative intent. A caller seeing "the buy exists but you can do nothing with it" gets the same user experience as "the buy does not exist."

## Two clarifications

### 1. Creation surface is never a business reason

Sales agents MUST NOT omit an action from `valid_actions` — or return `INVALID_STATE` on an otherwise-valid update — solely because the buy was created outside AdCP. `valid_actions` omissions are legitimate only when grounded in contractual, platform, or policy constraints that would apply equally to an AdCP-created buy in the same state.

A seller that returns non-AdCP buys with a systematically empty `valid_actions` is non-conformant.

### 2. Partitioning belongs at the account boundary

When a seller has a legitimate reason to keep a set of buys outside a caller's operational reach — child-seller models, NDA-scoped PMP deals, sandbox-vs-production separation, tenant-level privacy partitions — the correct mechanism is **a separate account** the caller is not authorized to reference.

Within-account filtering (returning only a subset of an account's buys to a caller authorized on that account) reintroduces the shadow-ledger problem #2963 was specifically designed to eliminate. The account boundary is the AdCP primitive for access partitioning; [`get_agent_capabilities`](/docs/protocol/get_agent_capabilities) is the introspection surface for the scope granted on a given account.

## Why file as a separate PR

#2993 is merged. Rather than re-opening that conversation, this PR adds a short, targeted tightening. Reviewers who approved #2993 can assess whether this further language is consistent with their prior intent — it reads as clarification, not change — and the diff is small enough (~32 lines across 3 files) to evaluate quickly.

## Changes

- `docs/media-buy/specification.mdx` — new **Partitioning belongs at the account boundary** subsection under Account Ownership vs. Creation Surface; strengthened MUST-NOT language on empty `valid_actions`.
- `docs/media-buy/task-reference/get_media_buys.mdx` — mirrors the specification tightening.
- `docs/media-buy/task-reference/update_media_buy.mdx` — mirrors the specification tightening and calls out that `INVALID_STATE` cannot be used to reject updates on non-AdCP buys that would otherwise be valid.

No schema changes.

## Test plan

- [ ] `npm run build:schemas` regenerates cleanly (verified)
- [ ] `npm run typecheck` passes (verified)
- [ ] Docs build verifies no broken links
- [ ] ad-tech-protocol-expert agrees the clarifications don't go beyond the spirit of #2993

## Related

- **#2993** (merged) — original account-ownership tightening this PR clarifies
- **#2994** — `get_agent_capabilities` + `attestation_verifier` scope (cross-referenced from the new partitioning language)
- **#3001** — Tier-2 Production Verified (which is why this loophole was identified — Path B requires the seller to actually permit webhook attach on non-AdCP buys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)