### PR TITLE
docs(governance): drop archived creative-agent from IPR bot scope

### DIFF
--- a/.changeset/ipr-bot-setup-archive-note.md
+++ b/.changeset/ipr-bot-setup-archive-note.md
@@ -1,0 +1,4 @@
+---
+---
+
+Drop `creative-agent` from the IPR Bot install list in `governance/ipr-bot-setup.md` — the repo is archived and read-only, so a PR workflow there has no effect. Updates the secret-scoping count from "five repos" to "four repos" to match. Active install scope is now `adcp`, `adcp-client`, `adcp-client-python`, `adcp-go`.

--- a/governance/ipr-bot-setup.md
+++ b/governance/ipr-bot-setup.md
@@ -36,13 +36,14 @@ Install on these repos only:
 - `adcontextprotocol/adcp-client`
 - `adcontextprotocol/adcp-client-python`
 - `adcontextprotocol/adcp-go`
-- `adcontextprotocol/creative-agent`
+
+`adcontextprotocol/creative-agent` is **archived** and read-only — no PR workflow is needed there since the repo can't accept contributions. If it ever gets unarchived, add the workflow at that point.
 
 `prebid/salesagent` lives in a different organization. If we want it covered, install a separate App in the `prebid` org or add the repo to a future cross-org strategy.
 
 ## Secrets
 
-Two organization-level secrets are required, scoped to the same five repos:
+Two organization-level secrets are required, scoped to the same four repos:
 
 | Secret | Source |
 |---|---|


### PR DESCRIPTION
Trivial doc patch: `creative-agent` is archived, so a PR workflow there has no effect. Removing from the IPR Bot install list. Active scope is now adcp, adcp-client, adcp-client-python, adcp-go.

Empirically discovered when rolling out the new callable workflow — creative-agent rejected the push with "This repository was archived so it is read-only."

🤖 Generated with [Claude Code](https://claude.com/claude-code)