### PR TITLE
ci(storyboards): lift floors to post-5.18.0 baseline

### DIFF
--- a/.changeset/lift-storyboard-floors-after-518.md
+++ b/.changeset/lift-storyboard-floors-after-518.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: lift Training Agent Storyboards floors to match the post-5.18.0 baseline. Framework dispatch jumped from 374→401 passing / 42→53 clean once `@adcp/client` 5.18.0's schema-aware injection (adcp-client#943, the fix for #940) landed; legacy ticked up 384→388 with `force_task_completion` (#3194). The reduced framework floor was set as a temporary measure during the 5.17.0 regression and is no longer needed.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -43,26 +43,32 @@ jobs:
             # 380→384 / 52→53 after implementing force_create_media_buy_arm
             # in the training-agent: the create_media_buy_async storyboard
             # (#3081) now passes 4 steps instead of grading not_applicable.
+            # 384→388 after bumping @adcp/client to 5.18.0 (#3191) and
+            # implementing force_task_completion (#3194).
             # Passing-step asymmetry with framework mode is intentional:
             # the two modes declare different capabilities, so the
             # storyboard runner skips a different subset of steps in each.
             # Both modes pass every step they run.
             min_clean_storyboards: 53
-            min_passing_steps: 384
+            min_passing_steps: 388
           - mode: framework
             flag_value: '1'
             # 390→393 after bumping @adcp/client to 5.15 + seller catalog
             # alignment (see legacy-mode comment).
             # 393→370 / 52→41 after bumping @adcp/client to 5.17.0: the
             # framework dispatch tightened request-side schema validation
-            # and the bundled storyboards send additional properties their
-            # own request schemas now reject (sync_plans, list_property_lists,
+            # and the bundled storyboards sent additional properties their
+            # own request schemas rejected (sync_plans, list_property_lists,
             # delete_property_list). Tracked at adcontextprotocol/adcp-client#940.
-            # Restore to 52 / 393 once the upstream fix lands (5.17.1+).
             # 370→374 / 41→42 after implementing force_create_media_buy_arm
             # (#3081 follow-up) — same +1 storyboard / +4 steps as legacy.
-            min_clean_storyboards: 42
-            min_passing_steps: 374
+            # 374→401 / 42→53 after bumping @adcp/client to 5.18.0 (#3191)
+            # which brought in adcp-client#943's schema-aware brand/account
+            # injection — the upstream fix for #940. Framework parity with
+            # legacy fully restored; passing-step asymmetry remains because
+            # framework declares more capabilities (more steps run, all pass).
+            min_clean_storyboards: 53
+            min_passing_steps: 401
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Closes the followup tracked at the end of #3084 — the temporary framework dispatch floor reduction is no longer needed now that `@adcp/client` 5.18.0 (#3191) is on main.

## What's new

| Mode | Floor (was) | Floor (now) | CI actual on main |
|---|---|---|---|
| Framework | 42 / 374 | **53 / 401** | 53/53 clean, 401 passing |
| Legacy | 53 / 384 | **53 / 388** | 53/53 clean, 388 passing |

Framework dispatch jumped 11 storyboards / 27 passing steps when 5.18.0 landed, because adcp-client#943's schema-aware brand/account injection is the upstream fix for adcp-client#940 (the original 5.17.0 regression). The reduced floor was a temporary measure during that regression window; main has been running well above it for ~24h.

## Source-of-truth check

Pulled from the latest main run (commit `11ab85f04`, run `24939615523`):
\`\`\`
Storyboards (framework dispatch):  storyboards: 53/53 clean
                                   Clean storyboards: 53 (floor: 42)
                                   Passing steps: 401 (floor: 374)

Storyboards (legacy dispatch):     storyboards: 53/53 clean
                                   Clean storyboards: 53 (floor: 53)
                                   Passing steps: 388 (floor: 384)
\`\`\`

CI is the source of truth here — local runs are contaminated by stale fixture state from previous sessions.

## Comment hygiene

Updated the inline comment in the workflow to:
- record what 5.18 + #943 did to the framework numbers
- note legacy moved 384→388 with #3194 (force_task_completion)
- correct the past-tense framing on the #940 entry (was "now reject", now "rejected") since the regression is closed

No protocol or training-agent change. CI-only.

## Test plan

- [x] `npm run typecheck` — clean
- [ ] CI passes (will fail loudly if the actual numbers ever drift below the new floors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)