### PR TITLE
chore(deps): bump @adcp/client 5.15 → 5.16 + restore fresh replayed assertion

### DIFF
--- a/.changeset/bump-adcp-client-5-16.md
+++ b/.changeset/bump-adcp-client-5-16.md
@@ -1,0 +1,30 @@
+---
+---
+
+Bump `@adcp/client` from `5.15.0` to `5.16.0` and restore positive
+coverage on the fresh-path `replayed` assertion.
+
+**5.16.0 brings** the two follow-ups our prior bump flagged:
+
+- **`field_value_or_absent` matcher** (adcp-client#873 → 5.16.0).
+  Passes when a field is absent OR present with a matching value;
+  fails only when present with a disallowed value. The envelope-spec
+  escape hatch we needed for `replayed` on fresh execution.
+- **Context-rejection hints** (adcp-client#870 → 5.16.0). Runner
+  emits non-fatal `context_value_rejected` hints when a seller's
+  error response's `available:` list would have accepted a value
+  that traces back to a prior-step `$context.*` write. Collapses
+  the "SDK bug vs seller bug" triage surface. Pass/fail unchanged;
+  hints surface on `StoryboardStepResult.hints[]`.
+
+**Spec-side use of the new matcher.** `universal/idempotency.yaml`'s
+`create_media_buy_initial` step regains a positive assertion on
+`replayed`: "if reported, must be false." The previous PR dropped
+that assertion entirely because `field_value` fired on spec-compliant
+agents that omit the field. `field_value_or_absent` restores coverage
+without penalizing omission. The replay step's `field_value:
+allowed_values: [true]` is unchanged.
+
+No training-agent code changes required — the catalog and handler
+paths 5.15 exercised continue to pass. Storyboard baselines stay
+52/52 in both dispatch modes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0",
       "dependencies": {
-        "@adcp/client": "5.15.0",
+        "@adcp/client": "5.16.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.15.0.tgz",
-      "integrity": "sha512-tssoOmNkeXvlyqiweXipLIfxlejnv3DFrv721xi6/4Aj9srcaiPtomqJSP4GVJXR34uYhm1M+igQYAK38rfrOA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.16.0.tgz",
+      "integrity": "sha512-2YFjCihUhrkdHeFnvZ/ng3ky1K9wOneYn5pQ+Xj9uGxj25skBzR7cp0D4OkR7YIhNA7sO+0O8A7cOrjmVmsgAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "5.15.0",
+    "@adcp/client": "5.16.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -270,14 +270,17 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Agent returns a media_buy_id for the initial request"
-          # NOTE: intentionally NO assertion on `replayed` here. Per
-          # `protocol-envelope.json`, fresh execution MAY omit the field,
-          # and `@adcp/client` >= 5.14 omits it (see adcp-client#859).
-          # The replay step below asserts `replayed: true` on the
-          # cached replay, which is the real regression surface. A
-          # fresh-path `field_value allowed_values: [false]` assertion
-          # has no `field_absent`-tolerant form today and would fail
-          # spec-correct agents.
+          # Per `protocol-envelope.json`, fresh execution MAY omit
+          # `replayed` entirely; agents that do report it MUST NOT
+          # report `true` on a fresh call. `field_value_or_absent`
+          # (adcp-client#873, shipped in 5.16) asserts that tolerance:
+          # passes when absent OR present-and-matching. The replay
+          # step below asserts the positive side (`replayed: true`
+          # on replay) with plain `field_value`.
+          - check: field_value_or_absent
+            path: "replayed"
+            allowed_values: [false]
+            description: "If reported on fresh execution, replayed must be false"
 
           - check: field_present
             path: "context"


### PR DESCRIPTION
## Summary
- Bump `@adcp/client` from `5.15.0` to `5.16.0`
- Use the newly-shipped `field_value_or_absent` matcher to restore positive coverage on the fresh-path `replayed` assertion in `universal/idempotency.yaml::create_media_buy_initial`
- No training-agent code changes — the catalog + handler paths 5.15 exercised continue to pass unchanged

## 5.16.0 ships the two follow-ups from our last bump

- **`field_value_or_absent` matcher** (adcp-client#873, filed from this repo). Passes when a field is absent OR present with a matching value; fails only when present with a disallowed value. The envelope-spec escape hatch we needed for `replayed` on fresh execution.
- **Context-rejection hints** (adcp-client#870 → 5.16.0). Runner emits non-fatal `context_value_rejected` hints when a seller's error response's `available:` list would have accepted a value that traces back to a prior-step `$context.*` write. Pass/fail unchanged; hints surface on `StoryboardStepResult.hints[]`.

Both upstream issues were closed by the 5.16 merge.

## Spec-side change

In `universal/idempotency.yaml`'s `create_media_buy_initial` step, replaced the comment block explaining the absent assertion with an actual `field_value_or_absent` assertion:

```yaml
- check: field_value_or_absent
  path: "replayed"
  allowed_values: [false]
  description: "If reported on fresh execution, replayed must be false"
```

The replay step's `field_value: allowed_values: [true]` on `replayed` is unchanged.

## Test plan
- [x] Framework mode: 52/52 clean, 393 passed / 0 failed / 37 skipped (unchanged from 5.15)
- [x] Legacy mode: 52/52 clean, 380 passed / 0 failed / 50 skipped (unchanged from 5.15)
- [x] Typecheck clean
- [x] Pre-commit (804/804 unit tests) green
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)