### PR TITLE
feat(addie): surface context_value_rejected hints in storyboard test-result UI

### DIFF
--- a/.changeset/addie-surface-hint-rendering.md
+++ b/.changeset/addie-surface-hint-rendering.md
@@ -1,0 +1,4 @@
+---
+---
+
+Addie: render `context_value_rejected` hints in `run_storyboard` and `run_storyboard_step` output. When `@adcp/client` ≥5.17.x attaches a `hints[]` array to a failing step result, Addie now surfaces each hint inline below the error/validation lines so Claude can present the root-cause diagnosis conversationally.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -28,7 +28,7 @@ import { loadRules } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.2';
+export const CODE_VERSION = '2026.04.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3594,6 +3594,7 @@ export function createMemberToolHandlers(
       output += `**Result:** ${result.overall_passed ? 'PASSED' : 'FAILED'} — ${result.passed_count} passed, ${result.failed_count} failed, ${result.skipped_count} skipped\n`;
       output += `**Duration:** ${(result.total_duration_ms / 1000).toFixed(1)}s\n\n`;
 
+      let anyHints = false;
       for (const phase of result.phases) {
         output += `### ${phase.phase_title} ${phase.passed ? '[PASS]' : '[FAIL]'}\n\n`;
 
@@ -3608,12 +3609,17 @@ export function createMemberToolHandlers(
             for (const v of step.validations.filter(v => !v.passed)) {
               output += `  Failed: ${v.description}${v.error ? ` — ${v.error}` : ''}\n`;
             }
+            for (const h of ((step as { hints?: Array<{ message: string }> }).hints ?? [])) {
+              output += `  Hint: ${sanitizeAgentField(h.message, 400)}\n`;
+              anyHints = true;
+            }
           }
         }
         output += '\n';
       }
 
       output += `Interpret these results conversationally. For failed steps, explain what the agent should return and suggest specific fixes.`;
+      if (anyHints) output += ` Hint lines identify the upstream root cause — treat them as the primary explanation and reference validation failures as supporting evidence.`;
       if (dryRun) output += ` This was a dry run — no production state was modified.`;
 
       return output;
@@ -3701,6 +3707,12 @@ export function createMemberToolHandlers(
 
         if (result.error) {
           output += `\n**Error:** ${result.error}\n`;
+        }
+
+        if (!result.passed) {
+          for (const h of ((result as { hints?: Array<{ message: string }> }).hints ?? [])) {
+            output += `\n**Hint:** ${sanitizeAgentField(h.message, 400)}\n`;
+          }
         }
 
         if (result.response) {


### PR DESCRIPTION
Closes #3055

## Summary

When `@adcp/client` ≥5.17.x attaches a `hints: StoryboardStepHint[]` array to a failing storyboard step result, Addie now renders each hint inline below the step's error/validation lines in both `run_storyboard` and `run_storyboard_step` MCP tool output. On the currently-pinned `@adcp/client` 5.16.0 the `?? []` fallback makes this a safe no-op — hints will silently not appear until the dep is bumped (see below).

**Files changed:**
- `server/src/addie/mcp/member-tools.ts` — hint rendering in `run_storyboard` (indented `  Hint:` per the existing `  Error:` / `  Failed:` pattern) and `run_storyboard_step` (bold `**Hint:**` per the existing `**Error:**` pattern); conditional trailing diagnostic instruction
- `server/src/addie/config-version.ts` — `CODE_VERSION` bump to `2026.04.3` (MCP tool implementation change per playbook)
- `.changeset/addie-surface-hint-rendering.md` — empty changeset (Addie server-only, no protocol impact)

**Non-breaking justification:** adds rendering of an optional field (`hints?`) that doesn't exist on the current pinned client version; the `?? []` fallback means existing behavior is fully preserved on 5.16.x. No protocol change, no schema change, no API surface change.

**Security:** `hint.message` is agent-controlled content (field values from the tested agent's response are embedded by the SDK into the hint string). Both render sites pass through `sanitizeAgentField(h.message, 400)` — stripping newlines, control characters, and backticks, capping at 400 chars — matching the established pattern for all other agent-sourced strings in this file.

## Manual step required (agent cannot touch package.json)

A human reviewer must bump `@adcp/client` from `5.16.0` to `5.17.x` in `package.json` before merging. The rendering code is safe to ship without the bump (graceful no-op), but hints will not appear until the dep is updated. The `as { hints?: ... }` type cast at the two render sites can be removed once the client type includes `hints` natively.

## Nits (not fixed — surface for reviewer)

- The trailing diagnostic instruction (`Hint lines identify the upstream root cause…`) is emitted per `run_storyboard` only. `run_storyboard_step` does not have an equivalent since it lacks the closing conversational directive. Could add one if desired.
- The `sanitizeAgentField` strips backticks, so hint messages lose inline code formatting (e.g., `` `pricing_option_id` `` → `pricing_option_id`). Acceptable tradeoff for injection safety; the messages remain readable.

## Pre-PR review

- **code-reviewer:** approved — type cast is idiomatic for this file; `sanitizeAgentField` correctly neutralizes agent-controlled content; `!result.passed` guard is consistent with `run_storyboard` behavior; no new error class introduced (1 nit: cast can be removed post-dep-bump)
- **prompt-engineer:** approved — `  Hint:` / `**Hint:**` format matches per-handler conventions; `sanitizeAgentField` resolves newline injection; conditional trailing instruction is correctly gated on hints being present

Session: https://claude.ai/code/session_01EECFdKzcHjApw8F9eYamod

---
_Generated by [Claude Code](https://claude.ai/code/session_01EECFdKzcHjApw8F9eYamod)_