### PR TITLE
docs(tasks/get): remove non-existent include_result flag from polling examples

### DIFF
--- a/.changeset/tasks-get-include-result-docs-fix.md
+++ b/.changeset/tasks-get-include-result-docs-fix.md
@@ -1,0 +1,10 @@
+---
+---
+
+docs(tasks/get): remove non-existent `include_result` flag from polling examples and clarify 3.0 completion-payload retrieval
+
+The `tasks/get` request schema (`static/schemas/source/core/tasks-get-request.json`) does not define an `include_result` field, and the response schema (`static/schemas/source/core/tasks-get-response.json`) does not define a `result` field. Five doc files were inviting buyers to send `include_result: true` and read a typed completion payload off the polled response — neither of which is supported by the 3.0 spec.
+
+Removed the spurious parameter from the polling examples in `task-lifecycle.mdx`, `async-operations.mdx` (two call sites), `error-handling.mdx`, and `orchestrator-design.mdx`. Added a note on the canonical `task-lifecycle` polling section stating that in 3.0, `tasks/get` returns task status and the completion payload (e.g. `media_buy_id`, `packages` from `create_media_buy`) is delivered via the seller's push notification to the buyer's webhook URL configured in `push_notification_config`. Buyers that need the completion payload MUST configure a webhook in 3.0; polling alone reports terminal status.
+
+A typed `include_result` request flag and a documented response projection on completion are tracked for 3.1 in #3123. This patch corrects the docs to match what 3.0 actually ships; the schema-additive fix is out of scope per the patch policy in `docs/reference/versioning.mdx` ("Patches never change schema — no new fields, no renamed fields, no new enum values").

--- a/docs/building/implementation/async-operations.mdx
+++ b/docs/building/implementation/async-operations.mdx
@@ -236,7 +236,11 @@ async function createCampaign(packages, budget) {
 Polling is a backup for `submitted` operations when webhooks aren't configured or as a fallback. Don't poll for `working` — the server delivers the result on the open connection.
 
 ```javascript
-async function pollForResult(taskId, options = {}) {
+// Polling tracks status to a terminal value. The completion payload
+// (e.g. media_buy_id, packages) is delivered to the webhook configured
+// on the original request via push_notification_config — see #3123 for
+// the planned 3.1 typed-result projection on tasks/get.
+async function pollUntilTerminal(taskId, options = {}) {
   const { maxWait = 86_400_000, pollInterval = 30_000 } = options;
   const startTime = Date.now();
 
@@ -248,8 +252,7 @@ async function pollForResult(taskId, options = {}) {
     await sleep(pollInterval);
 
     const response = await adcp.call('tasks/get', {
-      task_id: taskId,
-      include_result: true
+      task_id: taskId
     });
 
     if (['completed', 'failed', 'canceled'].includes(response.status)) {
@@ -313,8 +316,7 @@ async function onStartup() {
   for (const operation of pending) {
     // Check current status on server
     const response = await adcp.call('tasks/get', {
-      task_id: operation.task_id,
-      include_result: true
+      task_id: operation.task_id
     });
 
     // Update local state

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -410,11 +410,14 @@ class WebhookErrorHandler {
 
   async startPolling(taskId) {
     const response = await adcp.call('tasks/get', {
-      task_id: taskId,
-      include_result: true
+      task_id: taskId
     });
 
     if (['completed', 'failed', 'canceled'].includes(response.status)) {
+      // Status is terminal. The completion payload reaches the buyer
+      // through the webhook configured on the original request; if the
+      // webhook also failed, request a retry from the seller per their
+      // operational support channel.
       await this.processResult(taskId, response);
     } else {
       // Schedule next poll

--- a/docs/building/implementation/orchestrator-design.mdx
+++ b/docs/building/implementation/orchestrator-design.mdx
@@ -219,8 +219,7 @@ async def _poll_for_completion(self, operation_id, task_id, interval=60):
             poll_count += 1
 
             task_response = await self.adcp.call('tasks/get', {
-                'task_id': task_id,
-                'include_result': True
+                'task_id': task_id
             })
 
             await self.handle_operation_response(operation_id, task_response)

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -191,15 +191,18 @@ input-required → → → → →
 
 Don't poll for `working` — the server delivers the result on the open connection. Polling is a backup for `submitted` operations (webhooks are preferred).
 
+:::note Completion payload retrieval in 3.0
+The 3.0 `tasks/get` schema returns task status, timing, history, and (optionally) progress and error details. It does not specify a typed field for the terminal payload of a completed task — for `create_media_buy` and similar operations, the `media_buy_id`, `packages`, and other task-specific fields are delivered to the buyer's webhook URL configured via `push_notification_config` on the original request. Buyers that need the completion payload MUST configure a webhook in 3.0; polling alone reports terminal status. A typed `include_result` request flag and response projection are tracked for 3.1 in [#3123](https://github.com/adcontextprotocol/adcp/issues/3123).
+:::
+
 ```javascript
-// Polling is only for 'submitted' operations
-async function pollForResult(taskId, pollInterval = 30_000) {
+// Polling tracks status; the completion payload arrives via webhook.
+async function pollUntilTerminal(taskId, pollInterval = 30_000) {
   while (true) {
     await sleep(pollInterval);
 
     const response = await adcp.call('tasks/get', {
-      task_id: taskId,
-      include_result: true
+      task_id: taskId
     });
 
     if (['completed', 'failed', 'canceled'].includes(response.status)) {


### PR DESCRIPTION
## Summary

The 3.0 `tasks/get` request schema does not define an `include_result` field, and the response schema does not define a typed `result` field. Five doc files were inviting buyers to send `include_result: true` and read a typed completion payload off the polled response — neither is supported by the spec we shipped.

This patch corrects the docs to match what 3.0 actually ships:

- Removed `include_result: true` from the polling examples in `task-lifecycle.mdx`, `async-operations.mdx` (two call sites), `error-handling.mdx`, and `orchestrator-design.mdx`.
- Added a note on the canonical polling section in `task-lifecycle.mdx` stating that the completion payload (e.g. `media_buy_id`, `packages` from `create_media_buy`) is delivered via the seller's push notification to the buyer's webhook URL configured in `push_notification_config` on the original request. Buyers that need the completion payload MUST configure a webhook in 3.0; polling alone reports terminal status.
- Pointed the note at #3123, which tracks the 3.1 schema-additive fix.

## Why patch (3.0.1) and not minor (3.1)

Per `docs/reference/versioning.mdx`:

> A patch release (3.0.1, 3.1.2) changes only documentation, wording, or validation that was diverging from the documented spec. Patches never change schema — no new fields, no renamed fields, no new enum values.

This PR only removes diverging wording and clarifies the existing-3.0 retrieval path. The schema-additive fix (typed `include_result` request flag + documented response projection on completion) is the second half of the work and is intentionally out of scope here — see #3123 and the follow-up 3.1 PR.

## Test plan

- [x] `npm run test:unit` and `npm run typecheck` pass via pre-commit
- [x] `grep -rn "include_result" docs/ static/ server/src/` returns only the new note in `task-lifecycle.mdx` (which references the planned 3.1 field by name)
- [ ] Reviewer: confirm the webhook normative claim (buyers MUST configure webhook for payload retrieval in 3.0) reads correctly given existing seller behavior with `additionalProperties: true`

Closes part of #3123. Schema-additive follow-up tracked separately for 3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)