### PR TITLE
docs(governance): branch-protection verification smoke test

### DIFF
--- a/.changeset/ipr-bot-verify-protection.md
+++ b/.changeset/ipr-bot-verify-protection.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a "Verifying branch protection" section to `governance/ipr-bot-setup.md` documenting the smoke test for confirming the `IPR Policy / Signature` ruleset works (check posts, review enforcement holds, bot bypass still functions on adcp).

--- a/governance/ipr-bot-setup.md
+++ b/governance/ipr-bot-setup.md
@@ -116,3 +116,12 @@ The signatures committed historically remain valid; only the future signing path
    ```
 
 4. Open a test PR from a fresh fork or unsigned account to verify the full path: comment fires, signature lands in `adcp@main:signatures/ipr-signatures.json`, status check goes green.
+
+## Verifying branch protection
+
+When `IPR Policy / Signature` is added as a required status check on a repo's `main` ruleset, run this smoke test:
+
+1. Open any tiny PR (e.g. a whitespace nudge in a doc).
+2. Confirm `IPR Policy / Signature` posts on the PR's commit.
+3. Try to merge without an approving review — GitHub should block with "Required check is missing" or "Required reviews not met".
+4. Once approved + merged, on adcp specifically, confirm the next signature event still pushes a `chore(ipr):` commit straight to `main`. If those start failing, the **AAO IPR Bot** is not in the ruleset's bypass list — fix that and re-test.


### PR DESCRIPTION
Tiny doc update to verify the new branch protection ruleset on adcp works as expected.

Adds a short "Verifying branch protection" section to `governance/ipr-bot-setup.md` documenting the smoke test (check posts, review enforcement holds, bot bypass functions). This PR also doubles as the live smoke test.

## What to watch

- [ ] `IPR Policy / Signature` posts as a successful status check (Brian is signed)
- [ ] Merge button is greyed out / shows "Required reviews" — until approved
- [ ] After approval + merge, no `chore(ipr):` push should fire (no signature event in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)