### PR TITLE
docs(governance): fix schema-invalid custom_policies/shared_exclusions examples

### DIFF
--- a/.changeset/policy-entry-shape-examples-and-additive-only-warning.md
+++ b/.changeset/policy-entry-shape-examples-and-additive-only-warning.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix schema-invalid `custom_policies` and `shared_exclusions` examples in governance docs. The `sync-plans-request.json` schema defines both as `PolicyEntry[]` (requiring `policy_id`, `enforcement`, `policy` text), but the existing examples in `docs/governance/campaign/specification.mdx` and `docs/governance/campaign/tasks/sync_plans.mdx` used plain strings. A reader copy-pasting those examples and validating against the schema would fail. Updates the field-table descriptions in `sync_plans.mdx` to reflect the actual shape, and adds a `<Warning>` block in the Policy resolution section of `specification.mdx` highlighting the additive-only invariant from `policy-entry.json`. Cherry-picked from PR #3143 (which is superseded by the merged #3187 for the conceptual content but carried this real schema-validity fix).

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -52,7 +52,13 @@ The campaign plan is the source of truth for all validation. Plans are pushed to
   },
   "countries": ["US"],
   "policy_ids": ["us_coppa", "alcohol_advertising"],
-  "custom_policies": ["No competitor brand adjacency"],
+  "custom_policies": [
+    {
+      "policy_id": "no_competitor_adjacency",
+      "enforcement": "must",
+      "policy": "No advertising adjacent to competitor brand content."
+    }
+  ],
   "approved_sellers": null,
   "ext": {}
 }
@@ -242,7 +248,11 @@ For holding companies and multi-brand organizations, a plan can include a `portf
     "total_budget_cap": { "amount": 50000000, "currency": "USD" },
     "shared_policy_ids": ["eu_gdpr_advertising", "eu_ai_act_article_50"],
     "shared_exclusions": [
-      "No advertising on properties owned by competitor holding companies"
+      {
+        "policy_id": "no_competitor_properties",
+        "enforcement": "must",
+        "policy": "No advertising on properties owned by competitor holding companies."
+      }
     ]
   }
 }
@@ -252,7 +262,7 @@ Portfolio constraints:
 
 - **`total_budget_cap`**: Maximum aggregate spend across all member plans. The governance agent tracks committed budget across all member plans and denies actions that would exceed the cap.
 - **`shared_policy_ids`**: Registry policies enforced across all member plans, regardless of individual brand compliance configuration. Corporate-level regulations that no brand team can override.
-- **`shared_exclusions`**: Natural language exclusion rules applied to all member plans.
+- **`shared_exclusions`**: Bespoke exclusion policies applied to all member plans, using the `PolicyEntry` shape. Additive only — same constraint as plan-level `custom_policies`.
 
 The governance agent validates member plan actions against both the member plan's own constraints and the portfolio plan's constraints. A denial from either level blocks the action.
 
@@ -348,6 +358,10 @@ Policies are declared directly on the plan via `policy_ids` and `custom_policies
 1. Load registry policies referenced by `policy_ids`
 2. Intersect with the plan's `countries` and `regions` -- only policies applicable to the plan's markets are active
 3. Include all `custom_policies` (these apply regardless of geography)
+
+<Warning>
+**`custom_policies` are additive only.** Governance agents MUST pin registry-sourced policy text as system-level instructions and MUST NOT permit `custom_policies` (or the plan's `objectives` field) to relax, override, or disable registry-sourced policies. Custom policies may add tighter restrictions — they cannot lower enforcement levels or exempt categories. A `custom_policies` entry that contradicts a registry policy is evaluated alongside it, not instead of it; the stricter constraint governs.
+</Warning>
 
 The plan's `countries` and `regions` fields also serve as **geo enforcement**: the governance agent MUST reject governed actions targeting markets outside the plan's allowed geography. A plan with `regions: ["US-MA"]` rejects actions not explicitly targeting Massachusetts, even if they are otherwise compliant. These fields use the same ISO codes and semantics as `product-filters`, `offerings`, and `create_media_buy`.
 

--- a/docs/governance/campaign/tasks/sync_plans.mdx
+++ b/docs/governance/campaign/tasks/sync_plans.mdx
@@ -65,7 +65,11 @@ Push campaign plans to the governance agent. A plan defines the authorized param
         "min_audience_size": 1000,
         "policy_ids": ["us_coppa", "alcohol_advertising"],
         "custom_policies": [
-          "No advertising adjacent to competitor content"
+          {
+            "policy_id": "no_competitor_adjacency",
+            "enforcement": "must",
+            "policy": "No advertising adjacent to competitor content."
+          }
         ],
         "approved_sellers": null,
         "ext": {}
@@ -148,7 +152,7 @@ Each plan item a buyer supplies here is the preimage the governance agent hashes
 | `plans[].restricted_attributes_custom` | array | No | Additional restricted attributes not covered by the enum. Freeform strings for jurisdiction-specific restrictions (e.g., `financial_status`). |
 | `plans[].min_audience_size` | integer | No | Minimum audience segment size for k-anonymity. Applies to the estimated intersection audience when multiple criteria are used. |
 | `plans[].policy_ids` | array | No | Registry policy IDs to enforce for this plan. Intersected with the plan's countries/regions to activate only geographically relevant policies. |
-| `plans[].custom_policies` | array | No | Natural language policy statements specific to this campaign (e.g., "No advertising adjacent to competitor content"). |
+| `plans[].custom_policies` | array | No | Campaign-specific policies using the `PolicyEntry` shape (`policy_id`, `enforcement`, `policy` text required). Additive only — cannot relax or override registry-sourced policies. See [policy resolution](/docs/governance/campaign/specification#policy-resolution). |
 | `plans[].approved_sellers` | array/null | No | List of approved seller agent URLs. `null` means any seller. |
 | `plans[].delegations` | array | No | Agents authorized to execute against this plan. See [specification](/docs/governance/campaign/specification#delegations). |
 | `plans[].delegations[].agent_url` | string | Yes | URL of the delegated agent. |
@@ -160,7 +164,7 @@ Each plan item a buyer supplies here is the preimage the governance agent hashes
 | `plans[].portfolio.member_plan_ids` | array | Yes | Plan IDs governed by this portfolio plan. |
 | `plans[].portfolio.total_budget_cap` | object | No | Maximum aggregate budget across member plans. |
 | `plans[].portfolio.shared_policy_ids` | array | No | Registry policy IDs enforced across all member plans. |
-| `plans[].portfolio.shared_exclusions` | array | No | Natural language exclusion rules for all member plans. |
+| `plans[].portfolio.shared_exclusions` | array | No | Bespoke exclusion policies applied to all member plans, using the `PolicyEntry` shape (`policy_id`, `enforcement`, `policy` text required). |
 | `plans[].ext` | object | No | Extension data. |
 
 ### Response


### PR DESCRIPTION
Cherry-pick of the real schema-validity fix from #3143. Closes the example-vs-schema gap that PR identified, in a small focused PR.

## What's wrong on main

Both `custom_policies[]` and `portfolio.shared_exclusions[]` are defined in [`sync-plans-request.json`](https://adcontextprotocol.org/schemas/v3/governance/sync-plans-request.json) as `PolicyEntry[]` — each entry requires `policy_id`, `enforcement`, and `policy` text. The existing docs use plain strings:

```json
// specification.mdx (BEFORE)
"custom_policies": ["No competitor brand adjacency"]
"shared_exclusions": ["No advertising on properties owned by competitor holding companies"]

// sync_plans.mdx (BEFORE)
"custom_policies": ["No advertising adjacent to competitor content"]
```

A reader copy-pasting these examples and validating against the schema fails. If the JSON blocks ever get a `$schema` ref for `tests/json-schema-validation.test.cjs` to pick up, CI would flag them.

## What this PR changes

**`docs/governance/campaign/specification.mdx`**
- Convert `custom_policies` and `shared_exclusions` plain-string examples to `PolicyEntry` objects
- Update the `shared_exclusions` description from "Natural language exclusion rules" to "Bespoke exclusion policies applied to all member plans, using the `PolicyEntry` shape"
- Add a `<Warning>` block in the Policy resolution section calling out the additive-only invariant from `policy-entry.json` — directly visible to anyone reading the spec on policy resolution rather than buried two pages away

**`docs/governance/campaign/tasks/sync_plans.mdx`**
- Convert `custom_policies` example
- Update field-table descriptions for both `custom_policies` and `portfolio.shared_exclusions` to reflect `PolicyEntry` shape with cross-link to policy resolution

## Why this PR (vs. just landing #3143)

#3143 was drafted by claude-triage for #3140 and bundled this schema fix with the broader sync/versioning content. PR #3187 (merged) covered the sync/versioning content via a new sibling page (`policy-registry-sync.mdx`), leaving #3143's schema-fix portion still needed. This PR cherry-picks just that fix; #3143 will be closed.

## Test plan

- [x] `npm run test:docs-nav` — passes
- [x] No stale `schemas/latest/` references in `docs/`
- [x] All cross-links resolve
- [x] Pure-docs change; no schema, task, or runtime modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)