### PR TITLE
fix(compliance): add sandbox: true to media_buy_seller create_media_buy fixture steps

### DIFF
--- a/.changeset/fix-media-buy-compliance-sandbox-flag.md
+++ b/.changeset/fix-media-buy-compliance-sandbox-flag.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(compliance): add sandbox: true to create_media_buy sample_requests that use fixture product IDs
+
+Four media_buy_seller storyboard steps sent fixture product IDs (sports_preroll_q2, outdoor_ctv_q2, outdoor_display_q2, outdoor_video_q2) and a synthetic proposal_id (balanced_reach_q2) in create_media_buy sample_requests without sandbox: true on the account reference. Seller agents correctly reject unknown IDs with PRODUCT_NOT_FOUND under real catalog validation, causing the harness to report false failures against the seller.
+
+Fixed by adding sandbox: true to the account natural key in the sample_request of:
+- protocols/media-buy/index.yaml (create_buy/create_media_buy)
+- protocols/media-buy/scenarios/governance_conditions.yaml (buy_with_conditions/create_media_buy_conditions)
+- protocols/media-buy/scenarios/proposal_finalize.yaml (accept_proposal/create_media_buy)
+- protocols/media-buy/scenarios/governance_denied.yaml (buy_denied/create_media_buy_denied)
+
+Scenarios with controller_seeding: true and explicit fixtures blocks (governance_approved.yaml, delivery_reporting.yaml) are not affected — those product IDs are seeded into the seller's test environment before the scenario runs.

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -467,6 +467,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -183,6 +183,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -174,6 +174,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -229,6 +229,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           proposal_id: "balanced_reach_q2"
           total_budget:
             amount: 50000


### PR DESCRIPTION
Closes #3024

## Summary

Four `media_buy_seller` storyboard steps called `create_media_buy` with fixture product IDs (`sports_preroll_q2`, `outdoor_ctv_q2`, `outdoor_display_q2`, `outdoor_video_q2`) or a synthetic proposal ID (`balanced_reach_q2`) without `sandbox: true` on the account reference. Sellers with real catalog validation correctly return `PRODUCT_NOT_FOUND` for unknown fixture IDs — the bug is in the harness, not the seller.

The fix adds `sandbox: true` to the `account` natural key in the `sample_request` of each affected step. The `account-ref.json` schema explicitly supports this field; for implicit accounts it signals sandbox mode on the operation without requiring a separately provisioned account.

**Non-breaking justification:** adds an optional boolean field (`sandbox: true`) to YAML storyboard fixture data only. No schema files change, no required fields are added, no enum values change, no published protocol surface is altered.

## Files changed

| File | Step | Fixture IDs |
|---|---|---|
| `protocols/media-buy/index.yaml` | `create_buy/create_media_buy` | `sports_preroll_q2`, `lifestyle_display_q2` |
| `scenarios/governance_conditions.yaml` | `buy_with_conditions/create_media_buy_conditions` | `outdoor_ctv_q2` |
| `scenarios/governance_denied.yaml` | `buy_denied/create_media_buy_denied` | `outdoor_display_q2`, `outdoor_video_q2` |
| `scenarios/proposal_finalize.yaml` | `accept_proposal/create_media_buy` | synthetic `proposal_id: balanced_reach_q2` |

**Not touched:** `governance_approved.yaml` and `delivery_reporting.yaml` — both carry `controller_seeding: true` with explicit `fixtures` blocks; those product IDs are seeded into the seller's test environment before the scenario runs and do not need `sandbox: true`. Scenarios using `$context.product_id` (runtime lookup) are also unaffected.

## Notes for reviewers

- **`governance_denied` get_products step:** The `get_products_brief` step in `governance_denied.yaml` uses `outdoor_display_q2` / `outdoor_video_q2` without a seeded fixture block. In sandbox mode a real seller's `get_products` might return an empty set for these IDs; the subsequent `create_media_buy` step should still pass because `sandbox: true` exempts it from catalog validation, but a `get_products` false-failure on that step is a separate follow-up.

- **`sync_accounts` provisioning gap:** The `sync_accounts` steps in these storyboards provision production accounts (no `sandbox: true` on the account items). Whether a prior production `sync_accounts` for the same natural key satisfies a subsequent `sandbox: true` account reference in `create_media_buy` is an implementation ambiguity the current spec leaves open. This is pre-existing and deferred — the reporter's empirical evidence confirms the `create_media_buy` sandbox flag works in practice.

- **`refine_products.yaml`:** Uses `sports_preroll_q2` in a `get_products` refine step (not `create_media_buy`) without seeding. If sellers validate product IDs on refine calls this may produce false failures — tracked as a follow-up.

## Pre-PR review

- **code-reviewer:** approved — no blockers; changeset step-ID mismatch fixed before push; noted `refine_products.yaml` as out-of-scope follow-up
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `sandbox: true` on account-ref is a request-scoping signal, not a pointer to a pre-provisioned object; `sync_accounts` provisioning gap is pre-existing and out of scope

Session: https://claude.ai/code/session_01DBm4J35791jxQ1xo2Ykane

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBm4J35791jxQ1xo2Ykane)_