### PR TITLE
fix(addie): strip null bytes and guard empty Slack replies

### DIFF
--- a/.changeset/fix-addie-null-bytes-and-empty-slack-reply.md
+++ b/.changeset/fix-addie-null-bytes-and-empty-slack-reply.md
@@ -1,0 +1,9 @@
+---
+---
+
+fix(addie): strip U+0000 from thread message inserts and avoid empty Slack postMessage in active thread replies
+
+Two related Slack failures observed in production:
+
+1. `ThreadService.addMessage` was rejecting inserts with `unsupported Unicode escape sequence` when a tool result contained a null byte. Postgres TEXT/JSONB both reject U+0000, so we now strip null bytes from `content`, `content_sanitized`, `flag_reason`, `email_message_id`, the `tools_used` array, and the JSON-stringified `tool_calls` / `router_decision` fields before insertion.
+2. `handleActiveThreadReply` was calling `chat.postMessage` with an empty `text` when the model produced no usable output, causing Slack to return `no_text`. The active-thread reply path now falls back to the same apology used elsewhere in the bolt app instead of sending an empty message.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -3578,11 +3578,17 @@ async function handleActiveThreadReply({
   const activeThreadGuarded = guardBareJsonEnvelope(response.text, { pathTag: 'active-thread-reply' });
   const outputValidation = validateOutput(activeThreadGuarded.text);
 
-  // Send response in the thread
+  // Send response in the thread. Slack rejects postMessage with an empty
+  // `text` (no_text). If the model returned nothing or everything was
+  // sanitized away, fall back to a plain apology so the user isn't ignored.
+  const activeThreadSlackText = wrapUrlsForSlack(outputValidation.sanitized);
+  const activeThreadOutgoing = activeThreadSlackText.trim().length > 0
+    ? activeThreadSlackText
+    : "I'm sorry, I encountered an error. Please try again.";
   try {
     await boltApp.client.chat.postMessage({
       channel: channelId,
-      text: wrapUrlsForSlack(outputValidation.sanitized),
+      text: activeThreadOutgoing,
       thread_ts: threadTs, // Reply in the thread
     });
   } catch (error) {

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -12,6 +12,23 @@
 import { query, getPool } from '../db/client.js';
 import { logger } from '../logger.js';
 
+// Postgres TEXT and JSONB both reject U+0000. Tool results occasionally
+// surface null bytes from upstream APIs, which would otherwise blow up the
+// addMessage INSERT with "unsupported Unicode escape sequence" (JSONB) or
+// "invalid byte sequence for UTF8" (TEXT). Strip them at the boundary.
+const NULL_BYTE = String.fromCharCode(0);
+const NULL_BYTE_RE = new RegExp(NULL_BYTE, 'g');
+
+function stripNullBytesString(s: string): string {
+  return s.includes(NULL_BYTE) ? s.replace(NULL_BYTE_RE, '') : s;
+}
+
+function stripNullBytesFromJson(json: string): string {
+  // JSON.stringify encodes a null byte as a six-character backslash-u escape.
+  // Strip that encoded form and any raw null byte left in the output.
+  return json.replace(/\\u0000/g, '').replace(NULL_BYTE_RE, '');
+}
+
 // =====================================================
 // TYPES
 // =====================================================
@@ -445,17 +462,17 @@ export class ThreadService {
         [
           input.thread_id,
           input.role,
-          input.content,
-          input.content_sanitized ?? null,
-          input.tools_used ?? null,
-          input.tool_calls ? JSON.stringify(input.tool_calls) : null,
+          stripNullBytesString(input.content),
+          input.content_sanitized != null ? stripNullBytesString(input.content_sanitized) : null,
+          input.tools_used ? input.tools_used.map(stripNullBytesString) : null,
+          input.tool_calls ? stripNullBytesFromJson(JSON.stringify(input.tool_calls)) : null,
           input.knowledge_ids ?? null,
           input.model ?? null,
           input.latency_ms ?? null,
           input.tokens_input ?? null,
           input.tokens_output ?? null,
           input.flagged ?? false,
-          input.flag_reason ?? null,
+          input.flag_reason != null ? stripNullBytesString(input.flag_reason) : null,
           sequenceNumber,
           input.timing?.system_prompt_ms ?? null,
           input.timing?.total_llm_ms ?? null,
@@ -464,11 +481,11 @@ export class ThreadService {
           input.tokens_cache_creation ?? null,
           input.tokens_cache_read ?? null,
           input.active_rule_ids ?? null,
-          input.router_decision ? JSON.stringify(input.router_decision) : null,
+          input.router_decision ? stripNullBytesFromJson(JSON.stringify(input.router_decision)) : null,
           input.config_version_id ?? null,
-          input.email_message_id ?? null,
+          input.email_message_id != null ? stripNullBytesString(input.email_message_id) : null,
           input.user_id ?? null,
-          input.user_display_name ?? null,
+          input.user_display_name != null ? stripNullBytesString(input.user_display_name) : null,
         ]
       );
 


### PR DESCRIPTION
## Summary
- Strip U+0000 from every TEXT/JSONB field written by `ThreadService.addMessage` (`content`, `content_sanitized`, `flag_reason`, `email_message_id`, `tools_used[]`, `tool_calls`, `router_decision`). Postgres rejects null bytes in TEXT and ` ` escapes in JSONB, which was blowing up assistant message saves with `unsupported Unicode escape sequence` whenever a tool result contained a null byte.
- In `handleActiveThreadReply`, fall back to the standard apology when the model produced no usable text instead of calling `chat.postMessage` with `text: ""` (Slack returns `no_text`). Matches the existing guard in the DM streaming and channel-handler paths.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Verify in production logs that `Failed to save assistant message: unsupported Unicode escape sequence` no longer appears
- [ ] Verify in production logs that `Failed to send active thread reply: no_text` no longer appears
- [ ] Manually confirm an assistant reply still posts when the model returns valid text (regression check)
