### PR TITLE
fix(addie): invalid depth model ID causing 404s on deep-reasoning turns

### DIFF
--- a/.changeset/fix-addie-depth-model-1m-context.md
+++ b/.changeset/fix-addie-depth-model-1m-context.md
@@ -1,0 +1,9 @@
+---
+---
+
+Fix Addie 404 errors on deep-reasoning turns:
+
+- `ModelConfig.depth` default was `claude-opus-4-7[1m]`, which is not a valid Anthropic model ID (the `[1m]` suffix is not part of the model name). Any turn the router classified as `requires_depth` — expert consultation, multi-doc synthesis, protocol-level analysis — or any message in a working-group / council channel would 404 with `not_found_error: model: claude-opus-4-7[1m]`.
+- Default is now `claude-opus-4-7` (valid model ID).
+- 1M context is now enabled the correct way: via the `context-1m-2025-08-07` Anthropic beta flag, applied automatically to models listed in `MODELS_SUPPORTING_1M_CONTEXT` (currently Opus 4.7 and Sonnet 4.6). Opt out per-deploy with `CLAUDE_DISABLE_1M_CONTEXT=true`.
+- Addie's streaming path was switched from `client.messages.stream` to `client.beta.messages.stream` so it can pass `betas` alongside the existing non-stream beta call.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -10,7 +10,7 @@ import { logger } from '../logger.js';
 import type { AddieTool } from './types.js';
 import { ADDIE_FALLBACK_PROMPT, ADDIE_TOOL_REFERENCE, buildMessageTurnsWithMetadata } from './prompts.js';
 import { AddieDatabase } from '../db/addie-db.js';
-import { AddieModelConfig, ModelConfig, getModelBetas } from '../config/models.js';
+import { AddieModelConfig, getModelBetas } from '../config/models.js';
 import { getCurrentConfigVersionId } from './config-version.js';
 import { loadRules, invalidateRulesCache } from './rules/index.js';
 import { isMultimodalContent, extractMultimodalContent, isAllowedImageType, type FileReadResult } from './mcp/url-tools.js';

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -10,7 +10,7 @@ import { logger } from '../logger.js';
 import type { AddieTool } from './types.js';
 import { ADDIE_FALLBACK_PROMPT, ADDIE_TOOL_REFERENCE, buildMessageTurnsWithMetadata } from './prompts.js';
 import { AddieDatabase } from '../db/addie-db.js';
-import { AddieModelConfig, ModelConfig } from '../config/models.js';
+import { AddieModelConfig, ModelConfig, getModelBetas } from '../config/models.js';
 import { getCurrentConfigVersionId } from './config-version.js';
 import { loadRules, invalidateRulesCache } from './rules/index.js';
 import { isMultimodalContent, extractMultimodalContent, isAllowedImageType, type FileReadResult } from './mcp/url-tools.js';
@@ -664,7 +664,7 @@ export class AddieClaudeClient {
               }] : []),
             ],
             messages,
-            betas: ['web-search-2025-03-05'],
+            betas: ['web-search-2025-03-05', ...getModelBetas(effectiveModel)],
           }),
           { maxRetries: 3, initialDelayMs: 1000 },
           'processMessage'
@@ -1236,7 +1236,7 @@ export class AddieClaudeClient {
         const llmStart = Date.now();
 
         // Collect full response for tool handling
-        let currentResponse: Anthropic.Message | null = null;
+        let currentResponse: Anthropic.Beta.BetaMessage | null = null;
         const textChunks: string[] = [];
 
         // Retry loop for streaming API calls (handles overloaded_error)
@@ -1248,13 +1248,16 @@ export class AddieClaudeClient {
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
           try {
-            // Use streaming API
-            const stream = this.client.messages.stream({
+            // Use streaming API (beta namespace so we can pass `betas`,
+            // e.g. 1M-context on supported depth-tier models).
+            const modelBetas = getModelBetas(effectiveModel);
+            const stream = this.client.beta.messages.stream({
               model: effectiveModel,
               max_tokens: 4096,
               system: systemBlocks,
               tools: customTools,
               messages,
+              ...(modelBetas.length > 0 ? { betas: modelBetas } : {}),
             });
 
             // Process stream events
@@ -1425,7 +1428,7 @@ export class AddieClaudeClient {
 
         // Handle tool use
         if (currentResponse.stop_reason === 'tool_use') {
-          const toolUseBlocks = currentResponse.content.filter((c) => c.type === 'tool_use');
+          const toolUseBlocks = currentResponse.content.filter((c: Anthropic.Beta.BetaContentBlock) => c.type === 'tool_use');
 
           if (toolUseBlocks.length === 0) {
             // No tools to execute, return current text

--- a/server/src/config/models.ts
+++ b/server/src/config/models.ts
@@ -37,7 +37,7 @@ export const ModelConfig = {
    * Depth model for multi-step reasoning, expert consultation, and long-
    * context synthesis. Same model powers the AdCP triage routines so
    * Addie's deep-question answers stay consistent with GitHub triage.
-   * Default: claude-opus-4-7[1m] (newer, larger context)
+   * Default: claude-opus-4-7
    * Override: CLAUDE_MODEL_DEPTH
    *
    * Use this when the turn requires reasoning across many docs, multi-
@@ -45,8 +45,42 @@ export const ModelConfig = {
    * (billing accuracy) — depth is about thinking, precision is about
    * "don't hallucinate this number."
    */
-  depth: process.env.CLAUDE_MODEL_DEPTH || 'claude-opus-4-7[1m]',
+  depth: process.env.CLAUDE_MODEL_DEPTH || 'claude-opus-4-7',
 } as const;
+
+/**
+ * Anthropic beta flag that unlocks the 1M-token context window on
+ * supported Claude models. Passed via the `betas` array on the
+ * `/v1/messages` beta endpoint (NOT as a suffix on the model ID).
+ */
+export const CONTEXT_1M_BETA = 'context-1m-2025-08-07';
+
+/**
+ * Models that currently support the 1M context beta. Opus 4.7 is the
+ * depth-tier default; Sonnet 4.6 supports it too. Extend this list as
+ * Anthropic enables 1M on additional models.
+ */
+const MODELS_SUPPORTING_1M_CONTEXT = new Set<string>([
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+]);
+
+/**
+ * Returns additional Anthropic `betas` flags that should be enabled for
+ * the given model. Currently: 1M context on depth-tier models.
+ *
+ * Opt out per-model with `CLAUDE_DISABLE_1M_CONTEXT=true`.
+ */
+export function getModelBetas(model: string): string[] {
+  const betas: string[] = [];
+  if (
+    process.env.CLAUDE_DISABLE_1M_CONTEXT !== 'true' &&
+    MODELS_SUPPORTING_1M_CONTEXT.has(model)
+  ) {
+    betas.push(CONTEXT_1M_BETA);
+  }
+  return betas;
+}
 
 /**
  * Addie-specific model configuration


### PR DESCRIPTION
## Summary

- `ModelConfig.depth` default was `claude-opus-4-7[1m]` — the `[1m]` suffix is not part of any Anthropic model ID, so the `/v1/messages` API returned `404 not_found_error: model: claude-opus-4-7[1m]` on every turn the router classified as `requires_depth` (expert consultation, multi-doc synthesis, protocol-level analysis) and on every message in `wg-*` / `council-*` channels. Precision-routed (billing) and primary-routed (normal chat) turns were unaffected, which is why the errors looked intermittent.
- Fix: drop the `[1m]` suffix and enable 1M context the correct way — via the Anthropic `context-1m-2025-08-07` beta flag, applied automatically via a new `getModelBetas(model)` helper for models in `MODELS_SUPPORTING_1M_CONTEXT` (Opus 4.7, Sonnet 4.6). Opt out per-deploy with `CLAUDE_DISABLE_1M_CONTEXT=true`.
- Addie's streaming path switched from `client.messages.stream` to `client.beta.messages.stream` so it can pass `betas` alongside the existing non-stream beta call (`claude-client.ts`).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 820/820 pass
- [x] `npm run build` — clean
- [ ] After merge: confirm env vars in prod/staging don't still hold `CLAUDE_MODEL_DEPTH=claude-opus-4-7[1m]` (if they do, the code fix alone won't help — unset or set to `claude-opus-4-7`)
- [ ] Post-deploy: watch Addie error logs for `not_found_error` on depth-routed turns — should drop to zero
- [ ] Verify a depth-routed turn (e.g. `#wg-*` channel or an expert-consultation query) completes without error