### PR TITLE
patch: complete signed-requests reclassification (specialism → universal capability-gated storyboard)

### DIFF
--- a/.changeset/3075-signed-requests-universal.md
+++ b/.changeset/3075-signed-requests-universal.md
@@ -1,0 +1,22 @@
+---
+---
+
+patch: complete the signed-requests reclassification (specialism → universal capability-gated storyboard)
+
+Follow-up patch to #3076 that completes the `signed-requests` reclassification flagged in #3075.
+
+**File move:** `static/compliance/source/specialisms/signed-requests/index.yaml` → `static/compliance/source/universal/signed-requests.yaml`. Removed `protocol: media-buy` and `status: deprecated` (universal storyboards have neither — they're cross-protocol and inherent to the suite).
+
+**Test-kit update:** `static/compliance/source/test-kits/signed-requests-runner.yaml` — `applies_to.specialism: signed-requests` → `applies_to.universal_storyboard: signed-requests`. Header comments and references field updated to point at the universal storyboard. Test-kit file path is unchanged (still `test-kits/signed-requests-runner.yaml`).
+
+**Docs:** `docs/building/conformance.mdx` adds `signed_requests` to the universal-storyboards table, gated on `request_signing.supported: true` (mirrors `deterministic_testing` which is gated on `compliance_testing.supported: true`).
+
+**Schema:** `static/schemas/source/enums/specialism.json` — `signed-requests` enum value retained for backward compatibility on a new `x-deprecated-enum-values` allowlist that the build-time parity check (`scripts/build-compliance.cjs verifyEnumParity`) respects. 4.0 enum removal tracked at #3078.
+
+**Docs cross-link:** `docs/building/implementation/security.mdx` — Signed Requests (Transport Layer) section now points at the universal storyboard so readers landing on the implementation reference can find the conformance suite.
+
+**Cross-references:** updated comments in `static/compliance/source/universal/storyboard-schema.yaml` (illustrative `applies_to` syntax now uses `universal_storyboard:` instead of `specialism:` example), `static/compliance/source/universal/runner-output-contract.yaml` ("specialisms" → "storyboards"), and `static/compliance/source/specialisms/governance-aware-seller/index.yaml` (notes the reclassification while keeping the example pattern relevant).
+
+Why patch (per the rule established in #3076): conformance-suite changes version independently of spec, and this is a taxonomy reclassification that doesn't change what an agent must do on the wire. Sellers continue to advertise `request_signing.supported: true` and implement the verifier per the security profile; the runner now reaches them via the universal storyboard instead of the per-protocol specialism. No graded users today (the prior specialism was preview status). 28+ test vectors at `static/compliance/source/test-vectors/request-signing/` are unchanged and shared.
+
+Closes #3075.

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -56,8 +56,11 @@ Every agent MUST pass every storyboard below.
 | [`idempotency`](https://adcontextprotocol.org/compliance/latest/universal/idempotency) | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
 | [`security_baseline`](https://adcontextprotocol.org/compliance/latest/universal/security) | Unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |
 | [`deterministic_testing`](https://adcontextprotocol.org/compliance/latest/universal/deterministic-testing) | `comply_test_controller` state machine — skipped if `capabilities.compliance_testing.supported: false` |
+| [`signed_requests`](https://adcontextprotocol.org/compliance/latest/universal/signed-requests) | RFC 9421 transport-layer request-signing verification — skipped if `request_signing.supported: false`. |
 
 Agents that declare `capabilities.compliance_testing.supported: true` MUST implement the full [test controller](/docs/building/implementation/comply-test-controller); a partial controller is non-conformant, so declare `false` rather than ship one.
+
+Agents that declare `request_signing.supported: true` MUST implement the full RFC 9421 verifier per the [request-signing profile](/docs/building/implementation/security#signed-requests-transport-layer); a partial verifier is non-conformant, so declare `false` rather than ship one.
 
 ## Protocol conformance
 

--- a/docs/building/implementation/security.mdx
+++ b/docs/building/implementation/security.mdx
@@ -780,6 +780,8 @@ AdCP 3.0 defines this profile as **optional and capability-advertised** via `req
 - Shares JWKS discovery, SSRF rules, alg allowlist, revocation semantics, and key rotation with the [AdCP JWS profile](#adcp-jws-profile) above. Cross-purpose key reuse is forbidden: a request-signing JWK MUST declare `"adcp_use": "request-signing"`, `"use": "sig"`, `"key_ops": ["verify"]`, and a `kid` that does not appear on any other JWKS entry with a different `adcp_use`. Verifiers enforce all four; see [Agent key publication](#agent-key-publication).
 - Resolves the identity-bootstrapping dependency in [Buyer identity resolution](#buyer-identity-resolution) for governance: a seller that verifies a request signature has a cryptographically established signing agent identity and MAY use the signing agent's operator domain as the brand.json resolution input for the governance verification step.
 
+**Conformance.** Verifier behavior is graded by the universal capability-gated storyboard at [`/compliance/latest/universal/signed-requests`](https://adcontextprotocol.org/compliance/latest/universal/signed-requests), which runs for any agent advertising `request_signing.supported: true`. The storyboard exercises every step in the [verifier checklist](#verifier-checklist-requests) below and every canonicalization-edge rule in this profile, against the test vectors at [`/compliance/latest/test-vectors/request-signing/`](https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/).
+
 #### Transport scope
 
 | Class | 3.0 | 4.0 |

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -309,13 +309,21 @@ function verifyEnumParity(specialisms, protocols) {
   const enumSpecialisms = new Set(specialismEnum.enum);
   const enumProtocols = new Set(protocolEnum.enum);
 
+  // Enum values listed in `x-deprecated-enum-values` are retained for backward
+  // compatibility but their storyboard has been relocated or removed. The
+  // filesystem-backing requirement does not apply to them.
+  const deprecatedSpecialisms = new Set(specialismEnum['x-deprecated-enum-values'] || []);
+
   const missingFromEnum = [...fsSpecialisms].filter(x => !enumSpecialisms.has(x));
-  const missingFromFs = [...enumSpecialisms].filter(x => !fsSpecialisms.has(x));
+  const missingFromFs = [...enumSpecialisms]
+    .filter(x => !fsSpecialisms.has(x))
+    .filter(x => !deprecatedSpecialisms.has(x));
   if (missingFromEnum.length || missingFromFs.length) {
     const msg = [
       `Specialism enum drift between filesystem and specialism.json:`,
       missingFromEnum.length ? `  In filesystem but missing from enum: ${missingFromEnum.join(', ')}` : '',
-      missingFromFs.length ? `  In enum but missing from filesystem: ${missingFromFs.join(', ')}` : ''
+      missingFromFs.length ? `  In enum but missing from filesystem: ${missingFromFs.join(', ')}` : '',
+      missingFromFs.length ? `  (Add to "x-deprecated-enum-values" in specialism.json if intentionally retained for back-compat after storyboard removal.)` : ''
     ].filter(Boolean).join('\n');
     throw new Error(msg);
   }

--- a/static/compliance/source/specialisms/governance-aware-seller/index.yaml
+++ b/static/compliance/source/specialisms/governance-aware-seller/index.yaml
@@ -52,10 +52,11 @@ narrative: |
   Sellers that do not claim this specialism are graded `not_applicable` on
   these scenarios rather than failed. This mirrors the pattern used by the
   other governance-* specialisms (`governance-spend-authority`,
-  `governance-delivery-monitor`) and by `measurement-verification` and
-  `signed-requests` — cross-cutting capabilities are gated behind explicit
-  specialism claims instead of being force-included under every sales-*
-  specialism.
+  `governance-delivery-monitor`) and by `measurement-verification` —
+  cross-cutting capabilities that involve campaign behavior are gated behind
+  explicit specialism claims instead of being force-included under every
+  sales-* specialism. (`signed-requests` was previously listed here; it was
+  reclassified in 3.1 to a universal capability-gated storyboard.)
 
   Composition means the seller:
   - accepts `sync_governance` to register the buyer's governance agent URL and

--- a/static/compliance/source/test-kits/signed-requests-runner.yaml
+++ b/static/compliance/source/test-kits/signed-requests-runner.yaml
@@ -1,8 +1,9 @@
 # Signed-Requests Runner — Harness Contract Test Kit
 #
-# Applies to: specialisms/signed-requests/index.yaml
+# Applies to: universal/signed-requests.yaml (gated on
+# `request_signing.supported: true` in get_adcp_capabilities).
 #
-# The signed-requests specialism grades an agent's RFC 9421 verifier against 28
+# The signed-requests storyboard grades an agent's RFC 9421 verifier against 28
 # conformance vectors at /compliance/{version}/test-vectors/request-signing/.
 # Most vectors are pure black-box: the runner constructs a signed HTTP request,
 # sends it, and checks the response. Three negative vectors assert behavior that
@@ -13,16 +14,17 @@
 #   020-rate-abuse       — per-keyid replay cache must be at its configured cap
 #
 # This test-kit defines the coordination contract between a black-box runner and
-# a request-signing agent under test. Agents claiming the specialism MUST
-# pre-configure their verifier per this contract before the negative phase runs.
-# The runner reads this file to know (a) the keyids it will sign with, (b) how
-# to provoke each stateful negative vector, and (c) the grading-time cap values
-# it will target (which are NOT production recommendations — see each field).
-# See `scope` below for what the contract does NOT specify.
+# a request-signing agent under test. Agents advertising
+# `request_signing.supported: true` MUST pre-configure their verifier per this
+# contract before the negative phase runs. The runner reads this file to know
+# (a) the keyids it will sign with, (b) how to provoke each stateful negative
+# vector, and (c) the grading-time cap values it will target (which are NOT
+# production recommendations — see each field). See `scope` below for what the
+# contract does NOT specify.
 
 id: signed_requests_runner
 applies_to:
-  specialism: signed-requests
+  universal_storyboard: signed-requests
 
 description: |
   Coordination contract between a black-box runner and a request-signing agent
@@ -39,9 +41,9 @@ endpoint_scope: sandbox
 # its first step (the second copy is what the grader expects to be rejected).
 # Running this against a production endpoint would create a real media buy.
 # Graders MUST target a sandbox/staging endpoint or an idempotency-keyed
-# sacrificial path the agent discards post-grading. Agents claiming the
-# specialism SHOULD expose a dedicated grading endpoint rather than grading in
-# prod.
+# sacrificial path the agent discards post-grading. Agents advertising
+# `request_signing.supported: true` SHOULD expose a dedicated grading endpoint
+# rather than grading in prod.
 
 harness_mode: black_box
 # Agents participating in a white-box test harness (e.g., SDK internal tests
@@ -147,7 +149,7 @@ scope:
       counterparty only.
 
 references:
-  specialism: static/compliance/source/specialisms/signed-requests/index.yaml
+  universal_storyboard: static/compliance/source/universal/signed-requests.yaml
   test_vectors: /compliance/{version}/test-vectors/request-signing/
   verifier_checklist: /docs/building/implementation/security.mdx#verifier-checklist-requests
   runner_implementation: https://github.com/adcontextprotocol/adcp-client/issues/585

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -278,7 +278,7 @@ skip_result:
       A test-kit harness contract (e.g., signed-requests-runner) is not in
       scope for this grading run. detail MUST cite the contract key. Per
       the signed-requests-runner contract, unsatisfied contracts grade as
-      FAIL, not SKIP, for the specialisms that declare them — this reason
+      FAIL, not SKIP, for the storyboards that declare them — this reason
       applies only where the contract explicitly permits SKIP.
     peer_branch_taken: |
       The step is part of an `any_of` branch set (see storyboard-schema.yaml

--- a/static/compliance/source/universal/signed-requests.yaml
+++ b/static/compliance/source/universal/signed-requests.yaml
@@ -1,57 +1,50 @@
 id: signed_requests
 version: "1.0.0"
 title: "Signed requests — RFC 9421 transport-layer verification"
-protocol: media-buy
-status: deprecated
 category: signed_requests
-summary: "DEPRECATED — being reclassified from per-protocol specialism to a universal capability-gated storyboard. Agents that currently advertise `request_signing.supported: true` SHOULD NOT add `signed-requests` to their `specialisms` array; the universal storyboard at `/compliance/{version}/universal/signed-requests.yaml` (when published) covers the same conformance bar regardless of `supported_protocols`. See https://github.com/adcontextprotocol/adcp/issues/3075."
+summary: "Agent verifies RFC 9421 HTTP Signatures on incoming AdCP requests per the transport-layer profile. Universal capability-gated storyboard — runs for any agent advertising `request_signing.supported: true` regardless of `supported_protocols`. Graded against conformance vectors covering every checklist step and canonicalization-edge rule."
 track: security_transport
 required_tools:
   - get_adcp_capabilities
   # Additional tool families are exercised transport-layer only — the runner signs
   # requests targeting any mutating AdCP operation (create_media_buy, update_media_buy,
   # acquire_*, activate_signal, sync_creatives) and grades the verifier's response.
-  # See deprecation note in narrative below — this specialism is being reclassified as
-  # a universal capability-gated storyboard and will be removed from the specialism
-  # taxonomy in 4.0. Runner implementation tracked at adcontextprotocol/adcp#2331.
+  # The runner picks operations available given the agent's `supported_protocols`;
+  # operations the agent does not implement are skipped, not failed. Runner
+  # implementation tracked at adcontextprotocol/adcp#2331.
 
 narrative: |
-  **DEPRECATED** — this specialism is being reclassified as a universal capability-gated
-  storyboard. The signed-requests claim is a transport-layer concern that applies to every
-  AdCP agent regardless of `supported_protocols` — there is nothing media-buy-specific about
-  it. Classifying it as a media-buy specialism was a taxonomy error. The conformance bar
-  itself is unchanged; only the location moves. Tracked at
-  [#3075](https://github.com/adcontextprotocol/adcp/issues/3075).
+  Request signing is a transport-layer claim that applies to every AdCP agent regardless
+  of which protocols it speaks. RFC 9421 verification behavior is identical whether the
+  agent is a media-buy seller, a signals agent, a governance agent, a creative agent, or
+  a brand agent. This universal storyboard certifies that an agent correctly implements
+  the AdCP RFC 9421 request-signing verifier per
+  [`docs/building/implementation/security.mdx#signed-requests-transport-layer`](/docs/building/implementation/security#signed-requests-transport-layer).
 
-  **For agents:** do not add `signed-requests` to your `get_adcp_capabilities.specialisms`
-  array. Advertise `request_signing.supported: true` in the `request_signing` capability
-  block instead — that is the on-wire claim. Once the universal storyboard ships at
-  `/compliance/{version}/universal/signed-requests.yaml`, every agent advertising
-  `request_signing.supported: true` runs it automatically (same gating model as
-  `compliance_testing.supported`).
+  **Gating.** This storyboard runs for any agent advertising `request_signing.supported: true`
+  in `get_adcp_capabilities`. Agents that do not advertise support are not tested against
+  this storyboard — absence of advertisement is not a failure, it is a declaration that
+  the agent does not offer verified signed requests. Same gating model as
+  `deterministic_testing` (gated on `compliance_testing.supported: true`).
 
-  ---
+  **Backward-compatible specialism claims.** The deprecated `signed-requests` specialism
+  enum value remains in the schema for back-compat (see
+  [#3075](https://github.com/adcontextprotocol/adcp/issues/3075)). Agents that still
+  advertise `specialisms: ["signed-requests"]` are graded via this universal storyboard;
+  the runner SHOULD emit an informational notice (not a failure) advising the agent to
+  drop the now-redundant specialism claim and rely solely on `request_signing.supported: true`.
+  4.0 removes the enum value entirely — see
+  [#3078](https://github.com/adcontextprotocol/adcp/issues/3078).
 
-  *Original specialism description follows for historical reference; the conformance
-  content (vectors, contracts, runner harness) is unchanged and will move verbatim to
-  the universal storyboard location:*
+  **Composition with other storyboards.** This storyboard runs independently of any
+  specialism a seller also claims. A seller advertising `request_signing.supported: true`
+  AND `specialisms: ["sales-guaranteed"]` is graded on both — universal failure does not
+  exempt the specialism's pass, and a specialism pass does not paper over universal
+  failure. The overall AAO Verified verdict requires all gated storyboards to pass; the
+  runner reports per-storyboard outcomes so operators can isolate failures.
 
-  The signed-requests specialism certifies that an agent correctly implements the AdCP
-  RFC 9421 request-signing verifier per `docs/building/implementation/security.mdx#signed-requests-transport-layer`.
-
-  This is a transport-layer claim, not a protocol-specific one. A signed request can target
-  any mutating operation — most commonly `create_media_buy`, `update_media_buy`, `acquire_*`,
-  `activate_signal`, and `sync_creatives`. The claim is scoped to `media-buy` in this
-  preview specialism (a classification error fixed in #3075) — the verifier behavior is
-  the same across all mutating operations regardless of which protocols the agent supports.
-
-  The claim is certifiable only when the agent advertises `request_signing.supported: true`
-  in `get_adcp_capabilities`. An agent that does not advertise support is not tested against
-  this specialism — absence of advertisement is not a failure, it is a declaration that the
-  agent does not offer verified signed requests.
-
-  Grading is observable-behavior only. The runner constructs signed HTTP requests exactly
-  as documented in the conformance vectors at
+  **Grading.** Observable-behavior only. The runner constructs signed HTTP requests
+  exactly as documented in the conformance vectors at
   `/compliance/{version}/test-vectors/request-signing/` and sends them to the agent. The
   agent's responses are compared against the vectors' `expected_outcome`:
 
@@ -61,19 +54,20 @@ narrative: |
     The checklist step number is informational; grading is on the stable error code only.
 
   The runner supplies signed requests; the agent is the verifier. A separate signer-side
-  storyboard may follow but is out of scope for this specialism — signers are easier to get
-  right, and a signer that produces valid signatures is proven correct by a conformant
-  verifier accepting them.
+  storyboard may follow but is out of scope here — signers are easier to get right, and a
+  signer that produces valid signatures is proven correct by a conformant verifier
+  accepting them.
 
-  Three negative vectors — 016 (replayed nonce), 017 (key revoked), and 020 (per-keyid cap) —
-  assert verifier state the runner cannot set from the outside. Those vectors declare
-  `requires_contract` and are gated on the `signed_requests_runner` test-kit contract
-  at `test-kits/signed-requests-runner.yaml`, which specifies the runner's signing keyids,
-  a dedicated pre-revoked keyid (`test-revoked-2026`), and the grading-time per-keyid cap
-  the runner will target. Agents claiming the specialism MUST pre-configure their verifier
-  per that contract before the negative phase runs. If the agent does not satisfy the
-  contract (e.g., the runner can't coordinate the pre-state), the affected vectors grade
-  as FAIL, never as SKIP — the contract is a prerequisite for the claim, not an optional
+  **Stateful vectors.** Three negative vectors — 016 (replayed nonce), 017 (key revoked),
+  and 020 (per-keyid cap) — assert verifier state the runner cannot set from the outside.
+  Those vectors declare `requires_contract` and are gated on the `signed_requests_runner`
+  test-kit contract at `test-kits/signed-requests-runner.yaml`, which specifies the
+  runner's signing keyids, a dedicated pre-revoked keyid (`test-revoked-2026`), and the
+  grading-time per-keyid cap the runner will target. Agents advertising
+  `request_signing.supported: true` MUST pre-configure their verifier per that contract
+  before the negative phase runs. If the agent does not satisfy the contract (e.g., the
+  runner can't coordinate the pre-state), the affected vectors grade as FAIL, never as
+  SKIP — the contract is a prerequisite for the capability claim, not an optional
   extension.
 
 agent:
@@ -81,8 +75,7 @@ agent:
   capabilities:
     - verifies_request_signatures
   examples:
-    - "AdCP seller implementing request verification"
-    - "Any agent advertising `request_signing.supported: true`"
+    - "Any AdCP agent advertising `request_signing.supported: true` — sales agent, signals agent, governance agent, creative agent, or brand agent"
 
 caller:
   role: compliance_runner
@@ -109,9 +102,9 @@ phases:
         title: "Verify the agent declares request_signing.supported"
         narrative: |
           The runner calls `get_adcp_capabilities` and confirms that the agent declares
-          support for this specialism. Absence of `request_signing.supported: true` means
-          the agent has not opted into the claim; the runner SHOULD skip the remaining
-          phases.
+          support for the request-signing capability. Absence of `request_signing.supported: true`
+          means the agent has not opted into this storyboard; the runner SHOULD skip the
+          remaining phases.
         task: get_adcp_capabilities
         schema_ref: "protocol/get-adcp-capabilities-request.json"
         response_schema_ref: "protocol/get-adcp-capabilities-response.json"
@@ -120,7 +113,7 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring request_signing.supported: true. If false or absent,
-          the specialism does not apply and grading skips to a non-applicable outcome.
+          this storyboard does not apply and grading skips to a non-applicable outcome.
         sample_request:
           context:
             correlation_id: "signed_requests--get_capabilities"
@@ -202,10 +195,10 @@ grading:
   pass_criteria: |
     All vectors in positive/ produce 2xx, and all vectors in negative/ produce 401 with
     the expected error code byte-for-byte. Any single vector's failure to produce its
-    expected outcome fails the specialism. Vectors that declare `requires_contract`
+    expected outcome fails the storyboard. Vectors that declare `requires_contract`
     whose contract the runner cannot satisfy grade as FAIL, never as SKIP — the
-    signed-requests-runner contract is a prerequisite for the claim, not an optional
-    extension.
+    signed-requests-runner contract is a prerequisite for the capability claim, not an
+    optional extension.
   report_format: |
     Pass/fail per vector, with the response's error code (if any) and a diff against
     the vector's expected_outcome. Operators receive specific per-vector diagnostics

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -144,7 +144,8 @@
 #   Runner contract — carries a harness coordination contract. Declares:
 #     id                 string (short identifier)
 #     applies_to         object or list (which storyboards/specialisms consume
-#                        this contract, e.g., `{ specialism: signed-requests }`)
+#                        this contract, e.g., `{ universal_storyboard: signed-requests }`
+#                        or `{ specialism: sales-catalog-driven }`)
 #     + contract-specific fields describing how the runner should pre-configure
 #       the agent under test (e.g., `receiver_urls:`, `retry_replay_contract:`
 #       for webhook-receiver-runner; `endpoint_modes:` for signed-requests)
@@ -176,7 +177,7 @@
 # substitution_observer_runner`.
 #
 # Storyboards that test pure harness infrastructure without a specific brand
-# (e.g., `specialisms/signed-requests/index.yaml`,
+# (e.g., `universal/signed-requests.yaml`,
 # `universal/webhook-emission.yaml`) point `prerequisites.test_kit` directly
 # at the runner contract and fall back on `task_default:` when any
 # `$test_kit.operations.<name>` reference resolves to null (see Step field

--- a/static/schemas/source/enums/specialism.json
+++ b/static/schemas/source/enums/specialism.json
@@ -4,6 +4,10 @@
   "title": "AdCP Specialism",
   "description": "Specialized capability claims an agent can make. Each specialism maps to a compliance storyboard bundle published at /compliance/{version}/specialisms/{id}/. An agent asserts specialisms it supports in get_adcp_capabilities; the AAO compliance runner executes the matching storyboards to verify the claim.",
   "type": "string",
+  "x-deprecated-enum-values": [
+    "signed-requests"
+  ],
+  "x-deprecated-enum-values-doc": "Enum values listed here are retained for backward compatibility but their corresponding storyboard has been relocated or removed. Build-time parity checks (scripts/build-compliance.cjs verifyEnumParity) skip filesystem-backing enforcement for these values. Targeted for removal in a future major version.",
   "enum": [
     "audience-sync",
     "brand-rights",
@@ -46,6 +50,6 @@
     "sales-social": "Social media advertising platform with self-service flows",
     "signal-marketplace": "Marketplace signal agent reselling third-party data",
     "signal-owned": "Owned signal agent exposing first-party segments",
-    "signed-requests": "Agent verifies RFC 9421 transport-layer request signatures per the AdCP request-signing profile. Graded by exercising 29 conformance vectors (21 negative + 8 positive) against the agent's live verifier."
+    "signed-requests": "DEPRECATED in 3.1 — reclassified to /compliance/{version}/universal/signed-requests.yaml. Advertise request_signing.supported: true in get_adcp_capabilities; this enum value is retained until 4.0 for backward compat but is no longer needed. See https://github.com/adcontextprotocol/adcp/issues/3075 (reclassification) and https://github.com/adcontextprotocol/adcp/issues/3078 (4.0 enum removal)."
   }
 }


### PR DESCRIPTION
## Summary

Follow-up patch to #3076 that completes the `signed-requests` reclassification tracked in #3075. #3076 marked the preview specialism `deprecated` and added the storyboards-=-patch rule to versioning policy; this PR does the actual file move and cross-reference cleanup.

Closes #3075.

## Why patch

Per the rule established in #3076 ([versioning.mdx — Spec changes vs. conformance-suite changes](https://docs.adcontextprotocol.org/docs/reference/versioning#spec-changes-vs-conformance-suite-changes)):

> Adding, removing, renaming, or reclassifying preview-status specialisms; relocating storyboards between universal/protocol/specialism directories; refactoring scenario coverage; and adjusting runner behavior to match an unchanged spec are all patch changes.

This change reclassifies a preview-status specialism (no graded users today) and relocates its storyboard. On-wire seller obligation is unchanged — sellers continue to advertise `request_signing.supported: true` and implement the verifier per the security profile.

## Changes

**File move (62% similar — narrative tone updated, taxonomy fields dropped):**
- `static/compliance/source/specialisms/signed-requests/index.yaml` → `static/compliance/source/universal/signed-requests.yaml`
- Dropped `protocol: media-buy` (cross-protocol — verifier behavior is identical regardless of `supported_protocols`)
- Dropped `status: deprecated` (universal storyboards have no `status` field — they're inherent to the suite, not opt-in claims)
- Replaced deprecation framing with canonical universal-storyboard narrative; gating-on-`request_signing.supported: true` is the explicit `deterministic_testing` precedent
- All phases, vectors, prerequisites, and grading semantics preserved verbatim

**Test-kit update:**
- `static/compliance/source/test-kits/signed-requests-runner.yaml` — `applies_to.specialism: signed-requests` → `applies_to.universal_storyboard: signed-requests`
- `references` field points at the universal storyboard
- Header comments updated; file path itself is unchanged

**Docs:**
- `docs/building/conformance.mdx` — universal-storyboards table now includes `signed_requests` row, gated on `request_signing.supported: true`. Mirrors the `deterministic_testing` row (gated on `compliance_testing.supported: true`).

**Schema (backward-compatible):**
- `static/schemas/source/enums/specialism.json` — `signed-requests` enum value **retained** for backward compatibility. Description updated to flag the deprecation, point at the universal storyboard, and link #3075. Removal from the enum is a 4.0 breaking change (separate).

**Cross-references:**
- `static/compliance/source/universal/storyboard-schema.yaml` — illustrative `applies_to` syntax in comments now uses `universal_storyboard: signed-requests` instead of `specialism: signed-requests`; another comment block referencing `specialisms/signed-requests/index.yaml` updated to `universal/signed-requests.yaml`
- `static/compliance/source/universal/runner-output-contract.yaml` — "specialisms that declare them" → "storyboards that declare them"
- `static/compliance/source/specialisms/governance-aware-seller/index.yaml` — notes the reclassification while preserving the surrounding example pattern (other specialisms still listed)

**Unchanged:**
- 28+ test vectors at `static/compliance/source/test-vectors/request-signing/` — shared infrastructure referenced by both the test-kit and the universal storyboard
- The runner-implementation tracking issue at #2331 — independent of this taxonomy change
- The on-wire seller obligation (advertise `request_signing.supported: true`, implement RFC 9421 verifier per the security profile)

## Test plan

- [x] `npm run build:schemas` clean
- [x] No remaining specialism-style references to `signed-requests` outside its own narrative footnote and the deprecation marker on the enum entry
- [x] Mintlify broken-links check expected to pass (all references updated; 4.0-context links use issue refs, not internal pages)
- [ ] Verify `static/compliance/source/test-kits/substitution-observer-runner.yaml`'s `sibling_contract_signed_requests` reference (line 690) still resolves — it points at the test-kit file path which is unchanged

## Follow-ups

- **4.0** — remove `signed-requests` from `static/schemas/source/enums/specialism.json`. Breaking schema change, separate PR; the enum entry stays through 3.x for backward compatibility.
- **Runner implementation** at #2331 — independent of taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)