### PR TITLE
feat(schema): add x-status: experimental to all TMP schemas + seller-agent-ref

### DIFF
--- a/.changeset/tmp-experimental-marker.md
+++ b/.changeset/tmp-experimental-marker.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `x-status: experimental` to all 9 TMP schemas, completing the experimental-status contract already declared for `trusted_match.core` in `get_adcp_capabilities` and `experimental-status.mdx`. Mirrors the existing pattern on all 11 sponsored-intelligence schemas. Enables validators, doc generators, and tooling to identify TMP as an experimental surface. No wire-format or field changes.

--- a/.changeset/tmp-experimental-marker.md
+++ b/.changeset/tmp-experimental-marker.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": patch
 ---
 
 Add `x-status: experimental` to all 9 TMP schemas, completing the experimental-status contract already declared for `trusted_match.core` in `get_adcp_capabilities` and `experimental-status.mdx`. Mirrors the existing pattern on all 11 sponsored-intelligence schemas. Enables validators, doc generators, and tooling to identify TMP as an experimental surface. No wire-format or field changes.

--- a/.changeset/tmp-experimental-marker.md
+++ b/.changeset/tmp-experimental-marker.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Add `x-status: experimental` to all 9 TMP schemas, completing the experimental-status contract already declared for `trusted_match.core` in `get_adcp_capabilities` and `experimental-status.mdx`. Mirrors the existing pattern on all 11 sponsored-intelligence schemas. Enables validators, doc generators, and tooling to identify TMP as an experimental surface. No wire-format or field changes.
+Add `x-status: experimental` to all 9 TMP schemas and `core/seller-agent-ref.json` (exclusively referenced by TMP), completing the experimental-status contract already declared for `trusted_match.core` in `get_adcp_capabilities` and `experimental-status.mdx`. Mirrors the existing pattern on all 11 sponsored-intelligence schemas. Enables validators, doc generators, and tooling to identify TMP as an experimental surface. No wire-format or field changes.

--- a/static/schemas/source/core/seller-agent-ref.json
+++ b/static/schemas/source/core/seller-agent-ref.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/core/seller-agent-ref.json",
   "title": "Seller Agent Reference",
   "description": "Structured reference to a seller agent. The canonical identifier is the agent's URL as declared in the property publisher's adagents.json `authorized_agents[].url`. The optional `id` slot is reserved for a future registry-assigned stable identifier; it is not used today. This shape mirrors `format-id` and `ProviderEntry` — URL-first, with an ID slot for forward compatibility.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "agent_url": {

--- a/static/schemas/source/tmp/available-package.json
+++ b/static/schemas/source/tmp/available-package.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/available-package.json",
   "title": "Available Package",
   "description": "A package available for contextual matching. Synced to providers at media buy creation time — not sent per request. Providers cache this metadata and use it when evaluating context match requests for the placement. The `seller_agent` field binds the package to the originating seller agent; providers MUST use this binding rather than re-deriving seller identity from media_buy_id.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "package_id": {

--- a/static/schemas/source/tmp/context-match-request.json
+++ b/static/schemas/source/tmp/context-match-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/context-match-request.json",
   "title": "Context Match Request",
   "description": "Sent by publisher to router or provider to evaluate packages against contextual signals. The provider uses its synced package set for the placement. MUST NOT contain user identity. The request_id MUST NOT correlate with any identity match request_id. Extension fields (ext, context) are intentionally omitted — extension data in the context path could inadvertently carry or correlate user identity signals.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/tmp/context-match-response.json
+++ b/static/schemas/source/tmp/context-match-response.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/context-match-response.json",
   "title": "Context Match Response",
   "description": "Response from router or provider with offers for matched packages. An empty offers array means no packages matched. For simple GAM integration, package_id flows as a macro via signals. For rich integrations, the offer includes brand, price, summary, and optionally an inline creative manifest. Extension fields (ext, context) are intentionally omitted — extension data in the context path could inadvertently carry or correlate user identity signals.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "type": {

--- a/static/schemas/source/tmp/error.json
+++ b/static/schemas/source/tmp/error.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/error.json",
   "title": "TMP Error",
   "description": "Error response from a TMP provider or router. Returned instead of a normal response when the provider cannot process the request. Distinguishes errors from empty results (an empty offers array is a valid response meaning no matches, not an error).",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "type": {

--- a/static/schemas/source/tmp/identity-match-request.json
+++ b/static/schemas/source/tmp/identity-match-request.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/identity-match-request.json",
   "title": "Identity Match Request",
   "description": "Sent by publisher to evaluate user eligibility for packages using an opaque identity token. MUST NOT contain page context. The request_id MUST NOT correlate with any context match request_id. The package_ids MUST include ALL active packages for the buyer, not just those on the current page, to prevent set-correlation attacks. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "adcp_major_version": {

--- a/static/schemas/source/tmp/identity-match-response.json
+++ b/static/schemas/source/tmp/identity-match-response.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/identity-match-response.json",
   "title": "Identity Match Response",
   "description": "Response indicating which packages the user is eligible for. The ttl_sec field defines a caching contract: the router caches this response and returns cached eligibility without re-querying the buyer during the TTL window. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "type": {

--- a/static/schemas/source/tmp/offer-price.json
+++ b/static/schemas/source/tmp/offer-price.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/offer-price.json",
   "title": "Offer Price",
   "description": "Lightweight price for a TMP offer. Used when the product supports variable pricing and the buyer specifies a price at match time.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "amount": {

--- a/static/schemas/source/tmp/offer.json
+++ b/static/schemas/source/tmp/offer.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/offer.json",
   "title": "Offer",
   "description": "A buyer's response to a context match request. Generalizes package activation — a simple activation is an offer with just package_id. A rich response includes brand, price, summary, and optionally an inline creative manifest.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "package_id": {

--- a/static/schemas/source/tmp/provider-registration.json
+++ b/static/schemas/source/tmp/provider-registration.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/tmp/provider-registration.json",
   "title": "TMP Provider Registration",
   "description": "Declares a TMP provider's endpoint, capabilities, and operational parameters. Used in router configuration (static YAML or dynamic API) and referenced by product-level provider entries. The publisher controls which providers participate in their ad decisioning. Endpoint URLs MUST be validated against SSRF, and dynamic registration endpoints MUST authenticate callers — see docs/trusted-match/specification#provider-registration-security.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "provider_id": {


### PR DESCRIPTION
Closes #3062

Adds `"x-status": "experimental"` at the schema root of all 9 schemas in `static/schemas/source/tmp/` and `core/seller-agent-ref.json` (exclusively referenced by TMP). The `get_adcp_capabilities` response already declares `trusted_match.core` as experimental, and `experimental-status.mdx` already lists it; the schemas were the only missing piece. Mirrors the identical pattern on all 11 sponsored-intelligence schemas, enabling validators, doc generators, and tooling to consistently identify TMP as an experimental surface.

`seller-agent-ref.json` is included because `experimental-status.mdx` explicitly states `x-status` is not inherited through `$ref` — each schema in the surface must carry it directly. This schema is referenced exclusively by `tmp/available-package.json` and `tmp/offer.json`.

**Non-breaking justification:** adds an `x-status` metadata annotation only — no fields added or removed, no type changes, no required changes, no enum changes. JSON Schema draft-07 ignores unknown root-level keys; existing TMP validators and consumers are unaffected.

**Conflict resolved:** branch rebased over main after PR #2984 (`feat(tmp): require seller_agent on AvailablePackage`) merged. `available-package.json` resolution keeps main's extended description (with `seller_agent` binding language) and adds `x-status` — both changes preserved.

**Changeset:** `patch` (annotation change on experimental surface; `patch` → `patch`, no further downgrade per triage-experimental-bump-downgrade rule).

**Note for reviewer:** adcp-go's schema-drift linter (PR adcp-go#76) will report expected drift on all 10 changed files after this merges. This is correct behavior — the linter detects `x-status` was added. No adcp-go code changes needed.

**Pre-existing concern (not introduced by this PR):** The second protocol-expert pass flagged that `context-match-response.json`, `identity-match-response.json`, `offer.json`, and `error.json` set `additionalProperties: true` while the corresponding request schemas set `additionalProperties: false`. This inconsistency predates this PR and is worth a separate issue, but is out of scope here.

**Pre-PR review:**
- code-reviewer: approved — JSON valid, placement consistent with SI pattern, bump `patch` correct, conflict resolution verified byte-for-byte against main, changeset filename descriptive, 10/10 schemas covered
- ad-tech-protocol-expert: approved — draft-07 ignores unknown root keywords (no validator impact), `patch` bump sound per experimental-surface downgrade rule, schema-root annotation is complementary to (not redundant with) property-level annotation on `get_adcp_capabilities`, adcp-go drift linter poses no risk, rebase conflict resolution sound

Session: https://claude.ai/code/session_016xnjLF6QTXfJQkr549Zh9U

---
_Generated by [Claude Code](https://claude.ai/code/session_016xnjLF6QTXfJQkr549Zh9U)_