### PR TITLE
docs(compliance): enumerate a2a_submitted_artifact in storyboard-schema check list

### DIFF
--- a/.changeset/docs-storyboard-a2a-submitted-artifact-check.md
+++ b/.changeset/docs-storyboard-a2a-submitted-artifact-check.md
@@ -1,0 +1,13 @@
+---
+---
+
+docs(compliance): enumerate a2a_submitted_artifact in storyboard-schema check list
+
+Adds `a2a_submitted_artifact` to the canonical `check:` enum comment in
+`static/compliance/source/universal/storyboard-schema.yaml` and adds a sibling
+documentation section (modelled after the existing `refs_resolve` section) that
+describes the A2A wire-shape invariants the check asserts, its `not_applicable`
+self-skip on non-A2A transports, and its provenance (adcp-client#899 / #952).
+
+Documentation-only: the runner already supports the check as of adcp-client#952;
+no schema, task definition, or wire-format change.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -556,7 +556,7 @@
 # check: string (what to validate: "response_schema", "field_present", "field_value",
 #                "field_value_or_absent", "status_code", "http_status", "http_status_in",
 #                "error_code", "on_401_require_header", "resource_equals_agent_url",
-#                "any_of", "refs_resolve")
+#                "any_of", "refs_resolve", "a2a_submitted_artifact")
 # path: string (JSON path to the field, e.g., "formats[0].format_id")
 # value: any (expected value — string, number, or boolean; required when check is "field_value";
 #             accepted (optional) when check is "field_value_or_absent")
@@ -666,6 +666,15 @@
 #         key: agent_url
 #         equals: $agent_url
 #       on_out_of_scope: warn
+#
+# A2A wire-shape — use `check: a2a_submitted_artifact`:
+#   Verifies the cross-transport invariants for AdCP `submitted` arms over A2A:
+#   `Task.state === 'completed'`, `Task.id` /
+#   `Task.contextId` non-empty, `artifact.metadata.adcp_task_id` carries the
+#   handle, `artifact.parts[0].data.status === 'submitted'` preserves the AdCP
+#   discriminator. The check self-skips with `not_applicable` on non-A2A
+#   transports so storyboards can include it alongside MCP-shape assertions
+#   without forking by transport.
 #
 # --- Runner output ---
 #

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -668,11 +668,11 @@
 #       on_out_of_scope: warn
 #
 # A2A wire-shape — use `check: a2a_submitted_artifact`:
-#   Verifies the cross-transport invariants for AdCP `submitted` arms over A2A:
-#   `Task.state === 'completed'`, `Task.id` /
-#   `Task.contextId` non-empty, `artifact.metadata.adcp_task_id` carries the
-#   handle, `artifact.parts[0].data.status === 'submitted'` preserves the AdCP
-#   discriminator. The check self-skips with `not_applicable` on non-A2A
+#   Asserts the A2A envelope invariants for AdCP `submitted` arms: `Task.id` /
+#   `Task.contextId` non-empty, `Task.state` normalised to `completed` (A2A 0.3
+#   wire value `"completed"`; A2A 1.0 enum `"TASK_STATE_COMPLETED"`), and the
+#   last non-null, object-typed DataPart's `data.status === 'submitted'`
+#   preserving the AdCP discriminator. Grades `not_applicable` on non-A2A
 #   transports so storyboards can include it alongside MCP-shape assertions
 #   without forking by transport.
 #


### PR DESCRIPTION
Closes #3105

## Summary

Adds `a2a_submitted_artifact` to the canonical `check:` enum comment in `static/compliance/source/universal/storyboard-schema.yaml` and adds a sibling documentation section (modelled on the existing `refs_resolve` section). The runner already supports this check (adcp-client#952); without this doc update, storyboard authors copying patterns from existing scenarios won't discover it.

**Non-breaking justification:** Comment-only change to a YAML file. The runner doesn't enforce the comment enum at parse time. Additive enumeration; no schema, task definition, or wire-format change.

## What changed

- `check:` enum comment (line 559): `"refs_resolve"` → `"refs_resolve", "a2a_submitted_artifact"`
- New `# A2A wire-shape — use check: a2a_submitted_artifact:` section after the `refs_resolve` block, documenting: `Task.id`/`Task.contextId` non-empty, `Task.state` normalised to `completed` (both A2A 0.3 `"completed"` and A2A 1.0 `"TASK_STATE_COMPLETED"` wire values), last non-null object-typed DataPart's `data.status === 'submitted'`, and `not_applicable` grade on non-A2A transports.

## Pre-PR review

The proposed wording from the issue contained three inaccuracies caught by expert review and corrected before opening:

- `parts[0]` → **last non-null, object-typed DataPart** (last-wins semantics per test vectors task_011/task_017/task_002/task_020 in `static/test-vectors/a2a-response-extraction.json`)
- `Task.state === 'completed'` → **normalised to `completed`**, with both A2A 0.3 and 1.0 wire values documented explicitly
- `artifact.metadata.adcp_task_id` **removed** — not grounded in repo schemas or test vectors; explicitly out-of-scope per `create_media_buy_async.yaml:45-49`

**Pre-PR sign-offs:**
- code-reviewer: approved — no blockers; enum ordering (addition-order) and section placement correct
- ad-tech-protocol-expert: approved after blocker fixes — all three prior blockers resolved; nit on `submitted`-state DataPart extraction path noted (runner grades `not_applicable`, not silent misdirection)

Session: https://claude.ai/code/session_01EK9xRfKmujiZpL6GDrC5wQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK9xRfKmujiZpL6GDrC5wQ)_