### PR TITLE
chore(deps): bump @adcp/client 5.17.0 → 5.18.0

### DIFF
--- a/.changeset/bump-adcp-client-5-18-0.md
+++ b/.changeset/bump-adcp-client-5-18-0.md
@@ -1,0 +1,12 @@
+---
+---
+
+Bumps `@adcp/client` 5.17.0 → 5.18.0. The release ships our `get_media_buys` request-builder fix (adcp-client#987 closing #983), the broader placeholder-ID enricher audit (#991), schema-aware brand/account injection in the storyboard runner (#943), the new `a2a_context_continuity` validator for multi-step storyboards (#962), A2A wire-shape capture (#904), and triage-bot ergonomics that close the loop on adcp#3121 (#992, #993).
+
+Two breakages surfaced and fixed:
+
+- **Hint type widening.** `StoryboardStepHint` widened from `ContextValueRejectedHint` to a five-kind union (`context_value_rejected | shape_drift | missing_required_field | format_mismatch | monotonic_violation`). `renderAllHintFixPlans` in `server/src/addie/services/storyboard-fix-plan.ts` now accepts the broader type and filters to `context_value_rejected` for the existing render path. Richer rendering for the other four kinds is a follow-up — today they're silently dropped from the fix-plan section, but the runner's per-hint `message` field still surfaces them upstream.
+
+- **Strict request-schema validation in storyboard runner.** The `create_property_list` request schema declares `additionalProperties: false`; `pagination-integrity-property-lists.yaml` was passing a `list_type: "inclusion" | "exclusion"` field that isn't in the schema. 5.18.0's runner rejects unknown fields strictly. Removed the `list_type` field — it never affected agent behavior (no handler reads it).
+
+Multi-page upgrade for `get_media_buys_pagination_integrity` deferred — adcp-client's convention extractor populates `context.media_buy_id` from the first-page response, then the request-builder injects that ID and turns the second call into an ID-lookup. Filed adcp-client#998 with the diagnosis and fix options. Storyboard stays at the single-step pagination-envelope assertion until the SDK fix lands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0",
       "dependencies": {
-        "@adcp/client": "5.17.0",
+        "@adcp/client": "5.18.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.17.0.tgz",
-      "integrity": "sha512-pNZ1ojrI2qEvkh3skP7fI5OLfr3t8PghZu3ypqRWU7lY3BLwOkvA1VxTzwIbDQliOS1e/SFOSB55WiIpqlo6aQ==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.18.0.tgz",
+      "integrity": "sha512-Rg+7saZescCp9T+Is9OI90pTi8ppm/K6YTxPPIXYznUGgMLPVaGCabBmGNexAVhrjR6Ub87txU6re3ssT6jqTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "5.17.0",
+    "@adcp/client": "5.18.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/addie/services/storyboard-fix-plan.ts
+++ b/server/src/addie/services/storyboard-fix-plan.ts
@@ -14,7 +14,7 @@
  * hints to format.
  */
 
-import type { ContextValueRejectedHint } from '@adcp/client/testing';
+import type { ContextValueRejectedHint, StoryboardStepHint } from '@adcp/client/testing';
 
 export type { ContextValueRejectedHint };
 
@@ -208,12 +208,24 @@ function formatAcceptedList(values: unknown[]): string {
  * Convenience: render every hint on a step result as fix plans, joined
  * by horizontal rules. Returns `null` when there are no actionable
  * hints (lets callers omit the section entirely).
+ *
+ * Accepts the broader `StoryboardStepHint` union for forward compat —
+ * @adcp/client 5.18.0 widened the union to include `shape_drift`,
+ * `missing_required_field`, `format_mismatch`, and `monotonic_violation`
+ * kinds. We render only `context_value_rejected` here today; richer
+ * rendering for the other kinds is a follow-up. Unknown kinds are
+ * silently dropped — the runner's `message` field still surfaces them
+ * upstream of this renderer.
  */
 export function renderAllHintFixPlans(
-  hints: ContextValueRejectedHint[] | undefined,
+  hints: StoryboardStepHint[] | undefined,
   ctx: { current_step_id: string; current_task: string; surface: 'step' | 'full' }
 ): string | null {
   if (!hints || !hints.length) return null;
+  const rejectedHints = hints.filter(
+    (h): h is ContextValueRejectedHint => h.kind === 'context_value_rejected',
+  );
+  if (!rejectedHints.length) return null;
   // Dedup on (source_step_id, context_key, rejected_value) — the runner's
   // detector already de-dupes by `(context_key, rejected_value)` per error
   // (rejection-hints.ts), but a single response may carry the same drift
@@ -221,7 +233,7 @@ export function renderAllHintFixPlans(
   // fix plans separated by a horizontal rule reads like a bug.
   const seen = new Set<string>();
   const blocks: string[] = [];
-  for (const h of hints) {
+  for (const h of rejectedHints) {
     const key = `${h.source_step_id}::${h.context_key}::${stableStringify(h.rejected_value)}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/static/compliance/source/universal/property-lists-pagination-integrity.yaml
+++ b/static/compliance/source/universal/property-lists-pagination-integrity.yaml
@@ -116,7 +116,6 @@ phases:
             operator: "pinnacle-agency.example"
           name: "Approved News Publishers"
           description: "Inclusion list of brand-safe news publisher domains."
-          list_type: "inclusion"
           idempotency_key: "$generate:uuid_v4#pagination_integrity_property_lists_setup_create_list_1"
           context:
             correlation_id: "pagination_integrity_property_lists--setup_1"
@@ -147,7 +146,6 @@ phases:
             operator: "pinnacle-agency.example"
           name: "Gambling Sites Blocklist"
           description: "Exclusion list of gambling and wagering domains."
-          list_type: "exclusion"
           idempotency_key: "$generate:uuid_v4#pagination_integrity_property_lists_setup_create_list_2"
           context:
             correlation_id: "pagination_integrity_property_lists--setup_2"
@@ -179,7 +177,6 @@ phases:
             operator: "pinnacle-agency.example"
           name: "Premium Entertainment Properties"
           description: "Inclusion list of tier-one entertainment publisher domains."
-          list_type: "inclusion"
           idempotency_key: "$generate:uuid_v4#pagination_integrity_property_lists_setup_create_list_3"
           context:
             correlation_id: "pagination_integrity_property_lists--setup_3"


### PR DESCRIPTION
## Summary
Brings in this session's downstream wins:
- adcp-client#987 (closing #983) — `get_media_buys` request-builder fix; the immediate consumer of this bump
- adcp-client#991 — placeholder-ID enricher audit (broader pattern fix from the protocol reviewer's #983 follow-up flag)
- adcp-client#943 — schema-aware brand/account injection in the storyboard runner
- adcp-client#962 — `a2a_context_continuity` validator for multi-step storyboards
- adcp-client#904 — A2A wire-shape capture
- adcp-client#992, #993 — triage-bot ergonomics closing adcp#3121

## Compat fixes in this PR

### Hint type widened (5 kinds)
`StoryboardStepHint` widened from `ContextValueRejectedHint` alone to a five-kind union: `context_value_rejected | shape_drift | missing_required_field | format_mismatch | monotonic_violation`. `renderAllHintFixPlans` now accepts the broader type and filters to the kind it knows how to render. The other four kinds drop silently from the fix-plan section — the runner's per-hint `message` field still surfaces them upstream of this renderer. Richer rendering is a follow-up.

### Strict request-schema validation
5.18.0's storyboard runner rejects unknown request fields strictly. `pagination-integrity-property-lists.yaml` carried a `list_type: "inclusion" | "exclusion"` field that isn't in `create-property-list-request.json`'s properties (which has `additionalProperties: false`). Dropped it — no handler reads the field, no agent behavior change.

## Deferred: multi-page `get_media_buys` storyboard upgrade
The natural follow-on (upgrade `get_media_buys_pagination_integrity` from the single-step ID-lookup invariant back to the seeded continuation+terminal walk pattern) is **blocked** on a second SDK gap. adcp-client's convention extractor at `src/lib/testing/storyboard/context.ts` populates `context.media_buy_id` from `media_buys[0]` after every successful response. Then page 2's request-builder reads that populated context and injects `media_buy_ids: [<that ID>]`, turning the second call into an ID-lookup. The agent returns 1 buy with `total_count: 1`, failing the storyboard's `total_count: 3` assertion.

Filed adcontextprotocol/adcp-client#998 with the diagnosis and three fix options (preferred: don't extract `media_buy_id` from broad-list responses where `pagination.has_more` indicates list semantics). Storyboard stays at the single-step shape until that lands.

## Verified
- `npm run build` — typecheck + schemas + compliance + tarball all clean
- `npm run test:unit` — 834/834 pass (was 832 before the bump — 2 new tests from `@adcp/client/testing` re-exports)
- `npm run test:server-unit` — training-agent: 354/354 pass
- Pagination storyboard suite against training agent: **8/8 storyboards clean, 41/41 steps**
- `npm run test:storyboard-doc-parity && npm run test:pagination-invariant` — clean

## Test plan
- [x] Build clean
- [x] Unit tests pass (832→834)
- [x] All 8 pagination_integrity storyboards pass against training agent
- [x] Storyboard lint suite clean
- [x] Negative test: dropping `list_type` doesn't change observable agent behavior (no handler reads it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)