### PR TITLE
feat(brand-registry): daily Slack digest of pending logo moderation queue

### DIFF
--- a/.changeset/brand-logo-pending-digest.md
+++ b/.changeset/brand-logo-pending-digest.md
@@ -1,0 +1,8 @@
+---
+---
+
+New scheduled job `brand-logo-digest` posts a daily summary to the configured admin Slack channel when brand logos have been sitting in moderation review for more than 12 hours. Uses the existing in-process scheduler (`server/src/addie/jobs/scheduler.ts`) and the same `getAdminChannel()` system setting other admin alerts use.
+
+The pending queue was previously invisible — `getPendingLogos` had zero callers before #3137, and admins won't poll `list_pending_brand_logos` on their own. The 12-hour threshold gives #3154's auto-approve path time to handle owner uploads without surfacing them in the digest. Items younger than 12h, or runs where the queue is empty, produce no Slack noise.
+
+Closes #3151.

--- a/server/src/addie/jobs/brand-logo-digest.ts
+++ b/server/src/addie/jobs/brand-logo-digest.ts
@@ -1,0 +1,88 @@
+/**
+ * Brand Logo Pending-Review Digest
+ *
+ * Daily summary of brand logos sitting in the moderation queue, posted to
+ * the configured admin Slack channel. The pending queue is otherwise
+ * invisible — `getPendingLogos` had zero callers before #3137, and admins
+ * won't poll `list_pending_brand_logos` on their own. This job is the
+ * "you have N items waiting" nudge.
+ *
+ * Skips items younger than ~12h to give #3154's auto-approve path time to
+ * land owner uploads without a digest needing to mention them.
+ */
+
+import { logger } from '../../logger.js';
+import { BrandLogoDatabase } from '../../db/brand-logo-db.js';
+import { getAdminChannel } from '../../db/system-settings-db.js';
+import { sendChannelMessage } from '../../slack/client.js';
+
+const DIGEST_PAGE_SIZE = 25;
+const STALE_THRESHOLD_HOURS = 12;
+const BASE_URL = process.env.BASE_URL || 'https://agenticadvertising.org';
+
+function ageLabel(createdAt: Date | string): string {
+  const ms = Date.now() - new Date(createdAt).getTime();
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+export interface BrandLogoDigestResult {
+  pendingCount: number;
+  staleCount: number;
+  posted: boolean;
+}
+
+export async function runBrandLogoDigestJob(): Promise<BrandLogoDigestResult> {
+  const brandLogoDb = new BrandLogoDatabase();
+  const pending = await brandLogoDb.getPendingLogos(DIGEST_PAGE_SIZE, 0);
+
+  if (pending.length === 0) {
+    return { pendingCount: 0, staleCount: 0, posted: false };
+  }
+
+  const cutoff = Date.now() - STALE_THRESHOLD_HOURS * 3_600_000;
+  const stale = pending.filter(l => new Date(l.created_at).getTime() <= cutoff);
+
+  if (stale.length === 0) {
+    return { pendingCount: pending.length, staleCount: 0, posted: false };
+  }
+
+  const adminChan = await getAdminChannel();
+  if (!adminChan.channel_id) {
+    logger.info({ pendingCount: pending.length, staleCount: stale.length }, 'Brand logo digest: admin Slack channel not configured, skipping post');
+    return { pendingCount: pending.length, staleCount: stale.length, posted: false };
+  }
+
+  const lines: string[] = [
+    `*${stale.length} brand logo${stale.length === 1 ? '' : 's'} pending review* (older than ${STALE_THRESHOLD_HOURS}h)`,
+    '',
+  ];
+
+  // Cap visible items so a backlog doesn't produce an enormous Slack message
+  const VISIBLE = 10;
+  const visible = stale.slice(0, VISIBLE);
+  for (const logo of visible) {
+    const brand = logo.brand_name || logo.domain;
+    const uploader = logo.uploaded_by_email || 'unknown uploader';
+    const previewUrl = `${BASE_URL}/logos/brands/${logo.domain}/${logo.id}`;
+    lines.push(`• *<${previewUrl}|${brand}>* — ${logo.domain} · uploaded by ${uploader} · ${ageLabel(logo.created_at)} ago`);
+  }
+  if (stale.length > VISIBLE) {
+    lines.push(`_…and ${stale.length - VISIBLE} more_`);
+  }
+  lines.push('', `<${BASE_URL}/admin/brands|Open the moderation queue>`);
+
+  const text = `${stale.length} brand logo${stale.length === 1 ? '' : 's'} pending review`;
+  await sendChannelMessage(adminChan.channel_id, {
+    text,
+    blocks: [{
+      type: 'section' as const,
+      text: { type: 'mrkdwn' as const, text: lines.join('\n') },
+    }],
+  });
+
+  logger.info({ pendingCount: pending.length, staleCount: stale.length, channelId: adminChan.channel_id }, 'Posted brand logo pending-review digest');
+  return { pendingCount: pending.length, staleCount: stale.length, posted: true };
+}

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -36,6 +36,7 @@ import { runSocialPostIdeasJob } from './social-post-ideas.js';
 import { runConversationInsightsJob } from './conversation-insights.js';
 import { autoLinkUnmappedSlackUsers, autoAddVerifiedDomainUsersAsMembers } from '../../slack/sync.js';
 import { runCredentialDigestJob } from './credential-digest.js';
+import { runBrandLogoDigestJob } from './brand-logo-digest.js';
 import { runWgDigestJob, runWgDigestPrepJob } from './wg-digest.js';
 import { runComplianceHeartbeatJob } from './compliance-heartbeat.js';
 import { runShadowEvaluatorJob } from './shadow-evaluator.js';
@@ -346,6 +347,20 @@ export function registerAllJobs(): void {
     failureThreshold: 1,
     businessHours: { startHour: 9, endHour: 11, skipWeekends: true },
     shouldLogResult: (r) => r.posted || r.awardsFound > 0,
+  });
+
+  // Brand logo pending-review digest - daily reminder when items are stuck
+  // in moderation. The pending queue is otherwise invisible (admins won't
+  // poll list_pending_brand_logos), and members hit dead-letter UX while
+  // their logo waits.
+  jobScheduler.register({
+    name: 'brand-logo-digest',
+    description: 'Daily digest of brand logos pending review',
+    interval: { value: 24, unit: 'hours' },
+    initialDelay: { value: 25, unit: 'minutes' },
+    runner: runBrandLogoDigestJob,
+    businessHours: { startHour: 9, endHour: 10 },
+    shouldLogResult: (r) => r.posted || r.staleCount > 0,
   });
 
   // Social post ideas - generates social copy for members to share
@@ -803,6 +818,7 @@ export const JOB_NAMES = {
   WG_DIGEST: 'wg-digest',
   WG_DIGEST_PREP: 'wg-digest-prep',
   CREDENTIAL_DIGEST: 'credential-digest',
+  BRAND_LOGO_DIGEST: 'brand-logo-digest',
   SOCIAL_POST_IDEAS: 'social-post-ideas',
   CONVERSATION_INSIGHTS: 'conversation-insights',
   SLACK_AUTO_LINK: 'slack-auto-link',

--- a/server/tests/unit/brand-logo-digest.test.ts
+++ b/server/tests/unit/brand-logo-digest.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted, so shared spies must be created via vi.hoisted.
+const mocks = vi.hoisted(() => ({
+  getPendingLogos: vi.fn(),
+  getAdminChannel: vi.fn(),
+  sendChannelMessage: vi.fn(),
+}));
+
+vi.mock('../../src/db/brand-logo-db.js', () => ({
+  BrandLogoDatabase: class {
+    getPendingLogos = mocks.getPendingLogos;
+  },
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getAdminChannel: mocks.getAdminChannel,
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: mocks.sendChannelMessage,
+}));
+
+import { runBrandLogoDigestJob } from '../../src/addie/jobs/brand-logo-digest.js';
+
+const HOURS_AGO = (h: number) => new Date(Date.now() - h * 3_600_000).toISOString();
+
+function makeLogo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'logo-' + Math.random().toString(36).slice(2, 8),
+    domain: 'acme.com',
+    brand_name: 'Acme',
+    uploaded_by_email: 'jane@acme.com',
+    created_at: HOURS_AGO(48),
+    ...overrides,
+  };
+}
+
+describe('brand-logo-digest', () => {
+  beforeEach(() => {
+    mocks.getPendingLogos.mockReset();
+    mocks.getAdminChannel.mockReset();
+    mocks.sendChannelMessage.mockReset();
+    mocks.sendChannelMessage.mockResolvedValue({ ok: true });
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    mocks.getPendingLogos.mockResolvedValue([]);
+    const result = await runBrandLogoDigestJob();
+    expect(result).toEqual({ pendingCount: 0, staleCount: 0, posted: false });
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not post when every pending logo is younger than 12 hours', async () => {
+    mocks.getPendingLogos.mockResolvedValue([
+      makeLogo({ created_at: HOURS_AGO(2) }),
+      makeLogo({ created_at: HOURS_AGO(6) }),
+    ]);
+    const result = await runBrandLogoDigestJob();
+    expect(result.pendingCount).toBe(2);
+    expect(result.staleCount).toBe(0);
+    expect(result.posted).toBe(false);
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips posting if the admin channel is not configured', async () => {
+    mocks.getPendingLogos.mockResolvedValue([makeLogo({ created_at: HOURS_AGO(48) })]);
+    mocks.getAdminChannel.mockResolvedValue({ channel_id: null, channel_name: null });
+    const result = await runBrandLogoDigestJob();
+    expect(result.staleCount).toBe(1);
+    expect(result.posted).toBe(false);
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('posts a digest when stale items exist and the admin channel is configured', async () => {
+    mocks.getPendingLogos.mockResolvedValue([
+      makeLogo({ domain: 'thehook.es', brand_name: 'The Hook', uploaded_by_email: 'felipe@thehook.es', created_at: HOURS_AGO(72) }),
+      makeLogo({ domain: 'kyber1.com', brand_name: 'Kyber1', uploaded_by_email: 'philippe@kyber1.com', created_at: HOURS_AGO(36) }),
+      makeLogo({ created_at: HOURS_AGO(2) }), // fresh, excluded from stale count
+    ]);
+    mocks.getAdminChannel.mockResolvedValue({ channel_id: 'C123', channel_name: 'aao-admin' });
+
+    const result = await runBrandLogoDigestJob();
+
+    expect(result.pendingCount).toBe(3);
+    expect(result.staleCount).toBe(2);
+    expect(result.posted).toBe(true);
+    expect(mocks.sendChannelMessage).toHaveBeenCalledTimes(1);
+
+    const [channelId, message] = mocks.sendChannelMessage.mock.calls[0];
+    expect(channelId).toBe('C123');
+    expect(message.text).toBe('2 brand logos pending review');
+    const body = (message.blocks[0].text.text as string);
+    expect(body).toContain('thehook.es');
+    expect(body).toContain('felipe@thehook.es');
+    expect(body).toContain('kyber1.com');
+    expect(body).toContain('Open the moderation queue');
+    // Fresh item should not appear
+    expect(body).not.toMatch(/2h ago|3h ago|6h ago/);
+  });
+
+  it('caps the visible list and adds an overflow marker', async () => {
+    const fifteen = Array.from({ length: 15 }, (_, i) =>
+      makeLogo({ domain: `brand-${i}.example`, brand_name: `Brand ${i}`, created_at: HOURS_AGO(48) }),
+    );
+    mocks.getPendingLogos.mockResolvedValue(fifteen);
+    mocks.getAdminChannel.mockResolvedValue({ channel_id: 'C123', channel_name: 'aao-admin' });
+
+    const result = await runBrandLogoDigestJob();
+
+    expect(result.staleCount).toBe(15);
+    const body = (mocks.sendChannelMessage.mock.calls[0][1].blocks[0].text.text as string);
+    expect(body).toContain('and 5 more');
+  });
+});


### PR DESCRIPTION
## Summary

New scheduled job \`brand-logo-digest\` posts to the configured admin Slack channel when brand logos have been waiting in pending review for more than 12 hours. Built on the existing in-process scheduler — same shape as the credential digest.

Closes #3151.

## Why

The pending logo queue was invisible. Before #3137, \`getPendingLogos\` existed in the DB layer but had zero callers. After #3137, admins can call \`list_pending_brand_logos\` from chat, but they won't poll. Felipe's logo (thehook.es) sat for 7 days before he escalated. Philippe's (kyber1.com) the same.

This is the digest layer: admins find out the queue is non-empty without having to think about it.

## Design notes

- **12-hour minimum age**. Owner uploads that are about to be auto-approved (per #3154) don't trip the digest. Items younger than 12h are counted in \`pendingCount\` but excluded from \`staleCount\`; if no items are stale, the job posts nothing.
- **Empty queue → silent**. No "queue is empty" message — these are reminders for action, not status reports.
- **Capped output** at 10 visible items + an overflow marker (\`_…and N more_\`) so a backlog doesn't produce a Slack message that makes the channel unusable.
- **Business hours 9-10 ET**, no weekend skip — a 4-day-old logo shouldn't wait through Saturday/Sunday.
- **Admin channel from system setting** (\`getAdminChannel\`), same path other admin alerts use. If unconfigured, the job logs and skips.

## Test plan

- [x] 5 unit tests with mocked DB / Slack / system-settings (all passing)
- [x] Type-check clean
- [x] Pre-commit suite passes (832 tests on \`test:unit\`)
- [ ] Reviewer to verify on staging: insert a stale pending logo, run the job manually via the admin job-trigger UI, confirm the post lands in the configured admin channel.

## Files

- \`server/src/addie/jobs/brand-logo-digest.ts\` (new)
- \`server/src/addie/jobs/job-definitions.ts\` (registered + JOB_NAMES entry)
- \`server/tests/unit/brand-logo-digest.test.ts\` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)