### PR TITLE
schema(governance): mark governance-mode enum experimental + clarify per-check mode semantics

### DIFF
--- a/.changeset/governance-mode-experimental-status-and-per-check-clarification.md
+++ b/.changeset/governance-mode-experimental-status-and-per-check-clarification.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Mark `governance-mode.json` enum as `x-status: experimental` and clarify the per-check semantics of the audit-entry `mode` field.
+
+The enum is referenced exclusively from experimental schemas (`check-governance-response.json`, `get-plan-audit-logs-response.json` `entries[]`); annotating it explicitly prevents the enum from being treated as stable while its consumers are still experimental. The `entries[].mode` description is tightened to clarify that the field reflects the mode active for that specific check, distinct from a future `governed_actions[].mode` (which would describe the action's current mode and may differ if the plan has been re-synced since).

--- a/static/schemas/source/enums/governance-mode.json
+++ b/static/schemas/source/enums/governance-mode.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/enums/governance-mode.json",
   "title": "Governance Mode",
   "description": "Operating mode for a governance agent. Controls whether findings block execution.",
+  "x-status": "experimental",
   "type": "string",
   "enum": [
     "audit",

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -269,7 +269,7 @@
                 },
                 "mode": {
                   "$ref": "/schemas/enums/governance-mode.json",
-                  "description": "Governance mode active when this check was evaluated. Governance agents SHOULD populate this field on check entries, recording the mode from their runtime configuration at the moment check_governance was processed — not derived from a plan field. Absent for outcome entries and for pre-3.1 governance agents that do not surface mode on audit responses."
+                  "description": "Governance mode active at the moment this specific check was evaluated. Governance agents SHOULD populate this field on check entries, recording the mode from their runtime configuration at the moment check_governance was processed — not derived from a plan field. This is a per-check value: if the operator changes mode between checks for the same governed action, each entry records the mode active for that entry. A future `governed_actions[].mode` field would describe the action's current mode, which may differ from the most recent entry's `mode` if the plan has since been re-synced. Absent for outcome entries and for pre-3.1 governance agents that do not surface mode on audit responses."
                 },
                 "explanation": {
                   "type": "string",


### PR DESCRIPTION
Follow-up to #3160 nits.

## Summary

1. **`governance-mode.json` gains `x-status: "experimental"`.** The enum is referenced exclusively from experimental schemas (`check-governance-response.json`, `get-plan-audit-logs-response.json` `entries[]`). Annotating the enum explicitly prevents it from being treated as stable while its consumers are still experimental.

2. **`entries[].mode` description tightened.** Was: "Governance mode active when this check was evaluated." Now explicitly per-check, with a forward-pointing note that a future `governed_actions[].mode` would describe the action's current mode (which may differ from the most recent entry's `mode` if the plan has been re-synced since). This prevents confusion when the action-aggregate field eventually lands.

## Non-breaking justification

- `governance-mode.json` — `x-status` is metadata, not part of the validation surface
- `entries[].mode` — description-only change to an existing optional field

Both target schemas already carry `x-status: experimental`. No semantic change for existing producers or consumers.

## Test plan

- [x] Schema files still load and validate (`node tests/json-schema-validation.test.cjs` passes)
- [x] No stale `schemas/latest/` references in `docs/`
- [x] Changeset present (`patch` bump on the experimental governance surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)