### PR TITLE
feat(compliance): get_signals pagination cursor integrity

### DIFF
--- a/.changeset/get-signals-pagination-integrity.md
+++ b/.changeset/get-signals-pagination-integrity.md
@@ -1,0 +1,8 @@
+---
+---
+
+Adds `get_signals_pagination_integrity` — the second universal pagination-integrity storyboard, mirroring the cursor↔has_more invariant that gates `list_creatives` (#3095/#3100) onto `get_signals`. Sends a broad `signal_spec` ("audience") with `pagination.max_results: 1` and asserts the first page is non-terminal (`has_more=true` with cursor present). Page 2 follows the captured cursor and asserts schema conformance — the catalog size depends on the agent so the terminal state is not pinned, with the static lint covering cursor invariants on any sample fixture.
+
+Fixes the training agent's `get_signals` to honor `pagination.max_results` / `pagination.cursor` and emit a proper pagination block. Previously it capped internally at `MAX_SIGNAL_RESULTS=10` and returned no pagination field — exactly the dishonest shape this storyboard exists to catch. Negative-test verified: flipping the agent back to `has_more: false` fires the page-1 assertion with `Expected true, got false`.
+
+Generalizes the cursor codec from #3095 (`encodeCreativeCursor` / `decodeCreativeCursor`) into a `kind`-prefixed pair (`encodeOffsetCursor`, `decodeOffsetCursor`) so a list_creatives cursor can't decode to a meaningful offset on a different list endpoint. Existing list_creatives behavior preserved.

--- a/docs/building/compliance-catalog.mdx
+++ b/docs/building/compliance-catalog.mdx
@@ -28,6 +28,7 @@ Every agent runs every storyboard in `/compliance/{version}/universal/` regardle
 | `security` | **Authentication baseline — unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding.** See [Authentication](/docs/building/integration/authentication). |
 | `webhook-emission` | Outbound webhook conformance — stable `idempotency_key` across retries; RFC 9421 webhook signing (or HMAC fallback if the buyer opted in). Runs for any agent that accepts `push_notification_config` on any operation. |
 | `pagination-integrity` | `cursor` ↔ `has_more` invariant verified by walking a paginated `list_creatives` response from a continuation page through to terminal. |
+| `get-signals-pagination-integrity` | `cursor` ↔ `has_more` invariant verified by walking a paginated `get_signals` response under a broad query — page 1 must be non-terminal against any non-trivial catalog, page 2 follows the cursor. |
 | `deterministic-testing` | `comply_test_controller` state-machine verification — skipped if `capabilities.compliance_testing.supported: false`. |
 | `signed-requests` | RFC 9421 transport-layer request-signing verification — skipped if `request_signing.supported: false`. |
 

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -59,6 +59,7 @@ Every agent MUST pass every storyboard below.
 | [`security_baseline`](https://adcontextprotocol.org/compliance/latest/universal/security) | Unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |
 | [`webhook_emission`](https://adcontextprotocol.org/compliance/latest/universal/webhook-emission) | Outbound webhook conformance — stable `idempotency_key` across retries, RFC 9421 webhook signing (or opt-in HMAC fallback) on every delivery. Runs for any agent accepting `push_notification_config`. |
 | [`pagination_integrity`](https://adcontextprotocol.org/compliance/latest/universal/pagination-integrity) | `cursor` ↔ `has_more` invariant on paginated `list_creatives` responses, walked from a continuation page through to a terminal page |
+| [`get_signals_pagination_integrity`](https://adcontextprotocol.org/compliance/latest/universal/get-signals-pagination-integrity) | `cursor` ↔ `has_more` invariant on paginated `get_signals` responses under a broad query, with first-page non-terminal assertion against any non-trivial signals catalog |
 | [`deterministic_testing`](https://adcontextprotocol.org/compliance/latest/universal/deterministic-testing) | `comply_test_controller` state machine — skipped if `capabilities.compliance_testing.supported: false` |
 | [`signed_requests`](https://adcontextprotocol.org/compliance/latest/universal/signed-requests) | RFC 9421 transport-layer request-signing verification — skipped if `request_signing.supported: false`. |
 

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2504,10 +2504,23 @@ export async function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
   const rawSpec = req.signal_spec || req.brief;
   const signalSpec = typeof rawSpec === 'string' ? rawSpec : undefined;
   // Pagination shape (pagination.max_results, schema cap 100) takes precedence
-  // over the legacy top-level `max_results` (default 10 to keep semantic-search
-  // results focused). When neither is supplied, fall back to MAX_SIGNAL_RESULTS.
-  const requestedMax = req.pagination?.max_results ?? req.max_results ?? MAX_SIGNAL_RESULTS;
-  const maxResults = Math.min(typeof requestedMax === 'number' && requestedMax >= 1 ? requestedMax : MAX_SIGNAL_RESULTS, 100);
+  // over the legacy top-level `max_results` (no schema cap; this handler
+  // historically capped at 50 to keep semantic-search results focused). The two
+  // forms have different caps because they have different contracts —
+  // pagination.max_results is the standard envelope and matches the schema's
+  // documented 100 cap; top-level max_results is the predecessor and we
+  // preserve its tighter behavioral cap to avoid silently widening any caller
+  // currently relying on the 50 ceiling. Spec ambiguity on which form wins
+  // when both are present is tracked at adcontextprotocol/adcp#3113.
+  let maxResults: number;
+  const paginationMax = req.pagination?.max_results;
+  if (typeof paginationMax === 'number' && paginationMax >= 1) {
+    maxResults = Math.min(paginationMax, 100);
+  } else if (typeof req.max_results === 'number' && req.max_results >= 1) {
+    maxResults = Math.min(req.max_results, 50);
+  } else {
+    maxResults = MAX_SIGNAL_RESULTS;
+  }
   const offset = decodeOffsetCursor('signals', req.pagination?.cursor);
   if (offset === null) {
     return {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2105,29 +2105,41 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
   };
 }
 
-// Opaque offset-encoded cursor for in-memory list_creatives pagination.
-// Real backends would carry stable resource keys; an offset is sufficient
-// for the training agent because creatives.values() iterates in stable
-// insertion order. base64url keeps the token URL-safe and visibly opaque.
-function encodeCreativeCursor(offset: number): string {
-  return Buffer.from(`offset:${offset}`).toString('base64url');
+// Opaque offset-encoded cursors for in-memory paginated reads. Real backends
+// would carry stable resource keys; an offset is sufficient for the training
+// agent because the underlying iteration order is stable for every read this
+// powers (Map insertion order, static catalog order). base64url keeps the
+// token URL-safe and visibly opaque. The `kind` prefix scopes a cursor to a
+// specific list endpoint so a caller can't move a list_creatives cursor onto
+// list_creative_formats and accidentally land at a meaningful offset.
+function encodeOffsetCursor(kind: string, offset: number): string {
+  return Buffer.from(`${kind}:offset:${offset}`).toString('base64url');
 }
 
-// Returns null when the cursor is present but malformed. The caller MUST
-// surface INVALID_REQUEST in that case — silently restarting from offset 0
-// would teach a sloppy pattern (corrupt cursors duplicate items the caller
-// already saw). An absent cursor returns 0 (start of pagination).
-function decodeCreativeCursor(cursor: string | undefined): number | null {
+// Returns null when the cursor is present but malformed (or scoped to a
+// different list endpoint). The caller MUST surface INVALID_REQUEST in that
+// case — silently restarting from offset 0 would teach a sloppy pattern
+// (corrupt cursors duplicate items the caller already saw). An absent
+// cursor returns 0 (start of pagination).
+function decodeOffsetCursor(kind: string, cursor: string | undefined): number | null {
   if (!cursor) return 0;
   try {
     const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-    const m = /^offset:(\d+)$/.exec(decoded);
+    const m = new RegExp(`^${kind}:offset:(\\d+)$`).exec(decoded);
     if (!m) return null;
     const n = Number.parseInt(m[1], 10);
     return Number.isFinite(n) && n >= 0 ? n : null;
   } catch {
     return null;
   }
+}
+
+function encodeCreativeCursor(offset: number): string {
+  return encodeOffsetCursor('creatives', offset);
+}
+
+function decodeCreativeCursor(cursor: string | undefined): number | null {
+  return decodeOffsetCursor('creatives', cursor);
 }
 
 /** Sandbox rate card: returns CPM pricing based on account and creative format. */
@@ -2484,11 +2496,24 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
 const MAX_SIGNAL_RESULTS = 10;
 
 export async function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
-  const req = args as unknown as GetSignalsRequest & ToolArgs & { brief?: string };
+  const req = args as unknown as GetSignalsRequest & ToolArgs & {
+    brief?: string;
+    pagination?: { max_results?: number; cursor?: string };
+  };
   // Accept both signal_spec (protocol) and brief (SDK test tool)
   const rawSpec = req.signal_spec || req.brief;
   const signalSpec = typeof rawSpec === 'string' ? rawSpec : undefined;
-  const maxResults = Math.min(Math.max(req.max_results || MAX_SIGNAL_RESULTS, 1), 50);
+  // Pagination shape (pagination.max_results, schema cap 100) takes precedence
+  // over the legacy top-level `max_results` (default 10 to keep semantic-search
+  // results focused). When neither is supplied, fall back to MAX_SIGNAL_RESULTS.
+  const requestedMax = req.pagination?.max_results ?? req.max_results ?? MAX_SIGNAL_RESULTS;
+  const maxResults = Math.min(typeof requestedMax === 'number' && requestedMax >= 1 ? requestedMax : MAX_SIGNAL_RESULTS, 100);
+  const offset = decodeOffsetCursor('signals', req.pagination?.cursor);
+  if (offset === null) {
+    return {
+      errors: [{ code: 'INVALID_REQUEST', message: 'pagination.cursor is malformed' }] as TaskError[],
+    };
+  }
   const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
 
   const allSignals = getAllSignals();
@@ -2541,8 +2566,13 @@ export async function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
     }
   }
 
-  // Cap results
-  results = results.slice(0, maxResults);
+  // Slice to the requested page after filters/sorts have settled. Iteration
+  // order is stable across calls within a session because getAllSignals()
+  // returns the static catalog and SYNONYM_MAP scoring is deterministic.
+  const totalMatching = results.length;
+  const pageEnd = Math.min(offset + maxResults, totalMatching);
+  results = results.slice(offset, pageEnd);
+  const hasMore = pageEnd < totalMatching;
 
   // Build the training agent URL for deployment targets
   const agentUrl = getAgentUrl();
@@ -2605,7 +2635,21 @@ export async function handleGetSignals(args: ToolArgs, ctx: TrainingContext) {
   // Scope boundary note for identity resolution queries
   const identityTerms = ['identity', 'resolution', 'matching', 'graph', 'credit'];
   const hasIdentityTerm = rawTerms.some(t => identityTerms.includes(t));
-  const response: { signals: SignalResponse[]; note?: string } = { signals };
+  const response: {
+    signals: SignalResponse[];
+    pagination: { has_more: boolean; total_count: number; cursor?: string };
+    note?: string;
+  } = {
+    signals,
+    pagination: {
+      has_more: hasMore,
+      total_count: totalMatching,
+      // Cursor MUST be present iff has_more is true — see
+      // static/schemas/source/core/pagination-response.json. universal/
+      // pagination-integrity catches stale tokens on terminal pages.
+      ...(hasMore && { cursor: encodeOffsetCursor('signals', pageEnd) }),
+    },
+  };
   if (hasIdentityTerm) {
     const isCreditQuery = rawTerms.includes('credit');
     response.note = isCreditQuery

--- a/static/compliance/source/universal/get-signals-pagination-integrity.yaml
+++ b/static/compliance/source/universal/get-signals-pagination-integrity.yaml
@@ -1,0 +1,211 @@
+id: get_signals_pagination_integrity
+version: "1.0.0"
+title: "get_signals pagination cursor integrity"
+category: schema_validation
+summary: "Validates the cursor↔has_more invariant on a paginated get_signals response by walking from a continuation page to the next page under a broad query."
+track: signals
+required_tools:
+  - get_signals
+
+narrative: |
+  `get_signals` is the buyer's primary entry point into the signals
+  marketplace. The response carries the standard `pagination` envelope, so
+  the cursor↔has_more invariant that gates `list_creatives` (covered by
+  universal/pagination-integrity) gates this endpoint too.
+
+  This storyboard sends a deliberately broad `signal_spec` ("audience") so
+  any non-trivial signal catalog matches more than one entry, then asks
+  for `pagination.max_results: 1`. Conformant agents MUST report
+  `has_more: true` with a `cursor` on this page — an agent that caps
+  internally and reports `has_more: false` while more candidates match
+  fails the page-1 assertion. That's the dishonest-pagination shape this
+  storyboard exists to catch.
+
+  After capturing the cursor, the storyboard follows it on the second
+  call. The terminal state of that page depends on the agent's catalog
+  size and is not pinned — the second-page validations check
+  response-schema conformance only. The cursor↔has_more invariant on
+  any single page is enforced statically across all schema and storyboard
+  fixtures by `scripts/lint-pagination-invariant.cjs`; the storyboard's
+  job is the runtime catch on the page where the agent first decides
+  whether to honor `max_results`.
+
+  Catalog sizing: agents whose catalogs return zero or one match for
+  "audience" SHOULD declare themselves outside the catalog_signals
+  capability rather than passing this storyboard with a one-page result —
+  a signal marketplace with a single audience signal isn't a marketplace.
+  When such an agent runs the storyboard the first-page assertion fails
+  loud, which is the right grading: this is not a `not_applicable` case,
+  it's a too-thin catalog claiming a capability it can't honor.
+
+agent:
+  interaction_model: marketplace_catalog
+  capabilities:
+    - catalog_signals
+  examples:
+    - "Any AdCP agent that exposes a paginated get_signals over a non-trivial catalog"
+
+caller:
+  role: buyer_agent
+  example: "Compliance test harness"
+
+prerequisites:
+  description: |
+    No fixtures required. The agent's signal catalog is treated as given —
+    the storyboard sends a broad query and asserts pagination shape
+    invariants on whatever match set the agent returns. Any agent
+    declaring catalog_signals SHOULD have a non-trivial catalog matching
+    "audience".
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      Confirm the agent supports the signals protocol before exercising
+      get_signals.
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares signals in supported_protocols
+          before driving paginated get_signals.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring signals in supported_protocols.
+
+        sample_request:
+          context:
+            correlation_id: "get_signals_pagination_integrity--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "get_signals_pagination_integrity--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: pagination_walk
+    title: "Walk pages with a small max_results"
+    narrative: |
+      A broad `signal_spec` ("audience") against any non-trivial signals
+      catalog matches more than one entry. With `max_results: 1` the
+      first call MUST return a continuation page; the second call follows
+      the captured cursor.
+
+    steps:
+      - id: first_page
+        title: "Request the first page with max_results=1"
+        narrative: |
+          The buyer asks for up to one signal under a broad
+          natural-language query. Agents whose catalogs contain more than
+          one match (the expected case for any agent claiming
+          catalog_signals) MUST report `has_more=true` and a `cursor` the
+          buyer can follow.
+
+          The runner captures `pagination.cursor` into
+          `$context.signals_next_cursor` for the follow-up step. If the
+          agent reports `has_more=false` while more matches exist (the
+          dishonest pagination case), the field_value check on
+          `pagination.has_more` fires — surfacing the bug class this
+          storyboard exists to catch.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: get_signals_pagination_integrity
+        stateful: true
+        context_outputs:
+          - name: signals_next_cursor
+            path: "pagination.cursor"
+        expected: |
+          Return up to one signal matching the broad audience query with:
+          - pagination.has_more = true
+          - pagination.cursor present (an opaque continuation token)
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          signal_spec: "audience"
+          pagination:
+            max_results: 1
+
+          context:
+            correlation_id: "get_signals_pagination_integrity--first_page"
+        validations:
+          - check: response_schema
+            description: "Response matches get-signals-response.json schema"
+          - check: field_value
+            path: "pagination.has_more"
+            value: true
+            description: "A broad query against any non-trivial signal catalog must yield more than one match — first page is non-terminal"
+          - check: field_present
+            path: "pagination.cursor"
+            description: "has_more=true requires a cursor — without one the caller cannot continue"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "get_signals_pagination_integrity--first_page"
+            description: "Context correlation_id returned unchanged"
+
+      - id: next_page
+        title: "Follow the cursor"
+        narrative: |
+          The buyer follows the captured cursor under the same broad
+          query. The terminal state of this page depends on the agent's
+          catalog size — some agents exhaust the result set in two
+          pages, others continue paginating — so we do not pin
+          `has_more` here. Schema conformance MUST hold; the
+          cursor↔has_more invariant on this page is enforced by
+          `scripts/lint-pagination-invariant.cjs` against any sample
+          fixture and by the round-trip on `universal/
+          pagination-integrity.yaml`.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: get_signals_pagination_integrity
+        stateful: true
+        expected: |
+          Return the next page of signals with a schema-valid response.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          signal_spec: "audience"
+          pagination:
+            cursor: "$context.signals_next_cursor"
+            max_results: 1
+
+          context:
+            correlation_id: "get_signals_pagination_integrity--next_page"
+        validations:
+          - check: response_schema
+            description: "Response matches get-signals-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "get_signals_pagination_integrity--next_page"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
## Summary
Third storyboard in the rolling pagination conformance series — extends the cursor↔has_more invariant from `list_creatives` (#3095/#3100) onto `get_signals`.

- **Storyboard:** `static/compliance/source/universal/get-signals-pagination-integrity.yaml` sends `signal_spec: "audience"` with `pagination.max_results: 1`. Page 1 asserts `has_more=true` with a cursor (broad-query against any non-trivial signals catalog must be non-terminal). Page 2 follows the captured cursor and asserts schema conformance only — catalog size varies, can't pin terminal state.
- **Training agent fix:** `handleGetSignals` now honors `pagination.max_results` / `pagination.cursor` and emits a proper pagination block. Previously capped at `MAX_SIGNAL_RESULTS=10` internally and emitted no pagination — exactly the dishonest shape this storyboard catches.
- **Cursor codec:** generalized from #3095 into a `kind`-prefixed pair so a list_creatives cursor can't decode to a meaningful offset on a different endpoint. Old wrappers preserved; list_creatives behavior unchanged.

## Why softer page-2 assertions than #3095
The seeded `list_creatives` storyboard pins counts via `seed_creative` (3 fixtures). `get_signals` has no `seed_signal` scenario today, so this storyboard uses a broad query and asserts only what's portable: page 1 must be non-terminal under a broad query against any non-trivial catalog. The static lint (`scripts/lint-pagination-invariant.cjs`) covers cursor invariants on every sample fixture, and `pagination_integrity.yaml` exercises the full multi-page round-trip on the seedable side.

## Reviewed by
- **ad-tech-protocol-expert:** sound-with-caveats. Two flags addressed:
  1. **Field precedence:** the request schema declares both top-level `max_results` and `pagination.max_results` with no documented winner. Filed upstream as #3113. Storyboard implements pagination-wins; an agent that read the spec the other way could legitimately fail it. Resolution lives upstream.
  2. **kind-prefixed cursor:** correct defensive practice; keep.
- **code-reviewer:** no blockers. One concrete flag addressed in [3011a9fb](https://github.com/adcontextprotocol/adcp/commit/3011a9fb1) — preserve the legacy 50-cap on top-level `max_results` (pagination.max_results gets the schema's documented 100 cap).

## Verified
Negative-test by flipping the agent back to `has_more: false`:

```
× first_page: A broad query against any non-trivial signal catalog must yield more than one match — first page is non-terminal — Expected true, got false
```

Reverted — clean run restored.

## Series status
- ✅ #3095 — cursor↔has_more lint + storyboard + list_creatives fix (merged)
- ✅ #3100 — total_count honesty assertions on list_creatives storyboard (merged)
- 🟢 This PR — get_signals storyboard + agent fix
- 🟡 #3110 — list_accounts (triage in flight; CI failing on idempotency_key lint, codec needs to reuse #3109's `encodeOffsetCursor`)
- 📋 #3111 — get_media_buys (issue filed for triage)
- 📋 #3112 — governance lists trio (issue filed for triage)
- 📋 #3108 — list_creative_formats blocked on `seed_creative_format`
- 📋 #3113 — spec precedence question for `max_results`

## Test plan
- [x] `npm run build:compliance` clean (pagination-invariant lint + 7 storyboard lints)
- [x] `npm run test:pagination-invariant` — 16/16 pass
- [x] `npm run typecheck` — clean
- [x] `get_signals` unit tests — 20/20 pass
- [x] `pagination_integrity` (list_creatives) still passes — 6/6 steps
- [x] `get_signals_pagination_integrity` against training agent — 3/3 steps clean
- [x] Pre-commit unit suite — clean
- [x] Negative test: storyboard fires when agent reverts to `has_more: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)