### PR TITLE
fix(admin): expose stripe_subscription_id and price_lookup_key in GET /accounts/:orgId

### DIFF
--- a/.changeset/fix-admin-stripe-subscription-id-response.md
+++ b/.changeset/fix-admin-stripe-subscription-id-response.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix admin GET /accounts/:orgId not returning stripe_subscription_id and price_lookup_key in the subscription object. Both fields were written to the DB correctly by the webhook handler but were omitted from the response builder, causing operators to misread subscription state after cleanup operations.

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -835,16 +835,18 @@ export function setupAccountRoutes(
               }
             : null,
 
-          // Subscription details (for members)
+          // Subscription details
           subscription: org.subscription_status
             ? {
                 status: org.subscription_status,
+                stripe_subscription_id: org.stripe_subscription_id || null,
                 product_name: org.subscription_product_name,
                 amount: org.subscription_amount,
                 interval: org.subscription_interval,
                 currency: org.subscription_currency,
                 current_period_end: org.subscription_current_period_end,
                 canceled_at: org.subscription_canceled_at,
+                price_lookup_key: org.subscription_price_lookup_key || null,
               }
             : null,
 

--- a/server/tests/integration/admin-endpoints.test.ts
+++ b/server/tests/integration/admin-endpoints.test.ts
@@ -552,6 +552,59 @@ describe('Admin Endpoints Integration Tests', () => {
     });
   });
 
+  describe('GET /api/admin/accounts/:orgId (subscription fields)', () => {
+    const SUB_TEST_ORG_ID = 'org_sub_field_test';
+
+    beforeEach(async () => {
+      await pool.query(
+        `INSERT INTO organizations (
+           workos_organization_id, name, stripe_customer_id,
+           subscription_status, stripe_subscription_id, subscription_price_lookup_key,
+           subscription_product_name, subscription_amount, subscription_interval,
+           subscription_currency, created_at, updated_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO UPDATE SET
+           subscription_status = $4, stripe_subscription_id = $5,
+           subscription_price_lookup_key = $6`,
+        [
+          SUB_TEST_ORG_ID, 'Sub Field Test Org', 'cus_sub_field_test',
+          'active', 'sub_test123', 'member_annual',
+          'AgenticAdvertising.org Membership', 29900, 'year', 'usd',
+        ]
+      );
+    });
+
+    afterEach(async () => {
+      await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [SUB_TEST_ORG_ID]);
+    });
+
+    it('should include stripe_subscription_id and price_lookup_key in subscription object', async () => {
+      const response = await request(app)
+        .get(`/api/admin/accounts/${SUB_TEST_ORG_ID}`)
+        .expect(200);
+
+      expect(response.body.subscription).not.toBeNull();
+      expect(response.body.subscription.stripe_subscription_id).toBe('sub_test123');
+      expect(response.body.subscription.price_lookup_key).toBe('member_annual');
+    });
+
+    it('should return null (not undefined) for stripe fields when absent in DB', async () => {
+      await pool.query(
+        `UPDATE organizations SET stripe_subscription_id = NULL, subscription_price_lookup_key = NULL
+         WHERE workos_organization_id = $1`,
+        [SUB_TEST_ORG_ID]
+      );
+      const response = await request(app)
+        .get(`/api/admin/accounts/${SUB_TEST_ORG_ID}`)
+        .expect(200);
+
+      expect(Object.prototype.hasOwnProperty.call(response.body.subscription, 'stripe_subscription_id')).toBe(true);
+      expect(response.body.subscription.stripe_subscription_id).toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(response.body.subscription, 'price_lookup_key')).toBe(true);
+      expect(response.body.subscription.price_lookup_key).toBeNull();
+    });
+  });
+
   describe('Admin page routes (redirect regression)', () => {
     it('GET /admin/accounts should serve HTML, not redirect', async () => {
       const response = await request(app)


### PR DESCRIPTION
Closes #3210

The `subscription` object in `GET /api/admin/accounts/:orgId` was omitting `stripe_subscription_id` and `price_lookup_key` even though both fields exist on the `org` row (`SELECT o.*`). The webhook handler and manual-link route write them correctly; the response builder at `server/src/routes/admin/accounts.ts:838–849` was the gap. This caused operators to see `stripe_subscription_id: undefined` after a cleanup, making it look like the webhook hadn't fired even when the DB state was correct.

**Non-breaking justification:** adds two optional fields to an admin-only JSON response; no schema migration, no client contract change, no downstream required-field shift.

**Pre-PR review:**
- code-reviewer: approved — no security or correctness blockers; SQL in tests is fully parameterized
- internal-tools-strategist: approved after `?? null` → `|| null` fix to match the established Stripe-ID coercion pattern in this file; both new fields now use `|| null` consistent with `stripe_coupon_id`/`stripe_promotion_code` on line 855

**Notes:**
- The existing `subscription_status ? { ... } : null` guard means fields are hidden when `subscription_status` is NULL. An org where `subscription_status` was cleared but `stripe_subscription_id` is still set would return `subscription: null`. This is an edge case not covered by the reported bug (all audit orgs had a truthy `subscription_status`). Left as a follow-up to avoid scope creep; noted here for the reviewer.
- Five other fields in the subscription object (`product_name`, `amount`, etc.) still lack `|| null` guards — pre-existing inconsistency, not introduced here.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016ryoFkADzVuGBn6xkoSRwA

---
_Generated by [Claude Code](https://claude.ai/code/session_016ryoFkADzVuGBn6xkoSRwA)_