### PR TITLE
fix(billing): route invoice-request notifications to billing channel

### DIFF
--- a/.changeset/route-invoice-requests-to-billing-channel.md
+++ b/.changeset/route-invoice-requests-to-billing-channel.md
@@ -1,0 +1,4 @@
+---
+---
+
+Route invoice-request Slack notifications through the configured billing channel (`getBillingChannel`) via `notifyInvoiceSent`, instead of the catch-all `SLACK_WEBHOOK_URL`. The `notifyInvoiceSent` helper now carries the requester name and Stripe invoice ID, and sanitizes user-controlled fields against Slack mrkdwn injection.

--- a/server/src/notifications/billing.ts
+++ b/server/src/notifications/billing.ts
@@ -35,6 +35,19 @@ function maskEmail(email: string | null | undefined): string {
 }
 
 /**
+ * Strip Slack mrkdwn formatting chars and HTML-encode special chars so
+ * untrusted user input (e.g. WorkOS firstName) can't inject markup or links
+ * into a notification.
+ */
+function sanitizeMrkdwn(s: string): string {
+  return s
+    .replace(/[*_~`|]/g, '')
+    .replace(/[<>&]/g, (c) =>
+      c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;'
+    );
+}
+
+/**
  * Helper to create a header block
  */
 function headerBlock(text: string): SlackBlock {
@@ -192,21 +205,31 @@ export async function notifySubscriptionCancelled(data: {
 export async function notifyInvoiceSent(data: {
   organizationName: string;
   contactEmail: string;
+  contactName?: string;
   amount: number;
   currency: string;
   productName?: string;
+  invoiceId?: string;
 }): Promise<boolean> {
+  const safeOrg = sanitizeMrkdwn(data.organizationName);
+  const safeName = data.contactName ? sanitizeMrkdwn(data.contactName) : null;
+  const requestedBy = safeName
+    ? `${safeName} (${maskEmail(data.contactEmail)})`
+    : maskEmail(data.contactEmail);
+
+  const fields = [
+    { label: 'Organization', value: safeOrg },
+    { label: 'Requested By', value: requestedBy },
+    { label: 'Amount', value: formatAmount(data.amount, data.currency) },
+    { label: 'Product', value: data.productName || 'Membership' },
+  ];
+  if (data.invoiceId) {
+    fields.push({ label: 'Invoice ID', value: data.invoiceId });
+  }
+
   return sendBillingNotification(
-    `Invoice Sent: ${formatAmount(data.amount, data.currency)} to ${data.organizationName}`,
-    [
-      headerBlock('Invoice Sent'),
-      sectionBlock([
-        { label: 'Organization', value: data.organizationName },
-        { label: 'Sent To', value: maskEmail(data.contactEmail) },
-        { label: 'Amount', value: formatAmount(data.amount, data.currency) },
-        { label: 'Product', value: data.productName || 'Membership' },
-      ]),
-    ]
+    `Invoice Sent: ${formatAmount(data.amount, data.currency)} to ${safeOrg}`,
+    [headerBlock('Invoice Sent'), sectionBlock(fields)]
   );
 }
 

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -37,6 +37,7 @@ import {
 } from "../services/lusha.js";
 import { listEscalationsForUser } from "../db/escalation-db.js";
 import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
+import { notifyInvoiceSent } from "../notifications/billing.js";
 import { WorkOS } from "@workos-inc/node";
 
 const logger = createLogger("billing-public-routes");
@@ -378,33 +379,22 @@ export function createPublicBillingRouter(): Router {
         }
       }
 
-      const productDisplay = `${product.display_name} ($${(product.amount_cents / 100).toLocaleString()})`;
-
       logger.info(
         { invoiceId: result.invoiceId, orgId, lookupKey, userId: user.id },
         "Invoice request processed successfully"
       );
 
-      if (process.env.SLACK_WEBHOOK_URL) {
-        fetch(process.env.SLACK_WEBHOOK_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            text: `Invoice requested`,
-            blocks: [
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text: `*New Invoice Request*\n\n*Org:* ${org.name}\n*Requested by:* ${displayName} (${user.email})\n*Product:* ${productDisplay}\n*Invoice ID:* ${result.invoiceId}`,
-                },
-              },
-            ],
-          }),
-        }).catch((err) =>
-          logger.error({ err }, "Failed to send Slack notification for invoice request")
-        );
-      }
+      notifyInvoiceSent({
+        organizationName: org.name,
+        contactEmail: user.email,
+        contactName: displayName,
+        amount: product.amount_cents,
+        currency: product.currency,
+        productName: product.display_name,
+        invoiceId: result.invoiceId,
+      }).catch((err) =>
+        logger.error({ err }, "Failed to send billing channel notification for invoice request")
+      );
 
       res.json({
         success: true,


### PR DESCRIPTION
## Summary

- Invoice-request Slack notifications were posting via an inline `fetch(SLACK_WEBHOOK_URL, ...)` and landing in #aao-admin, bypassing the existing billing-channel system every other billing notification already uses.
- Route through `notifyInvoiceSent` (which uses `getBillingChannel()` from system_settings; admin-configurable, currently #admin-billing).
- Extend `notifyInvoiceSent` to carry requester name + Stripe invoice ID, and add a small `sanitizeMrkdwn` to defuse Slack formatting injection from WorkOS-supplied display names.

## Pre-merge check

- The billing channel must be set in `/admin/admin-settings.html`. If it's NULL in prod, invoice-request notifications will silently drop (matches behavior of other billing notifiers — payment succeeded/failed, subscription created/cancelled). Confirm before merging.

## Test plan

- [ ] Verify billing channel is set in production admin settings
- [ ] Trigger a test invoice request and confirm the notification lands in #admin-billing (not #aao-admin) with org, requester, amount, product, invoice ID
- [ ] Verify a user with `*` / `_` / `<` chars in their WorkOS firstName posts as plain text, not formatted markup

## Reviewer notes

- Email is now masked (`f***@adopshub.nl`) for consistency with the rest of `notifications/billing.ts`. Old inline message had it unmasked. Channel is private/admin-only either way.
- `SLACK_WEBHOOK_URL` is no longer read from this route. Other parts of the app still use it (notifyNewMemberProfile, working-group posts) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)