### PR TITLE
feat(skills): hoist call-adcp-agent + bundle skills/ into protocol tarball

### DIFF
--- a/.changeset/hoist-call-adcp-agent-skill.md
+++ b/.changeset/hoist-call-adcp-agent-skill.md
@@ -1,0 +1,12 @@
+---
+---
+
+Hoist the `call-adcp-agent` skill from `@adcp/client@5.17.0` into the canonical `skills/` directory of the adcp main repo and make it the cross-SDK source of truth.
+
+- New `skills/call-adcp-agent/SKILL.md` — agent-facing buyer-side wire contract (idempotency replay, account `oneOf` variants, async `status:'submitted'` polling, `adcp_error.issues[]` recovery). Frontmatter declares `adcp_version: "3.x"` and `type: cross-cutting` so the skill loader and SDK consumers can pin compatibility.
+- Per-protocol skills (`adcp-{brand,creative,governance,media-buy,si,signals}`) gain a one-line pointer at the top deferring cross-cutting rules to `call-adcp-agent`.
+- New `docs/protocol/calling-an-agent.mdx` — human-readable canonical narrative form, registered in both `docs.json` nav configs and cited from the SKILL.md.
+- `scripts/build-protocol-tarball.cjs` bundles `skills/` into the published protocol tarball at `adcontextprotocol.org/protocol/<version>.tgz`. SDKs (`@adcp/client`, `adcp` Python, `adcp-go`) already pull this tarball at sync time for schemas and compliance — they get skills for free, version-pinned, Sigstore-verified, no manual copy. `manifest.json.contents.skills` is now an enumerated list so SDK sync scripts can pick out skill names without re-walking the tree.
+- `server/src/addie/mcp/adcp-tools.ts` — `loadSkillDocs` is now frontmatter-driven (filters by `name: adcp-*` or `type: cross-cutting`) instead of hardcoding directory names. `resolveSkillsDir` is exported and tries multiple candidate paths so the loader works in dev (`server/src/`), production (`dist/`), and CWD layouts. Cross-cutting rules are consolidated into a single `BUYER_RULES_PREAMBLE` injected at the top of every search response. `call_adcp_task`'s tool description is trimmed to the two non-negotiable rules (`idempotency_key` replay, `issues[].variants[]` recovery). Failure-path output appends a recovery hint pointing at `issues[]`.
+- `Dockerfile` copies `/app/skills` into the runtime image and `docker-compose.yml` bind-mounts it for dev iteration. (Previously absent — the skill loader silently returned empty for all `adcp-*` skills in production.)
+- `tests/addie/buyer-skill-wiring.test.ts` — 12 new tests locking down the wiring (skill content, frontmatter pin, `resolveSkillsDir` resolution, search preamble injection, tool description shape).

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,9 @@ COPY --from=builder /app/server/src/addie/rules/*.md ./dist/addie/rules/
 COPY --from=builder /app/static ./static
 COPY --from=builder /app/docs ./docs
 
+# Skill docs read at runtime by Addie's ask_about_adcp_task / call_adcp_task loader.
+COPY --from=builder /app/skills ./skills
+
 # Shared agent-infrastructure read at Addie prompt-assembly time (rules/index.ts)
 # and by the triage routines. These are committed repo files; without them,
 # loadRules() silently degrades.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       - ./server/public:/app/server/public:ro
       # Mount docs directory for Addie knowledge base
       - ./docs:/app/docs:ro
+      # Mount skills/ so Addie's ask_about_adcp_task loader sees protocol skills
+      - ./skills:/app/skills:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs.json
+++ b/docs.json
@@ -102,6 +102,7 @@
                   },
                   "docs/protocol/architecture",
                   "docs/protocol/required-tasks",
+                  "docs/protocol/calling-an-agent",
                   {
                     "group": "Understanding AdCP",
                     "pages": [
@@ -605,6 +606,7 @@
               },
               "docs/protocol/architecture",
               "docs/protocol/required-tasks",
+              "docs/protocol/calling-an-agent",
               {
                 "group": "Understanding AdCP",
                 "pages": [

--- a/docs/protocol/calling-an-agent.mdx
+++ b/docs/protocol/calling-an-agent.mdx
@@ -1,0 +1,135 @@
+---
+title: Calling an AdCP agent
+sidebarTitle: Calling an agent
+description: "Wire-level invariants every AdCP buyer must follow: idempotency_key replay, account oneOf variants, async status:'submitted' polling, and error recovery from adcp_error.issues[]."
+"og:title": "AdCP — Calling an agent"
+---
+
+# Calling an AdCP agent
+
+This page is the canonical buyer-side wire contract: the rules that don't live cleanly in any single task schema, but apply to every mutating call you'll make. If you're building a buyer (DSP, planning tool, agentic client) and calling out to AdCP sales, creative, signals, governance, SI, or brand agents, read this once.
+
+The agent-facing version of this content lives at [`skills/call-adcp-agent/SKILL.md`](https://github.com/adcontextprotocol/adcp/blob/main/skills/call-adcp-agent/SKILL.md) — bundled into the [protocol tarball](/docs/building/schemas-and-sdks) so SDKs can ship it to coding agents.
+
+## Discovery chain
+
+Walk these in order on first contact with any new agent:
+
+1. **Agent card** (A2A) or **`tools/list`** (MCP): returns tool *names*. AdCP MCP servers no longer publish per-tool parameter schemas in `tools/list` — every tool shows `{type: 'object', properties: {}}`. Don't try to infer shape from there.
+2. **`get_adcp_capabilities`**: returns supported protocols, AdCP major versions, and feature flags. Tells you *which* tools this agent supports, not how to call them. See [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities).
+3. **`get_schema(tool_name)`** *(when the agent exposes it — pending standardization, see [#3057](https://github.com/adcontextprotocol/adcp/issues/3057))*: returns the JSON Schema for a specific tool's request/response.
+4. **Bundled schemas** (offline, authoritative): `dist/schemas/<adcp-version>/bundled/<protocol>/<tool>-{request,response}.json`. Every published AdCP version ships these, signed via Sigstore. SDKs sync them on install.
+
+## Idempotency: replay vs. new operation
+
+Every mutating tool requires an `idempotency_key` (UUID).
+
+- **Same key on retry** → server replays the **same response**, byte-for-byte. Use this for transport-level retries (timeout, 5xx, dropped connection).
+- **Fresh key** → **new operation**, regardless of body. Generating a new UUID because the previous attempt failed is the most common way naïve callers create duplicate media buys.
+- **Same key, different body** → server-defined; most agents return the original cached response and ignore the body change. Don't rely on it.
+
+For async flows, the replayed response carries the **same `task_id`** so polling continues against the same task instead of forking.
+
+`idempotency_key` is required on: `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, `sync_accounts`, `sync_catalogs`, `sync_event_sources`, `sync_plans`, `sync_governance`, `activate_signal`, `acquire_rights`, `log_event`, `report_usage`, `provide_performance_feedback`, `report_plan_outcome`, `create_property_list`, `update_property_list`, `delete_property_list`, `create_collection_list`, `update_collection_list`, `delete_collection_list`, `create_content_standards`, `update_content_standards`, `calibrate_content`, `si_initiate_session`, `si_send_message`.
+
+Missing the key → `adcp_error.code: 'VALIDATION_ERROR'` with `/idempotency_key` in `issues`.
+
+## `account` is `oneOf` — pick exactly one variant
+
+`account` is a discriminated union. On `create_media_buy` and `update_media_buy`, two variants:
+
+```json
+// variant 0: by seller-assigned id (from sync_accounts or list_accounts)
+"account": { "account_id": "seller_assigned_id" }
+
+// variant 1: by natural key (brand + operator, optional sandbox)
+"account": { "brand": { "domain": "acme.com" }, "operator": "sales.example" }
+```
+
+**Do NOT merge required fields across variants.** `additionalProperties: false` on each variant means `{account_id, brand}` fails BOTH.
+
+Other tools (e.g. `sync_creatives`) may accept a superset — always check the specific tool's schema.
+
+## Async responses: `status: 'submitted'` means queued
+
+A mutating tool can return one of three shapes:
+
+```json
+// Success (sync): the work is done
+{ "media_buy_id": "mb_123", "packages": [...], "confirmed_at": "..." }
+
+// Submitted (async): the work is queued
+{ "status": "submitted", "task_id": "tk_abc", "message": "Awaiting IO signature" }
+
+// Error: don't retry without fixing
+{ "errors": [{ "code": "PRODUCT_NOT_FOUND", "message": "..." }] }
+```
+
+When you see `status: 'submitted'`, the work is **not** complete. Poll via `tasks/get` (A2A) or the MCP async task extension, using the returned `task_id`. Over A2A the AdCP `task_id` also rides on `artifact.metadata.adcp_task_id`.
+
+## Error recovery — read `issues[]`
+
+Every validation failure produces an envelope shaped like:
+
+```json
+{
+  "adcp_error": {
+    "code": "VALIDATION_ERROR",
+    "recovery": "correctable",
+    "field": "/first/offending/pointer",
+    "issues": [
+      {
+        "pointer": "/account",
+        "keyword": "oneOf",
+        "message": "must match exactly one schema in oneOf",
+        "variants": [
+          { "index": 0, "required": ["account_id"],        "properties": ["account_id"] },
+          { "index": 1, "required": ["brand", "operator"], "properties": ["brand", "operator", "sandbox"] }
+        ]
+      },
+      { "pointer": "/brand/domain", "keyword": "required", "message": "must have required property 'domain'" }
+    ]
+  }
+}
+```
+
+- `issues[].pointer` — RFC 6901 JSON Pointer to the offending field
+- `issues[].keyword` — Ajv keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`)
+- `issues[].variants` — when `keyword` is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`
+
+**For `oneOf` failures, pick ONE variant from `variants[]` and send only its `required` fields.** This is the fastest recovery path when you didn't know the field was a union.
+
+`recovery` values:
+
+- `correctable` — buyer-side fix; read `issues[]`, patch the pointers, resend
+- `transient` — retry with the **same** `idempotency_key`
+- `terminal` — requires human action (account suspended, payment required); do not retry
+
+## Common shape pitfalls
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse on retries. |
+| `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
+| `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |
+| `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
+| Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
+
+## Transport notes
+
+- **MCP**: `tools/call` with `{ name: 'tool_name', arguments: {...} }`. Read `structuredContent` for the typed response.
+- **A2A**: `message/send` with a `DataPart` of shape `{ skill: 'tool_name', input: {...} }`. The typed response is at `task.artifacts[0].parts[0].data`.
+
+Both transports share idempotency, error shape, schema enforcement, and handler semantics. If a call works on one, the equivalent call works on the other.
+
+A common trap: **A2A `Task.state: 'completed'` is not the same as AdCP completion.** A2A task state describes the transport call lifecycle; AdCP-level completion is in the artifact's payload (`structuredContent.status` or `data.status`). A `completed` A2A task can still carry a `submitted` AdCP response.
+
+## Related
+
+- Per-task request/response shapes: see the protocol-specific reference (`/docs/media-buy/`, `/docs/creative/`, `/docs/signals/`, etc.).
+- [Protocol architecture](/docs/protocol/architecture) — how the protocol domains fit together.
+- [Required tasks](/docs/protocol/required-tasks) — which tasks an agent must implement to claim a specialism.
+- [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) — first call against any new agent.
+- [Schemas and SDKs](/docs/building/schemas-and-sdks) — how SDKs consume the protocol tarball (which now bundles `skills/`).

--- a/scripts/build-protocol-tarball.cjs
+++ b/scripts/build-protocol-tarball.cjs
@@ -20,6 +20,7 @@
  *     manifest.json
  *     schemas/...
  *     compliance/...
+ *     skills/...                  # call-adcp-agent + per-protocol skill docs
  *     openapi/registry.yaml
  *
  * Usage mirrors build-schemas.cjs:
@@ -38,6 +39,7 @@ const { execSync } = require('child_process');
 const ROOT = path.join(__dirname, '..');
 const DIST_SCHEMAS = path.join(ROOT, 'dist/schemas');
 const DIST_COMPLIANCE = path.join(ROOT, 'dist/compliance');
+const SKILLS_DIR = path.join(ROOT, 'skills');
 const OPENAPI_FILE = path.join(ROOT, 'static/openapi/registry.yaml');
 const CHANGELOG_FILE = path.join(ROOT, 'CHANGELOG.md');
 const OUT_DIR = path.join(ROOT, 'dist/protocol');
@@ -118,6 +120,7 @@ This tarball contains the complete AdCP protocol for version \`${version}\`${isD
 
 - \`schemas/\` — JSON Schemas for every task (request + response)
 - \`compliance/\` — Storyboard bundles (universal, domains/, specialisms/, test-kits/)
+- \`skills/\` — Agent-facing protocol skills (\`call-adcp-agent\` for buyer-side rules, \`adcp-*\` for per-protocol task semantics). SDKs ship these to give Claude/agents the cross-cutting wire contract.
 - \`openapi/registry.yaml\` — OpenAPI description of the registry endpoints
 - \`manifest.json\` — Version + contents summary
 - \`CHANGELOG.md\` — Release notes
@@ -144,9 +147,9 @@ for the enumerated domains + specialisms that agents can claim in
 ## Layout stability
 
 The directory structure inside \`adcp-{version}/\` (\`schemas/\`, \`compliance/\`,
-\`openapi/\`, \`manifest.json\`) is a stable contract within a given major
-version. Renames or moves inside this tree are breaking changes and only ship
-with a major bump.
+\`skills/\`, \`openapi/\`, \`manifest.json\`) is a stable contract within a given
+major version. Renames or moves inside this tree are breaking changes and only
+ship with a major bump.
 
 ## Docs
 
@@ -191,6 +194,10 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
     fs.copyFileSync(OPENAPI_FILE, path.join(openapiDst, 'registry.yaml'));
   }
 
+  if (fs.existsSync(SKILLS_DIR)) {
+    copyTree(SKILLS_DIR, path.join(bundleDir, 'skills'));
+  }
+
   if (fs.existsSync(CHANGELOG_FILE)) {
     fs.copyFileSync(CHANGELOG_FILE, path.join(bundleDir, 'CHANGELOG.md'));
   }
@@ -198,6 +205,17 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
   writeBundleReadme(bundleDir, version, isDev);
 
   const fileCount = walk(bundleDir).length;
+
+  // Enumerate skills so SDK sync scripts can pick them out without re-walking
+  // the tree, and so consumers can detect missing/added skills via the manifest.
+  const bundledSkillsDir = path.join(bundleDir, 'skills');
+  const skillNames = fs.existsSync(bundledSkillsDir)
+    ? fs.readdirSync(bundledSkillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory() && fs.existsSync(path.join(bundledSkillsDir, e.name, 'SKILL.md')))
+        .map(e => e.name)
+        .sort()
+    : [];
+
   const manifest = {
     adcp_version: version,
     generated_at: new Date().toISOString(),
@@ -205,6 +223,7 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
     contents: {
       schemas: fs.existsSync(schemasDst),
       compliance: fs.existsSync(path.join(bundleDir, 'compliance')),
+      skills: skillNames,
       openapi: fs.existsSync(path.join(bundleDir, 'openapi')),
       changelog: fs.existsSync(path.join(bundleDir, 'CHANGELOG.md')),
       readme: true

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -214,15 +214,69 @@ function tokenize(text: string): string[] {
     .filter(w => w.length > 1 && !STOP_WORDS.has(w));
 }
 
+/**
+ * Locate the skills/ directory across dev (tsx watch from server/src) and
+ * production (node dist/) layouts. Exported for tests.
+ */
+export function resolveSkillsDir(): string | null {
+  // Source layout: server/src/addie/mcp → 4 ups to repo root.
+  // Built layout:  dist/addie/mcp        → 3 ups to /app.
+  // CWD fallback for both `npm run` and Docker `node dist/index.js`.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, '../../../../skills'),
+    path.join(here, '../../../skills'),
+    path.join(process.cwd(), 'skills'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (fs.statSync(candidate).isDirectory()) return candidate;
+    } catch { /* not a directory; try next */ }
+  }
+  return null;
+}
+
+interface SkillFrontmatter {
+  name?: string;
+  type?: string;
+}
+
+function parseFrontmatter(raw: string): { frontmatter: SkillFrontmatter; body: string } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return { frontmatter: {}, body: raw };
+  const fm: SkillFrontmatter = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*"?([^"]*)"?\s*$/);
+    if (kv) fm[kv[1] as keyof SkillFrontmatter] = kv[2].trim();
+  }
+  return { frontmatter: fm, body: raw.slice(match[0].length) };
+}
+
+/**
+ * Map a skill's frontmatter to a search area.
+ * - `type: cross-cutting` → 'buyer' (the cross-cutting buyer skill)
+ * - `name: adcp-<X>`      → '<X>'   (per-protocol skills)
+ * - otherwise              → null (skip — not an AdCP skill)
+ */
+function areaForSkill(fm: SkillFrontmatter): string | null {
+  if (fm.type === 'cross-cutting') return 'buyer';
+  if (fm.name?.startsWith('adcp-')) return fm.name.slice('adcp-'.length);
+  return null;
+}
+
 function loadSkillDocs(): SkillSection[] {
   const sections: SkillSection[] = [];
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const skillsDir = path.join(__dirname, '../../../../skills');
+  const skillsDir = resolveSkillsDir();
+
+  if (!skillsDir) {
+    logger.warn({ cwd: process.cwd() }, 'Could not locate skills directory');
+    return sections;
+  }
 
   let dirs: string[];
   try {
     dirs = fs.readdirSync(skillsDir).filter(d =>
-      d.startsWith('adcp-') && fs.statSync(path.join(skillsDir, d)).isDirectory()
+      fs.statSync(path.join(skillsDir, d)).isDirectory()
     );
   } catch {
     logger.warn({ skillsDir }, 'Could not read skills directory');
@@ -231,18 +285,16 @@ function loadSkillDocs(): SkillSection[] {
 
   for (const dir of dirs) {
     const skillPath = path.join(skillsDir, dir, 'SKILL.md');
-    let content: string;
+    let raw: string;
     try {
-      content = fs.readFileSync(skillPath, 'utf-8');
+      raw = fs.readFileSync(skillPath, 'utf-8');
     } catch {
       continue;
     }
 
-    // Strip frontmatter
-    const fmMatch = content.match(/^---\n[\s\S]*?\n---\n/);
-    if (fmMatch) content = content.slice(fmMatch[0].length);
-
-    const area = dir.replace('adcp-', '');
+    const { frontmatter, body: content } = parseFrontmatter(raw);
+    const area = areaForSkill(frontmatter);
+    if (!area) continue;
 
     // Split by ## and ### headings
     const lines = content.split('\n');
@@ -338,10 +390,11 @@ function searchSkillDocs(question: string): string {
     }
   }
 
-  // Build response with character limit, reserving space for registry section
+  // Build response with character limit, reserving space for the buyer
+  // rules preamble (always-on cross-cutting rules) and the registry section.
   const MAX_CHARS = 6000;
-  const docBudget = MAX_CHARS - registrySection.length;
-  let result = '';
+  const docBudget = MAX_CHARS - registrySection.length - BUYER_RULES_PREAMBLE.length;
+  let result = BUYER_RULES_PREAMBLE;
 
   for (const { section } of matches) {
     const entry = `## ${section.heading} (${section.area})\n\n${section.content}\n\n---\n\n`;
@@ -353,6 +406,27 @@ function searchSkillDocs(question: string): string {
   return result.trim();
 }
 
+/**
+ * Buyer-side rule preamble injected on every search response. Single source
+ * of truth for the cross-cutting rules every AdCP caller must follow.
+ */
+const BUYER_RULES_PREAMBLE = [
+  '## Buyer-side rules (apply to every AdCP call)',
+  '',
+  '- **idempotency_key**: REQUIRED on every mutating task (UUID). Same key on retry replays the same response. Generating a fresh UUID after a failed attempt is how you double-book.',
+  '- **account is oneOf**: pick ONE variant — `{account_id}` OR `{brand:{domain}, operator}`. Don\'t merge fields across variants.',
+  '- **brand uses {domain}**, not `{brand_id}`.',
+  '- **budget is a number**; currency is implied by `pricing_option_id`.',
+  '- **format_id is `{agent_url, id}`**, never a bare string.',
+  '- **Async response `{status:"submitted", task_id}`** = queued, NOT done. Poll the task_id.',
+  '- **On adcp_error**: read `issues[]`. For oneOf failures, `issues[].variants[]` gives the exact valid shape — patch and retry, do not re-guess.',
+  '',
+  'Full skill: `skills/call-adcp-agent/SKILL.md`. Per-task shapes: search by task name below.',
+  '',
+  '---',
+  '',
+].join('\n');
+
 function formatAvailableAreas(): string {
   const areas = new Map<string, string[]>();
   for (const [name, meta] of Object.entries(ADCP_TASK_REGISTRY)) {
@@ -360,7 +434,8 @@ function formatAvailableAreas(): string {
     areas.get(meta.area)!.push(name);
   }
 
-  let result = 'Available AdCP protocol areas:\n\n';
+  let result = BUYER_RULES_PREAMBLE;
+  result += '## Available AdCP protocol areas\n\n';
   for (const [area, tasks] of areas) {
     result += `**${area}**: ${tasks.join(', ')}\n\n`;
   }
@@ -375,15 +450,15 @@ function formatAvailableAreas(): string {
 const askAboutAdcpTaskTool: AddieTool = {
   name: 'ask_about_adcp_task',
   description:
-    'Search AdCP protocol documentation to understand tasks, parameters, workflows, and concepts. Returns relevant sections from protocol documentation. Call this BEFORE call_adcp_task to learn what parameters a task needs.',
+    'Search AdCP protocol documentation for task parameters, workflows, concepts, or buyer rules. Call this BEFORE call_adcp_task when you need full parameter shapes for an uncommon task, or when an adcp_error response leaves you unsure how to recover.',
   usage_hints:
-    'use when you need to understand AdCP task parameters, workflows, or concepts before executing a task',
+    'use to look up AdCP task parameters or cross-cutting buyer rules',
   input_schema: {
     type: 'object',
     properties: {
       question: {
         type: 'string',
-        description: 'What you want to know about AdCP tasks (e.g., "how do I create a media buy?", "what parameters does get_signals accept?", "creative workflow")',
+        description: 'What you want to know (e.g., "how do I create a media buy?", "get_signals parameters", "what does status submitted mean", "how do I recover from oneOf validation error")',
       },
     },
     required: ['question'],
@@ -392,8 +467,15 @@ const askAboutAdcpTaskTool: AddieTool = {
 
 const callAdcpTaskTool: AddieTool = {
   name: 'call_adcp_task',
-  description:
-    'Execute any AdCP protocol task against an agent. For common tasks you can call directly — for uncommon tasks or when unsure about parameters, call ask_about_adcp_task first.',
+  description: [
+    'Execute any AdCP protocol task against an agent. For uncommon tasks or when unsure about parameters, call ask_about_adcp_task first.',
+    '',
+    'Two rules a search round-trip cannot rescue you from after a mutating call:',
+    '• idempotency_key: REQUIRED on every mutating task (UUID). Same key on retry replays the same response. Generating a fresh UUID after a failed attempt is how you double-book.',
+    '• On adcp_error: read issues[].variants[] before retrying. It lists the exact valid shape — do not re-guess.',
+    '',
+    'Full buyer rules: ask_about_adcp_task with area="buyer".',
+  ].join('\n'),
   usage_hints:
     'use when executing any AdCP protocol operation against a sales, creative, signals, governance, SI, or brand agent',
   input_schema: {
@@ -413,11 +495,12 @@ const callAdcpTaskTool: AddieTool = {
         description: [
           'Task-specific parameters. Quick reference for common tasks:',
           '• get_products: { brief, brand: { domain }, buying_mode?: "brief"|"wholesale"|"refine", filters?: { channels, budget_range } }',
-          '• create_media_buy: { brand: { domain }, packages: [{ product_id, pricing_option_id, budget }], start_time: { type: "asap"|"scheduled" }, end_time }',
-          '• update_media_buy: { account: { account_id | brand+operator }, media_buy_id, paused?, canceled?, packages?: [{ package_id, budget? }] }',
-          '• sync_creatives: { creatives: [{ creative_id, format_id: { agent_url, id }, assets }], assignments? }',
+          '• create_media_buy: { idempotency_key, brand: { domain }, packages: [{ product_id, pricing_option_id, budget }], start_time: { type: "asap"|"scheduled" }, end_time }',
+          '• update_media_buy: { idempotency_key, account: { account_id } OR { brand:{domain}, operator }, media_buy_id, paused?, canceled?, packages?: [{ package_id, budget? }] }',
+          '• sync_creatives: { idempotency_key, creatives: [{ creative_id, format_id: { agent_url, id }, assets }], assignments? }',
           '• build_creative: { message, target_format_id: { agent_url, id }, brand?: { domain } }',
           '• get_signals: { signal_spec, destinations?, countries? }',
+          '• activate_signal: { idempotency_key, signal_agent_segment_id, destinations: [{type, ...}] }',
           'For other tasks, call ask_about_adcp_task first.',
         ].join('\n'),
       },
@@ -574,7 +657,13 @@ export function createAdcpToolHandlers(
         const ctx = { mode: 'training' as const, userId };
         const result = await executeTrainingAgentTool(task, params, ctx);
         if (!result.success) {
-          return `**Task failed:** \`${task}\`\n\n**Error:** ${result.error}`;
+          return [
+            `**Task failed:** \`${task}\`\n`,
+            `**Error:** ${result.error}\n`,
+            `**Recovery:** if the error mentions a field shape (oneOf / required / additionalProperties), ` +
+            `read \`adcp_error.issues[].variants[]\` if present and patch the pointers. Reuse the same ` +
+            `\`idempotency_key\` on retry — fresh UUIDs cause duplicates.`,
+          ].join('\n');
         }
         let output = `**Task:** \`${task}\`\n**Status:** Success (sandbox)\n\n`;
         output += `**Response:**\n\`\`\`json\n${JSON.stringify(result.data, null, 2)}\n\`\`\``;
@@ -692,7 +781,14 @@ export function createAdcpToolHandlers(
         );
       }
 
-      return `**Task failed:** \`${task}\`\n\n**Error:** ${errorMessage}`;
+      return [
+        `**Task failed:** \`${task}\`\n`,
+        `**Error:** ${errorMessage}\n`,
+        `**Recovery:** if the error envelope includes \`adcp_error.issues[]\`, read it before retrying. ` +
+        `For \`oneOf\` failures, \`issues[].variants[]\` lists the valid shapes — patch the pointers and retry, do not re-guess. ` +
+        `Reuse the **same** \`idempotency_key\` on retry; generating a fresh UUID is how you double-book. ` +
+        `If you need parameter shapes, call \`ask_about_adcp_task\` with the failing field name as the question.`,
+      ].join('\n');
     }
   }
 

--- a/server/src/addie/prompts.ts
+++ b/server/src/addie/prompts.ts
@@ -63,12 +63,12 @@ When a developer pastes a URL or asks to test an agent, follow this flow:
 - test_io_execution: Test whether a buyer agent can execute deals through a publisher's agent. Takes real IO line items, maps each to the agent's product catalog using normalized channel/format/pricing matching, and constructs the exact create_media_buy JSON a buyer agent would send. Set execute=true to submit the request to the agent. The JSON output is the artifact — publishers can hand it to their eng team.
 
 **AdCP Protocol Operations (media buy, creative, signals, governance, SI, brand):**
-- call_adcp_task: Execute any AdCP protocol task. The params description includes a quick reference for common tasks — use it to call directly without discovery for well-known operations like get_products, create_media_buy, sync_creatives, build_creative, get_signals, get_brand_identity.
-- ask_about_adcp_task: Search protocol documentation for task parameters, workflows, and concepts. Use when you need full parameter details for uncommon tasks, or when the user asks "how does X work" questions about the protocol.
-- get_adcp_capabilities: Discover what tasks and features an agent supports.
+- call_adcp_task: Execute any AdCP protocol task. Read the tool description for the two non-negotiable buyer rules before calling.
+- ask_about_adcp_task: Search protocol docs for task parameters, workflows, or buyer rules. Every search result includes the cross-cutting rules preamble at the top — refer to it whenever you're unsure.
+- get_adcp_capabilities: Call once per new agent before any mutating task to learn what it supports.
 
-When to skip ask_about_adcp_task: If you already know the task parameters from the quick reference, conversation context, or prior tool results — call call_adcp_task directly. Don't add a discovery round-trip for common operations.
-When to use ask_about_adcp_task: For uncommon tasks (governance, SI, signals), when the user asks about protocol concepts/workflows, or when you're unsure about parameters.
+When to skip ask_about_adcp_task: If you already know the task parameters from conversation context or prior tool results — call call_adcp_task directly. Don't add a discovery round-trip for common operations.
+When to use ask_about_adcp_task: For uncommon tasks, when the user asks about protocol concepts/workflows, when you're unsure about parameters, or when an adcp_error response leaves you unsure how to recover (the issues[].variants[] guidance is the fastest path).
 
 **Agent Management (compliance monitoring for seller agents):**
 Compliance monitoring is for **seller agents** — MCP servers that expose inventory to buyer agents. This is how publishers and platforms track whether their agent stays protocol-compliant over time.

--- a/skills/adcp-brand/SKILL.md
+++ b/skills/adcp-brand/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Brand Protocol operations with brand agents - get bran
 
 This skill enables you to execute the AdCP Brand Protocol with brand agents. The Brand Protocol provides access to brand identity, creative guidelines, and licensable rights (talent, IP, content).
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The Brand Protocol provides 4 standardized tasks:

--- a/skills/adcp-creative/SKILL.md
+++ b/skills/adcp-creative/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Creative Protocol operations with creative agents - bu
 
 This skill enables you to execute the AdCP Creative Protocol with creative agents. Use the standard MCP tools (`list_creative_formats`, `build_creative`, `preview_creative`) exposed by the connected agent.
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The Creative Protocol provides 4 standardized tasks for building and previewing advertising creatives:

--- a/skills/adcp-governance/SKILL.md
+++ b/skills/adcp-governance/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Governance Protocol operations with governance agents 
 
 This skill enables you to execute the AdCP Governance Protocol with governance agents. Covers three areas: property lists (site-level targeting), collection lists (program-level targeting), and content standards (brand safety rules).
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The Governance Protocol provides 17 standardized tasks across three areas:

--- a/skills/adcp-media-buy/SKILL.md
+++ b/skills/adcp-media-buy/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Media Buy Protocol operations with sales agents - disc
 
 This skill enables you to execute the AdCP Media Buy Protocol with sales agents. Use the standard MCP tools (`get_products`, `create_media_buy`, `sync_creatives`, etc.) exposed by the connected agent.
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The Media Buy Protocol provides 11 standardized tasks for managing advertising campaigns:

--- a/skills/adcp-si/SKILL.md
+++ b/skills/adcp-si/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Sponsored Intelligence (SI) Protocol operations with b
 
 This skill enables you to execute the AdCP SI Protocol with brand agents. SI enables conversational commerce sessions where users engage directly with brand agents for shopping, inquiries, and transactions.
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The SI Protocol provides 4 standardized tasks for managing conversational sessions:

--- a/skills/adcp-signals/SKILL.md
+++ b/skills/adcp-signals/SKILL.md
@@ -7,6 +7,8 @@ description: Execute AdCP Signals Protocol operations with signal agents - disco
 
 This skill enables you to execute the AdCP Signals Protocol with signal agents. Use the standard MCP tools (`get_signals`, `activate_signal`) exposed by the connected agent.
 
+> **Buyer-side basics** — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`. This skill covers per-task semantics only.
+
 ## Overview
 
 The Signals Protocol provides 2 standardized tasks for discovering and activating targeting data:

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: call-adcp-agent
+description: Wire-level invariants for any AdCP buyer call — idempotency_key replay semantics, account `oneOf` variants, async `status:'submitted'`+`task_id` polling, error recovery from `adcp_error.issues[]`. Load before any per-protocol task skill (adcp-media-buy, adcp-creative, adcp-signals, adcp-governance, adcp-si, adcp-brand) when calling an AdCP agent as a buyer.
+adcp_version: "3.x"
+type: cross-cutting
+---
+
+# Call an AdCP agent
+
+## Overview
+
+AdCP (Ad Context Protocol) agents expose a fixed tool surface (`get_products`, `create_media_buy`, `get_signals`, …) over MCP or A2A. Tool names come from `get_adcp_capabilities`; exact request/response shapes live in the spec's bundled JSON Schemas at `dist/schemas/<adcp-version>/bundled/<protocol>/<tool>-{request,response}.json` (or via `get_schema` when the agent exposes it). This skill teaches the invariants that don't live cleanly in any schema: cross-tool patterns, async flow, error recovery.
+
+## When to Use
+
+- User wants to call a publisher / SSP / retail media network over AdCP
+- Tool names like `get_products`, `create_media_buy`, `sync_creatives`, `get_signals` appear in the available-tools list
+- Agent card advertises `protocolVersion: '0.3.0'` with `skills` listing AdCP tool names
+- **Not this skill:** building an AdCP seller agent (see `@adcp/client/skills/build-seller-agent/` and analogous SDK skills)
+
+## Discovery chain
+
+Walk these in order on first contact:
+
+1. **Agent card** (A2A) or **`tools/list`** (MCP): returns tool NAMES. AdCP MCP servers no longer publish per-tool parameter schemas in `tools/list` — everything shows `{type: 'object', properties: {}}`. Don't try to infer shape from here.
+2. **`get_adcp_capabilities`**: returns supported protocols (`media_buy`, `signals`, `creative`, …), AdCP major versions, feature flags. Tells you WHICH tools this agent supports, not how to call them.
+3. **`get_schema(tool_name)`** *(when the agent exposes it — pending standardization in [#3057](https://github.com/adcontextprotocol/adcp/issues/3057), not yet universal)*: returns the JSON Schema for a tool's request/response. Preferred over reading bundled schemas when available.
+4. **Bundled schemas** (offline, authoritative): `dist/schemas/<adcp-version>/bundled/<protocol>/<tool>-request.json` and `-response.json`. The adcp main repo publishes these; SDKs sync them (`npm run sync-schemas` in `@adcp/client`, equivalents in other SDKs). Substitute your target AdCP major version in the path.
+
+## Non-obvious rules every buyer must follow
+
+### `idempotency_key` is required on every mutating tool
+
+UUID format. The key is your retry-safety guarantee — and the most common way naive callers create duplicate media buys is by misunderstanding it:
+
+- **Same key on retry → replay.** The server returns the SAME response — same `task_id`, same `media_buy_id`, same shape, byte-for-byte. Use this for transport-level retries (timeout, 5xx, dropped connection).
+- **Fresh key on retry → NEW operation.** Generating a new UUID because the previous attempt failed is how you double-book. Reuse the key until you've seen a terminal response (success, error, or non-retryable error).
+- **Same key, different body → server-defined.** Most agents return the original cached response and ignore the body change. Don't rely on it — pick a fresh key only when you genuinely want a new operation.
+- For async flows, the replayed response carries the **same `task_id`**, so polling continues against the same task instead of forking a duplicate.
+
+Required on: `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, `sync_accounts`, `sync_catalogs`, `sync_event_sources`, `sync_plans`, `sync_governance`, `activate_signal`, `acquire_rights`, `log_event`, `report_usage`, `provide_performance_feedback`, `report_plan_outcome`, `create_property_list`, `update_property_list`, `delete_property_list`, `create_collection_list`, `update_collection_list`, `delete_collection_list`, `create_content_standards`, `update_content_standards`, `calibrate_content`, `si_initiate_session`, `si_send_message`.
+
+Missing the key → `adcp_error.code: 'VALIDATION_ERROR'` with `/idempotency_key` in `issues`.
+
+### `account` is a `oneOf` — pick ONE variant, send ONLY its fields
+
+Probably the single most common stumble for naive LLMs. `account` is a discriminated union. Per AdCP 3.0, two variants on `create_media_buy` / `update_media_buy`:
+
+```json
+// variant 0: by seller-assigned id (from sync_accounts or list_accounts)
+"account": { "account_id": "seller_assigned_id" }
+
+// variant 1: by natural key (brand + operator, optional sandbox)
+"account": { "brand": { "domain": "acme.com" }, "operator": "sales.example" }
+```
+
+**Do NOT merge required fields across variants** — `additionalProperties: false` on each variant means `{account_id, brand}` fails BOTH. Pick one variant and send only its fields. Always check the specific tool's schema because other tools (e.g. `sync_creatives`) may accept a superset.
+
+### `brand` takes `{domain}` — not `{brand_id}`
+
+```json
+"brand": { "domain": "acme.example" }
+```
+
+### Async responses: `status: 'submitted'` means "queued, poll later"
+
+A mutating tool can return one of three shapes:
+
+```json
+// Success (sync): the work is done
+{ "media_buy_id": "mb_123", "packages": [...], "confirmed_at": "..." }
+
+// Submitted (async): the work is queued
+{ "status": "submitted", "task_id": "tk_abc", "message": "Awaiting IO signature" }
+
+// Error: don't retry without fixing
+{ "errors": [{ "code": "PRODUCT_NOT_FOUND", "message": "..." }] }
+```
+
+When you see `status: 'submitted'`, the work is NOT complete. Poll via `tasks/get` (A2A) or the MCP async task extension, using the `task_id`. Over A2A the AdCP `task_id` also rides on `artifact.metadata.adcp_task_id` — both work.
+
+### `packages[*]` on media buys
+
+```json
+"packages": [
+  { "buyer_ref": "pkg_1", "product_id": "p_from_catalog", "budget": 10000, "pricing_option_id": "po_xyz" }
+]
+```
+
+`budget` is a **number** (not `{amount, currency}` — currency is implied by the pricing option). Required per package: `product_id`, `budget`, `pricing_option_id`. `buyer_ref` is optional but strongly recommended as a buyer-side correlation id across retries and reporting.
+
+## Error envelope — read `issues[]` to recover
+
+Every validation failure produces:
+
+```json
+{
+  "adcp_error": {
+    "code": "VALIDATION_ERROR",
+    "recovery": "correctable",
+    "field": "/first/offending/pointer",
+    "issues": [
+      {
+        "pointer": "/account",
+        "keyword": "oneOf",
+        "message": "must match exactly one schema in oneOf",
+        "variants": [
+          { "index": 0, "required": ["account_id"],        "properties": ["account_id"] },
+          { "index": 1, "required": ["brand", "operator"], "properties": ["brand", "operator", "sandbox"] }
+        ]
+      },
+      { "pointer": "/brand/domain", "keyword": "required", "message": "must have required property 'domain'" }
+    ]
+  }
+}
+```
+
+- `issues[].pointer` — RFC 6901 JSON Pointer to the field.
+- `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
+- `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
+
+Patch the pointers, don't re-guess what the skill or the `variants` already told you, resend. Three attempts should cover every field.
+
+## Minimal working examples
+
+### get_products
+
+```json
+{
+  "buying_mode": "brief",
+  "brief": "premium CTV sports inventory for live NBA finals in major US markets"
+}
+```
+
+Returns `{ products: [{ product_id, name, description, delivery_type, pricing_options, ... }] }`.
+
+### create_media_buy
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "account": { "account_id": "seller_assigned_id" },
+  "brand": { "domain": "acme.example" },
+  "start_time": "2026-05-01T00:00:00Z",
+  "end_time": "2026-05-31T23:59:59Z",
+  "packages": [
+    {
+      "buyer_ref": "pkg_1",
+      "product_id": "<product_id from get_products>",
+      "budget": 10000,
+      "pricing_option_id": "<pricing_option_id from product.pricing_options>"
+    }
+  ]
+}
+```
+
+If you don't have a `seller_assigned_id`, use the natural-key variant instead:
+`"account": { "brand": { "domain": "acme.example" }, "operator": "sales.example" }`.
+
+Returns **either** `{ media_buy_id, packages: [...], confirmed_at }` (sync) **or** `{ status: 'submitted', task_id, message }` (async — guaranteed / IO-signed flows).
+
+### sync_creatives
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "account": { "account_id": "seller_assigned_id" },
+  "creatives": [
+    {
+      "creative_id": "cr_1",
+      "name": "My Creative",
+      "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "video_1920x1080" },
+      "assets": {}
+    }
+  ]
+}
+```
+
+Per-creative required: `creative_id`, `name`, `format_id: { agent_url, id }`, `assets` (shape depends on `format_id`; start with `{}` then fill required asset keys per format spec). Returns `{ creatives: [{ creative_id, action, status }] }` — items may fail individually without failing the batch.
+
+### get_signals
+
+```json
+{
+  "signal_spec": "female professionals 25-54 in major US metros"
+}
+```
+
+Returns `{ signals: [{ signal_agent_segment_id, match_rate, pricing, ... }] }`. Note: the identifier field is `signal_agent_segment_id` (not `signal_id`) — used as input to `activate_signal` below.
+
+### activate_signal
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "signal_agent_segment_id": "sig_premium_ctv_sports",
+  "destinations": [
+    { "type": "platform", "platform": "the-trade-desk" }
+  ]
+}
+```
+
+`destinations[]` is a `oneOf`: either `{type: 'platform', platform, account?}` OR `{type, agent_url, account?}`. Pick one shape per destination.
+
+## Transport notes
+
+- **MCP**: `tools/call` with `{ name: 'tool_name', arguments: {...} }`. Returns `{ content, structuredContent, isError? }`. Read `structuredContent` for the typed response.
+- **A2A**: `message/send` with a `DataPart` of shape `{ skill: 'tool_name', input: {...} }` (the legacy key `parameters` is also accepted). Returns an A2A `Task`; the typed response is at `task.artifacts[0].parts[0].data`.
+
+Both transports share: idempotency, error shape, schema enforcement, and handler semantics. If a call works on one, the equivalent call works on the other.
+
+## Gotchas I keep seeing
+
+1. **Merging `oneOf` variants**: see the account section above. If you see three `additionalProperties` errors under one pointer, you merged. Drop to one variant.
+2. **`budget` as an object**: it's a number. Currency comes from the `pricing_option`.
+3. **`brand.brand_id` instead of `brand.domain`**: spec uses `domain`.
+4. **Forgetting `idempotency_key`**: required on every mutating tool; see the list above.
+5. **Treating A2A `Task.state: 'completed'` as AdCP completion**: A2A task state = transport call lifecycle. AdCP-level completion is in the artifact's payload (`structuredContent.status` or `data.status`). A `completed` A2A task can still carry a `submitted` AdCP response.
+6. **`format_id` as a string**: `format_id` is always an object `{ agent_url, id }` (and sometimes `{ width, height, duration_ms }` for dimensions). Sending `"format_id": "video_1920x1080"` fails with an `additionalProperties` / `type` error — pass the object.
+
+## Symptom → fix
+
+Quick lookup before reading the full envelope. Match what you see in `adcp_error.issues[*]`, apply the fix:
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
+| `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
+| `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |
+| `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
+| Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
+| `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
+| `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
+| `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
+| HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
+
+If your symptom isn't here, fall through to the next section.
+
+## If you get stuck
+
+Priority order:
+
+1. Re-read the failure's `issues[]`. The pointer list plus this skill covers 80% of cases.
+2. Call `get_schema(tool_name)` if the agent exposes it (see [#3057](https://github.com/adcontextprotocol/adcp/issues/3057) for the pending standard).
+3. Read the bundled JSON Schema at `dist/schemas/<adcp-version>/bundled/<protocol>/<tool>-request.json`.
+4. Consult the per-protocol skill in this repo (`skills/adcp-media-buy/`, `skills/adcp-creative/`, …) for specialism-specific patterns.
+
+## Related
+
+- [Calling an agent (docs)](https://adcontextprotocol.org/docs/protocol/calling-an-agent) — human-readable narrative form of this skill
+- `skills/adcp-media-buy/`, `skills/adcp-creative/`, `skills/adcp-signals/`, `skills/adcp-governance/`, `skills/adcp-si/`, `skills/adcp-brand/` — per-protocol task skills (layered on top of this one)
+- `@adcp/client/skills/build-seller-agent/SKILL.md` — building agents on the other side of the call
+- `dist/schemas/<adcp-version>/bundled/` — canonical JSON Schemas (every tool, pinned to the AdCP version)

--- a/tests/addie/buyer-skill-wiring.test.ts
+++ b/tests/addie/buyer-skill-wiring.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Buyer-Skill Wiring (call-adcp-agent)
+ *
+ * Ensures that:
+ * - The cross-cutting `call-adcp-agent` skill is loaded by Addie's skill index
+ *   (frontmatter-driven, not directory-name-driven)
+ * - Searches for buyer-side terms surface content from the buyer skill
+ * - Every search response carries the buyer-rules preamble at the top
+ * - call_adcp_task's tool description carries the two non-negotiable rules
+ *   (idempotency replay + issues[].variants recovery)
+ * - resolveSkillsDir locates skills/ in dev, prod, and CWD layouts
+ *
+ * Run with: npx vitest run tests/addie/buyer-skill-wiring.test.ts
+ */
+
+import { describe, expect, test } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  ADCP_TOOLS,
+  createAdcpToolHandlers,
+  resolveSkillsDir,
+} from '../../server/src/addie/mcp/adcp-tools.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = path.join(__dirname, '../../skills');
+
+describe('call-adcp-agent skill on disk', () => {
+  test('SKILL.md exists at the expected path', () => {
+    const skillPath = path.join(SKILLS_DIR, 'call-adcp-agent', 'SKILL.md');
+    expect(fs.existsSync(skillPath)).toBe(true);
+  });
+
+  test('skill body covers idempotency, oneOf, async submitted, and error envelope', () => {
+    const skillPath = path.join(SKILLS_DIR, 'call-adcp-agent', 'SKILL.md');
+    const body = fs.readFileSync(skillPath, 'utf-8');
+    expect(body).toMatch(/idempotency_key/);
+    expect(body).toMatch(/oneOf/);
+    expect(body).toMatch(/status:\s*'submitted'|status:\s*"submitted"/);
+    expect(body).toMatch(/adcp_error/);
+    expect(body).toMatch(/issues\[\]/);
+  });
+
+  test('frontmatter pins the AdCP version and tags the skill type', () => {
+    const skillPath = path.join(SKILLS_DIR, 'call-adcp-agent', 'SKILL.md');
+    const body = fs.readFileSync(skillPath, 'utf-8');
+    expect(body).toMatch(/^---[\s\S]*?adcp_version:\s*"3\.x"[\s\S]*?---/);
+    expect(body).toMatch(/^---[\s\S]*?type:\s*cross-cutting[\s\S]*?---/);
+  });
+});
+
+describe('resolveSkillsDir', () => {
+  test('locates the skills directory from the test runtime', () => {
+    const dir = resolveSkillsDir();
+    expect(dir).not.toBeNull();
+    expect(fs.statSync(dir!).isDirectory()).toBe(true);
+    // Basic sanity: contains at least the canonical buyer skill
+    expect(fs.existsSync(path.join(dir!, 'call-adcp-agent', 'SKILL.md'))).toBe(true);
+  });
+});
+
+describe('ask_about_adcp_task surfaces buyer rules', () => {
+  const handlers = createAdcpToolHandlers(null);
+  const ask = handlers.get('ask_about_adcp_task')!;
+
+  test('the no-keyword fallback shows the buyer preamble + protocol areas', async () => {
+    // Stop-word-only query short-circuits to formatAvailableAreas
+    const result = await ask({ question: 'the' });
+    expect(result).toMatch(/Buyer-side rules/);
+    expect(result).toMatch(/idempotency_key/);
+    expect(result).toMatch(/Available AdCP protocol areas/);
+  });
+
+  test('every search response begins with the buyer-rules preamble', async () => {
+    const result = await ask({ question: 'create a media buy' });
+    expect(result.indexOf('Buyer-side rules')).toBeGreaterThanOrEqual(0);
+    expect(result).toMatch(/idempotency_key/);
+    expect(result).toMatch(/account is oneOf/);
+    expect(result).toMatch(/issues\[\]\.variants\[\]/);
+  });
+
+  test('searching for "idempotency" returns buyer-area content', async () => {
+    const result = await ask({ question: 'idempotency' });
+    expect(result).toMatch(/idempotency_key/);
+    expect(result).toMatch(/\(buyer\)/);
+  });
+
+  test('searching for "oneOf" returns the variant rule', async () => {
+    const result = await ask({ question: 'oneOf variant account' });
+    expect(result).toMatch(/oneOf|variant/i);
+    expect(result).toMatch(/\(buyer\)/);
+  });
+
+  test('searching for "submitted" returns async polling guidance', async () => {
+    const result = await ask({ question: 'status submitted task_id' });
+    expect(result).toMatch(/submitted/);
+    expect(result).toMatch(/\(buyer\)/);
+  });
+
+  test('searching for "validation error" returns recovery guidance', async () => {
+    const result = await ask({ question: 'validation error recovery issues' });
+    expect(result).toMatch(/issues|recovery|VALIDATION_ERROR/i);
+    expect(result).toMatch(/\(buyer\)/);
+  });
+});
+
+describe('call_adcp_task tool description', () => {
+  const callTool = ADCP_TOOLS.find(t => t.name === 'call_adcp_task');
+
+  test('the tool exists', () => {
+    expect(callTool).toBeDefined();
+  });
+
+  test('description carries the two non-negotiable rules a search round-trip cannot rescue', () => {
+    // Per prompt-engineer review: only idempotency replay and issues[].variants[]
+    // recovery belong in the tool description (always-on context). The full rule
+    // list lives in the search preamble.
+    const desc = callTool!.description;
+    expect(desc).toMatch(/idempotency_key/);
+    expect(desc).toMatch(/double-book/);
+    expect(desc).toMatch(/issues\[\]\.variants\[\]/);
+    expect(desc).toMatch(/ask_about_adcp_task/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `skills/call-adcp-agent/SKILL.md` — agent-facing buyer-side wire contract (idempotency replay, account `oneOf` variants, async `status:'submitted'` polling, `adcp_error.issues[]` recovery). Hoisted from `@adcp/client@5.17.0` and made canonical here so all SDKs (`@adcp/client`, `adcp` Python, `adcp-go`) consume one source of truth.
- Cross-SDK distribution: `scripts/build-protocol-tarball.cjs` now bundles `skills/` into the published `/protocol/<version>.tgz`. SDKs already pull this tarball at sync time for schemas and compliance — version-pinned, Sigstore-verified, no manual copy. `manifest.json.contents.skills` is an enumerated list so SDK sync scripts can pick out skill names without re-walking the tree.
- Per-protocol skills (`adcp-{brand,creative,governance,media-buy,si,signals}`) gain a one-line pointer at the top deferring cross-cutting rules to `call-adcp-agent`.
- New `docs/protocol/calling-an-agent.mdx` — human-readable canonical narrative form, registered in `docs.json` and cited from the SKILL.md (and back).
- Addie wiring: `loadSkillDocs` is now frontmatter-driven (filters by `name: adcp-*` or `type: cross-cutting`) instead of hardcoding directory names. Cross-cutting rules live in a single `BUYER_RULES_PREAMBLE` injected at the top of every search response. `call_adcp_task`'s tool description trims to the two non-negotiable rules (`idempotency_key` replay + `issues[].variants[]` recovery). Failure-path output appends a recovery hint pointing at `issues[]`.
- **Two pre-existing prod bugs fixed along the way:**
  - `Dockerfile` was missing `COPY /app/skills` — skill loader silently returned empty for ALL `adcp-*` skills in production.
  - Skill loader's hardcoded relative-path traversal landed at `/skills` (root) in prod (`dist/`) layout. Replaced with `resolveSkillsDir()` candidate-list (works in dev, prod, and CWD layouts; exported and unit-tested).
- 12 new tests in `tests/addie/buyer-skill-wiring.test.ts` lock down skill content, frontmatter version pin, loader resolution, search preamble injection, and tool description shape. Pre-commit hook ran 832 tests + typecheck — all passed.

## Live test

Spun up `docker compose up`, logged in as `admin` dev user, asked Addie:

> "I want to call create_media_buy on test-agent.adcontextprotocol.org. What cross-cutting rules do I need to be aware of as a buyer?"

She called `ask_about_adcp_task`, cited `skills/call-adcp-agent/SKILL.md` as the source, and gave all five buyer rules verbatim — including the correct `oneOf` variants `{account_id}` OR `{brand:{domain}, operator}`. Anonymous tier (no AdCP tools exposed) had hallucinated `account_name+account_email`. The wiring is real.

## Pre-PR review

Five experts in parallel — agentic-product-architect, docs-expert, prompt-engineer, dx-expert, code-reviewer. Addressed all "must-fix" + most "should-fix" feedback before commit.

## Test plan

- [x] `npx vitest run tests/addie/` — 414 passing (was 402 before, +12 from new wiring tests + dropped scope tests)
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean
- [x] Pre-commit hook (`npm run test:unit && npm run typecheck`) — 832 tests passed
- [x] Live Addie conversation in docker compose — buyer rules surface correctly via `ask_about_adcp_task`
- [x] `npm run build:protocol-tarball` — verified `adcp-latest/skills/call-adcp-agent/SKILL.md` is in the tarball; manifest enumerates skills

## Follow-ups (not in this PR)

1. SDK-side wire-up to extract `skills/` from the tarball at sync time:
   - `@adcp/client` `scripts/sync-schemas.ts`
   - `adcp-client-python` equivalent
   - `adcp-go` equivalent
2. Once SDKs pull from canonical, remove the local copy from `@adcp/client/skills/call-adcp-agent/`.
3. Per docs-expert: link from per-task `.mdx` pages (e.g. `docs/media-buy/task-reference/create_media_buy.mdx`) to the canonical idempotency_key list rather than redefining inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)