### PR TITLE
feat(schema): add title to format.json oneOf asset-type branches for named codegen types

### DIFF
--- a/.changeset/fix-format-asset-oneof-titles.md
+++ b/.changeset/fix-format-asset-oneof-titles.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `title` to all `oneOf` branches in `format.json`'s `assets[]` array so codegen tools (json-schema-to-typescript, datamodel-code-generator, oapi-codegen) produce named, discriminated per-asset-type interfaces instead of collapsing them to an untyped union. Adds titles `IndividualImageAsset` … `IndividualCatalogAsset` and `RepeatableGroupAsset` at the top level, plus `GroupImageAsset` … `GroupWebhookAsset` for the nested branches inside `repeatable_group.assets[]`. Purely annotation-level; no validation or wire-format change.

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -199,6 +199,7 @@
       "items": {
         "oneOf": [
           {
+            "title": "IndividualImageAsset",
             "description": "Image asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -208,6 +209,7 @@
             }
           },
           {
+            "title": "IndividualVideoAsset",
             "description": "Video asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -217,6 +219,7 @@
             }
           },
           {
+            "title": "IndividualAudioAsset",
             "description": "Audio asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -226,6 +229,7 @@
             }
           },
           {
+            "title": "IndividualTextAsset",
             "description": "Text asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -235,6 +239,7 @@
             }
           },
           {
+            "title": "IndividualMarkdownAsset",
             "description": "Markdown asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -244,6 +249,7 @@
             }
           },
           {
+            "title": "IndividualHtmlAsset",
             "description": "HTML asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -253,6 +259,7 @@
             }
           },
           {
+            "title": "IndividualCssAsset",
             "description": "CSS asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -262,6 +269,7 @@
             }
           },
           {
+            "title": "IndividualJavaScriptAsset",
             "description": "JavaScript asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -271,6 +279,7 @@
             }
           },
           {
+            "title": "IndividualVastAsset",
             "description": "VAST asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -280,6 +289,7 @@
             }
           },
           {
+            "title": "IndividualDaastAsset",
             "description": "DAAST asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -289,6 +299,7 @@
             }
           },
           {
+            "title": "IndividualUrlAsset",
             "description": "URL asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -298,6 +309,7 @@
             }
           },
           {
+            "title": "IndividualWebhookAsset",
             "description": "Webhook asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -307,6 +319,7 @@
             }
           },
           {
+            "title": "IndividualBriefAsset",
             "description": "Brief asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -315,6 +328,7 @@
             }
           },
           {
+            "title": "IndividualCatalogAsset",
             "description": "Catalog asset",
             "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
             "properties": {
@@ -324,6 +338,7 @@
             }
           },
           {
+            "title": "RepeatableGroupAsset",
             "description": "Repeatable asset group (for carousels, slideshows, playlists, etc.)",
             "type": "object",
             "properties": {
@@ -365,6 +380,7 @@
                 "items": {
                   "oneOf": [
                     {
+                      "title": "GroupImageAsset",
                       "description": "Image asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -373,6 +389,7 @@
                       }
                     },
                     {
+                      "title": "GroupVideoAsset",
                       "description": "Video asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -381,6 +398,7 @@
                       }
                     },
                     {
+                      "title": "GroupAudioAsset",
                       "description": "Audio asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -389,6 +407,7 @@
                       }
                     },
                     {
+                      "title": "GroupTextAsset",
                       "description": "Text asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -397,6 +416,7 @@
                       }
                     },
                     {
+                      "title": "GroupMarkdownAsset",
                       "description": "Markdown asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -405,6 +425,7 @@
                       }
                     },
                     {
+                      "title": "GroupHtmlAsset",
                       "description": "HTML asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -413,6 +434,7 @@
                       }
                     },
                     {
+                      "title": "GroupCssAsset",
                       "description": "CSS asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -421,6 +443,7 @@
                       }
                     },
                     {
+                      "title": "GroupJavaScriptAsset",
                       "description": "JavaScript asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -429,6 +452,7 @@
                       }
                     },
                     {
+                      "title": "GroupVastAsset",
                       "description": "VAST asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -437,6 +461,7 @@
                       }
                     },
                     {
+                      "title": "GroupDaastAsset",
                       "description": "DAAST asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -445,6 +470,7 @@
                       }
                     },
                     {
+                      "title": "GroupUrlAsset",
                       "description": "URL asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {
@@ -453,6 +479,7 @@
                       }
                     },
                     {
+                      "title": "GroupWebhookAsset",
                       "description": "Webhook asset in group",
                       "allOf": [{ "$ref": "#/$defs/baseGroupAsset" }],
                       "properties": {


### PR DESCRIPTION
Closes #3069

## Summary

Adds `title` to all 27 `oneOf` branches in `static/schemas/source/core/format.json`'s `assets[]` array. Without branch-level `title`, `json-schema-to-typescript`, `datamodel-code-generator` (Python/Pydantic), `oapi-codegen` (Go), and similar tools collapse the union to `BaseIndividualAsset | RepeatableGroup` with no `asset_type` discriminator and no per-type `requirements` field — even though the requirements schemas themselves are already named. This PR fixes the root cause; the hand-authored type shim in `@adcp/client` (`src/lib/types/format-asset-slots.ts`) can be retired once SDKs regenerate against the updated schema.

**Titles added:**
- 14 individual asset slots: `IndividualImageAsset` … `IndividualCatalogAsset`
- 1 repeatable group wrapper: `RepeatableGroupAsset`
- 12 nested group asset slots: `GroupImageAsset` … `GroupWebhookAsset`

> **Naming note:** `brief` and `catalog` have no group-nested counterparts in the existing schema, so there is no `GroupBriefAsset` / `GroupCatalogAsset` — the omission mirrors the pre-existing schema structure.

> **Stability notice:** These 27 `title` values are stable published identifiers once released. Renaming any of them in a future release is a **breaking (major) change** under AdCP semver policy, since codegen consumers will have generated type names derived from them.

## Non-breaking justification

`title` is a JSON Schema draft-07 annotation keyword with no normative validation weight. Validators that previously accepted a document continue to accept it unchanged. No fields removed, no types changed, no required → optional changes. Downstream implementations that ignore `title` (all wire-format processors, VAST/OpenRTB adapters) are unaffected.

## Milestone routing

Changeset: `minor` (additive annotation to 27 schema branches). Per routing matrix, this targets the next open `X.Y.0` milestone on `main`. No active `X.Y.x` patch branch was found for 3.x; milestone to be assigned by reviewer.

## Pre-PR review

- **code-reviewer:** approved — all 27 titles present and correct; noted `patch` vs `minor` ambiguity (resolved as `minor`); nit on `RepeatableGroupAsset` asymmetry (intentional, documented above)
- **ad-tech-protocol-expert:** approved — non-breaking per spec; flagged changeset bump as blocker (fixed: `patch` → `minor`); confirmed title stability must be acknowledged (added above); nit on naming convention divergence from `<Verb><Noun>` pattern (structural union, different context — not applicable here)

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01AB3LdaadWVByiSMu4Nhu91)_