### PR TITLE
feat(agents): triage downgrades bump for experimental-surface changes

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -401,6 +401,29 @@ driven by the changeset bump level, not by vibes.
   changeset/release-please drives versioning repo-by-repo; follow
   each repo's local PR constraints.
 
+**Step 1a — Apply the experimental-surface downgrade.**
+
+Per [Experimental Status](/docs/reference/experimental-status), changes
+to surfaces marked experimental are explicitly allowed to break inside
+the current major. So a change that would be `minor` on a stable
+surface is `patch` on an experimental one; a change that would be
+`major` on stable is `minor` on experimental.
+
+| Stable bump | Experimental bump |
+|---|---|
+| `major` (breaking) | `minor` |
+| `minor` (additive) | `patch` |
+| `patch` (fix / clarification) | `patch` (no further downgrade) |
+
+How to detect "experimental":
+
+1. **Schema marker:** the touched JSON Schema has `"x-status": "experimental"` at the schema root **or** on the specific property being changed. The marker is schema-local — a stable schema that `$ref`s an experimental sub-schema is still stable.
+2. **Path heuristic (fallback for unmarked-but-known surfaces):** treat anything under `static/schemas/source/tmp/**`, `static/schemas/source/sponsored-intelligence/**`, or `static/schemas/source/a2ui/**` as experimental even if the `x-status` marker is missing. Surface "marker missing" in the run summary so a human can backfill.
+3. **Mixed diffs:** if the PR touches BOTH stable and experimental surfaces in a single change, take the **stable** bump level (no downgrade) — the stable touch is what gates the release contract.
+
+The downgrade does not apply to non-protocol changes (`--empty`),
+which never get a bump in the first place.
+
 **Step 2 — Fetch live release signal.**
 
 ```

--- a/.changeset/triage-experimental-bump-downgrade.md
+++ b/.changeset/triage-experimental-bump-downgrade.md
@@ -1,0 +1,4 @@
+---
+---
+
+Triage routine now applies the experimental-surface bump downgrade per docs/reference/experimental-status.mdx: changes scoped to surfaces marked `x-status: experimental` (or under known-experimental paths like `static/schemas/source/tmp/**`, `sponsored-intelligence/**`, `a2ui/**`) ship one bump level lower — minor → patch, major → minor, patch stays patch. Mixed stable+experimental diffs take the stable bump.


### PR DESCRIPTION
## Summary

Codifies in \`triage-prompt.md\` what [Experimental Status](/docs/reference/experimental-status) already says: surfaces with \`x-status: experimental\` MAY break inside the current major, so changes to them ship one bump level lower than the same change on a stable surface.

| Stable | Experimental |
|---|---|
| \`major\` | \`minor\` |
| \`minor\` | \`patch\` |
| \`patch\` | \`patch\` |

Detection: \`x-status: experimental\` on the touched schema/property is the canonical signal. Falls back to a path heuristic for \`tmp/**\`, \`sponsored-intelligence/**\`, and \`a2ui/**\`. Mixed diffs (stable + experimental in one PR) take the stable bump.

## Side observation

TMP schemas under \`static/schemas/source/tmp/**\` are NOT currently marked with \`x-status: experimental\` (sponsored-intelligence is — 11/11 marked). The routine will use the path heuristic and surface \"marker missing\" in the run summary so this can be backfilled. Worth filing a separate issue to add the marker across TMP.

## Test plan
- [ ] CI green
- [ ] Next TMP-only PR the routine drafts ships as \`patch\` (not \`minor\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)