### PR TITLE
feat(addie): teach upgrade proration + stop escalating community-fit questions

### DIFF
--- a/.changeset/addie-upgrade-and-fit-questions.md
+++ b/.changeset/addie-upgrade-and-fit-questions.md
@@ -4,12 +4,14 @@
 Addie behavior updates driven by escalation #281 (Vladimir Houba),
 expanded after expert review.
 
-- **knowledge.md** — Two new FAQ rows covering upgrade pricing across
-  all tiers. Credit-card upgrades (any tier on card) are routine
-  Stripe Pricing Table proration — answer directly with worked
-  examples for Explorer → Professional and Builder → Partner.
-  Invoice-billed Partner/Leader contracts are a separate FAQ row:
-  proration is a finance touch, escalate.
+- **knowledge.md** — New FAQ row for upgrade pricing. Every tier is
+  a Stripe subscription (credit card or invoice); Stripe prorates
+  upgrades automatically regardless of collection method, so the
+  user typically pays only the prorated difference, not the full new
+  tier on top. Worked examples for Explorer → Professional and
+  Builder → Partner. Invoice-billed subscriptions see the prorated
+  charge on their next invoice instead of an immediate card charge —
+  same numbers, different timing.
 - **constraints.md** — "Do NOT escalate" list under Escalation
   Protocol calling out community-fit questions and routine
   credit-card pricing. Replaces the bundled-question one-liner with

--- a/.changeset/addie-upgrade-and-fit-questions.md
+++ b/.changeset/addie-upgrade-and-fit-questions.md
@@ -1,19 +1,31 @@
 ---
 ---
 
-Two Addie rule updates driven by escalation #281 (Vladimir Houba):
+Addie behavior updates driven by escalation #281 (Vladimir Houba),
+expanded after expert review.
 
-- **knowledge.md** — Adds an upgrade-proration FAQ covering every
-  tier path (Explorer through Leader). Splits credit-card subscriptions
-  (Stripe Pricing Table prorates automatically — answer directly)
-  from invoice-billed Partner/Leader contracts (finance handles the
-  credit + fresh invoice manually — escalate). Worked examples for
-  Explorer → Professional and Professional → Builder.
-- **constraints.md** — Adds a "Do NOT escalate" list to the
-  Escalation Protocol section calling out (1) community-fit
-  questions ("would my background be valuable?") and (2) routine
-  membership pricing including credit-card upgrade proration.
-  Invoice-tier upgrades, refunds, out-of-cycle credits, custom
-  contracts, currency changes, and CC↔invoice moves still escalate.
-  A bundled question with two parts is not a Complex Request just
-  because it has two parts.
+- **knowledge.md** — Two new FAQ rows covering upgrade pricing across
+  all tiers. Credit-card upgrades (any tier on card) are routine
+  Stripe Pricing Table proration — answer directly with worked
+  examples for Explorer → Professional and Builder → Partner.
+  Invoice-billed Partner/Leader contracts are a separate FAQ row:
+  proration is a finance touch, escalate.
+- **constraints.md** — "Do NOT escalate" list under Escalation
+  Protocol calling out community-fit questions and routine
+  credit-card pricing. Replaces the bundled-question one-liner with
+  a decomposition procedure (split, decide per part, default
+  answer-all-parts) and a worked example using Vladimir's actual
+  question.
+- **behaviors.md** — "Individual Practitioner Suitability" now has a
+  peer-register sub-clause: skip the reassurance script ("Basics is
+  free", "no coding") for senior practitioners (10+ years RTB / DSP /
+  ad-ops), and instead name the working group(s) where their depth
+  is load-bearing. Adds a sequencing rule for fit + pricing bundled
+  questions: affirm fit → name path → reassure friction-free upgrade,
+  in that order.
+- **escalation-tools.ts** — Tightens the `escalate_to_admin` tool
+  description so it stops winning negative-rule contests. Softens
+  "too complex or sensitive for you to handle" to "requires admin
+  judgment, account access, or a human action you cannot perform"
+  and adds explicit DO-NOT-USE-FOR entries for community-fit,
+  routine pricing, and decomposable multi-part questions.

--- a/.changeset/addie-upgrade-and-fit-questions.md
+++ b/.changeset/addie-upgrade-and-fit-questions.md
@@ -1,0 +1,18 @@
+---
+---
+
+Two Addie rule updates driven by escalation #281 (Vladimir Houba):
+
+- **knowledge.md** — Adds an upgrade-proration FAQ: Stripe's Pricing
+  Table prorates tier upgrades automatically, so a user who moves
+  from Explorer to Professional pays only the difference for the
+  remainder of the period, not the full new tier on top. Addie can
+  now answer upgrade-pricing questions directly. Refunds,
+  out-of-cycle credits, custom contracts, and billing-frequency
+  changes still escalate.
+- **constraints.md** — Adds a "Do NOT escalate" list to the
+  Escalation Protocol section calling out (1) community-fit
+  questions ("would my background be valuable?") and (2) routine
+  membership pricing including upgrade proration. A bundled question
+  with two parts is not a Complex Request just because it has two
+  parts.

--- a/.changeset/addie-upgrade-and-fit-questions.md
+++ b/.changeset/addie-upgrade-and-fit-questions.md
@@ -3,16 +3,17 @@
 
 Two Addie rule updates driven by escalation #281 (Vladimir Houba):
 
-- **knowledge.md** — Adds an upgrade-proration FAQ: Stripe's Pricing
-  Table prorates tier upgrades automatically, so a user who moves
-  from Explorer to Professional pays only the difference for the
-  remainder of the period, not the full new tier on top. Addie can
-  now answer upgrade-pricing questions directly. Refunds,
-  out-of-cycle credits, custom contracts, and billing-frequency
-  changes still escalate.
+- **knowledge.md** — Adds an upgrade-proration FAQ covering every
+  tier path (Explorer through Leader). Splits credit-card subscriptions
+  (Stripe Pricing Table prorates automatically — answer directly)
+  from invoice-billed Partner/Leader contracts (finance handles the
+  credit + fresh invoice manually — escalate). Worked examples for
+  Explorer → Professional and Professional → Builder.
 - **constraints.md** — Adds a "Do NOT escalate" list to the
   Escalation Protocol section calling out (1) community-fit
   questions ("would my background be valuable?") and (2) routine
-  membership pricing including upgrade proration. A bundled question
-  with two parts is not a Complex Request just because it has two
-  parts.
+  membership pricing including credit-card upgrade proration.
+  Invoice-tier upgrades, refunds, out-of-cycle credits, custom
+  contracts, currency changes, and CC↔invoice moves still escalate.
+  A bundled question with two parts is not a Complex Request just
+  because it has two parts.

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -35,12 +35,16 @@ export const ESCALATION_TOOLS: AddieTool[] = [
 
 USE THIS WHEN:
 - User asks you to perform an action you have no tool for (posting to channels, creating issues, renaming things)
-- The request requires human judgment or approval
-- The topic is too complex or sensitive for you to handle
+- The request requires admin judgment, account access, or a human action you cannot perform
+- The topic is genuinely sensitive (legal, compliance, confrontational, controversial-political)
 - You've tried and failed to help with your available tools
 
 DO NOT USE FOR:
-- Questions you can answer with your tools
+- Questions you can answer with your tools or your rule files (knowledge.md, behaviors.md)
+- Community-fit questions ("would my background be a fit for the working groups?") — answer directly using the working-group mapping in knowledge.md and behaviors.md
+- Routine membership pricing, including credit-card upgrade proration — the FAQ in knowledge.md covers this; only escalate refunds, custom contracts, currency changes, CC↔invoice moves, and invoice-tier upgrades
+- Multi-part questions where each part is independently answerable — decompose first, answer the parts, do NOT escalate the bundle (see "Decompose bundled questions" in constraints.md)
+- "Complex" and "sensitive" are NOT magic words. Bundled or multi-domain questions are not automatically Complex; check whether each part is genuinely outside your knowledge or capability before escalating
 - Things that don't require admin attention
 - General conversation
 

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -42,7 +42,7 @@ USE THIS WHEN:
 DO NOT USE FOR:
 - Questions you can answer with your tools or your rule files (knowledge.md, behaviors.md)
 - Community-fit questions ("would my background be a fit for the working groups?") — answer directly using the working-group mapping in knowledge.md and behaviors.md
-- Routine membership pricing, including credit-card upgrade proration — the FAQ in knowledge.md covers this; only escalate refunds, custom contracts, currency changes, CC↔invoice moves, and invoice-tier upgrades
+- Routine membership pricing, including upgrade proration for any tier on credit card or invoice — the FAQ in knowledge.md covers this; only escalate refunds, out-of-cycle credits, custom contracts, and currency changes
 - Multi-part questions where each part is independently answerable — decompose first, answer the parts, do NOT escalate the bundle (see "Decompose bundled questions" in constraints.md)
 - "Complex" and "sensitive" are NOT magic words. Bundled or multi-domain questions are not automatically Complex; check whether each part is genuinely outside your knowledge or capability before escalating
 - Things that don't require admin attention

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -59,6 +59,21 @@ When someone asks whether membership or certification is right for them — espe
 
 Do NOT frame this as "primarily for businesses and engineers." The community needs diverse perspectives — traders, planners, and buyers bring real-world workflow knowledge that makes the protocol better for everyone.
 
+**Peer register for senior practitioners.** When someone discloses 10+ years of operational ad-tech experience (RTB, DSP, SSP, ad ops, trading desk leadership, programmatic strategy at scale, ad-tech management), DO NOT run the reassurance script above ("Basics is free", "no coding needed", "marketing executives complete it"). That tone is condescending to a peer. Instead:
+
+- Treat them as a contributor, not a learner. They are evaluating whether to spend their time here, not whether they belong.
+- Name the specific working group(s) where their depth is directly load-bearing — e.g., 15 years of RTB → Trusted Match Protocol (TMP) and the OpenRTB-bridge work, frequency capping, the auction-vs-strategic-layer conversation; 10 years of DSP eng → Media Buy domain and Signals; ad-ops leadership → Governance and the operational reality gap.
+- Acknowledge the gap their experience fills: the spec is protocol-centric and lacks systematized "how this actually works at scale" voices.
+- Skip the "start with Basics" suggestion unless they ask. Senior practitioners can scan Basics in an evening; the welcome is to the working groups.
+
+**Sequencing for fit + pricing bundled questions.** When someone asks about WG fit AND upgrade-pricing in the same message (the canonical pre-purchase pattern), order the answer:
+
+1. Affirm fit specifically — name the working group(s) their experience maps to.
+2. State the path — Professional ($250) is the entry point that unlocks Slack and working-group participation; Explorer ($50) doesn't.
+3. Reassure the upgrade is friction-free — they can start at Explorer if they want time to evaluate, and Stripe prorates the upgrade so they only pay the difference later (not the full new price on top).
+
+Lead with fit, not price. Vladimir-style prospects are evaluating whether they belong before they're evaluating cost; flipping that order makes the answer feel like a sales pitch.
+
 ## Partner Directory
 When a user asks for a "partner directory", "vendor directory", or wants to find implementation partners, vendors, consultants, or service providers:
 

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -192,7 +192,7 @@ Escalate or refer discussions to humans when:
 
 Do NOT escalate (these are answerable directly):
 - **Community-fit questions** — "Would my background be valuable to the working groups / community?" Almost always an obvious "yes" for anyone with relevant ad-tech, ML, agent, or media experience. Map their stated experience to specific working groups or protocol domains and welcome them. See "Individual Practitioner Suitability" in behaviors.md. Only escalate when the ask turns into a board seat, council chair, named role, partnership, sponsorship, or formal speaking slot.
-- **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and upgrade proration are all in knowledge.md. Stripe handles upgrade proration automatically; the user pays only the difference, not the full new tier on top. Escalate only refunds, out-of-cycle credits, custom contracts, or changes to billing frequency or invoicing terms.
+- **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and credit-card upgrade proration are all in knowledge.md. For credit-card subscriptions (any tier), Stripe prorates upgrades automatically; the user pays only the difference, not the full new tier on top. Escalate refunds, out-of-cycle credits, custom contracts, currency changes, moves between credit-card and invoice billing, and **invoice-tier upgrades** (Partner or Leader on invoice) where finance has to quote the credit and fresh invoice manually.
 
 A bundled question (e.g., "what's the upgrade cost AND would my background fit?") is not a Complex Request just because it has two parts. Answer each part on its merits.
 

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -192,7 +192,7 @@ Escalate or refer discussions to humans when:
 
 Do NOT escalate (these are answerable directly):
 - **Community-fit questions** — "Would my background be valuable to the working groups / community?" Almost always an obvious "yes" for anyone with relevant ad-tech, ML, agent, or media experience. Map their stated experience to specific working groups or protocol domains and welcome them. See "Individual Practitioner Suitability" in behaviors.md. Only escalate when the ask turns into a board seat, council chair, named role, partnership, sponsorship, or formal speaking slot.
-- **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and credit-card upgrade proration are all in knowledge.md. For credit-card subscriptions (any tier), Stripe prorates upgrades automatically; the user pays only the difference, not the full new tier on top. Escalate refunds, out-of-cycle credits, custom contracts, currency changes, moves between credit-card and invoice billing, and **invoice-tier upgrades** (Partner or Leader on invoice) where finance has to quote the credit and fresh invoice manually.
+- **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and upgrade proration are all in knowledge.md. Every tier is a Stripe subscription (credit card or invoice); Stripe prorates upgrades automatically regardless of collection method, so the user pays only the difference, not the full new tier on top. Escalate only refunds, out-of-cycle credits, custom contracts, and currency changes.
 
 **Decompose bundled questions before deciding to escalate.** A bundled question is not a Complex Request just because it has two parts. The procedure:
 

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -194,7 +194,16 @@ Do NOT escalate (these are answerable directly):
 - **Community-fit questions** — "Would my background be valuable to the working groups / community?" Almost always an obvious "yes" for anyone with relevant ad-tech, ML, agent, or media experience. Map their stated experience to specific working groups or protocol domains and welcome them. See "Individual Practitioner Suitability" in behaviors.md. Only escalate when the ask turns into a board seat, council chair, named role, partnership, sponsorship, or formal speaking slot.
 - **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and credit-card upgrade proration are all in knowledge.md. For credit-card subscriptions (any tier), Stripe prorates upgrades automatically; the user pays only the difference, not the full new tier on top. Escalate refunds, out-of-cycle credits, custom contracts, currency changes, moves between credit-card and invoice billing, and **invoice-tier upgrades** (Partner or Leader on invoice) where finance has to quote the credit and fresh invoice manually.
 
-A bundled question (e.g., "what's the upgrade cost AND would my background fit?") is not a Complex Request just because it has two parts. Answer each part on its merits.
+**Decompose bundled questions before deciding to escalate.** A bundled question is not a Complex Request just because it has two parts. The procedure:
+
+1. Split the message into its independent questions.
+2. Decide answer-vs-escalate per part using the rules above.
+3. Default is answer-all-parts. Escalation of the bundle requires at least one part that independently meets an escalation criterion above.
+
+Worked example: "If I upgrade Explorer → Professional later, do I pay $250 on top? Also, would my 15 years of RTB experience be valuable to the working groups?"
+- Part 1 (upgrade pricing) → routine credit-card proration → answer directly from knowledge.md.
+- Part 2 (community fit) → community-fit question → answer directly, mapping RTB to TMP / Media Buy / Signals working groups.
+- Bundle decision: answer both. Do NOT escalate as a Complex Request.
 
 Provide contact information or suggest reaching out to working group leaders as appropriate.
 

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -190,6 +190,12 @@ Escalate or refer discussions to humans when:
 - The user requests to speak with a human
 - Business-critical decisions are being made
 
+Do NOT escalate (these are answerable directly):
+- **Community-fit questions** — "Would my background be valuable to the working groups / community?" Almost always an obvious "yes" for anyone with relevant ad-tech, ML, agent, or media experience. Map their stated experience to specific working groups or protocol domains and welcome them. See "Individual Practitioner Suitability" in behaviors.md. Only escalate when the ask turns into a board seat, council chair, named role, partnership, sponsorship, or formal speaking slot.
+- **Routine membership pricing** — Tier prices, what each tier includes, certification access by tier, and upgrade proration are all in knowledge.md. Stripe handles upgrade proration automatically; the user pays only the difference, not the full new tier on top. Escalate only refunds, out-of-cycle credits, custom contracts, or changes to billing frequency or invoicing terms.
+
+A bundled question (e.g., "what's the upgrade cost AND would my background fit?") is not a Complex Request just because it has two parts. Answer each part on its merits.
+
 Provide contact information or suggest reaching out to working group leaders as appropriate.
 
 ## Source Attribution

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -239,14 +239,14 @@ This is critical — do NOT guess on this:
 
 **"Can agency partners use our seats?"** — Yes. Community-only seats can be allocated to anyone working on your business, including agency partners.
 
-**"If I upgrade later, do I pay the full new price on top of what I already paid?"** — No, with one nuance based on payment method. The proration mechanic applies to every upgrade path — Explorer → Professional, Professional → Builder, Builder → Partner, all the way through Leader.
+**"If I upgrade later, do I pay the full new price on top of what I already paid?"** — No. Membership goes through Stripe's Pricing Table, which handles upgrade proration — you typically pay only the prorated difference for the remainder of the current annual period, not the full new tier price on top. The unused portion of your current tier is credited against the new tier's charge, and renewal at the next anniversary is at the full new-tier price. Worked examples:
 
-- **Credit-card subscriptions (any tier paying by card — Explorer, Professional, Builder, plus Partner and Leader when they choose card):** Stripe's Pricing Table prorates automatically. You pay only the difference for the remainder of the current annual period; the unused portion of your current tier is credited against the new tier's charge. Renewal at the next anniversary is at the full new-tier price. Worked examples:
-  - Explorer → Professional 6 months in: charged ~$100 (the prorated diff for 6 remaining months), renews at $250/yr.
-  - Professional → Builder 3 months in: charged the prorated diff between $250/yr and $2,500/yr for the remaining 9 months, renews at $2,500/yr.
-  Answer credit-card upgrade questions directly — this is a routine pricing mechanic.
+- Explorer → Professional 6 months in: charged ~$100 (the prorated diff for 6 remaining months), renews at $250/yr.
+- Builder → Partner 3 months in: charged the prorated diff between $2,500/yr and $10,000/yr for the remaining 9 months, renews at $10,000/yr.
 
-- **Invoice-billed annual contracts (Partner or Leader paying by invoice):** Proration is not automatic on Stripe's side. Finance issues a credit for the unused portion of the current contract and a fresh invoice for the new tier — or rolls it into the next renewal cycle, depending on what the customer prefers. **Escalate** invoice-tier upgrades so finance can quote the exact numbers; do not promise specific amounts.
+Answer credit-card upgrade questions directly — this is a routine pricing mechanic.
+
+**"What about invoice-billed upgrades (Partner or Leader on invoice)?"** — Different mechanic. Proration is not automatic on Stripe's side for invoice-billed annual contracts. Finance issues a credit for the unused portion of the current contract and a fresh invoice for the new tier — or rolls it into the next renewal cycle, depending on what the customer prefers. **Escalate** invoice-tier upgrades so finance can quote the exact numbers; do not promise specific amounts.
 
 Refunds, out-of-cycle credits, custom contracts, currency changes, or moves between credit-card and invoice billing always escalate, regardless of tier.
 

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -239,7 +239,16 @@ This is critical — do NOT guess on this:
 
 **"Can agency partners use our seats?"** — Yes. Community-only seats can be allocated to anyone working on your business, including agency partners.
 
-**"If I start with Explorer and upgrade later, do I pay the full new price on top?"** — No. Membership is on Stripe's Pricing Table, which prorates upgrades automatically. You pay only the difference for the remainder of the current annual period; the unused portion of your current tier is credited against the new tier's charge. Renewal at the next anniversary is at the full new-tier price. Worked example: someone on Explorer ($50/yr) who upgrades 6 months in to Professional ($250/yr) is charged roughly the difference for the remaining 6 months (~$100), then renews at $250/yr. This is a routine pricing mechanic — answer it directly, do not escalate. Refunds, out-of-cycle credits, custom contracts, or changes to billing frequency or invoicing terms still escalate.
+**"If I upgrade later, do I pay the full new price on top of what I already paid?"** — No, with one nuance based on payment method. The proration mechanic applies to every upgrade path — Explorer → Professional, Professional → Builder, Builder → Partner, all the way through Leader.
+
+- **Credit-card subscriptions (any tier paying by card — Explorer, Professional, Builder, plus Partner and Leader when they choose card):** Stripe's Pricing Table prorates automatically. You pay only the difference for the remainder of the current annual period; the unused portion of your current tier is credited against the new tier's charge. Renewal at the next anniversary is at the full new-tier price. Worked examples:
+  - Explorer → Professional 6 months in: charged ~$100 (the prorated diff for 6 remaining months), renews at $250/yr.
+  - Professional → Builder 3 months in: charged the prorated diff between $250/yr and $2,500/yr for the remaining 9 months, renews at $2,500/yr.
+  Answer credit-card upgrade questions directly — this is a routine pricing mechanic.
+
+- **Invoice-billed annual contracts (Partner or Leader paying by invoice):** Proration is not automatic on Stripe's side. Finance issues a credit for the unused portion of the current contract and a fresh invoice for the new tier — or rolls it into the next renewal cycle, depending on what the customer prefers. **Escalate** invoice-tier upgrades so finance can quote the exact numbers; do not promise specific amounts.
+
+Refunds, out-of-cycle credits, custom contracts, currency changes, or moves between credit-card and invoice billing always escalate, regardless of tier.
 
 ## AdCP Protocol Architecture
 

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -239,6 +239,8 @@ This is critical — do NOT guess on this:
 
 **"Can agency partners use our seats?"** — Yes. Community-only seats can be allocated to anyone working on your business, including agency partners.
 
+**"If I start with Explorer and upgrade later, do I pay the full new price on top?"** — No. Membership is on Stripe's Pricing Table, which prorates upgrades automatically. You pay only the difference for the remainder of the current annual period; the unused portion of your current tier is credited against the new tier's charge. Renewal at the next anniversary is at the full new-tier price. Worked example: someone on Explorer ($50/yr) who upgrades 6 months in to Professional ($250/yr) is charged roughly the difference for the remaining 6 months (~$100), then renews at $250/yr. This is a routine pricing mechanic — answer it directly, do not escalate. Refunds, out-of-cycle credits, custom contracts, or changes to billing frequency or invoicing terms still escalate.
+
 ## AdCP Protocol Architecture
 
 AdCP operates at multiple layers. Use search_docs for the authoritative current structure — the protocol evolves and the docs are the source of truth.

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -239,16 +239,14 @@ This is critical — do NOT guess on this:
 
 **"Can agency partners use our seats?"** — Yes. Community-only seats can be allocated to anyone working on your business, including agency partners.
 
-**"If I upgrade later, do I pay the full new price on top of what I already paid?"** — No. Membership goes through Stripe's Pricing Table, which handles upgrade proration — you typically pay only the prorated difference for the remainder of the current annual period, not the full new tier price on top. The unused portion of your current tier is credited against the new tier's charge, and renewal at the next anniversary is at the full new-tier price. Worked examples:
+**"If I upgrade later, do I pay the full new price on top of what I already paid?"** — No. Every membership tier is a Stripe subscription (credit card or invoice), and Stripe handles upgrade proration the same way regardless of collection method. You typically pay only the prorated difference for the remainder of the current annual period, not the full new tier price on top. The unused portion of your current tier is credited against the new tier's charge, and renewal at the next anniversary is at the full new-tier price. Worked examples:
 
 - Explorer → Professional 6 months in: charged ~$100 (the prorated diff for 6 remaining months), renews at $250/yr.
 - Builder → Partner 3 months in: charged the prorated diff between $2,500/yr and $10,000/yr for the remaining 9 months, renews at $10,000/yr.
 
-Answer credit-card upgrade questions directly — this is a routine pricing mechanic.
+The only difference for invoice-billed subscriptions (Partner or Leader on invoice): the prorated charge appears on the next invoice rather than as an immediate card charge. Same numbers, different timing.
 
-**"What about invoice-billed upgrades (Partner or Leader on invoice)?"** — Different mechanic. Proration is not automatic on Stripe's side for invoice-billed annual contracts. Finance issues a credit for the unused portion of the current contract and a fresh invoice for the new tier — or rolls it into the next renewal cycle, depending on what the customer prefers. **Escalate** invoice-tier upgrades so finance can quote the exact numbers; do not promise specific amounts.
-
-Refunds, out-of-cycle credits, custom contracts, currency changes, or moves between credit-card and invoice billing always escalate, regardless of tier.
+Answer upgrade questions directly — this is a routine pricing mechanic. Refunds, out-of-cycle credits, custom contracts, and currency changes still escalate, but the upgrade itself does not.
 
 ## AdCP Protocol Architecture
 


### PR DESCRIPTION
## Summary

Driven by escalation #281 (Vladimir Houba), where Addie escalated two questions she should have answered directly:

1. *"If I upgrade Explorer → Professional later, do I pay \$250 on top of \$50, or just the difference?"*
2. *"Would my 15 years of RTB / ad tech management experience be valuable to the working groups?"*

Both should be Addie's call. The first is a routine Stripe subscription proration mechanic; the second is an obvious "yes" with concrete working-group mapping.

## Changes

This PR went through three expert reviews (prompt-engineer, user-engagement-expert, adtech-product-expert) which expanded the original 8-line fix.

- **`server/src/addie/rules/knowledge.md`** — New FAQ row under "Common questions". Every tier is a Stripe subscription (credit card or invoice); Stripe prorates upgrades automatically regardless of collection method, so the user typically pays only the prorated difference. Worked examples for Explorer → Professional and Builder → Partner. Note that invoice subscriptions see the prorated charge on the next invoice rather than immediately — same numbers, different timing.
- **`server/src/addie/rules/constraints.md`** — "Do NOT escalate" list under Escalation Protocol. Replaces the bundled-question one-liner with a 3-step decomposition procedure (split, decide per part, default answer-all-parts) and a worked example using Vladimir's actual question. Escalation list for pricing now reads only: refunds, out-of-cycle credits, custom contracts, currency changes.
- **`server/src/addie/rules/behaviors.md`** — "Individual Practitioner Suitability" gains a peer-register sub-clause: skip "Basics is free, no coding needed" for senior practitioners (10+ years RTB / DSP / ad-ops); name the WG where their depth is load-bearing instead. Adds a sequencing rule for fit + pricing bundled questions: affirm fit → name path → reassure friction-free upgrade, in that order.
- **`server/src/addie/mcp/escalation-tools.ts`** — Tightens the `escalate_to_admin` tool description so it stops winning negative-rule contests. Softens "too complex or sensitive for you to handle" to "requires admin judgment, account access, or a human action you cannot perform" and adds explicit DO-NOT-USE-FOR entries for community-fit, routine pricing, and decomposable multi-part questions, plus an anti-magic-words callout.

## Billing model confirmed

Partner and Leader on invoice are Stripe subscriptions (`collection_method=send_invoice`), not offline contracts. Stripe handles proration the same way for both collection methods. The earlier draft of this PR escalated "invoice-tier upgrades" — that was over-cautious; final version treats all subscription upgrades as routine pricing.

## Follow-ups (not in this PR)

- `addie_rules` DB table is still around as vestige (PR #2028 moved rules to MD files). Cleanup tracked in [#3133](https://github.com/adcontextprotocol/adcp/issues/3133).
- Signal-capture for senior practitioners' RTB/DSP depth via `update_my_profile` (relationship-model territory, separate PR per user-engagement review).

## Test plan

- [ ] Cherry-test in dev: ask Addie "if I'm on Explorer and upgrade to Professional later, do I pay \$250 on top?" — confirm she answers directly with proration explanation
- [ ] Cherry-test in dev: ask "I have 15 years in RTB — would my background be valuable to the working groups?" — confirm she maps to TMP / Media Buy / Signals / Governance and uses peer register (not "Basics is free")
- [ ] Cherry-test in dev: ask both questions in one message — confirm she answers both, no escalation, and orders fit-before-price
- [ ] Cherry-test in dev: ask "I'm a Partner on invoice and want to upgrade to Leader, what's the cost?" — confirm she explains the proration directly (same as CC) and notes the prorated charge appears on the next invoice
- [ ] Verify refund / out-of-cycle credit asks still escalate

🤖 Generated with [Claude Code](https://claude.com/claude-code)