### PR TITLE
docs(brand): acquire_rights request-validation clauses (#2680, #2681)

### DIFF
--- a/.changeset/acquire-rights-validation-clauses.md
+++ b/.changeset/acquire-rights-validation-clauses.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(brand): specify normative request-validation clauses for `acquire_rights` (closes #2680, #2681)
+
+Two campaign-field validations on `acquire_rights` were sensible-but-unspecified in 3.0, leaving implementers to disagree on identical requests:
+
+1. **Expired campaign window.** Brand agents MUST reject with `INVALID_REQUEST` and `field: "campaign.end_date"` when `campaign.end_date` is in the past at the time of the request. Issuing a zero-duration grant is almost always a buyer-side bug; deterministic rejection is more useful than silent expiry. Unlike `create_media_buy` (where `any_of` supports time-shifting a flight forward), rights grants attach to the requested period and cannot be retroactively shifted, so reject-only is the correct contract.
+
+2. **CPM-priced rights under a governed plan.** When the request carries an intent-phase `governance_context` token (the buyer's plan is governed) and the selected pricing option has `model: "cpm"`, brand agents MUST reject with `INVALID_REQUEST` and `field: "campaign.estimated_impressions"` when that field is omitted or `0`. When provided, projected commitment is `(pricing_option.price / 1000) × campaign.estimated_impressions` evaluated in `pricing_option.currency`. If `pricing_option.currency` differs from the plan's budget currency, the agent MUST reject with `field: "pricing_option_id"` — currency conversion is not specified. If the projected commitment exceeds remaining plan budget, the agent MUST reject with `field: "campaign.estimated_impressions"`. Non-CPM pricing options commit the flat amount regardless of volume; agents MUST NOT require `estimated_impressions` for governance projection on those.
+
+Added a new "Request validation" section to `docs/brand-protocol/tasks/acquire_rights.mdx` and tightened the field descriptions on `static/schemas/source/brand/acquire-rights-request.json` for `campaign.end_date` and `campaign.estimated_impressions` so the validation contract is discoverable from both the task reference and the schema.
+
+Patch-eligible: docs-only clarification of behavior the spec already implied. No schema shape changes (only description text); no new error codes (`INVALID_REQUEST` is already standard). The `governance_context` anchor and the `(price / 1000) × impressions` projection formula reference fields that exist on the published 3.0 schemas — this PR does not introduce new wire surface, only normative interpretation.

--- a/docs/brand-protocol/tasks/acquire_rights.mdx
+++ b/docs/brand-protocol/tasks/acquire_rights.mdx
@@ -203,6 +203,29 @@ The response uses a discriminated union on `status`:
 
 When `suggestions` is present on a rejected response, the rejection is actionable — the buyer can adjust their request and retry. When `suggestions` is absent, the rejection is final and the buyer should not retry for this rights/talent combination. This convention applies consistently across `acquire_rights` rejections, `get_rights` excluded results, and creative approval rejections.
 
+## Request validation
+
+Two campaign-field validations are normative for `acquire_rights`. Both produce `INVALID_REQUEST` with the offending `field` populated and `recovery: "correctable"` (the buyer can fix the request and retry).
+
+### Expired campaign window
+
+Brand agents MUST reject with `INVALID_REQUEST` and `field: "campaign.end_date"` when `campaign.end_date` is in the past at the time of the request. Acquiring rights for a window that has already elapsed produces a zero-duration grant and is almost always a buyer-side bug — surfacing it deterministically is more useful than silently issuing credentials that immediately expire.
+
+Unlike [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy), which supports an `any_of` past-start auto-adjust pattern (a flight can be time-shifted forward without re-licensing), rights grants are not time-shiftable: the contract attaches to the requested period, so reject-only is the correct contract for `acquire_rights`.
+
+Brand agents MAY also reject when `campaign.start_date` is more than the rights agent's configured grace window in the past (typically the rights agent rejects start dates earlier than `now - 24h` since rights cannot be retroactively granted); that decision is contract-specific and SHOULD use `field: "campaign.start_date"`. The `end_date < now` check is the normative floor.
+
+### CPM-priced rights under a governance plan
+
+When the buyer's request carries an intent-phase `governance_context` token on the [protocol envelope](/docs/building/implementation/security) (the buyer's plan is governed — see [Buyer-side governance invocation](/docs/governance/campaign/specification#buyer-side-governance-invocation)) and the selected pricing option has `model: "cpm"`, `campaign.estimated_impressions` is the input the brand agent uses to project commitment against remaining plan budget. To make that projection deterministic across implementations:
+
+- Brand agents MUST reject with `INVALID_REQUEST` and `field: "campaign.estimated_impressions"` when a `governance_context` is present, the selected `pricing_option.model` is `"cpm"`, and `campaign.estimated_impressions` is either omitted or `0`. Implementer-chosen defaults (e.g., assuming 1M impressions) are non-conformant — they hide a policy decision inside each implementation and produce different governance outcomes for identical requests.
+- When `estimated_impressions` is provided and non-zero, the projected commitment is `(pricing_option.price / 1000) × campaign.estimated_impressions`, evaluated in `pricing_option.currency`. If `pricing_option.currency` differs from the governance plan's budget currency (as carried on the plan), the brand agent MUST reject with `INVALID_REQUEST` and `field: "pricing_option_id"` — currency conversion is not specified for governance projection, so currency-mismatched offers cannot be cleared against a governed plan.
+- If the projected commitment exceeds the buyer's remaining plan budget, the agent MUST reject with `INVALID_REQUEST` and `field: "campaign.estimated_impressions"`, populating `reason` with the projected commitment and remaining budget so the buyer can adjust.
+- Non-CPM pricing options (`model: "flat_rate"`, etc.) commit the flat amount regardless of impression volume; brand agents MUST NOT require `estimated_impressions` for governance projection on those options. Buyers MAY still provide `estimated_impressions` for cap-tracking purposes.
+
+Requests without a `governance_context` token are unaffected by this validation — `estimated_impressions` remains optional in that case (sellers MAY refuse to transact ungoverned plans as a matter of commercial policy, per [Buyer-side governance invocation](/docs/governance/campaign/specification#buyer-side-governance-invocation), but that refusal is independent of this projection rule).
+
 ## Generation credentials
 
 When rights are acquired, the agent coordinates with LLM providers to issue scoped credentials:

--- a/static/schemas/source/brand/acquire-rights-request.json
+++ b/static/schemas/source/brand/acquire-rights-request.json
@@ -61,7 +61,7 @@
         "estimated_impressions": {
           "type": "integer",
           "minimum": 0,
-          "description": "Estimated total impressions for the campaign"
+          "description": "Estimated total impressions for the campaign. Required when the request carries an intent-phase governance_context token AND the selected pricing_option has model: 'cpm' — the brand agent projects commitment as (pricing_option.price / 1000) × estimated_impressions evaluated in pricing_option.currency. Brand agents MUST reject with INVALID_REQUEST (field: campaign.estimated_impressions) when CPM-priced rights are requested under a governance_context and this field is omitted or zero; implementer-chosen defaults are non-conformant. See the acquire_rights task reference for the full validation contract including currency-mismatch handling."
         },
         "start_date": {
           "type": "string",
@@ -71,7 +71,7 @@
         "end_date": {
           "type": "string",
           "format": "date",
-          "description": "Campaign end date (ISO 8601)"
+          "description": "Campaign end date (ISO 8601). Brand agents MUST reject with INVALID_REQUEST (field: campaign.end_date) when end_date is in the past at the time of the request — acquiring rights for an elapsed window produces a zero-duration grant and is almost always a buyer-side bug."
         }
       },
       "required": [


### PR DESCRIPTION
Closes #2680 (CPM governance projection unspecified) and #2681 (expired campaign window unspecified).

## Summary

Both issues were filed during 3.0 training-agent adoption when expert reviewers flagged the rejection paths as sensible-but-unspecified — implementers were already disagreeing on identical requests (e.g., the training agent picked a 1M-impressions default for missing CPM-projection input; another agent might pick 100k or skip projection entirely, producing different governance outcomes for the same buyer).

Adds a new **Request validation** section to `docs/brand-protocol/tasks/acquire_rights.mdx` and tightens the JSON-schema descriptions on `campaign.end_date` and `campaign.estimated_impressions` so the contract is discoverable from both the task reference and the schema.

## Two normative clauses

### Expired campaign window (#2681)

`MUST reject INVALID_REQUEST` with `field: "campaign.end_date"` when `campaign.end_date < now`. Acquiring rights for an elapsed window produces a zero-duration grant — almost always a buyer-side bug. Cross-references the `create_media_buy` `any_of` past-start pattern to explain why `acquire_rights` uses reject-only (rights grants are not time-shiftable; the contract attaches to the requested period).

### CPM-priced rights under a governed plan (#2680)

When the request carries an intent-phase `governance_context` token (per [Buyer-side governance invocation](/docs/governance/campaign/specification#buyer-side-governance-invocation)) **and** the selected `pricing_option.model == "cpm"`:

- `MUST reject INVALID_REQUEST` with `field: "campaign.estimated_impressions"` when that field is omitted or `0`. Implementer-chosen defaults (e.g., 1M) are non-conformant.
- Projection formula is `(pricing_option.price / 1000) × campaign.estimated_impressions` evaluated in `pricing_option.currency`.
- If `pricing_option.currency` differs from the plan's budget currency, `MUST reject INVALID_REQUEST` with `field: "pricing_option_id"`. No FX is specified for governance projection; currency-mismatched offers cannot clear against a governed plan.
- If projected commitment exceeds remaining plan budget, `MUST reject INVALID_REQUEST` with `field: "campaign.estimated_impressions"` and surface the projection in `reason`.
- Non-CPM pricing options (`flat_rate`, etc.) commit the flat amount regardless of volume; agents `MUST NOT` require `estimated_impressions` for governance projection on those.

Requests without a `governance_context` are unaffected — `estimated_impressions` remains optional in that case.

## Patch eligibility

`patch` changeset. No schema shape changes (description text only). No new error codes (`INVALID_REQUEST` is standard). The `governance_context` anchor and the `(price / 1000) × impressions` projection reference fields and tokens already on the published 3.0 wire surface.

The MUST clauses formalize the rejection paths the original-issue reporters say implementers were *already* picking — #2681 explicitly notes the training agent already rejects this way; #2680 notes the 1M-default was already flagged as non-conformant. Conformant implementations are not broken; this disambiguates two readings of the same rule.

## Expert review

`ad-tech-protocol-expert` reviewed twice:
- First pass flagged 3 blockers: schema field name mismatch (`pricing_option.cpm` doesn't exist), undefined "active governance plan" trigger, unspecified currency-mismatch behavior.
- Second pass after fixes: all three blockers resolved. Anchor is now the `governance_context` token (a concrete wire artifact, deterministic at request time), formula uses `pricing_option.price` with `pricing_option.model == "cpm"` qualifier, currency mismatch produces `field: "pricing_option_id"` rejection.

## Test plan

- [ ] Schema validation tests pass (`npm run test:schemas`)
- [ ] Snippet validation passes (`npm run test:snippets`)
- [ ] Spec docs render in Mintlify
- [ ] Cross-reference link to `governance/campaign/specification#buyer-side-governance-invocation` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)