### PR TITLE
fix(training-agent): restore 401 for unsigned create_media_buy on /mcp-strict

### DIFF
--- a/.changeset/fix-strict-rawbody-resolve-operation.md
+++ b/.changeset/fix-strict-rawbody-resolve-operation.md
@@ -1,0 +1,18 @@
+---
+---
+
+fix(training-agent): restore 401 for unsigned create_media_buy on /mcp-strict
+
+`resolveOperation` in `buildStrictAuthenticator` read `req.rawBody` exclusively and silently returned `undefined` when it was absent. In test harnesses that mount `express.json()` without the production `verify` callback, `rawBody` is never populated, so the `required_for: ['create_media_buy']` gate never fired and unsigned requests authenticated via bearer → 200.
+
+**Two-part fix:**
+
+1. `server/src/training-agent/index.ts` — `buildStrictAuthenticator`'s `resolveOperation` now falls back to `req.body` (already parsed by express.json) when `rawBody` is absent. Safe because `resolveOperation` drives only the `required_for` routing decision, not cryptographic verification — the signing authenticator's own `resolveOperation` deliberately remains `rawBody`-only.
+
+2. `server/src/training-agent/request-signing.ts` — `enforceSigningWhenWebhookAuthPresent` applies the same fallback for the webhook-authentication downgrade-resistance check so a test harness without the `verify` callback still catches `push_notification_config.authentication` payloads.
+
+3. `server/tests/integration/training-agent-strict.test.ts` — `beforeAll` now mirrors production `http.ts` by adding the `verify` callback to `express.json`, populating `req.rawBody` for all test requests.
+
+Non-protocol server change; `--empty` changeset per playbook.
+
+Closes #3080.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -166,11 +166,17 @@ function buildStrictAuthenticator(): Authenticator | null {
     fallback: bearerAuth,
     requiredFor: STRICT_REQUIRED_FOR,
     resolveOperation: (req) => {
+      // rawBody is populated by the production http.ts `verify` callback.
+      // Fall back to req.body (already-parsed by express.json) when rawBody
+      // is absent — e.g. in test harnesses that skip the verify callback.
+      // Safe here because resolveOperation drives only the required_for
+      // routing decision, not cryptographic verification.
       const raw = (req as { rawBody?: string }).rawBody;
-      if (!raw) return undefined;
       try {
-        const body = JSON.parse(raw) as { method?: string; params?: { name?: string } };
-        if (body.method === 'tools/call' && typeof body.params?.name === 'string') {
+        const body = raw
+          ? JSON.parse(raw) as { method?: string; params?: { name?: string } }
+          : (req as { body?: { method?: string; params?: { name?: string } } }).body;
+        if (body && body.method === 'tools/call' && typeof body.params?.name === 'string') {
           return body.params.name;
         }
       } catch {

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -254,7 +254,11 @@ function subtreeHasWebhookAuthentication(node: unknown, depth = 0): boolean {
 export function enforceSigningWhenWebhookAuthPresent(inner: Authenticator): Authenticator {
   const wrapped: Authenticator = async (req) => {
     if (!requestCarriesSignatureHeader(req.headers)) {
-      const raw = (req as { rawBody?: string }).rawBody;
+      // rawBody from the production http.ts verify callback; fall back to
+      // re-serialising req.body for test harnesses that omit the callback.
+      const rawBody = (req as { rawBody?: string }).rawBody;
+      const bodyForWebhookCheck = (req as { body?: unknown }).body;
+      const raw = rawBody ?? (bodyForWebhookCheck !== undefined ? JSON.stringify(bodyForWebhookCheck) : undefined);
       if (raw && bodyCarriesWebhookAuthentication(raw)) {
         throw new AuthError(
           'Signature required when push_notification_config.authentication is present.',

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -258,7 +258,12 @@ export function enforceSigningWhenWebhookAuthPresent(inner: Authenticator): Auth
       // re-serialising req.body for test harnesses that omit the callback.
       const rawBody = (req as { rawBody?: string }).rawBody;
       const bodyForWebhookCheck = (req as { body?: unknown }).body;
-      const raw = rawBody ?? (bodyForWebhookCheck !== undefined ? JSON.stringify(bodyForWebhookCheck) : undefined);
+      // Guard: JSON.stringify is safe only for plain objects (express.json always
+      // produces one, but a misconfigured parser could yield a Buffer or string).
+      const rawFallback = bodyForWebhookCheck !== null && typeof bodyForWebhookCheck === 'object' && !Array.isArray(bodyForWebhookCheck) && !Buffer.isBuffer(bodyForWebhookCheck)
+        ? JSON.stringify(bodyForWebhookCheck)
+        : undefined;
+      const raw = rawBody ?? rawFallback;
       if (raw && bodyCarriesWebhookAuthentication(raw)) {
         throw new AuthError(
           'Signature required when push_notification_config.authentication is present.',

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -77,7 +77,14 @@ describe('Training Agent /mcp-strict route', () => {
 
   beforeAll(() => {
     app = express();
-    app.use(express.json());
+    // Mirror production http.ts: populate req.rawBody via the verify callback
+    // so requireTokenStrict's resolveOperation can identify the tool name and
+    // apply the required_for gate without falling back to req.body.
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8');
+      },
+    }));
     app.use('/api/training-agent', createTrainingAgentRouter());
   });
 


### PR DESCRIPTION
Closes #3080

## Summary

`/mcp-strict` returned 200 instead of 401 for unsigned `create_media_buy` requests, breaking vector 001 (`request_signature_required`) on the compliance grader.

**Root cause:** `resolveOperation` in `buildStrictAuthenticator` read `req.rawBody` exclusively and returned `undefined` when it was absent. Test harnesses that mount `express.json()` without the production `verify` callback never populate `rawBody`, so `requireAuthenticatedOrSigned` couldn't identify the tool name, the `required_for: ['create_media_buy']` gate never fired, and a valid bearer authenticated the request → 200.

**Three-part fix:**

- **`server/src/training-agent/index.ts`** — `buildStrictAuthenticator`'s `resolveOperation` falls back to the already-parsed `req.body` when `rawBody` is absent. Safe: this function drives only the `required_for` routing decision, not cryptographic verification (the signing authenticator's own `resolveOperation` deliberately remains `rawBody`-only).
- **`server/src/training-agent/request-signing.ts`** — `enforceSigningWhenWebhookAuthPresent` applies the same fallback so the webhook-authentication downgrade-resistance check works in test harnesses that omit the `verify` callback.
- **`server/tests/integration/training-agent-strict.test.ts`** — `beforeAll` now mirrors production `http.ts` by adding the `verify` callback to `express.json`, populating `req.rawBody` for all test requests. The `req.body` fallback in the above two functions is defense-in-depth for harnesses that can't easily add the callback.

**Non-breaking justification:** server middleware and test wiring only. No schema, task definition, wire protocol, or public API surface changed.

**Note:** `buildRequestSigningAuthenticator`'s own `resolveOperation` in `request-signing.ts` (line ~159) intentionally has no `req.body` fallback — it feeds the RFC 9421 cryptographic verifier and must operate only on the exact raw bytes the signer committed to.

## Pre-PR review

- **code-reviewer:** approved — fix is minimal and correct; `resolveOperation` fallback is safe for its stated use; `JSON.stringify` round-trip in `enforceSigningWhenWebhookAuthPresent` is a nit (no correctness impact); `buildRequestSigningAuthenticator`'s intentional `rawBody`-only path is unchanged and correct.
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `--empty` changeset correct; RFC 9421 §2.3 boundary maintained; no wire protocol or compliance-suite taxonomy impact.

Session: https://claude.ai/code/session_01YFdqt5uh6hbhh37go5WA4T

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFdqt5uh6hbhh37go5WA4T)_