### PR TITLE
feat(schema): hoist 4 duplicate inline enum sets into shared enums/ definitions

### DIFF
--- a/.changeset/hoist-duplicate-inline-enums.md
+++ b/.changeset/hoist-duplicate-inline-enums.md
@@ -1,0 +1,27 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(schema): hoist 4 duplicate inline enum literal sets into shared `enums/` definitions (closes #3144)
+
+Several inline string-literal unions in the AdCP source schemas had byte-identical value sets across multiple parent schemas but no shared `$ref`, causing the TypeScript SDK to emit per-parent duplicate exports (`Account_PaymentTermsValues`, `GetAccountFinancialsSuccess_PaymentTermsValues`, etc.) when a single canonical `PaymentTermsValues` is what consumers expect.
+
+**New shared enum files added** (4 new `$id`-bearing schemas in `static/schemas/source/enums/`):
+
+- `payment-terms.json` — `["net_15","net_30","net_45","net_60","net_90","prepay"]`
+- `audio-channel-layout.json` — `["mono","stereo","5.1","7.1"]`
+- `media-buy-valid-action.json` — `["pause","resume","cancel","update_budget","update_dates","update_packages","add_packages","sync_creatives"]`
+- `rights-billing-period.json` — `["daily","weekly","monthly","quarterly","annual","one_time"]`
+
+**Schemas updated to use `$ref`** (10 files; wire format unchanged in all cases):
+
+- `core/account.json`, `account/sync-accounts-request.json`, `account/sync-accounts-response.json`, `account/get-account-financials-response.json` → `payment_terms` now refs `enums/payment-terms.json`
+- `core/assets/audio-asset.json`, `core/assets/video-asset.json` → `channels`/`audio_channels` now ref `enums/audio-channel-layout.json`
+- `media-buy/create-media-buy-response.json`, `media-buy/update-media-buy-response.json` → `valid_actions` items now ref `enums/media-buy-valid-action.json`
+- `brand/rights-terms.json`, `brand/rights-pricing-option.json` → `period` now refs `enums/rights-billing-period.json`
+
+**Not changed:** `core/insertion-order.json` `payment_terms` (`["net_30","net_60","net_90","prepaid","due_on_receipt"]` — different set, kept inline).
+
+Non-breaking: replacing inline `{"type":"string","enum":[...]}` with a `$ref` to an equivalent standalone schema produces an identical JSON Schema subgraph; all existing validators behave identically. The new named files are additive — this is `minor` per the repo's semantic versioning rules.
+
+After a `npm run sync-schemas` in `adcp-client`, the SDK will emit single canonical exports (`PaymentTermsValues`, `AudioChannelLayoutValues`, etc.) and should ship deprecated re-export aliases for any per-parent names that were in a published release.

--- a/static/schemas/source/account/get-account-financials-response.json
+++ b/static/schemas/source/account/get-account-financials-response.json
@@ -101,8 +101,7 @@
           "description": "Overall payment status. current: all obligations met. past_due: one or more invoices overdue. suspended: account suspended due to payment issues."
         },
         "payment_terms": {
-          "type": "string",
-          "enum": ["net_15", "net_30", "net_45", "net_60", "net_90", "prepay"],
+          "$ref": "/schemas/enums/payment-terms.json",
           "description": "Payment terms in effect for this account"
         },
         "invoices": {

--- a/static/schemas/source/account/sync-accounts-request.json
+++ b/static/schemas/source/account/sync-accounts-request.json
@@ -49,15 +49,7 @@
             "description": "Business entity details for the party responsible for payment. The agent provides this so the seller has the legal name, tax IDs, address, and bank details needed for formal B2B invoicing."
           },
           "payment_terms": {
-            "type": "string",
-            "enum": [
-              "net_15",
-              "net_30",
-              "net_45",
-              "net_60",
-              "net_90",
-              "prepay"
-            ],
+            "$ref": "/schemas/enums/payment-terms.json",
             "description": "Payment terms for this account. The seller must either accept these terms or reject the account — terms are never silently remapped. When omitted, the seller applies its default terms."
           },
           "sandbox": {

--- a/static/schemas/source/account/sync-accounts-response.json
+++ b/static/schemas/source/account/sync-accounts-response.json
@@ -106,15 +106,7 @@
                 "description": "Rate card applied to this account"
               },
               "payment_terms": {
-                "type": "string",
-                "enum": [
-                  "net_15",
-                  "net_30",
-                  "net_45",
-                  "net_60",
-                  "net_90",
-                  "prepay"
-                ],
+                "$ref": "/schemas/enums/payment-terms.json",
                 "description": "Payment terms agreed for this account. When the account is active, these are the binding terms for all invoices on this account."
               },
               "credit_limit": {

--- a/static/schemas/source/brand/rights-pricing-option.json
+++ b/static/schemas/source/brand/rights-pricing-option.json
@@ -33,8 +33,7 @@
       "minItems": 1
     },
     "period": {
-      "type": "string",
-      "enum": ["daily", "weekly", "monthly", "quarterly", "annual", "one_time"],
+      "$ref": "/schemas/enums/rights-billing-period.json",
       "description": "Billing period for flat_rate and time-based models"
     },
     "impression_cap": {

--- a/static/schemas/source/brand/rights-terms.json
+++ b/static/schemas/source/brand/rights-terms.json
@@ -13,8 +13,7 @@
       "pattern": "^[A-Z]{3}$"
     },
     "period": {
-      "type": "string",
-      "enum": ["daily", "weekly", "monthly", "quarterly", "annual", "one_time"]
+      "$ref": "/schemas/enums/rights-billing-period.json"
     },
     "uses": {
       "type": "array",

--- a/static/schemas/source/core/account.json
+++ b/static/schemas/source/core/account.json
@@ -50,8 +50,7 @@
       "description": "Identifier for the rate card applied to this account"
     },
     "payment_terms": {
-      "type": "string",
-      "enum": ["net_15", "net_30", "net_45", "net_60", "net_90", "prepay"],
+      "$ref": "/schemas/enums/payment-terms.json",
       "description": "Payment terms agreed for this account. Binding for all invoices when the account is active."
     },
     "credit_limit": {

--- a/static/schemas/source/core/assets/audio-asset.json
+++ b/static/schemas/source/core/assets/audio-asset.json
@@ -38,8 +38,7 @@
       "description": "Sampling rate in Hz (e.g., 44100, 48000, 96000)"
     },
     "channels": {
-      "type": "string",
-      "enum": ["mono", "stereo", "5.1", "7.1"],
+      "$ref": "/schemas/enums/audio-channel-layout.json",
       "description": "Channel configuration"
     },
     "bit_depth": {

--- a/static/schemas/source/core/assets/video-asset.json
+++ b/static/schemas/source/core/assets/video-asset.json
@@ -109,8 +109,7 @@
       "description": "Audio sampling rate in Hz (e.g., 44100, 48000)"
     },
     "audio_channels": {
-      "type": "string",
-      "enum": ["mono", "stereo", "5.1", "7.1"],
+      "$ref": "/schemas/enums/audio-channel-layout.json",
       "description": "Audio channel configuration"
     },
     "audio_bit_depth": {

--- a/static/schemas/source/core/requirements/video-asset-requirements.json
+++ b/static/schemas/source/core/requirements/video-asset-requirements.json
@@ -132,8 +132,7 @@
     "audio_channels": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["mono", "stereo", "5.1", "7.1"]
+        "$ref": "/schemas/enums/audio-channel-layout.json"
       },
       "description": "Accepted audio channel configurations"
     },

--- a/static/schemas/source/enums/audio-channel-layout.json
+++ b/static/schemas/source/enums/audio-channel-layout.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/audio-channel-layout.json",
+  "title": "Audio Channel Layout",
+  "description": "Audio channel configuration for audio and video assets",
+  "type": "string",
+  "enum": ["mono", "stereo", "5.1", "7.1"]
+}

--- a/static/schemas/source/enums/media-buy-valid-action.json
+++ b/static/schemas/source/enums/media-buy-valid-action.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/media-buy-valid-action.json",
+  "title": "Media Buy Valid Action",
+  "description": "Actions the buyer can perform on a media buy",
+  "type": "string",
+  "enum": ["pause", "resume", "cancel", "update_budget", "update_dates", "update_packages", "add_packages", "sync_creatives"]
+}

--- a/static/schemas/source/enums/payment-terms.json
+++ b/static/schemas/source/enums/payment-terms.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/payment-terms.json",
+  "title": "Payment Terms",
+  "description": "Standard payment terms for AdCP accounts",
+  "type": "string",
+  "enum": ["net_15", "net_30", "net_45", "net_60", "net_90", "prepay"],
+  "enumDescriptions": {
+    "net_15": "Payment due within 15 days of invoice",
+    "net_30": "Payment due within 30 days of invoice",
+    "net_45": "Payment due within 45 days of invoice",
+    "net_60": "Payment due within 60 days of invoice",
+    "net_90": "Payment due within 90 days of invoice",
+    "prepay": "Payment required before campaign delivery"
+  }
+}

--- a/static/schemas/source/enums/rights-billing-period.json
+++ b/static/schemas/source/enums/rights-billing-period.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/rights-billing-period.json",
+  "title": "Rights Billing Period",
+  "description": "Billing period for brand rights pricing",
+  "type": "string",
+  "enum": ["daily", "weekly", "monthly", "quarterly", "annual", "one_time"]
+}

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -46,8 +46,7 @@
           "type": "array",
           "description": "Actions the buyer can perform on this media buy after creation. Saves a round-trip to get_media_buys.",
           "items": {
-            "type": "string",
-            "enum": ["pause", "resume", "cancel", "update_budget", "update_dates", "update_packages", "add_packages", "sync_creatives"]
+            "$ref": "/schemas/enums/media-buy-valid-action.json"
           }
         },
         "packages": {

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -98,17 +98,7 @@
             "type": "array",
             "description": "Actions the buyer can perform on this media buy in its current state. Eliminates the need for agents to internalize the state machine — the seller declares what is permitted right now.",
             "items": {
-              "type": "string",
-              "enum": [
-                "pause",
-                "resume",
-                "cancel",
-                "update_budget",
-                "update_dates",
-                "update_packages",
-                "add_packages",
-                "sync_creatives"
-              ]
+              "$ref": "/schemas/enums/media-buy-valid-action.json"
             }
           },
           "history": {

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -47,8 +47,7 @@
           "type": "array",
           "description": "Actions the buyer can perform after this update. Saves a round-trip to get_media_buys.",
           "items": {
-            "type": "string",
-            "enum": ["pause", "resume", "cancel", "update_budget", "update_dates", "update_packages", "add_packages", "sync_creatives"]
+            "$ref": "/schemas/enums/media-buy-valid-action.json"
           }
         },
         "sandbox": {


### PR DESCRIPTION
Closes #3144

## Summary

Several inline string-literal unions in the AdCP source schemas had byte-identical value sets across multiple parent schemas but no shared `$ref`, causing the TypeScript SDK (`adcp-client#938`) to emit per-parent duplicate exports (`Account_PaymentTermsValues`, `GetAccountFinancialsSuccess_PaymentTermsValues`, etc.) when a single canonical export is what consumers expect.

This PR adds 4 shared enum definition files to `static/schemas/source/enums/` and updates 12 schemas to `$ref` them. Wire format is unchanged in all cases.

## Files changed

**4 new shared enum files:**
- `enums/payment-terms.json` — `["net_15","net_30","net_45","net_60","net_90","prepay"]`
- `enums/audio-channel-layout.json` — `["mono","stereo","5.1","7.1"]` (named distinct from existing `enums/channels.json` which covers media channels)
- `enums/media-buy-valid-action.json` — `["pause","resume","cancel","update_budget","update_dates","update_packages","add_packages","sync_creatives"]`
- `enums/rights-billing-period.json` — `["daily","weekly","monthly","quarterly","annual","one_time"]`

**12 schemas updated to `$ref` (inline → shared):**
- `core/account.json`, `account/sync-accounts-request.json`, `account/sync-accounts-response.json`, `account/get-account-financials-response.json` → `payment_terms`
- `core/assets/audio-asset.json`, `core/assets/video-asset.json`, `core/requirements/video-asset-requirements.json` → `channels`/`audio_channels`
- `media-buy/create-media-buy-response.json`, `media-buy/update-media-buy-response.json`, `media-buy/get-media-buys-response.json` → `valid_actions` items
- `brand/rights-terms.json`, `brand/rights-pricing-option.json` → `period`

**Not changed:** `core/insertion-order.json` `payment_terms` — its set `["net_30","net_60","net_90","prepaid","due_on_receipt"]` is a distinct enum (different values and spellings); kept inline intentionally.

**Also not changed:** `core/requirements/audio-asset-requirements.json` channels — its set `["mono","stereo"]` is a format-constraint subset, not the full layout type; left inline by design.

## Non-breaking justification

Replacing `{"type":"string","enum":[...]}` with a `$ref` to a standalone schema file containing the identical enum members resolves to the same JSON Schema subgraph. All existing validators produce identical results. No wire values added, removed, or reordered. Additive new named `$id`-bearing schemas → `minor` bump per the repo's semantic versioning rules.

## Milestone routing

Target: `3.1.0` milestone (`minor` bump, next open X.Y.0 per routing matrix). I could not confirm via API whether the `3.1.0` milestone is open — please apply milestone and confirm routing is correct before merge.

## Pre-PR review

- **code-reviewer**: approved with 1 blocker fixed (missed `video-asset-requirements.json`) and nits (missing `enumDescriptions` on 3 of 4 new files — deferred as follow-up since convention is not uniformly enforced across existing enums)
- **ad-tech-protocol-expert**: approved — non-breaking per spec; blocker fixed (`get-media-buys-response.json` missed inline enum); `x-status: experimental` placement correct on consuming schemas, not enum files; `minor` bump confirmed correct

**Nit deferred to follow-up:** `enumDescriptions` missing on `audio-channel-layout.json`, `media-buy-valid-action.json`, `rights-billing-period.json`. `payment-terms.json` has them. Can be added in a `--empty` docs-only follow-up.

Session: https://claude.ai/code/session_01CnLihr57i95Q8tV3x3wXPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnLihr57i95Q8tV3x3wXPE)_