### PR TITLE
docs(brand): apply URL canonicalization rule to brand.json agent URLs

### DIFF
--- a/.changeset/brand-json-canonicalization-link.md
+++ b/.changeset/brand-json-canonicalization-link.md
@@ -1,0 +1,33 @@
+---
+"adcontextprotocol": patch
+---
+
+**Apply the AdCP URL canonicalization rule to brand.json agent URLs.**
+
+Follow-up to #3067 — the canonicalization reference page now exists,
+and `seller-agent-ref`, `adagents.json` `authorized_agents[].url`,
+`format-id`, and `provider-registration` all link to it. `brand.json`
+declares additional agent URLs that fall in the same identifier-
+comparison class but weren't covered:
+
+- `brand_agent_entry.url` — the brand-declared agent endpoint (MCP or
+  A2A) used by callers resolving "is this the agent that signed this
+  artifact?" or matching against a discovery cache.
+- `brand_agent.url` — the brand agent MCP endpoint reference.
+- `rights_agent.url` — the rights agent MCP endpoint reference.
+
+All three now reference the AdCP URL canonicalization rules at
+`docs/reference/url-canonicalization` so two URLs differing only in
+case, default port, or percent-encoded unreserved characters compare
+equal during agent resolution.
+
+`logo.url`, `data_subject_contestation.url`, asset-library `url`, and
+the brand's primary `url` are *not* identifier-comparison keys (they
+point at human-facing pages or asset CDN endpoints), so they were
+left unchanged.
+
+`jwks_uri` (line 627) is a fetch target for JWKS download, not an
+identifier-comparison key — receivers HTTP-GET the URL as declared
+without comparing it to anything. Not in scope for this rule.
+
+No schema shape changes. Descriptions only.

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -549,7 +549,7 @@
           "type": "string",
           "format": "uri",
           "pattern": "^https://",
-          "description": "Brand agent MCP endpoint URL"
+          "description": "Brand agent MCP endpoint URL. Callers comparing this URL against another value (e.g., resolving 'is this the brand's declared agent?' against a discovery cache) MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization."
         },
         "id": {
           "type": "string",
@@ -568,7 +568,7 @@
           "type": "string",
           "format": "uri",
           "pattern": "^https://",
-          "description": "Rights agent MCP endpoint URL"
+          "description": "Rights agent MCP endpoint URL. Callers comparing this URL against another value (e.g., matching against a brand's declared rights endpoint) MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization."
         },
         "id": {
           "type": "string",
@@ -611,7 +611,7 @@
           "type": "string",
           "format": "uri",
           "pattern": "^https://",
-          "description": "Agent endpoint URL (MCP or A2A)"
+          "description": "Agent endpoint URL (MCP or A2A). Callers comparing a brand's declared agent URL against another value (e.g., resolving 'is this the agent that signed this artifact?' or matching against a discovery cache) MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization."
         },
         "id": {
           "type": "string",


### PR DESCRIPTION
## Summary

Follow-up to #3067. The URL canonicalization reference page now exists and `seller-agent-ref` / `adagents.json` / `format-id` / `provider-registration` all link to it. `brand.json` declares three additional agent URLs that fall in the same identifier-comparison class but weren't covered by that PR (kept narrow on scope).

This PR extends the same canonicalization rule to:

- **`brand_agent_entry.url`** — the agent declared by a brand or house
- **`brand_agent.url`** — brand agent MCP endpoint reference
- **`rights_agent.url`** — rights agent MCP endpoint reference

All three now reference `docs/reference/url-canonicalization` so two URLs differing only in case, default port, or percent-encoded unreserved characters compare equal during agent resolution.

## Out of scope (intentionally)

- `logo.url`, `data_subject_contestation.url`, asset-library `url`, and the brand's primary website `url` are *not* identifier-comparison keys (they point at human-facing pages or asset CDN endpoints). Left unchanged.
- `jwks_uri` is a fetch target for JWKS download — receivers HTTP-GET the URL as declared without comparing it to anything else. Not in scope for the canonicalization rule.

## Test plan

- [x] `npm run test:schemas` — 7/7 schema validation tests pass.
- [x] `npm run test:examples` — 34/34 example validation tests pass (no shape change; descriptions-only).
- [x] Pre-commit hook — 686/686 unit tests + typecheck pass.
- [x] Pre-push hook — passes (running cleanly post-#3070).
- [ ] CI broken-links + CodeQL.

## Related

- #3067 — URL canonicalization reference page (the source of the convention this PR extends)
- #2984 — TMP `seller_agent` (the change that motivated the canonicalization work)
- #3070 — Mintlify bump that surfaced doc-link enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)