### PR TITLE
feat(agents): triage routes PRs to milestone + release branch by bump level

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -385,13 +385,64 @@ usually unnecessary — the PR itself is the artifact.
 
 Apply `claude-triaged` + any matching bucket labels.
 
-### Milestone assignment
+### Milestone + release-branch routing
 
-Apply the milestone line **only** when there's explicit signal:
-issue names a target version, a linked PR is already in a milestone,
-or a version-shaped label (`v3.1`, `3.1-patch`) is present. Otherwise
-omit the milestone line entirely. Never infer a milestone from vibes.
-Never create new milestones. On RFC / epic / deferred: always omit.
+Every PR you open MUST resolve both a milestone (where the change is
+released) and a base branch (where the PR targets). The mapping is
+driven by the changeset bump level, not by vibes.
+
+**Step 1 — Decide the bump level.**
+
+- **Protocol repo (adcp) only:** the changeset file front-matter
+  names the bump level: `patch`, `minor`, or `major`. Non-protocol
+  changes (server, docs-only typos, infra) use `--empty` with no
+  bump — these get no milestone and target `main`.
+- **Sibling SDK repos (adcp-client, adcp-client-python, adcp-go):**
+  changeset/release-please drives versioning repo-by-repo; follow
+  each repo's local PR constraints.
+
+**Step 2 — Fetch live release signal.**
+
+```
+gh api repos/<owner>/<repo>/milestones --jq \
+  '.[] | select(.state == "open" and (.title | test("^\\d+\\.\\d+(\\.\\d+)?$"))) |
+  {title, number, due: .due_on}'
+gh api "repos/<owner>/<repo>/branches?per_page=100" --paginate --jq \
+  '.[] | select(.name | test("^\\d+\\.\\d+\\.x$")) | .name'
+```
+
+The repo publishes:
+- An open `X.Y.0` milestone = the next minor release
+- (Sometimes) an open `X.Y+1.0` milestone = the next major after that
+- Potentially an `X.Y.x` branch = the current patch line for the
+  last shipped minor
+- A `4.0` / `X.0` open milestone = the next major
+
+**Step 3 — Apply the routing matrix.**
+
+| Bump level | Milestone | Base branch | Notes |
+|---|---|---|---|
+| `major` | Next open `X.0` milestone (e.g., `4.0`) | `main` | If no next-major milestone is open, flag-for-human — don't invent one. |
+| `minor` | Next open `X.Y.0` milestone (e.g., `3.1.0`) | `main` | If no next-minor milestone is open, flag-for-human. |
+| `patch` | Next open `X.Y.Z` milestone if one exists; otherwise the active `X.Y.0` milestone | Active `X.Y.x` branch if it exists; otherwise **flag-for-human with "no patch branch open — needs @bokelley to cut one"** | Patches ship on the patch line, not `main`. |
+| `--empty` (no bump) | none | `main` | Server / docs typo / infra. |
+
+**Never create milestones.** If the expected milestone doesn't
+exist, surface the gap in the run summary and flag the PR for human
+review instead of inventing one.
+
+**Apply the milestone in the PR workflow:**
+
+```
+gh pr edit <PR#> --milestone "<title from gh api>"
+```
+
+Include the `Milestone:` line in the triage comment when you draft
+the PR so the reader sees the routing decision.
+
+**On RFC / epic / deferred issues:** omit the milestone line
+entirely — those don't ship as a single PR, they ship as whatever
+PR-shaped work emerges from the discussion.
 
 ## Non-breaking vs. breaking — the central question for Execute
 

--- a/.changeset/triage-milestone-branch-routing.md
+++ b/.changeset/triage-milestone-branch-routing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Triage routine now routes every drafted PR to the correct milestone and base branch based on the changeset bump level: major → next-major milestone on main; minor → next-minor milestone (e.g., 3.1.0) on main; patch → patch milestone on the X.Y.x branch (flag-for-human if no patch branch is open yet); --empty → no milestone, main. Replaces the conservative "only milestone on explicit signal" rule.


### PR DESCRIPTION
## Summary

Two related routing rules added to \`triage-prompt.md\`:

1. **Milestone assignment** — any \`minor\` changeset goes on the next open \`X.Y.0\` milestone (e.g. \`3.1.0\`); any \`major\` changeset goes on the next open \`X.0\` milestone (e.g. \`4.0\`); \`patch\` goes on the active patch milestone; \`--empty\` gets no milestone. Old rule was "only milestone on explicit signal" which left minor-bump PRs unmilestoned.
2. **Release-branch routing** — \`patch\` PRs target the active \`X.Y.x\` branch, not \`main\`. If no patch branch is open, flag-for-human with "needs @bokelley to cut one."

The routine still **never creates milestones** — if the expected one is missing, surface the gap and flag for human.

## Motivation

Caught on #3051 tonight (vast_tracker / daast_tracker for #2915) — a \`minor\` changeset that shipped unmilestoned and I had to \`gh pr edit --milestone\` manually. Also surfaced that no \`3.0.x\` patch branch is open yet, so any patch triage right now flags for human.

## Sibling repos

Not propagating — sibling SDK repos use release-please with their own repo-specific rules. The adcp protocol repo is the one where the milestone/branch mapping matters.

## Test plan
- [ ] CI green
- [ ] Next minor-bump PR the routine drafts includes the right milestone line in the triage comment AND on the PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)