### PR TITLE
fix(ipr): wrap createStatus payload so state reaches GitHub API

### DIFF
--- a/.changeset/fix-ipr-create-status-body.md
+++ b/.changeset/fix-ipr-create-status-body.md
@@ -1,0 +1,19 @@
+---
+---
+
+Fix `scripts/ipr/github.mjs` `createStatus` — payload was being passed
+at the wrong level of the `request()` option bag, so `state`/`context`
+never reached the GitHub statuses API.
+
+`request(method, path, { body, query })` reads the payload from
+`options.body`. `createIssueComment` and `updateIssueComment` already
+wrap correctly (`{ body }`). `createStatus` was passing `{ state,
+context, description, target_url }` directly at the top level, so the
+outgoing request had an empty body and GitHub responded with
+`422 Validation Failed: State is not included in the list`.
+
+Impact: the IPR Agreement check has been failing on every PR since
+the workflow rewrite in #3011 landed — both the "awaiting signature"
+pending status and the "signed" success status were hitting the same
+failure path. Fix wraps the payload in `{ body: { ... } }` so the
+state actually ships.

--- a/scripts/ipr/github.mjs
+++ b/scripts/ipr/github.mjs
@@ -78,10 +78,12 @@ export class GitHubClient {
 
   createStatus(owner, repo, sha, { state, context, description, targetUrl }) {
     return this.request('POST', `/repos/${owner}/${repo}/statuses/${sha}`, {
-      state,
-      context,
-      description: description?.slice(0, 140),
-      target_url: targetUrl,
+      body: {
+        state,
+        context,
+        description: description?.slice(0, 140),
+        target_url: targetUrl,
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary

One-line fix to `scripts/ipr/github.mjs` `createStatus`. Payload was being passed at the top level of the request options where `request()` expects it nested under `body:`. Result: outgoing request had no body, GitHub responded `422 Validation Failed: State is not included in the list`.

## Impact

**Every PR's `ipr-check` has been failing since #3011 landed.** Both the pending ("awaiting signature") and success ("already signed") status calls hit the same broken `createStatus` path. All currently-open PRs — mine, the 5.16 bump (#3034), the triage improvement chain (#3023, #3033), and every dependabot/feature PR — are red on this check.

## Fix

Wrap the payload in `{ body: { ... } }` so it actually gets sent. `createIssueComment` and `updateIssueComment` were already wrapping correctly; this restores symmetry.

```diff
 createStatus(owner, repo, sha, { state, context, description, targetUrl }) {
   return this.request('POST', `/repos/${owner}/${repo}/statuses/${sha}`, {
-    state,
-    context,
-    description: description?.slice(0, 140),
-    target_url: targetUrl,
+    body: {
+      state,
+      context,
+      description: description?.slice(0, 140),
+      target_url: targetUrl,
+    },
   });
 }
```

## Branch protection note

This PR's own `ipr-check` will fail (the workflow checks out from `main`, where the bug still exists). Needs admin bypass on that check to merge, after which every subsequent PR's `ipr-check` will start working.

## Test plan
- [x] Typecheck clean
- [x] Pre-commit unit tests pass
- [ ] Merge with ipr-check bypass
- [ ] Re-run CI on #3034 — `ipr-check` should transition to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)