### PR TITLE
fix(admin): detect Stripe orphan customers by email/name, not just metadata

### DIFF
--- a/.changeset/fix-stripe-orphan-customer-detection.md
+++ b/.changeset/fix-stripe-orphan-customer-detection.md
@@ -1,0 +1,9 @@
+---
+---
+
+Extend Stripe duplicate customer detector to find orphan customers by email or name+active-subscription, in addition to the existing metadata-based detection.
+
+- `findStripeCustomerMismatches()` now returns `match_reason: 'metadata' | 'email' | 'name'` on each result
+- A single Stripe customer scan (replacing two sequential scans) covers all three detection strategies
+- Admin UI and resolve endpoint field renamed `stripe_metadata_customer_id` → `orphan_customer_id`
+- "Both customers have activity" 400 error now includes actionable Stripe steps

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -384,16 +384,16 @@
         <button class="btn btn-secondary" id="auto-resolve-btn" style="display: none;" onclick="autoResolveAll()">Auto-Resolve Safe</button>
       </div>
       <div class="conflict-info-box">
-        A mismatch occurs when an organization has a Stripe customer in our database, but a <strong>different</strong> Stripe customer's metadata claims to belong to that same organization. This typically means the org has multiple Stripe customers (duplicate accounts).<br><br>
+        A mismatch occurs when an organization has a Stripe customer in our database, but a second duplicate customer exists in Stripe for the same org — detected by matching metadata, email address, or customer name with an active subscription. This typically means the org has multiple Stripe customers (duplicate accounts).<br><br>
         <strong>Auto-resolve:</strong> If only one customer has activity (invoices/subscriptions), the inactive one can be safely archived.
       </div>
       <table class="conflicts-table">
         <thead>
           <tr>
             <th>Organization</th>
-            <th>DB Customer</th>
-            <th>Metadata Customer</th>
-            <th>Suggested Action</th>
+            <th>Linked customer</th>
+            <th>Orphan customer</th>
+            <th>Suggested action</th>
           </tr>
         </thead>
         <tbody id="mismatches-body">
@@ -955,14 +955,15 @@
 
       tbody.innerHTML = allMismatches.map((mismatch, index) => {
         const dbActivity = mismatch.db_customer;
-        const metadataActivity = mismatch.metadata_customer;
+        const orphanActivity = mismatch.orphan_customer;
         const suggestedAction = mismatch.suggested_action;
         const canAutoResolve = mismatch.can_auto_resolve;
 
-        // Determine which customer should be highlighted as "keep" vs "remove"
         const dbIsKeep = suggestedAction === 'use_db';
-        const metadataIsKeep = suggestedAction === 'use_stripe_metadata';
+        const orphanIsKeep = suggestedAction === 'use_stripe_metadata';
         const needsManualReview = suggestedAction === 'manual_review';
+
+        const matchReasonLabel = { metadata: 'Matched by metadata', email: 'Matched by email', name: 'Matched by name' }[mismatch.match_reason] || escapeHtml(String(mismatch.match_reason ?? ''));
 
         let actionHtml = '';
         if (needsManualReview) {
@@ -971,19 +972,19 @@
               Manual review required
             </div>
             <div style="font-size: 11px; color: var(--color-text-muted); margin-bottom: 8px;">
-              Both customers have activity. Review in Stripe to decide.
+              Both customers have activity. In Stripe: cancel the subscription on the customer you want to remove, void any open invoices, then retry.
             </div>
-            <button class="btn btn-secondary btn-sm" onclick="resolveMismatch(${index}, 'use_db', false)" title="Keep DB customer">
-              Keep DB
+            <button class="btn btn-secondary btn-sm" onclick="resolveMismatch(${index}, 'use_db', false)" title="Keep linked customer">
+              Keep linked
             </button>
-            <button class="btn btn-secondary btn-sm" onclick="resolveMismatch(${index}, 'use_stripe_metadata', false)" title="Keep Metadata customer">
-              Keep Metadata
+            <button class="btn btn-secondary btn-sm" onclick="resolveMismatch(${index}, 'use_stripe_metadata', false)" title="Keep orphan customer">
+              Keep orphan
             </button>
           `;
         } else if (canAutoResolve) {
           const action = suggestedAction;
-          const keepId = action === 'use_db' ? mismatch.db_customer_id : mismatch.stripe_metadata_customer_id;
-          const deleteId = action === 'use_db' ? mismatch.stripe_metadata_customer_id : mismatch.db_customer_id;
+          const keepId = action === 'use_db' ? mismatch.db_customer_id : mismatch.orphan_customer_id;
+          const deleteId = action === 'use_db' ? mismatch.orphan_customer_id : mismatch.db_customer_id;
           actionHtml = `
             <div style="color: var(--color-success-600); font-weight: 500; margin-bottom: 8px;">
               Safe to auto-resolve
@@ -992,10 +993,10 @@
               Keep ${keepId.slice(-8)}, delete ${deleteId.slice(-8)}
             </div>
             <button class="btn btn-primary btn-sm" onclick="resolveMismatch(${index}, '${action}', true)" title="Keep active customer, delete inactive one">
-              Resolve & Delete
+              Resolve &amp; delete
             </button>
             <button class="btn btn-secondary btn-sm" onclick="resolveMismatch(${index}, '${action}', false)" title="Keep active customer, just clear metadata from other">
-              Resolve Only
+              Resolve only
             </button>
           `;
         } else {
@@ -1009,14 +1010,15 @@
         return `
           <tr data-index="${index}" style="${canAutoResolve ? 'background: var(--color-success-50);' : needsManualReview ? 'background: var(--color-error-50);' : ''}">
             <td>
-              <div><strong>${mismatch.org_name}</strong></div>
-              <div style="font-size: 11px; color: var(--color-text-muted);">${mismatch.org_id}</div>
+              <div><strong>${escapeHtml(mismatch.org_name)}</strong></div>
+              <div style="font-size: 11px; color: var(--color-text-muted);">${escapeHtml(mismatch.org_id)}</div>
+              <div style="font-size: 11px; margin-top: 4px;"><span class="badge badge-gray">${matchReasonLabel}</span></div>
             </td>
             <td style="border-left: 3px solid ${dbIsKeep ? 'var(--color-success-500)' : 'var(--color-gray-200)'};">
               <div style="margin-bottom: 4px;">
                 <strong>${mismatch.db_customer_id}</strong>
                 <span class="badge badge-success">Linked</span>
-                ${dbActivity?.has_activity ? '<span class="badge badge-warning">Has Activity</span>' : ''}
+                ${dbActivity?.has_activity ? '<span class="badge badge-warning">Has activity</span>' : ''}
               </div>
               <div style="font-size: 11px; margin-bottom: 4px;">
                 ${renderCustomerActivity(dbActivity, dbActivity?.has_activity)}
@@ -1027,17 +1029,17 @@
                 </a>
               </div>
             </td>
-            <td style="border-left: 3px solid ${metadataIsKeep ? 'var(--color-success-500)' : 'var(--color-gray-200)'};">
+            <td style="border-left: 3px solid ${orphanIsKeep ? 'var(--color-success-500)' : 'var(--color-gray-200)'};">
               <div style="margin-bottom: 4px;">
-                <strong>${mismatch.stripe_metadata_customer_id}</strong>
-                <span class="badge badge-gray">Metadata</span>
-                ${metadataActivity?.has_activity ? '<span class="badge badge-warning">Has Activity</span>' : ''}
+                <strong>${mismatch.orphan_customer_id}</strong>
+                <span class="badge badge-gray">Orphan</span>
+                ${orphanActivity?.has_activity ? '<span class="badge badge-warning">Has activity</span>' : ''}
               </div>
               <div style="font-size: 11px; margin-bottom: 4px;">
-                ${renderCustomerActivity(metadataActivity, metadataActivity?.has_activity)}
+                ${renderCustomerActivity(orphanActivity, orphanActivity?.has_activity)}
               </div>
               <div style="font-size: 11px;">
-                <a href="https://dashboard.stripe.com/customers/${mismatch.stripe_metadata_customer_id}" target="_blank" rel="noopener" style="color: var(--color-brand);">
+                <a href="https://dashboard.stripe.com/customers/${mismatch.orphan_customer_id}" target="_blank" rel="noopener" style="color: var(--color-brand);">
                   View in Stripe &rarr;
                 </a>
               </div>
@@ -1052,8 +1054,8 @@
 
     async function resolveMismatch(index, action, deleteInactive = false) {
       const mismatch = allMismatches[index];
-      const keepCustomer = action === 'use_db' ? mismatch.db_customer_id : mismatch.stripe_metadata_customer_id;
-      const removeCustomer = action === 'use_db' ? mismatch.stripe_metadata_customer_id : mismatch.db_customer_id;
+      const keepCustomer = action === 'use_db' ? mismatch.db_customer_id : mismatch.orphan_customer_id;
+      const removeCustomer = action === 'use_db' ? mismatch.orphan_customer_id : mismatch.db_customer_id;
 
       const confirmMsg = deleteInactive
         ? `Keep ${keepCustomer} for "${mismatch.org_name}"?\n\nThe inactive customer (${removeCustomer}) will be DELETED from Stripe.`
@@ -1071,7 +1073,7 @@
             org_id: mismatch.org_id,
             action: action,
             delete_inactive: deleteInactive,
-            stripe_metadata_customer_id: mismatch.stripe_metadata_customer_id,
+            orphan_customer_id: mismatch.orphan_customer_id,
           }),
         });
 
@@ -1117,14 +1119,14 @@
               org_id: mismatch.org_id,
               action: mismatch.suggested_action,
               delete_inactive: true,
-              stripe_metadata_customer_id: mismatch.stripe_metadata_customer_id,
+              orphan_customer_id: mismatch.orphan_customer_id,
             }),
           });
 
           if (response.ok) {
             resolved++;
             // Remove from array
-            const idx = allMismatches.findIndex(m => m.org_id === mismatch.org_id && m.stripe_metadata_customer_id === mismatch.stripe_metadata_customer_id);
+            const idx = allMismatches.findIndex(m => m.org_id === mismatch.org_id && m.orphan_customer_id === mismatch.orphan_customer_id);
             if (idx !== -1) allMismatches.splice(idx, 1);
           } else {
             console.error('Auto-resolve failed for', mismatch.org_name, await response.text());

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -657,6 +657,46 @@ export async function listCustomersWithOrgIds(): Promise<
   }
 }
 
+export interface CustomerDetail {
+  id: string;
+  email: string | null;
+  name: string | null;
+  workosOrgId: string | undefined;
+  hasActiveSubscription: boolean;
+}
+
+/**
+ * List all Stripe customers with details needed for duplicate detection by email/name.
+ * Unlike listCustomersWithOrgIds, returns every customer regardless of metadata.
+ */
+export async function listAllCustomersWithDetails(): Promise<CustomerDetail[]> {
+  if (!stripe) {
+    return [];
+  }
+
+  const results: CustomerDetail[] = [];
+
+  try {
+    for await (const customer of stripe.customers.list({ limit: 100, expand: ['data.subscriptions'] })) {
+      if ('deleted' in customer && customer.deleted) continue;
+      const cust = customer as Stripe.Customer;
+      const hasActiveSubscription =
+        cust.subscriptions?.data.some((s: Stripe.Subscription) => s.status === 'active' || s.status === 'trialing') ?? false;
+      results.push({
+        id: cust.id,
+        email: cust.email ?? null,
+        name: cust.name ?? null,
+        workosOrgId: cust.metadata?.workos_organization_id || undefined,
+        hasActiveSubscription,
+      });
+    }
+    return results;
+  } catch (error) {
+    logger.error({ err: error }, 'Error listing all Stripe customers');
+    return [];
+  }
+}
+
 export interface RevenueEvent {
   workos_organization_id: string;
   stripe_invoice_id: string;

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1,6 +1,6 @@
 import type { PoolClient } from 'pg';
 import { getPool, query } from './client.js';
-import { getStripeSubscriptionInfo, listCustomersWithOrgIds } from '../billing/stripe-client.js';
+import { getStripeSubscriptionInfo, listCustomersWithOrgIds, listAllCustomersWithDetails } from '../billing/stripe-client.js';
 import { WorkOS } from '@workos-inc/node';
 import { createLogger } from '../logger.js';
 import { CompanyTypeValue } from '../config/company-types.js';
@@ -1280,30 +1280,118 @@ export class OrganizationDatabase {
     org_id: string;
     org_name: string;
     db_customer_id: string;
-    stripe_metadata_customer_id: string;
+    orphan_customer_id: string;
+    match_reason: 'metadata' | 'email' | 'name';
   }>> {
-    const mismatches: Array<{
+    type Mismatch = {
       org_id: string;
       org_name: string;
       db_customer_id: string;
-      stripe_metadata_customer_id: string;
-    }> = [];
+      orphan_customer_id: string;
+      match_reason: 'metadata' | 'email' | 'name';
+    };
 
-    // Get all Stripe customers with org metadata
-    const stripeCustomers = await listCustomersWithOrgIds();
+    const mismatches: Mismatch[] = [];
+    // Single Stripe scan — used for all three detection strategies
+    const allCustomers = await listAllCustomersWithDetails();
 
-    for (const { stripeCustomerId, workosOrgId } of stripeCustomers) {
-      const localOrg = await this.getOrganization(workosOrgId);
+    const seen = new Set<string>();
+    const pairKey = (a: string, b: string) => [a, b].sort().join(':');
 
-      // Check if org exists and has a DIFFERENT customer ID than Stripe metadata suggests
-      if (localOrg && localOrg.stripe_customer_id && localOrg.stripe_customer_id !== stripeCustomerId) {
-        // Mismatch: Org has cus_X in DB, but Stripe customer cus_Y claims to belong to this org
-        mismatches.push({
-          org_id: workosOrgId,
-          org_name: localOrg.name,
-          db_customer_id: localOrg.stripe_customer_id,
-          stripe_metadata_customer_id: stripeCustomerId,
-        });
+    // Build reverse map: stripe customer ID → org (from DB)
+    const customerToOrg = new Map<string, string>();
+    const pool = getPool();
+    const orgRows = await pool.query<{ workos_organization_id: string; stripe_customer_id: string }>(
+      `SELECT workos_organization_id, stripe_customer_id FROM organizations WHERE stripe_customer_id IS NOT NULL`
+    );
+    for (const row of orgRows.rows) {
+      customerToOrg.set(row.stripe_customer_id, row.workos_organization_id);
+    }
+
+    // --- Strategy 1: metadata-based ---
+    // Flag any Stripe customer whose metadata points at an org that has a *different* DB customer.
+    for (const c of allCustomers) {
+      if (!c.workosOrgId) continue;
+      const localOrg = await this.getOrganization(c.workosOrgId);
+      if (localOrg && localOrg.stripe_customer_id && localOrg.stripe_customer_id !== c.id) {
+        const key = pairKey(localOrg.stripe_customer_id, c.id);
+        if (!seen.has(key)) {
+          seen.add(key);
+          mismatches.push({
+            org_id: c.workosOrgId,
+            org_name: localOrg.name,
+            db_customer_id: localOrg.stripe_customer_id,
+            orphan_customer_id: c.id,
+            match_reason: 'metadata',
+          });
+        }
+      }
+    }
+
+    // --- Strategies 2 & 3: email and name+active-sub matching ---
+
+    // Build a map from email (lowercase) → customer IDs
+    const byEmail = new Map<string, string[]>();
+    for (const c of allCustomers) {
+      if (c.email) {
+        const key = c.email.toLowerCase();
+        const group = byEmail.get(key) ?? [];
+        group.push(c.id);
+        byEmail.set(key, group);
+      }
+    }
+
+    // Build a map from name (lowercase) → customer IDs, only those with active subs
+    const byNameActiveSub = new Map<string, string[]>();
+    for (const c of allCustomers) {
+      if (c.name && c.hasActiveSubscription) {
+        const key = c.name.toLowerCase();
+        const group = byNameActiveSub.get(key) ?? [];
+        group.push(c.id);
+        byNameActiveSub.set(key, group);
+      }
+    }
+
+    const addEmailOrNameMismatch = async (
+      linkedId: string,
+      orphanId: string,
+      reason: 'email' | 'name'
+    ) => {
+      const key = pairKey(linkedId, orphanId);
+      if (seen.has(key)) return;
+      const orgId = customerToOrg.get(linkedId);
+      if (!orgId) return;
+      const localOrg = await this.getOrganization(orgId);
+      if (!localOrg) return;
+      seen.add(key); // only mark seen after successful resolution
+      mismatches.push({
+        org_id: orgId,
+        org_name: localOrg.name,
+        db_customer_id: linkedId,
+        orphan_customer_id: orphanId,
+        match_reason: reason,
+      });
+    };
+
+    for (const [, group] of byEmail) {
+      if (group.length < 2) continue;
+      const linked = group.filter((id) => customerToOrg.has(id));
+      const orphans = group.filter((id) => !customerToOrg.has(id));
+      for (const linkedId of linked) {
+        for (const orphanId of orphans) {
+          await addEmailOrNameMismatch(linkedId, orphanId, 'email');
+        }
+      }
+    }
+
+    for (const [, group] of byNameActiveSub) {
+      if (group.length < 2) continue;
+      const linked = group.filter((id) => customerToOrg.has(id));
+      const orphans = group.filter((id) => !customerToOrg.has(id));
+      for (const linkedId of linked) {
+        for (const orphanId of orphans) {
+          await addEmailOrNameMismatch(linkedId, orphanId, 'name');
+        }
       }
     }
 

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -1171,26 +1171,23 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       // Enrich each mismatch with activity data from Stripe
       const mismatches = await Promise.all(
         baseMismatches.map(async (mismatch) => {
-          const [dbCustomerActivity, metadataCustomerActivity] = await Promise.all([
+          const [dbCustomerActivity, orphanCustomerActivity] = await Promise.all([
             getCustomerActivity(mismatch.db_customer_id),
-            getCustomerActivity(mismatch.stripe_metadata_customer_id),
+            getCustomerActivity(mismatch.orphan_customer_id),
           ]);
 
           // Determine suggested action based on activity
           let suggested_action: 'use_db' | 'use_stripe_metadata' | 'manual_review' | null = null;
           let can_auto_resolve = false;
 
-          if (dbCustomerActivity && metadataCustomerActivity) {
-            if (dbCustomerActivity.has_activity && !metadataCustomerActivity.has_activity) {
-              // DB customer has activity, metadata customer doesn't - archive metadata customer
+          if (dbCustomerActivity && orphanCustomerActivity) {
+            if (dbCustomerActivity.has_activity && !orphanCustomerActivity.has_activity) {
               suggested_action = 'use_db';
               can_auto_resolve = true;
-            } else if (!dbCustomerActivity.has_activity && metadataCustomerActivity.has_activity) {
-              // Metadata customer has activity, DB customer doesn't - use metadata customer
+            } else if (!dbCustomerActivity.has_activity && orphanCustomerActivity.has_activity) {
               suggested_action = 'use_stripe_metadata';
               can_auto_resolve = true;
-            } else if (dbCustomerActivity.has_activity && metadataCustomerActivity.has_activity) {
-              // Both have activity - needs manual review
+            } else if (dbCustomerActivity.has_activity && orphanCustomerActivity.has_activity) {
               suggested_action = 'manual_review';
               can_auto_resolve = false;
             } else {
@@ -1203,7 +1200,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
           return {
             ...mismatch,
             db_customer: dbCustomerActivity,
-            metadata_customer: metadataCustomerActivity,
+            orphan_customer: orphanCustomerActivity,
             suggested_action,
             can_auto_resolve,
           };
@@ -1231,18 +1228,18 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   /**
    * POST /api/admin/stripe-mismatches/resolve
    * Resolve a Stripe customer mismatch by choosing which customer to keep for an org.
-   * Body: { org_id, action: "use_db" | "use_stripe_metadata", delete_inactive?: boolean, stripe_metadata_customer_id?: string }
+   * Body: { org_id, action: "use_db" | "use_stripe_metadata", delete_inactive?: boolean, orphan_customer_id?: string }
    *
    * - use_db: Keep the customer currently in DB, archive/delete the other customer
-   * - use_stripe_metadata: Use the customer from Stripe metadata, archive/delete the DB customer
+   * - use_stripe_metadata: Use the orphan customer from Stripe, archive/delete the DB customer
    * - delete_inactive: If true, delete the inactive customer in Stripe (only if it has no activity)
-   * - stripe_metadata_customer_id: Target a specific metadata customer (needed when org has 3+ Stripe customers)
+   * - orphan_customer_id: Target a specific orphan customer (needed when org has 3+ Stripe customers)
    *
    * Safety: Will refuse to proceed if both customers have activity (open invoices, subscriptions, paid invoices)
    */
   apiRouter.post("/stripe-mismatches/resolve", requireAuth, requireAdmin, async (req, res) => {
     try {
-      const { org_id, action, delete_inactive, stripe_metadata_customer_id } = req.body;
+      const { org_id, action, delete_inactive, orphan_customer_id } = req.body;
 
       if (!org_id || !action) {
         return res.status(400).json({
@@ -1275,10 +1272,10 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         });
       }
 
-      // Find the specific mismatch for this org (and specific metadata customer if provided)
+      // Find the specific mismatch for this org (and specific orphan customer if provided)
       const mismatches = await orgDb.findStripeCustomerMismatches();
-      const mismatch = stripe_metadata_customer_id
-        ? mismatches.find(m => m.org_id === org_id && m.stripe_metadata_customer_id === stripe_metadata_customer_id)
+      const mismatch = orphan_customer_id
+        ? mismatches.find(m => m.org_id === org_id && m.orphan_customer_id === orphan_customer_id)
         : mismatches.find(m => m.org_id === org_id);
 
       if (!mismatch) {
@@ -1289,25 +1286,25 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       }
 
       // Get activity data for both customers
-      const [dbCustomerActivity, metadataCustomerActivity] = await Promise.all([
+      const [dbCustomerActivity, orphanCustomerActivity] = await Promise.all([
         getCustomerActivity(mismatch.db_customer_id),
-        getCustomerActivity(mismatch.stripe_metadata_customer_id),
+        getCustomerActivity(mismatch.orphan_customer_id),
       ]);
 
       // Safety check: refuse if both have activity
-      if (dbCustomerActivity?.has_activity && metadataCustomerActivity?.has_activity) {
+      if (dbCustomerActivity?.has_activity && orphanCustomerActivity?.has_activity) {
         return res.status(400).json({
           error: "Both customers have activity",
-          message: "Both Stripe customers have activity (invoices/subscriptions). Manual review required - resolve in Stripe dashboard.",
+          message: `Both Stripe customers have activity. To proceed: (1) In the Stripe dashboard, cancel the subscription on the customer you want to remove and void or collect any open invoices. (2) Return here and retry. Linked customer: ${mismatch.db_customer_id}, orphan customer: ${mismatch.orphan_customer_id}.`,
           db_customer: dbCustomerActivity,
-          metadata_customer: metadataCustomerActivity,
+          orphan_customer: orphanCustomerActivity,
         });
       }
 
       // Determine which customer to keep and which to remove
-      const keepCustomerId = action === "use_db" ? mismatch.db_customer_id : mismatch.stripe_metadata_customer_id;
-      const removeCustomerId = action === "use_db" ? mismatch.stripe_metadata_customer_id : mismatch.db_customer_id;
-      const removeCustomerActivity = action === "use_db" ? metadataCustomerActivity : dbCustomerActivity;
+      const keepCustomerId = action === "use_db" ? mismatch.db_customer_id : mismatch.orphan_customer_id;
+      const removeCustomerId = action === "use_db" ? mismatch.orphan_customer_id : mismatch.db_customer_id;
+      const removeCustomerActivity = action === "use_db" ? orphanCustomerActivity : dbCustomerActivity;
 
       // Safety check: if requesting deletion, ensure we could fetch activity data
       if (delete_inactive && !removeCustomerActivity) {

--- a/server/tests/unit/stripe-orphan-detection.test.ts
+++ b/server/tests/unit/stripe-orphan-detection.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as clientModule from '../../src/db/client.js';
+import * as stripeClientModule from '../../src/billing/stripe-client.js';
+
+vi.mock('../../src/db/client.js');
+vi.mock('../../src/billing/stripe-client.js');
+
+// Stub WorkOS to avoid missing env var errors at import time
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const { OrganizationDatabase } = await import('../../src/db/organization-db.js');
+
+describe('findStripeCustomerMismatches — email / name detection', () => {
+  let orgDb: InstanceType<typeof OrganizationDatabase>;
+  let mockPool: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPool = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    };
+    vi.mocked(clientModule.getPool).mockReturnValue(mockPool);
+
+    orgDb = new OrganizationDatabase();
+  });
+
+  it('detects an orphan customer matched by email (ResponsiveAds shape)', async () => {
+    // Metadata scan finds nothing (orphan has no metadata)
+    vi.mocked(stripeClientModule.listCustomersWithOrgIds).mockResolvedValue([]);
+
+    // All-customers scan returns two customers with the same email
+    vi.mocked(stripeClientModule.listAllCustomersWithDetails).mockResolvedValue([
+      {
+        id: 'cus_LINKED',
+        email: 'matt@responsiveads.com',
+        name: 'Acme Corp',
+        workosOrgId: 'org_ABC',
+        hasActiveSubscription: true,
+      },
+      {
+        id: 'cus_ORPHAN',
+        email: 'Matt@responsiveads.com', // different case — still a match
+        name: 'Acme Corp',
+        workosOrgId: undefined,
+        hasActiveSubscription: true,
+      },
+    ]);
+
+    // DB: linked customer for org_ABC
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_ABC', stripe_customer_id: 'cus_LINKED' }],
+    });
+
+    // getOrganization for org_ABC
+    vi.spyOn(orgDb as any, 'getOrganization').mockResolvedValue({
+      workos_organization_id: 'org_ABC',
+      name: 'Acme Corp',
+      stripe_customer_id: 'cus_LINKED',
+    });
+
+    const mismatches = await orgDb.findStripeCustomerMismatches();
+
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0]).toMatchObject({
+      org_id: 'org_ABC',
+      db_customer_id: 'cus_LINKED',
+      orphan_customer_id: 'cus_ORPHAN',
+      match_reason: 'email',
+    });
+  });
+
+  it('deduplicates: metadata match is not also reported as email match', async () => {
+    // Metadata scan finds the mismatch
+    vi.mocked(stripeClientModule.listCustomersWithOrgIds).mockResolvedValue([
+      { stripeCustomerId: 'cus_META', workosOrgId: 'org_XYZ' },
+    ]);
+
+    vi.mocked(stripeClientModule.listAllCustomersWithDetails).mockResolvedValue([
+      {
+        id: 'cus_DB',
+        email: 'shared@example.com',
+        name: 'Pinnacle Media',
+        workosOrgId: 'org_XYZ',
+        hasActiveSubscription: false,
+      },
+      {
+        id: 'cus_META',
+        email: 'shared@example.com',
+        name: 'Pinnacle Media',
+        workosOrgId: 'org_XYZ', // has metadata but different from DB
+        hasActiveSubscription: false,
+      },
+    ]);
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_XYZ', stripe_customer_id: 'cus_DB' }],
+    });
+
+    vi.spyOn(orgDb as any, 'getOrganization').mockResolvedValue({
+      workos_organization_id: 'org_XYZ',
+      name: 'Pinnacle Media',
+      stripe_customer_id: 'cus_DB',
+    });
+
+    const mismatches = await orgDb.findStripeCustomerMismatches();
+
+    // Only one mismatch, reported as metadata, not duplicated as email
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0].match_reason).toBe('metadata');
+  });
+
+  it('detects orphan matched by name + active subscription', async () => {
+    vi.mocked(stripeClientModule.listCustomersWithOrgIds).mockResolvedValue([]);
+
+    vi.mocked(stripeClientModule.listAllCustomersWithDetails).mockResolvedValue([
+      {
+        id: 'cus_LINKED2',
+        email: null,
+        name: 'Nova Brands',
+        workosOrgId: 'org_NB',
+        hasActiveSubscription: true,
+      },
+      {
+        id: 'cus_ORPHAN2',
+        email: null,
+        name: 'Nova Brands',
+        workosOrgId: undefined,
+        hasActiveSubscription: true,
+      },
+    ]);
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_NB', stripe_customer_id: 'cus_LINKED2' }],
+    });
+
+    vi.spyOn(orgDb as any, 'getOrganization').mockResolvedValue({
+      workos_organization_id: 'org_NB',
+      name: 'Nova Brands',
+      stripe_customer_id: 'cus_LINKED2',
+    });
+
+    const mismatches = await orgDb.findStripeCustomerMismatches();
+
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0]).toMatchObject({
+      orphan_customer_id: 'cus_ORPHAN2',
+      match_reason: 'name',
+    });
+  });
+
+  it('ignores name matches where orphan has no active subscription', async () => {
+    vi.mocked(stripeClientModule.listCustomersWithOrgIds).mockResolvedValue([]);
+
+    vi.mocked(stripeClientModule.listAllCustomersWithDetails).mockResolvedValue([
+      {
+        id: 'cus_LINKED3',
+        email: null,
+        name: 'StreamHaus',
+        workosOrgId: 'org_SH',
+        hasActiveSubscription: true,
+      },
+      {
+        id: 'cus_STALE',
+        email: null,
+        name: 'StreamHaus',
+        workosOrgId: undefined,
+        hasActiveSubscription: false, // no active sub — should not be flagged by name
+      },
+    ]);
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ workos_organization_id: 'org_SH', stripe_customer_id: 'cus_LINKED3' }],
+    });
+
+    const mismatches = await orgDb.findStripeCustomerMismatches();
+
+    expect(mismatches).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #3200

`findStripeCustomerMismatches()` previously only surfaced duplicate Stripe customers when the orphan had `metadata.workos_organization_id` pointing at the org. Orphan customers created via legacy invoice flows or before the org link was established were invisible to `/admin/stripe-mismatches` and to the Addie cleanup tooling. This caused a production incident where a customer was about to be billed twice.

**Changes:**

- `stripe-client.ts`: New `listAllCustomersWithDetails()` — single Stripe pagination returning all customers with id/email/name/workosOrgId/hasActiveSubscription. Replaces the two-call pattern that previously ran `listCustomersWithOrgIds()` (metadata scan) followed by a second full traversal.
- `organization-db.ts`: Extended `findStripeCustomerMismatches()` with three detection strategies sharing one Stripe scan — (1) metadata-based (existing logic), (2) email match (case-insensitive), (3) name + both have active subscription. Returns `match_reason: 'metadata' | 'email' | 'name'` on each result. Field renamed `stripe_metadata_customer_id` → `orphan_customer_id`.
- `billing.ts`: Route updated for renamed field. "Both have activity" 400 error now names the specific Stripe steps (cancel sub, void invoice) so the operator knows what to do next.
- `admin-billing.html`: Column headers updated ("Linked customer" / "Orphan customer"), `match_reason` badge shown per row, manual-review guidance updated with actionable Stripe steps. XSS-safe: `org_name`, `org_id`, and the `match_reason` fallback are wrapped in `escapeHtml()`.
- `stripe-orphan-detection.test.ts`: Unit tests covering email match (ResponsiveAds shape), metadata dedup, name+active-sub match, and name-only-no-active-sub non-match.

**Non-breaking justification:** All changes are to internal admin-only endpoints (`requireAdmin` gated). Adding `match_reason` to the response is additive. The `stripe_metadata_customer_id` → `orphan_customer_id` rename is across the admin route + HTML simultaneously; no external callers.

**Known nit (not fixed):** Action value string `use_stripe_metadata` vs. button label "Keep orphan" — these are wire-protocol vs. display concerns and diverge intentionally. The action string is surfaced only in server logs; the label is display-only. Will align in a follow-up if audit log UI is added.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

**Pre-PR review:**
- code-reviewer: approved — XSS fixes applied, `seen.add` moved after successful push, double-pagination collapsed, changeset added; 1 nit (test coverage for null `getOrganization` in `addEmailOrNameMismatch`, not blocking)
- internal-tools-strategist: approved — double scan blocker fixed; nits documented in PR body above

Session: https://claude.ai/code/session_01FWt81QmLXAtRjkpKN9apoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWt81QmLXAtRjkpKN9apoF)_