### PR TITLE
feat(schema): add mode to get_plan_audit_logs audit entries

### DIFF
--- a/.changeset/audit-log-mode-on-entries.md
+++ b/.changeset/audit-log-mode-on-entries.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add optional `mode` field to `get_plan_audit_logs` audit entries, recording the governance mode (enforce/advisory/audit) active at check time. Surfaces the enforcement posture that produced each decision, closing a gap where audit and enforce modes produced identical-looking trails.

--- a/docs/governance/campaign/tasks/get_plan_audit_logs.mdx
+++ b/docs/governance/campaign/tasks/get_plan_audit_logs.mdx
@@ -146,6 +146,7 @@ You can combine `plan_ids` and `portfolio_plan_ids` to query both specific plans
           "caller": "https://ads.seller-example.com/adcp",
           "tool": "create_media_buy",
           "check_type": "execution",
+          "mode": "enforce",
           "governance_context": "gc_mb_seller_456",
           "plan_hash": "oR0jFDEtzcwgPbNf-Ofd_fZHYfAyD1TRbzGOFBVCG-c",
           "purchase_type": "media_buy",
@@ -251,6 +252,7 @@ You can combine `plan_ids` and `portfolio_plan_ids` to query both specific plans
 | `plans[].entries[].tool` | string | The AdCP tool (present for `check` entries). |
 | `plans[].entries[].status` | enum | Governance check status (present for `check` entries). |
 | `plans[].entries[].check_type` | enum | `intent` or `execution` (present for `check` entries). Inferred from the fields present on the original check request. |
+| `plans[].entries[].mode` | enum | `audit`, `advisory`, or `enforce` — governance mode active when this check was evaluated. Recorded by the governance agent from its runtime configuration at check time, not from a plan field. Present on check entries; absent on outcome entries and on governance agents that have not yet adopted this field. Lets auditors distinguish `approved` decisions made under `enforce` from those made under `audit` (where the agent could not have blocked anything). |
 | `plans[].entries[].explanation` | string | Human-readable explanation of the governance decision (present for `check` entries). |
 | `plans[].entries[].policies_evaluated` | array | Registry policy IDs evaluated during this check. |
 | `plans[].entries[].categories_evaluated` | array | Governance categories evaluated (e.g., `budget_authority`, `regulatory_compliance`). |

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -267,6 +267,10 @@
                   ],
                   "description": "Whether the check was an intent check (orchestrator) or execution check (seller). Inferred from the fields present on the original check request. Present for check entries."
                 },
+                "mode": {
+                  "$ref": "/schemas/enums/governance-mode.json",
+                  "description": "Governance mode active when this check was evaluated. Governance agents SHOULD populate this field on check entries, recording the mode from their runtime configuration at the moment check_governance was processed — not derived from a plan field. Absent for outcome entries and for pre-3.1 governance agents that do not surface mode on audit responses."
+                },
                 "explanation": {
                   "type": "string",
                   "description": "Human-readable explanation of the governance decision (present for check entries)."


### PR DESCRIPTION
Closes #3156

Adds an optional `mode` field (`$ref: /schemas/enums/governance-mode.json`) to `entries[]` items in `get-plan-audit-logs-response.json`. Without this field, an auditor reading the trail cannot tell whether `status: "approved" with critical finding` reflects a deliberate advisory posture or a governance agent that was in `audit` mode and could never have blocked anything.

**Non-breaking justification:** adds an optional field to an experimental schema (`x-status: "experimental"`); existing producers that omit the field remain valid, existing consumers that skip unknown fields are unaffected.

**Scope note:** `governed_actions[].mode` was deliberately deferred — mode can change mid-lifecycle for an action, making a single `mode` value on the aggregate ambiguous. That shape decision needs a separate issue. The `summary` mode-history suggestion from the issue is similarly deferred.

**Spec note:** `mode` is a governance-agent runtime configuration value, not a buyer-declared plan field. `sync-plans-request.json` has no `mode` field; governance agents populate this from their internal state at `check_governance` time, analogous to `plan_hash`.

**Pre-PR review:**
- code-reviewer: approved — no blockers; `$ref` path consistent with peer enum refs (`outcome`, `purchase_type`); `x-entity` absence correct for enum-typed fields; field placement logical
- ad-tech-protocol-expert: approved — non-breaking per experimental-schema policy; description updated to RFC 2119 SHOULD language per reviewer recommendation; IAB OpenRTB 3.0 Audit `dt` field is prior art for same optional-at-check-time pattern

**Nits (not blocking):**
- `governance-mode.json` lacks `x-status: "experimental"` — it's the first enum used exclusively in an experimental response; consider annotating before schema graduation
- When `governed_actions[].mode` is eventually added, the entries-level `mode` description should clarify it reflects mode at check time, not action-lifecycle mode

**Milestone:** 3.1.0
No patch branch (`3.0.x`) exists — this targets `main` for 3.1.0.

Session: https://claude.ai/code/session_0185Q8ottjpU8xDRzXQ5aJwx

---
_Generated by [Claude Code](https://claude.ai/code/session_0185Q8ottjpU8xDRzXQ5aJwx)_