### PR TITLE
test(training-agent): omit bearer in create_media_buy 401 assertion (#3080)

### DIFF
--- a/.changeset/fix-mcp-strict-bearer-bypass-test.md
+++ b/.changeset/fix-mcp-strict-bearer-bypass-test.md
@@ -1,0 +1,18 @@
+---
+---
+
+test(training-agent): fix /mcp-strict 401 test to omit bearer token
+
+The `unsigned create_media_buy on /mcp-strict returns 401` test was failing because
+`callTool` sends `Authorization: Bearer test-token-for-strict` by default. The SDK's
+`requireAuthenticatedOrSigned` short-circuits on a successful bearer result before the
+`required_for` gate runs — bearer bypass is intentional per SDK design (#2586).
+
+Fix: pass `{ auth: false }` so the test simulates the actual grader scenario. Compliance
+graders send no bearer token; they authenticate via RFC 9421 signature credentials only.
+With no bearer and no signature, the `required_for: ['create_media_buy']` gate fires and
+returns `401 request_signature_required` as expected.
+
+Non-protocol change (server test only); changeset is `--empty`.
+
+Closes #3080.

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -112,10 +112,11 @@ describe('Training Agent /mcp-strict route', () => {
 
   describe('presence-gated enforcement', () => {
     it('unsigned create_media_buy on /mcp-strict returns 401 request_signature_required', async () => {
+      // auth: false — bearer bypass (SDK #2586) short-circuits required_for; graders send no bearer.
       const res = await callTool(app, '/mcp-strict', 'create_media_buy', {
         account: { brand: { domain: 'strict-test.example.com' }, sandbox: true },
         idempotency_key: '550e8400-e29b-41d4-a716-446655440000',
-      });
+      }, { auth: false });
       expect(res.status).toBe(401);
       expect(res.body.error).toBe('request_signature_required');
       expect(res.body.error_description).toMatch(/create_media_buy.*signed/);

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -120,7 +120,7 @@ describe('Training Agent /mcp-strict route', () => {
       expect(res.status).toBe(401);
       expect(res.body.error).toBe('request_signature_required');
       expect(res.body.error_description).toMatch(/create_media_buy.*signed/);
-      expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+      expect(res.headers['www-authenticate']).toMatch(/Signature error="request_signature_required"/);
     });
 
     it('unsigned create_media_buy on /mcp still accepted (bearer fallthrough)', async () => {


### PR DESCRIPTION
Closes #3080

## Summary

Two-part fix for the `/mcp-strict` 401 test that was failing even after PR #3082 merged.

**Root cause:** `callTool` sends `Authorization: Bearer test-token-for-strict` by default. The SDK's `requireAuthenticatedOrSigned` short-circuits on a successful bearer result before the `required_for` gate runs (`auth-signature.js:146-147`: `if (fallbackResult !== null) return fallbackResult`). This is intentional SDK behavior per #2586 — a valid credential is sufficient even when signing is required for unauthenticated callers. PR #3082's `resolveOperation rawBody` fix only helps when bearer returns null; with a valid bearer present, `resolveOperation` is never reached in the `required_for` code path.

**Fix 1 — omit bearer:** Pass `{ auth: false }` on the failing test call to suppress the bearer token. This models the actual grader scenario: compliance graders don't carry bearer tokens — they authenticate via RFC 9421 signature credentials only. With no bearer and no signature on a `required_for` op, the gate fires and returns `401 request_signature_required`.

**Fix 2 — correct `www-authenticate` assertion:** The test was asserting `/^Bearer /` on the `WWW-Authenticate` header. Per `index.ts:207` and `static/compliance/source/universal/signed-requests.yaml:52/188`, `respondUnauthorized({ signatureError })` emits `WWW-Authenticate: Signature error="<code>"`, not a Bearer challenge. Fixed to `/Signature error="request_signature_required"/`, pinning exactly what the compliance grader reads.

**Non-breaking justification:** Server integration tests only. No schema, task definition, wire protocol, or public API surface changed.

**Aside — CI gap:** Vitest integration tests don't run in CI for this repo, which is why #3082, #3079, and the original regression all reported clean CI with a failing test. Wiring vitest into the CI pipeline needs a separate human-authored PR touching `.github/workflows/`.

## Pre-PR review (two iterations)

**Iteration 1:**
- **code-reviewer:** approved — `{ auth: false }` is type-safe per `callTool`'s signature; no test overlap with existing `POST /mcp-strict without auth` assertion (different tool, different rejection reason).
- **ad-tech-protocol-expert:** **blocker** — `www-authenticate` assertion `/^Bearer /` is wrong for the `signatureError` code path; grader reads `Signature error="..."` scheme, not Bearer.

**Iteration 2 (after fixing blocker):**
- **ad-tech-protocol-expert:** signed off — blocker resolved; both commits logically complete; assertion now matches the actual wire format from `respondUnauthorized({ signatureError })`; regex correctly non-anchored to tolerate additional challenge parameters.

Session: https://claude.ai/code/session_01S7aDiMrwhfYPr7FzYQdn9C