### PR TITLE
feat(triage): file bug-shaped escalations as GitHub issues

### DIFF
--- a/.changeset/escalation-file-as-github-issue.md
+++ b/.changeset/escalation-file-as-github-issue.md
@@ -1,0 +1,13 @@
+---
+---
+
+Escalation triage can now suggest filing bug-shaped escalations as GitHub
+issues. When a URL probe confirms the bug still repros (404/410 on the
+referenced AAO page), the classifier emits a `file_as_issue` suggestion
+with a pre-drafted title/body. Admins review the draft on
+`/admin/escalations/triage` and one-click file — Addie creates the issue
+via GITHUB_TOKEN, records the URL on the escalation, and marks it resolved.
+
+The draft is built from Addie-authored fields only (summary + context) —
+user PII (email, slack handle, display name, raw original request) is
+excluded by construction.

--- a/server/public/admin-escalation-triage.html
+++ b/server/public/admin-escalation-triage.html
@@ -27,6 +27,18 @@
     .tag-medium { background: #fef3c7; color: #92400e; }
     .tag-low { background: #dbeafe; color: #1e40af; }
     .tag-bucket { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
+    .tag-issue { background: #ede9fe; color: #5b21b6; }
+    .draft {
+      margin-top: var(--space-2);
+      background: var(--color-bg-subtle);
+      border-left: 3px solid #7c3aed;
+      padding: var(--space-2) var(--space-3);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-xs);
+    }
+    .draft .draft-title { font-weight: 700; color: var(--color-text-primary); font-family: var(--font-mono); }
+    .draft .draft-body { white-space: pre-wrap; color: var(--color-text-secondary); margin-top: var(--space-1); }
+    .draft-repo { font-family: var(--font-mono); color: var(--color-text-secondary); }
     .actions { display: flex; gap: var(--space-2); }
     button { border: 0; padding: 6px 12px; border-radius: var(--radius-sm); font-weight: 600; cursor: pointer; font-size: var(--text-sm); }
     .btn-accept { background: #16a34a; color: white; }
@@ -107,6 +119,21 @@
       tbody.innerHTML = suggestions.map(s => {
         const e = s.escalation || {};
         const evidence = (s.evidence || []).map(esc).join(' · ');
+        const isFile = s.suggested_status === 'file_as_issue';
+        const statusTag = isFile
+          ? `<span class="tag tag-issue">file_as_issue</span>`
+          : `<span class="tag tag-${esc(s.confidence)}">${esc(s.suggested_status)}</span>`;
+        const acceptLabel = isFile ? 'File as issue' : 'Accept';
+        const draft = s.proposed_github_issue;
+        const draftBlock = isFile && draft
+          ? `<div class="draft">
+              <div><span class="draft-repo">${esc(draft.repo)}</span> — <span class="draft-title">${esc(draft.title)}</span></div>
+              <div class="draft-body">${esc((draft.body || '').slice(0, 500))}</div>
+            </div>`
+          : '';
+        const linkBlock = e.github_issue_url
+          ? `<div class="reasoning">Filed: <a href="${esc(e.github_issue_url)}" target="_blank" rel="noopener">${esc(e.github_issue_url)}</a></div>`
+          : '';
         return `
           <tr data-id="${s.id}">
             <td>${e.id ?? '?'}</td>
@@ -114,12 +141,14 @@
               <div class="title">${esc(e.summary?.slice(0, 180) ?? '')}</div>
               <div class="reasoning">${esc(s.reasoning)}</div>
               <div class="evidence">${evidence}</div>
+              ${draftBlock}
+              ${linkBlock}
             </td>
-            <td><span class="tag tag-${esc(s.confidence)}">${esc(s.suggested_status)}</span></td>
+            <td>${statusTag}</td>
             <td><span class="tag tag-${esc(s.confidence)}">${esc(s.confidence)}</span></td>
             <td><span class="tag tag-bucket">${esc(s.bucket ?? '—')}</span></td>
             <td class="actions">
-              <button class="btn-accept" data-action="accept" data-id="${s.id}">Accept</button>
+              <button class="btn-accept" data-action="accept" data-id="${s.id}">${acceptLabel}</button>
               <button class="btn-reject" data-action="reject" data-id="${s.id}">Reject</button>
             </td>
           </tr>

--- a/server/src/addie/jobs/escalation-triage.ts
+++ b/server/src/addie/jobs/escalation-triage.ts
@@ -52,11 +52,28 @@ export interface TriageJobResult {
 type ClassificationVerdict = Omit<TriageSuggestionInput, 'escalation_id'> | null;
 
 /**
+ * Neutralise GitHub markdown constructs that could surprise readers of
+ * the filed issue. `@mentions` would ping real users when the draft is
+ * pasted; markdown images pull remote content that could track IPs.
+ * We break the syntax without destroying the readable text.
+ */
+function sanitiseForGithubBody(text: string): string {
+  return text
+    .replace(/(^|\s)@([A-Za-z0-9][A-Za-z0-9-]{0,38})/g, '$1`@$2`')
+    .replace(/!\[/g, '[');
+}
+
+/**
  * Build a GitHub issue draft from an escalation. PII is excluded on
  * purpose: the dedicated contact columns (`user_email`, `user_slack_handle`,
  * `user_display_name`) never enter the body, and `original_request` is
  * skipped because it tends to quote the user's raw message. The summary
- * is Addie's own scrubbed rewrite, so it's safe to include.
+ * is Addie's own scrubbed rewrite, and we additionally neutralise any
+ * `@mentions` or image tags she may have carried through.
+ *
+ * NOTE: callers writing into `addie_escalations.summary` or `.addie_context`
+ * are expected to keep them PII-free — a future intake that pipes raw user
+ * text into those columns would silently ship PII onto a public issue.
  */
 export function buildGithubIssueDraft(
   escalation: Escalation,
@@ -64,18 +81,18 @@ export function buildGithubIssueDraft(
 ): ProposedGithubIssue {
   const titleBase = (escalation.summary ?? 'Untitled escalation').trim();
   const title = titleBase.length > 80
-    ? `${titleBase.slice(0, 77).replace(/\s+\S*$/, '')}…`
+    ? `${titleBase.slice(0, 77).replace(/\s+\S*$/, '')}...`
     : titleBase;
 
   const lines: string[] = [];
   lines.push('Filed from an AAO member escalation via Addie triage.');
   lines.push('');
   lines.push('## Summary');
-  lines.push(escalation.summary ?? '');
+  lines.push(sanitiseForGithubBody(escalation.summary ?? ''));
   if (escalation.addie_context) {
     lines.push('');
     lines.push('## Context');
-    lines.push(escalation.addie_context);
+    lines.push(sanitiseForGithubBody(escalation.addie_context));
   }
   if (brokenUrls.length > 0) {
     lines.push('');
@@ -84,7 +101,11 @@ export function buildGithubIssueDraft(
   }
   lines.push('');
   lines.push(`---`);
-  lines.push(`Escalation #${escalation.id} · ${new Date(escalation.created_at).toISOString().slice(0, 10)}`);
+  const createdIso = (() => {
+    const t = escalation.created_at ? new Date(escalation.created_at).getTime() : NaN;
+    return Number.isFinite(t) ? new Date(t).toISOString().slice(0, 10) : 'unknown';
+  })();
+  lines.push(`Escalation #${escalation.id} · ${createdIso}`);
 
   return {
     title,

--- a/server/src/addie/jobs/escalation-triage.ts
+++ b/server/src/addie/jobs/escalation-triage.ts
@@ -18,6 +18,7 @@ import {
 import {
   insertSuggestionIfNew,
   getPendingSuggestionForEscalation,
+  type ProposedGithubIssue,
   type TriageSuggestionInput,
 } from '../../db/escalation-triage-db.js';
 import {
@@ -49,6 +50,49 @@ export interface TriageJobResult {
 }
 
 type ClassificationVerdict = Omit<TriageSuggestionInput, 'escalation_id'> | null;
+
+/**
+ * Build a GitHub issue draft from an escalation. PII is excluded on
+ * purpose: the dedicated contact columns (`user_email`, `user_slack_handle`,
+ * `user_display_name`) never enter the body, and `original_request` is
+ * skipped because it tends to quote the user's raw message. The summary
+ * is Addie's own scrubbed rewrite, so it's safe to include.
+ */
+export function buildGithubIssueDraft(
+  escalation: Escalation,
+  brokenUrls: string[],
+): ProposedGithubIssue {
+  const titleBase = (escalation.summary ?? 'Untitled escalation').trim();
+  const title = titleBase.length > 80
+    ? `${titleBase.slice(0, 77).replace(/\s+\S*$/, '')}…`
+    : titleBase;
+
+  const lines: string[] = [];
+  lines.push('Filed from an AAO member escalation via Addie triage.');
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(escalation.summary ?? '');
+  if (escalation.addie_context) {
+    lines.push('');
+    lines.push('## Context');
+    lines.push(escalation.addie_context);
+  }
+  if (brokenUrls.length > 0) {
+    lines.push('');
+    lines.push('## Repro');
+    for (const u of brokenUrls) lines.push(`- ${u}`);
+  }
+  lines.push('');
+  lines.push(`---`);
+  lines.push(`Escalation #${escalation.id} · ${new Date(escalation.created_at).toISOString().slice(0, 10)}`);
+
+  return {
+    title,
+    body: lines.join('\n'),
+    repo: process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp',
+    labels: ['from-escalation', 'needs-triage'],
+  };
+}
 
 /**
  * Decide a verdict for one escalation. Pure-ish — pulls related
@@ -83,25 +127,33 @@ export async function classifyEscalation(
   }
 
   // Rule 2 — URL probe for bug-shaped escalations.
-  // If the summary cites an AAO URL, hit it. 404/410 → still broken, keep open.
-  // 200/301/302 → likely fixed, suggest resolve with MEDIUM confidence.
-  // If every probe returns null (network error) → treat as "no signal"
-  // rather than falsely passing into the stale-ops rule.
+  //   404/410 → bug still repros; suggest filing a GitHub issue.
+  //   200/301/302 → likely fixed; suggest resolve at MEDIUM confidence.
+  //   all-null (network error) → no signal; don't fall through.
   const urls = extractAaoUrls(summary);
   if (urls.length > 0) {
     const sliced = urls.slice(0, 3);
-    // Probes run concurrently per-escalation so worst-case is one timeout
-    // window, not N timeouts multiplied.
     const probes = await Promise.all(
       sliced.map(async url => ({ url, status: await probeUrlStatus(url) })),
     );
     const probeEvidence = probes.map(p => `probe ${p.url} → ${p.status ?? 'err'}`);
 
-    if (probes.some(p => p.status === 404 || p.status === 410)) {
-      return null; // still broken; keep open
+    const brokenUrls = probes.filter(p => p.status === 404 || p.status === 410).map(p => p.url);
+    if (brokenUrls.length > 0 && bucket === 'bug' && !escalation.github_issue_url) {
+      return {
+        suggested_status: 'file_as_issue',
+        confidence: 'medium',
+        bucket,
+        reasoning: 'Bug still repros (URL returns 404/410). Propose filing as a GitHub issue so it lands in engineering triage.',
+        evidence: [...evidence, ...probeEvidence],
+        proposed_github_issue: buildGithubIssueDraft(escalation, brokenUrls),
+      };
+    }
+    if (brokenUrls.length > 0) {
+      return null; // still broken but already linked or not bug-shaped — leave for human
     }
     if (probes.every(p => p.status === null)) {
-      return null; // all probes failed — don't fall through to other rules
+      return null;
     }
     const allGood = probes.every(p => p.status != null && p.status >= 200 && p.status < 400);
     if (allGood && bucket === 'bug') {

--- a/server/src/addie/jobs/github-filer.ts
+++ b/server/src/addie/jobs/github-filer.ts
@@ -1,10 +1,8 @@
 /**
- * GitHub issue filer for escalation triage.
+ * GitHub issue filer.
  *
- * Thin wrapper around the GitHub REST API used by the "file as issue"
- * accept flow. Same pattern as knowledge-gap-closer's inline filer —
- * factored out so callers across Addie jobs can share one path and so
- * tests can mock a single seam.
+ * Thin wrapper around the GitHub REST API. Exposes a single seam so
+ * callers can share one path and tests can mock cleanly.
  */
 
 import { createLogger } from '../../logger.js';
@@ -39,9 +37,13 @@ export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue
 
   const repo = input.repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
 
+  // Bound the fetch so a GitHub outage can't hang the admin request.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
   try {
     const resp = await fetch(`https://api.github.com/repos/${repo}/issues`, {
       method: 'POST',
+      signal: controller.signal,
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
@@ -66,5 +68,7 @@ export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue
   } catch (err) {
     logger.error({ err, repo }, 'GitHub issue create threw');
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/server/src/addie/jobs/github-filer.ts
+++ b/server/src/addie/jobs/github-filer.ts
@@ -1,0 +1,70 @@
+/**
+ * GitHub issue filer for escalation triage.
+ *
+ * Thin wrapper around the GitHub REST API used by the "file as issue"
+ * accept flow. Same pattern as knowledge-gap-closer's inline filer —
+ * factored out so callers across Addie jobs can share one path and so
+ * tests can mock a single seam.
+ */
+
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('github-filer');
+
+export interface FileIssueInput {
+  title: string;
+  body: string;
+  /** Repo slug `owner/name`. Defaults to `GITHUB_REPO` env or `adcontextprotocol/adcp`. */
+  repo?: string;
+  labels?: string[];
+}
+
+export interface FiledIssue {
+  url: string;
+  number: number;
+  repo: string;
+}
+
+/**
+ * Create a GitHub issue using the GITHUB_TOKEN env var. Returns null on
+ * any failure (missing token, HTTP error, network error) so callers can
+ * keep the escalation open without swallowing the exception.
+ */
+export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue | null> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    logger.warn('GITHUB_TOKEN not set; cannot file issue');
+    return null;
+  }
+
+  const repo = input.repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
+
+  try {
+    const resp = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'aao-escalation-triage/1.0',
+      },
+      body: JSON.stringify({
+        title: input.title,
+        body: input.body,
+        labels: input.labels ?? [],
+      }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text().catch(() => '');
+      logger.error({ status: resp.status, err, repo }, 'GitHub issue create failed');
+      return null;
+    }
+
+    const issue = (await resp.json()) as { html_url: string; number: number };
+    return { url: issue.html_url, number: issue.number, repo };
+  } catch (err) {
+    logger.error({ err, repo }, 'GitHub issue create threw');
+    return null;
+  }
+}

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -53,6 +53,10 @@ export interface Escalation {
   perspective_id: string | null;
   /** Optional: denormalized slug for easy admin display without a join. */
   perspective_slug: string | null;
+  /** Set when a triage suggestion filed a GitHub issue for this escalation. */
+  github_issue_url: string | null;
+  github_issue_number: number | null;
+  github_issue_repo: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -287,6 +291,30 @@ export async function updateEscalationStatus(
     [id, status, resolvedBy || null, isResolved, notes || null]
   );
   return result.rows[0] || null;
+}
+
+/**
+ * Record a filed GitHub issue on an escalation. Called from the
+ * accept-as-file-issue flow in addie-admin so admins see the link
+ * on the escalations dashboard and later triage runs know to skip.
+ */
+export async function setEscalationGithubIssue(
+  id: number,
+  url: string,
+  number: number,
+  repo: string,
+): Promise<Escalation | null> {
+  const result = await query<Escalation>(
+    `UPDATE addie_escalations
+     SET github_issue_url = $2,
+         github_issue_number = $3,
+         github_issue_repo = $4,
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, url, number, repo],
+  );
+  return result.rows[0] ?? null;
 }
 
 /**

--- a/server/src/db/escalation-triage-db.ts
+++ b/server/src/db/escalation-triage-db.ts
@@ -129,6 +129,14 @@ export async function getPendingSuggestionForEscalation(
   return result.rows[0] ?? null;
 }
 
+/**
+ * Atomically reserve-and-record a decision on a suggestion. Returns the
+ * updated row on success, or null when the suggestion is already decided
+ * (meaning a concurrent caller got there first). The `AND decision IS NULL`
+ * clause makes this safe against two admins clicking accept simultaneously
+ * — important for `file_as_issue`, where a duplicate would file a second
+ * GitHub issue as a side effect.
+ */
 export async function recordDecision(
   id: number,
   decision: SuggestionDecision,
@@ -141,11 +149,34 @@ export async function recordDecision(
          reviewed_by = $3,
          reviewed_at = NOW(),
          decision_notes = $4
-     WHERE id = $1
+     WHERE id = $1 AND decision IS NULL
      RETURNING *`,
     [id, decision, reviewedBy, notes ?? null],
   );
   return result.rows[0] ?? null;
+}
+
+/**
+ * Release a decision that was set by `recordDecision`. Used as the
+ * compensating write when the follow-up external call (GitHub issue
+ * filing) fails, so another retry can claim the suggestion.
+ *
+ * Scoped to the reviewer who made the reservation to avoid clobbering
+ * a legitimate decision by a different admin.
+ */
+export async function releaseDecision(
+  id: number,
+  reviewedBy: string,
+): Promise<void> {
+  await query(
+    `UPDATE escalation_triage_suggestions
+     SET decision = NULL,
+         reviewed_by = NULL,
+         reviewed_at = NULL,
+         decision_notes = NULL
+     WHERE id = $1 AND reviewed_by = $2`,
+    [id, reviewedBy],
+  );
 }
 
 export async function getSuggestionStats(): Promise<{

--- a/server/src/db/escalation-triage-db.ts
+++ b/server/src/db/escalation-triage-db.ts
@@ -6,9 +6,16 @@
 
 import { query } from './client.js';
 
-export type SuggestedStatus = 'resolved' | 'wont_do' | 'keep_open';
+export type SuggestedStatus = 'resolved' | 'wont_do' | 'keep_open' | 'file_as_issue';
 export type SuggestionConfidence = 'high' | 'medium' | 'low';
 export type SuggestionDecision = 'accepted' | 'rejected' | 'superseded';
+
+export interface ProposedGithubIssue {
+  title: string;
+  body: string;
+  repo: string;
+  labels: string[];
+}
 
 export interface TriageSuggestion {
   id: number;
@@ -19,6 +26,7 @@ export interface TriageSuggestion {
   bucket: string | null;
   reasoning: string;
   evidence: string[];
+  proposed_github_issue: ProposedGithubIssue | null;
   reviewed_at: Date | null;
   reviewed_by: string | null;
   decision: SuggestionDecision | null;
@@ -32,6 +40,7 @@ export interface TriageSuggestionInput {
   bucket?: string | null;
   reasoning: string;
   evidence: string[];
+  proposed_github_issue?: ProposedGithubIssue | null;
 }
 
 /**
@@ -44,8 +53,8 @@ export async function insertSuggestionIfNew(
 ): Promise<TriageSuggestion | null> {
   const result = await query<TriageSuggestion>(
     `INSERT INTO escalation_triage_suggestions
-      (escalation_id, suggested_status, confidence, bucket, reasoning, evidence)
-     VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+      (escalation_id, suggested_status, confidence, bucket, reasoning, evidence, proposed_github_issue)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
      ON CONFLICT DO NOTHING
      RETURNING *`,
     [
@@ -55,6 +64,7 @@ export async function insertSuggestionIfNew(
       input.bucket ?? null,
       input.reasoning,
       JSON.stringify(input.evidence ?? []),
+      input.proposed_github_issue ? JSON.stringify(input.proposed_github_issue) : null,
     ],
   );
   return result.rows[0] ?? null;

--- a/server/src/db/migrations/429_escalation_github_issue_link.sql
+++ b/server/src/db/migrations/429_escalation_github_issue_link.sql
@@ -1,0 +1,35 @@
+-- Migration: link escalations to GitHub issues
+--
+-- When a triage suggestion resolves an escalation by filing a GitHub
+-- issue, we record the resulting issue on the escalation so:
+--   - admins can click through from the dashboard,
+--   - later triage runs skip items already linked to an issue,
+--   - resolution notes carry a durable reference.
+--
+-- Also extends escalation_triage_suggestions with a proposed-issue
+-- draft so the admin UI can show what will be filed before the admin
+-- clicks accept, and widens the suggested_status enum to include the
+-- file-as-issue action.
+
+ALTER TABLE addie_escalations
+  ADD COLUMN IF NOT EXISTS github_issue_url TEXT,
+  ADD COLUMN IF NOT EXISTS github_issue_number INT,
+  ADD COLUMN IF NOT EXISTS github_issue_repo TEXT;
+
+COMMENT ON COLUMN addie_escalations.github_issue_url IS
+  'Set when a triage suggestion filed a GitHub issue for this escalation.';
+
+ALTER TABLE escalation_triage_suggestions
+  ADD COLUMN IF NOT EXISTS proposed_github_issue JSONB;
+
+COMMENT ON COLUMN escalation_triage_suggestions.proposed_github_issue IS
+  'Draft { title, body, repo, labels } shown to admins for file_as_issue suggestions.';
+
+-- Widen the suggested_status check constraint. The existing check is a
+-- named constraint from migration 428; drop and recreate.
+ALTER TABLE escalation_triage_suggestions
+  DROP CONSTRAINT IF EXISTS escalation_triage_suggestions_status_chk;
+
+ALTER TABLE escalation_triage_suggestions
+  ADD CONSTRAINT escalation_triage_suggestions_status_chk
+    CHECK (suggested_status IN ('resolved', 'wont_do', 'keep_open', 'file_as_issue'));

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -43,6 +43,7 @@ import {
   listSuggestions,
   getSuggestion,
   recordDecision,
+  releaseDecision,
   getSuggestionStats,
   type SuggestionConfidence,
 } from "../db/escalation-triage-db.js";
@@ -1875,8 +1876,14 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
             });
           }
 
-          // File the issue first; if that fails, keep the escalation open
-          // rather than resolve on a ghost issue. Admin can retry.
+          // Reserve the suggestion atomically before calling GitHub, so
+          // two concurrent clicks can't both file an issue. If GitHub
+          // fails, release the reservation so a retry can claim it.
+          const claimed = await recordDecision(id, 'accepted', reviewer, req.body?.notes);
+          if (!claimed) {
+            return res.status(409).json({ error: "Already reviewed" });
+          }
+
           const filed = await fileGitHubIssue({
             title: draft.title,
             body: draft.body,
@@ -1884,25 +1891,30 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
             labels: draft.labels,
           });
           if (!filed) {
+            await releaseDecision(id, reviewer);
             return res.status(502).json({
               error: "GitHub API",
               message: "Failed to file issue — escalation left open. Retry later.",
             });
           }
 
-          await setEscalationGithubIssue(suggestion.escalation_id, filed.url, filed.number, filed.repo);
+          const updatedEsc = await setEscalationGithubIssue(
+            suggestion.escalation_id,
+            filed.url,
+            filed.number,
+            filed.repo,
+          );
           const notes = `Filed as ${filed.url} via triage suggestion #${id}.`;
-          const updatedEsc = await updateEscalationStatus(
+          const resolvedEsc = await updateEscalationStatus(
             suggestion.escalation_id,
             'resolved',
             reviewer,
             notes,
           );
-          const updatedSug = await recordDecision(id, 'accepted', reviewer, req.body?.notes);
           return res.json({
             success: true,
-            suggestion: updatedSug,
-            escalation: updatedEsc,
+            suggestion: claimed,
+            escalation: resolvedEsc ?? updatedEsc,
             issue: filed,
           });
         }

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -34,6 +34,7 @@ import {
   getEscalation,
   updateEscalationStatus,
   getEscalationStats,
+  setEscalationGithubIssue,
   buildResolutionNotificationMessage,
   type EscalationStatus,
   type EscalationCategory,
@@ -46,6 +47,7 @@ import {
   type SuggestionConfidence,
 } from "../db/escalation-triage-db.js";
 import { runEscalationTriageJob } from "../addie/jobs/escalation-triage.js";
+import { fileGitHubIssue } from "../addie/jobs/github-filer.js";
 import * as imageDb from "../db/addie-image-db.js";
 import {
   listInsights,
@@ -1862,6 +1864,47 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
           // Nothing to apply — record decision as accepted but don't mutate the escalation.
           const updated = await recordDecision(id, 'accepted', reviewer);
           return res.json({ success: true, suggestion: updated });
+        }
+
+        if (suggestion.suggested_status === 'file_as_issue') {
+          const draft = suggestion.proposed_github_issue;
+          if (!draft) {
+            return res.status(400).json({
+              error: "Bad request",
+              message: "file_as_issue suggestion missing proposed_github_issue draft",
+            });
+          }
+
+          // File the issue first; if that fails, keep the escalation open
+          // rather than resolve on a ghost issue. Admin can retry.
+          const filed = await fileGitHubIssue({
+            title: draft.title,
+            body: draft.body,
+            repo: draft.repo,
+            labels: draft.labels,
+          });
+          if (!filed) {
+            return res.status(502).json({
+              error: "GitHub API",
+              message: "Failed to file issue — escalation left open. Retry later.",
+            });
+          }
+
+          await setEscalationGithubIssue(suggestion.escalation_id, filed.url, filed.number, filed.repo);
+          const notes = `Filed as ${filed.url} via triage suggestion #${id}.`;
+          const updatedEsc = await updateEscalationStatus(
+            suggestion.escalation_id,
+            'resolved',
+            reviewer,
+            notes,
+          );
+          const updatedSug = await recordDecision(id, 'accepted', reviewer, req.body?.notes);
+          return res.json({
+            success: true,
+            suggestion: updatedSug,
+            escalation: updatedEsc,
+            issue: filed,
+          });
         }
 
         const notes = `Triage suggestion #${id}: ${suggestion.reasoning}`;

--- a/server/tests/integration/escalation-triage-endpoints.test.ts
+++ b/server/tests/integration/escalation-triage-endpoints.test.ts
@@ -186,7 +186,7 @@ describe('Escalation triage endpoints', () => {
     expect(mocks.fileGitHubIssue).toHaveBeenCalledTimes(1);
   });
 
-  it('502s on GitHub API failure and leaves the escalation untouched', async () => {
+  it('502s on GitHub API failure and leaves the escalation + suggestion open for retry', async () => {
     mocks.fileGitHubIssue.mockResolvedValue(null);
     const eid = await seedOpenEscalation('Bug: /some-page 404s');
     const sid = await seedSuggestion(eid, 'file_as_issue');
@@ -202,6 +202,35 @@ describe('Escalation triage endpoints', () => {
     );
     expect(esc.rows[0].status).toBe('open');
     expect(esc.rows[0].github_issue_url).toBeNull();
+
+    // Reservation is released so a retry can claim it.
+    const sug = await query<{ decision: string | null }>(
+      `SELECT decision FROM escalation_triage_suggestions WHERE id = $1`,
+      [sid],
+    );
+    expect(sug.rows[0].decision).toBeNull();
+  });
+
+  it('concurrent accepts on a file_as_issue suggestion file exactly one GitHub issue', async () => {
+    // Simulate two admins hitting accept at nearly the same moment.
+    // The atomic reservation on recordDecision should serialise them
+    // so only one call reaches fileGitHubIssue.
+    mocks.fileGitHubIssue.mockResolvedValue({
+      url: 'https://github.com/adcontextprotocol/adcp/issues/9001',
+      number: 9001,
+      repo: 'adcontextprotocol/adcp',
+    });
+    const eid = await seedOpenEscalation('Bug: /race 404s');
+    const sid = await seedSuggestion(eid, 'file_as_issue');
+
+    const [a, b] = await Promise.all([
+      request(app as never).post(`/api/admin/addie/escalations/suggestions/${sid}/accept`).send({}),
+      request(app as never).post(`/api/admin/addie/escalations/suggestions/${sid}/accept`).send({}),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual([200, 409]);
+    expect(mocks.fileGitHubIssue).toHaveBeenCalledTimes(1);
   });
 
   it('GET /escalations/suggestions matches the literal path and does not shadow into the :id handler', async () => {

--- a/server/tests/integration/escalation-triage-endpoints.test.ts
+++ b/server/tests/integration/escalation-triage-endpoints.test.ts
@@ -13,6 +13,15 @@ import { runMigrations } from '../../src/db/migrate.js';
  * plus the 409 double-apply guard that unit tests can't exercise
  * without a real table.
  */
+// Mock the GitHub filer so we don't actually hit api.github.com in tests.
+// A single hoisted spy lets each test drive the success / failure path.
+const mocks = vi.hoisted(() => ({
+  fileGitHubIssue: vi.fn(),
+}));
+vi.mock('../../src/addie/jobs/github-filer.js', () => ({
+  fileGitHubIssue: mocks.fileGitHubIssue,
+}));
+
 vi.mock('../../src/middleware/auth.js', () => ({
   requireAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
     (req as { user: unknown }).user = {
@@ -59,6 +68,7 @@ describe('Escalation triage endpoints', () => {
   beforeEach(async () => {
     await query('DELETE FROM escalation_triage_suggestions WHERE TRUE');
     await query("DELETE FROM addie_escalations WHERE user_email = 'triage-test@example.com'");
+    mocks.fileGitHubIssue.mockReset();
   });
 
   async function seedOpenEscalation(summary: string): Promise<number> {
@@ -71,13 +81,16 @@ describe('Escalation triage endpoints', () => {
     return res.rows[0].id;
   }
 
-  async function seedSuggestion(escalationId: number, status: 'resolved' | 'keep_open') {
+  async function seedSuggestion(escalationId: number, status: 'resolved' | 'keep_open' | 'file_as_issue') {
+    const draft = status === 'file_as_issue'
+      ? { title: 'Bug: /page is broken', body: 'draft body', repo: 'adcontextprotocol/adcp', labels: ['from-escalation'] }
+      : null;
     const res = await query<{ id: number }>(
       `INSERT INTO escalation_triage_suggestions
-         (escalation_id, suggested_status, confidence, bucket, reasoning, evidence)
-       VALUES ($1, $2, 'medium', 'bug', 'test reasoning', '[]'::jsonb)
+         (escalation_id, suggested_status, confidence, bucket, reasoning, evidence, proposed_github_issue)
+       VALUES ($1, $2, 'medium', 'bug', 'test reasoning', '[]'::jsonb, $3::jsonb)
        RETURNING id`,
-      [escalationId, status],
+      [escalationId, status, draft ? JSON.stringify(draft) : null],
     );
     return res.rows[0].id;
   }
@@ -149,6 +162,46 @@ describe('Escalation triage endpoints', () => {
       [eid],
     );
     expect(esc.rows[0].status).toBe('open');
+  });
+
+  it('accept on file_as_issue files the issue, records it on the escalation, and resolves', async () => {
+    mocks.fileGitHubIssue.mockResolvedValue({
+      url: 'https://github.com/adcontextprotocol/adcp/issues/4242',
+      number: 4242,
+      repo: 'adcontextprotocol/adcp',
+    });
+    const eid = await seedOpenEscalation('Bug: /some-page 404s');
+    const sid = await seedSuggestion(eid, 'file_as_issue');
+
+    const res = await request(app as never)
+      .post(`/api/admin/addie/escalations/suggestions/${sid}/accept`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.issue?.url).toBe('https://github.com/adcontextprotocol/adcp/issues/4242');
+    expect(res.body.escalation.status).toBe('resolved');
+    expect(res.body.escalation.github_issue_url).toBe('https://github.com/adcontextprotocol/adcp/issues/4242');
+    expect(res.body.escalation.github_issue_number).toBe(4242);
+    expect(res.body.escalation.resolution_notes).toMatch(/Filed as https:\/\/github.com\/adcontextprotocol\/adcp\/issues\/4242/);
+    expect(mocks.fileGitHubIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it('502s on GitHub API failure and leaves the escalation untouched', async () => {
+    mocks.fileGitHubIssue.mockResolvedValue(null);
+    const eid = await seedOpenEscalation('Bug: /some-page 404s');
+    const sid = await seedSuggestion(eid, 'file_as_issue');
+
+    const res = await request(app as never)
+      .post(`/api/admin/addie/escalations/suggestions/${sid}/accept`)
+      .send({});
+
+    expect(res.status).toBe(502);
+    const esc = await query<{ status: string; github_issue_url: string | null }>(
+      `SELECT status, github_issue_url FROM addie_escalations WHERE id = $1`,
+      [eid],
+    );
+    expect(esc.rows[0].status).toBe('open');
+    expect(esc.rows[0].github_issue_url).toBeNull();
   });
 
   it('GET /escalations/suggestions matches the literal path and does not shadow into the :id handler', async () => {

--- a/server/tests/unit/escalation-triage.test.ts
+++ b/server/tests/unit/escalation-triage.test.ts
@@ -210,6 +210,23 @@ describe('classifyEscalation', () => {
     expect(v).toBeNull();
   });
 
+  it('sanitises @mentions and image tags that could inject into the filed issue', async () => {
+    const draft = buildGithubIssueDraft(
+      {
+        ...esc({
+          summary: 'Bug: @adcontextprotocol/core please fix this.',
+          addie_context: 'User pasted ![tracking](https://evil.example/pixel.gif) inline.',
+        }),
+      } as Parameters<typeof buildGithubIssueDraft>[0],
+      [],
+    );
+
+    expect(draft.body).not.toMatch(/(^|\s)@adcontextprotocol\/core/);
+    expect(draft.body).toContain('`@adcontextprotocol`');
+    expect(draft.body).not.toContain('![tracking]');
+    expect(draft.body).toContain('[tracking](');
+  });
+
   it('omits user PII from the proposed issue body', async () => {
     // PII lives in dedicated columns (user_email, user_slack_handle,
     // user_display_name) and in original_request, which we skip entirely.

--- a/server/tests/unit/escalation-triage.test.ts
+++ b/server/tests/unit/escalation-triage.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../src/addie/jobs/escalation-triage-signals.js', async (importOrigin
   return { ...actual, probeUrlStatus: mocks.probeUrlStatus };
 });
 
-import { classifyEscalation } from '../../src/addie/jobs/escalation-triage.js';
+import { buildGithubIssueDraft, classifyEscalation } from '../../src/addie/jobs/escalation-triage.js';
 
 describe('escalation-triage signals', () => {
   it('extracts agenticadvertising.org URLs from free text and strips trailing punctuation', () => {
@@ -139,10 +139,26 @@ describe('classifyEscalation', () => {
     expect(v).toBeNull();
   });
 
-  it('keeps bug-shaped escalation open when the referenced URL still 404s', async () => {
+  it('suggests file_as_issue when the referenced URL still 404s and bucket is bug', async () => {
     mocks.probeUrlStatus.mockResolvedValue(404);
     const v = await classifyEscalation(
       esc({ summary: 'Bug: https://agenticadvertising.org/terms returns 404' }),
+      21,
+    );
+    expect(v?.suggested_status).toBe('file_as_issue');
+    expect(v?.confidence).toBe('medium');
+    expect(v?.proposed_github_issue).toBeDefined();
+    expect(v?.proposed_github_issue?.repo).toContain('/');
+    expect(v?.proposed_github_issue?.labels).toEqual(expect.arrayContaining(['from-escalation', 'needs-triage']));
+  });
+
+  it('does not re-propose file_as_issue when the escalation already has a github_issue_url', async () => {
+    mocks.probeUrlStatus.mockResolvedValue(404);
+    const v = await classifyEscalation(
+      esc({
+        summary: 'Bug: https://agenticadvertising.org/terms returns 404',
+        github_issue_url: 'https://github.com/adcontextprotocol/adcp/issues/9999',
+      }),
       21,
     );
     expect(v).toBeNull();
@@ -192,6 +208,32 @@ describe('classifyEscalation', () => {
     // getEscalation should never be called for self-ref — test fails if mock returned resolved.
     expect(mocks.getEscalation).not.toHaveBeenCalledWith(97);
     expect(v).toBeNull();
+  });
+
+  it('omits user PII from the proposed issue body', async () => {
+    // PII lives in dedicated columns (user_email, user_slack_handle,
+    // user_display_name) and in original_request, which we skip entirely.
+    // The body must only carry Addie-authored text (summary + addie_context).
+    const draft = buildGithubIssueDraft(
+      {
+        ...esc({
+          summary: 'Bug: /some-page is broken when users visit it',
+          user_email: 'pii@example.com',
+          user_slack_handle: 'pii-slack',
+          user_display_name: 'Jane Doe',
+          original_request: 'Hi team, I am jane.doe@example.com and my page broke',
+          addie_context: 'User confirmed the issue; capturing for platform review.',
+        }),
+      } as Parameters<typeof buildGithubIssueDraft>[0],
+      ['https://agenticadvertising.org/some-page'],
+    );
+
+    expect(draft.body).not.toContain('pii@example.com');
+    expect(draft.body).not.toContain('pii-slack');
+    expect(draft.body).not.toContain('Jane Doe');
+    expect(draft.body).not.toContain('jane.doe@example.com');
+    expect(draft.body).toContain('## Summary');
+    expect(draft.body).toContain('Bug: /some-page is broken');
   });
 
   it('returns null (no signal) when every URL probe fails, even for stale ops-bucket content', async () => {


### PR DESCRIPTION
## Summary

- New `file_as_issue` triage verdict for bug-shaped escalations whose referenced URL still 404/410s.
- The classifier drafts a GitHub issue (title + body + repo + labels) from Addie-authored fields only — user PII stays off GitHub by construction.
- Accept handler files the issue via `GITHUB_TOKEN`, writes the URL back to the escalation, and resolves it.

## Why

The product reviewer on PR #3048 flagged this as the top post-ship priority: *"GitHub routing first — it converts the highest-value signal (real bugs) into durable work, and dedupes with the planned routing flow so you don't build two classifiers. Make 'route to GitHub issue' one of the suggested actions in this PR's triage UI, not a parallel pipeline. One classifier, multiple resolution actions."*

This PR follows that guidance exactly — `file_as_issue` lives alongside `resolved` / `wont_do` / `keep_open` on the existing suggestions table and UI.

## What's in the box

- **Migration 429**
  - `addie_escalations.{github_issue_url, github_issue_number, github_issue_repo}` so the link is visible from the escalations dashboard and later triage runs skip already-linked items.
  - `escalation_triage_suggestions.proposed_github_issue jsonb` for the draft.
  - `suggested_status` check widened to include `file_as_issue`.
- **`server/src/addie/jobs/github-filer.ts`** — thin POST wrapper around GitHub's issues API. Mirrors `knowledge-gap-closer`'s pattern; logs + returns `null` on failure instead of throwing.
- **`buildGithubIssueDraft`** in `escalation-triage.ts` — builds the draft from `summary` + `addie_context` + the broken URLs. Omits every PII column and `original_request` on purpose.
- **Classifier extension** — bug-bucket + 404/410 → `file_as_issue`. Skipped when the escalation already has a `github_issue_url` so re-runs are idempotent.
- **Accept handler** — when `suggested_status === 'file_as_issue'`: files issue, records it on the escalation, resolves the escalation with `"Filed as <url>"`. If GitHub errors, returns 502 and leaves the escalation open so the admin can retry.
- **Admin UI** — `/admin/escalations/triage` now shows the proposed draft (repo/title/body preview) for `file_as_issue` suggestions and labels the button "File as issue". After filing, the issue link is rendered inline.

## PII design

- Dedicated columns (`user_email`, `user_slack_handle`, `user_display_name`) and `original_request` — all stay on the escalation row, never on the issue.
- Body is Addie-generated text (`summary` + `addie_context`), which is already scrubbed by the rule set governing Addie's escalation tool.
- A regression test asserts these exact PII strings don't appear in the draft body.

## Test plan

- [x] 18 unit tests passing (added `file_as_issue` verdict, dedup-on-existing-URL, PII scrub)
- [x] 2 new integration tests (accept-as-file-issue happy path; GitHub 502 leaves escalation open)
- [x] TypeScript + full test suite clean locally
- [ ] Post-merge: set `GITHUB_TOKEN` in prod env (or confirm present); run on-demand triage once; accept a suggestion; verify issue is filed and escalation shows the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)