### PR TITLE
fix(brand-registry): auto-approve logo uploads from verified domain owners

### DIFF
--- a/.changeset/brand-logo-owner-auto-approve.md
+++ b/.changeset/brand-logo-owner-auto-approve.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: auto-approve logo uploads from verified domain owners. Defines a single policy rule for `brand_logos.review_status` based on upload source (`brand_owner` → approved, `community` → pending). Fixes the asymmetry between the multipart upload path and the `update_company_logo` tool that caused verified owners' logos to sit invisible in the moderation queue. Closes #3150.

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -73,8 +73,8 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           return res.status(403).json({ error: 'You are banned from this brand registry' });
         }
 
-        // Verified domain owners and admin API key auto-approve; community uploads queue for review
-        const isOwner = user.id === 'admin_api_key' || await isVerifiedBrandOwner(user.id, domain, brandDb);
+        // Verified domain owners auto-approve; community uploads queue for review
+        const isOwner = await isVerifiedBrandOwner(user.id, domain, brandDb);
         const uploadSource: 'brand_owner' | 'community' = isOwner ? 'brand_owner' : 'community';
         const uploadReviewStatus: 'approved' | 'pending' = isOwner ? 'approved' : 'pending';
 
@@ -145,16 +145,7 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           return res.status(409).json({ error: 'Duplicate logo already exists for this brand' });
         }
 
-        // Auto-approved owner uploads: rebuild manifest only for non-verified-hosted brands
-        // (mirrors review endpoint — verified hosted brands manage their manifest via brand-identity)
-        if (isOwner) {
-          const hosted = await brandDb.getHostedBrandByDomain(domain);
-          if (!hosted || !hosted.domain_verified) {
-            await rebuildManifestLogos(domain, brandLogoDb, brandDb);
-          }
-        }
-
-        // If brand doesn't exist, create it
+        // If brand doesn't exist, create it (must run before manifest rebuild)
         const existing = await brandDb.getDiscoveredBrandByDomain(domain);
         if (!existing) {
           try {
@@ -172,6 +163,15 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           } catch (err) {
             // Brand may have been created concurrently — not an error
             logger.debug({ err, domain }, 'Brand creation skipped (may already exist)');
+          }
+        }
+
+        // Auto-approved owner uploads: rebuild manifest only for non-verified-hosted brands
+        // (mirrors review endpoint — verified hosted brands manage their manifest via brand-identity)
+        if (isOwner) {
+          const hosted = await brandDb.getHostedBrandByDomain(domain);
+          if (!hosted || !hosted.domain_verified) {
+            await rebuildManifestLogos(domain, brandLogoDb, brandDb);
           }
         }
 

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -9,7 +9,7 @@ import { logoUploadRateLimiter } from '../middleware/rate-limit.js';
 import { BrandLogoDatabase } from '../db/brand-logo-db.js';
 import { BrandDatabase } from '../db/brand-db.js';
 import { BansDatabase } from '../db/bans-db.js';
-import { canReviewBrandLogos } from '../services/brand-logo-auth.js';
+import { canReviewBrandLogos, isVerifiedBrandOwner } from '../services/brand-logo-auth.js';
 import { enrichUserWithMembership } from '../utils/html-config.js';
 import {
   validateLogoTags,
@@ -73,6 +73,11 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           return res.status(403).json({ error: 'You are banned from this brand registry' });
         }
 
+        // Verified domain owners and admin API key auto-approve; community uploads queue for review
+        const isOwner = user.id === 'admin_api_key' || await isVerifiedBrandOwner(user.id, domain, brandDb);
+        const uploadSource: 'brand_owner' | 'community' = isOwner ? 'brand_owner' : 'community';
+        const uploadReviewStatus: 'approved' | 'pending' = isOwner ? 'approved' : 'pending';
+
         if (!req.file) {
           return res.status(400).json({ error: 'File is required' });
         }
@@ -128,8 +133,8 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           tags,
           width,
           height,
-          source: 'community',
-          review_status: 'pending',
+          source: uploadSource,
+          review_status: uploadReviewStatus,
           uploaded_by_user_id: user.id,
           uploaded_by_email: user.email,
           upload_note: note,
@@ -138,6 +143,15 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
 
         if (!logo) {
           return res.status(409).json({ error: 'Duplicate logo already exists for this brand' });
+        }
+
+        // Auto-approved owner uploads: rebuild manifest only for non-verified-hosted brands
+        // (mirrors review endpoint — verified hosted brands manage their manifest via brand-identity)
+        if (isOwner) {
+          const hosted = await brandDb.getHostedBrandByDomain(domain);
+          if (!hosted || !hosted.domain_verified) {
+            await rebuildManifestLogos(domain, brandLogoDb, brandDb);
+          }
         }
 
         // If brand doesn't exist, create it
@@ -176,7 +190,7 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           success: true,
           domain,
           logo_id: logo.id,
-          review_status: 'pending',
+          review_status: logo.review_status,
           url: `/logos/brands/${domain}/${logo.id}`,
         });
       } catch (error) {

--- a/server/src/services/brand-identity.ts
+++ b/server/src/services/brand-identity.ts
@@ -119,22 +119,16 @@ export async function updateBrandIdentity(
       const bj = applyToBrandJson({
         house: { domain: brandDomain, name: displayName },
       }, displayName, logoUrl, brandColor);
-      // Attribute brand_owner source when the org has verified domain ownership
-      const hostedResult = await client.query<{ domain_verified: boolean }>(
-        'SELECT domain_verified FROM hosted_brands WHERE domain = $1 AND workos_organization_id = $2 LIMIT 1',
-        [brandDomain, workosOrganizationId]
-      );
-      const sourceType = hostedResult.rows[0]?.domain_verified ? 'brand_owner' : 'community';
       await client.query(
         `INSERT INTO brands (workos_organization_id, domain, brand_manifest, brand_name, source_type, review_status, is_public, has_brand_manifest)
-         VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), $5, 'approved', $4, true)
+         VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), 'community', 'approved', $4, true)
          ON CONFLICT (domain) DO UPDATE SET
            brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
            workos_organization_id = COALESCE(EXCLUDED.workos_organization_id, brands.workos_organization_id),
            is_public = COALESCE(EXCLUDED.is_public, brands.is_public),
            has_brand_manifest = true,
            updated_at = NOW()`,
-        [workosOrganizationId, brandDomain, JSON.stringify(bj), true, sourceType]
+        [workosOrganizationId, brandDomain, JSON.stringify(bj), true]
       );
     }
 

--- a/server/src/services/brand-identity.ts
+++ b/server/src/services/brand-identity.ts
@@ -119,16 +119,22 @@ export async function updateBrandIdentity(
       const bj = applyToBrandJson({
         house: { domain: brandDomain, name: displayName },
       }, displayName, logoUrl, brandColor);
+      // Attribute brand_owner source when the org has verified domain ownership
+      const hostedResult = await client.query<{ domain_verified: boolean }>(
+        'SELECT domain_verified FROM hosted_brands WHERE domain = $1 AND workos_organization_id = $2 LIMIT 1',
+        [brandDomain, workosOrganizationId]
+      );
+      const sourceType = hostedResult.rows[0]?.domain_verified ? 'brand_owner' : 'community';
       await client.query(
         `INSERT INTO brands (workos_organization_id, domain, brand_manifest, brand_name, source_type, review_status, is_public, has_brand_manifest)
-         VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), 'community', 'approved', $4, true)
+         VALUES ($1, $2, $3, COALESCE($3::jsonb->>'name', $2), $5, 'approved', $4, true)
          ON CONFLICT (domain) DO UPDATE SET
            brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
            workos_organization_id = COALESCE(EXCLUDED.workos_organization_id, brands.workos_organization_id),
            is_public = COALESCE(EXCLUDED.is_public, brands.is_public),
            has_brand_manifest = true,
            updated_at = NOW()`,
-        [workosOrganizationId, brandDomain, JSON.stringify(bj), true]
+        [workosOrganizationId, brandDomain, JSON.stringify(bj), true, sourceType]
       );
     }
 

--- a/server/src/services/brand-logo-auth.ts
+++ b/server/src/services/brand-logo-auth.ts
@@ -43,7 +43,7 @@ async function isRegistryModerator(userId: string): Promise<boolean> {
   }
 }
 
-async function isVerifiedBrandOwner(userId: string, domain: string, brandDb: BrandDatabase): Promise<boolean> {
+export async function isVerifiedBrandOwner(userId: string, domain: string, brandDb: BrandDatabase): Promise<boolean> {
   try {
     const hosted = await brandDb.getHostedBrandByDomain(domain);
     if (!hosted || !hosted.domain_verified) return false;


### PR DESCRIPTION
Closes #3150

## Summary

Defines a single upload policy rule for `POST /api/brands/:domain/logos` based on domain ownership, eliminating the asymmetry between the multipart upload path and the `update_company_logo` / `brand-identity` path:

| source | review_status |
|---|---|
| `brand_owner` (verified domain) | `approved` |
| `community` | `pending` |

Previously both paths wrote `review_status` differently depending on which table they hit (`brand_manifest` vs `brand_logos`), not on who was uploading. Verified owners' multipart uploads sat invisible in the moderation queue indefinitely.

## Changes

- **`brand-logo-auth.ts`** — exports `isVerifiedBrandOwner` (previously private), so the upload route can reuse the same ownership gate already used by the review endpoint
- **`brand-logos.ts`** POST handler:
  - Calls `isVerifiedBrandOwner` after the ban check to determine `uploadSource` and `uploadReviewStatus`
  - Passes those values to `insertBrandLogo` instead of hardcoded `'community'` / `'pending'`
  - Returns actual `logo.review_status` in the 201 response (was always `'pending'`)
  - Manifest rebuild runs after `createDiscoveredBrand` (correct ordering — rebuild needs the brand row to exist)
  - Rebuild is skipped for verified hosted brands, mirroring the review endpoint's existing behaviour

## Non-breaking justification

Same API shape — no field names, types, or enum values removed or renamed. `brand_owner` and `approved` were already valid values in both `brand_logos.source` and `brand_logos.review_status`; only the logic that selects them has changed. Existing community uploads are unaffected.

## Out of scope (noted for follow-up)

- **`brand-identity.ts` source_type attribution** — the INSERT path in `updateBrandIdentity` fires only when the brand doesn't exist yet in `brands`. By the time a domain is verified, the brand record already exists (UPDATE path), so fixing `source_type` there needs a different approach. Noted for a follow-up issue.
- **Rejected logo re-upload** — `insertBrandLogo`'s partial index predicate (`WHERE review_status IN ('pending', 'approved')`) doesn't cover `rejected` rows; a verified owner re-uploading an identical rejected SHA-256 would create a ghost duplicate. Functionally benign (`listBrandLogos` returns the new approved row; rejected rows are excluded from cap counts) but semantically messy. Needs a separate fix (upsert from rejected → approved, or explicit pre-insert check).

## Pre-PR review

- code-reviewer: approved after fixes — removed unreachable `admin_api_key` short-circuit (blocked by membership gate), reordered manifest rebuild after brand creation, reverted broken `hosted_brands` query in `brand-identity.ts`
- internal-tools-strategist: approved — policy correct, rebuild case analysis confirmed, transaction locking safe

Session: https://claude.ai/code/session_01VSr1uSm6uUgKuSLD5rU1jf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSr1uSm6uUgKuSLD5rU1jf)_