### PR TITLE
fix(docs): absolute URLs for signatures links in IPR_POLICY

### DIFF
--- a/.changeset/fix-ipr-signatures-link.md
+++ b/.changeset/fix-ipr-signatures-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Mintlify broken-links check failure introduced by #3011. IPR_POLICY.md §8 linked to `./signatures/README.md` and `./signatures/ipr-signatures.json` via relative paths; Mintlify's checker treats those as broken because the targets aren't in the docs tree it validates. Switch to absolute github.com URLs (same pattern used for IPR_POLICY itself in CONTRIBUTING.md). Unblocks docs-path-touching PRs from failing the `broken-links` workflow.

--- a/IPR_POLICY.md
+++ b/IPR_POLICY.md
@@ -103,6 +103,6 @@ Foundation pull request containing the exact phrase:
 A single signature, recorded by GitHub user identity, applies to all future
 Contributions from that Contributor across Foundation repositories. The
 canonical ledger of signatures lives at
-[`signatures/ipr-signatures.json`](./signatures/ipr-signatures.json); see
-[`signatures/README.md`](./signatures/README.md) for the mechanics, how to
-sign, and how to operate the ledger.
+[`signatures/ipr-signatures.json`](https://github.com/adcontextprotocol/adcp/blob/main/signatures/ipr-signatures.json);
+see [`signatures/README.md`](https://github.com/adcontextprotocol/adcp/blob/main/signatures/README.md)
+for the mechanics, how to sign, and how to operate the ledger.


### PR DESCRIPTION
## Summary

Mintlify's broken-links checker treats relative paths to files outside the registered docs tree as broken. The links to `./signatures/README.md` and `./signatures/ipr-signatures.json` added in #3011 are in `IPR_POLICY.md` (repo root, not docs/), which means the checker fails on any PR whose path filter trips the broken-links workflow.

Switch both links to absolute github.com URLs — same pattern already used for `IPR_POLICY.md` itself in `CONTRIBUTING.md`.

Unblocks #2994 (the buy terms PR that hit this) and any other in-flight PR touching files in the `broken-links.yml` path list.

## Test plan

- [x] `grep -n signatures IPR_POLICY.md` — both links are now absolute URLs
- [ ] CI: `broken-links` workflow runs and passes on this PR
- [ ] After merge: #2994 re-runs `broken-links` and goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)