### PR TITLE
docs(media-buy): require sellers to persist status, not recompute from dates

### DIFF
--- a/.changeset/seller-status-persistence-docs.md
+++ b/.changeset/seller-status-persistence-docs.md
@@ -1,0 +1,8 @@
+---
+---
+
+Add explicit seller implementation guidance: media buy `status` must be stored as a persisted database field and updated only via protocol events — not recomputed from flight-date arithmetic. Date logic cannot produce `paused`, `canceled`, or `rejected`; recomputing silently suppresses those states and breaks `valid_actions`.
+
+Added a normative note to `docs/media-buy/media-buys/index.mdx` (lifecycle states section) and a brief cross-referencing callout in `docs/building/implementation/seller-integration.mdx`.
+
+Closes #3028

--- a/docs/building/implementation/seller-integration.mdx
+++ b/docs/building/implementation/seller-integration.mdx
@@ -140,6 +140,10 @@ Implement `create_media_buy` to accept campaign instructions from buyer agents. 
 
 Your platform processes the buy according to your normal workflow — whether that's instant activation, internal review, or an approval queue. AdCP's asynchronous status system (`completed`, `working`, `submitted`, `input-required`) lets you model any workflow.
 
+<Note>
+**Status must be persisted, not computed from flight dates.** Store `status` as an explicit database field, updated only by protocol events — not by comparing `start_time`/`end_time` to the current date. Date arithmetic cannot produce `paused`, `canceled`, or `rejected`; those states are driven by explicit commands. See [lifecycle states](/docs/media-buy/media-buys#lifecycle-states) for the full implementation requirement.
+</Note>
+
 </Steps>
 
 ## Industry-specific guidance

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -276,6 +276,8 @@ Any non-terminal ──── update(canceled: true) ──▶ canceled (termina
 
 **Terminal states**: `completed`, `rejected`, and `canceled` are terminal — no transitions out. Sellers MUST reject updates to terminal-state media buys with error code `INVALID_STATE`.
 
+**Seller implementation requirement — persist status, never recompute from dates**: `status` MUST be stored as an explicit field and mutated only by protocol events. Flight-date arithmetic cannot represent `paused`, `canceled`, or `rejected` — those are driven by explicit commands, not the clock. Sellers that recompute `status` from `start_time`/`end_time` at request time will silently drop these states, breaking `valid_actions` for every buyer reading the media buy. The correct approach: date comparison sets the initial status at `create_media_buy` time (`pending_creatives`, `pending_start`, or `active`); after that, the state machine owns the field.
+
 **Discovering valid actions**: The `get_media_buys` response includes `valid_actions` for each media buy — a list of actions the buyer can perform in the current state. Agents SHOULD use this instead of hardcoding the state machine:
 
 ```json


### PR DESCRIPTION
Closes #3028

## Summary

Adds explicit seller implementation guidance that media buy `status` MUST be stored as a persisted database field and mutated only by protocol events — not recomputed from `start_time`/`end_time` at request time. Flight-date arithmetic cannot produce `paused`, `canceled`, or `rejected`; those states are driven by explicit commands (pause request, cancellation, rejection decision). Sellers that recompute status from dates will silently suppress these states and break `valid_actions` for every buyer reading the media buy.

**Non-breaking justification:** Pure doc addition — two new paragraphs in existing MDX files. No schema, enum, task definition, or API surface touched. Existing clients unaffected.

## Changes

- `docs/media-buy/media-buys/index.mdx` — Authoritative normative note added in the Lifecycle States section (after Terminal states, before Discovering valid actions), with the full implementation requirement and the correct initial-status pattern.
- `docs/building/implementation/seller-integration.mdx` — Brief cross-referencing `<Note>` callout in "Accept and fulfill buys" section, with a link to the authoritative text in `index.mdx`.
- `.changeset/seller-status-persistence-docs.md` — `--empty` changeset (non-protocol docs change).

## Pre-PR review

- **code-reviewer:** approved — no blockers; changeset present, prose accurate, placement correct.
- **docs-expert:** approved — blockers resolved; seller-integration note is concise with cross-link; index.mdx carries the full requirement in correct read-order position. Nit noted: the index.mdx paragraph uses bold inline text rather than a `<Note>` component; does not affect agent-parseability or semantic correctness, left as-is.

## Notes for reviewer

The bug that prompted this issue is in the Prebid Sales Agent (`github.com/prebid/salesagent`), a community example not maintained by this team. The fix to that repo is out of scope here. A triage comment on the issue directs the reporter to the right location.

Session: https://claude.ai/code/session_01Wo5ELnGNASGvgUq6DsLT8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo5ELnGNASGvgUq6DsLT8n)_