### PR TITLE
feat(billing): integrity invariants framework — Phase 1 (#3181)

### DIFF
--- a/.changeset/integrity-invariants-phase-1.md
+++ b/.changeset/integrity-invariants-phase-1.md
@@ -1,0 +1,16 @@
+---
+---
+
+Add Phase 1 of the cross-system integrity-invariants framework (#3181).
+
+Each invariant is a self-contained assertion about state across WorkOS, Stripe, and AAO Postgres. The runner orchestrates evaluation, isolates failures, and produces a per-violation report. New admin endpoints `GET /api/admin/integrity/check` (run all) and `GET /api/admin/integrity/check/:name` (run one) surface the report on demand.
+
+Phase 1 ships five invariants:
+
+- `stripe-customer-org-metadata-bidirectional` (critical) — every org's stripe_customer_id resolves to a Stripe customer whose metadata.workos_organization_id points back at the same org. Catches Triton-shape cross-contamination.
+- `one-active-stripe-sub-per-org` (critical) — no org has more than one live (active/trialing/past_due) Stripe subscription. The literal Triton failure mode.
+- `stripe-customer-resolves` (critical) — every referenced Stripe customer exists and is not deleted.
+- `org-row-matches-live-stripe-sub` (warning) — when an org has both a stripe_subscription_id and a live status, the row's mirrored amount/lookup_key/status agree with Stripe.
+- `workos-membership-row-exists-in-workos` (warning, sampled) — random sample of active organization_memberships rows are reflected in WorkOS.
+
+Phase 2 (separate PR) will add scheduled runs, persisted reports, Slack alerting, and an admin dashboard page. Phase 3+ extends to webhook-miss detection and inverse-walk orphan detection.

--- a/server/src/audit/integrity/README.md
+++ b/server/src/audit/integrity/README.md
@@ -1,0 +1,79 @@
+# Integrity invariants
+
+Each invariant in this directory is a self-contained assertion about state across **WorkOS**, **Stripe**, and **AAO Postgres**. The runner executes them on demand (Phase 1) or on a schedule (Phase 2, future), collects violations, and surfaces them in the admin UI.
+
+## When to add a new invariant
+
+If you find yourself thinking "I wish we'd noticed sooner that X had drifted from Y," that's an invariant. Concretely:
+
+- A bug surfaced because two stores said different things → file an invariant that asserts they agree.
+- A migration / refactor made a previously-implicit assumption explicit → encode it.
+- A webhook handler is the only thing keeping a row up to date → audit periodically that it actually is.
+
+Phase 1 deliberately ships only five invariants. Five is enough to demonstrate the framework and catch the highest-cost failure modes (Triton-shape bugs). Phase 2+ adds breadth.
+
+## How to add an invariant
+
+1. Drop a file in `invariants/` exporting a single `Invariant` value:
+
+   ```ts
+   import type { Invariant, InvariantContext, InvariantResult } from '../types.js';
+
+   export const myInvariant: Invariant = {
+     name: 'descriptive-kebab-case-name',
+     description: 'One-sentence "why does this matter."',
+     severity: 'critical' | 'warning' | 'info',
+     async check(ctx: InvariantContext): Promise<InvariantResult> {
+       // Walk your working set, emit Violation[] on mismatch.
+       return { checked: N, violations: [...] };
+     },
+   };
+   ```
+
+2. Register it in `invariants/index.ts`:
+
+   ```ts
+   import { myInvariant } from './my-invariant.js';
+   export const ALL_INVARIANTS: readonly Invariant[] = [
+     // ...
+     myInvariant,
+   ];
+   ```
+
+3. Add a unit test under `server/tests/unit/integrity-invariants/`. Mock the DB and external APIs through the `InvariantContext` shape; the test surface should be tiny.
+
+## Severity guide
+
+- **`critical`** — the violation indicates active financial / data-integrity damage. Triton's two-active-subs case is critical. Operators should be paged.
+- **`warning`** — drift that's recoverable but should be investigated. Tier mismatch (DB vs Stripe) is warning, because it can be a transient webhook race.
+- **`info`** — the entity is in a permitted-but-unusual state worth noting. Use sparingly; too much info-level noise drowns the criticals.
+
+## Running
+
+On demand:
+
+- `GET /api/admin/integrity/invariants` — list all registered invariants
+- `GET /api/admin/integrity/check` — run all, return report
+- `GET /api/admin/integrity/check/:name` — run one
+- Both accept `?sample_size=N` and `?since=ISO8601` query params
+
+The runner executes invariants sequentially. One throwing doesn't cancel the others — its failure becomes a meta-violation in the report.
+
+## Performance
+
+- Phase 1 invariants iterate AAO orgs as the primary key set (~hundreds-to-thousands at current scale) and call Stripe/WorkOS for each. A full pass takes ~30s.
+- The membership-resolve invariant samples (default 200 random rows). Set `?sample_size=N` to widen.
+- A scheduled runner will be added in Phase 2 alongside a persisted `integrity_runs` table for time-series tracking.
+
+## What this framework deliberately doesn't do
+
+- **Auto-remediation.** Phase 1 detects; humans decide. Auto-fix is Phase 3+.
+- **Real-time monitoring.** Webhooks remain the primary sync mechanism. Invariants catch what webhooks miss.
+- **Stripe-customer enumeration.** We walk AAO orgs and check Stripe for each. Catching orphans on the *Stripe* side (customers with no AAO row) requires the inverse walk and is Phase 3+.
+- **Replace `POST /api/admin/accounts/:orgId/sync`.** That endpoint is for explicit single-org reconciliation. Invariants tell you which orgs to sync.
+
+## Reference
+
+- Original proposal: `.context/proposals/integrity-invariants.md` (in workspace, not committed)
+- Issue: #3181 (broader systematic-audit ask)
+- Triton/Encypher incident: PRs #3142, #3171, #3183 (Apr 2026)

--- a/server/src/audit/integrity/index.ts
+++ b/server/src/audit/integrity/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Public surface of the integrity-invariants module.
+ */
+export type {
+  Severity,
+  SubjectType,
+  Violation,
+  InvariantOptions,
+  InvariantContext,
+  InvariantResult,
+  Invariant,
+  InvariantRunStats,
+  InvariantRunReport,
+} from './types.js';
+
+export { runAllInvariants, runOneInvariant } from './runner.js';
+export { ALL_INVARIANTS, getInvariantByName } from './invariants/index.js';

--- a/server/src/audit/integrity/invariants/index.ts
+++ b/server/src/audit/integrity/invariants/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Registry of all integrity invariants. Adding a new invariant:
+ *   1. Drop a file in this directory implementing the Invariant contract.
+ *   2. Import + add it to ALL_INVARIANTS below.
+ *   3. Add a unit test under server/tests/unit/integrity-invariants/.
+ *
+ * The order here is the order they run in. Cheap, broadly-applicable
+ * invariants (DB-only) should come before expensive ones (Stripe / WorkOS
+ * round-trips per row).
+ */
+import type { Invariant } from '../types.js';
+import { stripeCustomerOrgMetadataBidirectionalInvariant } from './stripe-customer-org-metadata-bidirectional.js';
+import { oneActiveStripeSubPerOrgInvariant } from './one-active-stripe-sub-per-org.js';
+import { stripeCustomerResolvesInvariant } from './stripe-customer-resolves.js';
+import { orgRowMatchesLiveStripeSubInvariant } from './org-row-matches-live-stripe-sub.js';
+import { workosMembershipRowExistsInWorkosInvariant } from './workos-membership-row-exists-in-workos.js';
+
+export const ALL_INVARIANTS: readonly Invariant[] = [
+  stripeCustomerOrgMetadataBidirectionalInvariant,
+  oneActiveStripeSubPerOrgInvariant,
+  stripeCustomerResolvesInvariant,
+  orgRowMatchesLiveStripeSubInvariant,
+  workosMembershipRowExistsInWorkosInvariant,
+];
+
+export function getInvariantByName(name: string): Invariant | undefined {
+  return ALL_INVARIANTS.find((inv) => inv.name === name);
+}

--- a/server/src/audit/integrity/invariants/one-active-stripe-sub-per-org.ts
+++ b/server/src/audit/integrity/invariants/one-active-stripe-sub-per-org.ts
@@ -1,0 +1,88 @@
+/**
+ * Invariant: no org has more than one live Stripe subscription on its
+ * Stripe customer. "Live" here means active, trialing, or past_due —
+ * the same set blockIfActiveSubscription refuses to mint over (#3171).
+ *
+ * Triton had two simultaneous active subscriptions ($10K Corporate +
+ * duplicate $3K Builder) for ~5 months before anyone noticed. This is
+ * the invariant that would have surfaced it.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+const LIVE_STATUSES = new Set(['active', 'trialing', 'past_due']);
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_customer_id: string;
+}
+
+export const oneActiveStripeSubPerOrgInvariant: Invariant = {
+  name: 'one-active-stripe-sub-per-org',
+  description:
+    'For every org with a Stripe customer, the customer has at most one live ' +
+    '(active/trialing/past_due) subscription. Two live subs on the same ' +
+    'customer is the literal failure mode of the Triton/Encypher incident.',
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, stripe, logger } = ctx;
+    const violations: Violation[] = [];
+
+    const result = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_customer_id
+         FROM organizations
+        WHERE stripe_customer_id IS NOT NULL`,
+    );
+
+    for (const org of result.rows) {
+      try {
+        const subs = await stripe.subscriptions.list({
+          customer: org.stripe_customer_id,
+          status: 'all',
+          limit: 20,
+        });
+        const live = subs.data.filter((s) => LIVE_STATUSES.has(s.status));
+        if (live.length <= 1) continue;
+
+        violations.push({
+          invariant: 'one-active-stripe-sub-per-org',
+          severity: 'critical',
+          subject_type: 'organization',
+          subject_id: org.workos_organization_id,
+          message:
+            `Stripe customer ${org.stripe_customer_id} has ${live.length} live subscriptions ` +
+            `(expected ≤ 1)`,
+          details: {
+            org_name: org.name,
+            stripe_customer_id: org.stripe_customer_id,
+            subscriptions: live.map((s) => ({
+              id: s.id,
+              status: s.status,
+              lookup_key: s.items.data[0]?.price?.lookup_key ?? null,
+              unit_amount: s.items.data[0]?.price?.unit_amount ?? null,
+              created: s.created,
+            })),
+          },
+          remediation_hint:
+            'Identify the duplicate (usually the most recently created or the one with a voided invoice), ' +
+            'cancel it via Stripe API or dashboard, and re-sync the org row from the surviving subscription.',
+        });
+      } catch (err) {
+        logger.warn(
+          { err, orgId: org.workos_organization_id, customerId: org.stripe_customer_id },
+          'one-active-stripe-sub-per-org: subscriptions.list failed; recording transient violation',
+        );
+        violations.push({
+          invariant: 'one-active-stripe-sub-per-org',
+          severity: 'warning',
+          subject_type: 'organization',
+          subject_id: org.workos_organization_id,
+          message: `Could not list Stripe subscriptions for ${org.stripe_customer_id}: ${err instanceof Error ? err.message : String(err)}`,
+          details: { org_name: org.name, stripe_customer_id: org.stripe_customer_id },
+        });
+      }
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/org-row-matches-live-stripe-sub.ts
+++ b/server/src/audit/integrity/invariants/org-row-matches-live-stripe-sub.ts
@@ -8,12 +8,7 @@
  * (webhook in flight) and we don't want to page on every brief skew.
  */
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
-
-function isStripeNotFound(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false;
-  const e = err as { code?: string; statusCode?: number };
-  return e.code === 'resource_missing' || e.statusCode === 404;
-}
+import { isStripeNotFound } from '../stripe-helpers.js';
 
 const LIVE_STATUSES = new Set(['active', 'trialing', 'past_due']);
 

--- a/server/src/audit/integrity/invariants/org-row-matches-live-stripe-sub.ts
+++ b/server/src/audit/integrity/invariants/org-row-matches-live-stripe-sub.ts
@@ -1,0 +1,128 @@
+/**
+ * Invariant: when an AAO org row points to a live Stripe subscription, the
+ * row's mirrored fields (subscription_amount, subscription_price_lookup_key,
+ * subscription_status) match what Stripe currently reports. Catches drift
+ * from missed webhooks or manual Stripe-dashboard edits.
+ *
+ * Severity is `warning`, not `critical`: tier mismatch could be transient
+ * (webhook in flight) and we don't want to page on every brief skew.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+function isStripeNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: string; statusCode?: number };
+  return e.code === 'resource_missing' || e.statusCode === 404;
+}
+
+const LIVE_STATUSES = new Set(['active', 'trialing', 'past_due']);
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_subscription_id: string;
+  subscription_status: string | null;
+  subscription_amount: number | null;
+  subscription_price_lookup_key: string | null;
+}
+
+export const orgRowMatchesLiveStripeSubInvariant: Invariant = {
+  name: 'org-row-matches-live-stripe-sub',
+  description:
+    'When an org has a stripe_subscription_id and a live (active/trialing/past_due) ' +
+    'subscription_status, the row\'s mirrored fields (amount, lookup_key, status) ' +
+    'match what Stripe reports for that subscription. Catches webhook-miss drift.',
+  severity: 'warning',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, stripe, logger } = ctx;
+    const violations: Violation[] = [];
+
+    const result = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_subscription_id,
+              subscription_status, subscription_amount, subscription_price_lookup_key
+         FROM organizations
+        WHERE stripe_subscription_id IS NOT NULL
+          AND subscription_status = ANY($1::text[])`,
+      [Array.from(LIVE_STATUSES)],
+    );
+
+    for (const org of result.rows) {
+      try {
+        const sub = await stripe.subscriptions.retrieve(org.stripe_subscription_id);
+        const price = sub.items.data[0]?.price;
+        const stripeAmount = price?.unit_amount ?? null;
+        const stripeLookupKey = price?.lookup_key ?? null;
+        const stripeStatus = sub.status;
+
+        const mismatches: Record<string, { row: unknown; stripe: unknown }> = {};
+
+        if (org.subscription_status !== stripeStatus) {
+          mismatches.status = { row: org.subscription_status, stripe: stripeStatus };
+        }
+        if (org.subscription_amount !== stripeAmount) {
+          mismatches.amount = { row: org.subscription_amount, stripe: stripeAmount };
+        }
+        if (org.subscription_price_lookup_key !== stripeLookupKey) {
+          mismatches.lookup_key = {
+            row: org.subscription_price_lookup_key,
+            stripe: stripeLookupKey,
+          };
+        }
+
+        if (Object.keys(mismatches).length === 0) continue;
+
+        violations.push({
+          invariant: 'org-row-matches-live-stripe-sub',
+          severity: 'warning',
+          subject_type: 'organization',
+          subject_id: org.workos_organization_id,
+          message:
+            `Org row drifts from Stripe subscription ${sub.id}: ` +
+            Object.entries(mismatches)
+              .map(([k, v]) => `${k} (row=${JSON.stringify(v.row)}, stripe=${JSON.stringify(v.stripe)})`)
+              .join('; '),
+          details: {
+            org_name: org.name,
+            stripe_subscription_id: sub.id,
+            mismatches,
+          },
+          remediation_hint:
+            'Run POST /api/admin/accounts/:orgId/sync to re-pull subscription state from Stripe, ' +
+            'or replay the most recent customer.subscription.updated webhook for this customer.',
+        });
+      } catch (err) {
+        if (isStripeNotFound(err)) {
+          violations.push({
+            invariant: 'org-row-matches-live-stripe-sub',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Org references non-existent Stripe subscription ${org.stripe_subscription_id}`,
+            details: {
+              org_name: org.name,
+              stripe_subscription_id: org.stripe_subscription_id,
+            },
+            remediation_hint:
+              'The subscription was deleted in Stripe but the org row still references it. ' +
+              'Null out stripe_subscription_id and re-derive subscription state from current Stripe data.',
+          });
+        } else {
+          logger.warn(
+            { err, orgId: org.workos_organization_id, subId: org.stripe_subscription_id },
+            'org-row-matches-live-stripe-sub: transient Stripe error',
+          );
+          violations.push({
+            invariant: 'org-row-matches-live-stripe-sub',
+            severity: 'warning',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Could not retrieve Stripe subscription ${org.stripe_subscription_id}: ${err instanceof Error ? err.message : String(err)}`,
+            details: { org_name: org.name, stripe_subscription_id: org.stripe_subscription_id },
+          });
+        }
+      }
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/stripe-customer-org-metadata-bidirectional.ts
+++ b/server/src/audit/integrity/invariants/stripe-customer-org-metadata-bidirectional.ts
@@ -1,0 +1,102 @@
+/**
+ * Invariant: every AAO org's `stripe_customer_id` resolves to a Stripe
+ * customer whose `metadata.workos_organization_id` points back at the same
+ * org. The bidirectional pointer is what guarantees a Stripe write fires
+ * the right downstream AAO state — Triton's incident was the literal
+ * symptom of this invariant being silently violated.
+ */
+import type Stripe from 'stripe';
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_customer_id: string;
+}
+
+export const stripeCustomerOrgMetadataBidirectionalInvariant: Invariant = {
+  name: 'stripe-customer-org-metadata-bidirectional',
+  description:
+    "Every org's stripe_customer_id resolves to a Stripe customer whose " +
+    'metadata.workos_organization_id matches the AAO org ID. Without this, a ' +
+    'Stripe write (subscription, invoice, charge) attributes to the wrong org ' +
+    "downstream — exactly Triton's April 2026 mess in literal form.",
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, stripe, logger } = ctx;
+    const violations: Violation[] = [];
+
+    const result = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_customer_id
+         FROM organizations
+        WHERE stripe_customer_id IS NOT NULL`,
+    );
+
+    for (const org of result.rows) {
+      try {
+        const customer = await stripe.customers.retrieve(org.stripe_customer_id);
+        if ('deleted' in customer && customer.deleted) {
+          // Treat as orphan — its own invariant handles the "deleted customer
+          // still referenced" case; here we only check metadata when present.
+          continue;
+        }
+        const c = customer as Stripe.Customer;
+        const stamped = c.metadata?.workos_organization_id;
+
+        if (!stamped) {
+          violations.push({
+            invariant: 'stripe-customer-org-metadata-bidirectional',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Stripe customer ${c.id} has no workos_organization_id metadata stamped`,
+            details: {
+              org_name: org.name,
+              stripe_customer_id: c.id,
+              stripe_customer_email: c.email,
+            },
+            remediation_hint:
+              'Update the Stripe customer metadata to include workos_organization_id, or unlink the org from this customer if it was created in error.',
+          });
+          continue;
+        }
+
+        if (stamped !== org.workos_organization_id) {
+          violations.push({
+            invariant: 'stripe-customer-org-metadata-bidirectional',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message:
+              `Stripe customer ${c.id} is metadata-attributed to ${stamped} ` +
+              `but is referenced by org ${org.workos_organization_id}`,
+            details: {
+              org_name: org.name,
+              stripe_customer_id: c.id,
+              stripe_customer_email: c.email,
+              metadata_workos_organization_id: stamped,
+            },
+            remediation_hint:
+              `Either fix the Stripe customer metadata to point at ${org.workos_organization_id}, ` +
+              `or set this org's stripe_customer_id to null and re-link to the correct customer.`,
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          { err, orgId: org.workos_organization_id, customerId: org.stripe_customer_id },
+          'stripe-customer-org-metadata-bidirectional: Stripe lookup failed; recording transient violation',
+        );
+        violations.push({
+          invariant: 'stripe-customer-org-metadata-bidirectional',
+          severity: 'warning',
+          subject_type: 'organization',
+          subject_id: org.workos_organization_id,
+          message: `Could not retrieve Stripe customer ${org.stripe_customer_id}: ${err instanceof Error ? err.message : String(err)}`,
+          details: { org_name: org.name, stripe_customer_id: org.stripe_customer_id },
+        });
+      }
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/stripe-customer-org-metadata-bidirectional.ts
+++ b/server/src/audit/integrity/invariants/stripe-customer-org-metadata-bidirectional.ts
@@ -7,6 +7,7 @@
  */
 import type Stripe from 'stripe';
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+import { getStripeCustomerCached } from '../stripe-helpers.js';
 
 interface OrgRow {
   workos_organization_id: string;
@@ -23,7 +24,7 @@ export const stripeCustomerOrgMetadataBidirectionalInvariant: Invariant = {
     "downstream — exactly Triton's April 2026 mess in literal form.",
   severity: 'critical',
   async check(ctx: InvariantContext): Promise<InvariantResult> {
-    const { pool, stripe, logger } = ctx;
+    const { pool, logger } = ctx;
     const violations: Violation[] = [];
 
     const result = await pool.query<OrgRow>(
@@ -34,7 +35,7 @@ export const stripeCustomerOrgMetadataBidirectionalInvariant: Invariant = {
 
     for (const org of result.rows) {
       try {
-        const customer = await stripe.customers.retrieve(org.stripe_customer_id);
+        const customer = await getStripeCustomerCached(ctx, org.stripe_customer_id);
         if ('deleted' in customer && customer.deleted) {
           // Treat as orphan — its own invariant handles the "deleted customer
           // still referenced" case; here we only check metadata when present.

--- a/server/src/audit/integrity/invariants/stripe-customer-resolves.ts
+++ b/server/src/audit/integrity/invariants/stripe-customer-resolves.ts
@@ -5,12 +5,7 @@
  * otherwise produce silent webhook drops on the next subscription event.
  */
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
-
-function isStripeNotFound(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false;
-  const e = err as { code?: string; statusCode?: number };
-  return e.code === 'resource_missing' || e.statusCode === 404;
-}
+import { getStripeCustomerCached, isStripeNotFound } from '../stripe-helpers.js';
 
 interface OrgRow {
   workos_organization_id: string;
@@ -26,7 +21,7 @@ export const stripeCustomerResolvesInvariant: Invariant = {
     'next subscription event for that customer.',
   severity: 'critical',
   async check(ctx: InvariantContext): Promise<InvariantResult> {
-    const { pool, stripe, logger } = ctx;
+    const { pool, logger } = ctx;
     const violations: Violation[] = [];
 
     const result = await pool.query<OrgRow>(
@@ -37,7 +32,7 @@ export const stripeCustomerResolvesInvariant: Invariant = {
 
     for (const org of result.rows) {
       try {
-        const customer = await stripe.customers.retrieve(org.stripe_customer_id);
+        const customer = await getStripeCustomerCached(ctx, org.stripe_customer_id);
         if ('deleted' in customer && customer.deleted) {
           violations.push({
             invariant: 'stripe-customer-resolves',

--- a/server/src/audit/integrity/invariants/stripe-customer-resolves.ts
+++ b/server/src/audit/integrity/invariants/stripe-customer-resolves.ts
@@ -1,0 +1,93 @@
+/**
+ * Invariant: every AAO `organizations.stripe_customer_id` resolves to a
+ * non-deleted Stripe customer. Catches the "Stripe customer was hand-deleted
+ * via dashboard but the FK on the org row is still set" case, which would
+ * otherwise produce silent webhook drops on the next subscription event.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+function isStripeNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: string; statusCode?: number };
+  return e.code === 'resource_missing' || e.statusCode === 404;
+}
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_customer_id: string;
+}
+
+export const stripeCustomerResolvesInvariant: Invariant = {
+  name: 'stripe-customer-resolves',
+  description:
+    'Every org.stripe_customer_id resolves to a Stripe customer that is not ' +
+    'marked deleted. A dangling reference produces silent webhook drops on the ' +
+    'next subscription event for that customer.',
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, stripe, logger } = ctx;
+    const violations: Violation[] = [];
+
+    const result = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_customer_id
+         FROM organizations
+        WHERE stripe_customer_id IS NOT NULL`,
+    );
+
+    for (const org of result.rows) {
+      try {
+        const customer = await stripe.customers.retrieve(org.stripe_customer_id);
+        if ('deleted' in customer && customer.deleted) {
+          violations.push({
+            invariant: 'stripe-customer-resolves',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Org references deleted Stripe customer ${org.stripe_customer_id}`,
+            details: {
+              org_name: org.name,
+              stripe_customer_id: org.stripe_customer_id,
+            },
+            remediation_hint:
+              'Either restore the customer in Stripe or null out the org\'s stripe_customer_id ' +
+              '(after confirming no in-flight payments depend on it).',
+          });
+        }
+      } catch (err) {
+        // Stripe SDK throws on 404. We treat that as "doesn't exist" — same
+        // as deleted from our perspective.
+        if (isStripeNotFound(err)) {
+          violations.push({
+            invariant: 'stripe-customer-resolves',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Org references non-existent Stripe customer ${org.stripe_customer_id}`,
+            details: {
+              org_name: org.name,
+              stripe_customer_id: org.stripe_customer_id,
+            },
+            remediation_hint:
+              'Null out the org\'s stripe_customer_id and re-link to a valid customer if one exists.',
+          });
+        } else {
+          logger.warn(
+            { err, orgId: org.workos_organization_id, customerId: org.stripe_customer_id },
+            'stripe-customer-resolves: transient Stripe lookup error',
+          );
+          violations.push({
+            invariant: 'stripe-customer-resolves',
+            severity: 'warning',
+            subject_type: 'organization',
+            subject_id: org.workos_organization_id,
+            message: `Could not retrieve Stripe customer ${org.stripe_customer_id}: ${err instanceof Error ? err.message : String(err)}`,
+            details: { org_name: org.name, stripe_customer_id: org.stripe_customer_id },
+          });
+        }
+      }
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/workos-membership-row-exists-in-workos.ts
+++ b/server/src/audit/integrity/invariants/workos-membership-row-exists-in-workos.ts
@@ -1,0 +1,96 @@
+/**
+ * Invariant (sampled): a random sample of active organization_memberships
+ * rows correspond to memberships that exist in WorkOS. Catches stale rows
+ * left behind when a WorkOS deletion webhook was missed or fired before
+ * AAO was ready.
+ *
+ * Sampled because we have many memberships and full enumeration per run
+ * would burn WorkOS API budget. The sample window cycles via ORDER BY
+ * RANDOM(), so over many runs we cover the whole population probabilistically.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+const DEFAULT_SAMPLE_SIZE = 200;
+
+interface MembershipRow {
+  workos_user_id: string;
+  workos_organization_id: string;
+  workos_membership_id: string | null;
+  status: string;
+}
+
+export const workosMembershipRowExistsInWorkosInvariant: Invariant = {
+  name: 'workos-membership-row-exists-in-workos',
+  description:
+    'Random sample of active organization_memberships rows have a ' +
+    'corresponding live membership in WorkOS. Catches stale rows from ' +
+    'missed delete webhooks. Sampled (default 200/run) so we cycle ' +
+    'through the population over multiple runs.',
+  severity: 'warning',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, workos, logger, options } = ctx;
+    const sampleSize = options?.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+    const violations: Violation[] = [];
+
+    // ORDER BY RANDOM() is fine at our scale (tens of thousands of rows).
+    // If membership counts grow significantly, switch to TABLESAMPLE.
+    const result = await pool.query<MembershipRow>(
+      `SELECT workos_user_id, workos_organization_id, workos_membership_id, status
+         FROM organization_memberships
+        WHERE status = 'active'
+        ORDER BY RANDOM()
+        LIMIT $1`,
+      [sampleSize],
+    );
+
+    for (const row of result.rows) {
+      try {
+        const memberships = await workos.userManagement.listOrganizationMemberships({
+          userId: row.workos_user_id,
+          organizationId: row.workos_organization_id,
+        });
+        if (memberships.data.length === 0) {
+          violations.push({
+            invariant: 'workos-membership-row-exists-in-workos',
+            severity: 'warning',
+            subject_type: 'membership',
+            subject_id: `${row.workos_user_id}:${row.workos_organization_id}`,
+            message:
+              `organization_memberships row marked active for user ${row.workos_user_id} in ` +
+              `org ${row.workos_organization_id}, but WorkOS reports no such membership`,
+            details: {
+              workos_user_id: row.workos_user_id,
+              workos_organization_id: row.workos_organization_id,
+              workos_membership_id: row.workos_membership_id,
+            },
+            remediation_hint:
+              'Either delete the stale row (if WorkOS is the source of truth and the user has been removed) ' +
+              'or re-create the WorkOS membership (if AAO is the source of truth and the deletion was accidental).',
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          {
+            err,
+            userId: row.workos_user_id,
+            orgId: row.workos_organization_id,
+          },
+          'workos-membership-row-exists-in-workos: WorkOS lookup failed',
+        );
+        violations.push({
+          invariant: 'workos-membership-row-exists-in-workos',
+          severity: 'warning',
+          subject_type: 'membership',
+          subject_id: `${row.workos_user_id}:${row.workos_organization_id}`,
+          message: `WorkOS lookup failed for user ${row.workos_user_id} in org ${row.workos_organization_id}: ${err instanceof Error ? err.message : String(err)}`,
+          details: {
+            workos_user_id: row.workos_user_id,
+            workos_organization_id: row.workos_organization_id,
+          },
+        });
+      }
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/runner.ts
+++ b/server/src/audit/integrity/runner.ts
@@ -1,0 +1,91 @@
+/**
+ * Invariant runner. Executes a list of invariants in sequence, isolates
+ * failures (one invariant throwing doesn't cancel the others), and returns
+ * an aggregated report.
+ */
+import type {
+  Invariant,
+  InvariantContext,
+  InvariantRunReport,
+  InvariantRunStats,
+  Severity,
+  Violation,
+} from './types.js';
+
+export async function runAllInvariants(
+  invariants: readonly Invariant[],
+  ctx: InvariantContext,
+): Promise<InvariantRunReport> {
+  const startedAt = new Date();
+  const violations: Violation[] = [];
+  const stats: Record<string, InvariantRunStats> = {};
+
+  // Sequential by design (Phase 1): predictable Stripe/WorkOS API budget,
+  // simpler reasoning, no race against per-invariant rate limits. Phase 2
+  // can introduce bounded parallelism once we've measured real costs.
+  for (const inv of invariants) {
+    stats[inv.name] = await runOneInvariantInto(inv, ctx, violations);
+  }
+
+  const completedAt = new Date();
+  const violationsBySeverity: Record<Severity, number> = {
+    critical: 0,
+    warning: 0,
+    info: 0,
+  };
+  for (const v of violations) {
+    violationsBySeverity[v.severity]++;
+  }
+
+  return {
+    started_at: startedAt,
+    completed_at: completedAt,
+    total_violations: violations.length,
+    violations_by_severity: violationsBySeverity,
+    violations,
+    stats,
+  };
+}
+
+export async function runOneInvariant(
+  invariant: Invariant,
+  ctx: InvariantContext,
+): Promise<InvariantRunReport> {
+  return runAllInvariants([invariant], ctx);
+}
+
+async function runOneInvariantInto(
+  invariant: Invariant,
+  ctx: InvariantContext,
+  appendViolationsTo: Violation[],
+): Promise<InvariantRunStats> {
+  const t0 = Date.now();
+  try {
+    const result = await invariant.check(ctx);
+    appendViolationsTo.push(...result.violations);
+    return {
+      ms: Date.now() - t0,
+      checked: result.checked,
+      violations: result.violations.length,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    ctx.logger.error({ err, invariant: invariant.name }, 'Invariant check threw');
+    // Record a meta-violation so the failure is visible in the report
+    // and operators don't see a silently-incomplete check.
+    const metaViolation: Violation = {
+      invariant: invariant.name,
+      severity: 'warning',
+      subject_type: 'configuration',
+      subject_id: invariant.name,
+      message: `Invariant check failed to run: ${error}`,
+    };
+    appendViolationsTo.push(metaViolation);
+    return {
+      ms: Date.now() - t0,
+      checked: 0,
+      violations: 1,
+      error,
+    };
+  }
+}

--- a/server/src/audit/integrity/runner.ts
+++ b/server/src/audit/integrity/runner.ts
@@ -20,11 +20,19 @@ export async function runAllInvariants(
   const violations: Violation[] = [];
   const stats: Record<string, InvariantRunStats> = {};
 
+  // Allocate a fresh per-run Stripe customer cache so invariants that hit
+  // `customers.retrieve` for the same id only pay the API call once per run.
+  // (#1 and #3 in Phase 1 both walk the same set.) Caller can override by
+  // pre-populating ctx.stripeCustomerCache; we leave that alone.
+  const ctxWithCache: InvariantContext = ctx.stripeCustomerCache
+    ? ctx
+    : { ...ctx, stripeCustomerCache: new Map() };
+
   // Sequential by design (Phase 1): predictable Stripe/WorkOS API budget,
   // simpler reasoning, no race against per-invariant rate limits. Phase 2
   // can introduce bounded parallelism once we've measured real costs.
   for (const inv of invariants) {
-    stats[inv.name] = await runOneInvariantInto(inv, ctx, violations);
+    stats[inv.name] = await runOneInvariantInto(inv, ctxWithCache, violations);
   }
 
   const completedAt = new Date();

--- a/server/src/audit/integrity/stripe-helpers.ts
+++ b/server/src/audit/integrity/stripe-helpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared Stripe helpers for integrity invariants.
+ *
+ * The customer-fetch cache is the important one: three Phase-1 invariants
+ * call `stripe.customers.retrieve` for the same set of orgs. Without
+ * coalescing, a full /check run makes ~3N Stripe API calls when N would
+ * suffice. The cache lives for one run (one InvariantContext lifetime).
+ */
+import type Stripe from 'stripe';
+import type { InvariantContext } from './types.js';
+
+/** True for the shape Stripe SDK throws on a 404 / resource_missing. */
+export function isStripeNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: string; statusCode?: number };
+  return e.code === 'resource_missing' || e.statusCode === 404;
+}
+
+/**
+ * Retrieve a Stripe customer, sharing the result with any other invariant
+ * in the same run that needs the same id. Caches successes only — failures
+ * fall through to each invariant's own error handling so transient errors
+ * surface as warnings, not silently-cached null results.
+ *
+ * The cache is opt-in via `ctx.stripeCustomerCache`. The runner creates a
+ * fresh Map per run; tests that don't pass one fall back to direct calls.
+ */
+export async function getStripeCustomerCached(
+  ctx: InvariantContext,
+  customerId: string,
+): Promise<Stripe.Customer | Stripe.DeletedCustomer> {
+  const cache = ctx.stripeCustomerCache;
+  if (cache) {
+    const hit = cache.get(customerId);
+    if (hit) return hit;
+  }
+  const customer = await ctx.stripe.customers.retrieve(customerId);
+  if (cache) cache.set(customerId, customer);
+  return customer;
+}

--- a/server/src/audit/integrity/types.ts
+++ b/server/src/audit/integrity/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Integrity-invariant framework types.
+ *
+ * Each invariant is a self-contained assertion about state across WorkOS,
+ * Stripe, and AAO Postgres. Violations are reported per offending entity,
+ * not in aggregate, so operators can act on them individually.
+ */
+import type { Pool } from 'pg';
+import type Stripe from 'stripe';
+import type { WorkOS } from '@workos-inc/node';
+import type { Logger } from 'pino';
+
+export type Severity = 'critical' | 'warning' | 'info';
+
+/**
+ * What kind of entity the violation is about. Used for grouping in admin UI
+ * and for narrowing remediation actions. Add new subject types here when a
+ * new invariant needs one — keeping this tight prevents drift.
+ */
+export type SubjectType =
+  | 'organization'
+  | 'user'
+  | 'subscription'
+  | 'customer'
+  | 'membership'
+  | 'configuration';
+
+export interface Violation {
+  /** Identifier of the invariant that fired this violation. */
+  invariant: string;
+  severity: Severity;
+  subject_type: SubjectType;
+  /** Stable identifier of the offending entity (org id, customer id, etc.). */
+  subject_id: string;
+  /** Human-readable summary, safe to show in admin UI. */
+  message: string;
+  /** Structured details for programmatic remediation. */
+  details?: Record<string, unknown>;
+  /** Optional admin-facing fix suggestion. */
+  remediation_hint?: string;
+}
+
+export interface InvariantOptions {
+  /**
+   * For invariants that walk a sampled subset of entities, the maximum
+   * number to check in one run. Sampled invariants are responsible for
+   * cycling through different rows over multiple runs.
+   */
+  sampleSize?: number;
+  /**
+   * Skip rows whose `updated_at` is before this date. Lets a periodic
+   * runner focus on recently-changed entities.
+   */
+  sinceUpdated?: Date;
+}
+
+export interface InvariantContext {
+  pool: Pool;
+  stripe: Stripe;
+  workos: WorkOS;
+  logger: Logger;
+  options?: InvariantOptions;
+}
+
+export interface InvariantResult {
+  /** Number of entities the invariant inspected this run. */
+  checked: number;
+  violations: Violation[];
+}
+
+export interface Invariant {
+  /** Stable, URL-safe identifier. Used in routes, logs, persisted reports. */
+  name: string;
+  /** One-paragraph explanation surfaced in admin UI / dashboards. */
+  description: string;
+  /** Default severity for this invariant's violations. */
+  severity: Severity;
+  check: (ctx: InvariantContext) => Promise<InvariantResult>;
+}
+
+export interface InvariantRunStats {
+  ms: number;
+  checked: number;
+  violations: number;
+  /** Set when the invariant's check function threw. */
+  error?: string;
+}
+
+export interface InvariantRunReport {
+  started_at: Date;
+  completed_at: Date;
+  total_violations: number;
+  violations_by_severity: Record<Severity, number>;
+  violations: Violation[];
+  /** Per-invariant timing + counts for performance tracking. */
+  stats: Record<string, InvariantRunStats>;
+}

--- a/server/src/audit/integrity/types.ts
+++ b/server/src/audit/integrity/types.ts
@@ -10,6 +10,14 @@ import type Stripe from 'stripe';
 import type { WorkOS } from '@workos-inc/node';
 import type { Logger } from 'pino';
 
+/**
+ * Per-run shared cache for Stripe customers. Three Phase-1 invariants call
+ * `stripe.customers.retrieve` for the same set of orgs; this Map dedupes
+ * those calls within one /check run. Successes only — failures fall
+ * through to per-invariant warning handling.
+ */
+export type StripeCustomerCache = Map<string, Stripe.Customer | Stripe.DeletedCustomer>;
+
 export type Severity = 'critical' | 'warning' | 'info';
 
 /**
@@ -60,6 +68,12 @@ export interface InvariantContext {
   workos: WorkOS;
   logger: Logger;
   options?: InvariantOptions;
+  /**
+   * Shared per-run Stripe customer cache. The runner allocates a fresh Map
+   * per /check call so invariants that hit `customers.retrieve` for the
+   * same id only pay the API call once. Optional so tests can omit it.
+   */
+  stripeCustomerCache?: StripeCustomerCache;
 }
 
 export interface InvariantResult {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -37,6 +37,7 @@ import { setupRelationshipRoutes } from "./admin/relationships.js";
 import { setupSimulationRoutes } from "./admin/simulations.js";
 import { setupIllustrationRoutes } from "./admin/illustrations.js";
 import { setupAddieCostRoutes } from "./admin/addie-costs.js";
+import { setupIntegrityRoutes } from "./admin/integrity.js";
 import { getAllNewsletters } from "../newsletters/registry.js";
 import { createNewsletterAdminRoutes } from "../newsletters/admin-routes.js";
 // Ensure newsletters register themselves before routes mount
@@ -178,6 +179,9 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
 
   // Addie cost-cap observability (per-user Anthropic spend)
   setupAddieCostRoutes(apiRouter);
+
+  // Cross-system integrity invariants (WorkOS ↔ Stripe ↔ AAO Postgres)
+  setupIntegrityRoutes(apiRouter, { workos });
 
   // Unified newsletter admin routes
   for (const nlConfig of getAllNewsletters()) {

--- a/server/src/routes/admin/index.ts
+++ b/server/src/routes/admin/index.ts
@@ -24,3 +24,4 @@ export { setupAccountsBillingRoutes } from './accounts-billing.js';
 export { setupBrandEnrichmentRoutes } from './brand-enrichment.js';
 export { setupGeoRoutes } from './geo.js';
 export { setupAnnouncementsRoutes } from './announcements.js';
+export { setupIntegrityRoutes } from './integrity.js';

--- a/server/src/routes/admin/integrity.ts
+++ b/server/src/routes/admin/integrity.ts
@@ -1,0 +1,134 @@
+/**
+ * Admin routes for the integrity-invariants framework.
+ *
+ *   GET /api/admin/integrity/invariants      - list all registered invariants
+ *   GET /api/admin/integrity/check           - run every invariant; return report
+ *   GET /api/admin/integrity/check/:name     - run one invariant; return report
+ *
+ * Phase 1 surface: on-demand only. Phase 2 will add scheduled runs and a
+ * persisted `integrity_runs` table for graphing drift over time.
+ */
+import type { Router } from 'express';
+import type { WorkOS } from '@workos-inc/node';
+import { requireAuth, requireAdmin } from '../../middleware/auth.js';
+import { getPool } from '../../db/client.js';
+import { stripe } from '../../billing/stripe-client.js';
+import { createLogger } from '../../logger.js';
+import {
+  runAllInvariants,
+  runOneInvariant,
+  ALL_INVARIANTS,
+  getInvariantByName,
+  type InvariantContext,
+  type InvariantOptions,
+} from '../../audit/integrity/index.js';
+
+const logger = createLogger('admin-integrity-routes');
+
+interface IntegrityRoutesConfig {
+  workos: WorkOS | null;
+}
+
+export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesConfig): void {
+  const { workos } = config;
+
+  apiRouter.get('/integrity/invariants', requireAuth, requireAdmin, (_req, res) => {
+    res.json({
+      invariants: ALL_INVARIANTS.map((inv) => ({
+        name: inv.name,
+        description: inv.description,
+        severity: inv.severity,
+      })),
+    });
+  });
+
+  apiRouter.get('/integrity/check', requireAuth, requireAdmin, async (req, res) => {
+    if (!stripe) {
+      return res.status(503).json({
+        error: 'Stripe not configured',
+        message: 'Integrity checks require STRIPE_SECRET_KEY.',
+      });
+    }
+    if (!workos) {
+      return res.status(503).json({
+        error: 'WorkOS not configured',
+        message: 'Integrity checks require WorkOS env vars.',
+      });
+    }
+
+    const ctx: InvariantContext = {
+      pool: getPool(),
+      stripe,
+      workos,
+      logger,
+      options: parseOptions(req.query),
+    };
+
+    try {
+      const report = await runAllInvariants(ALL_INVARIANTS, ctx);
+      logger.info(
+        {
+          totalViolations: report.total_violations,
+          bySeverity: report.violations_by_severity,
+          ms: report.completed_at.getTime() - report.started_at.getTime(),
+          adminEmail: req.user?.email,
+        },
+        'Integrity check completed',
+      );
+      res.json(report);
+    } catch (err) {
+      logger.error({ err }, 'Integrity check failed');
+      res.status(500).json({ error: 'Integrity check failed', message: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  apiRouter.get('/integrity/check/:name', requireAuth, requireAdmin, async (req, res) => {
+    if (!stripe) {
+      return res.status(503).json({ error: 'Stripe not configured' });
+    }
+    if (!workos) {
+      return res.status(503).json({ error: 'WorkOS not configured' });
+    }
+
+    const invariant = getInvariantByName(req.params.name);
+    if (!invariant) {
+      return res.status(404).json({
+        error: 'Invariant not found',
+        message: `No invariant registered with name "${req.params.name}". List available invariants at GET /api/admin/integrity/invariants.`,
+      });
+    }
+
+    const ctx: InvariantContext = {
+      pool: getPool(),
+      stripe,
+      workos,
+      logger,
+      options: parseOptions(req.query),
+    };
+
+    try {
+      const report = await runOneInvariant(invariant, ctx);
+      res.json(report);
+    } catch (err) {
+      logger.error({ err, invariant: invariant.name }, 'Single invariant check failed');
+      res.status(500).json({ error: 'Integrity check failed', message: err instanceof Error ? err.message : String(err) });
+    }
+  });
+}
+
+function parseOptions(query: Record<string, unknown>): InvariantOptions | undefined {
+  const opts: InvariantOptions = {};
+  if (typeof query.sample_size === 'string') {
+    const n = Number.parseInt(query.sample_size, 10);
+    if (Number.isFinite(n) && n > 0 && n <= 10_000) {
+      opts.sampleSize = n;
+    }
+  }
+  if (typeof query.since === 'string') {
+    const d = new Date(query.since);
+    if (!Number.isNaN(d.getTime())) {
+      opts.sinceUpdated = d;
+    }
+  }
+  return Object.keys(opts).length > 0 ? opts : undefined;
+}

--- a/server/src/routes/admin/integrity.ts
+++ b/server/src/routes/admin/integrity.ts
@@ -8,7 +8,7 @@
  * Phase 1 surface: on-demand only. Phase 2 will add scheduled runs and a
  * persisted `integrity_runs` table for graphing drift over time.
  */
-import type { Router } from 'express';
+import type { Request, Router } from 'express';
 import type { WorkOS } from '@workos-inc/node';
 import { requireAuth, requireAdmin } from '../../middleware/auth.js';
 import { getPool } from '../../db/client.js';
@@ -25,8 +25,50 @@ import {
 
 const logger = createLogger('admin-integrity-routes');
 
+/**
+ * Realistic upper bound on per-run sample size. Each unit costs at least one
+ * external API call; 1000 is well above any genuine run while preventing a
+ * misclick from burning rate-limit budget for the whole product.
+ */
+const MAX_SAMPLE_SIZE = 1000;
+
 interface IntegrityRoutesConfig {
   workos: WorkOS | null;
+}
+
+interface ParsedOptions {
+  options: InvariantOptions | undefined;
+  /** Set when query input was malformed; caller should 400. */
+  error?: { field: string; message: string };
+}
+
+/**
+ * Detect Stripe-key-mode vs DATABASE_URL environment mismatch. A staging app
+ * pointed at a live Stripe key (or vice versa) would surface thousands of
+ * phantom critical violations because the Stripe-side state and the AAO-side
+ * state describe entirely different worlds. Cheap heuristic: if the URL host
+ * looks like prod and the key is `sk_test_*`, refuse. Phase 2 can graduate
+ * this to a probe-and-cache. Returns null when no mismatch is detected.
+ */
+function detectEnvMismatch(): string | null {
+  const stripeKey = process.env.STRIPE_SECRET_KEY ?? '';
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  if (!stripeKey || !databaseUrl) return null;
+
+  const isLiveKey = stripeKey.startsWith('sk_live_');
+  const isTestKey = stripeKey.startsWith('sk_test_');
+  const looksProd =
+    databaseUrl.includes('agenticadvertising.org') ||
+    databaseUrl.includes('aao-prod') ||
+    /\.fly\.dev/.test(databaseUrl);
+
+  if (looksProd && isTestKey) {
+    return 'STRIPE_SECRET_KEY is sk_test_* but DATABASE_URL points at production. Refusing to run integrity checks against this mismatched configuration.';
+  }
+  if (!looksProd && isLiveKey) {
+    return 'STRIPE_SECRET_KEY is sk_live_* but DATABASE_URL does not look like production. Refusing to run integrity checks — would attribute live Stripe state against staging Postgres.';
+  }
+  return null;
 }
 
 export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesConfig): void {
@@ -43,25 +85,20 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
   });
 
   apiRouter.get('/integrity/check', requireAuth, requireAdmin, async (req, res) => {
-    if (!stripe) {
-      return res.status(503).json({
-        error: 'Stripe not configured',
-        message: 'Integrity checks require STRIPE_SECRET_KEY.',
-      });
-    }
-    if (!workos) {
-      return res.status(503).json({
-        error: 'WorkOS not configured',
-        message: 'Integrity checks require WorkOS env vars.',
-      });
+    const guard = guardPreconditions(req, workos);
+    if (guard) return res.status(guard.status).json(guard.body);
+
+    const parsed = parseOptions(req.query);
+    if (parsed.error) {
+      return res.status(400).json({ error: 'Invalid query parameter', message: parsed.error.message });
     }
 
     const ctx: InvariantContext = {
       pool: getPool(),
-      stripe,
-      workos,
+      stripe: stripe!,
+      workos: workos!,
       logger,
-      options: parseOptions(req.query),
+      options: parsed.options,
     };
 
     try {
@@ -83,12 +120,8 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
   });
 
   apiRouter.get('/integrity/check/:name', requireAuth, requireAdmin, async (req, res) => {
-    if (!stripe) {
-      return res.status(503).json({ error: 'Stripe not configured' });
-    }
-    if (!workos) {
-      return res.status(503).json({ error: 'WorkOS not configured' });
-    }
+    const guard = guardPreconditions(req, workos);
+    if (guard) return res.status(guard.status).json(guard.body);
 
     const invariant = getInvariantByName(req.params.name);
     if (!invariant) {
@@ -98,12 +131,17 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
       });
     }
 
+    const parsed = parseOptions(req.query);
+    if (parsed.error) {
+      return res.status(400).json({ error: 'Invalid query parameter', message: parsed.error.message });
+    }
+
     const ctx: InvariantContext = {
       pool: getPool(),
-      stripe,
-      workos,
+      stripe: stripe!,
+      workos: workos!,
       logger,
-      options: parseOptions(req.query),
+      options: parsed.options,
     };
 
     try {
@@ -116,19 +154,68 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
   });
 }
 
-function parseOptions(query: Record<string, unknown>): InvariantOptions | undefined {
+function guardPreconditions(
+  _req: Request,
+  workos: WorkOS | null,
+): { status: number; body: Record<string, unknown> } | null {
+  if (!stripe) {
+    return {
+      status: 503,
+      body: {
+        error: 'Stripe not configured',
+        message: 'Integrity checks require STRIPE_SECRET_KEY.',
+      },
+    };
+  }
+  if (!workos) {
+    return {
+      status: 503,
+      body: {
+        error: 'WorkOS not configured',
+        message: 'Integrity checks require WORKOS_API_KEY and WORKOS_CLIENT_ID.',
+      },
+    };
+  }
+  const mismatch = detectEnvMismatch();
+  if (mismatch) {
+    return {
+      status: 412,
+      body: {
+        error: 'Environment mismatch',
+        message: mismatch,
+      },
+    };
+  }
+  return null;
+}
+
+function parseOptions(query: Record<string, unknown>): ParsedOptions {
   const opts: InvariantOptions = {};
-  if (typeof query.sample_size === 'string') {
+
+  if (query.sample_size !== undefined) {
+    if (typeof query.sample_size !== 'string') {
+      return { options: undefined, error: { field: 'sample_size', message: 'sample_size must be a string integer' } };
+    }
     const n = Number.parseInt(query.sample_size, 10);
-    if (Number.isFinite(n) && n > 0 && n <= 10_000) {
-      opts.sampleSize = n;
+    if (!Number.isFinite(n) || n <= 0 || String(n) !== query.sample_size.trim()) {
+      return { options: undefined, error: { field: 'sample_size', message: `sample_size must be a positive integer (got "${query.sample_size}")` } };
     }
+    if (n > MAX_SAMPLE_SIZE) {
+      return { options: undefined, error: { field: 'sample_size', message: `sample_size cannot exceed ${MAX_SAMPLE_SIZE}` } };
+    }
+    opts.sampleSize = n;
   }
-  if (typeof query.since === 'string') {
+
+  if (query.since !== undefined) {
+    if (typeof query.since !== 'string') {
+      return { options: undefined, error: { field: 'since', message: 'since must be an ISO 8601 date string' } };
+    }
     const d = new Date(query.since);
-    if (!Number.isNaN(d.getTime())) {
-      opts.sinceUpdated = d;
+    if (Number.isNaN(d.getTime())) {
+      return { options: undefined, error: { field: 'since', message: `since is not a valid ISO 8601 date (got "${query.since}")` } };
     }
+    opts.sinceUpdated = d;
   }
-  return Object.keys(opts).length > 0 ? opts : undefined;
+
+  return { options: Object.keys(opts).length > 0 ? opts : undefined };
 }

--- a/server/src/routes/admin/integrity.ts
+++ b/server/src/routes/admin/integrity.ts
@@ -57,10 +57,25 @@ function detectEnvMismatch(): string | null {
 
   const isLiveKey = stripeKey.startsWith('sk_live_');
   const isTestKey = stripeKey.startsWith('sk_test_');
+
+  // Parse the URL and inspect its host explicitly. Substring checks against
+  // the raw URL string would match a hostile path/query like
+  // postgres://user@evil.example/?aao-prod=1, which is exactly what CodeQL's
+  // js/incomplete-url-substring-sanitization rule warns about.
+  let host = '';
+  try {
+    host = new URL(databaseUrl).hostname.toLowerCase();
+  } catch {
+    // DATABASE_URL is malformed; treat as "looks like development" so live
+    // keys against an unparsable URL are still refused below.
+    host = '';
+  }
+
   const looksProd =
-    databaseUrl.includes('agenticadvertising.org') ||
-    databaseUrl.includes('aao-prod') ||
-    /\.fly\.dev/.test(databaseUrl);
+    host.endsWith('.agenticadvertising.org') ||
+    host === 'agenticadvertising.org' ||
+    host.startsWith('aao-prod') ||
+    host.endsWith('.fly.dev');
 
   if (looksProd && isTestKey) {
     return 'STRIPE_SECRET_KEY is sk_test_* but DATABASE_URL points at production. Refusing to run integrity checks against this mismatched configuration.';
@@ -115,7 +130,7 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
       res.json(report);
     } catch (err) {
       logger.error({ err }, 'Integrity check failed');
-      res.status(500).json({ error: 'Integrity check failed', message: err instanceof Error ? err.message : String(err) });
+      res.status(500).json({ error: 'Integrity check failed', message: 'See server logs for details.' });
     }
   });
 
@@ -149,7 +164,7 @@ export function setupIntegrityRoutes(apiRouter: Router, config: IntegrityRoutesC
       res.json(report);
     } catch (err) {
       logger.error({ err, invariant: invariant.name }, 'Single invariant check failed');
-      res.status(500).json({ error: 'Integrity check failed', message: err instanceof Error ? err.message : String(err) });
+      res.status(500).json({ error: 'Integrity check failed', message: 'See server logs for details.' });
     }
   });
 }

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Tests for the five Phase-1 integrity invariants.
+ *
+ * Each test covers the happy path (no violations) and the failure mode the
+ * invariant exists to detect. Mocks the DB pool, Stripe, and WorkOS through
+ * the InvariantContext shape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { stripeCustomerOrgMetadataBidirectionalInvariant } from '../../../src/audit/integrity/invariants/stripe-customer-org-metadata-bidirectional.js';
+import { oneActiveStripeSubPerOrgInvariant } from '../../../src/audit/integrity/invariants/one-active-stripe-sub-per-org.js';
+import { stripeCustomerResolvesInvariant } from '../../../src/audit/integrity/invariants/stripe-customer-resolves.js';
+import { orgRowMatchesLiveStripeSubInvariant } from '../../../src/audit/integrity/invariants/org-row-matches-live-stripe-sub.js';
+import { workosMembershipRowExistsInWorkosInvariant } from '../../../src/audit/integrity/invariants/workos-membership-row-exists-in-workos.js';
+import { ALL_INVARIANTS, getInvariantByName } from '../../../src/audit/integrity/invariants/index.js';
+import type { InvariantContext } from '../../../src/audit/integrity/types.js';
+
+const mockPoolQuery = vi.fn();
+const mockStripeCustomersRetrieve = vi.fn();
+const mockStripeSubsList = vi.fn();
+const mockStripeSubsRetrieve = vi.fn();
+const mockWorkosListMemberships = vi.fn();
+
+function makeCtx(): InvariantContext {
+  return {
+    pool: { query: mockPoolQuery } as unknown as InvariantContext['pool'],
+    stripe: {
+      customers: { retrieve: mockStripeCustomersRetrieve },
+      subscriptions: { list: mockStripeSubsList, retrieve: mockStripeSubsRetrieve },
+    } as unknown as InvariantContext['stripe'],
+    workos: {
+      userManagement: { listOrganizationMemberships: mockWorkosListMemberships },
+    } as unknown as InvariantContext['workos'],
+    logger: {
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      debug: vi.fn(), trace: vi.fn(), fatal: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    } as unknown as InvariantContext['logger'],
+  };
+}
+
+beforeEach(() => {
+  mockPoolQuery.mockReset();
+  mockStripeCustomersRetrieve.mockReset();
+  mockStripeSubsList.mockReset();
+  mockStripeSubsRetrieve.mockReset();
+  mockWorkosListMemberships.mockReset();
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Registry sanity
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('invariants registry', () => {
+  it('registers all five Phase-1 invariants under unique names', () => {
+    expect(ALL_INVARIANTS).toHaveLength(5);
+    const names = ALL_INVARIANTS.map((i) => i.name);
+    expect(new Set(names).size).toBe(5);
+  });
+
+  it('resolves invariants by name', () => {
+    expect(getInvariantByName('one-active-stripe-sub-per-org')).toBe(oneActiveStripeSubPerOrgInvariant);
+    expect(getInvariantByName('does-not-exist')).toBeUndefined();
+  });
+
+  it('every invariant has a non-empty description and a valid severity', () => {
+    for (const inv of ALL_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+      expect(['critical', 'warning', 'info']).toContain(inv.severity);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// stripe-customer-org-metadata-bidirectional
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('stripe-customer-org-metadata-bidirectional', () => {
+  it('passes when every customer is metadata-stamped with the correct org id', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_1' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({
+      id: 'cus_1',
+      email: 'a@b',
+      metadata: { workos_organization_id: 'org_1' },
+    });
+
+    const result = await stripeCustomerOrgMetadataBidirectionalInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags a customer whose metadata points to a different org (Triton-shape)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_triton', name: 'Triton', stripe_customer_id: 'cus_triton' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({
+      id: 'cus_triton',
+      email: 'erik@encypher.com',
+      metadata: { workos_organization_id: 'org_encypher' }, // wrong!
+    });
+
+    const result = await stripeCustomerOrgMetadataBidirectionalInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_id).toBe('org_triton');
+    expect(result.violations[0].message).toContain('org_encypher');
+    expect(result.violations[0].details?.metadata_workos_organization_id).toBe('org_encypher');
+  });
+
+  it('flags a customer with no workos_organization_id metadata at all', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_x', name: 'Test', stripe_customer_id: 'cus_x' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({ id: 'cus_x', email: 'a@b', metadata: {} });
+
+    const result = await stripeCustomerOrgMetadataBidirectionalInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toContain('no workos_organization_id metadata stamped');
+  });
+
+  it('skips deleted Stripe customers (the resolve invariant handles those)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_x', name: 'X', stripe_customer_id: 'cus_x' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({ id: 'cus_x', deleted: true });
+
+    const result = await stripeCustomerOrgMetadataBidirectionalInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// one-active-stripe-sub-per-org
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('one-active-stripe-sub-per-org', () => {
+  it('passes when a customer has exactly one live subscription', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_1' }],
+    });
+    mockStripeSubsList.mockResolvedValueOnce({
+      data: [
+        { id: 'sub_1', status: 'active', items: { data: [{ price: { lookup_key: 'aao_x', unit_amount: 1000 } }] }, created: 1 },
+      ],
+    });
+
+    const result = await oneActiveStripeSubPerOrgInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags Triton-shape: two simultaneous active subscriptions', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_triton', name: 'Triton', stripe_customer_id: 'cus_triton' }],
+    });
+    mockStripeSubsList.mockResolvedValueOnce({
+      data: [
+        { id: 'sub_corporate', status: 'active', items: { data: [{ price: { lookup_key: 'aao_membership_corporate_5m', unit_amount: 1000000 } }] }, created: 1 },
+        { id: 'sub_builder', status: 'active', items: { data: [{ price: { lookup_key: 'aao_membership_builder_3000', unit_amount: 300000 } }] }, created: 2 },
+      ],
+    });
+
+    const result = await oneActiveStripeSubPerOrgInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_id).toBe('org_triton');
+    expect(result.violations[0].message).toContain('2 live subscriptions');
+    const subs = result.violations[0].details?.subscriptions as Array<{ id: string }>;
+    expect(subs.map((s) => s.id).sort()).toEqual(['sub_builder', 'sub_corporate']);
+  });
+
+  it('treats trialing and past_due as live (would-stack)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_x', name: 'X', stripe_customer_id: 'cus_x' }],
+    });
+    mockStripeSubsList.mockResolvedValueOnce({
+      data: [
+        { id: 'sub_a', status: 'trialing', items: { data: [{ price: { lookup_key: 'a', unit_amount: 100 } }] }, created: 1 },
+        { id: 'sub_b', status: 'past_due', items: { data: [{ price: { lookup_key: 'b', unit_amount: 200 } }] }, created: 2 },
+      ],
+    });
+
+    const result = await oneActiveStripeSubPerOrgInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('does not flag canceled subscriptions', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_x', name: 'X', stripe_customer_id: 'cus_x' }],
+    });
+    mockStripeSubsList.mockResolvedValueOnce({
+      data: [
+        { id: 'sub_active', status: 'active', items: { data: [{ price: { lookup_key: 'a', unit_amount: 100 } }] }, created: 1 },
+        { id: 'sub_old', status: 'canceled', items: { data: [{ price: { lookup_key: 'old', unit_amount: 50 } }] }, created: 0 },
+      ],
+    });
+
+    const result = await oneActiveStripeSubPerOrgInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// stripe-customer-resolves
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('stripe-customer-resolves', () => {
+  it('passes when every customer resolves and is not deleted', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_1' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({ id: 'cus_1' });
+
+    const result = await stripeCustomerResolvesInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags a deleted customer', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_1' }],
+    });
+    mockStripeCustomersRetrieve.mockResolvedValueOnce({ id: 'cus_1', deleted: true });
+
+    const result = await stripeCustomerResolvesInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].message).toContain('deleted');
+  });
+
+  it('flags a 404 (customer never existed or was hard-deleted)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_gone' }],
+    });
+    const notFound = Object.assign(new Error('No such customer'), { code: 'resource_missing', statusCode: 404 });
+    mockStripeCustomersRetrieve.mockRejectedValueOnce(notFound);
+
+    const result = await stripeCustomerResolvesInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].message).toContain('non-existent');
+  });
+
+  it('records a transient warning on Stripe API errors that aren\'t 404', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_1', name: 'Acme', stripe_customer_id: 'cus_1' }],
+    });
+    mockStripeCustomersRetrieve.mockRejectedValueOnce(Object.assign(new Error('rate limit'), { code: 'rate_limit', statusCode: 429 }));
+
+    const result = await stripeCustomerResolvesInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('warning');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// org-row-matches-live-stripe-sub
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('org-row-matches-live-stripe-sub', () => {
+  function orgRow(overrides: Partial<{
+    subscription_status: string; subscription_amount: number; subscription_price_lookup_key: string;
+  }> = {}) {
+    return {
+      workos_organization_id: 'org_1',
+      name: 'Acme',
+      stripe_subscription_id: 'sub_1',
+      subscription_status: 'active',
+      subscription_amount: 1000000,
+      subscription_price_lookup_key: 'aao_membership_corporate_5m',
+      ...overrides,
+    };
+  }
+
+  function stripeSub(overrides: Partial<{
+    status: string; lookup_key: string; unit_amount: number;
+  }> = {}) {
+    return {
+      id: 'sub_1',
+      status: overrides.status ?? 'active',
+      items: {
+        data: [{
+          price: {
+            lookup_key: overrides.lookup_key ?? 'aao_membership_corporate_5m',
+            unit_amount: overrides.unit_amount ?? 1000000,
+          },
+        }],
+      },
+    };
+  }
+
+  it('passes when row mirrors live Stripe state', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [orgRow()] });
+    mockStripeSubsRetrieve.mockResolvedValueOnce(stripeSub());
+
+    const result = await orgRowMatchesLiveStripeSubInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags amount drift', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [orgRow({ subscription_amount: 300000 })] });
+    mockStripeSubsRetrieve.mockResolvedValueOnce(stripeSub());
+
+    const result = await orgRowMatchesLiveStripeSubInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('warning');
+    const m = result.violations[0].details?.mismatches as Record<string, { row: unknown; stripe: unknown }>;
+    expect(m.amount).toEqual({ row: 300000, stripe: 1000000 });
+  });
+
+  it('flags lookup_key drift', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [orgRow({ subscription_price_lookup_key: 'aao_membership_builder_3000' })] });
+    mockStripeSubsRetrieve.mockResolvedValueOnce(stripeSub());
+
+    const result = await orgRowMatchesLiveStripeSubInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+    const m = result.violations[0].details?.mismatches as Record<string, unknown>;
+    expect(m.lookup_key).toBeDefined();
+  });
+
+  it('flags status drift', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [orgRow({ subscription_status: 'active' })] });
+    mockStripeSubsRetrieve.mockResolvedValueOnce(stripeSub({ status: 'past_due' }));
+
+    const result = await orgRowMatchesLiveStripeSubInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('escalates to critical when the Stripe subscription is gone (404)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [orgRow()] });
+    mockStripeSubsRetrieve.mockRejectedValueOnce(Object.assign(new Error('no sub'), { code: 'resource_missing', statusCode: 404 }));
+
+    const result = await orgRowMatchesLiveStripeSubInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].message).toContain('non-existent');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// workos-membership-row-exists-in-workos
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('workos-membership-row-exists-in-workos', () => {
+  it('passes when every sampled membership row resolves in WorkOS', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1', status: 'active' }],
+    });
+    mockWorkosListMemberships.mockResolvedValueOnce({ data: [{ id: 'mem_1' }] });
+
+    const result = await workosMembershipRowExistsInWorkosInvariant.check(makeCtx());
+    expect(result.checked).toBe(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags rows that no longer exist in WorkOS', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_user_id: 'u_stale', workos_organization_id: 'org_1', workos_membership_id: 'mem_stale', status: 'active' }],
+    });
+    mockWorkosListMemberships.mockResolvedValueOnce({ data: [] });
+
+    const result = await workosMembershipRowExistsInWorkosInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('warning');
+    expect(result.violations[0].subject_type).toBe('membership');
+    expect(result.violations[0].subject_id).toBe('u_stale:org_1');
+  });
+
+  it('records a warning when WorkOS lookup fails', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1', status: 'active' }],
+    });
+    mockWorkosListMemberships.mockRejectedValueOnce(new Error('WorkOS down'));
+
+    const result = await workosMembershipRowExistsInWorkosInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('warning');
+    expect(result.violations[0].message).toContain('WorkOS down');
+  });
+
+  it('respects a custom sampleSize via context options', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    await workosMembershipRowExistsInWorkosInvariant.check({
+      ...makeCtx(),
+      options: { sampleSize: 50 },
+    });
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(expect.any(String), [50]);
+  });
+});

--- a/server/tests/unit/integrity/runner.test.ts
+++ b/server/tests/unit/integrity/runner.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the integrity-invariant runner. Verifies sequential execution,
+ * isolation of failures, severity tallying, and meta-violation emission.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runAllInvariants, runOneInvariant } from '../../../src/audit/integrity/runner.js';
+import type { Invariant, InvariantContext, InvariantResult } from '../../../src/audit/integrity/types.js';
+
+function makeCtx(): InvariantContext {
+  return {
+    pool: {} as InvariantContext['pool'],
+    stripe: {} as InvariantContext['stripe'],
+    workos: {} as InvariantContext['workos'],
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    } as unknown as InvariantContext['logger'],
+  };
+}
+
+function makeInvariant(
+  name: string,
+  result: InvariantResult | (() => Promise<InvariantResult>),
+): Invariant {
+  return {
+    name,
+    description: `Test invariant ${name}`,
+    severity: 'critical',
+    check: async () => (typeof result === 'function' ? result() : result),
+  };
+}
+
+describe('runAllInvariants', () => {
+  it('runs each invariant in order and aggregates violations', async () => {
+    const ctx = makeCtx();
+    const callOrder: string[] = [];
+    const invariants: Invariant[] = [
+      {
+        name: 'a',
+        description: 'a',
+        severity: 'critical',
+        check: async () => {
+          callOrder.push('a');
+          return { checked: 1, violations: [] };
+        },
+      },
+      {
+        name: 'b',
+        description: 'b',
+        severity: 'warning',
+        check: async () => {
+          callOrder.push('b');
+          return {
+            checked: 2,
+            violations: [
+              {
+                invariant: 'b',
+                severity: 'warning',
+                subject_type: 'organization',
+                subject_id: 'org_1',
+                message: 'mismatch',
+              },
+            ],
+          };
+        },
+      },
+    ];
+
+    const report = await runAllInvariants(invariants, ctx);
+
+    expect(callOrder).toEqual(['a', 'b']);
+    expect(report.total_violations).toBe(1);
+    expect(report.violations_by_severity).toEqual({ critical: 0, warning: 1, info: 0 });
+    expect(report.violations[0].invariant).toBe('b');
+    expect(report.stats.a.checked).toBe(1);
+    expect(report.stats.a.violations).toBe(0);
+    expect(report.stats.b.checked).toBe(2);
+    expect(report.stats.b.violations).toBe(1);
+  });
+
+  it('isolates a thrown invariant: subsequent invariants still run, throwing one becomes a meta-violation', async () => {
+    const ctx = makeCtx();
+    const invariants: Invariant[] = [
+      makeInvariant('first', { checked: 0, violations: [] }),
+      {
+        name: 'broken',
+        description: 'broken',
+        severity: 'critical',
+        check: async () => {
+          throw new Error('Stripe API down');
+        },
+      },
+      makeInvariant('after', {
+        checked: 5,
+        violations: [
+          {
+            invariant: 'after',
+            severity: 'critical',
+            subject_type: 'organization',
+            subject_id: 'org_x',
+            message: 'something',
+          },
+        ],
+      }),
+    ];
+
+    const report = await runAllInvariants(invariants, ctx);
+
+    expect(report.violations).toHaveLength(2); // meta-violation + after's own
+    const meta = report.violations.find((v) => v.invariant === 'broken');
+    expect(meta).toBeDefined();
+    expect(meta!.severity).toBe('warning');
+    expect(meta!.subject_type).toBe('configuration');
+    expect(meta!.message).toContain('Stripe API down');
+    expect(report.stats.broken.error).toBe('Stripe API down');
+    expect(report.stats.after.checked).toBe(5); // ran despite earlier throw
+  });
+
+  it('counts violations by severity correctly', async () => {
+    const ctx = makeCtx();
+    const invariants: Invariant[] = [
+      makeInvariant('a', {
+        checked: 1,
+        violations: [
+          { invariant: 'a', severity: 'critical', subject_type: 'organization', subject_id: '1', message: 'x' },
+          { invariant: 'a', severity: 'critical', subject_type: 'organization', subject_id: '2', message: 'y' },
+          { invariant: 'a', severity: 'warning', subject_type: 'organization', subject_id: '3', message: 'z' },
+          { invariant: 'a', severity: 'info', subject_type: 'organization', subject_id: '4', message: 'q' },
+        ],
+      }),
+    ];
+
+    const report = await runAllInvariants(invariants, ctx);
+    expect(report.violations_by_severity).toEqual({ critical: 2, warning: 1, info: 1 });
+  });
+
+  it('records timing on each invariant', async () => {
+    const ctx = makeCtx();
+    const invariants: Invariant[] = [makeInvariant('a', { checked: 0, violations: [] })];
+    const report = await runAllInvariants(invariants, ctx);
+    expect(report.stats.a.ms).toBeGreaterThanOrEqual(0);
+    expect(report.completed_at.getTime()).toBeGreaterThanOrEqual(report.started_at.getTime());
+  });
+});
+
+describe('runOneInvariant', () => {
+  it('runs a single invariant and returns a single-entry report', async () => {
+    const ctx = makeCtx();
+    const inv = makeInvariant('only', {
+      checked: 3,
+      violations: [{ invariant: 'only', severity: 'critical', subject_type: 'organization', subject_id: '1', message: 'x' }],
+    });
+
+    const report = await runOneInvariant(inv, ctx);
+
+    expect(Object.keys(report.stats)).toEqual(['only']);
+    expect(report.total_violations).toBe(1);
+  });
+});

--- a/server/tests/unit/integrity/runner.test.ts
+++ b/server/tests/unit/integrity/runner.test.ts
@@ -162,3 +162,56 @@ describe('runOneInvariant', () => {
     expect(report.total_violations).toBe(1);
   });
 });
+
+describe('runAllInvariants — Stripe customer cache sharing', () => {
+  it('allocates a fresh shared Stripe-customer cache for the run, visible to all invariants', async () => {
+    const seenCaches: Array<unknown> = [];
+    const ctx = makeCtx();
+    const invariants: Invariant[] = [
+      {
+        name: 'a',
+        description: 'a',
+        severity: 'info',
+        check: async (innerCtx) => {
+          seenCaches.push(innerCtx.stripeCustomerCache);
+          return { checked: 0, violations: [] };
+        },
+      },
+      {
+        name: 'b',
+        description: 'b',
+        severity: 'info',
+        check: async (innerCtx) => {
+          seenCaches.push(innerCtx.stripeCustomerCache);
+          return { checked: 0, violations: [] };
+        },
+      },
+    ];
+
+    await runAllInvariants(invariants, ctx);
+
+    expect(seenCaches[0]).toBeInstanceOf(Map);
+    expect(seenCaches[0]).toBe(seenCaches[1]); // same Map across invariants in one run
+  });
+
+  it('preserves a caller-supplied cache instead of allocating a new one', async () => {
+    const callerCache = new Map();
+    const seenCaches: Array<unknown> = [];
+    const ctx: InvariantContext = { ...makeCtx(), stripeCustomerCache: callerCache };
+    const invariants: Invariant[] = [
+      {
+        name: 'a',
+        description: 'a',
+        severity: 'info',
+        check: async (innerCtx) => {
+          seenCaches.push(innerCtx.stripeCustomerCache);
+          return { checked: 0, violations: [] };
+        },
+      },
+    ];
+
+    await runAllInvariants(invariants, ctx);
+
+    expect(seenCaches[0]).toBe(callerCache);
+  });
+});

--- a/server/tests/unit/integrity/stripe-helpers.test.ts
+++ b/server/tests/unit/integrity/stripe-helpers.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the Stripe-customer fetch cache used by the integrity invariants.
+ * Three invariants in Phase 1 hit `customers.retrieve` for the same set of
+ * orgs; this cache dedupes those calls within one /check run.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { getStripeCustomerCached, isStripeNotFound } from '../../../src/audit/integrity/stripe-helpers.js';
+import type { InvariantContext } from '../../../src/audit/integrity/types.js';
+
+function makeCtx(retrieve: (id: string) => Promise<unknown>, cache?: Map<string, unknown>): InvariantContext {
+  return {
+    pool: {} as InvariantContext['pool'],
+    workos: {} as InvariantContext['workos'],
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), fatal: vi.fn(), child: vi.fn().mockReturnThis() } as unknown as InvariantContext['logger'],
+    stripe: {
+      customers: { retrieve },
+    } as unknown as InvariantContext['stripe'],
+    stripeCustomerCache: cache as InvariantContext['stripeCustomerCache'],
+  };
+}
+
+describe('getStripeCustomerCached', () => {
+  it('hits Stripe API on first call, caches result for subsequent calls', async () => {
+    const retrieve = vi.fn().mockResolvedValue({ id: 'cus_1', metadata: {} });
+    const cache = new Map();
+    const ctx = makeCtx(retrieve, cache);
+
+    const a = await getStripeCustomerCached(ctx, 'cus_1');
+    const b = await getStripeCustomerCached(ctx, 'cus_1');
+
+    expect(retrieve).toHaveBeenCalledOnce();
+    expect(a).toBe(b);
+    expect(cache.size).toBe(1);
+  });
+
+  it('caches different ids independently', async () => {
+    const retrieve = vi.fn(async (id: string) => ({ id, metadata: {} }));
+    const ctx = makeCtx(retrieve, new Map());
+
+    const a = await getStripeCustomerCached(ctx, 'cus_1');
+    const b = await getStripeCustomerCached(ctx, 'cus_2');
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to direct calls when no cache is provided in context', async () => {
+    const retrieve = vi.fn().mockResolvedValue({ id: 'cus_1', metadata: {} });
+    const ctx = makeCtx(retrieve); // no cache
+
+    await getStripeCustomerCached(ctx, 'cus_1');
+    await getStripeCustomerCached(ctx, 'cus_1');
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failures — next call retries', async () => {
+    const retrieve = vi.fn()
+      .mockRejectedValueOnce(new Error('rate limit'))
+      .mockResolvedValueOnce({ id: 'cus_1', metadata: {} });
+    const cache = new Map();
+    const ctx = makeCtx(retrieve, cache);
+
+    await expect(getStripeCustomerCached(ctx, 'cus_1')).rejects.toThrow('rate limit');
+    expect(cache.size).toBe(0);
+
+    const result = await getStripeCustomerCached(ctx, 'cus_1');
+    expect((result as { id: string }).id).toBe('cus_1');
+    expect(cache.size).toBe(1);
+  });
+});
+
+describe('isStripeNotFound', () => {
+  it('returns true for code=resource_missing', () => {
+    expect(isStripeNotFound({ code: 'resource_missing' })).toBe(true);
+  });
+
+  it('returns true for statusCode=404', () => {
+    expect(isStripeNotFound({ statusCode: 404 })).toBe(true);
+  });
+
+  it('returns false for other shapes', () => {
+    expect(isStripeNotFound({ code: 'rate_limit', statusCode: 429 })).toBe(false);
+    expect(isStripeNotFound(new Error('something'))).toBe(false);
+    expect(isStripeNotFound(null)).toBe(false);
+    expect(isStripeNotFound(undefined)).toBe(false);
+    expect(isStripeNotFound('string')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the immediate scope of #3181 by adding a small framework for cross-system data-integrity invariants, plus the five Phase-1 checks that would have caught the Triton/Encypher incident months before it surfaced.

The framing: WorkOS, Stripe, and AAO Postgres are three independent stores of truth. Today nothing audits whether they agree — webhooks mostly keep things current, but lost events and dashboard-edit drift go undetected. This framework gives each invariant a tiny self-contained shape (\`Invariant.check(ctx) → Violation[]\`) and a runner that orchestrates them, isolates failures, and produces a per-violation report.

## What's in Phase 1

**Module:** \`server/src/audit/integrity/\`
- \`types.ts\` — \`Invariant\`, \`Violation\`, \`InvariantContext\`, \`InvariantRunReport\`
- \`runner.ts\` — \`runAllInvariants(invariants, ctx)\` and \`runOneInvariant(invariant, ctx)\`. Sequential by design; one invariant throwing becomes a meta-violation, doesn't cancel the rest.
- \`invariants/\` — five Phase-1 checks (3 critical, 2 warning)
- \`README.md\` — how to add an invariant

**Five invariants** (severity: criticals are the ones that would have caught Triton):

| Invariant | Severity | Catches |
|---|---|---|
| \`stripe-customer-org-metadata-bidirectional\` | critical | Triton-shape: customer.metadata.workos_organization_id != org.workos_organization_id |
| \`one-active-stripe-sub-per-org\` | critical | Two simultaneous live subs on one customer (the literal Triton incident) |
| \`stripe-customer-resolves\` | critical | Org references a deleted or non-existent Stripe customer |
| \`org-row-matches-live-stripe-sub\` | warning | DB tier/amount/status drift from Stripe (webhook-miss) |
| \`workos-membership-row-exists-in-workos\` | warning, sampled | Stale org_memberships rows from missed delete webhooks |

**Admin endpoints:**
- \`GET /api/admin/integrity/invariants\` — list registered invariants
- \`GET /api/admin/integrity/check\` — run all, return aggregate report
- \`GET /api/admin/integrity/check/:name\` — run one
- All admin-only. \`?sample_size=N\` and \`?since=ISO8601\` query params for tunables.

## Tests

- 29 unit tests across runner + 5 invariants. Each test mocks the \`InvariantContext\` (DB pool, Stripe, WorkOS) so invariants can be exercised in isolation.
- Each invariant has explicit happy-path and failure-mode coverage. The Triton failure mode (\`one-active-stripe-sub-per-org\` with two live subs) is asserted directly.

## Phase 2 (separate PR, scoped in the design doc)

- Scheduled runs via the existing \`server/src/addie/jobs/scheduler.ts\` framework
- Persisted reports in an \`integrity_runs\` / \`integrity_violations\` table
- Slack alerting via \`notifySystemError\` on critical violations
- Admin dashboard page (\`/admin/integrity\`)
- Stripe Customer Portal config invariant (the original narrow #3181 ask — checking that grandfathered prices aren't exposed in \`subscription_update.products\`)

## Phase 3+ (file as separate)

- Webhook-miss detection (compare Stripe event log to local idempotency-token log)
- Auto-quarantine for criticals (pause billing intake until violation clears)
- Inverse walk: enumerate Stripe customers / WorkOS orgs to catch *orphans* (entities in external store with no AAO row)
- One-click admin remediation for common violation shapes

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:server-unit\` — 122/123 files pass (1 skipped, no failures)
- [ ] Manual: run \`GET /api/admin/integrity/check\` against staging; confirm no critical violations on a healthy fleet
- [ ] Manual: run \`GET /api/admin/integrity/check/one-active-stripe-sub-per-org\` against staging; sanity check timing (~30s for full Stripe enumeration is normal)

## References

- Issue #3181 — original narrow ask, expanded scope
- PR #3142 — issuer-identity lockdown
- PR #3171 — duplicate-subscription guard
- PR #3183 — concurrent-intake advisory lock (separate, in flight)
- Triton/Encypher incident (Apr 2026) — root motivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)