### PR TITLE
feat(compliance): pagination total_count honesty assertions

### DIFF
--- a/.changeset/pagination-total-count-honesty.md
+++ b/.changeset/pagination-total-count-honesty.md
@@ -1,0 +1,6 @@
+---
+---
+
+Extends `pagination_integrity` with count-honesty assertions that complement the cursor↔has_more invariant. Each page now asserts `query_summary.total_matching = 3`, `query_summary.returned` matches the slice (2 then 1), and `pagination.total_count` equals 3 when volunteered (`field_value_or_absent` so omitting it stays conformant per the schema).
+
+Catches the dishonest pagination class where an agent honors `max_results` and the cursor handshake but lies in the summary numbers — under-reporting `total_count` to hide inventory the same way a dishonest `has_more: false` would, or drifting `total_matching` between pages. Verified by spot-flipping the training agent's `total_count` to the page-local count: page-1 assertion fires with the expected diagnostic.

--- a/static/compliance/source/universal/pagination-integrity.yaml
+++ b/static/compliance/source/universal/pagination-integrity.yaml
@@ -29,11 +29,17 @@ narrative: |
   carries a stale cursor onto the terminal page fails the second-page
   assertion.
 
-  The `total_count` field is intentionally not checked. The schema permits
-  agents to omit it (some backends cannot compute it cheaply) and asserting
-  on it would conflate honesty about what's still on the wire with honesty
-  about an upstream platform's full result set — only the former is
-  observable from the caller's seat.
+  The `total_count` field is allowed to be absent (some backends cannot
+  compute it cheaply per the pagination-response schema) but when an agent
+  volunteers it, the value MUST match the seeded fixture count of three.
+  This is the count-honesty half of the invariant: an agent that returns
+  `total_count: 2` while three creatives are seeded is hiding inventory
+  the way `has_more: false` would, just on a different field.
+  `query_summary.total_matching` is required by the response schema and
+  asserted unconditionally; `query_summary.returned` MUST equal the size
+  of each page's slice (2 on the continuation page, 1 on the terminal
+  page) — drift here flags an agent whose summary numbers don't match
+  what it actually emitted.
 
 agent:
   interaction_model: stateful_preloaded
@@ -164,6 +170,18 @@ phases:
           - check: field_present
             path: "pagination.cursor"
             description: "has_more=true requires a cursor — without one the caller cannot continue"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 3
+            description: "Three fixtures seeded — total_matching MUST reflect the full result set, not just this page"
+          - check: field_value
+            path: "query_summary.returned"
+            value: 2
+            description: "max_results=2 capped this page at 2 items — query_summary.returned MUST match the slice"
+          - check: field_value_or_absent
+            path: "pagination.total_count"
+            allowed_values: [3]
+            description: "If volunteered, total_count MUST equal the seeded set size — under-reporting hides inventory the same way a dishonest has_more does"
 
           - check: field_present
             path: "context"
@@ -223,6 +241,18 @@ phases:
             path: "pagination.cursor"
             allowed_values: [null]
             description: "Terminal page MUST omit cursor (null also accepted for clients that explicitly clear the field)"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 3
+            description: "total_matching MUST stay stable across pages — drift between pages is a query-summary bug"
+          - check: field_value
+            path: "query_summary.returned"
+            value: 1
+            description: "One creative left after the first page returned two — query_summary.returned MUST match the slice"
+          - check: field_value_or_absent
+            path: "pagination.total_count"
+            allowed_values: [3]
+            description: "total_count (when volunteered) MUST stay stable across pages and equal the seeded set size"
 
           - check: field_present
             path: "context"


### PR DESCRIPTION
## Summary
Extends `pagination_integrity` with three runtime assertions per page:
- `query_summary.total_matching = 3` (always — schema requires the field)
- `query_summary.returned` matches the slice (2 on continuation, 1 on terminal)
- `pagination.total_count = 3` when volunteered (`field_value_or_absent` preserves the schema's optional stance)

## Why
Closes the deferred follow-up from #3095. The protocol reviewer flagged that the cursor↔has_more storyboard tested wire-level honesty but didn't exercise count-level honesty. An agent can honor `max_results` and the cursor handshake while still lying in the summary — under-reporting `total_count` to hide inventory the same way a dishonest `has_more: false` would, or drifting `total_matching` across pages.

These assertions are pure internal-consistency checks: they don't require upstream visibility (the storyboard knows the seeded set is 3) so they catch the dishonesty without conflating wire honesty with platform honesty. `total_count` stays optional via `field_value_or_absent allowed_values: [3]` — agents whose backends can't compute it cheaply remain conformant; agents that volunteer it must tell the truth.

## Verified
Spot-checked the assertion fires correctly by flipping the training agent's `total_count` from `totalMatching` (the truthful 3) to `pageCreatives.length` (the dishonest page-local 2). Page-1 assertion fired with diagnostic:

```
× first_page: If volunteered, total_count MUST equal the seeded set size — under-reporting hides inventory the same way a dishonest has_more does — Expected absent or one of [3], got 2
```

Reverted the agent — clean run again.

## Test plan
- [x] `npm run build:compliance` — pagination-invariant lint and 7 storyboard lints clean
- [x] `npm run test:pagination-invariant` — 16/16 tests pass
- [x] `npm run typecheck` — clean
- [x] Pre-commit unit suite — 820/820 tests pass
- [x] `pagination_integrity` against training agent: 6/6 steps clean
- [x] Negative test: storyboard fires when training agent under-reports `total_count`
- [x] All 8 creative storyboards still pass (61/62 steps, 1 expected skip in branch_set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)