### PR TITLE
fix(admin): backfill revenue_events in /sync for missed invoice.paid webhooks

### DIFF
--- a/.changeset/sync-backfill-revenue-events.md
+++ b/.changeset/sync-backfill-revenue-events.md
@@ -1,0 +1,4 @@
+---
+---
+
+Extend `POST /api/admin/accounts/:orgId/sync` to backfill `revenue_events` rows for paid Stripe invoices that were never recorded (missed `invoice.paid` webhooks due to orphaned customer metadata). The backfill walks all paid invoices for the customer using paginated auto-iteration, upserts with `ON CONFLICT (stripe_invoice_id) DO NOTHING` so webhook-written rows win, and returns `revenue_events_synced: N` at the top level of the sync response. The admin sync UI now surfaces the count. Fixes silent MRR undercounting when a Stripe customer is re-linked after an orphan scenario.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -2809,6 +2809,9 @@
         else if (result.workos?.error) parts.push(`WorkOS: ${result.workos.error}`);
         if (result.stripe?.success) parts.push('Stripe ✓');
         else if (result.stripe?.error) parts.push(`Stripe: ${result.stripe.error}`);
+        if (typeof result.revenue_events_synced === 'number') {
+          parts.push(`${result.revenue_events_synced} payment${result.revenue_events_synced === 1 ? '' : 's'} synced`);
+        }
 
         statusEl.textContent = parts.join(' · ');
         statusEl.className = `sync-status ${result.success ? 'sync-success' : 'sync-error'}`;

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -321,7 +321,9 @@ export function setupAccountsBillingRoutes(
                           : (invoice.subscription && 'id' in invoice.subscription
                             ? invoice.subscription.id : null),
                         typeof invoice.payment_intent === 'string'
-                          ? invoice.payment_intent : null,
+                          ? invoice.payment_intent
+                          : (invoice.payment_intent && 'id' in invoice.payment_intent
+                            ? invoice.payment_intent.id : null),
                         charge?.id || null,
                         invoice.amount_paid,
                         invoice.currency,

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -53,6 +53,7 @@ export function setupAccountsBillingRoutes(
             error?: string;
           };
           updated?: boolean;
+          revenue_events_synced?: number;
         } = { success: false };
 
         const orgResult = await pool.query(
@@ -243,6 +244,112 @@ export function setupAccountsBillingRoutes(
                       error: "No active subscription or paid membership invoice found",
                     };
                   }
+                }
+
+                // Backfill revenue_events for any missed invoice.paid webhooks.
+                // Idempotent: ON CONFLICT DO NOTHING so webhook-written rows win.
+                try {
+                  let revenueEventsSynced = 0;
+                  const productCache = new Map<string, string>();
+
+                  for await (const invoice of stripe.invoices.list({
+                    customer: org.stripe_customer_id,
+                    status: 'paid',
+                    limit: 100,
+                    expand: ['data.subscription', 'data.charge'],
+                  })) {
+                    if (invoice.amount_paid <= 0) continue;
+
+                    const primaryLine = invoice.lines?.data[0];
+                    let productId: string | null = null;
+                    let productName: string | null = null;
+                    let priceId: string | null = null;
+                    let billingInterval: string | null = null;
+
+                    if (primaryLine?.price) {
+                      const price = primaryLine.price;
+                      priceId = price.id;
+                      billingInterval = price.recurring?.interval || null;
+                      const product = price.product;
+                      if (typeof product === 'string') {
+                        productId = product;
+                        if (!productCache.has(product)) {
+                          try {
+                            const p = await stripe.products.retrieve(product);
+                            productCache.set(product, p.name);
+                          } catch {
+                            // product name stays null; not fatal
+                          }
+                        }
+                        productName = productCache.get(product) || primaryLine.description || null;
+                      } else if (product && typeof product === 'object' && 'name' in product) {
+                        productId = product.id;
+                        productName = product.name;
+                        productCache.set(product.id, product.name);
+                      }
+                    }
+
+                    if (!productName) {
+                      productName = invoice.description || null;
+                    }
+
+                    let revenueType = 'subscription_recurring';
+                    if (invoice.billing_reason === 'subscription_create') {
+                      revenueType = 'subscription_initial';
+                    } else if (!invoice.subscription) {
+                      revenueType = 'one_time';
+                    }
+
+                    const charge = typeof invoice.charge === 'object' ? invoice.charge : null;
+                    const paidAt = new Date(
+                      ((invoice.status_transitions?.paid_at || invoice.created) * 1000),
+                    );
+
+                    const upsertResult = await pool.query(
+                      `INSERT INTO revenue_events (
+                        workos_organization_id, stripe_invoice_id, stripe_subscription_id,
+                        stripe_payment_intent_id, stripe_charge_id, amount_paid, currency,
+                        revenue_type, billing_reason, product_id, product_name, price_id,
+                        billing_interval, paid_at, period_start, period_end
+                      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                      ON CONFLICT (stripe_invoice_id) DO NOTHING`,
+                      [
+                        orgId,
+                        invoice.id,
+                        typeof invoice.subscription === 'string'
+                          ? invoice.subscription
+                          : (invoice.subscription && 'id' in invoice.subscription
+                            ? invoice.subscription.id : null),
+                        typeof invoice.payment_intent === 'string'
+                          ? invoice.payment_intent : null,
+                        charge?.id || null,
+                        invoice.amount_paid,
+                        invoice.currency,
+                        revenueType,
+                        invoice.billing_reason || null,
+                        productId,
+                        productName,
+                        priceId,
+                        billingInterval,
+                        paidAt,
+                        invoice.period_start ? new Date(invoice.period_start * 1000) : null,
+                        invoice.period_end ? new Date(invoice.period_end * 1000) : null,
+                      ],
+                    );
+
+                    if (upsertResult.rowCount && upsertResult.rowCount > 0) {
+                      revenueEventsSynced++;
+                    }
+                  }
+
+                  syncResults.revenue_events_synced = revenueEventsSynced;
+                  logger.info({ orgId, revenueEventsSynced }, 'Backfilled revenue_events from sync');
+                } catch (revenueBackfillError) {
+                  logger.error(
+                    { err: revenueBackfillError, orgId },
+                    'Failed to backfill revenue_events during sync — subscription sync succeeded',
+                  );
+                  // Don't fail the sync response; backfill failure is non-fatal
                 }
               }
             } catch (error) {

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -252,11 +252,13 @@ export function setupAccountsBillingRoutes(
                   let revenueEventsSynced = 0;
                   const productCache = new Map<string, string>();
 
+                  // Drop the expand options — the code below normalizes both
+                  // string-id and expanded-object forms uniformly, so paying
+                  // for the 2N expansions is wasted budget on large customers.
                   for await (const invoice of stripe.invoices.list({
                     customer: org.stripe_customer_id,
                     status: 'paid',
                     limit: 100,
-                    expand: ['data.subscription', 'data.charge'],
                   })) {
                     if (invoice.amount_paid <= 0) continue;
 
@@ -300,31 +302,52 @@ export function setupAccountsBillingRoutes(
                       revenueType = 'one_time';
                     }
 
-                    const charge = typeof invoice.charge === 'object' ? invoice.charge : null;
+                    // Normalize string-id and expanded-object forms uniformly.
+                    const subscriptionId =
+                      typeof invoice.subscription === 'string'
+                        ? invoice.subscription
+                        : (invoice.subscription && 'id' in invoice.subscription
+                          ? invoice.subscription.id : null);
+                    const paymentIntentId =
+                      typeof invoice.payment_intent === 'string'
+                        ? invoice.payment_intent
+                        : (invoice.payment_intent && 'id' in invoice.payment_intent
+                          ? invoice.payment_intent.id : null);
+                    const chargeId =
+                      typeof invoice.charge === 'string'
+                        ? invoice.charge
+                        : (invoice.charge && 'id' in invoice.charge
+                          ? invoice.charge.id : null);
+
                     const paidAt = new Date(
                       ((invoice.status_transitions?.paid_at || invoice.created) * 1000),
                     );
+
+                    // Mirror the webhook's metadata shape at server/src/http.ts:3935-3940
+                    // so backfilled rows match webhook-written rows exactly.
+                    // Future reporting that joins on hosted_invoice_url etc. won't
+                    // see holes for backfilled rows.
+                    const metadataPayload = JSON.stringify({
+                      invoice_number: invoice.number,
+                      hosted_invoice_url: invoice.hosted_invoice_url,
+                      invoice_pdf: invoice.invoice_pdf,
+                      metadata: invoice.metadata,
+                    });
 
                     const upsertResult = await pool.query(
                       `INSERT INTO revenue_events (
                         workos_organization_id, stripe_invoice_id, stripe_subscription_id,
                         stripe_payment_intent_id, stripe_charge_id, amount_paid, currency,
                         revenue_type, billing_reason, product_id, product_name, price_id,
-                        billing_interval, paid_at, period_start, period_end
-                      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                        billing_interval, paid_at, period_start, period_end, metadata
+                      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
                       ON CONFLICT (stripe_invoice_id) DO NOTHING`,
                       [
                         orgId,
                         invoice.id,
-                        typeof invoice.subscription === 'string'
-                          ? invoice.subscription
-                          : (invoice.subscription && 'id' in invoice.subscription
-                            ? invoice.subscription.id : null),
-                        typeof invoice.payment_intent === 'string'
-                          ? invoice.payment_intent
-                          : (invoice.payment_intent && 'id' in invoice.payment_intent
-                            ? invoice.payment_intent.id : null),
-                        charge?.id || null,
+                        subscriptionId,
+                        paymentIntentId,
+                        chargeId,
                         invoice.amount_paid,
                         invoice.currency,
                         revenueType,
@@ -336,6 +359,7 @@ export function setupAccountsBillingRoutes(
                         paidAt,
                         invoice.period_start ? new Date(invoice.period_start * 1000) : null,
                         invoice.period_end ? new Date(invoice.period_end * 1000) : null,
+                        metadataPayload,
                       ],
                     );
 

--- a/server/tests/integration/admin-sync-revenue-backfill.test.ts
+++ b/server/tests/integration/admin-sync-revenue-backfill.test.ts
@@ -71,7 +71,7 @@ const mockCustomersRetrieve = vi.fn().mockResolvedValue({
 });
 const mockProductsRetrieve = vi.fn().mockResolvedValue({
   id: 'prod_backfill_test_001',
-  name: 'AgenticAdvertising.org Membership',
+  name: 'Pinnacle Media Annual Plan',
 });
 
 vi.mock('../../src/billing/stripe-client.js', () => ({

--- a/server/tests/integration/admin-sync-revenue-backfill.test.ts
+++ b/server/tests/integration/admin-sync-revenue-backfill.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { HTTPServer } from '../../src/http.js';
+import request from 'supertest';
+import { getPool, initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import type { Pool } from 'pg';
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_test_admin', email: 'admin@test.com', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+async function* fakeInvoiceIterator(items: unknown[]) {
+  for (const item of items) yield item;
+}
+
+function makeStripeInvoiceList(items: unknown[]) {
+  return fakeInvoiceIterator(items);
+}
+
+const FAKE_INVOICE = {
+  id: 'in_backfill_test_001',
+  amount_paid: 250000,
+  currency: 'usd',
+  billing_reason: 'subscription_create',
+  subscription: 'sub_backfill_test_001',
+  payment_intent: 'pi_backfill_test_001',
+  charge: { id: 'ch_backfill_test_001' },
+  status_transitions: { paid_at: Math.floor(Date.now() / 1000) - 86400 },
+  created: Math.floor(Date.now() / 1000) - 86400,
+  period_start: Math.floor(Date.now() / 1000) - 86400,
+  period_end: Math.floor(Date.now() / 1000) + 86400 * 365,
+  description: null,
+  lines: {
+    data: [{
+      id: 'il_backfill_test_001',
+      price: {
+        id: 'price_backfill_test_001',
+        recurring: { interval: 'year' },
+        product: 'prod_backfill_test_001',
+      },
+      description: 'AgenticAdvertising.org Membership',
+    }],
+  },
+};
+
+const mockInvoicesList = vi.fn().mockImplementation(() => makeStripeInvoiceList([FAKE_INVOICE]));
+const mockCustomersRetrieve = vi.fn().mockResolvedValue({
+  id: 'cus_test_backfill',
+  deleted: false,
+  subscriptions: {
+    data: [{
+      id: 'sub_backfill_test_001',
+      status: 'active',
+      current_period_end: Math.floor(Date.now() / 1000) + 86400 * 365,
+      canceled_at: null,
+      items: {
+        data: [{
+          price: {
+            unit_amount: 250000,
+            currency: 'usd',
+            recurring: { interval: 'year' },
+          },
+        }],
+      },
+    }],
+  },
+});
+const mockProductsRetrieve = vi.fn().mockResolvedValue({
+  id: 'prod_backfill_test_001',
+  name: 'AgenticAdvertising.org Membership',
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: {
+    customers: { retrieve: mockCustomersRetrieve },
+    invoices: { list: mockInvoicesList },
+    products: { retrieve: mockProductsRetrieve },
+    webhooks: {
+      constructEvent: vi.fn().mockImplementation((body: any) => {
+        return typeof body === 'string' ? JSON.parse(body) : JSON.parse(body.toString());
+      }),
+    },
+  },
+  STRIPE_WEBHOOK_SECRET: null,
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerPortalSession: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  fetchAllPaidInvoices: vi.fn().mockResolvedValue([]),
+  fetchAllRefunds: vi.fn().mockResolvedValue([]),
+  getPendingInvoices: vi.fn().mockResolvedValue([]),
+  getBillingProducts: vi.fn().mockResolvedValue([]),
+  getStripeSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  listCustomersWithOrgIds: vi.fn().mockResolvedValue(new Map()),
+}));
+
+describe('POST /api/admin/accounts/:orgId/sync — revenue_events backfill', () => {
+  let server: HTTPServer;
+  let app: any;
+  let pool: Pool;
+  const TEST_ORG_ID = 'org_test_sync_backfill';
+  const TEST_CUSTOMER_ID = 'cus_test_backfill';
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, stripe_customer_id, created_at, updated_at)
+       VALUES ($1, $2, $3, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET stripe_customer_id = $3`,
+      [TEST_ORG_ID, 'Sync Backfill Test Org', TEST_CUSTOMER_ID],
+    );
+
+    server = new HTTPServer();
+    await server.start(0);
+    app = server.app;
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM revenue_events WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM revenue_events WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    mockInvoicesList.mockImplementation(() => makeStripeInvoiceList([FAKE_INVOICE]));
+  });
+
+  it('inserts a revenue_events row for a missed invoice and returns revenue_events_synced: 1', async () => {
+    const response = await request(app)
+      .post(`/api/admin/accounts/${TEST_ORG_ID}/sync`)
+      .expect(200);
+
+    expect(response.body.revenue_events_synced).toBe(1);
+
+    const rows = await pool.query(
+      'SELECT * FROM revenue_events WHERE workos_organization_id = $1',
+      [TEST_ORG_ID],
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0].stripe_invoice_id).toBe(FAKE_INVOICE.id);
+    expect(Number(rows.rows[0].amount_paid)).toBe(FAKE_INVOICE.amount_paid);
+    expect(rows.rows[0].revenue_type).toBe('subscription_initial');
+  });
+
+  it('is idempotent — running sync twice does not duplicate revenue_events rows', async () => {
+    const first = await request(app)
+      .post(`/api/admin/accounts/${TEST_ORG_ID}/sync`)
+      .expect(200);
+    expect(first.body.revenue_events_synced).toBe(1);
+
+    // Reset mock to return same invoice again
+    mockInvoicesList.mockImplementation(() => makeStripeInvoiceList([FAKE_INVOICE]));
+
+    const second = await request(app)
+      .post(`/api/admin/accounts/${TEST_ORG_ID}/sync`)
+      .expect(200);
+    expect(second.body.revenue_events_synced).toBe(0);
+
+    const rows = await pool.query(
+      'SELECT COUNT(*) AS count FROM revenue_events WHERE workos_organization_id = $1',
+      [TEST_ORG_ID],
+    );
+    expect(Number(rows.rows[0].count)).toBe(1);
+  });
+
+  it('returns revenue_events_synced: 0 when the row already exists (pre-written by webhook)', async () => {
+    await pool.query(
+      `INSERT INTO revenue_events (workos_organization_id, stripe_invoice_id, amount_paid, currency, revenue_type, paid_at)
+       VALUES ($1, $2, $3, $4, $5, NOW())`,
+      [TEST_ORG_ID, FAKE_INVOICE.id, FAKE_INVOICE.amount_paid, FAKE_INVOICE.currency, 'subscription_initial'],
+    );
+
+    const response = await request(app)
+      .post(`/api/admin/accounts/${TEST_ORG_ID}/sync`)
+      .expect(200);
+
+    expect(response.body.revenue_events_synced).toBe(0);
+
+    const rows = await pool.query(
+      'SELECT COUNT(*) AS count FROM revenue_events WHERE workos_organization_id = $1',
+      [TEST_ORG_ID],
+    );
+    expect(Number(rows.rows[0].count)).toBe(1);
+  });
+
+  it('returns 0 when the customer has no paid invoices', async () => {
+    mockInvoicesList.mockImplementation(() => makeStripeInvoiceList([]));
+
+    const response = await request(app)
+      .post(`/api/admin/accounts/${TEST_ORG_ID}/sync`)
+      .expect(200);
+
+    expect(response.body.revenue_events_synced).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #3211

`POST /api/admin/accounts/:orgId/sync` repaired subscription state but left `revenue_events` empty when `invoice.paid` webhooks were missed (e.g., during the orphaned-customer scenario). After re-linking a customer, the org showed an active subscription but payment history stayed empty and revenue dashboards silently undercounted. This PR extends the sync endpoint to walk all paid Stripe invoices for the customer and upsert `revenue_events` rows, returning `revenue_events_synced: N` at the top level of the response. The admin sync UI surfaces the count.

**Non-breaking justification:** adds an optional `revenue_events_synced` field to the sync response and a new paginated upsert block inside an existing admin-only endpoint; no schema changes, no existing callers affected.

**Pre-PR review:**
- internal-tools-strategist: approved — both blockers resolved (pagination via `for await` auto-iterator with `limit: 100`, `ON CONFLICT DO NOTHING` so webhook-written rows win); two nits noted (stale `limit: 10` on membership-invoice lookup at line 188 pre-existing, `revenue_events_synced` not set on deleted-customer path)
- code-reviewer: approved — payment_intent expanded-object guard hardened, fictional product name fixed per playbook; remaining nits (charge null guard style, add error-branch test) surfaced below

**Nits (not fixed in this PR):**
- `stripe.invoices.list({ limit: 10 })` at line 188 (no-subscription membership lookup) should be paginated in a follow-up — it's pre-existing and out of scope here
- `revenue_events_synced` is absent (not `0`) when `customer.deleted` — the UI guard `typeof result.revenue_events_synced === 'number'` handles this correctly
- No test for the backfill error branch (Stripe throws during list) — follow-up

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ryicq3ihf9h3uiMSP79ELF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ryicq3ihf9h3uiMSP79ELF)_