### PR TITLE
fix(security): escape quotes in escapeHtml for HTML attribute safety

### DIFF
--- a/.changeset/escape-html-attribute-context-hardening.md
+++ b/.changeset/escape-html-attribute-context-hardening.md
@@ -1,0 +1,8 @@
+---
+---
+
+`escapeHtml` helpers in 63 server/public HTML pages now escape `"` and `'` in addition to `<>&`, so values interpolated into HTML attribute contexts (`src="${escapeHtml(...)}"`, `data-*` attrs, etc.) can't break out of the attribute even if upstream validation lets a quote through. Defense-in-depth for #3153.
+
+The `div.textContent → div.innerHTML` round-trip historically only escaped `<>&`, leaving the helper unsafe for the dominant call site (HTML attributes in template literals). Pages that already used a manual `replace()` chain were already safe and weren't touched.
+
+Behavior change for callers: text content with quotes now renders with `&quot;` / `&#39;` entities — visually identical in browsers, byte-different in inspect-element. The `tests/community/profile-edit.test.ts` assertion was updated accordingly.

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -1500,7 +1500,7 @@
         if (!str) return '';
         const div = document.createElement('div');
         div.textContent = str;
-        return div.innerHTML;
+        return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
       }
 
       async function validateDomain() {

--- a/server/public/admin-addie-costs.html
+++ b/server/public/admin-addie-costs.html
@@ -247,7 +247,7 @@
       if (text === null || text === undefined) return '';
       const div = document.createElement('div');
       div.textContent = String(text);
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function formatTimestamp(iso) {

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -2982,7 +2982,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function copyThreadId(el) {

--- a/server/public/admin-analytics.html
+++ b/server/public/admin-analytics.html
@@ -497,7 +497,7 @@
     function escapeHtml(str) {
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     async function loadMembershipMetrics() {

--- a/server/public/admin-announcements.html
+++ b/server/public/admin-announcements.html
@@ -472,7 +472,7 @@
       if (text === null || text === undefined) return '';
       const div = document.createElement('div');
       div.textContent = String(text);
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Arrow-key nav across the filter tabs. Follows the WAI-ARIA

--- a/server/public/admin-audit.html
+++ b/server/public/admin-audit.html
@@ -392,7 +392,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Event listeners for filters

--- a/server/public/admin-bans.html
+++ b/server/public/admin-bans.html
@@ -603,7 +603,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function escapeAttr(text) {

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -481,7 +481,7 @@
     function escapeHtml(str) {
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function showError(message) {

--- a/server/public/admin-brands.html
+++ b/server/public/admin-brands.html
@@ -1108,7 +1108,7 @@
       if (str == null) return '';
       const div = document.createElement('div');
       div.textContent = String(str);
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Populate search from URL param (used by domain health "Review in Brands" links)

--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -399,7 +399,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function formatDate(dateString) {

--- a/server/public/admin-data-cleanup.html
+++ b/server/public/admin-data-cleanup.html
@@ -927,7 +927,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
   </script>
 </body>

--- a/server/public/admin-email.html
+++ b/server/public/admin-email.html
@@ -600,7 +600,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function openCreateCampaignModal() {

--- a/server/public/admin-escalations.html
+++ b/server/public/admin-escalations.html
@@ -422,7 +422,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/admin-feeds.html
+++ b/server/public/admin-feeds.html
@@ -1274,7 +1274,7 @@
     function escapeHtml(text) {
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Toggle email subscription for a feed

--- a/server/public/admin-geo.html
+++ b/server/public/admin-geo.html
@@ -573,7 +573,7 @@
       if (str == null) return '';
       const div = document.createElement('div');
       div.textContent = String(str);
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function formatDate(dateString) {

--- a/server/public/admin-manifest-refs.html
+++ b/server/public/admin-manifest-refs.html
@@ -515,7 +515,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/admin-meetings.html
+++ b/server/public/admin-meetings.html
@@ -943,7 +943,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function escapeJs(text) {

--- a/server/public/admin-moltbook.html
+++ b/server/public/admin-moltbook.html
@@ -771,7 +771,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/admin-network-health.html
+++ b/server/public/admin-network-health.html
@@ -823,7 +823,7 @@
     function escapeHtml(str) {
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     init();

--- a/server/public/admin-notification-channels.html
+++ b/server/public/admin-notification-channels.html
@@ -744,7 +744,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/admin-outreach.html
+++ b/server/public/admin-outreach.html
@@ -733,7 +733,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Load analytics data (time stats + goal stats)

--- a/server/public/admin-policies.html
+++ b/server/public/admin-policies.html
@@ -469,7 +469,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Close modal on outside click

--- a/server/public/admin-referrals.html
+++ b/server/public/admin-referrals.html
@@ -651,7 +651,7 @@
     function escapeHtml(str) {
       const div = document.createElement('div');
       div.textContent = String(str || '');
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     let companySearchTimer;

--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -1107,7 +1107,7 @@ loadAuditHistory();
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/admin-users.html
+++ b/server/public/admin-users.html
@@ -1945,7 +1945,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Escape for use in JavaScript string literals within onclick attributes

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -1728,7 +1728,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Escape string for use in JavaScript (for onclick handlers)

--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -941,7 +941,7 @@
     function escapeHtml(text) {
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     async function loadAccountViewCounts() {

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -537,7 +537,7 @@
         if (!str) return '';
         const div = document.createElement('div');
         div.textContent = String(str);
-        return div.innerHTML;
+        return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     window.addEventListener('DOMContentLoaded', async () => {

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -3621,7 +3621,7 @@
         if (!str) return '';
         const div = document.createElement('div');
         div.textContent = str;
-        return div.innerHTML;
+        return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
       }
 
       function escapeAttr(str) {

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -591,7 +591,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   function escapeAttr(str) {

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -3132,7 +3132,7 @@
         if (!text) return '';
         const div = document.createElement('div');
         div.textContent = text;
-        return div.innerHTML;
+        return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
       }
 
       // Current conversation channel (web or slack)

--- a/server/public/committees.html
+++ b/server/public/committees.html
@@ -764,7 +764,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     async function handleInterest(committeeSlug, committeeName, buttonEl) {

--- a/server/public/community/connections.html
+++ b/server/public/community/connections.html
@@ -413,7 +413,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
   </script>
 </body>

--- a/server/public/community/hub.html
+++ b/server/public/community/hub.html
@@ -996,7 +996,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function relDate(s) {

--- a/server/public/community/person-card.js
+++ b/server/public/community/person-card.js
@@ -364,5 +364,5 @@ function escapeHtmlPC(str) {
   if (!str) return '';
   const div = document.createElement('div');
   div.textContent = str;
-  return div.innerHTML;
+  return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -1428,7 +1428,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function formatTier(tier) {

--- a/server/public/community/profile-edit.js
+++ b/server/public/community/profile-edit.js
@@ -14,7 +14,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
   function slugify(text) {
     return text.toLowerCase().trim()

--- a/server/public/dashboard-api-keys.html
+++ b/server/public/dashboard-api-keys.html
@@ -546,7 +546,7 @@
     function escapeHtml(str) {
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/dashboard-emails.html
+++ b/server/public/dashboard-emails.html
@@ -381,7 +381,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     async function toggleCategory(categoryId, enabled) {

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1919,7 +1919,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Load and display user's agreements

--- a/server/public/dashboard-nav.js
+++ b/server/public/dashboard-nav.js
@@ -7,7 +7,7 @@
   function escapeHtml(str) {
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   // Check if legacy org needs profile info - runs on all dashboard pages

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -1292,7 +1292,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Helper to check if the CURRENT org (not any org) has active subscription

--- a/server/public/events.html
+++ b/server/public/events.html
@@ -491,7 +491,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Initialize

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -236,7 +236,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   function safeUrl(url) {

--- a/server/public/industry-gatherings.html
+++ b/server/public/industry-gatherings.html
@@ -614,7 +614,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     init();

--- a/server/public/join-cta.js
+++ b/server/public/join-cta.js
@@ -738,5 +738,5 @@ function escapeHtml(text) {
   if (!text) return '';
   const div = document.createElement('div');
   div.textContent = text;
-  return div.innerHTML;
+  return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/server/public/js/thread-widget.js
+++ b/server/public/js/thread-widget.js
@@ -40,7 +40,7 @@ const ThreadWidget = (function() {
     if (!text) return '';
     const div = document.createElement('div');
     div.textContent = text;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   /**

--- a/server/public/latest/index.html
+++ b/server/public/latest/index.html
@@ -318,7 +318,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     loadSections();

--- a/server/public/latest/section.html
+++ b/server/public/latest/section.html
@@ -321,7 +321,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     loadSection();

--- a/server/public/logo-preview.html
+++ b/server/public/logo-preview.html
@@ -288,7 +288,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   function getFileExtension(url) {

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -2599,7 +2599,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
   </script>
 </body>

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -2464,7 +2464,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
   </script>
 </body>

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -1411,7 +1411,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Event listeners

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -30,7 +30,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   // Determine if running locally

--- a/server/public/oauth-complete.html
+++ b/server/public/oauth-complete.html
@@ -121,7 +121,7 @@
     function escapeHtml(text) {
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     const params = new URLSearchParams(window.location.search);

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -991,7 +991,7 @@
     function escapeHtml(text) {
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     async function acceptInvitation(invitationId) {

--- a/server/public/org-index-old.html
+++ b/server/public/org-index-old.html
@@ -696,7 +696,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   document.addEventListener('DOMContentLoaded', async () => {

--- a/server/public/perspectives/utils.js
+++ b/server/public/perspectives/utils.js
@@ -94,7 +94,7 @@ function escapeHtml(text) {
   if (!text) return '';
   const div = document.createElement('div');
   div.textContent = text;
-  return div.innerHTML;
+  return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 /**

--- a/server/public/policies.html
+++ b/server/public/policies.html
@@ -647,7 +647,7 @@
     if (!str) return '';
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   function escapeAttr(str) {

--- a/server/public/property-viewer.html
+++ b/server/public/property-viewer.html
@@ -403,7 +403,7 @@
         if (str == null) return '';
         const div = document.createElement('div');
         div.textContent = String(str);
-        return div.innerHTML;
+        return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
       }
 
       function escapeAttr(str) {

--- a/server/public/team.html
+++ b/server/public/team.html
@@ -1147,7 +1147,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // Load verified domains

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -2407,7 +2407,7 @@
       if (!str) return '';
       const div = document.createElement('div');
       div.textContent = str;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     function handlePostAnchor() {

--- a/server/public/working-groups/manage.html
+++ b/server/public/working-groups/manage.html
@@ -1406,7 +1406,7 @@
       if (!text) return '';
       const div = document.createElement('div');
       div.textContent = text;
-      return div.innerHTML;
+      return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
     // =========================================================================

--- a/tests/community/profile-edit.test.ts
+++ b/tests/community/profile-edit.test.ts
@@ -75,10 +75,11 @@ describe('profile-edit: pure helpers', () => {
     expect(win.ProfileEdit.slugify('CAPS & symbols!')).toBe('caps-symbols');
   });
 
-  it('escapeHtml escapes HTML entities', () => {
+  it('escapeHtml escapes HTML entities including quotes for attribute safety', () => {
     expect(win.ProfileEdit.escapeHtml('<script>alert("xss")</script>')).toBe(
-      '&lt;script&gt;alert("xss")&lt;/script&gt;'
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
     );
+    expect(win.ProfileEdit.escapeHtml("O'Brien")).toBe('O&#39;Brien');
     expect(win.ProfileEdit.escapeHtml('')).toBe('');
     expect(win.ProfileEdit.escapeHtml(null as unknown as string)).toBe('');
   });


### PR DESCRIPTION
## Summary

The \`textContent → innerHTML\` round-trip used by 63 \`escapeHtml\` helpers across \`server/public\` escaped \`<>&\` but not \`"\` or \`'\`. Pages that interpolated \`escapeHtml(...)\` into a double-quoted attribute (\`src="\${escapeHtml(url)}"\`, \`data-*="\${escapeHtml(value)}"\`, etc.) were one quote-bypass away from breaking out of the attribute. Upstream validators reject raw quotes today, but defense in depth costs us nothing.

This patch appends \`.replace(/"/g, '&quot;').replace(/'/g, '&#39;')\` to the \`return div.innerHTML;\` line in every helper that used the unsafe variant. Pages that already used a manual \`.replace()\` chain (17 files) were left alone — they were already safe.

## Why

security-reviewer flagged this on #3137. The \`javascript:\` URI vector against \`<img src>\` is a non-issue (modern browsers don't execute it), but quote-breaking through interpolated attributes is a real class of XSS that this defense closes.

## Behavior

Text content with quotes now renders with \`&quot;\` / \`&#39;\` entities. Browsers display them identically; only \`view-source\` differs.

The lone test that asserted the old behavior (\`tests/community/profile-edit.test.ts\`) was updated to assert the new encoding.

## Out of scope

- Splitting into \`escapeHtmlText\` / \`escapeHtmlAttr\` helpers (would have touched 40+ call sites; this approach is mechanical and equivalent in safety)
- Replacing the per-page inline helper with a shared utility (the duplication is real but pre-existing)

Closes #3153.

## Test plan

- [x] Type-check passes
- [x] Full unit suite passes (832 tests)
- [ ] Reviewer to spot-check rendered output on dashboard / member-profile (no visible regressions expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)