### PR TITLE
feat(compliance): v3 envelope integrity — schema constraint + storyboard for task_status/response_status prohibition

### DIFF
--- a/.changeset/v3-envelope-integrity-conformance.md
+++ b/.changeset/v3-envelope-integrity-conformance.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(compliance): add v3 envelope integrity storyboard and schema enforcement for legacy status field prohibition
+
+Formalises the normative MUST NOT on `task_status` and `response_status` envelope fields (established in #2987 / #3021) as machine-checkable constraints:
+
+1. `static/schemas/source/core/protocol-envelope.json` — adds `"task_status": { "not": {} }` and `"response_status": { "not": {} }` to the properties block. These v2 legacy field names are already prohibited by prose; the schema now encodes that prohibition so any JSON Schema validator can detect violations without reading the migration guide.
+
+2. `static/compliance/source/universal/v3-envelope-integrity.yaml` — new universal storyboard (applies to all agent interaction models) that asserts `status` is present and `task_status` / `response_status` are absent at the envelope top-level. Scope is intentionally limited to the envelope root; nested `payload` domain data may legitimately carry a field named `task_status`.
+
+Note: the `field_absent` check type used in the storyboard validation steps requires runner support in `@adcp/client`. The `response_schema` check against `protocol-envelope.json` is immediately effective for schema-aware validators. Closes #3041.

--- a/static/compliance/source/universal/v3-envelope-integrity.yaml
+++ b/static/compliance/source/universal/v3-envelope-integrity.yaml
@@ -1,0 +1,103 @@
+id: v3_envelope_integrity
+version: "1.0.0"
+title: "v3 envelope integrity — no legacy status fields"
+category: schema_validation
+summary: "v3 protocol envelopes MUST NOT carry task_status or response_status — v2 legacy field names that have no semantics in v3."
+track: core
+required_tools: []  # protocol-level: get_adcp_capabilities is mandatory for all agents
+
+narrative: |
+  AdCP 3.0 normalises all task lifecycle state onto a single `status` field (values
+  defined in the task-status enum). The v2 `task_status` and `response_status` field
+  names have no semantics in v3 — carrying them on a v3 envelope is a normative
+  MUST NOT per the migration guide, task-lifecycle.mdx, and the protocol-envelope
+  schema. See docs/reference/migration/index.mdx and
+  docs/building/implementation/task-lifecycle.mdx.
+
+  This storyboard documents the machine-check assertion and asserts the canonical v3
+  `status` field is present. The explicit envelope-root field-absence checks
+  (asserting task_status and response_status are absent) require `field_absent`
+  runner support in @adcp/client — those checks are marked TODO below and are not
+  executed until the runner ships that check type. The schema-level constraint
+  (protocol-envelope.json marking both fields as `not: {}`) is the immediately
+  effective enforcement path for any schema-aware validator operating on the full
+  protocol envelope.
+
+  Scope: envelope top-level only. Domain data inside `payload` (e.g., a reporting
+  row carrying a field named task_status) is outside this prohibition and is not
+  checked here.
+
+agent:
+  interaction_model: "*"  # applies to every agent regardless of protocol or specialism
+  examples:
+    - "Any AdCP agent (seller, signals, creative, retail media, SI, governance)"
+
+caller:
+  role: buyer_agent
+  example: "Compliance test harness"
+
+prerequisites:
+  description: |
+    No test-kit credentials required. get_adcp_capabilities is a public operation
+    that every AdCP agent must expose without authentication.
+
+phases:
+  - id: envelope_integrity_check
+    title: "v3 envelope must not carry legacy v2 status field names"
+    narrative: |
+      Call get_adcp_capabilities and verify the response envelope carries the
+      canonical v3 status field. The complementary absence assertions for
+      task_status and response_status require field_absent runner support
+      (see TODO comments on the validation steps below).
+
+    steps:
+      - id: no_legacy_status_fields
+        title: "Envelope carries canonical v3 status; no legacy v2 status field names"
+        narrative: |
+          get_adcp_capabilities is the lightest call every agent supports and
+          requires no credentials. The response envelope must carry the canonical
+          v3 `status` field and must not carry task_status or response_status.
+          The protocol-envelope.json schema marks both fields as forbidden
+          (`not: {}`) to make this constraint detectable by schema-aware validators.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: envelope_integrity
+        stateful: false
+        expected: |
+          Response envelope:
+          - MUST contain status (the v3 canonical field)
+          - MUST NOT contain task_status (v2 legacy, no v3 semantics)
+          - MUST NOT contain response_status (v2 legacy, no v3 semantics)
+          Both forbidden fields are marked not: {} in protocol-envelope.json so
+          any schema-aware validator that validates the full protocol envelope
+          will detect violations.
+
+        sample_request:
+          context:
+            correlation_id: "v3_envelope_integrity--no_legacy_status"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "status"
+            description: "Envelope carries the canonical v3 status field"
+          # TODO: restore these as field_absent checks once @adcp/client runner ships
+          # the field_absent check type. Until then, the schema-level not: {} constraint
+          # in protocol-envelope.json is the enforcement path for schema-aware validators.
+          #
+          # - check: field_absent
+          #   path: "task_status"
+          #   description: "Envelope root MUST NOT carry task_status (v2 legacy; no v3 semantics)"
+          # - check: field_absent
+          #   path: "response_status"
+          #   description: "Envelope root MUST NOT carry response_status (v2 legacy; no v3 semantics)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "v3_envelope_integrity--no_legacy_status"
+            description: "Context correlation_id returned unchanged"

--- a/static/schemas/source/core/protocol-envelope.json
+++ b/static/schemas/source/core/protocol-envelope.json
@@ -47,6 +47,14 @@
       "type": "object",
       "description": "The actual task-specific response data. This is the content defined in individual task response schemas (e.g., get-products-response.json, create-media-buy-response.json). Contains only domain-specific data without protocol-level fields.",
       "additionalProperties": true
+    },
+    "task_status": {
+      "$comment": "Explicitly forbidden: v2 legacy field name with no semantics in v3. MUST NOT appear on v3 protocol envelopes. See docs/reference/migration/index.mdx and docs/building/implementation/task-lifecycle.mdx.",
+      "not": {}
+    },
+    "response_status": {
+      "$comment": "Explicitly forbidden: v2 legacy field name with no semantics in v3. MUST NOT appear on v3 protocol envelopes. See docs/reference/migration/index.mdx and docs/building/implementation/task-lifecycle.mdx.",
+      "not": {}
     }
   },
   "required": [


### PR DESCRIPTION
Closes #3041

## Summary

Formalises the normative MUST NOT on `task_status` and `response_status` envelope fields (established in #2987 / #3021) as machine-checkable constraints. Two changes:

1. **`static/schemas/source/core/protocol-envelope.json`** — adds `"task_status": { "not": {} }` and `"response_status": { "not": {} }` to the `properties` block. Any schema-aware validator that validates the full v3 protocol envelope will now detect these legacy field names as schema violations without reading the migration guide prose.

2. **`static/compliance/source/universal/v3-envelope-integrity.yaml`** — new universal storyboard (`interaction_model: "*"`) that asserts the canonical v3 `status` field is present on a `get_adcp_capabilities` response. Field-absence assertions for the two prohibited fields are included as commented-out TODO steps, pending `field_absent` runner support in `@adcp/client` (see cross-repo dependency below).

## Non-breaking justification

Adds `not: {}` constraints to two property names (`task_status`, `response_status`) that were already normatively MUST NOT per the migration guide and task-lifecycle.mdx. No conformant v3 implementation uses these fields; no v3 downstream is broken. The `protocol-envelope.json` source schema is what changes — released `dist/schemas/` versions are unaffected until the next release cycle.

## Cross-repo dependency

The storyboard's explicit field-absence checks (`field_absent`) require a new check type in `@adcp/client`. Those validations are commented out with TODO markers. Until the runner ships `field_absent`, the machine-checkable enforcement path is the `not: {}` schema constraint for external schema validators. The storyboard itself (asserting `status` is present and context is echoed) runs cleanly today.

**Immediate enforcement (today):** schema-aware validators using `protocol-envelope.json` directly.
**Deferred enforcement:** `@adcp/client` runner `field_absent` check type — needs a separate PR to `adcontextprotocol/adcp-client`.

## Open questions answered in triage

- **Scope:** envelope top-level only (domain `payload` data may carry `task_status` legitimately)
- **Aliases:** only `task_status` and `response_status` (MUST NOT per spec); `state`/`phase` out of scope
- **Placement:** `universal/` (not `security.yaml`; not `schema-validation.yaml` which is implicitly scoped to sellers)
- **v2 sunset gating:** not needed — agents in dual-stack mode that fail this check have a v3 serialiser bug, which is exactly what this check is for

## Pre-PR review

- **code-reviewer:** approved — blockers resolved (removed `field_absent` active checks; corrected narrative claim about `response_schema` path; upgraded changeset to `minor`). Nits noted: correlation_id separator style, `$comment` path staleness risk (low).
- **ad-tech-protocol-expert:** approved — schema pattern (`not: {}`), `universal/` placement, no v2 gating, and `minor` changeset type all confirmed sound.

Session: https://claude.ai/code/session_0144VBMThUyhomU346keD32C

---
_Generated by [Claude Code](https://claude.ai/code/session_0144VBMThUyhomU346keD32C)_