### PR TITLE
fix(compliance): restore replayed assertion on fresh create_media_buy

### DIFF
--- a/.changeset/restore-replayed-assertion-fresh-create-media-buy.md
+++ b/.changeset/restore-replayed-assertion-fresh-create-media-buy.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restore positive `replayed` assertion on the fresh-path `create_media_buy_initial` step in `universal/idempotency.yaml`, now using the `field_value_or_absent` matcher (documented in #3032, shipped in `@adcp/client` 5.16.0). Fresh execution MAY omit `replayed` per `protocol-envelope.json`, but if present it MUST be `false` — this closes the coverage gap opened in #3013 without penalizing spec-correct agents that omit the field.

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -270,14 +270,10 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Agent returns a media_buy_id for the initial request"
-          # NOTE: intentionally NO assertion on `replayed` here. Per
-          # `protocol-envelope.json`, fresh execution MAY omit the field,
-          # and `@adcp/client` >= 5.14 omits it (see adcp-client#859).
-          # The replay step below asserts `replayed: true` on the
-          # cached replay, which is the real regression surface. A
-          # fresh-path `field_value allowed_values: [false]` assertion
-          # has no `field_absent`-tolerant form today and would fail
-          # spec-correct agents.
+          - check: field_value_or_absent
+            path: "replayed"
+            allowed_values: [false]
+            description: "If replayed is present on fresh execution, it MUST be false (protocol-envelope.json)"
 
           - check: field_present
             path: "context"


### PR DESCRIPTION
Closes #3031

## Summary

Restores the positive `replayed` assertion on the fresh-path `create_media_buy_initial` step in `universal/idempotency.yaml`, using the newly-documented `field_value_or_absent` matcher (spec: #3032 — merged; SDK: `@adcp/client` 5.16.0 via adcp-client#876).

Per `protocol-envelope.json`, fresh execution MAY omit the `replayed` field, but if present it MUST be `false`. The old `field_value` check penalized spec-correct agents that omitted the field; the new matcher passes on absent-or-false and fails only on `replayed: true` (the real regression surface).

## Change

```diff
- # NOTE: intentionally NO assertion on `replayed` here. Per
- # `protocol-envelope.json`, fresh execution MAY omit the field,
- # ... (eight-line comment explaining the gap) ...
+ - check: field_value_or_absent
+   path: "replayed"
+   allowed_values: [false]
+   description: "If replayed is present on fresh execution, it MUST be false (protocol-envelope.json)"
```

The replay-side assertion (`field_value` on `replayed: true`) at the `create_media_buy_replay` step is unchanged.

## Validation

- `node scripts/build-compliance.cjs` — builds clean (10 universal, 6 protocols, 20 specialisms)
- All 7 storyboard lint test suites pass (93/93 tests)
- Storyboard schema already documents `field_value_or_absent` with `allowed_values` (via #3032)

## Changeset

`--empty` — changes `static/compliance/source/universal/` (compliance infrastructure), not the published AdCP protocol schema or task definitions. No package version bump.

## Related

- #3013 — envelope clarification that dropped the original assertion
- #3030 — spec enum docs (issue)
- #3032 — spec enum docs (PR, merged)
- adcp-client#873 — matcher proposal
- adcp-client#876 — SDK matcher (shipped in 5.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)