### PR TITLE
feat(admin): transfer_brand_ownership tool for brand registry

### DIFF
--- a/.changeset/brand-ownership-transfer-admin-tool.md
+++ b/.changeset/brand-ownership-transfer-admin-tool.md
@@ -1,0 +1,8 @@
+---
+---
+
+Add `transfer_brand_ownership` admin tool to Addie's admin panel.
+
+Admins can now transfer a brand domain from one organization to another via a single tool call — no more direct database surgery for acquisitions, org renames, or "original uploader left" cases. The operation writes a revision to the `brand_revisions` audit trail before updating `brands.workos_organization_id`.
+
+Two items from the issue that need more design are deferred: the soft-claim model (spoofing risk when `brand_manifest` is non-empty) and the `claim_disputed_brand` member tool (better modeled as a `dispute_type: brand_ownership` escalation using the existing escalation system).

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -1576,6 +1576,35 @@ For logo changes, use update_member_logo instead.`,
       required: ['domain', 'logo_id', 'action'],
     },
   },
+
+  // ============================================
+  // BRAND REGISTRY TOOLS
+  // ============================================
+  {
+    name: 'transfer_brand_ownership',
+    description: `Transfer ownership of a brand domain from one organization to another. Records a revision for audit. Use after out-of-band verification (acquisition docs, support ticket, legal correspondence) confirms the new org should own the domain.
+
+Do not use to resolve unverified disputes — use the escalation queue for those. This is for confirmed transfers only.`,
+    usage_hints: 'Get new_org_id from get_account. Pair with resolve_escalation to close the related support ticket after transfer.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        domain: {
+          type: 'string',
+          description: 'Brand domain to transfer (e.g., "nova-brands.com")',
+        },
+        new_org_id: {
+          type: 'string',
+          description: 'WorkOS organization ID of the new owner (e.g., "org_01HW...")',
+        },
+        reason: {
+          type: 'string',
+          description: 'Reason for the transfer, recorded in the audit trail (e.g., "Acquisition by Pinnacle Agency — see ticket #4821")',
+        },
+      },
+      required: ['domain', 'new_org_id', 'reason'],
+    },
+  },
 ];
 
 /**
@@ -8487,6 +8516,48 @@ Use add_committee_leader to assign a leader.`;
       if (error instanceof ToolError) throw error;
       logger.error({ error, logoId, domain, action }, 'Error reviewing brand logo');
       throw new ToolError(`Failed to ${action} logo: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  });
+
+  // ============================================
+  // BRAND REGISTRY HANDLERS
+  // ============================================
+
+  handlers.set('transfer_brand_ownership', async (input) => {
+    const rawDomain = input.domain as string;
+    const newOrgId = input.new_org_id as string;
+    const reason = input.reason as string;
+
+    if (!rawDomain) throw new ToolError('domain is required');
+    if (!newOrgId) throw new ToolError('new_org_id is required');
+    if (!reason || reason.length < 20) throw new ToolError('reason must be descriptive (at least 20 characters)');
+
+    const domain = canonicalizeBrandDomain(rawDomain);
+    const adminUserId = memberContext?.workos_user?.workos_user_id ?? 'system:addie-admin';
+    const adminEmail = memberContext?.workos_user?.email;
+    const adminName = memberContext?.workos_user?.first_name;
+
+    try {
+      const result = await brandDbForLogos.transferBrandOwnership(domain, newOrgId, reason, {
+        userId: adminUserId,
+        email: adminEmail,
+        name: adminName,
+      });
+
+      logger.info({ domain, oldOrgId: result.oldOrgId, newOrgId, adminUserId }, 'Addie: brand ownership transferred');
+
+      return JSON.stringify({
+        success: true,
+        domain,
+        old_org_id: result.oldOrgId ?? null,
+        new_org_id: newOrgId,
+        revision_number: result.revisionNumber,
+        reason,
+      }, null, 2);
+    } catch (error) {
+      if (error instanceof ToolError) throw error;
+      logger.error({ error, domain, newOrgId }, 'Error transferring brand ownership');
+      throw new ToolError(`Failed to transfer ownership: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   });
 

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -8526,11 +8526,19 @@ Use add_committee_leader to assign a leader.`;
   handlers.set('transfer_brand_ownership', async (input) => {
     const rawDomain = input.domain as string;
     const newOrgId = input.new_org_id as string;
-    const reason = input.reason as string;
+    const rawReason = input.reason as string;
 
     if (!rawDomain) throw new ToolError('domain is required');
     if (!newOrgId) throw new ToolError('new_org_id is required');
-    if (!reason || reason.length < 20) throw new ToolError('reason must be descriptive (at least 20 characters)');
+    if (!/^org_[A-Z0-9]{20,}$/.test(newOrgId)) {
+      throw new ToolError(`new_org_id ${newOrgId} is not a valid WorkOS organization id (expected "org_..." format).`);
+    }
+    if (!rawReason || rawReason.length < 20) {
+      throw new ToolError('reason must be descriptive (at least 20 characters)');
+    }
+    // Cap so the audit revision can't be bloated to MB by a typo or
+    // prompt-injected long reason; matches review_brand_logo's note cap.
+    const reason = rawReason.slice(0, 1000);
 
     const domain = canonicalizeBrandDomain(rawDomain);
     const adminUserId = memberContext?.workos_user?.workos_user_id ?? 'system:addie-admin';
@@ -8549,7 +8557,7 @@ Use add_committee_leader to assign a leader.`;
       return JSON.stringify({
         success: true,
         domain,
-        old_org_id: result.oldOrgId ?? null,
+        old_org_id: result.oldOrgId,
         new_org_id: newOrgId,
         revision_number: result.revisionNumber,
         reason,

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -362,6 +362,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'review_brand_logo',
       'update_member_logo',
       'update_member_profile',
+      'transfer_brand_ownership',
     ],
     adminOnly: true,
   },

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -1039,6 +1039,71 @@ export class BrandDatabase {
     return parseInt(result.rows[0].count, 10);
   }
 
+  // ========== Ownership Transfer ==========
+
+  /**
+   * Transfer brand domain ownership to a new org, writing a revision for audit.
+   * Out-of-band verification (legal docs, support ticket) must happen before calling.
+   */
+  async transferBrandOwnership(
+    domain: string,
+    newOrgId: string,
+    reason: string,
+    editor: { userId: string; email?: string; name?: string },
+  ): Promise<{ oldOrgId: string | null; revisionNumber: number }> {
+    const canonicalDomain = domain.toLowerCase();
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+
+      const lockResult = await client.query(
+        'SELECT * FROM brands WHERE domain = $1 FOR UPDATE',
+        [canonicalDomain]
+      );
+      if (lockResult.rows.length === 0) {
+        throw new Error(`Brand not found: ${domain}`);
+      }
+
+      const current = lockResult.rows[0];
+      const oldOrgId = current.workos_organization_id ?? null;
+
+      const revResult = await client.query<{ next_rev: number }>(
+        'SELECT COALESCE(MAX(revision_number), 0) + 1 AS next_rev FROM brand_revisions WHERE brand_domain = $1',
+        [canonicalDomain]
+      );
+      const revisionNumber = revResult.rows[0].next_rev;
+
+      await client.query(
+        `INSERT INTO brand_revisions (
+          brand_domain, revision_number, snapshot,
+          editor_user_id, editor_email, editor_name, edit_summary
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          canonicalDomain,
+          revisionNumber,
+          JSON.stringify(current),
+          editor.userId,
+          editor.email ?? null,
+          editor.name ?? null,
+          `Ownership transferred to ${newOrgId}: ${reason}`,
+        ]
+      );
+
+      await client.query(
+        'UPDATE brands SET workos_organization_id = $1, updated_at = NOW() WHERE domain = $2',
+        [newOrgId, canonicalDomain]
+      );
+
+      await client.query('COMMIT');
+      return { oldOrgId, revisionNumber };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
   // ========== Helpers ==========
 
   private deserializeHostedBrand(row: HostedBrand): HostedBrand {

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -1,4 +1,5 @@
 import { query, getClient } from './client.js';
+import { canonicalizeBrandDomain } from '../services/identifier-normalization.js';
 import type {
   HostedBrand,
   DiscoveredBrand,
@@ -1044,14 +1045,16 @@ export class BrandDatabase {
   /**
    * Transfer brand domain ownership to a new org, writing a revision for audit.
    * Out-of-band verification (legal docs, support ticket) must happen before calling.
+   * Rejects unowned brands — there's nothing to transfer; use the normal
+   * registration path to claim them.
    */
   async transferBrandOwnership(
     domain: string,
     newOrgId: string,
     reason: string,
     editor: { userId: string; email?: string; name?: string },
-  ): Promise<{ oldOrgId: string | null; revisionNumber: number }> {
-    const canonicalDomain = domain.toLowerCase();
+  ): Promise<{ oldOrgId: string; revisionNumber: number }> {
+    const canonicalDomain = canonicalizeBrandDomain(domain);
     const client = await getClient();
     try {
       await client.query('BEGIN');
@@ -1061,11 +1064,25 @@ export class BrandDatabase {
         [canonicalDomain]
       );
       if (lockResult.rows.length === 0) {
-        throw new Error(`Brand not found: ${domain}`);
+        throw new Error(`Brand not found: ${canonicalDomain}`);
       }
 
       const current = lockResult.rows[0];
       const oldOrgId = current.workos_organization_id ?? null;
+      if (!oldOrgId) {
+        throw new Error(`Brand ${canonicalDomain} has no current owner — there is nothing to transfer. Have the new org claim it through the normal registration path instead.`);
+      }
+      if (oldOrgId === newOrgId) {
+        throw new Error(`Brand ${canonicalDomain} is already owned by ${newOrgId}.`);
+      }
+
+      const orgCheck = await client.query<{ exists: boolean }>(
+        `SELECT EXISTS(SELECT 1 FROM organizations WHERE workos_organization_id = $1) AS exists`,
+        [newOrgId]
+      );
+      if (!orgCheck.rows[0]?.exists) {
+        throw new Error(`new_org_id ${newOrgId} does not exist in the organizations table.`);
+      }
 
       const revResult = await client.query<{ next_rev: number }>(
         'SELECT COALESCE(MAX(revision_number), 0) + 1 AS next_rev FROM brand_revisions WHERE brand_domain = $1',


### PR DESCRIPTION
Refs #3152

## Summary

Adds `transfer_brand_ownership` to Addie's admin tool panel. Admins can now move a brand domain from one WorkOS org to another via a single tool call, with a full-row revision snapshot written to `brand_revisions` before the ownership update. Eliminates direct database surgery for acquisitions, org renames, and "original uploader left" cases.

**What ships in this PR:**
- `BrandDatabase.transferBrandOwnership(domain, newOrgId, reason, editor)` — `SELECT * FOR UPDATE` → revision INSERT → `UPDATE workos_organization_id` → COMMIT
- `transfer_brand_ownership` admin tool in `ADMIN_TOOLS` + handler in `createAdminToolHandlers`
- `--empty` changeset (server-only, no protocol impact)

**What is deferred (needs more design — see issue):**
- `claim_disputed_brand` member tool — experts agree this should be a `dispute_type: 'brand_ownership'` variant on the existing escalation schema, not a standalone MCP tool or new service
- Soft-claim model — blocked on two issues: (1) `deleteHostedBrand` clears `workos_organization_id` but not `brand_manifest`, so an incoming org would inherit the prior org's brand data silently; (2) `generateVerificationToken` is orphaned (no caller) — domain verification is currently pointer-only and can't safely gate a takeover

## Non-breaking justification

Adds a new admin tool; no public schema or API surface changed. Existing callers unaffected.

## Pre-PR review

- **code-reviewer**: approved — blocker fixed (changed `SELECT id, workos_organization_id` → `SELECT *` so revision snapshot captures full row; also added `editor.name` passthrough and normalized `domain.toLowerCase()` to one call)
- **internal-tools-strategist**: approved — tool description is clear, `old_org_id` in response is warranted, `reason` min-length bumped to 20 chars

**Nits (not fixed, noted for follow-up):**
- Optional `escalation_id` input field would let Addie pass the ticket ref directly into the revision `edit_summary` rather than holding it across two tool calls
- `reason.length < 20` is still permissive; could tighten further if abuse observed in practice

Session: https://claude.ai/code/session_01XmWfbQQkuuX3DB8VpukZsu