### PR TITLE
feat(admin): list_orphaned_brands tool to audit relinquished brand pool

### DIFF
--- a/.changeset/list-orphaned-brands-admin-tool.md
+++ b/.changeset/list-orphaned-brands-admin-tool.md
@@ -1,0 +1,8 @@
+---
+---
+
+New `list_orphaned_brands` admin tool surfaces brands awaiting adoption — the prior owner relinquished, the manifest is preserved for the next claimant — so admins can audit the queue without raw DB access. Returns prior owner org name + id, days since relinquished, and a manifest preview (logo, color) per row.
+
+Pairs with the existing `transfer_brand_ownership` tool: when an admin confirms the legitimate next owner out of band, run transfer to hand it off; otherwise the row sits in the orphan pool until someone claims via the normal brand-identity flow (which now requires an explicit adopt-or-clear decision).
+
+Closes the "orphaned rows accumulate with no admin view" gap from the #3168 review.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -8410,11 +8410,17 @@ Use add_committee_leader to assign a leader.`;
   handlers.set('list_orphaned_brands', async (input) => {
     const limit = Math.min(Math.max((input.limit as number) ?? 50, 1), 200);
     const offset = Math.max((input.offset as number) ?? 0, 0);
+    const adminUserId = memberContext?.workos_user?.workos_user_id ?? 'system:addie-admin';
 
     try {
       const orphaned = await brandDbForLogos.listOrphanedBrands(limit, offset);
+      // Log every invocation so a bulk-enumeration pattern (e.g., compromised
+      // admin token sweeping the orphan pool for relinquish signals) shows up
+      // in audit logs. Matches the pattern used by other admin list_* tools.
+      logger.info({ adminUserId, count: orphaned.length, limit, offset }, 'Addie: admin listed orphaned brands');
+
       if (orphaned.length === 0) {
-        return JSON.stringify({ success: true, message: 'No orphaned brands awaiting adoption.', count: 0, brands: [] });
+        return JSON.stringify({ success: true, message: 'No orphaned brands awaiting adoption.', count: 0, brands: [] }, null, 2);
       }
 
       const now = Date.now();
@@ -8423,8 +8429,8 @@ Use add_committee_leader to assign a leader.`;
         brand_name: b.brand_name,
         prior_owner_org_id: b.prior_owner_org_id,
         prior_owner_org_name: b.prior_owner_org_name,
-        relinquished_at: b.relinquished_at,
-        days_since_relinquished: Math.floor((now - new Date(b.relinquished_at).getTime()) / 86_400_000),
+        last_updated_at: b.last_updated_at,
+        days_since_relinquished: Math.floor((now - new Date(b.last_updated_at).getTime()) / 86_400_000),
         logo_url: b.manifest_preview.logo_url ?? null,
         brand_color: b.manifest_preview.brand_color ?? null,
       }));

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -1604,6 +1604,24 @@ Do not use to resolve unverified disputes — use the escalation queue for those
       required: ['domain', 'new_org_id', 'reason'],
     },
   },
+  {
+    name: 'list_orphaned_brands',
+    description: `List brand domains in the orphaned state — a prior owner relinquished and the manifest is preserved for adoption. Use this to audit relinquished brands, see which ones have stale data, and trigger admin cleanup or reach out to potential adopters. Returns prior owner org name + id, when relinquished, and a manifest preview so admins can decide at a glance.`,
+    usage_hints: 'Use to answer "what brands are awaiting adoption?" or to find a specific orphaned domain. Pair with transfer_brand_ownership when an admin has confirmed the right next owner out of band.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum brands to return (default 50, max 200)',
+        },
+        offset: {
+          type: 'number',
+          description: 'Pagination offset (default 0)',
+        },
+      },
+    },
+  },
 ];
 
 /**
@@ -8386,6 +8404,35 @@ Use add_committee_leader to assign a leader.`;
       if (error instanceof ToolError) throw error;
       logger.error({ error, domain, newOrgId }, 'Error transferring brand ownership');
       throw new ToolError(`Failed to transfer ownership: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  });
+
+  handlers.set('list_orphaned_brands', async (input) => {
+    const limit = Math.min(Math.max((input.limit as number) ?? 50, 1), 200);
+    const offset = Math.max((input.offset as number) ?? 0, 0);
+
+    try {
+      const orphaned = await brandDbForLogos.listOrphanedBrands(limit, offset);
+      if (orphaned.length === 0) {
+        return JSON.stringify({ success: true, message: 'No orphaned brands awaiting adoption.', count: 0, brands: [] });
+      }
+
+      const now = Date.now();
+      const brands = orphaned.map(b => ({
+        domain: b.domain,
+        brand_name: b.brand_name,
+        prior_owner_org_id: b.prior_owner_org_id,
+        prior_owner_org_name: b.prior_owner_org_name,
+        relinquished_at: b.relinquished_at,
+        days_since_relinquished: Math.floor((now - new Date(b.relinquished_at).getTime()) / 86_400_000),
+        logo_url: b.manifest_preview.logo_url ?? null,
+        brand_color: b.manifest_preview.brand_color ?? null,
+      }));
+
+      return JSON.stringify({ success: true, count: brands.length, brands }, null, 2);
+    } catch (error) {
+      logger.error({ error }, 'Error listing orphaned brands');
+      throw new ToolError(`Failed to list orphaned brands: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   });
 

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -363,6 +363,7 @@ export const TOOL_SETS: Record<string, ToolSet> = {
       'update_member_logo',
       'update_member_profile',
       'transfer_brand_ownership',
+      'list_orphaned_brands',
     ],
     adminOnly: true,
   },

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -368,6 +368,15 @@ export class BrandDatabase {
    * manifest preserved for adoption. Joins the prior org name for admin display
    * so the queue is readable without a separate lookup. Newest-first because
    * recently relinquished brands are the most likely to need attention.
+   *
+   * The returned `last_updated_at` is the row's `updated_at` column. While a
+   * brand is orphaned, only `deleteHostedBrand` writes to it (the read paths
+   * filter orphans out, and the write paths — claimOrphanedHostedBrand,
+   * updateBrandIdentity, transferBrandOwnership — all clear the orphan flag
+   * as part of the same UPDATE), so in practice this equals "relinquished
+   * at." If a future code path mutates an orphan without clearing the flag,
+   * this field starts to drift; rename to a dedicated `manifest_orphaned_at`
+   * column at that point.
    */
   async listOrphanedBrands(
     limit = 50,
@@ -377,7 +386,7 @@ export class BrandDatabase {
     brand_name: string | null;
     prior_owner_org_id: string | null;
     prior_owner_org_name: string | null;
-    relinquished_at: Date;
+    last_updated_at: Date;
     manifest_preview: { logo_url?: string; brand_color?: string };
   }>> {
     const result = await query<{
@@ -385,12 +394,12 @@ export class BrandDatabase {
       brand_name: string | null;
       prior_owner_org_id: string | null;
       prior_owner_org_name: string | null;
-      relinquished_at: Date;
+      last_updated_at: Date;
       brand_manifest: Record<string, unknown> | null;
     }>(
       `SELECT b.domain, b.brand_name, b.prior_owner_org_id,
               o.name AS prior_owner_org_name,
-              b.updated_at AS relinquished_at,
+              b.updated_at AS last_updated_at,
               b.brand_manifest
        FROM brands b
        LEFT JOIN organizations o ON o.workos_organization_id = b.prior_owner_org_id
@@ -408,7 +417,7 @@ export class BrandDatabase {
         brand_name: row.brand_name,
         prior_owner_org_id: row.prior_owner_org_id,
         prior_owner_org_name: row.prior_owner_org_name,
-        relinquished_at: row.relinquished_at,
+        last_updated_at: row.last_updated_at,
         manifest_preview: {
           logo_url: resolved?.logo_url,
           brand_color: resolved?.brand_color,

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -364,6 +364,60 @@ export class BrandDatabase {
   }
 
   /**
+   * List brand rows currently in the orphaned state — prior owner relinquished,
+   * manifest preserved for adoption. Joins the prior org name for admin display
+   * so the queue is readable without a separate lookup. Newest-first because
+   * recently relinquished brands are the most likely to need attention.
+   */
+  async listOrphanedBrands(
+    limit = 50,
+    offset = 0,
+  ): Promise<Array<{
+    domain: string;
+    brand_name: string | null;
+    prior_owner_org_id: string | null;
+    prior_owner_org_name: string | null;
+    relinquished_at: Date;
+    manifest_preview: { logo_url?: string; brand_color?: string };
+  }>> {
+    const result = await query<{
+      domain: string;
+      brand_name: string | null;
+      prior_owner_org_id: string | null;
+      prior_owner_org_name: string | null;
+      relinquished_at: Date;
+      brand_manifest: Record<string, unknown> | null;
+    }>(
+      `SELECT b.domain, b.brand_name, b.prior_owner_org_id,
+              o.name AS prior_owner_org_name,
+              b.updated_at AS relinquished_at,
+              b.brand_manifest
+       FROM brands b
+       LEFT JOIN organizations o ON o.workos_organization_id = b.prior_owner_org_id
+       WHERE b.manifest_orphaned = TRUE
+       ORDER BY b.updated_at DESC
+       LIMIT $1 OFFSET $2`,
+      [limit, offset]
+    );
+    return result.rows.map(row => {
+      const resolved = row.brand_manifest
+        ? resolveBrandFromJson(row.domain, row.brand_manifest, false)
+        : null;
+      return {
+        domain: row.domain,
+        brand_name: row.brand_name,
+        prior_owner_org_id: row.prior_owner_org_id,
+        prior_owner_org_name: row.prior_owner_org_name,
+        relinquished_at: row.relinquished_at,
+        manifest_preview: {
+          logo_url: resolved?.logo_url,
+          brand_color: resolved?.brand_color,
+        },
+      };
+    });
+  }
+
+  /**
    * Generate verification token for a hosted brand
    */
   async generateVerificationToken(id: string): Promise<string | null> {


### PR DESCRIPTION
## Summary

New \`list_orphaned_brands\` admin tool. Closes the "orphaned rows accumulate with no admin view" gap that adtech-product-expert flagged on #3168.

## What it does

When a hosted brand is relinquished, the row enters an orphan state: ownership cleared, manifest preserved, \`is_public=false\`. #3168 shipped the relinquish + adoption-at-claim plumbing but left admins without a way to *see* what's in the orphan pool. This tool fixes that.

\`list_orphaned_brands\` returns one row per orphaned brand:

- \`domain\`
- \`prior_owner_org_id\` + \`prior_owner_org_name\` (joined from organizations)
- \`relinquished_at\` + \`days_since_relinquished\`
- Manifest preview: \`logo_url\` + \`brand_color\`

Newest-first ordering so the most-recent relinquishments surface first.

## Pairs with

- \`transfer_brand_ownership\` (#3159) — when an admin confirms the legitimate next owner out of band, transfer to hand off
- \`update_company_logo\` member tool — orphaned brands become claimable through the normal flow once a prospective new owner identifies themselves; the orphan-decision is then forced explicitly in the chat (\`orphan_manifest_decision_required\` 409)

## Test plan

- [x] Type-check passes
- [x] 834 unit tests pass
- [ ] Reviewer to verify on staging: relinquish a test brand via DELETE \`/api/brands/hosted/:domain\`, run \`list_orphaned_brands\` from chat, confirm the row appears with prior owner name + manifest preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)