### PR TITLE
feat(compliance): document field_value_or_absent matcher + restore replayed assertions

### DIFF
--- a/.changeset/document-field-value-or-absent-matcher.md
+++ b/.changeset/document-field-value-or-absent-matcher.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Document `field_value_or_absent` in the storyboard-schema.yaml check enum and restore the fresh-path `replayed` assertion in `universal/idempotency.yaml` using it. Closes #3030 (enum docs) and #3031 (idempotency storyboard assertion). Matcher ships in @adcp/client 5.16.0 (adcp-client#876); requires a reviewer to bump the SDK pin before merging.
+Document `field_value_or_absent` in the storyboard-schema.yaml check enum and restore the fresh-path `replayed` assertion in `universal/idempotency.yaml` using it. Closes #3030 (enum docs) and #3031 (idempotency storyboard assertion). Matcher ships in @adcp/client 5.16.0 (adcp-client#876).

--- a/.changeset/document-field-value-or-absent-matcher.md
+++ b/.changeset/document-field-value-or-absent-matcher.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document `field_value_or_absent` in the storyboard-schema.yaml check enum and restore the fresh-path `replayed` assertion in `universal/idempotency.yaml` using it. Closes #3030 (enum docs) and #3031 (idempotency storyboard assertion). Matcher ships in @adcp/client 5.16.0 (adcp-client#876); requires a reviewer to bump the SDK pin before merging.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -454,6 +454,7 @@ function classifyOutcome(step) {
       check === 'response_schema' ||
       check === 'field_present' ||
       check === 'field_value' ||
+      check === 'field_value_or_absent' ||
       check === 'http_status' ||
       check === 'http_status_in'
     );

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -270,14 +270,10 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Agent returns a media_buy_id for the initial request"
-          # NOTE: intentionally NO assertion on `replayed` here. Per
-          # `protocol-envelope.json`, fresh execution MAY omit the field,
-          # and `@adcp/client` >= 5.14 omits it (see adcp-client#859).
-          # The replay step below asserts `replayed: true` on the
-          # cached replay, which is the real regression surface. A
-          # fresh-path `field_value allowed_values: [false]` assertion
-          # has no `field_absent`-tolerant form today and would fail
-          # spec-correct agents.
+          - check: field_value_or_absent
+            path: "replayed"
+            allowed_values: [false]
+            description: "If replayed is present on fresh execution, it must be false"
 
           - check: field_present
             path: "context"

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -517,6 +517,10 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Fresh key returns a media_buy_id"
+          - check: field_value_or_absent
+            path: "replayed"
+            allowed_values: [false]
+            description: "If replayed is present on fresh-key execution, it must be false"
 
           - check: field_present
             path: "context"

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -71,9 +71,9 @@ validation_result:
   required_fields:
     - check                   # Validation kind from storyboard-schema.yaml:
                               # response_schema | field_present | field_value |
-                              # status_code | http_status | http_status_in |
-                              # error_code | on_401_require_header |
-                              # resource_equals_agent_url | any_of
+                              # field_value_or_absent | status_code | http_status |
+                              # http_status_in | error_code | on_401_require_header |
+                              # resource_equals_agent_url | any_of | refs_resolve
     - passed                  # boolean
     - description             # human-readable description copied from the
                               # storyboard validation entry (so the implementor
@@ -86,21 +86,26 @@ validation_result:
                               # failures. Null only when the failure is
                               # transport-level and no payload was returned.
     - expected                # machine-readable expected value:
-                              #   response_schema → schema $id that was applied
-                              #   field_value     → expected value (any JSON type)
-                              #   field_present   → the path that should resolve
-                              #   status_code     → expected status
-                              #   error_code      → expected error code
-                              #   any_of          → array of acceptable forms
+                              #   response_schema        → schema $id that was applied
+                              #   field_value            → expected value (any JSON type)
+                              #   field_value_or_absent  → allowed_values array from
+                              #                            the validation entry
+                              #   field_present          → the path that should resolve
+                              #   status_code            → expected status
+                              #   error_code             → expected error code
+                              #   any_of                 → array of acceptable forms
     - actual                  # machine-readable actual value observed:
-                              #   response_schema → array of schema errors
-                              #                     (each { instance_path,
-                              #                     schema_path, keyword,
-                              #                     message })
-                              #   field_value     → actual value (any JSON type)
-                              #   field_present   → null (the field was missing)
-                              #                     or the observed non-object
-                              #                     value
+                              #   response_schema        → array of schema errors
+                              #                            (each { instance_path,
+                              #                            schema_path, keyword,
+                              #                            message })
+                              #   field_value            → actual value (any JSON type)
+                              #   field_value_or_absent  → actual value (any JSON type);
+                              #                            null when check is emitted for
+                              #                            a present-but-disallowed value
+                              #   field_present          → null (the field was missing)
+                              #                            or the observed non-object
+                              #                            value
     - schema_id               # $id of the response schema applied. Required
                               # when check == response_schema, null otherwise.
     - schema_url              # Resolvable URL the implementor can fetch to

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -561,9 +561,9 @@
 #             required for "field_value_or_absent" when allowed_values is not provided)
 # allowed_values: array (acceptable values for "field_value", "field_value_or_absent",
 #                        "http_status_in", "error_code", "any_of")
-# For "field_value_or_absent": passes when the field is absent OR present and contained in
-#   `allowed_values` or equal to `value`; fails only when the field is present with a disallowed
-#   value.
+# For "field_value_or_absent": passes when the field is absent OR when it is present and
+#   (equal to `value` or contained in `allowed_values`); fails only when the field is present
+#   with a disallowed value.
 #   Use for envelope-optional fields where silence is spec-compliant but a wrong value is not.
 #   Requires @adcp/client >= 5.16.0 (adcp-client#876).
 # description: string (human-readable description of validation)

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -553,12 +553,19 @@
 # --- Validation ---
 #
 # check: string (what to validate: "response_schema", "field_present", "field_value",
-#                "status_code", "http_status", "http_status_in", "error_code",
-#                "on_401_require_header", "resource_equals_agent_url", "any_of",
+#                "field_value_or_absent", "status_code", "http_status", "http_status_in",
+#                "error_code", "on_401_require_header", "resource_equals_agent_url", "any_of",
 #                "refs_resolve")
 # path: string (JSON path to the field, e.g., "formats[0].format_id")
-# value: any (expected value — string, number, or boolean; required when check is "field_value")
-# allowed_values: array (acceptable values for "field_value", "http_status_in", "error_code", "any_of")
+# value: any (expected value — string, number, or boolean; required when check is "field_value";
+#             required for "field_value_or_absent" when allowed_values is not provided)
+# allowed_values: array (acceptable values for "field_value", "field_value_or_absent",
+#                        "http_status_in", "error_code", "any_of")
+# For "field_value_or_absent": passes when the field is absent OR present and contained in
+#   `allowed_values` or equal to `value`; fails only when the field is present with a disallowed
+#   value.
+#   Use for envelope-optional fields where silence is spec-compliant but a wrong value is not.
+#   Requires @adcp/client >= 5.16.0 (adcp-client#876).
 # description: string (human-readable description of validation)
 #
 # Error-shape validation — use `check: error_code`:


### PR DESCRIPTION
Closes #3030
Closes #3031

## Summary

`@adcp/client` 5.16.0 (adcp-client#876) shipped a new storyboard check matcher `field_value_or_absent` — passes when the field is absent OR present with an allowed value; fails only when present with a disallowed value. This is the right tool for envelope-optional fields like `replayed` where the spec permits omission but prohibits `true` on fresh execution.

This PR does three things:

1. **Documents `field_value_or_absent`** in `static/compliance/source/universal/storyboard-schema.yaml` (check enum + semantics prose) and `runner-output-contract.yaml` (expected/actual field contract for runner implementors). Closes #3030.
2. **Restores the `replayed` assertion** in `universal/idempotency.yaml::create_media_buy_initial` using the new matcher. The assertion was dropped in #3013 because `field_value` fires when the field is absent, penalising spec-correct agents that omit `replayed` on fresh execution. `field_value_or_absent` closes the gap. Closes #3031.
3. **Adds the symmetric assertion** to `create_media_buy_fresh_key` (the other fresh-execution step) for consistent coverage.
4. **Adds `field_value_or_absent` to `lint-storyboard-contradictions.cjs`** `hasPositiveAssertion` allowlist so steps using this check are correctly classified as success-path assertions by the linter.

**Non-breaking justification:** adds new optional assertions to two storyboard steps and a new enum value to documentation. Agents that omit `replayed` on fresh execution (spec-correct) pass. Agents that set `replayed: false` explicitly pass. Only agents that set `replayed: true` on a fresh (non-replay) call fail — that is already a spec violation per PR #3013.

## ⚠️ Merge gate — SDK pin bump required

`package.json` currently pins `@adcp/client` at `5.15.0`. The `field_value_or_absent` check ships in `5.16.0` (adcp-client#876). Runners that evaluate storyboards via the SDK will hit an `unknown_check` error on the two new assertions until the pin is bumped. **A reviewer must bump `package.json` to `@adcp/client >= 5.16.0` before merging.** (The agent cannot edit `package.json` per repo policy.)

## Pre-PR review

- **code-reviewer** (round 1): approved after fixes — added symmetric assertion to `create_media_buy_fresh_key`, added `field_value_or_absent` to `hasPositiveAssertion` in contradiction linter, clarified `value`/`allowed_values` doc prose.
- **code-reviewer** (round 2): approved after `runner-output-contract.yaml` check vocab and expected/actual entries were added; SDK pin noted as human gate.
- **ad-tech-protocol-expert**: approved — `field_value_or_absent` with `allowed_values: [false]` is the correct encoding of "MAY be omitted but MUST NOT be `true`"; non-breaking per spec; SDK pin flagged for human action.

Session: https://claude.ai/code/session_01FquZ6MmTXxv9cMCB9r8nbi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FquZ6MmTXxv9cMCB9r8nbi)_