### PR TITLE
fix(billing): refuse to mint a duplicate subscription on an org

### DIFF
--- a/.changeset/duplicate-subscription-guard.md
+++ b/.changeset/duplicate-subscription-guard.md
@@ -1,0 +1,6 @@
+---
+---
+
+Refuse to mint a new Stripe subscription/invoice when the org already has an active, trialing, or past_due one.
+
+`POST /api/checkout-session`, `POST /api/invoice-request`, and `POST /api/invite/:token/accept` now all run a duplicate-subscription guard before issuing billing. If the org has a live subscription, they return 409 with the existing subscription details and a Stripe Customer Portal URL. Tier upgrades and payment-method changes belong in the portal, not these intake routes — without this guard, two of them in sequence produced the duplicate $3K Builder sub on top of Triton's active $10K Corporate sub (Apr 2026).

--- a/server/src/billing/active-subscription-guard.ts
+++ b/server/src/billing/active-subscription-guard.ts
@@ -1,0 +1,92 @@
+/**
+ * Refuse to mint a new Stripe subscription/invoice when one is already active
+ * on the org.
+ *
+ * Three routes can issue billing on an org's behalf
+ * (`POST /api/checkout-session`, `POST /api/invoice-request`,
+ * `POST /api/invite/:token/accept`). None of them used to check whether the
+ * org already had an active subscription before minting a new one — which is
+ * how Triton ended up with two simultaneous active subs (a $10K Corporate
+ * paid in Dec 2025 plus a duplicate $3K Builder created Apr 2026 with a
+ * voided invoice). Tier upgrades belong in the Stripe Customer Portal, not
+ * these intake routes.
+ */
+
+import { OrganizationDatabase } from '../db/organization-db.js';
+import { createCustomerPortalSession } from './stripe-client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('active-subscription-guard');
+
+export interface ActiveSubscriptionBlock {
+  status: 409;
+  body: {
+    error: 'Active subscription exists';
+    message: string;
+    existing_subscription: {
+      status: string;
+      product_name?: string;
+      amount_cents?: number;
+    };
+    customer_portal_url?: string;
+  };
+}
+
+/**
+ * Set of subscription statuses where minting another subscription would
+ * duplicate live state. `past_due` is included because creating a second sub
+ * on a customer with a past_due one stacks two unresolved invoices instead of
+ * letting the user fix payment on the existing one. `canceled`, `unpaid`, and
+ * `incomplete_expired` are *not* included — those are recoverable by
+ * re-subscribing.
+ */
+const BLOCKING_STATUSES = new Set(['active', 'trialing', 'past_due']);
+
+/**
+ * Returns a 409 payload if the org already has a live subscription,
+ * otherwise null. Caller short-circuits with
+ * `res.status(409).json(block.body)` when this returns a value.
+ *
+ * @param orgId    workos_organization_id of the org being billed
+ * @param orgDb    OrganizationDatabase instance (DI for testing)
+ * @param returnUrl Where to send the user back to from the Stripe Customer Portal
+ */
+export async function blockIfActiveSubscription(
+  orgId: string,
+  orgDb: OrganizationDatabase,
+  returnUrl: string,
+): Promise<ActiveSubscriptionBlock | null> {
+  const info = await orgDb.getSubscriptionInfo(orgId);
+  if (!info || !BLOCKING_STATUSES.has(info.status)) {
+    return null;
+  }
+
+  const org = await orgDb.getOrganization(orgId);
+  let portalUrl: string | undefined;
+  if (org?.stripe_customer_id) {
+    try {
+      portalUrl = (await createCustomerPortalSession(org.stripe_customer_id, returnUrl)) || undefined;
+    } catch (err) {
+      logger.warn({ err, orgId }, 'Failed to create customer portal session for active-sub block');
+    }
+  }
+
+  const productName = info.product_name || `${info.lookup_key ?? 'membership'}`;
+  const amountDisplay = info.amount_cents
+    ? `$${(info.amount_cents / 100).toLocaleString()}`
+    : 'an active tier';
+
+  return {
+    status: 409,
+    body: {
+      error: 'Active subscription exists',
+      message: `This organization is already on ${productName} (${amountDisplay}). To change tiers, cancel, or update payment method, use the Stripe Customer Portal.`,
+      existing_subscription: {
+        status: info.status,
+        product_name: info.product_name,
+        amount_cents: info.amount_cents,
+      },
+      ...(portalUrl ? { customer_portal_url: portalUrl } : {}),
+    },
+  };
+}

--- a/server/src/billing/active-subscription-guard.ts
+++ b/server/src/billing/active-subscription-guard.ts
@@ -12,7 +12,7 @@
  * these intake routes.
  */
 
-import { OrganizationDatabase } from '../db/organization-db.js';
+import { OrganizationDatabase, TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
 import { createCustomerPortalSession } from './stripe-client.js';
 import { createLogger } from '../logger.js';
 
@@ -33,14 +33,32 @@ export interface ActiveSubscriptionBlock {
 }
 
 /**
- * Set of subscription statuses where minting another subscription would
- * duplicate live state. `past_due` is included because creating a second sub
- * on a customer with a past_due one stacks two unresolved invoices instead of
- * letting the user fix payment on the existing one. `canceled`, `unpaid`, and
- * `incomplete_expired` are *not* included — those are recoverable by
- * re-subscribing.
+ * Statuses where another paid subscription would duplicate live state.
+ * Reuses `TIER_PRESERVING_STATUSES` from organization-db.ts — same set
+ * (active, past_due, trialing), same intent (a paid relationship exists).
+ * `canceled`, `unpaid`, and `incomplete_expired` are recoverable by
+ * re-subscribing and intentionally pass through.
  */
-const BLOCKING_STATUSES = new Set(['active', 'trialing', 'past_due']);
+const BLOCKING_STATUSES: ReadonlySet<string> = new Set(TIER_PRESERVING_STATUSES);
+
+function formatAmount(cents: number): string {
+  // Render as fixed 2-decimal currency; otherwise $250.50 displays as "$250.5".
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export interface BlockOptions {
+  /**
+   * Where to redirect the user after they finish in the Stripe Customer
+   * Portal. Pass undefined to suppress the portal URL entirely — required on
+   * the invite-acceptance path, where the requester has only `member` role
+   * on the org and a portal session would grant `admin`-equivalent control
+   * over the org's subscription, payment method, and cancellation.
+   */
+  customerPortalReturnUrl?: string;
+}
 
 /**
  * Returns a 409 payload if the org already has a live subscription,
@@ -49,38 +67,49 @@ const BLOCKING_STATUSES = new Set(['active', 'trialing', 'past_due']);
  *
  * @param orgId    workos_organization_id of the org being billed
  * @param orgDb    OrganizationDatabase instance (DI for testing)
- * @param returnUrl Where to send the user back to from the Stripe Customer Portal
+ * @param options.customerPortalReturnUrl  When provided, the 409 includes a
+ *   single-use Stripe Customer Portal URL the requester can follow to
+ *   manage the existing subscription. Omit on routes where the requester
+ *   does not have admin authority over the org (e.g., invite acceptance
+ *   for a not-yet-member or a `member`-role user).
  */
 export async function blockIfActiveSubscription(
   orgId: string,
   orgDb: OrganizationDatabase,
-  returnUrl: string,
+  options: BlockOptions = {},
 ): Promise<ActiveSubscriptionBlock | null> {
   const info = await orgDb.getSubscriptionInfo(orgId);
   if (!info || !BLOCKING_STATUSES.has(info.status)) {
     return null;
   }
 
-  const org = await orgDb.getOrganization(orgId);
   let portalUrl: string | undefined;
-  if (org?.stripe_customer_id) {
-    try {
-      portalUrl = (await createCustomerPortalSession(org.stripe_customer_id, returnUrl)) || undefined;
-    } catch (err) {
-      logger.warn({ err, orgId }, 'Failed to create customer portal session for active-sub block');
+  if (options.customerPortalReturnUrl) {
+    const org = await orgDb.getOrganization(orgId);
+    if (org?.stripe_customer_id) {
+      try {
+        portalUrl = (await createCustomerPortalSession(
+          org.stripe_customer_id,
+          options.customerPortalReturnUrl,
+        )) || undefined;
+      } catch (err) {
+        logger.warn({ err, orgId }, 'Failed to create customer portal session for active-sub block');
+      }
     }
   }
 
-  const productName = info.product_name || `${info.lookup_key ?? 'membership'}`;
-  const amountDisplay = info.amount_cents
-    ? `$${(info.amount_cents / 100).toLocaleString()}`
-    : 'an active tier';
+  const productName = info.product_name || info.lookup_key || 'membership';
+  const amountDisplay = info.amount_cents != null ? formatAmount(info.amount_cents) : 'an active tier';
+
+  const remediation = portalUrl
+    ? 'To change tiers, cancel, or update payment method, use the Stripe Customer Portal.'
+    : 'To change tiers, cancel, or update payment method, contact finance@agenticadvertising.org or sign in to the dashboard at https://agenticadvertising.org/dashboard/membership.';
 
   return {
     status: 409,
     body: {
       error: 'Active subscription exists',
-      message: `This organization is already on ${productName} (${amountDisplay}). To change tiers, cancel, or update payment method, use the Stripe Customer Portal.`,
+      message: `This organization is already on ${productName} (${amountDisplay}). ${remediation}`,
       existing_subscription: {
         status: info.status,
         product_name: info.product_name,

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -259,12 +259,12 @@ export function createPublicBillingRouter(): Router {
       }
 
       // Refuse if the org already has an active subscription. Tier changes go
-      // through the Stripe Customer Portal, not this intake route.
-      const activeBlock = await blockIfActiveSubscription(
-        orgId,
-        orgDb,
-        `${req.protocol}://${req.get('host')}/dashboard/membership`,
-      );
+      // through the Stripe Customer Portal, not this intake route. The
+      // requester is an authenticated member of the org (verified above), so
+      // it's safe to surface the portal URL.
+      const activeBlock = await blockIfActiveSubscription(orgId, orgDb, {
+        customerPortalReturnUrl: `${req.protocol}://${req.get('host')}/dashboard/membership`,
+      });
       if (activeBlock) {
         return res.status(activeBlock.status).json(activeBlock.body);
       }
@@ -493,12 +493,12 @@ export function createPublicBillingRouter(): Router {
         const baseUrl = `${protocol}://${host}`;
 
         // Refuse if the org already has an active subscription. Tier changes go
-        // through the Stripe Customer Portal, not this checkout intake.
-        const activeBlock = await blockIfActiveSubscription(
-          orgId,
-          orgDb,
-          `${baseUrl}/dashboard/membership`,
-        );
+        // through the Stripe Customer Portal, not this checkout intake. The
+        // requester is a verified org member, so the portal URL is safe to
+        // include.
+        const activeBlock = await blockIfActiveSubscription(orgId, orgDb, {
+          customerPortalReturnUrl: `${baseUrl}/dashboard/membership`,
+        });
         if (activeBlock) {
           return res.status(activeBlock.status).json(activeBlock.body);
         }

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -24,6 +24,7 @@ import {
 } from "../billing/stripe-client.js";
 import * as referralDb from "../db/referral-codes-db.js";
 import { sanitizeBillingAddress } from "../billing/billing-address.js";
+import { blockIfActiveSubscription } from "../billing/active-subscription-guard.js";
 import {
   OrganizationDatabase,
   type CompanyType,
@@ -257,6 +258,17 @@ export function createPublicBillingRouter(): Router {
         }
       }
 
+      // Refuse if the org already has an active subscription. Tier changes go
+      // through the Stripe Customer Portal, not this intake route.
+      const activeBlock = await blockIfActiveSubscription(
+        orgId,
+        orgDb,
+        `${req.protocol}://${req.get('host')}/dashboard/membership`,
+      );
+      if (activeBlock) {
+        return res.status(activeBlock.status).json(activeBlock.body);
+      }
+
       // Product must be eligible for this org type (individual → personal
       // workspace, company → non-personal org).
       const customerType = org.is_personal ? 'individual' : 'company';
@@ -479,6 +491,17 @@ export function createPublicBillingRouter(): Router {
         const host = req.get("host");
         const protocol = req.protocol;
         const baseUrl = `${protocol}://${host}`;
+
+        // Refuse if the org already has an active subscription. Tier changes go
+        // through the Stripe Customer Portal, not this checkout intake.
+        const activeBlock = await blockIfActiveSubscription(
+          orgId,
+          orgDb,
+          `${baseUrl}/dashboard/membership`,
+        );
+        if (activeBlock) {
+          return res.status(activeBlock.status).json(activeBlock.body);
+        }
 
         // Determine referral discount to apply at checkout.
         // Priority 1: accepted referral (prospect already accepted invitation — use that discount)

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -157,11 +157,15 @@ export function createInvitesRouter(): Router {
       // Refuse if the org already has an active subscription. Accepting this
       // invite would mint a duplicate sub on the same Stripe customer — the
       // Triton Apr-2026 incident in literal form.
-      const baseUrl = process.env.BASE_URL || 'https://agenticadvertising.org';
+      //
+      // We deliberately omit `customerPortalReturnUrl`: the invite recipient
+      // gets `member` role on the org (not `admin`), and a Stripe Customer
+      // Portal session would grant them admin-equivalent control over the
+      // existing subscription. The 409 message points them at the dashboard
+      // and finance@ instead.
       const activeBlock = await blockIfActiveSubscription(
         org.workos_organization_id,
         orgDb,
-        `${baseUrl}/dashboard/membership`,
       );
       if (activeBlock) {
         return res.status(activeBlock.status).json(activeBlock.body);

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -25,6 +25,7 @@ import {
   createCoupon,
 } from '../billing/stripe-client.js';
 import { sanitizeBillingAddress } from '../billing/billing-address.js';
+import { blockIfActiveSubscription } from '../billing/active-subscription-guard.js';
 import * as referralDb from '../db/referral-codes-db.js';
 
 const logger = createLogger('invites-routes');
@@ -151,6 +152,19 @@ export function createInvitesRouter(): Router {
           error: 'Tier no longer available',
           message: 'The membership tier in this invite is no longer available.',
         });
+      }
+
+      // Refuse if the org already has an active subscription. Accepting this
+      // invite would mint a duplicate sub on the same Stripe customer — the
+      // Triton Apr-2026 incident in literal form.
+      const baseUrl = process.env.BASE_URL || 'https://agenticadvertising.org';
+      const activeBlock = await blockIfActiveSubscription(
+        org.workos_organization_id,
+        orgDb,
+        `${baseUrl}/dashboard/membership`,
+      );
+      if (activeBlock) {
+        return res.status(activeBlock.status).json(activeBlock.body);
       }
 
       // Ensure the accepting user is a member of the target org.

--- a/server/tests/unit/active-subscription-guard.test.ts
+++ b/server/tests/unit/active-subscription-guard.test.ts
@@ -32,6 +32,8 @@ function makeOrgDb(opts: {
   } as unknown as OrganizationDatabase;
 }
 
+const PORTAL_RETURN_URL = 'https://app/dashboard/membership';
+
 describe('blockIfActiveSubscription', () => {
   beforeEach(() => {
     mockCreatePortal.mockReset();
@@ -39,19 +41,19 @@ describe('blockIfActiveSubscription', () => {
 
   it('returns null when org has no subscription info', async () => {
     const orgDb = makeOrgDb({ info: null });
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
     expect(result).toBeNull();
   });
 
   it('returns null when subscription status is "none"', async () => {
     const orgDb = makeOrgDb({ info: { status: 'none' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
     expect(result).toBeNull();
   });
 
   it('returns null when subscription is canceled', async () => {
     const orgDb = makeOrgDb({ info: { status: 'canceled' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
     expect(result).toBeNull();
   });
 
@@ -62,7 +64,7 @@ describe('blockIfActiveSubscription', () => {
     });
     mockCreatePortal.mockResolvedValueOnce('https://billing.stripe.com/p/session/x');
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.body.existing_subscription.status).toBe('past_due');
@@ -70,7 +72,7 @@ describe('blockIfActiveSubscription', () => {
 
   it('returns null when subscription is unpaid (recoverable by re-subscribing)', async () => {
     const orgDb = makeOrgDb({ info: { status: 'unpaid' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
     expect(result).toBeNull();
   });
 
@@ -89,33 +91,65 @@ describe('blockIfActiveSubscription', () => {
       },
     });
 
-    const result = await blockIfActiveSubscription('org_triton', orgDb, 'https://app/dashboard/membership');
+    const result = await blockIfActiveSubscription('org_triton', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe(409);
     expect(result!.body.error).toBe('Active subscription exists');
     expect(result!.body.message).toContain('Corporate Membership');
-    expect(result!.body.message).toContain('$10,000');
+    expect(result!.body.message).toContain('$10,000.00');
+    expect(result!.body.message).toContain('Stripe Customer Portal');
     expect(result!.body.existing_subscription).toEqual({
       status: 'active',
       product_name: 'Corporate Membership',
       amount_cents: 1000000,
     });
     expect(result!.body.customer_portal_url).toBe('https://billing.stripe.com/p/session/test');
-    expect(mockCreatePortal).toHaveBeenCalledWith('cus_triton', 'https://app/dashboard/membership');
+    expect(mockCreatePortal).toHaveBeenCalledWith('cus_triton', PORTAL_RETURN_URL);
   });
 
   it('blocks when subscription is trialing', async () => {
     const orgDb = makeOrgDb({
-      info: { status: 'trialing', amount_cents: 250 },
+      info: { status: 'trialing', amount_cents: 25050 },
       org: { stripe_customer_id: 'cus_x' },
     });
     mockCreatePortal.mockResolvedValueOnce(null);
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.body.existing_subscription.status).toBe('trialing');
+  });
+
+  it('formats fractional dollar amounts with 2 decimal places', async () => {
+    const orgDb = makeOrgDb({
+      info: { status: 'active', amount_cents: 25050 },
+      org: { stripe_customer_id: null },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+
+    expect(result).not.toBeNull();
+    // $250.50 must render with cents — toLocaleString defaults drop them.
+    expect(result!.body.message).toContain('$250.50');
+  });
+
+  it('omits customer_portal_url when caller does not pass customerPortalReturnUrl (privilege check)', async () => {
+    // The invite-acceptance route omits returnUrl because the recipient gets
+    // `member` role only and a portal session would grant admin-equivalent
+    // control over the org's subscription.
+    const orgDb = makeOrgDb({
+      info: { status: 'active', amount_cents: 1000000, product_name: 'Corporate Membership' },
+      org: { stripe_customer_id: 'cus_triton' },
+    });
+
+    const result = await blockIfActiveSubscription('org_triton', orgDb /* no options */);
+
+    expect(result).not.toBeNull();
+    expect(result!.body.customer_portal_url).toBeUndefined();
+    expect(result!.body.message).toContain('finance@agenticadvertising.org');
+    expect(result!.body.message).not.toContain('Stripe Customer Portal');
+    expect(mockCreatePortal).not.toHaveBeenCalled();
   });
 
   it('omits customer_portal_url when org has no Stripe customer id', async () => {
@@ -124,10 +158,12 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.body.customer_portal_url).toBeUndefined();
+    // Falls back to the finance@ message when portal URL can't be generated.
+    expect(result!.body.message).toContain('finance@agenticadvertising.org');
     expect(mockCreatePortal).not.toHaveBeenCalled();
   });
 
@@ -138,10 +174,11 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: 'cus_x' },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.body.customer_portal_url).toBeUndefined();
+    expect(result!.body.message).toContain('finance@agenticadvertising.org');
   });
 
   it('falls back to lookup_key in the message when product_name is missing', async () => {
@@ -154,7 +191,7 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
 
     expect(result).not.toBeNull();
     expect(result!.body.message).toContain('aao_membership_builder_3000');

--- a/server/tests/unit/active-subscription-guard.test.ts
+++ b/server/tests/unit/active-subscription-guard.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the duplicate-active-subscription guard.
+ *
+ * The guard is wired into POST /api/checkout-session, /api/invoice-request,
+ * and /api/invite/:token/accept. Together those three are the only paths
+ * that can mint a Stripe subscription/invoice on an org's behalf. Without
+ * this guard, two of them in sequence produced Triton's duplicate $3K
+ * Builder sub on top of an active $10K Corporate sub (Apr 2026).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const mockCreatePortal = vi.fn<(customerId: string, returnUrl: string) => Promise<string | null>>();
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  createCustomerPortalSession: (customerId: string, returnUrl: string) =>
+    mockCreatePortal(customerId, returnUrl),
+}));
+
+const { blockIfActiveSubscription } = await import('../../src/billing/active-subscription-guard.js');
+import type { OrganizationDatabase, SubscriptionInfo, Organization } from '../../src/db/organization-db.js';
+
+function makeOrgDb(opts: {
+  info: SubscriptionInfo | null;
+  org?: Partial<Organization> | null;
+}): OrganizationDatabase {
+  return {
+    getSubscriptionInfo: vi.fn().mockResolvedValue(opts.info),
+    getOrganization: vi.fn().mockResolvedValue(opts.org ?? null),
+  } as unknown as OrganizationDatabase;
+}
+
+describe('blockIfActiveSubscription', () => {
+  beforeEach(() => {
+    mockCreatePortal.mockReset();
+  });
+
+  it('returns null when org has no subscription info', async () => {
+    const orgDb = makeOrgDb({ info: null });
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when subscription status is "none"', async () => {
+    const orgDb = makeOrgDb({ info: { status: 'none' } });
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when subscription is canceled', async () => {
+    const orgDb = makeOrgDb({ info: { status: 'canceled' } });
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    expect(result).toBeNull();
+  });
+
+  it('blocks when subscription is past_due — minting another sub would stack unresolved invoices', async () => {
+    const orgDb = makeOrgDb({
+      info: { status: 'past_due', amount_cents: 300000 },
+      org: { stripe_customer_id: 'cus_x' },
+    });
+    mockCreatePortal.mockResolvedValueOnce('https://billing.stripe.com/p/session/x');
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+
+    expect(result).not.toBeNull();
+    expect(result!.body.existing_subscription.status).toBe('past_due');
+  });
+
+  it('returns null when subscription is unpaid (recoverable by re-subscribing)', async () => {
+    const orgDb = makeOrgDb({ info: { status: 'unpaid' } });
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+    expect(result).toBeNull();
+  });
+
+  it('blocks when subscription is active and includes a customer portal URL', async () => {
+    mockCreatePortal.mockResolvedValueOnce('https://billing.stripe.com/p/session/test');
+    const orgDb = makeOrgDb({
+      info: {
+        status: 'active',
+        product_name: 'Corporate Membership',
+        amount_cents: 1000000,
+        lookup_key: 'aao_membership_corporate_5m',
+      },
+      org: {
+        workos_organization_id: 'org_triton',
+        stripe_customer_id: 'cus_triton',
+      },
+    });
+
+    const result = await blockIfActiveSubscription('org_triton', orgDb, 'https://app/dashboard/membership');
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(409);
+    expect(result!.body.error).toBe('Active subscription exists');
+    expect(result!.body.message).toContain('Corporate Membership');
+    expect(result!.body.message).toContain('$10,000');
+    expect(result!.body.existing_subscription).toEqual({
+      status: 'active',
+      product_name: 'Corporate Membership',
+      amount_cents: 1000000,
+    });
+    expect(result!.body.customer_portal_url).toBe('https://billing.stripe.com/p/session/test');
+    expect(mockCreatePortal).toHaveBeenCalledWith('cus_triton', 'https://app/dashboard/membership');
+  });
+
+  it('blocks when subscription is trialing', async () => {
+    const orgDb = makeOrgDb({
+      info: { status: 'trialing', amount_cents: 250 },
+      org: { stripe_customer_id: 'cus_x' },
+    });
+    mockCreatePortal.mockResolvedValueOnce(null);
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+
+    expect(result).not.toBeNull();
+    expect(result!.body.existing_subscription.status).toBe('trialing');
+  });
+
+  it('omits customer_portal_url when org has no Stripe customer id', async () => {
+    const orgDb = makeOrgDb({
+      info: { status: 'active', amount_cents: 5000 },
+      org: { stripe_customer_id: null },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+
+    expect(result).not.toBeNull();
+    expect(result!.body.customer_portal_url).toBeUndefined();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+
+  it('omits customer_portal_url and does not throw when portal creation fails', async () => {
+    mockCreatePortal.mockRejectedValueOnce(new Error('Stripe down'));
+    const orgDb = makeOrgDb({
+      info: { status: 'active', amount_cents: 5000 },
+      org: { stripe_customer_id: 'cus_x' },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+
+    expect(result).not.toBeNull();
+    expect(result!.body.customer_portal_url).toBeUndefined();
+  });
+
+  it('falls back to lookup_key in the message when product_name is missing', async () => {
+    const orgDb = makeOrgDb({
+      info: {
+        status: 'active',
+        amount_cents: 300000,
+        lookup_key: 'aao_membership_builder_3000',
+      },
+      org: { stripe_customer_id: null },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, 'https://app/dashboard');
+
+    expect(result).not.toBeNull();
+    expect(result!.body.message).toContain('aao_membership_builder_3000');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the second half of the Triton/Encypher incident. PR #3142 closed the **wrong-identity** door (caller-supplied emails could become the Stripe customer of record). This PR closes the **wrong-number-of-subs** door (no path may mint a subscription/invoice on an org that already has a live one).

## What changed

New helper `server/src/billing/active-subscription-guard.ts` exporting `blockIfActiveSubscription(orgId, orgDb, returnUrl)`. Returns `null` when safe; returns a 409 payload (with existing subscription details + a Stripe Customer Portal URL) when blocking.

Wired into the three routes that can mint billing on an org's behalf:

- `POST /api/checkout-session` — server/src/routes/billing-public.ts
- `POST /api/invoice-request` — server/src/routes/billing-public.ts
- `POST /api/invite/:token/accept` — server/src/routes/invites.ts

Blocking statuses: `active`, `trialing`, `past_due`. Non-blocking: `canceled`, `unpaid`, `incomplete_expired`, `none` (those are recoverable by re-subscribing).

## Why past_due also blocks

Without this, a member whose card got declined could click invoice-request and stack a *second* past_due sub on top of the first one. The right path for them is the customer portal (update payment method, retry the existing invoice) — which is what the 409 message points them to.

## Tier upgrade path

Existing members who want to change tiers or update payment method use the Stripe Customer Portal (already wired up via `createCustomerPortalSession` and Addie's `get_billing_portal` tool). The 409 includes `customer_portal_url` so the UI can deep-link them straight to it.

## Tests

`server/tests/unit/active-subscription-guard.test.ts` — 10 cases covering all status branches, missing org row, portal-creation failure, and message content.

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 834/834
- [x] `npm run test:server-unit` — 2208/2208 (10 new)

## Test plan (manual)

- [ ] As an existing active member, hit `POST /api/checkout-session` for any tier → expect 409 with `customer_portal_url`
- [ ] As an existing active member, click an invite link from another tier and accept → expect 409 (would have created Triton-style duplicate)
- [ ] As a canceled member, hit `POST /api/invoice-request` for renewal → expect 200 (allowed re-subscribe)
- [ ] As a brand-new prospect, accept an invite → expect 200 (unchanged behavior)

## Follow-up: direct-link join flow with payment chooser

The next UX iteration (filed separately): replace per-invite tokens with shareable `/join` links that include a tier hint, walk WorkOS sign-in/sign-up, render the agreement, then offer card / invoice / wire as payment method choices. See the linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)