### PR TITLE
feat(tasks/get): add include_result + result fields for typed completion-payload retrieval (3.1)

### DIFF
--- a/.changeset/tasks-get-include-result-3-1.md
+++ b/.changeset/tasks-get-include-result-3-1.md
@@ -1,0 +1,21 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(tasks/get): add `include_result` request flag and `result` response field for typed completion-payload retrieval
+
+Closes #3123. The 3.0 `tasks/get` schemas defined task status, timing, history, progress, and error fields, but no typed mechanism for buyers polling a `submitted` task to retrieve the terminal payload (e.g. `media_buy_id` and `packages` from a completed `create_media_buy`). The 3.0 docs invited buyers to send `include_result: true` against a parameter that wasn't in the schema; the SDK at adcp-client read `status.result` against a field that wasn't there either. Patch #3127 corrected the docs for 3.0; this change adds the field for 3.1.
+
+**Request schema** (`static/schemas/source/core/tasks-get-request.json`): added `include_result` (boolean, default `false`). Sellers MUST honor the flag when the task is in a terminal status; for non-terminal statuses (`submitted`, `working`, `input-required`, `auth-required`) the flag has no effect. Status-only polls remain cheap by default.
+
+**Response schema** (`static/schemas/source/core/tasks-get-response.json`): added `result` (object, `additionalProperties: true`) populated only when `status: completed` and `include_result: true` was sent. Shape matches the original task response payload for the task's `task_type` — for example, `task_type: create_media_buy` returns `result: { media_buy_id, packages, status }`. For `failed`/`canceled`, sellers continue to use the existing `error` field; `result` is for the success terminal only. The `status: completed` constraint is documented in the field description rather than expressed via JSON Schema's conditional validation, matching how `error` documents its `failed` constraint.
+
+**Why a typed `result` instead of flat top-level merge.** AdCP's flat-structure principle ("task fields at top level") applies to the original task response, where the response carries one task. `tasks/get` is a meta-call about an arbitrary task whose `task_type` is variable — flat-merging the terminal payload at top level would force progress/error/result fields to share namespace and would couple the tasks/get response shape to the union of every task's response shape. Naming the projection `result` makes the typed retrieval explicit, parallels MCP's `tasks/result` envelope, and matches what existing SDK code already attempts to read.
+
+**Why minor and not patch.** Per `docs/reference/versioning.mdx`: "Add a new error code or new optional field to a request/response schema | Minor" and "Patches never change schema — no new fields, no renamed fields, no new enum values." Targets the 3.1 milestone (late June 2026).
+
+**Docs**: added an explanatory paragraph to the polling section of `task-lifecycle.mdx`. The other four call sites (`async-operations.mdx` ×2, `error-handling.mdx`, `orchestrator-design.mdx`) where `include_result: true` was previously stripped by patch #3127 will be re-introduced when this branch rebases on the merged patch.
+
+**Forward compatibility**: 3.0 sellers ignore unknown request fields per `additionalProperties: true`, so a 3.1 buyer sending `include_result: true` to a 3.0 seller gets the 3.0 behavior (no `result` field on the response) — no error, no break. Buyers that need 3.1 semantics check `adcp.major_versions` advertised by the seller.
+
+**Cross-repo**: unblocks adcp-client#967 (SDK polling-cycle hardening) and adcp-client-python equivalent. The SDK's `pollTaskCompletion.TaskResult.data` extraction will read `response.result` when present, falling back to `response` for 3.0 sellers that splat task fields via `additionalProperties`.

--- a/docs/building/implementation/task-lifecycle.mdx
+++ b/docs/building/implementation/task-lifecycle.mdx
@@ -191,6 +191,8 @@ input-required → → → → →
 
 Don't poll for `working` — the server delivers the result on the open connection. Polling is a backup for `submitted` operations (webhooks are preferred).
 
+Send `include_result: true` to receive the terminal task payload on the polled response once the task reaches `status: completed`. The `result` object on the response carries the same shape the original task would have returned synchronously — for example, polling a `create_media_buy` task returns `result: { media_buy_id, packages, status }`. Webhooks remain the supported delivery mechanism (see [Push Notifications](/docs/building/implementation/webhooks)); `include_result` is the typed polling alternative for buyers that prefer pull over push.
+
 ```javascript
 // Polling is only for 'submitted' operations
 async function pollForResult(taskId, pollInterval = 30_000) {
@@ -203,6 +205,8 @@ async function pollForResult(taskId, pollInterval = 30_000) {
     });
 
     if (['completed', 'failed', 'canceled'].includes(response.status)) {
+      // response.result carries the terminal payload when status === 'completed'
+      // response.error carries error details when status === 'failed'
       return response;
     }
   }

--- a/static/schemas/source/core/tasks-get-request.json
+++ b/static/schemas/source/core/tasks-get-request.json
@@ -21,6 +21,11 @@
       "default": false,
       "description": "Include full conversation history for this task (may increase response size)"
     },
+    "include_result": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include the terminal task payload on the response when the task has reached `status: completed`. When true, the response carries a `result` object whose shape matches the original task response payload (e.g., for `task_type: create_media_buy`, `result` contains the same `media_buy_id`, `packages`, and `status` a synchronous `create_media_buy` completion would have produced). Defaults to false to keep status-only polls cheap. Sellers MUST honor this flag when the task is in a terminal status; for non-terminal statuses the flag has no effect."
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -44,6 +49,13 @@
       "data": {
         "task_id": "task_123",
         "include_history": true
+      }
+    },
+    {
+      "description": "Retrieve completion payload for a terminal create_media_buy task",
+      "data": {
+        "task_id": "task_789",
+        "include_result": true
       }
     }
   ]

--- a/static/schemas/source/core/tasks-get-response.json
+++ b/static/schemas/source/core/tasks-get-response.json
@@ -107,6 +107,11 @@
       ],
       "additionalProperties": true
     },
+    "result": {
+      "type": "object",
+      "description": "Terminal task payload, populated only when `status` is `completed` and `include_result` was true on the request. The shape matches the original task response payload for the task's `task_type` — for example, when `task_type` is `create_media_buy`, `result` carries the same `media_buy_id`, `packages`, and `status` that a synchronous `create_media_buy` completion would have produced. Sellers MUST NOT populate `result` for non-terminal statuses (`submitted`, `working`, `input-required`, `auth-required`); for `failed`/`canceled` use `error` instead. Buyers SHOULD treat `result` as authoritative for the terminal payload — webhooks remain the supported delivery mechanism, and this field is the typed retrieval path.",
+      "additionalProperties": true
+    },
     "history": {
       "type": "array",
       "description": "Complete conversation history for this task (only included if include_history was true in request)",


### PR DESCRIPTION
## Summary

Closes #3123. Adds the schema-level fix: a typed `include_result` request flag and a typed `result` response field on `tasks/get`, so buyers polling a `submitted` task can retrieve the terminal payload (e.g. `media_buy_id`, `packages` from a completed `create_media_buy`) without depending on `additionalProperties` undocumented behavior.

This is the 3.1 follow-up to #3127 (3.0.1 docs patch). #3127 stops the 3.0 docs from describing a parameter that doesn't exist; this PR makes the parameter exist for 3.1.

## Changes

**`static/schemas/source/core/tasks-get-request.json`** — adds `include_result` (boolean, default `false`). Sellers MUST honor the flag when the task is in a terminal status; for non-terminal statuses the flag has no effect. New example in the schema's `examples` array.

**`static/schemas/source/core/tasks-get-response.json`** — adds `result` (object, `additionalProperties: true`) populated only when `status: completed` and `include_result: true` was sent. Shape matches the original task response payload for the task's `task_type`. For `failed`/`canceled`, sellers continue to use the existing `error` field; `result` is for the success terminal only.

**`docs/building/implementation/task-lifecycle.mdx`** — adds an explanatory paragraph to the polling section. The four other call sites previously stripped by patch #3127 (`async-operations.mdx` ×2, `error-handling.mdx`, `orchestrator-design.mdx`) are intentionally left for the rebase post-#3127-merge to keep this PR focused on the schema change.

## Why a typed `result` instead of flat top-level merge

AdCP's flat-structure principle ("task fields at top level") applies to the original task response, where the response carries one task. `tasks/get` is a meta-call about an arbitrary task whose `task_type` is variable — flat-merging the terminal payload at top level would force progress/error/result fields to share namespace with task-specific fields and would couple the `tasks/get` response shape to the union of every task's response shape. Naming the projection `result` makes the typed retrieval explicit, parallels MCP's `tasks/result` envelope, and matches what existing SDK code at adcp-client already attempts to read (`status.result`).

## Versioning

Per `docs/reference/versioning.mdx:93`:
> Add a new error code or new optional field to a request/response schema | Minor

And per `docs/reference/versioning.mdx:121`:
> Patches never change schema — no new fields, no renamed fields, no new enum values.

This PR is **minor** and targets the **3.1 milestone** (late June 2026). The 3.0.1 patch is #3127.

## Forward compatibility

3.0 sellers ignore unknown request fields per `additionalProperties: true`, so a 3.1 buyer sending `include_result: true` to a 3.0 seller gets the 3.0 behavior (no `result` field on the response) — no error, no break. Buyers that need 3.1 semantics check `adcp.major_versions` advertised by the seller.

## Cross-repo

Unblocks adcp-client#967 (SDK polling-cycle hardening) and the adcp-client-python equivalent. The SDK's `pollTaskCompletion` `TaskResult.data` extraction will read `response.result` when present, falling back to `response` itself for 3.0 sellers that splat task fields via `additionalProperties`.

## Test plan

- [x] `npm run build:schemas` produces a valid bundled `tasks-get-request.json` with `include_result` and `tasks-get-response.json` with `result`
- [x] `npm run test:unit` and `npm run typecheck` pass via pre-commit hook
- [ ] Reviewer: confirm the `result` shape semantics ("matches the original task response payload for the task's `task_type`") read correctly against working-group expectations
- [ ] Reviewer: confirm the `failed`/`canceled` exclusion ("for failed/canceled use `error` instead") matches working-group intent
- [ ] Once #3127 lands, rebase this PR and re-introduce `include_result: true` to the four polling examples that were stripped by the patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)