### PR TITLE
fix(compliance): field_value_or_absent lint allowlist + fresh-key replayed assertion

### DIFF
--- a/.changeset/fvora-lint-and-fresh-key.md
+++ b/.changeset/fvora-lint-and-fresh-key.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(compliance): add field_value_or_absent to contradiction-lint allowlist and cover fresh-key idempotency step
+
+Follow-up to #3032 (documented the check) and #3034 (restored the initial-step `replayed` assertion). Two small gaps remained, both surfaced when triaging the superseded PR #3037:
+
+1. **`scripts/lint-storyboard-contradictions.cjs`** — `hasPositiveAssertion` listed `field_present`, `field_value`, `response_schema`, `http_status`, `http_status_in` but not `field_value_or_absent`. Any storyboard using `field_value_or_absent` as its only positive assertion was misclassified as `unspecified`. Added to the allowlist so the linter correctly classifies such steps as `success`.
+
+2. **`static/compliance/source/universal/idempotency.yaml`** — the `create_media_buy_fresh_key` step is a non-replay call, so the same `replayed` tolerance that #3034 restored on `create_media_buy_initial` applies here: `replayed` MAY be omitted, but if present MUST NOT be `true`. Added the symmetric `field_value_or_absent [false]` assertion so fresh-key coverage is not weaker than initial-call coverage.
+
+Non-breaking: both additions are purely additive (new allowlist entry + new optional assertion on a step that was already asserting other fields). Agents that omit `replayed` on fresh execution pass both (spec-correct). Only agents setting `replayed: true` on a fresh call fail — already a spec violation per PR #3013.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -454,6 +454,7 @@ function classifyOutcome(step) {
       check === 'response_schema' ||
       check === 'field_present' ||
       check === 'field_value' ||
+      check === 'field_value_or_absent' ||
       check === 'http_status' ||
       check === 'http_status_in'
     );

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -524,6 +524,13 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Fresh key returns a media_buy_id"
+          # Fresh-key execution is a non-replay call — same tolerance as
+          # create_media_buy_initial applies: `replayed` MAY be omitted,
+          # but if present MUST NOT be `true`.
+          - check: field_value_or_absent
+            path: "replayed"
+            allowed_values: [false]
+            description: "If reported on fresh-key execution, replayed must be false"
 
           - check: field_present
             path: "context"


### PR DESCRIPTION
Follow-up to the two PRs that landed the `field_value_or_absent` matcher on main earlier today:

- **#3032** — documented `field_value_or_absent` in the storyboard check enum (closed #3030).
- **#3034** — bumped `@adcp/client` to 5.16 and restored the `replayed` assertion on `create_media_buy_initial` (closed #3031).

Triaging the superseded PR #3037 surfaced two small gaps those PRs didn't pick up.

## Changes

### 1. Lint allowlist — `scripts/lint-storyboard-contradictions.cjs`

`hasPositiveAssertion` listed `response_schema`, `field_present`, `field_value`, `http_status`, `http_status_in` — but not `field_value_or_absent`. Any storyboard using `field_value_or_absent` as its only positive assertion gets misclassified as `unspecified` by the contradiction linter. Added the new check to the allowlist.

### 2. Fresh-key coverage — `static/compliance/source/universal/idempotency.yaml`

`create_media_buy_fresh_key` is a non-replay call, so the same `replayed` tolerance #3034 restored on `create_media_buy_initial` applies: `replayed` MAY be omitted, but if present MUST NOT be `true`. Main has the assertion on the initial step only; this PR adds the symmetric assertion on the fresh-key step so fresh-key coverage is not weaker than initial-call coverage.

## Non-breaking

Both additions are purely additive:
- New allowlist entry is a no-op for existing storyboards (they classify the same way).
- New optional assertion on `create_media_buy_fresh_key` — agents that omit `replayed` on fresh execution pass (spec-correct); only agents setting `replayed: true` on a fresh call fail, which is already a spec violation per #3013.

No schema changes, no new error codes, no wire-format impact. `--empty` changeset.

## Relationship to #3037

PR #3037 was opened before #3032 and #3034 merged and attempted to do all three things (doc the matcher, restore the assertion, update the lint + fresh-key step). With #3032 and #3034 merged, only the last two items remained unique — this PR lands them minimally. Closing #3037 as superseded.

## Test plan

- [ ] `npm run test:storyboard-contradictions` passes (lint classifies correctly)
- [ ] Storyboard YAML validates against `storyboard-schema.yaml`
- [ ] `create_media_buy_fresh_key` compliance runs pass for spec-correct agents (replayed omitted) and spec-correct agents (replayed: false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)