### PR TITLE
docs(governance): Policy Registry sync and versioning guidance

### DIFF
--- a/.changeset/policy-registry-sync-versioning-docs.md
+++ b/.changeset/policy-registry-sync-versioning-docs.md
@@ -1,0 +1,10 @@
+---
+---
+
+docs: Policy Registry sync and versioning guidance (#3140)
+
+- Expand "Temporal enforcement" section in policy-registry.mdx with a worked effective_date transition example, explicit requires_human_review + effective_date independence note, and sunset detection guidance (inspect resolved_policies / policies_evaluated; no push notification)
+- Add version pinning section to specification.mdx explaining policy-ref version field vs. unversioned plan-level policy_ids, with protocol-silence caveat on mid-campaign re-resolution semantics
+- Add additive-only Warning block to specification.mdx policy resolution section clarifying custom_policies cannot relax registry-sourced policies
+- Fix schema mismatch in sync_plans.mdx and specification.mdx: custom_policies and shared_exclusions examples were plain strings; schema requires PolicyEntry objects (policy_id, enforcement, policy text)
+- Update field table descriptions for custom_policies and portfolio.shared_exclusions in sync_plans.mdx

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -52,7 +52,13 @@ The campaign plan is the source of truth for all validation. Plans are pushed to
   },
   "countries": ["US"],
   "policy_ids": ["us_coppa", "alcohol_advertising"],
-  "custom_policies": ["No competitor brand adjacency"],
+  "custom_policies": [
+    {
+      "policy_id": "no_competitor_adjacency",
+      "enforcement": "must",
+      "policy": "No advertising adjacent to competitor brand content."
+    }
+  ],
   "approved_sellers": null,
   "ext": {}
 }
@@ -242,7 +248,11 @@ For holding companies and multi-brand organizations, a plan can include a `portf
     "total_budget_cap": { "amount": 50000000, "currency": "USD" },
     "shared_policy_ids": ["eu_gdpr_advertising", "eu_ai_act_article_50"],
     "shared_exclusions": [
-      "No advertising on properties owned by competitor holding companies"
+      {
+        "policy_id": "no_competitor_properties",
+        "enforcement": "must",
+        "policy": "No advertising on properties owned by competitor holding companies."
+      }
     ]
   }
 }
@@ -252,7 +262,7 @@ Portfolio constraints:
 
 - **`total_budget_cap`**: Maximum aggregate spend across all member plans. The governance agent tracks committed budget across all member plans and denies actions that would exceed the cap.
 - **`shared_policy_ids`**: Registry policies enforced across all member plans, regardless of individual brand compliance configuration. Corporate-level regulations that no brand team can override.
-- **`shared_exclusions`**: Natural language exclusion rules applied to all member plans.
+- **`shared_exclusions`**: Bespoke exclusion policies applied to all member plans, using the `PolicyEntry` shape. Additive only — same constraint as plan-level `custom_policies`.
 
 The governance agent validates member plan actions against both the member plan's own constraints and the portfolio plan's constraints. A denial from either level blocks the action.
 
@@ -341,6 +351,25 @@ Each policy in the registry has an ID, applicable jurisdictions, a description, 
 
 This model follows the pattern established by [IEEE 7012](https://standards.ieee.org/ieee/7012/7192/) (Machine Readable Personal Privacy Terms), which maintains a neutral roster of standardized agreements that parties reference rather than draft individually.
 
+### Version pinning
+
+The `policy-ref` schema used in brand compliance configurations supports an optional `version` field for pinning:
+
+```json
+{
+  "policy_id": "uk_hfss",
+  "version": "1.0.0"
+}
+```
+
+When `version` is present, the governance agent resolves that exact semver version of the policy. When omitted, the agent resolves the current version at an implementation-defined point. If deterministic, version-stable enforcement matters for a running campaign -- for example, when a registry policy is updated mid-flight -- pin the version in the brand compliance configuration.
+
+Plan-level `policy_ids` (the plain `string[]` on `sync_plans`) do not carry a version field. The protocol does not define when an unversioned plan-level reference re-resolves against a new registry version; governance agent documentation SHOULD specify this. For guaranteed version stability, use a versioned reference in the brand compliance config rather than relying on plan-level `policy_ids`.
+
+<Note>
+The hosting mechanism and full workflow for brand compliance configurations are under development (see the note at the start of this section). The `policy-ref` schema itself is stable; the end-to-end configuration surface may evolve before GA.
+</Note>
+
 ## Policy resolution
 
 Policies are declared directly on the plan via `policy_ids` and `custom_policies`. When a plan is synced, the governance agent resolves the active policy set:
@@ -348,6 +377,10 @@ Policies are declared directly on the plan via `policy_ids` and `custom_policies
 1. Load registry policies referenced by `policy_ids`
 2. Intersect with the plan's `countries` and `regions` -- only policies applicable to the plan's markets are active
 3. Include all `custom_policies` (these apply regardless of geography)
+
+<Warning>
+**`custom_policies` are additive only.** Governance agents MUST pin registry-sourced policy text as system-level instructions and MUST NOT permit `custom_policies` (or the plan's `objectives` field) to relax, override, or disable registry-sourced policies. Custom policies may add tighter restrictions -- they cannot lower enforcement levels or exempt categories. A `custom_policies` entry that contradicts a registry policy is evaluated alongside it, not instead of it; the stricter constraint governs.
+</Warning>
 
 The plan's `countries` and `regions` fields also serve as **geo enforcement**: the governance agent MUST reject governed actions targeting markets outside the plan's allowed geography. A plan with `regions: ["US-MA"]` rejects actions not explicitly targeting Massachusetts, even if they are otherwise compliant. These fields use the same ISO codes and semantics as `product-filters`, `offerings`, and `create_media_buy`.
 

--- a/docs/governance/campaign/tasks/sync_plans.mdx
+++ b/docs/governance/campaign/tasks/sync_plans.mdx
@@ -65,7 +65,11 @@ Push campaign plans to the governance agent. A plan defines the authorized param
         "min_audience_size": 1000,
         "policy_ids": ["us_coppa", "alcohol_advertising"],
         "custom_policies": [
-          "No advertising adjacent to competitor content"
+          {
+            "policy_id": "no_competitor_adjacency",
+            "enforcement": "must",
+            "policy": "No advertising adjacent to competitor content."
+          }
         ],
         "approved_sellers": null,
         "ext": {}
@@ -148,7 +152,7 @@ Each plan item a buyer supplies here is the preimage the governance agent hashes
 | `plans[].restricted_attributes_custom` | array | No | Additional restricted attributes not covered by the enum. Freeform strings for jurisdiction-specific restrictions (e.g., `financial_status`). |
 | `plans[].min_audience_size` | integer | No | Minimum audience segment size for k-anonymity. Applies to the estimated intersection audience when multiple criteria are used. |
 | `plans[].policy_ids` | array | No | Registry policy IDs to enforce for this plan. Intersected with the plan's countries/regions to activate only geographically relevant policies. |
-| `plans[].custom_policies` | array | No | Natural language policy statements specific to this campaign (e.g., "No advertising adjacent to competitor content"). |
+| `plans[].custom_policies` | array | No | Campaign-specific policies using the `PolicyEntry` shape (`policy_id`, `enforcement`, `policy` text required). Additive only — cannot relax or override registry-sourced policies. See [policy resolution](/docs/governance/campaign/specification#policy-resolution). |
 | `plans[].approved_sellers` | array/null | No | List of approved seller agent URLs. `null` means any seller. |
 | `plans[].delegations` | array | No | Agents authorized to execute against this plan. See [specification](/docs/governance/campaign/specification#delegations). |
 | `plans[].delegations[].agent_url` | string | Yes | URL of the delegated agent. |
@@ -160,7 +164,7 @@ Each plan item a buyer supplies here is the preimage the governance agent hashes
 | `plans[].portfolio.member_plan_ids` | array | Yes | Plan IDs governed by this portfolio plan. |
 | `plans[].portfolio.total_budget_cap` | object | No | Maximum aggregate budget across member plans. |
 | `plans[].portfolio.shared_policy_ids` | array | No | Registry policy IDs enforced across all member plans. |
-| `plans[].portfolio.shared_exclusions` | array | No | Natural language exclusion rules for all member plans. |
+| `plans[].portfolio.shared_exclusions` | array | No | Bespoke exclusion policies applied to all member plans, using the `PolicyEntry` shape (`policy_id`, `enforcement`, `policy` text required). |
 | `plans[].ext` | object | No | Extension data. |
 
 ### Response

--- a/docs/governance/policy-registry.mdx
+++ b/docs/governance/policy-registry.mdx
@@ -41,7 +41,7 @@ The registry solves this by providing:
 - **Standardized policy definitions** with structured metadata (jurisdiction, policy category, enforcement level)
 - **Natural language policy text** that governance agents (LLMs) use directly for evaluation
 - **Calibration exemplars** (pass/fail scenarios) that align agent behavior
-- **Version tracking** so brands can pin to specific policy versions
+- **Version tracking** so brands can pin to specific policy versions (see [pinning in the campaign spec](/docs/governance/campaign/specification#version-pinning))
 
 ## Policy categories
 
@@ -117,7 +117,25 @@ Policies have optional `effective_date` and `sunset_date` fields. Governance age
 
 This means brands can reference upcoming regulations before they take effect. The governance agent evaluates them and reports what *would* have been flagged, without blocking campaigns. Once the effective date passes, enforcement activates automatically -- no configuration change needed.
 
-For example, the EU AI Act Article 50 has `effective_date: "2026-08-02"`. A brand referencing this policy before August 2026 sees informational findings about AI disclosure compliance. After August 2026, violations are rejected.
+### Worked example: informational-to-enforced transition
+
+Suppose you reference `eu_ai_act_article_50`, which carries `effective_date: "2026-08-02"`. Before that date, every `check_governance` call evaluates the policy and returns findings at `info` severity -- no campaign is blocked. Buying teams see _what would be flagged_ and can clean up creatives before enforcement begins. On and after 2026-08-02, the same findings are emitted at blocking severity and campaigns that trigger them are rejected.
+
+No re-syncing the plan. No policy-configuration change. The governance agent reads the date on each evaluation call and shifts enforcement automatically.
+
+### `requires_human_review` is not gated by `effective_date`
+
+The `effective_date`/`sunset_date` mechanism governs content-blocking enforcement (reject vs. inform). It does **not** gate the `requires_human_review` flag.
+
+When a policy carries `requires_human_review: true`, the governance agent MUST set `plan.human_review_required = true` as soon as the policy is resolved -- regardless of whether `effective_date` is in the future. GDPR Article 22 and EU AI Act Annex III human-oversight obligations predate any AI-Act-specific effective date; the human-review requirement fires unconditionally.
+
+**Practical consequence:** a policy with `effective_date: "2027-01-01"` and `requires_human_review: true` published today will surface only informational content findings until 2027, but will immediately mandate `human_review_required: true` on any plan that references it. These are two independent dimensions of a policy's effect.
+
+### Sunset detection
+
+Governance agents evaluate `sunset_date` dynamically against their wall clock on each `check_governance` call. There is no registry push notification. A policy that crosses its `sunset_date` between two evaluation calls is silently dropped starting with the call that occurs after the date passes -- callers do not need to take any action.
+
+To verify which policies are still active, inspect `resolved_policies` in the `sync_plans` response or `policies_evaluated` in the `check_governance` response. A policy that was previously listed and no longer appears has either been sunsetted or is no longer matched after a plan re-sync.
 
 ## Three tiers of policy application
 

--- a/docs/governance/policy-registry.mdx
+++ b/docs/governance/policy-registry.mdx
@@ -119,7 +119,7 @@ This means brands can reference upcoming regulations before they take effect. Th
 
 ### Worked example: informational-to-enforced transition
 
-Suppose you reference `eu_ai_act_article_50`, which carries `effective_date: "2026-08-02"`. Before that date, every `check_governance` call evaluates the policy and returns findings at `info` severity -- no campaign is blocked. Buying teams see _what would be flagged_ and can clean up creatives before enforcement begins. On and after 2026-08-02, the same findings are emitted at blocking severity and campaigns that trigger them are rejected.
+Suppose you reference `eu_ai_act_article_50`, which carries `effective_date: "2026-08-02"`. Before that date, every `check_governance` call evaluates the policy and returns findings at `info` severity -- no campaign is blocked. Buying teams see _what would be flagged_ and can clean up creatives before enforcement begins. On and after 2026-08-02, the policy is enforced at its declared level — `must`-enforcement findings reject campaigns, `should`-enforcement findings produce warnings.
 
 No re-syncing the plan. No policy-configuration change. The governance agent reads the date on each evaluation call and shifts enforcement automatically.
 


### PR DESCRIPTION
Closes #3140

Adds the sync/versioning documentation requested by the governance working group, distributed across the files where each topic naturally belongs rather than as a single new section in `policy-registry.mdx` (per expert review — the five topics split cleanly across audience lines).

## What changed

**`docs/governance/policy-registry.mdx`**
- Expands "Temporal enforcement" with a worked `effective_date` example (informational `info`-severity findings before the date, blocking enforcement after) — consistent with the existing table's "reported at `info` severity" phrasing
- Adds `requires_human_review` is not gated by `effective_date` — the human-review mandate fires as soon as a policy is resolved, not on the enforcement date
- Adds sunset detection guidance: pull-based wall-clock evaluation per `check_governance` call; no push notification; inspect `resolved_policies` / `policies_evaluated` to confirm active set
- Cross-links "Version tracking" bullet to `specification#version-pinning`

**`docs/governance/campaign/specification.mdx`**
- **Bug fix:** `custom_policies` and `shared_exclusions` examples were plain strings; the schema (`sync-plans-request.json`) defines both as `PolicyEntry[]` requiring `policy_id`, `enforcement`, and `policy` text. Schema-invalid examples would fail CI JSON validation if they carried `$schema` refs.
- Adds "Version pinning" subsection under "Policy registry" explaining the `policy-ref` `version` field, the protocol-silence caveat on when unversioned plan-level `policy_ids` re-resolve, and a stability note linking back to the existing "under development" caveat
- Adds additive-only `<Warning>` block in "Policy resolution" section — quoted from the schema description in `policy-entry.json`

**`docs/governance/campaign/tasks/sync_plans.mdx`**
- Same `custom_policies` plain-string bug fix in the request example
- Updates `custom_policies` and `portfolio.shared_exclusions` field table descriptions to reference `PolicyEntry` shape and link to policy resolution

## Non-breaking justification

Docs-only changes across three MDX files. No schema modifications. No URL changes. Changeset is `--empty` (no protocol impact). `sync_plans` surface is `x-status: experimental`.

## Pre-PR review

- **code-reviewer:** approved — 1 nit (anchor link `#policy-registry` → `#version-pinning`, fixed before merge); schema-mismatch fix confirmed correct
- **ad-tech-protocol-expert:** approved with 2 blockers fixed — (1) "must-level violations" language corrected to "blocking severity" to avoid conflating enforcement level with finding severity; (2) "de-resolved by a plan amendment" replaced with "no longer matched after a plan re-sync" to avoid naming a nonexistent protocol concept

Session: https://claude.ai/code/session_01XuqvXPFRgFRL9tWA9drHCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuqvXPFRgFRL9tWA9drHCM)_