### PR TITLE
fix(billing): close intake race with per-org advisory lock (#3179)

### DIFF
--- a/.changeset/intake-race-advisory-lock.md
+++ b/.changeset/intake-race-advisory-lock.md
@@ -1,0 +1,8 @@
+---
+---
+
+Close the millisecond intake race that the duplicate-subscription guard couldn't on its own (#3179).
+
+`POST /api/invoice-request` and `POST /api/invite/:token/accept` now wrap their `blockIfActiveSubscription` re-check + Stripe write in a per-org Postgres advisory lock (`pg_advisory_xact_lock(hashtext(orgId))`). Two concurrent intakes for the same org serialize: the first acquires the lock, runs the guard against live Stripe state, mints the subscription/invoice, commits, and releases; the second acquires the lock, runs the guard, sees the now-existing subscription, and returns 409.
+
+`POST /api/checkout-session` is intentionally not wrapped in the lock — Stripe Checkout sessions don't create the subscription until the user completes the hosted page, so two concurrent calls just produce two session URLs; the actual duplication can only happen if the user pays on both. That race is closed at the webhook layer (separate follow-up).

--- a/server/src/billing/org-intake-lock.ts
+++ b/server/src/billing/org-intake-lock.ts
@@ -15,6 +15,25 @@
 
 import type { PoolClient } from 'pg';
 import { getPool } from '../db/client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('org-intake-lock');
+
+/**
+ * Hard caps on lock acquisition + statement execution inside the locked
+ * transaction. Without these, a stuck Stripe call (network blip, slow
+ * webhook hop) parks a pool connection indefinitely and queues every other
+ * intake for the same org behind it.
+ *
+ * - lock_timeout: how long the inner `pg_advisory_xact_lock` may wait for
+ *   another transaction to release the same key. After this, PG raises an
+ *   error and we roll back; the caller surfaces a 500 and the user retries.
+ * - statement_timeout: ceiling for any single statement inside the
+ *   transaction. Stripe's slowest p99 invoice/subscription create is well
+ *   under 30s; this is a safety net, not a performance budget.
+ */
+const LOCK_TIMEOUT_MS = 10_000;
+const STATEMENT_TIMEOUT_MS = 30_000;
 
 /**
  * Run `fn` while holding a transaction-scoped advisory lock keyed on the
@@ -39,16 +58,26 @@ export async function withOrgIntakeLock<T>(
   try {
     try {
       await client.query('BEGIN');
+      // Per-transaction timeouts: prevents a stuck Stripe call from parking
+      // this connection indefinitely and queueing other same-org intakes.
+      await client.query(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT_MS}ms'`);
+      await client.query(`SET LOCAL statement_timeout = '${STATEMENT_TIMEOUT_MS}ms'`);
       await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [orgId]);
       const result = await fn();
       await client.query('COMMIT');
       return result;
     } catch (err) {
-      // Best-effort rollback; if it fails, surface the original error.
+      // Best-effort rollback. If ROLLBACK itself fails it usually means the
+      // connection dropped mid-transaction — log so we know about it (the
+      // pool client auto-discards dead connections, so no leak), but
+      // surface the original error rather than the rollback failure.
       try {
         await client.query('ROLLBACK');
-      } catch {
-        // intentionally swallowed — we re-throw `err` below
+      } catch (rollbackErr) {
+        logger.warn(
+          { err: rollbackErr, orgId, originalErr: err instanceof Error ? err.message : String(err) },
+          'ROLLBACK failed inside withOrgIntakeLock — connection likely dropped',
+        );
       }
       throw err;
     }

--- a/server/src/billing/org-intake-lock.ts
+++ b/server/src/billing/org-intake-lock.ts
@@ -1,0 +1,58 @@
+/**
+ * Postgres advisory-lock helper that serializes billing intakes for a single
+ * organization across all paths that mint a Stripe subscription/invoice.
+ *
+ * Without this, two concurrent requests can both pass `blockIfActiveSubscription`
+ * (the read-then-write race the security review of #3171 flagged) and create
+ * two subscriptions on the same Stripe customer — the same shape as the
+ * months-apart Triton bug, just compressed to milliseconds.
+ *
+ * `pg_advisory_xact_lock(hashtext(orgId))` blocks any other transaction that
+ * tries to acquire the same key until this transaction commits or rolls back.
+ * Lock release is automatic on transaction end, so we don't have to track
+ * release manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { getPool } from '../db/client.js';
+
+/**
+ * Run `fn` while holding a transaction-scoped advisory lock keyed on the
+ * organization id. Other concurrent calls for the same org wait until this
+ * one's transaction commits or rolls back; calls for different orgs don't
+ * contend. Lock release is automatic when the transaction ends.
+ *
+ * The lock serializes serialization of `getSubscriptionInfo` reads against
+ * subsequent Stripe writes — `getSubscriptionInfo` queries Stripe live, so
+ * by the time the second caller's guard runs, the first caller's
+ * subscription is already visible in Stripe and the guard correctly blocks.
+ *
+ * The callback does not need to use the locked client; the lock is held by
+ * this connection alone, but serialization is enforced regardless of which
+ * connection the caller's other queries use.
+ */
+export async function withOrgIntakeLock<T>(
+  orgId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const client: PoolClient = await getPool().connect();
+  try {
+    try {
+      await client.query('BEGIN');
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [orgId]);
+      const result = await fn();
+      await client.query('COMMIT');
+      return result;
+    } catch (err) {
+      // Best-effort rollback; if it fails, surface the original error.
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // intentionally swallowed — we re-throw `err` below
+      }
+      throw err;
+    }
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -24,7 +24,11 @@ import {
 } from "../billing/stripe-client.js";
 import * as referralDb from "../db/referral-codes-db.js";
 import { sanitizeBillingAddress } from "../billing/billing-address.js";
-import { blockIfActiveSubscription } from "../billing/active-subscription-guard.js";
+import {
+  blockIfActiveSubscription,
+  type ActiveSubscriptionBlock,
+} from "../billing/active-subscription-guard.js";
+import { withOrgIntakeLock } from "../billing/org-intake-lock.js";
 import {
   OrganizationDatabase,
   type CompanyType,
@@ -369,15 +373,35 @@ export function createPublicBillingRouter(): Router {
 
       logger.info({ orgId, lookupKey, userId: user.id }, 'Invoice request received');
 
-      const result = await createAndSendInvoice(invoiceData);
+      // Lock + re-guard + Stripe write must be atomic per-org. The early
+      // `blockIfActiveSubscription` above handles the common case fast; this
+      // section closes the millisecond race where two concurrent intakes both
+      // pass that early check before either has minted a sub.
+      const intake = await withOrgIntakeLock<
+        | { kind: 'block'; block: ActiveSubscriptionBlock }
+        | { kind: 'invoiceFailed' }
+        | { kind: 'success'; invoiceResult: NonNullable<Awaited<ReturnType<typeof createAndSendInvoice>>> }
+      >(orgId, async () => {
+        const racedBlock = await blockIfActiveSubscription(orgId, orgDb, {
+          customerPortalReturnUrl: `${req.protocol}://${req.get('host')}/dashboard/membership`,
+        });
+        if (racedBlock) return { kind: 'block', block: racedBlock };
+        const invoiceResult = await createAndSendInvoice(invoiceData);
+        if (!invoiceResult) return { kind: 'invoiceFailed' };
+        return { kind: 'success', invoiceResult };
+      });
 
-      if (!result) {
+      if (intake.kind === 'block') {
+        return res.status(intake.block.status).json(intake.block.body);
+      }
+      if (intake.kind === 'invoiceFailed') {
         return res.status(500).json({
           error: "Failed to create invoice",
           message:
             "Could not create or send invoice. Please contact finance@agenticadvertising.org for assistance.",
         });
       }
+      const result = intake.invoiceResult;
 
       if (validatedInvoiceReferralCode) {
         try {

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -25,7 +25,11 @@ import {
   createCoupon,
 } from '../billing/stripe-client.js';
 import { sanitizeBillingAddress } from '../billing/billing-address.js';
-import { blockIfActiveSubscription } from '../billing/active-subscription-guard.js';
+import {
+  blockIfActiveSubscription,
+  type ActiveSubscriptionBlock,
+} from '../billing/active-subscription-guard.js';
+import { withOrgIntakeLock } from '../billing/org-intake-lock.js';
 import * as referralDb from '../db/referral-codes-db.js';
 
 const logger = createLogger('invites-routes');
@@ -252,19 +256,42 @@ export function createInvitesRouter(): Router {
         [user.firstName, user.lastName].filter(Boolean).join(' ') ||
         user.email;
 
-      const invoiceResult = await createAndSendInvoice({
-        lookupKey: invite.lookup_key,
-        companyName: org.name,
-        contactName,
-        contactEmail: user.email,
-        billingAddress: sanitizedAddress,
-        workosOrganizationId: org.workos_organization_id,
-        couponId: couponId ?? org.stripe_coupon_id ?? undefined,
-        // Token-keyed idempotency. Two concurrent clicks converge to one
-        // subscription on Stripe's side; the DB atomic mark below then picks
-        // one winner and the other sees 409.
-        idempotencyKey: `invite_${invite.token}`,
+      // Lock + re-guard + Stripe write must be atomic per-org. The early
+      // `blockIfActiveSubscription` above handles the common case fast; this
+      // section closes the race where two concurrent intakes (e.g., two
+      // invite-accept clicks racing a different intake path) both pass the
+      // early check before either has minted a sub.
+      const intake = await withOrgIntakeLock<
+        | { kind: 'block'; block: ActiveSubscriptionBlock }
+        | { kind: 'success'; invoiceResult: NonNullable<Awaited<ReturnType<typeof createAndSendInvoice>>> }
+        | { kind: 'invoiceFailed' }
+      >(org.workos_organization_id, async () => {
+        const racedBlock = await blockIfActiveSubscription(
+          org.workos_organization_id,
+          orgDb,
+        );
+        if (racedBlock) return { kind: 'block', block: racedBlock };
+        const result = await createAndSendInvoice({
+          lookupKey: invite.lookup_key,
+          companyName: org.name,
+          contactName,
+          contactEmail: user.email,
+          billingAddress: sanitizedAddress,
+          workosOrganizationId: org.workos_organization_id,
+          couponId: couponId ?? org.stripe_coupon_id ?? undefined,
+          // Token-keyed idempotency. Two concurrent clicks converge to one
+          // subscription on Stripe's side; the DB atomic mark below then picks
+          // one winner and the other sees 409.
+          idempotencyKey: `invite_${invite.token}`,
+        });
+        if (!result) return { kind: 'invoiceFailed' };
+        return { kind: 'success', invoiceResult: result };
       });
+
+      if (intake.kind === 'block') {
+        return res.status(intake.block.status).json(intake.block.body);
+      }
+      const invoiceResult = intake.kind === 'success' ? intake.invoiceResult : null;
 
       if (!invoiceResult) {
         logger.error({ orgId: org.workos_organization_id, lookupKey: invite.lookup_key },

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -263,8 +263,8 @@ export function createInvitesRouter(): Router {
       // early check before either has minted a sub.
       const intake = await withOrgIntakeLock<
         | { kind: 'block'; block: ActiveSubscriptionBlock }
-        | { kind: 'success'; invoiceResult: NonNullable<Awaited<ReturnType<typeof createAndSendInvoice>>> }
         | { kind: 'invoiceFailed' }
+        | { kind: 'success'; invoiceResult: NonNullable<Awaited<ReturnType<typeof createAndSendInvoice>>> }
       >(org.workos_organization_id, async () => {
         const racedBlock = await blockIfActiveSubscription(
           org.workos_organization_id,
@@ -302,12 +302,14 @@ export function createInvitesRouter(): Router {
       }
       const invoiceResult = intake.invoiceResult;
 
+      // INVARIANT: in-lock-guard-re-check
       // markMembershipInviteAccepted runs OUTSIDE the lock. That is safe
       // only because the in-lock `blockIfActiveSubscription` re-check
-      // catches duplicate-sub attempts: a third concurrent click on the
-      // same invite will block when its lock-internal guard reads the
-      // Stripe-side sub this acceptance just minted. Do not remove the
-      // re-guard inside the lock without re-thinking this invariant.
+      // (above, inside withOrgIntakeLock) catches duplicate-sub attempts:
+      // a third concurrent click on the same invite will block when its
+      // lock-internal guard reads the Stripe-side sub this acceptance just
+      // minted. Do not remove the re-guard inside the lock without
+      // re-thinking this invariant.
       const accepted = await markMembershipInviteAccepted(
         token,
         user.id,

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -291,9 +291,7 @@ export function createInvitesRouter(): Router {
       if (intake.kind === 'block') {
         return res.status(intake.block.status).json(intake.block.body);
       }
-      const invoiceResult = intake.kind === 'success' ? intake.invoiceResult : null;
-
-      if (!invoiceResult) {
+      if (intake.kind === 'invoiceFailed') {
         logger.error({ orgId: org.workos_organization_id, lookupKey: invite.lookup_key },
           'createAndSendInvoice returned null on invite accept');
         return res.status(500).json({
@@ -302,7 +300,14 @@ export function createInvitesRouter(): Router {
             "We couldn't issue your invoice. Please contact finance@agenticadvertising.org.",
         });
       }
+      const invoiceResult = intake.invoiceResult;
 
+      // markMembershipInviteAccepted runs OUTSIDE the lock. That is safe
+      // only because the in-lock `blockIfActiveSubscription` re-check
+      // catches duplicate-sub attempts: a third concurrent click on the
+      // same invite will block when its lock-internal guard reads the
+      // Stripe-side sub this acceptance just minted. Do not remove the
+      // re-guard inside the lock without re-thinking this invariant.
       const accepted = await markMembershipInviteAccepted(
         token,
         user.id,

--- a/server/tests/unit/org-intake-lock.test.ts
+++ b/server/tests/unit/org-intake-lock.test.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
 });
 
 describe('withOrgIntakeLock', () => {
-  it('takes a transaction, advisory-locks on hashtext(orgId), runs fn, commits, releases the connection', async () => {
+  it('takes a transaction, sets per-tx timeouts, advisory-locks on hashtext(orgId), runs fn, commits, releases the connection', async () => {
     const fn = vi.fn().mockResolvedValue('ok');
 
     const result = await withOrgIntakeLock('org_test_123', fn);
@@ -40,12 +40,14 @@ describe('withOrgIntakeLock', () => {
     expect(result).toBe('ok');
     expect(fn).toHaveBeenCalledOnce();
 
-    // Calls must be in order: BEGIN → lock → (fn) → COMMIT
+    // Calls must be in order: BEGIN → lock_timeout → statement_timeout → lock → (fn) → COMMIT
     const calls = mockClientQuery.mock.calls.map((c) => c[0]);
     expect(calls[0]).toBe('BEGIN');
-    expect(calls[1]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
-    expect(mockClientQuery.mock.calls[1][1]).toEqual(['org_test_123']);
-    expect(calls[2]).toBe('COMMIT');
+    expect(calls[1]).toMatch(/^SET LOCAL lock_timeout = '\d+ms'$/);
+    expect(calls[2]).toMatch(/^SET LOCAL statement_timeout = '\d+ms'$/);
+    expect(calls[3]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
+    expect(mockClientQuery.mock.calls[3][1]).toEqual(['org_test_123']);
+    expect(calls[4]).toBe('COMMIT');
     expect(mockClientRelease).toHaveBeenCalledOnce();
   });
 
@@ -56,11 +58,11 @@ describe('withOrgIntakeLock', () => {
     await expect(withOrgIntakeLock('org_x', fn)).rejects.toThrow('Stripe API down');
 
     const calls = mockClientQuery.mock.calls.map((c) => c[0]);
-    expect(calls).toEqual([
-      'BEGIN',
-      'SELECT pg_advisory_xact_lock(hashtext($1))',
-      'ROLLBACK',
-    ]);
+    expect(calls[0]).toBe('BEGIN');
+    expect(calls[1]).toMatch(/^SET LOCAL lock_timeout/);
+    expect(calls[2]).toMatch(/^SET LOCAL statement_timeout/);
+    expect(calls[3]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
+    expect(calls[4]).toBe('ROLLBACK');
     expect(mockClientRelease).toHaveBeenCalledOnce();
   });
 
@@ -68,6 +70,8 @@ describe('withOrgIntakeLock', () => {
     const err = new Error('serialization failure');
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL statement_timeout
       .mockRejectedValueOnce(err);          // pg_advisory_xact_lock
 
     const fn = vi.fn();
@@ -76,10 +80,11 @@ describe('withOrgIntakeLock', () => {
 
     expect(fn).not.toHaveBeenCalled();
     const calls = mockClientQuery.mock.calls.map((c) => c[0]);
-    // BEGIN ran, lock query failed, then ROLLBACK best-effort
     expect(calls[0]).toBe('BEGIN');
-    expect(calls[1]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
-    expect(calls[2]).toBe('ROLLBACK');
+    expect(calls[1]).toMatch(/^SET LOCAL lock_timeout/);
+    expect(calls[2]).toMatch(/^SET LOCAL statement_timeout/);
+    expect(calls[3]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
+    expect(calls[4]).toBe('ROLLBACK');
     expect(mockClientRelease).toHaveBeenCalledOnce();
   });
 
@@ -87,12 +92,14 @@ describe('withOrgIntakeLock', () => {
     const fnErr = new Error('Stripe rejected');
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // lock
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL statement_timeout
+      .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
       .mockRejectedValueOnce(new Error('rollback failed')); // ROLLBACK
 
     const fn = vi.fn().mockRejectedValue(fnErr);
 
-    // Original fn error is preserved; rollback failure is swallowed.
+    // Original fn error is preserved; rollback failure is logged but swallowed.
     await expect(withOrgIntakeLock('org_x', fn)).rejects.toThrow('Stripe rejected');
 
     expect(mockClientRelease).toHaveBeenCalledOnce();

--- a/server/tests/unit/org-intake-lock.test.ts
+++ b/server/tests/unit/org-intake-lock.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the per-org Postgres advisory-lock helper that serializes
+ * billing intakes (invoice-request, invite-accept) to close the millisecond
+ * race the security review of #3171 flagged.
+ *
+ * The helper takes a transaction-scoped advisory lock keyed on
+ * hashtext(orgId), runs the provided callback inside the transaction, and
+ * commits on success / rolls back on error. The lock auto-releases at
+ * transaction end.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClientQuery = vi.fn<(sql: string, params?: unknown[]) => Promise<unknown>>();
+const mockClientRelease = vi.fn<() => void>();
+const mockPoolConnect = vi.fn<() => Promise<{ query: typeof mockClientQuery; release: typeof mockClientRelease }>>();
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({ connect: mockPoolConnect }),
+}));
+
+const { withOrgIntakeLock } = await import('../../src/billing/org-intake-lock.js');
+
+beforeEach(() => {
+  mockClientQuery.mockReset();
+  mockClientRelease.mockReset();
+  mockPoolConnect.mockReset();
+  mockPoolConnect.mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+  mockClientQuery.mockResolvedValue({ rows: [] });
+});
+
+describe('withOrgIntakeLock', () => {
+  it('takes a transaction, advisory-locks on hashtext(orgId), runs fn, commits, releases the connection', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const result = await withOrgIntakeLock('org_test_123', fn);
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledOnce();
+
+    // Calls must be in order: BEGIN → lock → (fn) → COMMIT
+    const calls = mockClientQuery.mock.calls.map((c) => c[0]);
+    expect(calls[0]).toBe('BEGIN');
+    expect(calls[1]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
+    expect(mockClientQuery.mock.calls[1][1]).toEqual(['org_test_123']);
+    expect(calls[2]).toBe('COMMIT');
+    expect(mockClientRelease).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and re-throws when fn throws', async () => {
+    const err = new Error('Stripe API down');
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withOrgIntakeLock('org_x', fn)).rejects.toThrow('Stripe API down');
+
+    const calls = mockClientQuery.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual([
+      'BEGIN',
+      'SELECT pg_advisory_xact_lock(hashtext($1))',
+      'ROLLBACK',
+    ]);
+    expect(mockClientRelease).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and re-throws when the lock query itself fails', async () => {
+    const err = new Error('serialization failure');
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockRejectedValueOnce(err);          // pg_advisory_xact_lock
+
+    const fn = vi.fn();
+
+    await expect(withOrgIntakeLock('org_x', fn)).rejects.toThrow('serialization failure');
+
+    expect(fn).not.toHaveBeenCalled();
+    const calls = mockClientQuery.mock.calls.map((c) => c[0]);
+    // BEGIN ran, lock query failed, then ROLLBACK best-effort
+    expect(calls[0]).toBe('BEGIN');
+    expect(calls[1]).toBe('SELECT pg_advisory_xact_lock(hashtext($1))');
+    expect(calls[2]).toBe('ROLLBACK');
+    expect(mockClientRelease).toHaveBeenCalledOnce();
+  });
+
+  it('still releases the connection when ROLLBACK itself fails', async () => {
+    const fnErr = new Error('Stripe rejected');
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // lock
+      .mockRejectedValueOnce(new Error('rollback failed')); // ROLLBACK
+
+    const fn = vi.fn().mockRejectedValue(fnErr);
+
+    // Original fn error is preserved; rollback failure is swallowed.
+    await expect(withOrgIntakeLock('org_x', fn)).rejects.toThrow('Stripe rejected');
+
+    expect(mockClientRelease).toHaveBeenCalledOnce();
+  });
+
+  it('returns the typed result from fn', async () => {
+    interface Outcome { kind: 'success'; id: string }
+    const fn = vi.fn<() => Promise<Outcome>>().mockResolvedValue({ kind: 'success', id: 'inv_123' });
+
+    const result = await withOrgIntakeLock<Outcome>('org_x', fn);
+
+    expect(result).toEqual({ kind: 'success', id: 'inv_123' });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3179. PR #3171 introduced \`blockIfActiveSubscription\` to refuse minting a duplicate sub when one already exists, but the guard is a non-transactional read followed by a non-transactional Stripe write. Two concurrent intakes can both pass the read and both create a subscription — the millisecond version of the months-apart Triton bug.

This PR wraps the (re-guard + Stripe write) section of \`POST /api/invoice-request\` and \`POST /api/invite/:token/accept\` in a Postgres advisory lock keyed on \`hashtext(orgId)\`. \`getSubscriptionInfo\` queries Stripe live, so by the time a second caller acquires the lock and re-runs the guard, the first caller's subscription is already visible and the guard correctly blocks.

## What changed

- \`server/src/billing/org-intake-lock.ts\` (new) — \`withOrgIntakeLock(orgId, fn)\` helper. Opens a transaction, takes \`pg_advisory_xact_lock(hashtext(orgId))\`, runs fn, commits on success / rolls back on error. Lock release is automatic on transaction end.
- \`server/src/routes/billing-public.ts\` — invoice-request now does (re-guard + createAndSendInvoice) inside the lock. The original fast-path guard call early in the handler is preserved as a short-circuit for the common case.
- \`server/src/routes/invites.ts\` — same pattern on invite-accept.
- \`server/tests/unit/org-intake-lock.test.ts\` (new) — 5 tests covering BEGIN/lock/COMMIT ordering, ROLLBACK on fn error, ROLLBACK on lock-acquisition error, connection release on rollback failure, typed return passthrough.

## What's deliberately not in scope

\`POST /api/checkout-session\` is **not** wrapped in the lock. Stripe Checkout sessions are URLs, not subscriptions — the actual sub gets created only when the user completes the hosted page. Two concurrent calls just produce two session URLs; the user would have to pay on both for it to matter. That race lives at the \`customer.subscription.created\` webhook layer and will be closed in a separate follow-up issue.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:server-unit\` — 2211/2211 (5 new)
- [ ] Manual concurrency test: open two browser tabs to the dashboard's "Pay by invoice" flow, click both at once, confirm only one invoice issues and the second returns 409 with the existing sub's details

## References

- PR #3171 — the duplicate-subscription guard this PR completes
- Issue #3179 — security M1 finding
- The Triton/Encypher incident (Apr 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)