### PR TITLE
docs(protocol): clarify format_id object shape vs format definition object

### DIFF
--- a/.changeset/format-id-docs-clarification.md
+++ b/.changeset/format-id-docs-clarification.md
@@ -1,0 +1,8 @@
+---
+---
+
+Clarify format_id (structured object reference) vs format (full definition object) naming convention.
+
+Adds normative docs, schema description updates, and llms.txt entries to prevent two recurring
+implementation errors: setting format_id to a plain string, and putting a format_id object into a
+format definition slot. No protocol wire change — purely additive docs and schema descriptions.

--- a/docs.json
+++ b/docs.json
@@ -103,6 +103,7 @@
                   "docs/protocol/architecture",
                   "docs/protocol/required-tasks",
                   "docs/protocol/calling-an-agent",
+                  "docs/protocol/format-references",
                   {
                     "group": "Understanding AdCP",
                     "pages": [
@@ -609,6 +610,7 @@
               "docs/protocol/architecture",
               "docs/protocol/required-tasks",
               "docs/protocol/calling-an-agent",
+              "docs/protocol/format-references",
               {
                 "group": "Understanding AdCP",
                 "pages": [

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -141,6 +141,10 @@ This approach allows publishers to present complex formats without constraining 
 
 ## Referencing Formats
 
+<Note>
+  For a normative contrast between `format_id` (structured reference object) and `format` (full definition object) — including the two most common validation errors — see [Format References](/docs/protocol/format-references).
+</Note>
+
 AdCP uses structured format identifiers everywhere to avoid ambiguity and namespace collisions.
 
 ### Structured Format IDs (Required Everywhere)

--- a/docs/creative/template-format-ids.mdx
+++ b/docs/creative/template-format-ids.mdx
@@ -580,3 +580,4 @@ Creatives specify pixel dimensions: `{id: "dooh_static", width: 1920, height: 56
 - [Creative Manifests](/docs/creative/creative-manifests) - Complete manifest structure
 - [Format Discovery](/docs/creative/formats) - How buyers discover formats
 - [Placement Targeting](/docs/media-buy/creatives) - Assigning creatives to placements
+- [Format References](/docs/protocol/format-references) - Normative contrast between `format_id` (pointer) and `format` (definition), including named validation errors

--- a/docs/protocol/format-references.mdx
+++ b/docs/protocol/format-references.mdx
@@ -1,0 +1,104 @@
+---
+title: Format References
+description: "Normative reference for format_id (structured identifier object) vs format (full definition object) in AdCP."
+---
+
+AdCP uses two related but distinct concepts when working with creative formats. Their names are similar, which causes a recurring implementation error — this page defines both precisely and names the two failure modes.
+
+## format\_id — structured reference object
+
+`format_id` is **always a JSON object**, never a plain string. It identifies a format by the agent that declared it and the format's local slug:
+
+```json
+{
+  "agent_url": "https://creatives.adcontextprotocol.org",
+  "id": "display_300x250"
+}
+```
+
+Optional dimension and duration fields extend it for parameterized template formats:
+
+```json
+{
+  "agent_url": "https://creatives.adcontextprotocol.org",
+  "id": "display_static",
+  "width": 300,
+  "height": 250
+}
+```
+
+`format_id` is a **pointer** — it names a format without carrying its definition.
+
+## format — full definition object
+
+`format` is the complete specification of a creative format. It is returned by `list_creative_formats` and related tasks. A `format` object contains a `format_id` as one of its properties, plus the asset requirements, render specs, and all other metadata:
+
+```json
+{
+  "format_id": {
+    "agent_url": "https://creatives.adcontextprotocol.org",
+    "id": "display_300x250"
+  },
+  "name": "Display Banner 300×250",
+  "assets": [
+    { "asset_id": "image", "asset_type": "image", "item_type": "individual", "required": true }
+  ],
+  "renders": [
+    { "role": "primary", "dimensions": { "width": 300, "height": 250 } }
+  ]
+}
+```
+
+A `format` is a **definition** — it describes what the format requires and how it renders.
+
+## Contrast at a glance
+
+| Concept | Field name | JSON type | Use |
+|---------|-----------|-----------|-----|
+| Format identifier | `format_id` | `object` — `{ agent_url, id }` | Pointer. Used in creative manifests, request filters, placement declarations. |
+| Format definition | `format` | `object` — full spec | Returned by `list_creative_formats`. Contains `format_id` as a nested field. |
+| Array of identifiers | `format_ids` | `array` of `format_id` objects | Filter parameter on `list_creatives`, `list_creative_formats`, and related requests. |
+| Array of definitions | `formats` | `array` of `format` objects | Response field on `list_creative_formats`. |
+
+## Two named failure modes
+
+### Anti-pattern A — string in a `format_id` slot
+
+```json
+// Wrong: format_id must be an object, not a plain string
+{ "format_id": "display_300x250" }
+
+// Correct
+{ "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" } }
+```
+
+AJV error: `format_id must be of type object`. Cause: the `.id` string inside the `format_id` object looks like a self-contained name and is sometimes extracted and used directly.
+
+### Anti-pattern B — format_id object in a `format` / `formats` slot
+
+```json
+// Wrong: a formats[] element must be a full definition object, not a bare format_id
+{
+  "formats": [
+    { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" }
+  ]
+}
+
+// Correct
+{
+  "formats": [
+    {
+      "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" },
+      "name": "Display Banner 300×250",
+      "assets": [ "..." ]
+    }
+  ]
+}
+```
+
+AJV error: `formats[0] must have required property 'name'`. Cause: `format_id` and `format` are both objects; the shorter object is sometimes put in the slot that expects the larger one.
+
+## See also
+
+- [Creative Formats](/docs/creative/formats) — full format object structure, asset types, and render specs
+- [Template Format IDs](/docs/creative/template-format-ids) — parameterized format IDs for dimension-variable templates

--- a/docs/protocol/format-references.mdx
+++ b/docs/protocol/format-references.mdx
@@ -11,7 +11,7 @@ AdCP uses two related but distinct concepts when working with creative formats. 
 
 ```json
 {
-  "agent_url": "https://creatives.adcontextprotocol.org",
+  "agent_url": "https://creative.adcontextprotocol.org",
   "id": "display_300x250"
 }
 ```
@@ -20,7 +20,7 @@ Optional dimension and duration fields extend it for parameterized template form
 
 ```json
 {
-  "agent_url": "https://creatives.adcontextprotocol.org",
+  "agent_url": "https://creative.adcontextprotocol.org",
   "id": "display_static",
   "width": 300,
   "height": 250
@@ -36,7 +36,7 @@ Optional dimension and duration fields extend it for parameterized template form
 ```json
 {
   "format_id": {
-    "agent_url": "https://creatives.adcontextprotocol.org",
+    "agent_url": "https://creative.adcontextprotocol.org",
     "id": "display_300x250"
   },
   "name": "Display Banner 300×250",
@@ -73,7 +73,7 @@ Wrong — `format_id` must be an object, not a plain string:
 Correct:
 
 ```json
-{ "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" } }
+{ "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250" } }
 ```
 
 AJV error: `format_id must be of type object`. Cause: the `.id` string inside the `format_id` object looks like a self-contained name and is sometimes extracted and used directly.
@@ -85,7 +85,7 @@ Wrong — a `formats[]` element must be a full definition object, not a bare `fo
 ```json
 {
   "formats": [
-    { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" }
+    { "agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250" }
   ]
 }
 ```
@@ -96,9 +96,9 @@ Correct:
 {
   "formats": [
     {
-      "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" },
+      "format_id": { "agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250" },
       "name": "Display Banner 300×250",
-      "assets": [ "..." ]
+      "assets": [ { "asset_id": "image", "asset_type": "image", "item_type": "individual", "required": true } ]
     }
   ]
 }

--- a/docs/protocol/format-references.mdx
+++ b/docs/protocol/format-references.mdx
@@ -1,6 +1,7 @@
 ---
 title: Format References
 description: "Normative reference for format_id (structured identifier object) vs format (full definition object) in AdCP."
+"og:title": "AdCP — Format References"
 ---
 
 AdCP uses two related but distinct concepts when working with creative formats. Their names are similar, which causes a recurring implementation error — this page defines both precisely and names the two failure modes.

--- a/docs/protocol/format-references.mdx
+++ b/docs/protocol/format-references.mdx
@@ -64,27 +64,35 @@ A `format` is a **definition** — it describes what the format requires and how
 
 ### Anti-pattern A — string in a `format_id` slot
 
-```json
-// Wrong: format_id must be an object, not a plain string
-{ "format_id": "display_300x250" }
+Wrong — `format_id` must be an object, not a plain string:
 
-// Correct
+```json
+{ "format_id": "display_300x250" }
+```
+
+Correct:
+
+```json
 { "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" } }
 ```
 
 AJV error: `format_id must be of type object`. Cause: the `.id` string inside the `format_id` object looks like a self-contained name and is sometimes extracted and used directly.
 
-### Anti-pattern B — format_id object in a `format` / `formats` slot
+### Anti-pattern B — format\_id object in a `format` / `formats` slot
+
+Wrong — a `formats[]` element must be a full definition object, not a bare `format_id`:
 
 ```json
-// Wrong: a formats[] element must be a full definition object, not a bare format_id
 {
   "formats": [
     { "agent_url": "https://creatives.adcontextprotocol.org", "id": "display_300x250" }
   ]
 }
+```
 
-// Correct
+Correct:
+
+```json
 {
   "formats": [
     {

--- a/server/public/llms.txt
+++ b/server/public/llms.txt
@@ -79,6 +79,8 @@ Served by AgenticAdvertising.org:
 - **Task**: A discrete unit of work in AdCP (e.g., get_products, create_media_buy)
 - **Media product**: An advertising opportunity offered by a publisher or platform
 - **Content standards**: Brand safety and suitability rules that govern where ads can appear
+- **format_id**: A structured object — never a plain string — that identifies a creative format by its declaring agent and local slug: `{ "agent_url": "https://...", "id": "display_300x250" }`. Optionally includes `width`/`height` (integers) or `duration_ms` (number) for parameterized template formats. `format_id` is a pointer to a format, not the format definition itself.
+- **format** (definition object): The complete format specification returned by `list_creative_formats`. Contains a `format_id` plus `name`, `assets`, `renders`, and other fields. A `format` object always wraps a `format_id`; they are not interchangeable — `format_id` is the reference, `format` is the definition.
 
 ## Full documentation
 

--- a/static/schemas/source/content-standards/artifact.json
+++ b/static/schemas/source/content-standards/artifact.json
@@ -19,7 +19,7 @@
     },
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Optional reference to a format definition. Uses the same format registry as creative formats."
+      "description": "Always a structured object {agent_url, id} — never a plain string. Optional reference to a format definition. Uses the same format registry as creative formats."
     },
     "url": {
       "type": "string",

--- a/static/schemas/source/core/creative-asset.json
+++ b/static/schemas/source/core/creative-asset.json
@@ -16,7 +16,7 @@
     },
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Format identifier specifying which format this creative conforms to. Can be: (1) concrete format_id referencing a format with fixed dimensions, (2) template format_id referencing a template format, or (3) parameterized format_id with dimensions/duration parameters for template formats."
+      "description": "Always a structured object {agent_url, id} — never a plain string. Format identifier specifying which format this creative conforms to. Can be: (1) concrete format_id referencing a format with fixed dimensions, (2) template format_id referencing a template format, or (3) parameterized format_id with dimensions/duration parameters for template formats."
     },
     "assets": {
       "type": "object",

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -7,7 +7,7 @@
   "properties": {
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Format identifier this manifest is for. Can be a template format (id only) or a deterministic format (id + dimensions/duration). For dimension-specific creatives, include width/height/unit in the format_id to create a unique identifier (e.g., {id: 'display_static', width: 300, height: 250, unit: 'px'})."
+      "description": "Always a structured object {agent_url, id} — never a plain string. Format identifier this manifest is for. Can be a template format (id only) or a deterministic format (id + dimensions/duration). For dimension-specific creatives, include width/height/unit in the format_id to create a unique identifier (e.g., {id: 'display_static', width: 300, height: 250, unit: 'px'})."
     },
     "assets": {
       "type": "object",

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -7,7 +7,7 @@
   "properties": {
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Always a structured object {agent_url, id} — never a plain string. Format identifier this manifest is for. Can be a template format (id only) or a deterministic format (id + dimensions/duration). For dimension-specific creatives, include width/height/unit in the format_id to create a unique identifier (e.g., {id: 'display_static', width: 300, height: 250, unit: 'px'})."
+      "description": "Always a structured object {agent_url, id} — never a plain string. Format identifier this manifest is for. Can be a template format (id only) or a deterministic format (id + dimensions/duration). For dimension-specific creatives, include width/height in the format_id to create a unique identifier (e.g., {id: 'display_static', width: 300, height: 250})."
     },
     "assets": {
       "type": "object",

--- a/static/schemas/source/core/format-id.json
+++ b/static/schemas/source/core/format-id.json
@@ -2,14 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/format-id.json",
   "title": "Format Reference (Structured Object)",
-  "description": "A JSON object — never a plain string — that identifies a creative format by its declaring agent and local slug. Required properties: agent_url (URI of the agent that owns the format) and id (alphanumeric slug). Example: {\"agent_url\": \"https://creatives.adcontextprotocol.org\", \"id\": \"display_300x250\"}. Can reference: (1) a concrete format with fixed dimensions (id only), (2) a template format without parameters (id only), or (3) a template format with parameters (id + dimensions/duration). Template formats accept parameters in format_id while concrete formats have fixed dimensions in their definition. Parameterized format IDs create unique, specific format variants. Using a plain string here is a schema violation.",
+  "description": "A JSON object — never a plain string — that identifies a creative format by its declaring agent and local slug. Required properties: agent_url (URI of the agent that owns the format) and id (slug matching [a-zA-Z0-9_-]+). Example: {\"agent_url\": \"https://creative.adcontextprotocol.org\", \"id\": \"display_300x250\"}. Can reference: (1) a concrete format with fixed dimensions (id only), (2) a template format without parameters (id only), or (3) a template format with parameters (id + dimensions/duration). Template formats accept parameters in format_id while concrete formats have fixed dimensions in their definition. Parameterized format IDs create unique, specific format variants. Using a plain string here is a schema violation.",
   "x-entity": "creative_format",
   "type": "object",
   "properties": {
     "agent_url": {
       "type": "string",
       "format": "uri",
-      "description": "URL of the agent that defines this format (e.g., 'https://creatives.adcontextprotocol.org' for standard formats, or 'https://publisher.com/.well-known/adcp/sales' for custom formats). Callers comparing two `format-id` values MUST canonicalize `agent_url` per the AdCP URL canonicalization rules before treating two formats as the same. See docs/reference/url-canonicalization."
+      "description": "URL of the agent that defines this format (e.g., 'https://creative.adcontextprotocol.org' for standard formats, or 'https://publisher.com/.well-known/adcp/sales' for custom formats). Callers comparing two `format-id` values MUST canonicalize `agent_url` per the AdCP URL canonicalization rules before treating two formats as the same. See docs/reference/url-canonicalization."
     },
     "id": {
       "type": "string",

--- a/static/schemas/source/core/format-id.json
+++ b/static/schemas/source/core/format-id.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/format-id.json",
-  "title": "Format ID",
-  "description": "Structured format identifier with agent URL and format name. Can reference: (1) a concrete format with fixed dimensions (id only), (2) a template format without parameters (id only), or (3) a template format with parameters (id + dimensions/duration). Template formats accept parameters in format_id while concrete formats have fixed dimensions in their definition. Parameterized format IDs create unique, specific format variants.",
+  "title": "Format Reference (Structured Object)",
+  "description": "A JSON object — never a plain string — that identifies a creative format by its declaring agent and local slug. Required properties: agent_url (URI of the agent that owns the format) and id (alphanumeric slug). Example: {\"agent_url\": \"https://creatives.adcontextprotocol.org\", \"id\": \"display_300x250\"}. Can reference: (1) a concrete format with fixed dimensions (id only), (2) a template format without parameters (id only), or (3) a template format with parameters (id + dimensions/duration). Template formats accept parameters in format_id while concrete formats have fixed dimensions in their definition. Parameterized format IDs create unique, specific format variants. Using a plain string here is a schema violation.",
   "x-entity": "creative_format",
   "type": "object",
   "properties": {

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -61,7 +61,7 @@
   "properties": {
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Structured format identifier with agent URL and format name"
+      "description": "This format's own identifier — a structured object {agent_url, id}, not a string. See /schemas/core/format-id.json for the full shape."
     },
     "name": {
       "type": "string",

--- a/static/schemas/source/creative/preview-creative-request.json
+++ b/static/schemas/source/creative/preview-creative-request.json
@@ -22,7 +22,7 @@
     },
     "format_id": {
       "$ref": "/schemas/core/format-id.json",
-      "description": "Format identifier for rendering the preview. Defaults to creative_manifest.format_id if omitted. Used in single mode."
+      "description": "Always a structured object {agent_url, id} — never a plain string. Format identifier for rendering the preview. Defaults to creative_manifest.format_id if omitted. Used in single mode."
     },
     "inputs": {
       "type": "array",


### PR DESCRIPTION
Closes #3089

## Summary

Implementors (and LLMs) repeatedly make two errors when working with creative formats: setting `format_id` to a plain string (`"display_300x250"`), or putting a bare `format_id` object where a full `format` definition is expected. Both are caught by AJV but recur because the naming doesn't telegraph the shape difference.

This PR implements **Option B** from the issue (non-breaking 3.x doc clarification) and defers Option A (rename `format_id` → `format_ref`) to 4.0 as a breaking change requiring an RFC.

**Changes:**
- `docs/protocol/format-references.mdx` — new normative page: contrast table (`format_id` pointer vs `format` definition), two named anti-patterns with AJV error messages and correct/wrong JSON examples
- `docs/creative/formats.mdx` — `<Note>` callout linking to the new page under "## Referencing Formats"
- `docs/creative/template-format-ids.mdx` — back-link in See Also
- `server/public/llms.txt` — two `## Key terms` bullets for `format_id` and `format` (machine-readable path)
- `static/schemas/source/core/format-id.json` — title updated to "Format Reference (Structured Object)"; description rewritten to lead with "A JSON object — never a plain string"
- `static/schemas/source/core/format.json`, `creative-manifest.json`, `creative-asset.json`, `preview-creative-request.json`, `content-standards/artifact.json` — local `format_id` description overrides prepended with "Always a structured object {agent_url, id} — never a plain string"
- `docs.json` — nav entry added in both version groups

**Non-breaking justification:** all changes are additive — a new doc page, description text prepended to existing schema fields (no type or structural changes), llms.txt bullets, and nav entries. No wire schema fields added, removed, or renamed. Existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved after 3 blockers fixed (agent URL singular/plural inconsistency, `//` comments in JSON blocks, "alphanumeric" description not matching `[a-zA-Z0-9_-]+` pattern, `unit` field in format_id example that doesn't exist on the schema)
- docs-expert: approved after 2 blockers fixed (same URL issue, `//` comments in JSON blocks) + 1 nit addressed (template-format-ids.mdx back-link added)

**Note:** The pre-existing `agent_url` field description in `format-id.json` (line 12) uses `creatives.adcontextprotocol.org` (plural), inconsistent with all doc examples. Left as a pre-existing issue — tracked in run summary.

Session: https://claude.ai/code/session_01769oXbPvUmWai97XxSeHrz

---
_Generated by [Claude Code](https://claude.ai/code/session_01769oXbPvUmWai97XxSeHrz)_