### PR TITLE
patch: force_task_completion + create_media_buy_async submitted -> completed roundtrip

### DIFF
--- a/.changeset/force-task-completion-roundtrip.md
+++ b/.changeset/force-task-completion-roundtrip.md
@@ -1,0 +1,23 @@
+---
+---
+
+patch: force_task_completion controller scenario + create_media_buy_async storyboard extends to full submitted → completed roundtrip
+
+Closes the loop on #3081 / #3104 / #3115. The `create_media_buy_async` storyboard previously validated only the submitted-envelope wire shape (`status='submitted'`, `task_id` present, no `media_buy_id`); the submitted → completed transition was deferred because no controller scenario could resolve the task deterministically. This PR adds the missing primitive and extends the storyboard to exercise the full async lifecycle, anchoring the spec invariants formalized in #3126 (typed `result` + `include_result` on `tasks/get`).
+
+**New controller scenario `force_task_completion`.**
+
+`{ scenario: 'force_task_completion', params: { task_id, result } }`. Resolves a submitted task to `completed` and stamps `result` (validated against `async-response-data.json`, the same `anyOf` union the push-notification webhook and `tasks/get` polling responses use) on the seller's task store. Subsequent `tasks/get(task_id, include_result: true)` MUST surface the result verbatim. Returns the standard `StateTransitionSuccess` shape with `previous_state: 'submitted'` / `current_state: 'completed'`. Sellers MUST emit `NOT_FOUND` for unknown task_ids and `INVALID_TRANSITION` if the task is already terminal. Added to:
+- `static/schemas/source/compliance/comply-test-controller-request.json` (enum + `result` param + conditional `if/then` requiring `task_id` and `result`)
+- `static/schemas/source/compliance/comply-test-controller-response.json` (added to `list_scenarios.scenarios` enum; reuses the existing `StateTransitionSuccess` branch)
+- `docs/building/implementation/comply-test-controller.mdx` (new `### force_task_completion` section + inline params doc + tool-definition enum + example)
+
+**Storyboard extension.** `static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml` bumped from v1.0.0 to v1.1.0. Added `tasks_get` to `required_tools` and two new phases:
+- `force_task_completion`: calls the controller with the captured `$context.forced_task_id` and a fixture `CreateMediaBuyResponse` result (`media_buy_id`, `packages`); asserts the state transition response.
+- `poll_task_completed`: calls `tasks/get` with `include_result: true`; asserts `status='completed'`, `result.media_buy_id` matches the registered value (catches sellers that fabricate a fresh ID), and the response validates against `tasks-get-response.json`.
+
+Title and summary updated to reflect the full roundtrip. Narrative documents the three new invariants the polling phase locks (status='completed' on terminal poll, include_result honored, result.media_buy_id verbatim).
+
+**Out of scope.** Webhook (`push_notification_config`) delivery is not asserted; webhook conformance lives in dedicated webhook-receiver storyboards. Transport-level wire-shape probes (A2A `Task.state`, `artifact.metadata.adcp_task_id`) remain runner-side concerns at adcp-client#904.
+
+Why patch: conformance-suite content addition + new sandbox-only controller scenario, both opt-in via `UNKNOWN_SCENARIO` grading. No on-wire seller obligations change for sellers that already implement `tasks/get` with `include_result` per the schema.

--- a/.changeset/force-task-completion-roundtrip.md
+++ b/.changeset/force-task-completion-roundtrip.md
@@ -1,23 +1,17 @@
 ---
 ---
 
-patch: force_task_completion controller scenario + create_media_buy_async storyboard extends to full submitted → completed roundtrip
+patch: force_task_completion controller scenario
 
-Closes the loop on #3081 / #3104 / #3115. The `create_media_buy_async` storyboard previously validated only the submitted-envelope wire shape (`status='submitted'`, `task_id` present, no `media_buy_id`); the submitted → completed transition was deferred because no controller scenario could resolve the task deterministically. This PR adds the missing primitive and extends the storyboard to exercise the full async lifecycle, anchoring the spec invariants formalized in #3126 (typed `result` + `include_result` on `tasks/get`).
+Adds the controller primitive needed to test the async `create_media_buy` submitted → completed roundtrip end-to-end. Companion to `force_create_media_buy_arm` (#3104): that scenario drives the seller into the submitted envelope; this one closes the loop by transitioning the task store entry from `submitted` to `completed` and stamping the result that subsequent [`tasks/get`](/docs/protocol/calling-an-agent#async-task-polling) calls return when `include_result: true` (formalized in #3126).
 
-**New controller scenario `force_task_completion`.**
+**Scenario semantics.** `{ scenario: 'force_task_completion', params: { task_id, result } }`. The seller stores `result` (validated against `async-response-data.json`) against `task_id` and surfaces it verbatim on the next `tasks/get(task_id)` with `include_result: true`. Returns the standard `StateTransitionSuccess` shape with `previous_state: 'submitted'` / `current_state: 'completed'`. Sellers MUST emit `NOT_FOUND` for unknown task_ids and `INVALID_TRANSITION` if the task is already terminal.
 
-`{ scenario: 'force_task_completion', params: { task_id, result } }`. Resolves a submitted task to `completed` and stamps `result` (validated against `async-response-data.json`, the same `anyOf` union the push-notification webhook and `tasks/get` polling responses use) on the seller's task store. Subsequent `tasks/get(task_id, include_result: true)` MUST surface the result verbatim. Returns the standard `StateTransitionSuccess` shape with `previous_state: 'submitted'` / `current_state: 'completed'`. Sellers MUST emit `NOT_FOUND` for unknown task_ids and `INVALID_TRANSITION` if the task is already terminal. Added to:
-- `static/schemas/source/compliance/comply-test-controller-request.json` (enum + `result` param + conditional `if/then` requiring `task_id` and `result`)
-- `static/schemas/source/compliance/comply-test-controller-response.json` (added to `list_scenarios.scenarios` enum; reuses the existing `StateTransitionSuccess` branch)
-- `docs/building/implementation/comply-test-controller.mdx` (new `### force_task_completion` section + inline params doc + tool-definition enum + example)
+**Files.**
+- `static/schemas/source/compliance/comply-test-controller-request.json` — added to enum, new `result` param ($ref `async-response-data.json`), conditional `if/then` requiring `task_id` and `result`.
+- `static/schemas/source/compliance/comply-test-controller-response.json` — added to `list_scenarios.scenarios` enum (sellers advertising support don't schema-fail their own list response). Reuses the existing `StateTransitionSuccess` branch.
+- `docs/building/implementation/comply-test-controller.mdx` — new `### force_task_completion` section + inline params doc + tool-definition enum + example.
 
-**Storyboard extension.** `static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml` bumped from v1.0.0 to v1.1.0. Added `tasks_get` to `required_tools` and two new phases:
-- `force_task_completion`: calls the controller with the captured `$context.forced_task_id` and a fixture `CreateMediaBuyResponse` result (`media_buy_id`, `packages`); asserts the state transition response.
-- `poll_task_completed`: calls `tasks/get` with `include_result: true`; asserts `status='completed'`, `result.media_buy_id` matches the registered value (catches sellers that fabricate a fresh ID), and the response validates against `tasks-get-response.json`.
+**Storyboard extension lives in the follow-up.** The `create_media_buy_async` storyboard is unchanged in this PR. Extending it to exercise the new scenario via `tasks/get` polling lands together with the training-agent's implementation of `force_task_completion`, mirroring the #3104 → #3115 pattern. That keeps the runner from grading the storyboard as `failed` during the window where the controller scenario exists in spec but no reference seller implements it yet (the half-implemented case can't gracefully degrade to `not_applicable` because the storyboard's earlier phases already pass).
 
-Title and summary updated to reflect the full roundtrip. Narrative documents the three new invariants the polling phase locks (status='completed' on terminal poll, include_result honored, result.media_buy_id verbatim).
-
-**Out of scope.** Webhook (`push_notification_config`) delivery is not asserted; webhook conformance lives in dedicated webhook-receiver storyboards. Transport-level wire-shape probes (A2A `Task.state`, `artifact.metadata.adcp_task_id`) remain runner-side concerns at adcp-client#904.
-
-Why patch: conformance-suite content addition + new sandbox-only controller scenario, both opt-in via `UNKNOWN_SCENARIO` grading. No on-wire seller obligations change for sellers that already implement `tasks/get` with `include_result` per the schema.
+Why patch: new sandbox-only controller scenario, opt-in via `UNKNOWN_SCENARIO` grading. No on-wire seller obligations change for sellers that already implement `tasks/get` with `include_result` per the schema.

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -204,7 +204,7 @@ The submitted-arm wire shape is otherwise implementation-dependent: most sellers
 
 ### `force_task_completion`
 
-Resolves a previously-submitted async task to `completed` with a buyer-supplied result payload. The companion to `force_create_media_buy_arm`: that scenario drives the seller into the submitted envelope; this one closes the loop by transitioning the task store entry from `submitted` to `completed` and stamping the result that subsequent [`tasks/get`](/docs/protocol/calling-an-agent#async-task-polling) calls return when `include_result: true`.
+Resolves a previously-submitted async task to `completed` with a buyer-supplied result payload. The companion to `force_create_media_buy_arm`: that scenario drives the seller into the submitted envelope; this one closes the loop by transitioning the task store entry to `completed` and stamping the result that subsequent [`tasks/get`](/docs/building/implementation/async-operations#polling-for-submitted-operations) calls return when `include_result: true`.
 
 The submitted → completed lifecycle is otherwise non-deterministic — real task completions ride on out-of-band signals (IO countersignature, batch processor cron, governance human review). Storyboards cannot wait. This scenario lets a runner pin the completion deterministically immediately after registering the directive, so the buyer-side polling assertion fires on the same wire shape buyers will observe in production.
 
@@ -212,8 +212,8 @@ The submitted → completed lifecycle is otherwise non-deterministic — real ta
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `task_id` | string | Yes | Task to resolve. MUST match an existing task in the seller's store. Typically captured from the prior `create_media_buy` submitted-envelope response (or registered via `force_create_media_buy_arm`). |
-| `result` | [`async-response-data`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json) | Yes | Completion payload to record. Validates against the same `anyOf` union the push-notification webhook and `tasks/get` polling responses use. For `create_media_buy`, this is a `CreateMediaBuyResponse` with `media_buy_id` and `packages`. |
+| `task_id` | string | Yes | Task to resolve. MUST resolve within the caller's authenticated sandbox account; sellers MUST return `NOT_FOUND` (not `FORBIDDEN`, per the multi-tenant convention above) for `task_id`s belonging to other accounts. Typically captured from the prior `create_media_buy` submitted-envelope response (or registered via `force_create_media_buy_arm`). |
+| `result` | [`async-response-data`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json) | Yes | Completion payload to record. Validates against the same `anyOf` union the push-notification webhook and `tasks/get` polling responses use. For `create_media_buy`, this is a `CreateMediaBuyResponse` with `media_buy_id` and `packages`. Sellers MUST emit `INVALID_PARAMS` if `result` does not validate against the response branch for the task's original method. Sellers MAY reject `result` payloads exceeding 256 KB with `INVALID_PARAMS`; storyboards MUST stay below this. |
 
 **Example:**
 
@@ -233,9 +233,26 @@ The submitted → completed lifecycle is otherwise non-deterministic — real ta
 }
 ```
 
-**Response.** Returns the standard [`StateTransitionSuccess`](#state-transition-responses-force_) shape with `previous_state: "submitted"` and `current_state: "completed"`. Sellers MUST emit `NOT_FOUND` if `task_id` is unknown, and `INVALID_TRANSITION` if the task is already terminal (`completed` / `failed` / `cancelled`).
+**Response.** Returns a state-transition success shape:
 
-**Buyer-side observation.** After this scenario runs, a `tasks/get(task_id)` request with `include_result: true` MUST return `status: "completed"` and the registered `result` verbatim. Sellers that fail to surface the result (or surface a different value) break the round-trip contract and fail the `create_media_buy_async` storyboard's polling phase.
+```json
+{
+  "success": true,
+  "previous_state": "submitted",
+  "current_state": "completed",
+  "message": "Task task_async_signed_io_q2 transitioned from submitted to completed"
+}
+```
+
+Source state MUST be `submitted`, `working`, or `input-required`; any other source returns `INVALID_TRANSITION`. Sellers MUST emit `NOT_FOUND` if `task_id` is unknown to the caller's account, and `INVALID_TRANSITION` if the task is already terminal (`completed` / `failed` / `canceled`). Forcing a task to `failed` is out of scope for this scenario; the input-required arm of `force_create_media_buy_arm` covers the buyer-input-needed failure path.
+
+**Replay semantics.** Replays with identical params before the task is terminal are idempotent no-ops. Replays with diverging params before the task is terminal MUST overwrite the registered result (last-write-wins) — same precedent as `force_create_media_buy_arm`'s "second call overwrites." After the task is terminal, every replay returns `INVALID_TRANSITION` regardless of params.
+
+**Cross-protocol obligations.**
+- **Push notifications.** If the buyer registered `push_notification_config.url` on the original `create_media_buy`, forcing completion MUST fire the webhook with the same payload `tasks/get(task_id, include_result: true)` would return. Otherwise the storyboard can only test polling, not push delivery.
+- **`simulate_delivery` / `simulate_budget_spend`.** Once forced to completed with a valid `CreateMediaBuyResponse` carrying `media_buy_id`, the resulting media buy MUST be addressable by those scenarios. Round-tripping through `force_task_completion` is the supported path for storyboards that need a media buy without going through the synchronous flow.
+
+**Buyer-side observation.** After this scenario runs, a `tasks/get(task_id)` request with `include_result: true` MUST return `status: "completed"` and the registered `result` with all caller-supplied fields preserved. Sellers MAY augment with seller-controlled fields (e.g., `created_at`, `dsp_*` IDs, normalized currency casing) but MUST NOT overwrite caller-supplied values. The `result` payload is buyer-controlled in sandbox and round-trips through the seller's store — buyers polling `tasks/get` MUST treat the response as untrusted seller output (per AdCP convention) regardless of the fact that they originated the bytes. This makes `force_task_completion` the natural place for a runner to inject adversarial payloads when testing buyer-side sanitization on the polling path.
 
 ### `force_session_status`
 

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -57,6 +57,7 @@ Sellers that implement compliance test controller MUST:
           "force_account_status",
           "force_media_buy_status",
           "force_create_media_buy_arm",
+          "force_task_completion",
           "force_session_status",
           "simulate_delivery",
           "simulate_budget_spend",
@@ -70,7 +71,7 @@ Sellers that implement compliance test controller MUST:
       },
       "params": {
         "type": "object",
-        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}."
+        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_task_completion: {task_id, result}. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}."
       }
     },
     "required": ["scenario"]
@@ -200,6 +201,41 @@ The submitted-arm wire shape is otherwise implementation-dependent: most sellers
 `forced.task_id` is present only when `arm: submitted`.
 
 **Consumption and idempotency.** The directive is keyed to the caller's authenticated sandbox account (account + principal pair) and is consumed by the next `create_media_buy` call from that account. Subsequent calls without a fresh directive return the seller's default arm. Buyer-side `idempotency_key` semantics are unchanged: if the caller replays a `create_media_buy` request that already consumed a directive, the seller MUST replay the cached response (the request idempotency cache wins) and MUST NOT re-evaluate against the now-empty directive slot. Sellers MUST NOT match a directive against a `create_media_buy` call from a different account or principal, even within the same transport connection. A second `force_create_media_buy_arm` call before the directive is consumed overwrites the prior one.
+
+### `force_task_completion`
+
+Resolves a previously-submitted async task to `completed` with a buyer-supplied result payload. The companion to `force_create_media_buy_arm`: that scenario drives the seller into the submitted envelope; this one closes the loop by transitioning the task store entry from `submitted` to `completed` and stamping the result that subsequent [`tasks/get`](/docs/protocol/calling-an-agent#async-task-polling) calls return when `include_result: true`.
+
+The submitted → completed lifecycle is otherwise non-deterministic — real task completions ride on out-of-band signals (IO countersignature, batch processor cron, governance human review). Storyboards cannot wait. This scenario lets a runner pin the completion deterministically immediately after registering the directive, so the buyer-side polling assertion fires on the same wire shape buyers will observe in production.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `task_id` | string | Yes | Task to resolve. MUST match an existing task in the seller's store. Typically captured from the prior `create_media_buy` submitted-envelope response (or registered via `force_create_media_buy_arm`). |
+| `result` | [`async-response-data`](https://adcontextprotocol.org/schemas/v3/core/async-response-data.json) | Yes | Completion payload to record. Validates against the same `anyOf` union the push-notification webhook and `tasks/get` polling responses use. For `create_media_buy`, this is a `CreateMediaBuyResponse` with `media_buy_id` and `packages`. |
+
+**Example:**
+
+```json
+{
+  "scenario": "force_task_completion",
+  "params": {
+    "task_id": "task_async_signed_io_q2",
+    "result": {
+      "media_buy_id": "mb_async_signed_io_q2",
+      "status": "active",
+      "packages": [
+        { "package_id": "pkg-0", "product_id": "async_signed_io_q2", "budget": 30000 }
+      ]
+    }
+  }
+}
+```
+
+**Response.** Returns the standard [`StateTransitionSuccess`](#state-transition-responses-force_) shape with `previous_state: "submitted"` and `current_state: "completed"`. Sellers MUST emit `NOT_FOUND` if `task_id` is unknown, and `INVALID_TRANSITION` if the task is already terminal (`completed` / `failed` / `cancelled`).
+
+**Buyer-side observation.** After this scenario runs, a `tasks/get(task_id)` request with `include_result: true` MUST return `status: "completed"` and the registered `result` verbatim. Sellers that fail to surface the result (or surface a different value) break the round-trip contract and fail the `create_media_buy_async` storyboard's polling phase.
 
 ### `force_session_status`
 

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
@@ -1,12 +1,11 @@
 id: media_buy_seller/create_media_buy_async
-version: "1.1.0"
-title: "Seller returns submitted task envelope and resolves it via tasks/get when create_media_buy goes async"
+version: "1.0.0"
+title: "Seller returns submitted task envelope when create_media_buy goes async"
 category: media_buy_seller
-summary: "Verifies the full async create_media_buy roundtrip: the seller emits the submitted envelope (status='submitted', task_id present, no media_buy_id), the controller resolves the task to completed, and tasks/get with include_result returns the recorded media_buy_id verbatim."
+summary: "Verifies the AdCP-payload wire shape of the submitted-arm response from create_media_buy: status='submitted', task_id present, no media_buy_id and no packages on the envelope."
 track: media_buy
 required_tools:
   - create_media_buy
-  - tasks_get
   - comply_test_controller
 
 narrative: |
@@ -43,20 +42,6 @@ narrative: |
   storyboard catches sellers that fabricate a fresh task_id instead of honoring the
   registered directive.
 
-  Submitted → completed roundtrip. After the submitted-envelope shape is validated, the
-  controller force-completes the task with a buyer-supplied result payload (the
-  CreateMediaBuyResponse the seller would have emitted on a synchronous success). The
-  buyer then calls tasks/get(task_id, include_result: true) and asserts the seller
-  surfaces status='completed' plus the recorded result verbatim. This anchors three
-  invariants the spec just formalized in the tasks/get response (#3126):
-
-  1. tasks/get on a completed async task returns status='completed' (not still
-     'submitted', not 'working')
-  2. include_result: true makes the seller emit the typed result field; sellers MUST
-     NOT silently drop it
-  3. result.media_buy_id MUST equal the value the controller registered — sellers that
-     fabricate a fresh media_buy_id break the polling contract
-
   Out of scope (by design). Transport-level wire-shape assertions — A2A Task.state and
   artifact.metadata.adcp_task_id placement, MCP structuredContent envelope details — are
   runner-side concerns, not storyboard assertions. The runner exercises this scenario
@@ -64,10 +49,9 @@ narrative: |
   adcp-client#904 for the runner-side probes; this storyboard provides the deterministic
   driver.
 
-  Webhook delivery (push_notification_config) is not asserted by this storyboard. The
-  buyer either polls tasks/get (this scenario) or waits on a webhook; both are first-
-  class delivery mechanisms in the spec. Webhook conformance lives in the dedicated
-  webhook-receiver storyboards.
+  The submitted → completed transition (forcing the task to resolve and asserting the
+  completion artifact carries media_buy_id) is deferred to a follow-up scenario. It needs
+  a force_task_completion controller scenario that does not exist yet.
 
 agent:
   interaction_model: media_buy_seller
@@ -245,117 +229,4 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "create_media_buy_async--create_media_buy_submitted"
-            description: "Context correlation_id returned unchanged"
-
-  - id: force_task_completion
-    title: "Resolve the submitted task to completed via comply_test_controller"
-    narrative: |
-      The buyer's poll cannot test completion until the task actually completes,
-      and real completions ride on out-of-band signals (IO countersignature,
-      batch processor cron) the storyboard cannot wait for. Use
-      force_task_completion to pin the completion deterministically: register
-      the result payload (the CreateMediaBuyResponse the seller would have
-      emitted on a synchronous success) against the captured task_id. The next
-      tasks/get with include_result must surface this result verbatim.
-
-    steps:
-      - id: force_task_completed
-        title: "Force the task to completed with a CreateMediaBuyResponse result"
-        requires_tool: comply_test_controller
-        narrative: |
-          Mint a media_buy_id and a packages array, then register them as the
-          completion result. The seller MUST persist this result in its task
-          store and surface it on subsequent tasks/get(task_id, include_result)
-          calls. Sellers that fabricate a different media_buy_id or drop the
-          packages array fail the polling assertion in the next phase.
-        task: comply_test_controller
-        comply_scenario: create_media_buy
-        stateful: true
-        expected: |
-          Return a successful state transition:
-          - success: true
-          - previous_state: 'submitted'
-          - current_state: 'completed'
-
-        sample_request:
-          scenario: "force_task_completion"
-          params:
-            task_id: "$context.forced_task_id"
-            result:
-              media_buy_id: "mb_async_signed_io_q2"
-              status: "active"
-              packages:
-                - package_id: "pkg-0"
-                  product_id: "async_signed_io_q2"
-                  budget: 30000
-          context:
-            correlation_id: "create_media_buy_async--force_task_completed"
-        validations:
-          - check: field_value
-            path: "success"
-            allowed_values: [true]
-            description: "Controller accepts the completion directive"
-          - check: field_value
-            path: "current_state"
-            value: "completed"
-            description: "Task transitioned to completed"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "create_media_buy_async--force_task_completed"
-            description: "Context correlation_id returned unchanged"
-
-  - id: poll_task_completed
-    title: "tasks/get returns completed status and the recorded result"
-    narrative: |
-      The buyer polls tasks/get with the captured task_id and
-      include_result: true. The seller MUST surface status='completed' and
-      return the result payload registered by force_task_completion verbatim
-      — same media_buy_id, same packages. This anchors the spec invariant
-      formalized in #3126: include_result on a completed async task delivers
-      the typed result field, and the value mirrors what the seller would
-      have emitted on a synchronous success or a webhook callback.
-
-    steps:
-      - id: tasks_get_completed
-        title: "Poll tasks/get with include_result and observe the completion artifact"
-        task: tasks_get
-        schema_ref: "core/tasks-get-request.json"
-        response_schema_ref: "core/tasks-get-response.json"
-        doc_ref: "/protocol/calling-an-agent#async-task-polling"
-        comply_scenario: create_media_buy
-        stateful: true
-        expected: |
-          Return the completed task with the registered result:
-          - status: 'completed'
-          - result.media_buy_id: 'mb_async_signed_io_q2'
-          - result.packages[0].product_id: 'async_signed_io_q2'
-
-        sample_request:
-          task_id: "$context.forced_task_id"
-          include_result: true
-          context:
-            correlation_id: "create_media_buy_async--tasks_get_completed"
-        validations:
-          - check: response_schema
-            description: "Response matches tasks-get-response.json"
-          - check: field_value
-            path: "status"
-            value: "completed"
-            description: "Task status is 'completed' (not 'submitted', not 'working')"
-          - check: field_present
-            path: "result"
-            description: "result is present because include_result was true and status is completed"
-          - check: field_value
-            path: "result.media_buy_id"
-            value: "mb_async_signed_io_q2"
-            description: "result.media_buy_id matches the value registered by force_task_completion — sellers that fabricate a fresh media_buy_id break the polling contract"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "create_media_buy_async--tasks_get_completed"
             description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
@@ -1,11 +1,12 @@
 id: media_buy_seller/create_media_buy_async
-version: "1.0.0"
-title: "Seller returns submitted task envelope when create_media_buy goes async"
+version: "1.1.0"
+title: "Seller returns submitted task envelope and resolves it via tasks/get when create_media_buy goes async"
 category: media_buy_seller
-summary: "Verifies the AdCP-payload wire shape of the submitted-arm response from create_media_buy: status='submitted', task_id present, no media_buy_id and no packages on the envelope."
+summary: "Verifies the full async create_media_buy roundtrip: the seller emits the submitted envelope (status='submitted', task_id present, no media_buy_id), the controller resolves the task to completed, and tasks/get with include_result returns the recorded media_buy_id verbatim."
 track: media_buy
 required_tools:
   - create_media_buy
+  - tasks_get
   - comply_test_controller
 
 narrative: |
@@ -42,6 +43,20 @@ narrative: |
   storyboard catches sellers that fabricate a fresh task_id instead of honoring the
   registered directive.
 
+  Submitted → completed roundtrip. After the submitted-envelope shape is validated, the
+  controller force-completes the task with a buyer-supplied result payload (the
+  CreateMediaBuyResponse the seller would have emitted on a synchronous success). The
+  buyer then calls tasks/get(task_id, include_result: true) and asserts the seller
+  surfaces status='completed' plus the recorded result verbatim. This anchors three
+  invariants the spec just formalized in the tasks/get response (#3126):
+
+  1. tasks/get on a completed async task returns status='completed' (not still
+     'submitted', not 'working')
+  2. include_result: true makes the seller emit the typed result field; sellers MUST
+     NOT silently drop it
+  3. result.media_buy_id MUST equal the value the controller registered — sellers that
+     fabricate a fresh media_buy_id break the polling contract
+
   Out of scope (by design). Transport-level wire-shape assertions — A2A Task.state and
   artifact.metadata.adcp_task_id placement, MCP structuredContent envelope details — are
   runner-side concerns, not storyboard assertions. The runner exercises this scenario
@@ -49,9 +64,10 @@ narrative: |
   adcp-client#904 for the runner-side probes; this storyboard provides the deterministic
   driver.
 
-  The submitted → completed transition (forcing the task to resolve and asserting the
-  completion artifact carries media_buy_id) is deferred to a follow-up scenario. It needs
-  a force_task_completion controller scenario that does not exist yet.
+  Webhook delivery (push_notification_config) is not asserted by this storyboard. The
+  buyer either polls tasks/get (this scenario) or waits on a webhook; both are first-
+  class delivery mechanisms in the spec. Webhook conformance lives in the dedicated
+  webhook-receiver storyboards.
 
 agent:
   interaction_model: media_buy_seller
@@ -229,4 +245,117 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "create_media_buy_async--create_media_buy_submitted"
+            description: "Context correlation_id returned unchanged"
+
+  - id: force_task_completion
+    title: "Resolve the submitted task to completed via comply_test_controller"
+    narrative: |
+      The buyer's poll cannot test completion until the task actually completes,
+      and real completions ride on out-of-band signals (IO countersignature,
+      batch processor cron) the storyboard cannot wait for. Use
+      force_task_completion to pin the completion deterministically: register
+      the result payload (the CreateMediaBuyResponse the seller would have
+      emitted on a synchronous success) against the captured task_id. The next
+      tasks/get with include_result must surface this result verbatim.
+
+    steps:
+      - id: force_task_completed
+        title: "Force the task to completed with a CreateMediaBuyResponse result"
+        requires_tool: comply_test_controller
+        narrative: |
+          Mint a media_buy_id and a packages array, then register them as the
+          completion result. The seller MUST persist this result in its task
+          store and surface it on subsequent tasks/get(task_id, include_result)
+          calls. Sellers that fabricate a different media_buy_id or drop the
+          packages array fail the polling assertion in the next phase.
+        task: comply_test_controller
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Return a successful state transition:
+          - success: true
+          - previous_state: 'submitted'
+          - current_state: 'completed'
+
+        sample_request:
+          scenario: "force_task_completion"
+          params:
+            task_id: "$context.forced_task_id"
+            result:
+              media_buy_id: "mb_async_signed_io_q2"
+              status: "active"
+              packages:
+                - package_id: "pkg-0"
+                  product_id: "async_signed_io_q2"
+                  budget: 30000
+          context:
+            correlation_id: "create_media_buy_async--force_task_completed"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller accepts the completion directive"
+          - check: field_value
+            path: "current_state"
+            value: "completed"
+            description: "Task transitioned to completed"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "create_media_buy_async--force_task_completed"
+            description: "Context correlation_id returned unchanged"
+
+  - id: poll_task_completed
+    title: "tasks/get returns completed status and the recorded result"
+    narrative: |
+      The buyer polls tasks/get with the captured task_id and
+      include_result: true. The seller MUST surface status='completed' and
+      return the result payload registered by force_task_completion verbatim
+      — same media_buy_id, same packages. This anchors the spec invariant
+      formalized in #3126: include_result on a completed async task delivers
+      the typed result field, and the value mirrors what the seller would
+      have emitted on a synchronous success or a webhook callback.
+
+    steps:
+      - id: tasks_get_completed
+        title: "Poll tasks/get with include_result and observe the completion artifact"
+        task: tasks_get
+        schema_ref: "core/tasks-get-request.json"
+        response_schema_ref: "core/tasks-get-response.json"
+        doc_ref: "/protocol/calling-an-agent#async-task-polling"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Return the completed task with the registered result:
+          - status: 'completed'
+          - result.media_buy_id: 'mb_async_signed_io_q2'
+          - result.packages[0].product_id: 'async_signed_io_q2'
+
+        sample_request:
+          task_id: "$context.forced_task_id"
+          include_result: true
+          context:
+            correlation_id: "create_media_buy_async--tasks_get_completed"
+        validations:
+          - check: response_schema
+            description: "Response matches tasks-get-response.json"
+          - check: field_value
+            path: "status"
+            value: "completed"
+            description: "Task status is 'completed' (not 'submitted', not 'working')"
+          - check: field_present
+            path: "result"
+            description: "result is present because include_result was true and status is completed"
+          - check: field_value
+            path: "result.media_buy_id"
+            value: "mb_async_signed_io_q2"
+            description: "result.media_buy_id matches the value registered by force_task_completion — sellers that fabricate a fresh media_buy_id break the polling contract"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "create_media_buy_async--tasks_get_completed"
             description: "Context correlation_id returned unchanged"

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -84,7 +84,7 @@
         },
         "result": {
           "$ref": "/schemas/core/async-response-data.json",
-          "description": "Completion payload to record against the task. Used by force_task_completion. Validates against the async-response-data union — for create_media_buy this is a CreateMediaBuyResponse with media_buy_id and packages. The seller MUST surface this verbatim on the next tasks/get(task_id) call when include_result is true."
+          "description": "Completion payload to record against the task. Used by force_task_completion. Validates against the async-response-data union — for create_media_buy this is a CreateMediaBuyResponse with media_buy_id and packages. The seller MUST surface this on the next tasks/get(task_id) call when include_result is true, with all caller-supplied fields preserved (sellers MAY augment with seller-controlled fields like created_at or dsp_* IDs but MUST NOT overwrite caller-supplied values). Sellers MUST emit INVALID_PARAMS if the payload does not validate against the response branch for the task's original method, and MAY reject payloads exceeding 256 KB with INVALID_PARAMS."
         }
       },
       "additionalProperties": true

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -14,6 +14,7 @@
         "force_account_status",
         "force_media_buy_status",
         "force_create_media_buy_arm",
+        "force_task_completion",
         "force_session_status",
         "simulate_delivery",
         "simulate_budget_spend",
@@ -80,6 +81,10 @@
         "format_id": {
           "type": "string",
           "description": "Creative format ID to seed. Used by seed_creative_format. The seller MUST expose this format ID in list_creative_formats responses for the duration of the compliance session."
+        },
+        "result": {
+          "$ref": "/schemas/core/async-response-data.json",
+          "description": "Completion payload to record against the task. Used by force_task_completion. Validates against the async-response-data union — for create_media_buy this is a CreateMediaBuyResponse with media_buy_id and packages. The seller MUST surface this verbatim on the next tasks/get(task_id) call when include_result is true."
         }
       },
       "additionalProperties": true
@@ -114,6 +119,17 @@
                 "then": { "required": ["task_id"] }
               }
             ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "scenario": { "const": "force_task_completion" } } },
+      "then": {
+        "required": ["params"],
+        "properties": {
+          "params": {
+            "required": ["task_id", "result"]
           }
         }
       }
@@ -203,6 +219,22 @@
           "arm": "submitted",
           "task_id": "task_async_signed_io_q2",
           "message": "Awaiting IO signature from sales team; typical turnaround 2–4 hours"
+        }
+      }
+    },
+    {
+      "description": "Force a previously-submitted create_media_buy task to completion with a result payload",
+      "data": {
+        "scenario": "force_task_completion",
+        "params": {
+          "task_id": "task_async_signed_io_q2",
+          "result": {
+            "media_buy_id": "mb_async_signed_io_q2",
+            "status": "active",
+            "packages": [
+              { "package_id": "pkg-0", "product_id": "async_signed_io_q2", "budget": 30000 }
+            ]
+          }
         }
       }
     },

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -20,6 +20,7 @@
               "force_account_status",
               "force_media_buy_status",
               "force_create_media_buy_arm",
+              "force_task_completion",
               "force_session_status",
               "simulate_delivery",
               "simulate_budget_spend",


### PR DESCRIPTION
## Summary

Closes the loop on #3081 / #3104 / #3115. The `create_media_buy_async` storyboard now exercises the full async lifecycle — submitted envelope, controller-driven completion, then `tasks/get` polling — instead of stopping at the initial submitted response.

- **New controller scenario `force_task_completion`** — registers a `result` payload (validated against `async-response-data.json`) against an existing submitted task. Subsequent `tasks/get(task_id, include_result: true)` MUST surface it verbatim. Returns `StateTransitionSuccess` with `previous_state: 'submitted'` / `current_state: 'completed'`. `NOT_FOUND` on unknown task_ids; `INVALID_TRANSITION` on already-terminal tasks.
- **Storyboard extension (v1.0.0 → v1.1.0)** — adds `tasks_get` to `required_tools` and two new phases:
  - `force_task_completion`: captures `$context.forced_task_id` from phase 2, registers a fixture `CreateMediaBuyResponse` as the result.
  - `poll_task_completed`: calls `tasks/get` with `include_result: true`, asserts `status='completed'` and `result.media_buy_id` matches the registered value — catches sellers that fabricate a fresh ID instead of honoring the registered one.

This anchors the three invariants the spec formalized in #3126:
1. `tasks/get` on a completed async task returns `status: 'completed'` (not stuck at `submitted` / `working`)
2. `include_result: true` makes the seller emit the typed `result` field
3. `result.media_buy_id` matches the seller's registered completion artifact verbatim

## Out of scope

- Webhook (`push_notification_config`) delivery is not asserted; webhook conformance lives in dedicated webhook-receiver storyboards.
- Transport-level wire-shape probes (A2A `Task.state`, `artifact.metadata.adcp_task_id`) remain runner-side at adcp-client#904.

## Adoption

Sellers without `force_task_completion` return `UNKNOWN_SCENARIO` and the storyboard's polling phase grades `not_applicable` for that branch. The training-agent in this repo will pick up the implementation in a follow-up PR (matching the pattern from #3115). adcp-client-python and adcp-go reference agents will follow.

## Why patch

Conformance-suite content addition + new sandbox-only controller scenario, both opt-in via `UNKNOWN_SCENARIO` grading. No on-wire seller obligations change for sellers that already implement `tasks/get` with `include_result` per the schema.

## Test plan

- [x] `npm run build:schemas` + `npm run test:schemas` — 486 schemas valid, examples self-validate (covers the new `force_task_completion` example with `result: $ref async-response-data.json`)
- [x] `npm run build:compliance` — all seven storyboard lint scripts pass; the extended `create_media_buy_async` builds cleanly (16 universal, 6 protocols, 19 specialisms in dist/)
- [x] `node scripts/lint-storyboard-sample-request-schema.cjs` — no new drift
- [x] Pre-commit (`test:unit` + `typecheck`) clean
- [x] Pre-push (`verify-version-sync` + mintlify broken-links) clean
- [ ] CI: storyboard lints, schema tests, training-agent-storyboards (`force_task_completion` will return `UNKNOWN_SCENARIO` until the training-agent follow-up; expect not_applicable on the new phases)
- [ ] CI: broken-links workflow (authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)