### PR TITLE
chore(training-agent): drop deprecated signed-requests specialism claim

### DIFF
--- a/.changeset/training-agent-drop-signed-requests-specialism.md
+++ b/.changeset/training-agent-drop-signed-requests-specialism.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore(training-agent): drop deprecated `signed-requests` specialism claim
+
+Follow-up to #3077: the training agent's capability advertisement no longer claims `specialisms: ['signed-requests']`. Per the universal storyboard's narrative, advertising `request_signing.supported: true` is now the sole correct mechanism — the deprecated specialism claim is redundant and the runner emits an informational notice when it sees one. The training agent is the dogfood reference, so it goes first.
+
+Touches both dispatch paths (`task-handlers.ts` legacy and `framework-server.ts` framework-default) plus the integration tests that previously asserted the deprecated claim was present. Test fixture in `tests/lint-storyboard-test-kits.test.cjs` updated from `applies_to.specialism: 'signed-requests'` to `applies_to.universal_storyboard: 'signed-requests'` to match the post-reclassification syntax.
+
+No protocol surface change — the spec already deprecated the enum value in #3076 and #3077.

--- a/server/src/training-agent/FRAMEWORK_MIGRATION.md
+++ b/server/src/training-agent/FRAMEWORK_MIGRATION.md
@@ -104,7 +104,7 @@ The `mode`/`userId`/`moduleId`/`trackId`/`learnerLevel` fields are only populate
 
 ### 10. Custom capabilities block
 
-Our `handleGetAdcpCapabilities` returns a bespoke shape with `publisher_domains`, `compliance_testing.scenarios[]`, `specialisms: ['signed-requests']`, `request_signing`, etc. The framework auto-generates capabilities from registered tools — useful, but doesn't know about the training-agent-specific fields.
+Our `handleGetAdcpCapabilities` returns a bespoke shape with `publisher_domains`, `compliance_testing.scenarios[]`, `request_signing`, etc. The framework auto-generates capabilities from registered tools — useful, but doesn't know about the training-agent-specific fields.
 
 Resolution: override `get_adcp_capabilities` via `server.tool(...)` after `createAdcpServer` returns. Our override wins (McpServer's `.tool()` replaces prior registrations). Straightforward once the `server.tool()` typing issues are resolved (blocker #2).
 

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -516,7 +516,7 @@ export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpSe
 
     capabilities: {
       major_versions: [3],
-      specialisms: ['signed-requests'],
+      specialisms: [],
       features: {
         inlineCreativeManagement: true,
         propertyListFiltering: true,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2360,7 +2360,7 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     },
     supported_protocols: ['media_buy', 'creative', 'governance', 'signals', 'brand'],
-    specialisms: ['signed-requests'],
+    specialisms: [],
     request_signing: {
       supported: signingCap.supported,
       covers_content_digest: signingCap.covers_content_digest,

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -96,17 +96,25 @@ describe('Training Agent /mcp-strict route', () => {
     it('/mcp returns required_for: [] (sandbox)', async () => {
       const res = await callTool(app, '/mcp', 'get_adcp_capabilities', {});
       expect(res.status).toBe(200);
-      const inner = innerResponse(res) as { request_signing: { required_for: string[] }; specialisms: string[] };
+      const inner = innerResponse(res) as {
+        request_signing: { supported: boolean; required_for: string[] };
+        specialisms?: string[];
+      };
+      expect(inner.request_signing.supported).toBe(true);
       expect(inner.request_signing.required_for).toEqual([]);
-      expect(inner.specialisms).toContain('signed-requests');
+      expect(inner.specialisms ?? []).not.toContain('signed-requests');
     });
 
     it('/mcp-strict returns required_for: ["create_media_buy"] (grader target)', async () => {
       const res = await callTool(app, '/mcp-strict', 'get_adcp_capabilities', {});
       expect(res.status).toBe(200);
-      const inner = innerResponse(res) as { request_signing: { required_for: string[] }; specialisms: string[] };
+      const inner = innerResponse(res) as {
+        request_signing: { supported: boolean; required_for: string[] };
+        specialisms?: string[];
+      };
+      expect(inner.request_signing.supported).toBe(true);
       expect(inner.request_signing.required_for).toEqual(['create_media_buy']);
-      expect(inner.specialisms).toContain('signed-requests');
+      expect(inner.specialisms ?? []).not.toContain('signed-requests');
     });
   });
 

--- a/tests/lint-storyboard-test-kits.test.cjs
+++ b/tests/lint-storyboard-test-kits.test.cjs
@@ -36,7 +36,7 @@ test('classify: brand kit (auth.api_key only)', () => {
 });
 
 test('classify: runner contract (applies_to only)', () => {
-  const { hasApiKey, hasAppliesTo } = classify({ applies_to: { specialism: 'signed-requests' } });
+  const { hasApiKey, hasAppliesTo } = classify({ applies_to: { universal_storyboard: 'signed-requests' } });
   assert.equal(hasApiKey, false);
   assert.equal(hasAppliesTo, true);
 });
@@ -44,7 +44,7 @@ test('classify: runner contract (applies_to only)', () => {
 test('classify: hybrid (future branded-runner — both markers)', () => {
   const { hasApiKey, hasAppliesTo } = classify({
     auth: { api_key: 'demo-x-v1' },
-    applies_to: { specialism: 'signed-requests' },
+    applies_to: { universal_storyboard: 'signed-requests' },
   });
   assert.equal(hasApiKey, true);
   assert.equal(hasAppliesTo, true);


### PR DESCRIPTION
## Summary

Follow-up to #3077 (signed-requests reclassification). The training agent — our dogfood reference implementation — still advertises `specialisms: ['signed-requests']` in its capability response. Per the universal storyboard's narrative, that claim is now redundant: agents declare request-signing support via `request_signing.supported: true` only, and the runner emits an informational notice when it sees the deprecated specialism. This PR makes the training agent the first to demonstrate the post-reclassification posture.

## Changes

- **`server/src/training-agent/task-handlers.ts`** — legacy dispatch capability response: `specialisms: ['signed-requests']` → `specialisms: []`.
- **`server/src/training-agent/framework-server.ts`** — framework dispatch config (now the default): same change, `capabilities.specialisms: []`.
- **`server/tests/integration/training-agent-strict.test.ts`** — capability tests previously asserted `specialisms.toContain('signed-requests')`. They now assert `request_signing.supported: true` and `specialisms` does NOT contain the deprecated value. Defensive against the framework stripping empty arrays from the response (`specialisms ?? []`).
- **`server/src/training-agent/FRAMEWORK_MIGRATION.md`** — drop stale reference to the deprecated claim in the bespoke-shape inventory.
- **`tests/lint-storyboard-test-kits.test.cjs`** — classification fixtures use `applies_to.universal_storyboard: 'signed-requests'` (matches the post-#3077 test-kit shape from `signed-requests-runner.yaml`) instead of `applies_to.specialism: 'signed-requests'`. The `classify` function only checks for *presence* of `applies_to`, so the test still passes — this is a fixture-accuracy cleanup so future readers don't copy the stale shape.

## Why patch / `--empty` changeset

This is server code — no protocol surface change. The spec-level deprecation already landed in #3076 (storyboards-=-patch policy + preview→deprecated status) and #3077 (file move + `x-deprecated-enum-values` allowlist). This PR just brings our own implementation in line with the spec it just shipped.

## Out of scope (filing separately)

While running the strict-route tests I noticed `unsigned create_media_buy on /mcp-strict returns 401 request_signature_required` is failing on `main` already (returns 200, not 401). Not caused by this PR — verified by stashing my changes and re-running on a clean tree. Filing as a separate issue.

## Test plan

- [x] `npx vitest run tests/integration/training-agent-strict.test.ts` — capability tests pass; presence-gated tests pass except the pre-existing 401 failure noted above.
- [x] `node tests/lint-storyboard-test-kits.test.cjs` — all 9 lint tests pass with the updated fixtures.
- [x] `node scripts/build-compliance.cjs` — `✓ 11 universal, 6 protocols, 19 specialisms` (no regression).
- [x] TypeScript precommit hook — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)