### PR TITLE
fix(schema): clarify policies_evaluated includes inline policy IDs

### DIFF
--- a/.changeset/fix-policies-evaluated-description.md
+++ b/.changeset/fix-policies-evaluated-description.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify `policies_evaluated` description in `check-governance-response.json` and `get-plan-audit-logs-response.json`. The previous wording ("Registry policy IDs...") incorrectly implied only registry-resolved IDs are valid; governance agents also record inline `policy_id`s from `custom_policies`. Both schemas carry `x-status: experimental`. Description-only correction; no type, enum, or wire change.

--- a/.changeset/fix-policies-evaluated-description.md
+++ b/.changeset/fix-policies-evaluated-description.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Clarify `policies_evaluated` description in `check-governance-response.json` and `get-plan-audit-logs-response.json`. The previous wording ("Registry policy IDs...") incorrectly implied only registry-resolved IDs are valid; governance agents also record inline `policy_id`s from `custom_policies`. Both schemas carry `x-status: experimental`. Description-only correction; no type, enum, or wire change.
+Clarify `policies_evaluated` description in `check-governance-response.json` and `get-plan-audit-logs-response.json`. The previous wording ("Registry policy IDs...") was incomplete and misleading: governance agents also record inline `policy_id`s from `custom_policies` in this field, and a consumer reading the description literally could write a parser that filters them out. The new wording names both sources. Both schemas carry `x-status: experimental`. Description-only clarification; no type, enum, or wire change.

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -127,7 +127,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Registry policy IDs evaluated during this check."
+      "description": "Policy IDs evaluated during this check. Includes registry policy IDs (resolved via the policy registry) and any inline `policy_id`s declared in the plan's `custom_policies`."
     },
     "mode": {
       "$ref": "/schemas/enums/governance-mode.json",

--- a/static/schemas/source/governance/get-plan-audit-logs-response.json
+++ b/static/schemas/source/governance/get-plan-audit-logs-response.json
@@ -280,7 +280,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Registry policy IDs evaluated during this check (present for check entries)."
+                  "description": "Policy IDs evaluated during this check. Includes registry policy IDs (resolved via the policy registry) and any inline `policy_id`s declared in the plan's `custom_policies`. Present for check entries."
                 },
                 "categories_evaluated": {
                   "type": "array",


### PR DESCRIPTION
Closes #3197

Both `check-governance-response.json` and `get-plan-audit-logs-response.json` described `policies_evaluated[]` as "Registry policy IDs evaluated during this check." That wording is **incomplete and misleading** — not factually wrong. Registry IDs *are* recorded there, but governance agents also record inline `policy_id`s from `custom_policies[]` in the same field, and the schema's `items: { type: string }` doesn't constrain the value to a registry pattern. A consumer reading the description literally could write a parser that filters inline IDs out, silently discarding legitimate audit data. The surrounding `findings[].policy_id` `$comment` already acknowledges this dual sourcing (see #2685).

This PR corrects both descriptions to name both sources, using stable prose ("resolved via the policy registry") rather than a hardcoded endpoint path.

**Non-breaking justification:** Description-only change to two fields typed `array of string`. No type, enum, required/optional, or default change. Both schemas carry `"x-status": "experimental"`. Existing producers that only emit registry IDs remain valid; existing consumers are unaffected.

**Routing note:** No `3.0.x` patch branch exists for v3. This targets `main`; @bokelley should confirm whether it rolls into 3.1.0 or a patch branch should be cut. Changeset is `patch` per the description-clarification rule.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on changeset body wording and endpoint path (both addressed)
- ad-tech-protocol-expert: approved — description accurate, removed hardcoded `/api/policies/resolve` path per nit; notes portfolio `shared_exclusions` is a follow-on edge case, not a blocker

Session: https://claude.ai/code/session_019ifGJSzvNENp17eN8BS15Y