### PR TITLE
docs(compliance): list all required product fields in schema-validation storyboard

### DIFF
--- a/.changeset/fix-schema-validation-expected-text.md
+++ b/.changeset/fix-schema-validation-expected-text.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(compliance): list all eight required product fields in schema-validation storyboard
+
+The `get_products_schema` step's `expected` description listed only four of the eight required fields in `core/product.json`, leading external implementors to believe their responses were well-formed when they were missing `description`, `publisher_properties`, and `reporting_capabilities`. Updated to enumerate all eight required fields and note that `reporting_capabilities` must be a fully-formed object with its own required sub-fields, not an empty object. No change to validation logic or schema.

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -93,11 +93,20 @@ phases:
         comply_scenario: schema_compliance
         stateful: false
         expected: |
-          Return products matching the brief. Each product must have:
-          - product_id: unique identifier
-          - name: human-readable name
-          - delivery_type: guaranteed or non_guaranteed
-          - pricing_options: at least one pricing option
+          Return products matching the brief. Each product must have all eight required fields:
+          - product_id: unique identifier for the product
+          - name: human-readable product name
+          - description: detailed description of the product and its inventory
+          - publisher_properties: array (minItems: 1) of publisher property selectors
+          - format_ids: array of format_id objects — each with agent_url (URI) and id
+          - delivery_type: "guaranteed" or "non_guaranteed"
+          - pricing_options: array (minItems: 1) — each with pricing_option_id, pricing_model, and currency
+          - reporting_capabilities: fully-formed object with required sub-fields:
+              available_reporting_frequencies, expected_delay_minutes, timezone,
+              supports_webhooks, available_metrics, date_range_support
+
+          Responses missing any of these fields fail schema validation regardless of
+          what other fields are present.
 
         sample_request:
           buying_mode: "brief"


### PR DESCRIPTION
Closes #3065

The `get_products_schema` step's `expected` description listed only four of the eight required fields from `core/product.json`, causing external implementors to believe their responses were conformant when they were missing `description`, `publisher_properties`, and `reporting_capabilities`. This directly caused issue #3065 where @fgranata's seller agent passed four of the eight fields but still failed `schema_compliance`.

Updated the prose to enumerate all eight required fields and note that `reporting_capabilities` must be a fully-formed object (not empty) with its own six required sub-fields. Added `currency` to the `pricing_options` description per code-reviewer finding that it is required on all concrete pricing option types. No validation logic, `check:` assertions, or schema definitions were changed.

**Non-breaking justification:** Changes only the human-readable `expected:` prose field in the storyboard YAML. All validation logic (`check:` fields), JSON schemas, and wire format are unchanged. Existing implementations that pass are unaffected.

**Nit (not fixed, scope-appropriate):** The `validations:` block in `get_products_schema` only explicitly checks `product_id` and `delivery_type` via `field_present` — the other six required fields are only caught by `check: response_schema`. Adding six more `field_present` checks would make failures more actionable but is out of scope for this prose-only fix.

**Pre-PR review:**
- code-reviewer: approved — prose accurately reflects `core/product.json` required array; `currency` blocker fixed; noted nit about hardcoded count "eight" which is accurate for v3
- ad-tech-protocol-expert (Step 4 consultation): confirmed root cause and field accuracy; `delivery_type` description and `format_ids` object-array description verified correct

Session: https://claude.ai/code/session_01Voi2bgVQPwVfyBytBfMAjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Voi2bgVQPwVfyBytBfMAjj)_