### PR TITLE
fix(brand-identity): logo registry tooling, validation, and admin queue

### DIFF
--- a/.changeset/brand-identity-tools-and-validation.md
+++ b/.changeset/brand-identity-tools-and-validation.md
@@ -1,0 +1,25 @@
+---
+---
+
+Brand identity hygiene + Addie tooling rework, triggered by two stuck-logo escalations (thehook.es, kyber1.com):
+
+**Member self-service**
+- `update_company_logo` — new member tool so a logged-in user can update their own logo or brand color through Addie chat. Was previously admin-only via `update_member_logo`, which forced an escalation for every "fix my logo" request.
+
+**Admin tooling**
+- `list_pending_brand_logos`, `list_brand_logos`, `review_brand_logo` — surface the registry approval queue and let aao-admin members approve/reject from any thread. `getPendingLogos` existed in the DB layer but had no caller, so uploads sat invisible until manually escalated.
+- Wired `update_member_logo` and `update_member_profile` into the `admin` tool set — they were defined but unreachable from the router, the same shape of gap that hid the new logo-review tools.
+- `canReviewBrandLogos` accepts the synthetic `admin_api_key` user so internal tooling can read pending logos via `GET /api/brands/:domain/logos`.
+
+**Validation hardening**
+- `checkLogoUrlIsImage` HEAD-fetches saved logo URLs and rejects responses that aren't `image/*`. Catches Google Drive `/view` and Dropbox preview pages that silently return HTML and render as a broken image once stored. Wired into both the member-facing `PUT /api/me/member-profile/brand-identity` and admin/member Addie tools.
+- `canonicalizeBrandDomain` strips `https://`, `www.`, `m.`, paths, queries, fragments, and lowercases. Applied on every brand-identity save so members no longer split-brain into separate `kyber1.com` / `www.kyber1.com` registry rows.
+
+**Resolver fixes**
+- `resolveBrandFromJson` accepts the singular `logo: {url}` shape and the `brand_colors` alias used by some real-world brand.json publishers (e.g. `house_portfolio` variants). Previously these brands appeared logoless on member surfaces despite declaring a valid logo. `referrals.ts` and `si-chat.ts` switched to the shared resolver instead of inline `brands[0].logos[0]` extraction.
+
+**UI fallback**
+- Logo `<img>` elements on the dashboard sidebar and member-profile page now swap to the placeholder when the URL fails to load (broken host, expired link, viewer page). Already-stored bad URLs no longer leave the section visually empty.
+
+**Refactor**
+- Extracted shared `updateBrandIdentity` service so the route handler, the new `update_company_logo` member tool, and the existing `update_member_logo` admin tool all run identical transaction logic, validation, and canonicalization.

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -3769,10 +3769,13 @@
           // Store profile data for use in action buttons
           window.currentMemberProfile = profile;
 
-          // Compact profile preview for sidebar card
+          // Compact profile preview for sidebar card. The onerror swap to the
+          // 🏢 placeholder catches the case where the saved logo URL is dead
+          // or returns HTML (Drive viewer, expired link, etc).
+          const fallbackLogoHtml = `<div style="width: 48px; height: 48px; border-radius: 8px; background: var(--color-bg-subtle); display: flex; align-items: center; justify-content: center; font-size: 20px;">🏢</div>`;
           const logoHtml = profile.resolved_brand?.logo_url
-            ? `<img src="${escapeHtml(profile.resolved_brand.logo_url)}" alt="" style="width: 48px; height: 48px; border-radius: 8px; object-fit: cover;">`
-            : `<div style="width: 48px; height: 48px; border-radius: 8px; background: var(--color-bg-subtle); display: flex; align-items: center; justify-content: center; font-size: 20px;">🏢</div>`;
+            ? `<img src="${escapeHtml(profile.resolved_brand.logo_url)}" alt="" style="width: 48px; height: 48px; border-radius: 8px; object-fit: cover;" onerror="this.outerHTML=${JSON.stringify(fallbackLogoHtml)}">`
+            : fallbackLogoHtml;
 
           const statusBadge = profile.is_public
             ? '<span style="display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; background: var(--color-success-100); color: var(--color-success-700); border-radius: 4px; font-size: 11px; font-weight: 500;">✓ Public</span>'

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1514,13 +1514,19 @@
         const manageLink = document.getElementById('brand-manage-link');
         manageLink.href = '/brands?domain=' + encodeURIComponent(profile.primary_brand_domain);
 
-        // Show logo if available
+        // Show logo if available. If the URL fails to load (broken host,
+        // viewer page that returns HTML, expired link), restore the
+        // "No logo" placeholder so the section never renders empty.
         const logoPreview = document.getElementById('brand-logo-preview');
         if (profile.resolved_brand?.logo_url) {
+          const placeholderHtml = logoPreview.innerHTML;
           var img = document.createElement('img');
           img.src = profile.resolved_brand.logo_url;
           img.style.cssText = 'max-width: 76px; max-height: 56px; object-fit: contain;';
           img.alt = '';
+          img.onerror = function() {
+            logoPreview.innerHTML = placeholderHtml;
+          };
           logoPreview.textContent = '';
           logoPreview.appendChild(img);
         }

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -113,10 +113,16 @@ import { assessHistoricalBehavior } from '../services/outreach-simulator.js';
 import { getMemberCapabilities } from '../../db/outbound-db.js';
 import { getActionItems as getActionItemsDb, type ActionStatus, type ActionType, type ActionPriority } from '../../db/account-management-db.js';
 import { captureEvent } from '../../utils/posthog.js';
+import { BrandLogoDatabase } from '../../db/brand-logo-db.js';
+import { rebuildManifestLogos } from '../../services/brand-logo-service.js';
+import { updateBrandIdentity, BrandIdentityError } from '../../services/brand-identity.js';
+import { canonicalizeBrandDomain } from '../../services/identifier-normalization.js';
 
 const logger = createLogger('addie-admin-tools');
 const orgDb = new OrganizationDatabase();
 const slackDb = new SlackDatabase();
+const brandLogoDb = new BrandLogoDatabase();
+const brandDbForLogos = new BrandDatabase();
 const wgDb = new WorkingGroupDatabase();
 
 // The slug for the AAO admin working group
@@ -1503,6 +1509,71 @@ For logo changes, use update_member_logo instead.`,
         },
       },
       required: [],
+    },
+  },
+
+  // ============================================
+  // BRAND LOGO REVIEW TOOLS
+  // ============================================
+  {
+    name: 'list_pending_brand_logos',
+    description: 'List brand logos awaiting moderator review across the registry. Returns logo IDs, domains, uploader email, tags, and how long they have been pending. Use this to triage the registry approval queue or answer "what logos need approval?"',
+    usage_hints: 'Pair with review_brand_logo to approve or reject from the queue. Pending logos block the company-listing display until reviewed.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum logos to return (default 25, max 100)',
+        },
+        offset: {
+          type: 'number',
+          description: 'Pagination offset (default 0)',
+        },
+      },
+    },
+  },
+  {
+    name: 'list_brand_logos',
+    description: 'List every logo for ONE specific brand domain — pending, approved, rejected, deleted — to investigate why a brand\'s logo is or is not displaying. Use this when you have a domain in hand. For the global moderation queue across all domains, use list_pending_brand_logos instead.',
+    usage_hints: 'Use when a member reports their logo is "disappearing" or stuck on a known domain. Pending status means an admin must approve via review_brand_logo.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        domain: {
+          type: 'string',
+          description: 'Brand domain (e.g., "thehook.es")',
+        },
+      },
+      required: ['domain'],
+    },
+  },
+  {
+    name: 'review_brand_logo',
+    description: 'Approve, reject, or delete a pending brand logo. Approving makes it visible on the brand\'s company listing; rejecting hides it; deleting tombstones it. Triggers manifest rebuild on approve for unverified brands.',
+    usage_hints: 'Get the logo_id from list_pending_brand_logos or list_brand_logos. Always include a short note explaining the decision so the uploader gets useful feedback.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        domain: {
+          type: 'string',
+          description: 'Brand domain the logo belongs to',
+        },
+        logo_id: {
+          type: 'string',
+          description: 'Logo UUID (from list_pending_brand_logos)',
+        },
+        action: {
+          type: 'string',
+          enum: ['approve', 'reject', 'delete'],
+          description: 'approve = publish, reject = hide with reason, delete = tombstone',
+        },
+        note: {
+          type: 'string',
+          description: 'Reviewer note (max 500 chars). Required for reject/delete; helpful on approve.',
+        },
+      },
+      required: ['domain', 'logo_id', 'action'],
     },
   },
 ];
@@ -7693,22 +7764,8 @@ Use add_committee_leader to assign a leader.`;
       return '❌ Provide either org_name or slug to identify the member.';
     }
 
-    // Validate the logo URL
-    try {
-      const parsed = new URL(logoUrl);
-      if (parsed.protocol !== 'https:') {
-        return '❌ logo_url must use HTTPS.';
-      }
-    } catch {
-      return `❌ Invalid logo_url: "${logoUrl}". Provide a fully-qualified HTTPS URL.`;
-    }
-    if (logoUrl.length > 2000) {
-      return '❌ logo_url must be 2000 characters or less.';
-    }
-
     try {
       const mDb = new MemberDatabase();
-      const bDb = new BrandDatabase();
 
       // Find the member profile
       let profile = null;
@@ -7734,111 +7791,24 @@ Use add_committee_leader to assign a leader.`;
         return `❌ No member profile found for "${orgName || slug}". Use get_account to verify they exist.`;
       }
 
-      // Determine brand domain: use existing link or derive from contact_website
-      let brandDomain = profile.primary_brand_domain;
-      if (!brandDomain) {
-        if (profile.contact_website) {
-          try {
-            brandDomain = new URL(profile.contact_website).hostname;
-          } catch {
-            brandDomain = undefined;
-          }
-        }
-        if (!brandDomain) {
-          return `❌ No brand domain set for **${profile.display_name}**. Ask them to add their website to their profile first, or set primary_brand_domain manually.`;
-        }
-      }
-
-      // Use a transaction so both the brand update and profile link succeed or fail together
-      const pool = getPool();
-      const client = await pool.connect();
-      let wasUpdate = false;
       try {
-        await client.query('BEGIN');
-
-        // Read inside transaction with row lock to prevent concurrent insert race
-        const existingResult = await client.query(
-          'SELECT id, workos_organization_id, brand_manifest AS brand_json FROM brands WHERE domain = $1 FOR UPDATE',
-          [brandDomain]
-        );
-        const existing = existingResult.rows[0] || null;
-        wasUpdate = !!existing;
-
-        // Warn if admin tool is crossing org boundaries
-        if (existing && existing.workos_organization_id && existing.workos_organization_id !== profile.workos_organization_id) {
-          logger.warn(
-            { brandDomain, existingOrgId: existing.workos_organization_id, targetOrgId: profile.workos_organization_id },
-            'Admin tool updating brand owned by a different organization'
-          );
+        const result = await updateBrandIdentity({
+          workosOrganizationId: profile.workos_organization_id,
+          displayName: profile.display_name,
+          profile,
+          logoUrl,
+        });
+        invalidateMemberContextCache();
+        const action = result.wasUpdate ? 'updated' : 'set';
+        logger.info({ profileId: profile.id, brandDomain: result.brandDomain, logoUrl, action }, 'Member logo updated');
+        return `✅ Logo ${action} for **${profile.display_name}**.\n- Domain: ${result.brandDomain}\n- Logo: ${logoUrl}`;
+      } catch (err) {
+        if (err instanceof BrandIdentityError) {
+          return `❌ ${err.message}`;
         }
-
-        if (existing) {
-          // Update logo in existing hosted brand
-          const bj = { ...(existing.brand_json as Record<string, unknown>) };
-          const brands = (bj.brands as Array<Record<string, unknown>> | undefined) ?? [];
-          if (brands.length > 0) {
-            const primaryBrand = { ...brands[0] };
-            const logos = (primaryBrand.logos as Array<Record<string, unknown>> | undefined) ?? [];
-            primaryBrand.logos = logos.length > 0
-              ? [{ ...logos[0], url: logoUrl }, ...logos.slice(1)]
-              : [{ url: logoUrl }];
-            bj.brands = [primaryBrand, ...brands.slice(1)];
-          } else {
-            bj.brands = [{
-              id: profile.display_name.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
-              names: [{ en: profile.display_name }],
-              logos: [{ url: logoUrl }],
-              colors: {},
-            }];
-          }
-          await client.query(
-            'UPDATE brands SET brand_manifest = $1, updated_at = NOW() WHERE id = $2',
-            [JSON.stringify(bj), existing.id]
-          );
-        } else {
-          // Create a new hosted brand entry
-          const brandJson = {
-            house: { domain: brandDomain, name: profile.display_name },
-            brands: [{
-              id: profile.display_name.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
-              names: [{ en: profile.display_name }],
-              logos: [{ url: logoUrl }],
-              colors: {},
-            }],
-          };
-          await client.query(
-            `INSERT INTO brands (workos_organization_id, domain, brand_manifest, brand_name, source_type, review_status, is_public, has_brand_manifest)
-             VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), 'community', 'approved', $4, true)
-             ON CONFLICT (domain) DO UPDATE SET
-               brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
-               workos_organization_id = COALESCE(EXCLUDED.workos_organization_id, brands.workos_organization_id),
-               is_public = COALESCE(EXCLUDED.is_public, brands.is_public),
-               has_brand_manifest = true,
-               updated_at = NOW()`,
-            [profile.workos_organization_id, brandDomain, JSON.stringify(brandJson), true]
-          );
-        }
-
-        // Link the profile to this brand domain if not already set
-        if (!profile.primary_brand_domain) {
-          await client.query(
-            'UPDATE member_profiles SET primary_brand_domain = $1, updated_at = NOW() WHERE id = $2',
-            [brandDomain, profile.id]
-          );
-        }
-
-        await client.query('COMMIT');
-      } catch (error) {
-        await client.query('ROLLBACK');
-        throw error;
-      } finally {
-        client.release();
+        logger.error({ error: err, orgName, slug, logoUrl }, 'Error updating member logo');
+        return `❌ Failed to update logo: ${err instanceof Error ? err.message : 'Unknown error'}`;
       }
-
-      invalidateMemberContextCache();
-      const action = wasUpdate ? 'updated' : 'set';
-      logger.info({ profileId: profile.id, brandDomain, logoUrl, action }, 'Member logo updated');
-      return `✅ Logo ${action} for **${profile.display_name}**.\n- Domain: ${brandDomain}\n- Logo: ${logoUrl}`;
     } catch (error) {
       logger.error({ error, orgName, slug, logoUrl }, 'Error updating member logo');
       return `❌ Failed to update logo: ${error instanceof Error ? error.message : 'Unknown error'}`;
@@ -8382,6 +8352,141 @@ Use add_committee_leader to assign a leader.`;
     } catch (error) {
       logger.error({ error }, 'Error fetching action items');
       throw new ToolError(`Failed to fetch action items: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  });
+
+  // ============================================
+  // BRAND LOGO REVIEW HANDLERS
+  // ============================================
+
+  handlers.set('list_pending_brand_logos', async (input) => {
+    const limit = Math.min(Math.max((input.limit as number) ?? 25, 1), 100);
+    const offset = Math.max((input.offset as number) ?? 0, 0);
+
+    try {
+      const pending = await brandLogoDb.getPendingLogos(limit, offset);
+      if (pending.length === 0) {
+        return JSON.stringify({ success: true, message: 'No brand logos pending review.', count: 0, logos: [] });
+      }
+
+      const now = Date.now();
+      const logos = pending.map(l => ({
+        logo_id: l.id,
+        domain: l.domain,
+        brand_name: l.brand_name ?? null,
+        content_type: l.content_type,
+        source: l.source,
+        tags: l.tags,
+        width: l.width,
+        height: l.height,
+        uploaded_by_email: l.uploaded_by_email,
+        upload_note: l.upload_note,
+        created_at: l.created_at,
+        age_hours: Math.round((now - new Date(l.created_at).getTime()) / 3_600_000),
+        preview_url: `/logos/brands/${l.domain}/${l.id}`,
+      }));
+
+      return JSON.stringify({ success: true, count: logos.length, logos }, null, 2);
+    } catch (error) {
+      logger.error({ error }, 'Error listing pending brand logos');
+      throw new ToolError(`Failed to list pending brand logos: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  });
+
+  handlers.set('list_brand_logos', async (input) => {
+    const rawDomain = input.domain as string;
+    if (!rawDomain) throw new ToolError('domain is required');
+    const domain = canonicalizeBrandDomain(rawDomain);
+
+    try {
+      const logos = await brandLogoDb.listBrandLogos(domain, { include_all_statuses: true });
+      const summary = logos.map(l => ({
+        logo_id: l.id,
+        review_status: l.review_status,
+        source: l.source,
+        content_type: l.content_type,
+        tags: l.tags,
+        width: l.width,
+        height: l.height,
+        uploaded_by_email: l.uploaded_by_email,
+        upload_note: l.upload_note,
+        review_note: l.review_note,
+        reviewed_at: l.reviewed_at,
+        created_at: l.created_at,
+        preview_url: `/logos/brands/${domain}/${l.id}`,
+      }));
+
+      const counts = summary.reduce<Record<string, number>>((acc, l) => {
+        acc[l.review_status] = (acc[l.review_status] ?? 0) + 1;
+        return acc;
+      }, {});
+
+      return JSON.stringify({ success: true, domain, total: summary.length, by_status: counts, logos: summary }, null, 2);
+    } catch (error) {
+      logger.error({ error, domain }, 'Error listing brand logos');
+      throw new ToolError(`Failed to list logos for ${domain}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  });
+
+  handlers.set('review_brand_logo', async (input) => {
+    const rawDomain = input.domain as string;
+    const logoId = input.logo_id as string;
+    const action = input.action as string;
+    const note = typeof input.note === 'string' ? input.note.slice(0, 500) : undefined;
+
+    if (!rawDomain) throw new ToolError('domain is required');
+    if (!logoId) throw new ToolError('logo_id is required');
+    if (!action) throw new ToolError('action is required');
+
+    const domain = canonicalizeBrandDomain(rawDomain);
+    const statusMap: Record<string, 'approved' | 'rejected' | 'deleted'> = {
+      approve: 'approved',
+      reject: 'rejected',
+      delete: 'deleted',
+    };
+    const status = statusMap[action];
+    if (!status) throw new ToolError(`Invalid action "${action}". Must be approve, reject, or delete.`);
+
+    if ((status === 'rejected' || status === 'deleted') && !note) {
+      throw new ToolError(`A note is required when you ${action} a logo so the uploader gets useful feedback.`);
+    }
+
+    const reviewerId = memberContext?.workos_user?.workos_user_id ?? 'system:addie-admin';
+
+    try {
+      const updated = await brandLogoDb.updateLogoReviewStatus(logoId, domain, status, reviewerId, note);
+      if (!updated) {
+        throw new ToolError(`Logo ${logoId} not found for domain ${domain}.`);
+      }
+
+      if (status === 'approved') {
+        const hosted = await brandDbForLogos.getHostedBrandByDomain(domain);
+        if (!hosted || !hosted.domain_verified) {
+          await rebuildManifestLogos(domain, brandLogoDb, brandDbForLogos);
+        }
+        try {
+          await brandDbForLogos.editDiscoveredBrand(domain, {
+            edit_summary: `Logo approved by ${reviewerId}`,
+            editor_user_id: reviewerId,
+            editor_email: memberContext?.workos_user?.email ?? 'addie@agenticadvertising.org',
+          });
+        } catch {
+          // Non-critical — approval succeeded regardless
+        }
+      }
+
+      logger.info({ logoId, domain, action, reviewerId }, 'Addie: brand logo reviewed');
+      return JSON.stringify({
+        success: true,
+        logo_id: logoId,
+        domain,
+        review_status: status,
+        note: note ?? null,
+      }, null, 2);
+    } catch (error) {
+      if (error instanceof ToolError) throw error;
+      logger.error({ error, logoId, domain, action }, 'Error reviewing brand logo');
+      throw new ToolError(`Failed to ${action} logo: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   });
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -56,6 +56,8 @@ import {
   getPendingProposals,
 } from '../../db/industry-feeds-db.js';
 import { MemberDatabase } from '../../db/member-db.js';
+import { updateBrandIdentity, BrandIdentityError } from '../../services/brand-identity.js';
+import { canonicalizeBrandDomain } from '../../services/identifier-normalization.js';
 import { ComplianceDatabase } from '../../db/compliance-db.js';
 import { getPool, query } from '../../db/client.js';
 import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-db.js';
@@ -636,8 +638,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'update_company_listing',
     description:
-      "Update the company's directory listing — how the organization appears in the member directory and to Addie. Can update tagline, description, contact info, social links, and headquarters. Only updates fields that are provided.",
-    usage_hints: 'use when user wants to update company tagline, description, contact info, or directory listing',
+      "Update the company's directory listing text fields — tagline, description, contact info, social links, and headquarters. Only updates fields that are provided. For logo or brand color, use update_company_logo instead.",
+    usage_hints: 'use when user wants to update company tagline, description, contact info, or directory listing. For logo or brand color, use update_company_logo instead.',
     input_schema: {
       type: 'object',
       properties: {
@@ -657,6 +659,26 @@ export const MEMBER_TOOLS: AddieTool[] = [
         linkedin_url: { type: 'string', description: 'LinkedIn company page URL' },
         twitter_url: { type: 'string', description: 'Twitter/X profile URL' },
         headquarters: { type: 'string', description: 'Headquarters location (e.g., "New York, NY")' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'update_company_logo',
+    description:
+      "Update the company logo or brand color on the directory listing. Use when a member wants to upload, change, or fix their company logo. The logo URL must be a publicly accessible HTTPS image (PNG, JPG, SVG, etc.) — file-viewer links like Google Drive don't work.",
+    usage_hints: 'Use when the user says "update our logo", "fix my company logo", "set the brand color", or shares a logo URL. Validates that the URL returns an actual image before saving.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        logo_url: {
+          type: 'string',
+          description: 'Public HTTPS URL to the logo image (PNG, JPG, SVG, WebP). Omit to leave unchanged.',
+        },
+        brand_color: {
+          type: 'string',
+          description: 'Primary brand color as a hex string (e.g., "#FF5733"). Omit to leave unchanged.',
+        },
       },
       required: [],
     },
@@ -2061,6 +2083,62 @@ export function createMemberToolHandlers(
 
     const updatedFields = Object.keys(updates).join(', ');
     return `Company listing updated! Updated: ${updatedFields}\n\nView at https://agenticadvertising.org/members/`;
+  });
+
+  handlers.set('update_company_logo', async (input) => {
+    if (!memberContext?.workos_user?.workos_user_id) {
+      return 'You need to be logged in to update your company logo. Please log in at https://agenticadvertising.org/dashboard first.';
+    }
+
+    const logoUrl = typeof input.logo_url === 'string' ? input.logo_url.trim() : undefined;
+    const brandColor = typeof input.brand_color === 'string' ? input.brand_color.trim() : undefined;
+    if (!logoUrl && !brandColor) {
+      return 'Provide a logo_url or brand_color to update.';
+    }
+
+    const orgId = memberContext.organization?.workos_organization_id;
+    if (!orgId) {
+      return "Your account isn't linked to an organization yet. Visit https://agenticadvertising.org/member-profile to set up your company listing.";
+    }
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    if (!profile) {
+      return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one first!";
+    }
+
+    let fallbackDomainHint: string | undefined;
+    if (!profile.primary_brand_domain && !profile.contact_website && logoUrl) {
+      try {
+        fallbackDomainHint = canonicalizeBrandDomain(new URL(logoUrl).hostname);
+      } catch { /* validated below */ }
+    }
+
+    try {
+      const result = await updateBrandIdentity({
+        workosOrganizationId: orgId,
+        displayName: profile.display_name,
+        profile,
+        logoUrl,
+        brandColor,
+        fallbackDomainHint,
+      });
+      // Dynamic import: member-context.js transitively constructs a WorkOS
+      // client at module load, which would break tests that import this file
+      // without WORKOS_API_KEY in the env. Loading it here defers that until
+      // the handler actually runs.
+      const { invalidateMemberContextCache } = await import('../member-context.js');
+      invalidateMemberContextCache();
+      const parts: string[] = [];
+      if (logoUrl) parts.push(`logo set to ${logoUrl}`);
+      if (brandColor) parts.push(`brand color set to ${brandColor}`);
+      return `Done — ${parts.join(', ')} for ${profile.display_name} (${result.brandDomain}). It may take a moment for the change to appear in the member directory.`;
+    } catch (err) {
+      if (err instanceof BrandIdentityError) {
+        return err.message;
+      }
+      logger.error({ err, orgId }, 'update_company_logo: failed');
+      return 'Something went wrong updating your logo. Please try again, or edit directly at https://agenticadvertising.org/member-profile';
+    }
   });
 
   // ============================================

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -119,12 +119,13 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     // conversation. Duplicating them here caused Sonnet to hallucinate that
     // content submission/retrieval and outreach preferences were unavailable
     // when the router didn't pick `member`. See #2998.
-    description: 'Manage member profile, working groups, committees, and account settings. Includes listing working group documents and attaching assets to content.',
+    description: 'Manage member profile, working groups, committees, and account settings. Includes listing working group documents, attaching assets to content, and updating the company logo or brand color.',
     tools: [
       'get_my_profile',
       'update_my_profile',
       'get_company_listing',
       'update_company_listing',
+      'update_company_logo',
       'list_working_groups',
       'get_working_group',
       'join_working_group',
@@ -294,7 +295,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     // admins regardless of routing. Duplicating them here caused Sonnet to
     // hallucinate that escalation management was unavailable when `admin` wasn't
     // selected. See #2998.
-    description: 'Administrative operations - manage prospects, organizations, feeds, escalations, user roles, committee/working group leadership, event management (create/update events, manage registrations, invites, attendee lists), member insights and engagement analytics, community-wide engagement ranking (admin only)',
+    description: 'Administrative operations - manage prospects, organizations, feeds, escalations, user roles, committee/working group leadership, event management (create/update events, manage registrations, invites, attendee lists), member insights and engagement analytics, community-wide engagement ranking, brand logo registry review queue (approve/reject pending logos), edit a member\'s directory profile or logo on their behalf (admin only)',
     tools: [
       // Event management (admin)
       'create_event',
@@ -356,6 +357,11 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'send_outreach',
       'lookup_person',
       'get_action_items',
+      'list_pending_brand_logos',
+      'list_brand_logos',
+      'review_brand_logo',
+      'update_member_logo',
+      'update_member_profile',
     ],
     adminOnly: true,
   },

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -12,6 +12,14 @@ import type {
 /**
  * Extract logos and colors from a brand JSON structure, resolving both
  * light-background and dark-background logo URLs.
+ *
+ * Real brand.json files use several shapes for the logo field:
+ *  - brands[0].logos: [{url, ...}]   (per-brand array)
+ *  - logos: [{url, ...}]             (top-level array)
+ *  - logo: {url, ...}                (singular object — schema-valid at brand level)
+ * Colors may appear as `colors` or `brand_colors` at top level.
+ * Resolve all of them so a publisher who follows the spec but picks the
+ * shorter idiom doesn't silently lose their logo on member surfaces.
  */
 export function resolveBrandFromJson(
   domain: string,
@@ -20,8 +28,19 @@ export function resolveBrandFromJson(
 ): MemberBrandInfo {
   const brands = brandJson.brands as Array<Record<string, unknown>> | undefined;
   const primaryBrand = brands?.[0];
-  const logos = (primaryBrand?.logos ?? brandJson.logos) as Array<Record<string, unknown>> | undefined;
-  const colors = (primaryBrand?.colors ?? brandJson.colors) as Record<string, unknown> | undefined;
+
+  const collectLogos = (source: Record<string, unknown> | undefined): Array<Record<string, unknown>> | undefined => {
+    if (!source) return undefined;
+    if (Array.isArray(source.logos)) return source.logos as Array<Record<string, unknown>>;
+    if (source.logo && typeof source.logo === 'object') return [source.logo as Record<string, unknown>];
+    return undefined;
+  };
+
+  const logos = collectLogos(primaryBrand) ?? collectLogos(brandJson);
+  const colors = (primaryBrand?.colors
+    ?? brandJson.colors
+    ?? primaryBrand?.brand_colors
+    ?? brandJson.brand_colors) as Record<string, unknown> | undefined;
 
   const typedLogos: BrandLogo[] | undefined = logos
     ?.filter(l => typeof l.url === 'string' && l.url)

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -26,6 +26,8 @@ import { VALID_MEMBER_OFFERINGS, isValidAgentVisibility } from "../types.js";
 import type { MemberBrandInfo, AgentVisibility, AgentConfig } from "../types.js";
 import type { CrawlerService } from "../crawler.js";
 import { validateCrawlDomain } from "../utils/url-security.js";
+import { canonicalizeBrandDomain } from "../services/identifier-normalization.js";
+import { updateBrandIdentity, BrandIdentityError } from "../services/brand-identity.js";
 import { recordProfilePublishedIfNeeded } from "../services/profile-publish-event.js";
 import { gateAgentVisibilityForCaller, type VisibilityWarning } from "../services/agent-visibility-gate.js";
 
@@ -1175,32 +1177,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       const requestedOrgId = req.query.org as string | undefined;
       const { logo_url, brand_color } = req.body;
 
-      // Validate inputs
-      if (!logo_url && !brand_color) {
-        return res.status(400).json({
-          error: 'Missing fields',
-          message: 'Provide at least one of logo_url or brand_color.',
-        });
-      }
-
-      if (logo_url) {
-        try {
-          const parsed = new URL(logo_url);
-          if (parsed.protocol !== 'https:') {
-            return res.status(400).json({ error: 'Invalid logo URL', message: 'logo_url must use HTTPS.' });
-          }
-        } catch {
-          return res.status(400).json({ error: 'Invalid logo URL', message: 'logo_url must be a valid URL.' });
-        }
-        if (logo_url.length > 2000) {
-          return res.status(400).json({ error: 'Invalid logo URL', message: 'logo_url must be 2000 characters or less.' });
-        }
-      }
-
-      if (brand_color && !/^#[0-9a-fA-F]{6}$/.test(brand_color)) {
-        return res.status(400).json({ error: 'Invalid brand color', message: 'brand_color must be a hex color (e.g., #FF5733).' });
-      }
-
       // Auth: resolve target org (same pattern as /visibility route)
       const isDevUserProfile = isDevModeEnabled() && Object.values(DEV_USERS).some(du => du.id === user.id) && requestedOrgId?.startsWith('org_dev_');
       let targetOrgId: string;
@@ -1229,7 +1205,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
 
       const profile = await memberDb.getProfileByOrgId(targetOrgId);
 
-      // Resolve org name for brand_json (profile display_name if available, else org table)
+      // Resolve display name: profile if available, else org name
       let displayName: string;
       if (profile?.display_name) {
         displayName = profile.display_name;
@@ -1241,119 +1217,43 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         displayName = org.name;
       }
 
-      // Derive brand domain: profile fields first, then logo URL hostname
-      let brandDomain = profile?.primary_brand_domain;
-      if (!brandDomain && profile?.contact_website) {
-        try { brandDomain = new URL(profile.contact_website).hostname; } catch { /* ignore */ }
-      }
-      if (!brandDomain && logo_url) {
+      // If no brand domain on file, fall back to the logo URL hostname (only if
+      // the candidate domain isn't already owned by another org)
+      let fallbackDomainHint: string | undefined;
+      if (!profile?.primary_brand_domain && !profile?.contact_website && logo_url) {
         try {
-          const candidate = new URL(logo_url).hostname;
+          const candidate = canonicalizeBrandDomain(new URL(logo_url).hostname);
           const existingBrand = await brandDb.getHostedBrandByDomain(candidate);
           if (!existingBrand || !existingBrand.workos_organization_id || existingBrand.workos_organization_id === targetOrgId) {
-            brandDomain = candidate;
+            fallbackDomainHint = candidate;
           }
         } catch { /* ignore */ }
       }
-      if (!brandDomain) {
-        return res.status(400).json({
-          error: 'No brand domain',
-          message: 'Provide a logo URL hosted on your own domain so we can determine your brand domain.',
-        });
-      }
-      brandDomain = brandDomain.toLowerCase();
 
-      // Transaction: update/create hosted brand + link profile if it exists
-      const pool = getPool();
-      const client = await pool.connect();
+      let result;
       try {
-        await client.query('BEGIN');
-
-        // Read inside transaction with row lock to prevent concurrent insert race
-        const existingResult = await client.query(
-          'SELECT id, workos_organization_id, brand_manifest AS brand_json FROM brands WHERE domain = $1 FOR UPDATE',
-          [brandDomain]
-        );
-        const existing = existingResult.rows[0] || null;
-
-        // Ownership check: don't let one org overwrite another org's brand
-        if (existing && existing.workos_organization_id && existing.workos_organization_id !== targetOrgId) {
-          throw Object.assign(new Error('This brand domain is managed by another organization.'), { statusCode: 403 });
+        result = await updateBrandIdentity({
+          workosOrganizationId: targetOrgId,
+          displayName,
+          profile: profile ?? null,
+          logoUrl: logo_url,
+          brandColor: brand_color,
+          fallbackDomainHint,
+        });
+      } catch (err: any) {
+        if (err instanceof BrandIdentityError) {
+          return res.status(err.statusCode).json({ error: 'Invalid request', message: err.message });
         }
-
-        if (existing) {
-          const bj = { ...(existing.brand_json as Record<string, unknown>) };
-          const brands = (bj.brands as Array<Record<string, unknown>> | undefined) ?? [];
-          if (brands.length > 0) {
-            const primaryBrand = { ...brands[0] };
-            if (logo_url) {
-              const logos = (primaryBrand.logos as Array<Record<string, unknown>> | undefined) ?? [];
-              primaryBrand.logos = logos.length > 0
-                ? [{ ...logos[0], url: logo_url }, ...logos.slice(1)]
-                : [{ url: logo_url }];
-            }
-            if (brand_color) {
-              primaryBrand.colors = { ...(primaryBrand.colors as Record<string, unknown> || {}), primary: brand_color };
-            }
-            bj.brands = [primaryBrand, ...brands.slice(1)];
-          } else {
-            bj.brands = [{
-              id: displayName.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
-              names: [{ en: displayName }],
-              logos: logo_url ? [{ url: logo_url }] : [],
-              colors: brand_color ? { primary: brand_color } : {},
-            }];
-          }
-          await client.query(
-            'UPDATE brands SET brand_manifest = $1, workos_organization_id = COALESCE(workos_organization_id, $3), updated_at = NOW() WHERE id = $2',
-            [JSON.stringify(bj), existing.id, targetOrgId]
-          );
-        } else {
-          const brandJson = {
-            house: { domain: brandDomain, name: displayName },
-            brands: [{
-              id: displayName.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
-              names: [{ en: displayName }],
-              logos: logo_url ? [{ url: logo_url }] : [],
-              colors: brand_color ? { primary: brand_color } : {},
-            }],
-          };
-          await client.query(
-            `INSERT INTO brands (workos_organization_id, domain, brand_manifest, brand_name, source_type, review_status, is_public, has_brand_manifest)
-             VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), 'community', 'approved', $4, true)
-             ON CONFLICT (domain) DO UPDATE SET
-               brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
-               workos_organization_id = COALESCE(EXCLUDED.workos_organization_id, brands.workos_organization_id),
-               is_public = COALESCE(EXCLUDED.is_public, brands.is_public),
-               has_brand_manifest = true,
-               updated_at = NOW()`,
-            [targetOrgId, brandDomain, JSON.stringify(brandJson), true]
-          );
-        }
-
-        // Link brand domain back to profile if profile exists and doesn't have one
-        if (profile && !profile.primary_brand_domain) {
-          await client.query(
-            'UPDATE member_profiles SET primary_brand_domain = $1, updated_at = NOW() WHERE id = $2',
-            [brandDomain, profile.id]
-          );
-        }
-
-        await client.query('COMMIT');
-      } catch (error) {
-        await client.query('ROLLBACK');
-        throw error;
-      } finally {
-        client.release();
+        throw err;
       }
 
-      const resolvedBrand = await resolveBrand(brandDb, brandDomain);
+      const resolvedBrand = await resolveBrand(brandDb, result.brandDomain);
       invalidateMemberContextCache();
 
       const duration = Date.now() - startTime;
-      logger.info({ profileId: profile?.id, orgId: targetOrgId, brandDomain, durationMs: duration }, 'Brand identity updated');
+      logger.info({ profileId: profile?.id, orgId: targetOrgId, brandDomain: result.brandDomain, durationMs: duration }, 'Brand identity updated');
 
-      res.json({ brand: resolvedBrand, brand_domain: brandDomain });
+      res.json({ brand: resolvedBrand, brand_domain: result.brandDomain });
     } catch (error: any) {
       const duration = Date.now() - startTime;
       const statusCode = error?.statusCode || 500;

--- a/server/src/routes/referrals.ts
+++ b/server/src/routes/referrals.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { createLogger } from '../logger.js';
 import { getReferralCode, acceptReferralCode, getAcceptedReferralForOrg } from '../db/referral-codes-db.js';
 import { MemberDatabase } from '../db/member-db.js';
-import { BrandDatabase } from '../db/brand-db.js';
+import { BrandDatabase, resolveBrandFromJson } from '../db/brand-db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { query } from '../db/client.js';
 import { emailPrefsDb } from '../db/email-preferences-db.js';
@@ -47,24 +47,19 @@ export function createReferralsRouter(): Router {
       let logo_url: string | null = null;
       let brand_color: string | null = null;
       if (profile?.primary_brand_domain) {
-        const hosted = await brandDb.getHostedBrandByDomain(profile.primary_brand_domain);
-        if (hosted) {
-          const bj = hosted.brand_json as Record<string, unknown>;
-          const brands = bj.brands as Array<Record<string, unknown>> | undefined;
-          const primary = brands?.[0];
-          const logos = primary?.logos as Array<Record<string, unknown>> | undefined;
-          const colors = primary?.colors as Record<string, unknown> | undefined;
-          logo_url = (logos?.[0]?.url as string) || null;
-          brand_color = (colors?.primary as string) || null;
+        const domain = profile.primary_brand_domain;
+        const hosted = await brandDb.getHostedBrandByDomain(domain);
+        if (hosted?.brand_json) {
+          const resolved = resolveBrandFromJson(domain, hosted.brand_json as Record<string, unknown>, hosted.domain_verified ?? false);
+          logo_url = resolved.logo_url ?? null;
+          brand_color = resolved.brand_color ?? null;
         }
         if (!logo_url) {
-          const discovered = await brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
-          if (discovered) {
-            const manifest = discovered.brand_manifest as Record<string, unknown> | undefined;
-            const logos = manifest?.logos as Array<Record<string, unknown>> | undefined;
-            const colors = manifest?.colors as Record<string, unknown> | undefined;
-            logo_url = (logos?.[0]?.url as string) || null;
-            brand_color = brand_color || (colors?.primary as string) || null;
+          const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
+          if (discovered?.brand_manifest) {
+            const resolved = resolveBrandFromJson(domain, discovered.brand_manifest as Record<string, unknown>, discovered.domain_verified ?? false);
+            logo_url = resolved.logo_url ?? null;
+            brand_color = brand_color || (resolved.brand_color ?? null);
           }
         }
       }

--- a/server/src/routes/si-chat.ts
+++ b/server/src/routes/si-chat.ts
@@ -12,6 +12,7 @@ import { optionalAuth } from "../middleware/auth.js";
 import { siDb, type SiSession } from "../db/si-db.js";
 import { siAgentService } from "../addie/services/si-agent-service.js";
 import { query } from "../db/client.js";
+import { resolveBrandFromJson } from "../db/brand-db.js";
 import { sanitizeInput } from "../addie/security.js";
 
 const logger = createLogger("si-chat-routes");
@@ -53,19 +54,16 @@ async function getBrandProfile(memberProfileId: string): Promise<{
 
   if (result.rows.length === 0) return null;
   const row = result.rows[0];
-  const bj = row.brand_json as Record<string, unknown> | null;
-  const brands = bj?.brands as Array<Record<string, unknown>> | undefined;
-  const primaryBrand = brands?.[0];
-  const logos = primaryBrand?.logos as Array<Record<string, unknown>> | undefined;
-  const colors = primaryBrand?.colors as Record<string, unknown> | undefined;
+  const bj = (row.brand_json as Record<string, unknown> | null) ?? {};
+  const resolved = resolveBrandFromJson(row.slug, bj, false);
   return {
     id: row.id,
     display_name: row.display_name,
     slug: row.slug,
     tagline: row.tagline,
     description: row.description,
-    logo_url: (logos?.[0]?.url as string | undefined) ?? null,
-    brand_color: (colors?.primary as string | undefined) ?? null,
+    logo_url: resolved.logo_url ?? null,
+    brand_color: resolved.brand_color ?? null,
   };
 }
 

--- a/server/src/services/brand-identity.ts
+++ b/server/src/services/brand-identity.ts
@@ -1,0 +1,194 @@
+/**
+ * Brand identity update service.
+ *
+ * Shared by:
+ *  - PUT /api/me/member-profile/brand-identity (member self-service via web UI)
+ *  - update_company_logo Addie tool (member self-service via chat)
+ *  - update_member_logo Addie tool (admin acting on behalf of a member)
+ *
+ * Centralizes brand-domain canonicalization, logo URL validation, and the
+ * brands+member_profiles transaction so all three paths produce identical
+ * brand_manifest shapes and stay in sync.
+ */
+
+import { getPool } from '../db/client.js';
+import { canonicalizeBrandDomain, assertValidBrandDomain } from './identifier-normalization.js';
+import { checkLogoUrlIsImage } from './brand-logo-service.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('brand-identity');
+
+export interface UpdateBrandIdentityInput {
+  /** WorkOS organization id that owns the profile (used as ownership boundary on the brands row). */
+  workosOrganizationId: string;
+  /** Display name used when minting a new brand record. */
+  displayName: string;
+  /** Member profile, if one exists. Required for primary_brand_domain link-back. */
+  profile?: {
+    id: string;
+    primary_brand_domain?: string;
+    contact_website?: string;
+  } | null;
+  /** New logo URL. HTTPS, must HEAD-resolve to image/*. Pass undefined to leave unchanged. */
+  logoUrl?: string | null;
+  /** New primary brand color. #RRGGBB. Pass undefined to leave unchanged. */
+  brandColor?: string | null;
+  /** Domain hint used when the profile has no primary_brand_domain yet (e.g., logo URL hostname). */
+  fallbackDomainHint?: string;
+}
+
+export interface UpdateBrandIdentityResult {
+  brandDomain: string;
+  wasUpdate: boolean;
+}
+
+export class BrandIdentityError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message);
+    this.name = 'BrandIdentityError';
+  }
+}
+
+export async function updateBrandIdentity(
+  input: UpdateBrandIdentityInput,
+): Promise<UpdateBrandIdentityResult> {
+  const { profile, workosOrganizationId, displayName, logoUrl, brandColor, fallbackDomainHint } = input;
+
+  if (logoUrl === undefined && brandColor === undefined) {
+    throw new BrandIdentityError(400, 'Provide at least one of logo_url or brand_color.');
+  }
+
+  if (logoUrl) {
+    if (logoUrl.length > 2000) {
+      throw new BrandIdentityError(400, 'Logo URL must be 2000 characters or less.');
+    }
+    const check = await checkLogoUrlIsImage(logoUrl);
+    if (!check.ok) {
+      throw new BrandIdentityError(400, check.reason);
+    }
+  }
+
+  if (brandColor && !/^#[0-9a-fA-F]{6}$/.test(brandColor)) {
+    throw new BrandIdentityError(400, 'Brand color must be a hex color (e.g., #FF5733).');
+  }
+
+  // Pick a brand domain. Prefer the profile's, fall back to website hostname,
+  // then to a hint from the caller (typically the logo URL hostname).
+  let brandDomain = profile?.primary_brand_domain ?? undefined;
+  if (!brandDomain && profile?.contact_website) {
+    try { brandDomain = new URL(profile.contact_website).hostname; } catch { /* ignore */ }
+  }
+  if (!brandDomain && fallbackDomainHint) {
+    brandDomain = fallbackDomainHint;
+  }
+  if (!brandDomain) {
+    throw new BrandIdentityError(400, 'No brand domain set. Add your website to your profile first.');
+  }
+  brandDomain = canonicalizeBrandDomain(brandDomain);
+  try {
+    assertValidBrandDomain(brandDomain);
+  } catch (err) {
+    throw new BrandIdentityError(400, err instanceof Error ? err.message : 'Invalid brand domain.');
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  let wasUpdate = false;
+  try {
+    await client.query('BEGIN');
+
+    const existingResult = await client.query<{ id: string; workos_organization_id: string | null; brand_json: Record<string, unknown> }>(
+      'SELECT id, workos_organization_id, brand_manifest AS brand_json FROM brands WHERE domain = $1 FOR UPDATE',
+      [brandDomain]
+    );
+    const existing = existingResult.rows[0] ?? null;
+    wasUpdate = !!existing;
+
+    // Ownership boundary: don't let one org overwrite another's brand
+    if (existing && existing.workos_organization_id && existing.workos_organization_id !== workosOrganizationId) {
+      throw new BrandIdentityError(403, 'This brand domain is managed by another organization.');
+    }
+
+    if (existing) {
+      const bj = applyToBrandJson(existing.brand_json ?? {}, displayName, logoUrl, brandColor);
+      await client.query(
+        'UPDATE brands SET brand_manifest = $1, workos_organization_id = COALESCE(workos_organization_id, $3), updated_at = NOW() WHERE id = $2',
+        [JSON.stringify(bj), existing.id, workosOrganizationId]
+      );
+    } else {
+      const bj = applyToBrandJson({
+        house: { domain: brandDomain, name: displayName },
+      }, displayName, logoUrl, brandColor);
+      await client.query(
+        `INSERT INTO brands (workos_organization_id, domain, brand_manifest, brand_name, source_type, review_status, is_public, has_brand_manifest)
+         VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), 'community', 'approved', $4, true)
+         ON CONFLICT (domain) DO UPDATE SET
+           brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
+           workos_organization_id = COALESCE(EXCLUDED.workos_organization_id, brands.workos_organization_id),
+           is_public = COALESCE(EXCLUDED.is_public, brands.is_public),
+           has_brand_manifest = true,
+           updated_at = NOW()`,
+        [workosOrganizationId, brandDomain, JSON.stringify(bj), true]
+      );
+    }
+
+    if (profile && profile.primary_brand_domain !== brandDomain) {
+      await client.query(
+        'UPDATE member_profiles SET primary_brand_domain = $1, updated_at = NOW() WHERE id = $2',
+        [brandDomain, profile.id]
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+
+  logger.info({ profileId: profile?.id, brandDomain, wasUpdate, hasLogo: !!logoUrl, hasColor: !!brandColor }, 'Brand identity updated');
+  return { brandDomain, wasUpdate };
+}
+
+
+/**
+ * Apply logo + color updates to a brand_manifest, preserving everything else.
+ * Always writes to brands[0].logos[0].url and brands[0].colors.primary so the
+ * canonical resolver picks them up regardless of input shape.
+ */
+function applyToBrandJson(
+  source: Record<string, unknown>,
+  displayName: string,
+  logoUrl: string | null | undefined,
+  brandColor: string | null | undefined,
+): Record<string, unknown> {
+  const bj = { ...source };
+  const brands = (bj.brands as Array<Record<string, unknown>> | undefined) ?? [];
+
+  let primaryBrand: Record<string, unknown>;
+  if (brands.length > 0) {
+    primaryBrand = { ...brands[0] };
+  } else {
+    primaryBrand = {
+      id: displayName.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
+      names: [{ en: displayName }],
+    };
+  }
+
+  if (logoUrl !== undefined && logoUrl !== null) {
+    const existingLogos = (primaryBrand.logos as Array<Record<string, unknown>> | undefined) ?? [];
+    primaryBrand.logos = existingLogos.length > 0
+      ? [{ ...existingLogos[0], url: logoUrl }, ...existingLogos.slice(1)]
+      : [{ url: logoUrl }];
+  }
+
+  if (brandColor !== undefined && brandColor !== null) {
+    const existingColors = (primaryBrand.colors as Record<string, unknown> | undefined) ?? {};
+    primaryBrand.colors = { ...existingColors, primary: brandColor };
+  }
+
+  bj.brands = [primaryBrand, ...brands.slice(1)];
+  return bj;
+}
+

--- a/server/src/services/brand-logo-auth.ts
+++ b/server/src/services/brand-logo-auth.ts
@@ -68,15 +68,16 @@ async function isVerifiedBrandOwner(userId: string, domain: string, brandDb: Bra
 /**
  * Check if a user can review brand logos for the given domain.
  * Returns true if the user is a registry moderator or verified brand owner.
+ * The static ADMIN_API_KEY synthetic user (id: 'admin_api_key') always passes —
+ * internal tooling and platform admins authenticated via ADMIN_API_KEY review by definition.
  */
 export async function canReviewBrandLogos(
   userId: string,
   domain: string,
   brandDb: BrandDatabase,
 ): Promise<boolean> {
-  // Check moderator first (cheaper, cached)
+  if (userId === 'admin_api_key') return true;
   if (await isRegistryModerator(userId)) return true;
-  // Then check brand ownership
   return isVerifiedBrandOwner(userId, domain, brandDb);
 }
 

--- a/server/src/services/brand-logo-service.ts
+++ b/server/src/services/brand-logo-service.ts
@@ -9,9 +9,108 @@ import sharp from 'sharp';
 import { BrandLogoDatabase, type BrandLogoSummary } from '../db/brand-logo-db.js';
 import { BrandDatabase } from '../db/brand-db.js';
 import { getLogoUrl } from './logo-cdn.js';
+import { safeFetch } from '../utils/url-security.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('brand-logo-service');
+
+const KNOWN_NON_IMAGE_HOSTS = new Set([
+  'drive.google.com',
+  'docs.google.com',
+  'dropbox.com',
+  'www.dropbox.com',
+]);
+
+export interface LogoUrlCheck {
+  ok: true;
+  contentType: string;
+}
+export interface LogoUrlCheckError {
+  ok: false;
+  reason: string;
+}
+
+/**
+ * Verify a public logo URL points to an actual image, not an HTML viewer or
+ * an auth-walled file share. Catches the common Google Drive `/view?usp=...`
+ * and Dropbox preview pages which silently serve HTML and render as a broken
+ * image once stored. Issues a HEAD request through safeFetch (SSRF-protected)
+ * with a short timeout so the save endpoint stays snappy.
+ */
+export async function checkLogoUrlIsImage(rawUrl: string): Promise<LogoUrlCheck | LogoUrlCheckError> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'Logo URL is not a valid URL.' };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'Logo URL must use HTTPS.' };
+  }
+  if (KNOWN_NON_IMAGE_HOSTS.has(parsed.hostname.toLowerCase())) {
+    return {
+      ok: false,
+      reason: `That ${parsed.hostname} link points to a file-viewer page, not the image itself. Paste a direct image URL instead — usually one ending in .png, .jpg, or .svg.`,
+    };
+  }
+
+  const FETCH_TIMEOUT_MS = 5000;
+
+  async function fetchWithTimeout(method: 'HEAD' | 'GET'): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(new Error('Logo URL check timed out')), FETCH_TIMEOUT_MS);
+    try {
+      return await safeFetch(rawUrl, { method, maxRedirects: 3, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // Cancel response bodies we never read so a malicious slow-body server
+  // can't tie up a connection for the full timeout window.
+  function discardBody(r: Response): void {
+    r.body?.cancel().catch(() => {/* already closed or never opened */});
+  }
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout('HEAD');
+  } catch (err) {
+    return { ok: false, reason: `Could not reach the logo URL: ${err instanceof Error ? err.message : 'unknown error'}` };
+  }
+
+  // Some hosts reject HEAD with 405/501 — fall back to GET. Body is cancelled
+  // immediately after we read the headers so we never buffer the image.
+  if (response.status === 405 || response.status === 501) {
+    discardBody(response);
+    try {
+      response = await fetchWithTimeout('GET');
+    } catch (err) {
+      return { ok: false, reason: `Could not reach the logo URL: ${err instanceof Error ? err.message : 'unknown error'}` };
+    }
+  }
+
+  try {
+    if (!response.ok) {
+      return { ok: false, reason: `Logo URL returned HTTP ${response.status}. Make sure the URL is publicly accessible without authentication.` };
+    }
+
+    const contentType = (response.headers.get('content-type') ?? '').toLowerCase().split(';')[0].trim();
+    if (!contentType) {
+      return { ok: false, reason: 'Logo URL did not return a Content-Type header.' };
+    }
+    if (!contentType.startsWith('image/')) {
+      return {
+        ok: false,
+        reason: `That URL returns ${contentType}, not an image. Paste a direct image URL — usually one ending in .png, .jpg, or .svg.`,
+      };
+    }
+
+    return { ok: true, contentType };
+  } finally {
+    discardBody(response);
+  }
+}
 
 export const ALLOWED_TAGS = new Set([
   // Variant
@@ -49,7 +148,7 @@ export async function detectContentType(buffer: Buffer): Promise<string | null> 
     return 'image/svg+xml';
   }
 
-  return result ? null : null;
+  return null;
 }
 
 export function sanitizeSvg(buffer: Buffer): Buffer {

--- a/server/src/services/identifier-normalization.ts
+++ b/server/src/services/identifier-normalization.ts
@@ -13,9 +13,28 @@ export interface NormalizeResult {
 }
 
 /**
- * Normalize a domain to its canonical form.
+ * Normalize a domain to its canonical form for the brand registry, member
+ * profiles, and other surfaces that key on the bare apex.
  * Strips protocol, path, query, fragment, trailing dot, www/m prefix. Lowercases.
  */
+export function canonicalizeBrandDomain(raw: string): string {
+  return normalizeDomain(raw).value;
+}
+
+const BRAND_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+/**
+ * Throw if the canonicalized value isn't a plausible domain (multi-label,
+ * RFC-1123-ish). Defends against polluting the brands.domain key with values
+ * like "localhost", empty strings, or unparseable garbage from upstream
+ * profile fields.
+ */
+export function assertValidBrandDomain(canonical: string): void {
+  if (!BRAND_DOMAIN_RE.test(canonical) || canonical.length > 253) {
+    throw new Error(`"${canonical}" is not a valid brand domain.`);
+  }
+}
+
 function normalizeDomain(raw: string): { value: string; reason: string | null } {
   let canonical = raw.trim();
   // Strip protocol

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -183,14 +183,14 @@ export async function safeFetch(
   const signal = options?.signal;
 
   // URL is validated above by validateFetchUrl (rejects private IPs, link-local, etc).
-  let response = await fetch(sanitizeUrl(parsedUrl), { method, headers, redirect: 'manual', signal }); // lgtm[js/request-forgery]
+  let response = await fetch(sanitizeUrl(parsedUrl), { method, headers, redirect: 'manual', signal });
 
   for (let i = 0; i < maxRedirects && [301, 302, 303, 307, 308].includes(response.status); i++) {
     const location = response.headers.get('location');
     if (!location) throw new Error('Redirect with no Location header');
     // validateRedirectTarget re-validates the resolved hop against the same private-IP rules.
     const redirectUrl = await validateRedirectTarget(location, parsedUrl);
-    response = await fetch(sanitizeUrl(redirectUrl), { method, headers, redirect: 'manual', signal }); // lgtm[js/request-forgery]
+    response = await fetch(sanitizeUrl(redirectUrl), { method, headers, redirect: 'manual', signal });
   }
 
   return response;

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -172,21 +172,23 @@ export function validateExternalUrl(raw: string): string | null {
  */
 export async function safeFetch(
   url: string,
-  options?: { headers?: Record<string, string>; maxRedirects?: number },
+  options?: { headers?: Record<string, string>; maxRedirects?: number; method?: 'GET' | 'HEAD'; signal?: AbortSignal },
 ): Promise<Response> {
   const parsedUrl = new URL(url);
   await validateFetchUrl(parsedUrl);
 
   const headers = options?.headers ?? {};
   const maxRedirects = options?.maxRedirects ?? 5;
+  const method = options?.method ?? 'GET';
+  const signal = options?.signal;
 
-  let response = await fetch(sanitizeUrl(parsedUrl), { headers, redirect: 'manual' });
+  let response = await fetch(sanitizeUrl(parsedUrl), { method, headers, redirect: 'manual', signal });
 
   for (let i = 0; i < maxRedirects && [301, 302, 303, 307, 308].includes(response.status); i++) {
     const location = response.headers.get('location');
     if (!location) throw new Error('Redirect with no Location header');
     const redirectUrl = await validateRedirectTarget(location, parsedUrl);
-    response = await fetch(sanitizeUrl(redirectUrl), { headers, redirect: 'manual' });
+    response = await fetch(sanitizeUrl(redirectUrl), { method, headers, redirect: 'manual', signal });
   }
 
   return response;

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -182,13 +182,15 @@ export async function safeFetch(
   const method = options?.method ?? 'GET';
   const signal = options?.signal;
 
-  let response = await fetch(sanitizeUrl(parsedUrl), { method, headers, redirect: 'manual', signal });
+  // URL is validated above by validateFetchUrl (rejects private IPs, link-local, etc).
+  let response = await fetch(sanitizeUrl(parsedUrl), { method, headers, redirect: 'manual', signal }); // lgtm[js/request-forgery]
 
   for (let i = 0; i < maxRedirects && [301, 302, 303, 307, 308].includes(response.status); i++) {
     const location = response.headers.get('location');
     if (!location) throw new Error('Redirect with no Location header');
+    // validateRedirectTarget re-validates the resolved hop against the same private-IP rules.
     const redirectUrl = await validateRedirectTarget(location, parsedUrl);
-    response = await fetch(sanitizeUrl(redirectUrl), { method, headers, redirect: 'manual', signal });
+    response = await fetch(sanitizeUrl(redirectUrl), { method, headers, redirect: 'manual', signal }); // lgtm[js/request-forgery]
   }
 
   return response;

--- a/server/tests/unit/canonicalize-brand-domain.test.ts
+++ b/server/tests/unit/canonicalize-brand-domain.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeBrandDomain, assertValidBrandDomain } from '../../src/services/identifier-normalization.js';
+
+describe('canonicalizeBrandDomain', () => {
+  it('strips https:// protocol', () => {
+    expect(canonicalizeBrandDomain('https://example.com')).toBe('example.com');
+  });
+
+  it('strips www. prefix', () => {
+    expect(canonicalizeBrandDomain('www.kyber1.com')).toBe('kyber1.com');
+  });
+
+  it('strips m. mobile prefix', () => {
+    expect(canonicalizeBrandDomain('m.example.com')).toBe('example.com');
+  });
+
+  it('lowercases the result', () => {
+    expect(canonicalizeBrandDomain('Example.COM')).toBe('example.com');
+  });
+
+  it('strips trailing slash and dot', () => {
+    expect(canonicalizeBrandDomain('example.com/')).toBe('example.com');
+    expect(canonicalizeBrandDomain('example.com.')).toBe('example.com');
+  });
+
+  it('strips path, query, and fragment', () => {
+    expect(canonicalizeBrandDomain('example.com/about?foo=bar#baz')).toBe('example.com');
+  });
+
+  it('handles a fully composed messy URL', () => {
+    expect(canonicalizeBrandDomain('HTTPS://www.Kyber1.COM/dashboard?ref=foo')).toBe('kyber1.com');
+  });
+
+  it('passes through clean apex unchanged', () => {
+    expect(canonicalizeBrandDomain('kyber1.com')).toBe('kyber1.com');
+  });
+
+  it('preserves non-www subdomains', () => {
+    expect(canonicalizeBrandDomain('app.kyber1.com')).toBe('app.kyber1.com');
+  });
+});
+
+describe('assertValidBrandDomain', () => {
+  it('accepts a typical apex domain', () => {
+    expect(() => assertValidBrandDomain('kyber1.com')).not.toThrow();
+  });
+
+  it('accepts a multi-label subdomain', () => {
+    expect(() => assertValidBrandDomain('app.kyber1.com')).not.toThrow();
+  });
+
+  it('rejects a single-label hostname', () => {
+    expect(() => assertValidBrandDomain('localhost')).toThrow();
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => assertValidBrandDomain('')).toThrow();
+  });
+
+  it('rejects whitespace and arbitrary text', () => {
+    expect(() => assertValidBrandDomain('not a domain')).toThrow();
+  });
+
+  it('rejects a name longer than 253 chars', () => {
+    const long = 'a'.repeat(250) + '.com';
+    expect(() => assertValidBrandDomain(long)).toThrow();
+  });
+});

--- a/server/tests/unit/resolve-brand-from-json.test.ts
+++ b/server/tests/unit/resolve-brand-from-json.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBrandFromJson } from '../../src/db/brand-db.js';
+
+describe('resolveBrandFromJson', () => {
+  it('resolves logos[] under brands[0]', () => {
+    const result = resolveBrandFromJson('acme.com', {
+      brands: [
+        {
+          names: [{ en: 'Acme' }],
+          logos: [{ url: 'https://acme.com/logo.png', background: 'light-bg' }],
+          colors: { primary: '#ff0000' },
+        },
+      ],
+    }, true);
+
+    expect(result.logo_url).toBe('https://acme.com/logo.png');
+    expect(result.brand_color).toBe('#ff0000');
+    expect(result.name).toBe('Acme');
+    expect(result.verified).toBe(true);
+  });
+
+  it('resolves top-level logos[] when brands is missing', () => {
+    const result = resolveBrandFromJson('acme.com', {
+      name: 'Acme',
+      logos: [{ url: 'https://acme.com/logo.png' }],
+      colors: { primary: '#00ff00' },
+    }, false);
+
+    expect(result.logo_url).toBe('https://acme.com/logo.png');
+    expect(result.brand_color).toBe('#00ff00');
+  });
+
+  it('resolves top-level singular logo object — thehook.es shape', () => {
+    // This is the actual brand.json shape from thehook.es. Their logo was
+    // not displaying because the resolver only checked `logos` (plural).
+    const result = resolveBrandFromJson('thehook.es', {
+      name: 'The Hook',
+      logo: { url: 'https://thehook.es/images/logo-thehook-negro.png' },
+      brand_colors: { primary: '#4db1d5', secondary: '#000000' },
+      house: { name: 'The Hook', domain: 'thehook.es', architecture: 'house_of_brands' },
+      brands: [
+        { id: 'rephook', names: [{ en: 'RepHook' }] },
+        { id: 'genmatic', names: [{ en: 'Genmatic' }] },
+      ],
+    }, true);
+
+    expect(result.logo_url).toBe('https://thehook.es/images/logo-thehook-negro.png');
+    expect(result.brand_color).toBe('#4db1d5');
+    expect(result.name).toBe('The Hook');
+  });
+
+  it('prefers a brand-level logo over a top-level one', () => {
+    const result = resolveBrandFromJson('acme.com', {
+      logo: { url: 'https://example.com/wrong.png' },
+      brands: [
+        {
+          names: [{ en: 'Acme' }],
+          logos: [{ url: 'https://acme.com/right.png' }],
+        },
+      ],
+    }, false);
+
+    expect(result.logo_url).toBe('https://acme.com/right.png');
+  });
+
+  it('selects light-bg variant for default and dark-bg for the dark slot', () => {
+    const result = resolveBrandFromJson('acme.com', {
+      brands: [
+        {
+          logos: [
+            { url: 'https://acme.com/dark.png', background: 'dark-bg' },
+            { url: 'https://acme.com/light.png', background: 'light-bg' },
+            { url: 'https://acme.com/transparent.png', background: 'transparent-bg' },
+          ],
+        },
+      ],
+    }, false);
+
+    expect(result.logo_url).toBe('https://acme.com/light.png');
+    expect(result.logo_url_dark).toBe('https://acme.com/dark.png');
+  });
+
+  it('returns no logo when none is declared', () => {
+    const result = resolveBrandFromJson('empty.com', { name: 'Empty' }, false);
+    expect(result.logo_url).toBeUndefined();
+    expect(result.brand_color).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two member escalations (thehook.es, kyber1.com) hit the same shape of bug: saved logos either didn't render (broken Drive viewer URL stored verbatim in brand_manifest) or were stuck in `pending` review with no admin path to triage. The capability existed in the database layer but no tool, route, or UI exposed it.

This PR closes the loop end to end:

- **Member self-service** — new `update_company_logo` Addie tool. A logged-in member can now say "fix my logo" and Addie has the capability instead of escalating.
- **Admin moderation** — `list_pending_brand_logos`, `list_brand_logos`, `review_brand_logo` for the aao-admin queue. `getPendingLogos` existed in the DB layer with zero callers.
- **Validation** — `checkLogoUrlIsImage` HEAD-validates URLs before save (AbortController-timeout, body-cancel, file-viewer host blocklist). Catches Drive `/view` and Dropbox preview pages that silently return HTML.
- **Canonicalization** — `canonicalizeBrandDomain` strips `www.`/`m.`/protocol/path on every save so `kyber1.com` and `www.kyber1.com` stop split-braining into separate registry rows. `assertValidBrandDomain` blocks garbage values.
- **Resolver fix** — `resolveBrandFromJson` accepts the singular `logo: {url}` shape and the `brand_colors` alias used by some real-world brand.json publishers (e.g. `house_portfolio` variants). Brands declaring valid logos in those shapes were previously rendering empty.
- **UI fallback** — logo `<img>` elements on the dashboard sidebar and member-profile page swap to the placeholder when the URL fails to load.
- **Auth** — `canReviewBrandLogos` accepts the synthetic `admin_api_key` user so internal tooling can read pending logos via `GET /api/brands/:domain/logos`.

## Refactor

Extracted shared logic into `services/brand-identity.ts` so the web PUT handler, the new member tool, and the existing admin tool all run identical transaction, validation, and canonicalization logic. Previously the same SQL was duplicated across three call sites with subtle drift.

## Production data fix

Kyber1's `www.kyber1.com` brand_manifest was already corrected in production (Drive viewer URL → working S3 PNG) via the existing API. Philippe should see his logo on next page load.

## Reviews

Ran the change through code-reviewer, security-reviewer, agentic-product-architect, and adtech-product-expert subagents. Applied feedback: AbortController-based timeout, response-body cancellation in the URL validator, `canonicalizeBrandDomain` used consistently across admin handlers, `assertValidBrandDomain` defense-in-depth, tool description disambiguation, member-facing error message softening (no ❌, less lecturing).

Out-of-scope follow-ups flagged by reviewers (filing as separate issues): brand-ownership transfer flow, pending-queue digest notification, verified-domain-owner auto-approve heuristic, attribute-context quote escaping in `escapeHtml`.

## Test plan

- [x] `npm run test:unit` passes (832 tests, including 27 new ones across resolver and canonicalization helpers)
- [x] `npm run typecheck` passes
- [x] Production data fix verified via API (`/api/brands/resolve?domain=www.kyber1.com` returns the S3 PNG)
- [ ] Reviewer to sanity-check Addie's tool selection on a synthetic prompt: "Hi, can you fix my logo?" should pick `update_company_logo`, not escalate
- [ ] Reviewer to verify `list_pending_brand_logos` queue is non-empty in staging post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)