### PR TITLE
docs(spec): prohibit dual-emission of legacy status fields alongside v3 status

### DIFF
--- a/.changeset/prohibit-dual-status-emission.md
+++ b/.changeset/prohibit-dual-status-emission.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Clarify that v3 agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any alias) alongside the v3 `status` field. Adds a migration checklist row, a conformance warning in the task-lifecycle reference, and an `x-adcp-conformance` annotation on the protocol envelope schema's `status` property. Closes #2987.
+Clarify that v3 agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any alias) alongside the v3 `status` field. Adds a migration checklist row, a conformance warning in the task-lifecycle reference, and extends the protocol envelope schema's `status` description with the prohibition. Closes #2987.

--- a/.changeset/prohibit-dual-status-emission.md
+++ b/.changeset/prohibit-dual-status-emission.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify that v3 agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any alias) alongside the v3 `status` field. Adds a migration checklist row, a conformance warning in the task-lifecycle reference, and an `x-adcp-conformance` annotation on the protocol envelope schema's `status` property. Closes #2987.

--- a/.changeset/prohibit-dual-status-emission.md
+++ b/.changeset/prohibit-dual-status-emission.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": patch
 ---
 
 Clarify that v3 agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any alias) alongside the v3 `status` field. Adds a migration checklist row, a conformance warning in the task-lifecycle reference, and extends the protocol envelope schema's `status` description with the prohibition. Closes #2987.

--- a/.changeset/triage-ship-more.md
+++ b/.changeset/triage-ship-more.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Flip the triage routine's default from "flag unless obviously a small bug" to "execute unless the change is breaking, ambiguous, or high-risk." Drops the <150-line scope cap, the classification-only-Bug-or-Doc gate, and the blanket prohibition on `static/schemas/source/**` edits. Adds a crisp non-breaking-vs-breaking definition as the primary Execute/Flag binary, adds evergreen content as a first-class always-PR-able bucket, and guards `infra/agents` bucket as always-Flag (self-modification risk). CODEOWNERS + human review still gate every merge.
+Flip the triage routine's default from "flag unless obviously a small bug" to "execute unless the change is breaking, ambiguous, or high-risk." Drops the under-150-line scope cap, the classification-only-Bug-or-Doc gate, and the blanket prohibition on `static/schemas/source/**` edits. Adds a crisp non-breaking-vs-breaking definition as the primary Execute/Flag binary, adds evergreen content as a first-class always-PR-able bucket, and guards `infra/agents` bucket as always-Flag (self-modification risk). CODEOWNERS + human review still gate every merge.

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -46,7 +46,7 @@ Every AdCP response uses a **flat structure** where task-specific fields are at 
 ```
 
 :::warning Single status field required
-Agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any other alias) alongside `status`. The `status` field is the single authoritative task state. Agents emitting both are non-conformant and will fail storyboard testing.
+Agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any other alias) alongside `status`. The `status` field is the single authoritative task state. Agents emitting both are non-conformant.
 :::
 
 ## Status Handling

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -46,7 +46,7 @@ Every AdCP response uses a **flat structure** where task-specific fields are at 
 ```
 
 :::warning Single status field required
-Agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any other alias) alongside `status`. The `status` field is the single authoritative task state. Agents emitting both are non-conformant.
+Agents MUST NOT emit the legacy `task_status` or `response_status` fields alongside `status`. The `status` field is the single authoritative task state. Agents emitting either alongside `status` are non-conformant.
 :::
 
 ## Status Handling

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -45,6 +45,10 @@ Every AdCP response uses a **flat structure** where task-specific fields are at 
 }
 ```
 
+:::warning Single status field required
+Agents MUST NOT emit legacy status fields (`task_status`, `response_status`, or any other alias) alongside `status`. The `status` field is the single authoritative task state. Agents emitting both are non-conformant and will fail storyboard testing.
+:::
+
 ## Status Handling
 
 ### Basic Pattern

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -50,7 +50,7 @@ Each row is a breaking change. **Effort** indicates the typical work involved:
 | Products | `buying_mode` required on every `get_products` request | New requirement | [get_products reference](/docs/media-buy/task-reference/get_products) |
 | Media buy status | `pending_activation` → `pending_start` | Rename | [Media buys](/docs/media-buy/media-buys) |
 | Media buy status | `pending_creatives` added (no creatives assigned yet) | New requirement | [Media buys](/docs/media-buy/media-buys) |
-| Task status | Legacy status fields (`task_status`, `response_status`, or any alias) MUST NOT be emitted alongside v3 `status` — remove all pre-v3 status fields | Rename | [Task lifecycle](/docs/building/implementation/task-lifecycle) |
+| Task status | Legacy status fields (`task_status`, `response_status`, or any alias) MUST NOT be emitted alongside v3 `status` — remove all pre-v3 status fields | Restructure | [Task lifecycle](/docs/building/implementation/task-lifecycle) |
 | Capabilities | `compliance_testing` capability block on `get_adcp_capabilities` | Additive | [Capability discovery](/docs/protocol/get_adcp_capabilities#compliance_testing) |
 | Idempotency | `idempotency_key` required on all mutating requests (UUID v4) | New requirement | [Security § Idempotency](/docs/building/implementation/security) |
 | Request signing | RFC 9421 Ed25519 signing profile (optional in 3.0, mandatory under AdCP Verified) | Additive | [Security § Request signing](/docs/building/implementation/security) |

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -50,6 +50,7 @@ Each row is a breaking change. **Effort** indicates the typical work involved:
 | Products | `buying_mode` required on every `get_products` request | New requirement | [get_products reference](/docs/media-buy/task-reference/get_products) |
 | Media buy status | `pending_activation` → `pending_start` | Rename | [Media buys](/docs/media-buy/media-buys) |
 | Media buy status | `pending_creatives` added (no creatives assigned yet) | New requirement | [Media buys](/docs/media-buy/media-buys) |
+| Task status | Legacy status fields (`task_status`, `response_status`, or any alias) MUST NOT be emitted alongside v3 `status` — remove all pre-v3 status fields | Rename | [Task lifecycle](/docs/building/implementation/task-lifecycle) |
 | Capabilities | `compliance_testing` capability block on `get_adcp_capabilities` | Additive | [Capability discovery](/docs/protocol/get_adcp_capabilities#compliance_testing) |
 | Idempotency | `idempotency_key` required on all mutating requests (UUID v4) | New requirement | [Security § Idempotency](/docs/building/implementation/security) |
 | Request signing | RFC 9421 Ed25519 signing profile (optional in 3.0, mandatory under AdCP Verified) | Additive | [Security § Request signing](/docs/building/implementation/security) |

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -27,6 +27,7 @@ Each row is a breaking change. **Effort** indicates the typical work involved:
 
 - **Rename** — Field name changed, same semantics. Find-and-replace.
 - **Restructure** — Shape changed (e.g., string → object, single → array). Requires code changes.
+- **Remove** — Field existed in v2, removed in v3. Find-and-delete.
 - **New requirement** — Didn't exist in v2. Requires new implementation.
 
 | Area | Change | Effort | Details |
@@ -50,7 +51,7 @@ Each row is a breaking change. **Effort** indicates the typical work involved:
 | Products | `buying_mode` required on every `get_products` request | New requirement | [get_products reference](/docs/media-buy/task-reference/get_products) |
 | Media buy status | `pending_activation` → `pending_start` | Rename | [Media buys](/docs/media-buy/media-buys) |
 | Media buy status | `pending_creatives` added (no creatives assigned yet) | New requirement | [Media buys](/docs/media-buy/media-buys) |
-| Task status | Legacy status fields (`task_status`, `response_status`, or any alias) MUST NOT be emitted alongside v3 `status` — remove all pre-v3 status fields | Restructure | [Task lifecycle](/docs/building/implementation/task-lifecycle) |
+| Task status | Legacy `task_status` and `response_status` fields MUST NOT be emitted alongside v3 `status` — remove both | Remove | [Task lifecycle](/docs/building/implementation/task-lifecycle) |
 | Capabilities | `compliance_testing` capability block on `get_adcp_capabilities` | Additive | [Capability discovery](/docs/protocol/get_adcp_capabilities#compliance_testing) |
 | Idempotency | `idempotency_key` required on all mutating requests (UUID v4) | New requirement | [Security § Idempotency](/docs/building/implementation/security) |
 | Request signing | RFC 9421 Ed25519 signing profile (optional in 3.0, mandatory under AdCP Verified) | Additive | [Security § Request signing](/docs/building/implementation/security) |

--- a/static/schemas/source/core/protocol-envelope.json
+++ b/static/schemas/source/core/protocol-envelope.json
@@ -16,7 +16,7 @@
     },
     "status": {
       "$ref": "/schemas/enums/task-status.json",
-      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer. Agents MUST NOT emit legacy status fields (task_status, response_status, or any alias) alongside this field — the status field is the single authoritative task state."
+      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer. Agents MUST NOT emit the legacy task_status or response_status fields alongside this field — the status field is the single authoritative task state."
     },
     "message": {
       "type": "string",

--- a/static/schemas/source/core/protocol-envelope.json
+++ b/static/schemas/source/core/protocol-envelope.json
@@ -16,7 +16,8 @@
     },
     "status": {
       "$ref": "/schemas/enums/task-status.json",
-      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer."
+      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer.",
+      "x-adcp-conformance": "Agents MUST NOT emit legacy status fields (task_status, response_status, or any alias) alongside this field. The status field is the single authoritative task state."
     },
     "message": {
       "type": "string",

--- a/static/schemas/source/core/protocol-envelope.json
+++ b/static/schemas/source/core/protocol-envelope.json
@@ -16,8 +16,7 @@
     },
     "status": {
       "$ref": "/schemas/enums/task-status.json",
-      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer.",
-      "x-adcp-conformance": "Agents MUST NOT emit legacy status fields (task_status, response_status, or any alias) alongside this field. The status field is the single authoritative task state."
+      "description": "Current task execution state. Indicates whether the task is completed, in progress (working), submitted for async processing, failed, or requires user input. Managed by the protocol layer. Agents MUST NOT emit legacy status fields (task_status, response_status, or any alias) alongside this field — the status field is the single authoritative task state."
     },
     "message": {
       "type": "string",


### PR DESCRIPTION
Closes #2987

## Summary

AdCP v3 defines `status` as the single authoritative task state, but the spec said nothing about agents that continue emitting a legacy `task_status` (or similar) field alongside it during migration. Scope3 flagged this as an active ambiguity: buyers were assuming v3 `status` wins on terminal states but had no normative text to cite.

This PR closes the gap with explicit MUST NOT language in three places:

- **Migration checklist** (`docs/reference/migration/index.mdx`): adds a "Task status" row so migrating agents have a concrete action item.
- **Task lifecycle reference** (`docs/building/implementation/task-lifecycle.mdx`): adds a `:::warning` callout immediately after the Response Structure section — the primary reference implementors consult from code.
- **Protocol envelope schema** (`static/schemas/source/core/protocol-envelope.json`): extends the `status` property `description` with the prohibition (sibling keywords on `$ref` nodes are ignored by draft-07 validators; description is the correct channel for this).

## Non-breaking justification

Adds optional normative text and documentation only. No field added, removed, renamed, or made required. No enum values changed. No existing clients need to change code to keep working — the prohibition targets behavior that was already incorrect per intent.

## Pre-PR review

Two rounds of review were completed (cap: 2). Both experts approved the substantive conformance language.

- **code-reviewer**: approved — all three prior blockers confirmed fixed; changeset description updated to remove stale x-adcp-conformance reference.
- **ad-tech-protocol-expert**: approved content; raised one open question on effort label taxonomy (see below).

**Open nit for reviewers:** The migration table effort label is `Restructure`. The protocol expert argues the closest match for a field-removal prohibition is `Rename` ("find-and-replace semantics"); the code reviewer considers `Restructure` ("requires code changes") equally valid. Neither `Rename` nor `Restructure` is a perfect fit — the table legend has no `Remove` category. Please pick whichever reads more accurately to you; either is fine. I stopped at the 2-iteration cap rather than introducing a third loop over taxonomy.

Session: https://claude.ai/code/session_01XeNaS3wfWQApdBpDsU5gC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeNaS3wfWQApdBpDsU5gC7)_