### PR TITLE
test(registry): baseline coverage for reader cutover (PR 3 of #3177)

### DIFF
--- a/.changeset/registry-reader-baseline-tests.md
+++ b/.changeset/registry-reader-baseline-tests.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add baseline integration coverage for the federated index + property registry reader functions ahead of the property registry unification (issue #3177).
+
+Tests-only, no production code changes. PR 1 (#3195) shipped the empty `publishers` + `adagents_authorization_overrides` schema. PR 4 will swap the readers under `getPropertiesForAgent` / `getPropertiesForDomain` / `getAgentsForDomain` / `validateAgentForProduct` / `getAllPropertiesForRegistry` and friends, plus the public registry endpoints (`/registry/agents`, `/registry/publishers`, `/registry/publisher`, `/registry/operator`, `/registry/stats`) and the directory MCP tools (`lookup_domain`, `list_publishers`), to consult the new schema. These four new test files pin the I/O of the current readers — same fixtures, same response shapes / counts / ordering — so the cutover fails loudly if it changes any caller-visible behavior.

--- a/server/tests/integration/registry-reader-baseline-authorizations.test.ts
+++ b/server/tests/integration/registry-reader-baseline-authorizations.test.ts
@@ -230,9 +230,14 @@ describe('Registry reader baseline — agent + authorization reads', () => {
   // ──────────────────────────────────────────────────────────────────
 
   describe('bulkGetFirstAuthForAgents', () => {
-    it('prefers adagents_json over agent_claim for the same agent', async () => {
-      // Insert agent_claim first to verify the function does not use
-      // discovered_at to pick — only `ORDER BY source` matters.
+    it('prefers verified authorization (adagents_json) over an unverified claim (agent_claim) for the same agent', async () => {
+      // Verified-over-unverified is the load-bearing protocol invariant
+      // here. PR 4 may swap to a different priority mechanism (an
+      // explicit precedence column, an `adagents_authorization_overrides`
+      // join, etc.) and that's fine — but the contract that an
+      // adagents_json row wins over an agent_claim row for the same
+      // agent must hold. We insert agent_claim first to verify the
+      // priority is NOT discovered_at-based.
       await fedDb.upsertAuthorization({
         agent_url: AGENT_X,
         publisher_domain: PUB_B,
@@ -253,7 +258,7 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       expect(first!.authorized_for).toBe('all');
     });
 
-    it('returns one row per agent in the input batch and skips agents with no auth', async () => {
+    it('returns one row per agent in the input batch, with source preserved per agent, and skips agents with no auth', async () => {
       await fedDb.upsertAuthorization({
         agent_url: AGENT_X,
         publisher_domain: PUB_A,
@@ -268,7 +273,12 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_X, AGENT_Y, AGENT_Z]);
       expect(map.size).toBe(2);
       expect(map.get(AGENT_X)?.publisher_domain).toBe(PUB_A);
+      expect(map.get(AGENT_X)?.source).toBe('adagents_json');
+      // Pin the agent_claim source round-trip explicitly so PR 4 can't
+      // normalize source to 'verified'/'unverified' or filter unverified
+      // agents out of the bulk result.
       expect(map.get(AGENT_Y)?.publisher_domain).toBe(PUB_B);
+      expect(map.get(AGENT_Y)?.source).toBe('agent_claim');
       expect(map.has(AGENT_Z)).toBe(false);
     });
   });
@@ -362,6 +372,32 @@ describe('Registry reader baseline — agent + authorization reads', () => {
         authorized_count: 2,
         source: 'adagents_json',
       });
+      // The 'all' selector returns no per-item enumeration. PR 4 must
+      // not start emitting `unauthorized_items` for this selector type
+      // — that's a different field-shape contract from by_id (property
+      // ids) and by_tag (tag names).
+      expect(result.selectors[0].unauthorized_items).toBeUndefined();
+    });
+
+    it('selection_type=by_id with an empty property_ids array short-circuits to source=none', async () => {
+      // The by_id path explicitly short-circuits when property_ids=[]
+      // without consulting the publisher-level authorization graph.
+      // This is the only place source='none' is returned without a
+      // getAuthorizationSource lookup; PR 4 could unify the selector
+      // dispatch and break this without noticing.
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        { publisher_domain: PUB_A, selection_type: 'by_id', property_ids: [] },
+      ]);
+      expect(result.total_requested).toBe(0);
+      expect(result.total_authorized).toBe(0);
+      expect(result.selectors[0]).toMatchObject({
+        publisher_domain: PUB_A,
+        selection_type: 'by_id',
+        requested_count: 0,
+        authorized_count: 0,
+        unauthorized_items: [],
+        source: 'none',
+      });
     });
 
     it('selection_type=by_id flags unauthorized property ids', async () => {
@@ -436,14 +472,44 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       ]);
       expect(result.selectors[0].source).toBe('none');
     });
+
+    it('reports source=none even when the publisher has been crawled but the agent has no auth row', async () => {
+      // Distinct workflow signal vs. the empty-registry case: a buyer
+      // seeing source='none' when discovered_publishers has a row for
+      // the domain means "publisher is known to us, this agent just
+      // isn't authorized" rather than "publisher has not been observed
+      // yet". PR 4 introduces a publishers cache (#3195) and could
+      // accidentally fold the new cache row into source determination,
+      // upgrading source='none' to 'adagents_json' for an unauthorized
+      // agent. This pins that source is determined by
+      // agent_publisher_authorizations alone.
+      await fedDb.upsertPublisher({
+        domain: PUB_B,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: false,
+      });
+      const result = await fedDb.validateAgentForProduct(AGENT_Z, [
+        { publisher_domain: PUB_B, selection_type: 'all' },
+      ]);
+      expect(result.selectors[0].source).toBe('none');
+      expect(result.total_authorized).toBe(0);
+      expect(result.authorized).toBe(false);
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────
-  // Wildcard agent — '*' is a literal in the schema today (no implicit
-  // expansion at the SQL layer). PR 4 must preserve that.
+  // Wildcard agent — '*' is an internal storage convention, not an
+  // AdCP-protocol-defined value. The adagents.json schema (3.0) requires
+  // `authorized_agents[].url` to be `format: "uri"`, so the wire-level
+  // protocol does not admit '*' literally. The behavior pinned here is
+  // strictly that the storage layer round-trips a literal '*' through
+  // upsert + read on the same reader. Whether PR 4 keeps the literal,
+  // drops it, or replaces it with a sentinel column is an open design
+  // choice — we deliberately do NOT pin cross-reader expansion-prevention
+  // semantics that would lock that choice in.
   // ──────────────────────────────────────────────────────────────────
 
-  describe("wildcard agent ('*')", () => {
+  describe("wildcard agent ('*') — storage round-trip only", () => {
     beforeEach(async () => {
       await fedDb.upsertAuthorization({
         agent_url: AGENT_WILDCARD,
@@ -452,34 +518,10 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       });
     });
 
-    it('getAgentsForDomain returns the literal "*" row', async () => {
+    it('getAgentsForDomain round-trips the literal "*" row that was upserted', async () => {
       const auths = await fedDb.getAgentsForDomain(PUB_A);
       const urls = auths.map((a) => a.agent_url);
       expect(urls).toContain(AGENT_WILDCARD);
-    });
-
-    it('getDomainsForAgent("*") returns rows for the literal wildcard agent only', async () => {
-      const auths = await fedDb.getDomainsForAgent(AGENT_WILDCARD);
-      expect(auths.length).toBe(1);
-      expect(auths[0].agent_url).toBe(AGENT_WILDCARD);
-      expect(auths[0].publisher_domain).toBe(PUB_A);
-    });
-
-    it('a non-wildcard agent does not implicitly inherit the wildcard row', async () => {
-      // No row for AGENT_X — '*' must NOT expand at read time.
-      const auths = await fedDb.getDomainsForAgent(AGENT_X);
-      expect(auths).toEqual([]);
-    });
-
-    it('bulkGetFirstAuthForAgents treats "*" as a literal agent_url key', async () => {
-      // PR 4 must not special-case the wildcard inside the bulk path
-      // any differently from the single-agent reader.
-      const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_WILDCARD]);
-      const first = map.get(AGENT_WILDCARD);
-      expect(first).toBeTruthy();
-      expect(first!.agent_url).toBe(AGENT_WILDCARD);
-      expect(first!.publisher_domain).toBe(PUB_A);
-      expect(first!.source).toBe('adagents_json');
     });
   });
 });

--- a/server/tests/integration/registry-reader-baseline-authorizations.test.ts
+++ b/server/tests/integration/registry-reader-baseline-authorizations.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Baseline coverage for agent/authorization reader functions ahead of the
+ * property registry unification (issue #3177). PR 4 will swap these
+ * readers from agent_publisher_authorizations / agent_property_authorizations
+ * to consult the new `publishers` cache + `adagents_authorization_overrides`
+ * layer (#3195). Same I/O must hold across the cutover.
+ *
+ * What this file covers:
+ *   - PropertyDatabase.getAgentAuthorizationsForDomain
+ *   - FederatedIndexDatabase.getAgentsForDomain
+ *   - FederatedIndexDatabase.getDomainsForAgent
+ *   - FederatedIndexDatabase.getPublisherDomainsForAgent
+ *   - FederatedIndexDatabase.bulkGetFirstAuthForAgents (incl. source preference)
+ *   - FederatedIndexDatabase.validateAgentForProduct (all three selector kinds)
+ *
+ * Property/publisher-side readers live in the sibling -properties file.
+ *
+ * Fixtures use the *.registry-baseline.example domain suffix with an
+ * `auth-` prefix so we don't collide with the -properties file or any
+ * parallel registry-* test.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+
+// `auth-` prefix scopes this file's fixtures away from the sibling
+// baseline files (prop-, endpoint-, mcp-) so concurrent file execution
+// can't trample state.
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const DOMAIN_PREFIX = 'auth-';
+const AGENT_PREFIX = 'https://auth-';
+const PUB_A = `${DOMAIN_PREFIX}acme${DOMAIN_SUFFIX}`;
+const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
+const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
+const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
+const AGENT_Z = `${AGENT_PREFIX}sales-z.registry-baseline.example`;
+const AGENT_WILDCARD = '*';
+
+describe('Registry reader baseline — agent + authorization reads', () => {
+  let pool: Pool;
+  let fedDb: FederatedIndexDatabase;
+  let propDb: PropertyDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    fedDb = new FederatedIndexDatabase();
+    propDb = new PropertyDatabase();
+  });
+
+  // Cleanup keyed strictly to this file's `auth-` prefix + the literal
+  // wildcard agent ('*'). Sibling baseline files use disjoint prefixes
+  // so concurrent file execution can't trample state.
+  const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
+  const AGENT_LIKE = `${AGENT_PREFIX}%${DOMAIN_SUFFIX}`;
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE property_id IN (
+         SELECT id FROM discovered_properties WHERE publisher_domain LIKE $1
+       )
+          OR agent_url LIKE $2
+          OR agent_url = $3`,
+      [DOMAIN_LIKE, AGENT_LIKE, AGENT_WILDCARD]
+    );
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM agent_publisher_authorizations WHERE publisher_domain LIKE $1 OR agent_url LIKE $2 OR agent_url = $3',
+      [DOMAIN_LIKE, AGENT_LIKE, AGENT_WILDCARD]
+    );
+    await pool.query(
+      'DELETE FROM discovered_publishers WHERE domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_agents WHERE agent_url LIKE $1',
+      [AGENT_LIKE]
+    );
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Empty registry — readers must tolerate absence cleanly.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('empty registry', () => {
+    it('getAgentsForDomain returns []', async () => {
+      const auths = await fedDb.getAgentsForDomain(PUB_A);
+      expect(auths).toEqual([]);
+    });
+
+    it('getDomainsForAgent returns []', async () => {
+      const auths = await fedDb.getDomainsForAgent(AGENT_X);
+      expect(auths).toEqual([]);
+    });
+
+    it('getAgentAuthorizationsForDomain returns []', async () => {
+      const rows = await propDb.getAgentAuthorizationsForDomain(PUB_A);
+      expect(rows).toEqual([]);
+    });
+
+    it('bulkGetFirstAuthForAgents returns an empty Map for an empty input array', async () => {
+      const map = await fedDb.bulkGetFirstAuthForAgents([]);
+      expect(map.size).toBe(0);
+    });
+
+    it('bulkGetFirstAuthForAgents returns an empty Map when no rows match', async () => {
+      const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_X, AGENT_Y]);
+      expect(map.size).toBe(0);
+    });
+
+    it('validateAgentForProduct on an empty registry returns authorized=false', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        { publisher_domain: PUB_A, selection_type: 'all' },
+      ]);
+      expect(result.authorized).toBe(false);
+      expect(result.total_requested).toBe(0);
+      expect(result.total_authorized).toBe(0);
+      expect(result.coverage_percentage).toBe(0);
+      expect(result.selectors).toHaveLength(1);
+      expect(result.selectors[0].source).toBe('none');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // getAgentsForDomain / getDomainsForAgent ordering contract.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('basic authorization reads', () => {
+    beforeEach(async () => {
+      // Two agents authorized for PUB_A: one via adagents_json, one via
+      // agent_claim. ORDER BY source puts adagents_json first.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_A,
+        source: 'agent_claim',
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+      // AGENT_X also represents PUB_B.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_B,
+        source: 'adagents_json',
+      });
+    });
+
+    it('getAgentsForDomain orders rows by (source, agent_url)', async () => {
+      const auths = await fedDb.getAgentsForDomain(PUB_A);
+      expect(auths.length).toBe(2);
+      expect(auths[0]).toMatchObject({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        source: 'adagents_json',
+        authorized_for: 'all',
+      });
+      expect(auths[1]).toMatchObject({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_A,
+        source: 'agent_claim',
+      });
+    });
+
+    it('getDomainsForAgent orders rows by (source, publisher_domain) for one agent', async () => {
+      const auths = await fedDb.getDomainsForAgent(AGENT_X);
+      const pubs = auths.map((a) => a.publisher_domain);
+      expect(pubs).toEqual([PUB_A, PUB_B]);
+      expect(auths.every((a) => a.agent_url === AGENT_X)).toBe(true);
+    });
+
+    it('getAgentAuthorizationsForDomain reports only property-level authorizations', async () => {
+      // Property-level authorization is a different graph from
+      // agent_publisher_authorizations — populating the publisher-level
+      // graph alone must NOT bleed into property-level reads.
+      const rows = await propDb.getAgentAuthorizationsForDomain(PUB_A);
+      expect(rows).toEqual([]);
+    });
+
+    it('getAgentAuthorizationsForDomain reports rows once a property is linked', async () => {
+      await fedDb.upsertProperty({
+        property_id: 'auth-prop-a',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Auth Acme Site',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+      });
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      const propRow = props[0] as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propRow.id,
+        authorized_for: 'all',
+      });
+
+      const rows = await propDb.getAgentAuthorizationsForDomain(PUB_A);
+      expect(rows.length).toBe(1);
+      expect(rows[0]).toMatchObject({
+        agent_url: AGENT_X,
+        property_name: 'Auth Acme Site',
+        authorized_for: 'all',
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // bulkGetFirstAuthForAgents — DISTINCT ON behavior + source priority.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('bulkGetFirstAuthForAgents', () => {
+    it('prefers adagents_json over agent_claim for the same agent', async () => {
+      // Insert agent_claim first to verify the function does not use
+      // discovered_at to pick — only `ORDER BY source` matters.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_B,
+        source: 'agent_claim',
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+
+      const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_X]);
+      const first = map.get(AGENT_X);
+      expect(first).toBeTruthy();
+      expect(first!.source).toBe('adagents_json');
+      expect(first!.publisher_domain).toBe(PUB_A);
+      expect(first!.authorized_for).toBe('all');
+    });
+
+    it('returns one row per agent in the input batch and skips agents with no auth', async () => {
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        source: 'adagents_json',
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_B,
+        source: 'agent_claim',
+      });
+
+      const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_X, AGENT_Y, AGENT_Z]);
+      expect(map.size).toBe(2);
+      expect(map.get(AGENT_X)?.publisher_domain).toBe(PUB_A);
+      expect(map.get(AGENT_Y)?.publisher_domain).toBe(PUB_B);
+      expect(map.has(AGENT_Z)).toBe(false);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // validateAgentForProduct — selector contracts.
+  //
+  // These pin the *output shape* of the validator. Internal SQL is free
+  // to change in PR 4 as long as the same fixtures produce the same
+  // selectors[] / coverage_percentage / total_* values.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('validateAgentForProduct', () => {
+    // Three properties on PUB_A. AGENT_X is authorized for two of them.
+    // No property authorization for AGENT_Y, but AGENT_Y has a publisher-
+    // level adagents_json claim — used to assert that source='none' vs
+    // 'adagents_json' / 'agent_claim' is reported even when properties
+    // counts disagree.
+    let propIds: { home: string; news: string; mobile: string };
+
+    beforeEach(async () => {
+      await fedDb.upsertProperty({
+        property_id: 'auth-home',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Home',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+        tags: ['flagship'],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'auth-news',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'News',
+        identifiers: [{ type: 'domain', value: `news.${PUB_A}` }],
+        tags: ['flagship', 'news'],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'auth-mobile',
+        publisher_domain: PUB_A,
+        property_type: 'mobile_app',
+        name: 'Mobile',
+        identifiers: [{ type: 'ios_bundle', value: 'com.acme.app' }],
+        tags: ['mobile'],
+      });
+
+      const all = await fedDb.getPropertiesForDomain(PUB_A);
+      const byPropId = new Map(all.map((p) => [p.property_id!, p as unknown as { id: string }]));
+      propIds = {
+        home: byPropId.get('auth-home')!.id,
+        news: byPropId.get('auth-news')!.id,
+        mobile: byPropId.get('auth-mobile')!.id,
+      };
+
+      // AGENT_X authorized for home + news only (not mobile).
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propIds.home,
+      });
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propIds.news,
+      });
+
+      // Publisher-level authorizations record the source signal.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        source: 'adagents_json',
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_A,
+        source: 'agent_claim',
+      });
+    });
+
+    it('selection_type=all reports partial coverage when agent has subset', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        { publisher_domain: PUB_A, selection_type: 'all' },
+      ]);
+      expect(result.total_requested).toBe(3);
+      expect(result.total_authorized).toBe(2);
+      expect(result.coverage_percentage).toBe(67);
+      expect(result.authorized).toBe(false);
+      expect(result.selectors).toHaveLength(1);
+      expect(result.selectors[0]).toMatchObject({
+        publisher_domain: PUB_A,
+        selection_type: 'all',
+        requested_count: 3,
+        authorized_count: 2,
+        source: 'adagents_json',
+      });
+    });
+
+    it('selection_type=by_id flags unauthorized property ids', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        {
+          publisher_domain: PUB_A,
+          selection_type: 'by_id',
+          property_ids: ['auth-home', 'auth-mobile'],
+        },
+      ]);
+      expect(result.total_requested).toBe(2);
+      expect(result.total_authorized).toBe(1);
+      expect(result.coverage_percentage).toBe(50);
+      expect(result.selectors[0].unauthorized_items).toEqual(['auth-mobile']);
+      expect(result.selectors[0].source).toBe('adagents_json');
+    });
+
+    it('selection_type=by_id returns authorized=true for a fully covered subset', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        {
+          publisher_domain: PUB_A,
+          selection_type: 'by_id',
+          property_ids: ['auth-home', 'auth-news'],
+        },
+      ]);
+      expect(result.authorized).toBe(true);
+      expect(result.coverage_percentage).toBe(100);
+      expect(result.selectors[0].unauthorized_items).toEqual([]);
+    });
+
+    it('selection_type=by_tag reports tag-level unauthorized items', async () => {
+      // 'flagship' covers home + news (both authorized). 'mobile' covers
+      // mobile (unauthorized). Two requested, two authorized for flagship,
+      // zero authorized for mobile.
+      const result = await fedDb.validateAgentForProduct(AGENT_X, [
+        {
+          publisher_domain: PUB_A,
+          selection_type: 'by_tag',
+          property_tags: ['flagship', 'mobile'],
+        },
+      ]);
+      expect(result.selectors).toHaveLength(1);
+      expect(result.selectors[0].selection_type).toBe('by_tag');
+      // Tags missing from the agent's covered set surface in unauthorized_items.
+      expect(result.selectors[0].unauthorized_items).toEqual(['mobile']);
+    });
+
+    it('reports source=agent_claim for an agent with only an unverified claim', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_Y, [
+        { publisher_domain: PUB_A, selection_type: 'all' },
+      ]);
+      expect(result.selectors[0].source).toBe('agent_claim');
+      expect(result.total_authorized).toBe(0);
+      expect(result.authorized).toBe(false);
+    });
+
+    it('reports source=none when an agent has no publisher-level row at all', async () => {
+      const result = await fedDb.validateAgentForProduct(AGENT_Z, [
+        { publisher_domain: PUB_A, selection_type: 'all' },
+      ]);
+      expect(result.selectors[0].source).toBe('none');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Wildcard agent — '*' is a literal in the schema today (no implicit
+  // expansion at the SQL layer). PR 4 must preserve that.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe("wildcard agent ('*')", () => {
+    beforeEach(async () => {
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_WILDCARD,
+        publisher_domain: PUB_A,
+        source: 'adagents_json',
+      });
+    });
+
+    it('getAgentsForDomain returns the literal "*" row', async () => {
+      const auths = await fedDb.getAgentsForDomain(PUB_A);
+      const urls = auths.map((a) => a.agent_url);
+      expect(urls).toContain(AGENT_WILDCARD);
+    });
+
+    it('getDomainsForAgent("*") returns rows for the literal wildcard agent only', async () => {
+      const auths = await fedDb.getDomainsForAgent(AGENT_WILDCARD);
+      expect(auths.length).toBe(1);
+      expect(auths[0].agent_url).toBe(AGENT_WILDCARD);
+      expect(auths[0].publisher_domain).toBe(PUB_A);
+    });
+
+    it('a non-wildcard agent does not implicitly inherit the wildcard row', async () => {
+      // No row for AGENT_X — '*' must NOT expand at read time.
+      const auths = await fedDb.getDomainsForAgent(AGENT_X);
+      expect(auths).toEqual([]);
+    });
+  });
+});

--- a/server/tests/integration/registry-reader-baseline-authorizations.test.ts
+++ b/server/tests/integration/registry-reader-baseline-authorizations.test.ts
@@ -190,10 +190,11 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       expect(auths.every((a) => a.agent_url === AGENT_X)).toBe(true);
     });
 
-    it('getAgentAuthorizationsForDomain reports only property-level authorizations', async () => {
-      // Property-level authorization is a different graph from
-      // agent_publisher_authorizations — populating the publisher-level
-      // graph alone must NOT bleed into property-level reads.
+    it('getAgentAuthorizationsForDomain returns [] when only publisher-level rows exist (no bleed into property-level reads)', async () => {
+      // Property-level and publisher-level authorization are separate
+      // graphs. The publisher-level rows seeded in beforeEach must not
+      // surface through this property-level reader. PR 4 must preserve
+      // this separation.
       const rows = await propDb.getAgentAuthorizationsForDomain(PUB_A);
       expect(rows).toEqual([]);
     });
@@ -391,10 +392,13 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       expect(result.selectors[0].unauthorized_items).toEqual([]);
     });
 
-    it('selection_type=by_tag reports tag-level unauthorized items', async () => {
-      // 'flagship' covers home + news (both authorized). 'mobile' covers
-      // mobile (unauthorized). Two requested, two authorized for flagship,
-      // zero authorized for mobile.
+    it('selection_type=by_tag pins property-counting semantics + tag-level unauthorized items', async () => {
+      // Selector tags ['flagship', 'mobile'] match all three properties
+      // via tags && operator: home (flagship) + news (flagship) +
+      // mobile (mobile). AGENT_X is authorized for home + news only.
+      // So: requested=3 (matched properties), authorized=2, coverage=67.
+      // Tag coverage: flagship is covered (home + news both authorized),
+      // mobile is not (mobile property unauthorized) → unauthorized=['mobile'].
       const result = await fedDb.validateAgentForProduct(AGENT_X, [
         {
           publisher_domain: PUB_A,
@@ -403,9 +407,18 @@ describe('Registry reader baseline — agent + authorization reads', () => {
         },
       ]);
       expect(result.selectors).toHaveLength(1);
-      expect(result.selectors[0].selection_type).toBe('by_tag');
-      // Tags missing from the agent's covered set surface in unauthorized_items.
-      expect(result.selectors[0].unauthorized_items).toEqual(['mobile']);
+      expect(result.total_requested).toBe(3);
+      expect(result.total_authorized).toBe(2);
+      expect(result.coverage_percentage).toBe(67);
+      expect(result.authorized).toBe(false);
+      expect(result.selectors[0]).toMatchObject({
+        publisher_domain: PUB_A,
+        selection_type: 'by_tag',
+        requested_count: 3,
+        authorized_count: 2,
+        unauthorized_items: ['mobile'],
+        source: 'adagents_json',
+      });
     });
 
     it('reports source=agent_claim for an agent with only an unverified claim', async () => {
@@ -456,6 +469,17 @@ describe('Registry reader baseline — agent + authorization reads', () => {
       // No row for AGENT_X — '*' must NOT expand at read time.
       const auths = await fedDb.getDomainsForAgent(AGENT_X);
       expect(auths).toEqual([]);
+    });
+
+    it('bulkGetFirstAuthForAgents treats "*" as a literal agent_url key', async () => {
+      // PR 4 must not special-case the wildcard inside the bulk path
+      // any differently from the single-agent reader.
+      const map = await fedDb.bulkGetFirstAuthForAgents([AGENT_WILDCARD]);
+      const first = map.get(AGENT_WILDCARD);
+      expect(first).toBeTruthy();
+      expect(first!.agent_url).toBe(AGENT_WILDCARD);
+      expect(first!.publisher_domain).toBe(PUB_A);
+      expect(first!.source).toBe('adagents_json');
     });
   });
 });

--- a/server/tests/integration/registry-reader-baseline-mcp.test.ts
+++ b/server/tests/integration/registry-reader-baseline-mcp.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Baseline coverage for the directory MCP tools that consult the
+ * federated index ahead of the property registry unification (issue
+ * #3177). PR 4 will swap the FederatedIndexService readers under these
+ * tools to the new publishers / adagents_authorization_overrides schema
+ * shipped in #3195. Same fixtures must produce the same JSON returned
+ * to the MCP client across the cutover.
+ *
+ * Tools covered:
+ *   - lookup_domain   → FederatedIndexService.lookupDomain
+ *   - list_publishers → FederatedIndexService.listAllPublishers
+ *
+ * `list_authorized_properties` is the upstream sales-agent tool name —
+ * it lives on a sales-agent MCP, not on the directory. It is intentionally
+ * out of scope here; PR 4 doesn't touch the upstream tool's contract.
+ *
+ * Fixtures use the *.registry-baseline.example domain suffix with an
+ * `mcp-` prefix so we don't collide with the sibling baseline files.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+import { createDirectoryToolHandlers } from '../../src/addie/mcp/directory-tools.js';
+
+// `mcp-` prefix scopes this file's fixtures away from the sibling
+// baseline files (prop-, auth-, endpoint-) so concurrent file execution
+// can't trample state.
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const DOMAIN_PREFIX = 'mcp-';
+const AGENT_PREFIX = 'https://mcp-';
+const PUB_A = `${DOMAIN_PREFIX}acme${DOMAIN_SUFFIX}`;
+const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
+const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
+const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
+
+interface LookupDomainResult {
+  domain: string;
+  authorized_agents: Array<{
+    url: string;
+    authorized_for?: string;
+    source: 'registered' | 'discovered';
+    member?: { slug: string; display_name: string };
+  }>;
+  sales_agents_claiming: Array<{
+    url: string;
+    source: 'registered' | 'discovered';
+    member?: { slug: string; display_name: string };
+  }>;
+}
+
+interface ListPublishersResult {
+  publishers: Array<{
+    domain: string;
+    source: 'registered' | 'discovered';
+    has_valid_adagents?: boolean;
+    discovered_from?: { agent_url: string };
+  }>;
+  count: number;
+}
+
+describe('Registry reader baseline — MCP directory tools', () => {
+  let pool: Pool;
+  let fedDb: FederatedIndexDatabase;
+  let handlers: Map<string, (args: Record<string, unknown>) => Promise<string>>;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    fedDb = new FederatedIndexDatabase();
+    handlers = createDirectoryToolHandlers();
+  });
+
+  const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
+  const AGENT_LIKE = `${AGENT_PREFIX}%${DOMAIN_SUFFIX}`;
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE agent_url LIKE $1
+          OR property_id IN (
+            SELECT id FROM discovered_properties WHERE publisher_domain LIKE $2
+          )`,
+      [AGENT_LIKE, DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM agent_publisher_authorizations WHERE publisher_domain LIKE $1 OR agent_url LIKE $2',
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_publishers WHERE domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_agents WHERE agent_url LIKE $1',
+      [AGENT_LIKE]
+    );
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // lookup_domain
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('lookup_domain', () => {
+    it('returns empty arrays for an unseen domain', async () => {
+      const lookup = handlers.get('lookup_domain')!;
+      const raw = await lookup({ domain: PUB_A });
+      const result = JSON.parse(raw) as LookupDomainResult;
+      expect(result.domain).toBe(PUB_A);
+      expect(result.authorized_agents).toEqual([]);
+      expect(result.sales_agents_claiming).toEqual([]);
+    });
+
+    it('returns an error envelope when domain arg is missing', async () => {
+      const lookup = handlers.get('lookup_domain')!;
+      const raw = await lookup({});
+      const result = JSON.parse(raw) as { error: string };
+      expect(result.error).toMatch(/domain is required/i);
+    });
+
+    it('separates adagents_json-authorized agents from agent_claim sales claims', async () => {
+      // adagents_json: AGENT_X -> PUB_A. Goes into authorized_agents.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+      // agent_claim: AGENT_Y -> PUB_A. Does NOT go into authorized_agents.
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_A,
+        source: 'agent_claim',
+      });
+      // sales_agents_claiming sources from discovered_publishers, not
+      // agent_publisher_authorizations.
+      await fedDb.upsertPublisher({
+        domain: PUB_A,
+        discovered_by_agent: AGENT_Y,
+        has_valid_adagents: false,
+      });
+
+      const lookup = handlers.get('lookup_domain')!;
+      const raw = await lookup({ domain: PUB_A });
+      const result = JSON.parse(raw) as LookupDomainResult;
+
+      // authorized_agents: only the adagents_json row. Source is 'discovered'
+      // because no member profile registers AGENT_X.
+      expect(result.authorized_agents.length).toBe(1);
+      expect(result.authorized_agents[0]).toMatchObject({
+        url: AGENT_X,
+        authorized_for: 'all',
+        source: 'discovered',
+      });
+
+      // sales_agents_claiming: from the discovered_publishers row.
+      expect(result.sales_agents_claiming.length).toBe(1);
+      expect(result.sales_agents_claiming[0]).toMatchObject({
+        url: AGENT_Y,
+        source: 'discovered',
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // list_publishers
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('list_publishers', () => {
+    it('returns an envelope with publishers + count fields', async () => {
+      const list = handlers.get('list_publishers')!;
+      const raw = await list({});
+      const result = JSON.parse(raw) as ListPublishersResult;
+      expect(Array.isArray(result.publishers)).toBe(true);
+      expect(typeof result.count).toBe('number');
+      expect(result.count).toBe(result.publishers.length);
+    });
+
+    it('includes our seeded publisher with source=discovered', async () => {
+      await fedDb.upsertPublisher({
+        domain: PUB_A,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: true,
+      });
+
+      const list = handlers.get('list_publishers')!;
+      const raw = await list({});
+      const result = JSON.parse(raw) as ListPublishersResult;
+
+      const ours = result.publishers.find((p) => p.domain === PUB_A);
+      expect(ours).toBeTruthy();
+      expect(ours!.source).toBe('discovered');
+      expect(ours!.has_valid_adagents).toBe(true);
+      expect(ours!.discovered_from?.agent_url).toBe(AGENT_X);
+    });
+
+    it('deduplicates by domain across multiple discovering agents', async () => {
+      // Two sales agents both claim PUB_B. listAllPublishers de-dupes
+      // on domain, so the publisher should appear exactly once.
+      await fedDb.upsertPublisher({
+        domain: PUB_B,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: true,
+      });
+      await fedDb.upsertPublisher({
+        domain: PUB_B,
+        discovered_by_agent: AGENT_Y,
+        has_valid_adagents: false,
+      });
+
+      const list = handlers.get('list_publishers')!;
+      const raw = await list({});
+      const result = JSON.parse(raw) as ListPublishersResult;
+      const matching = result.publishers.filter((p) => p.domain === PUB_B);
+      expect(matching.length).toBe(1);
+    });
+  });
+});

--- a/server/tests/integration/registry-reader-baseline-properties.test.ts
+++ b/server/tests/integration/registry-reader-baseline-properties.test.ts
@@ -218,6 +218,79 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
       );
       expect(wrongValue).toEqual([]);
     });
+
+    it('findAgentsForPropertyIdentifier returns [] when the property has no agent_property_authorizations row (INNER JOIN contract)', async () => {
+      // Insert a property with the same identifier under a *different*
+      // publisher and no authorization. The current implementation uses
+      // an INNER JOIN against agent_property_authorizations, so this row
+      // must be invisible. PR 4 swapping to LEFT JOIN would silently
+      // return ghost agent_url=null rows; this test catches that.
+      const ORPHAN_DOMAIN = `prop-orphan${DOMAIN_SUFFIX}`;
+      await fedDb.upsertProperty({
+        property_id: 'orphan-prop',
+        publisher_domain: ORPHAN_DOMAIN,
+        property_type: 'website',
+        name: 'Orphan Site',
+        identifiers: [{ type: 'orphan_id', value: 'orphan-only' }],
+      });
+      const matches = await fedDb.findAgentsForPropertyIdentifier(
+        'orphan_id',
+        'orphan-only'
+      );
+      expect(matches).toEqual([]);
+    });
+
+    it('findAgentsForPropertyIdentifier orders results by (publisher_domain, agent_url)', async () => {
+      // Seed a second publisher with a property carrying an identifier
+      // shared with PUB_A's home property. Two agents on each side give
+      // us a four-row result with a stable expected order.
+      const SHARED_TYPE = 'shared_id';
+      const SHARED_VALUE = 'shared-1';
+      await fedDb.upsertProperty({
+        property_id: 'order-a',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Order A Site',
+        identifiers: [{ type: SHARED_TYPE, value: SHARED_VALUE }],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'order-b',
+        publisher_domain: PUB_B,
+        property_type: 'website',
+        name: 'Order B Site',
+        identifiers: [{ type: SHARED_TYPE, value: SHARED_VALUE }],
+      });
+      const aProps = await fedDb.getPropertiesForDomain(PUB_A);
+      const bProps = await fedDb.getPropertiesForDomain(PUB_B);
+      const aRow = aProps.find((p) => p.property_id === 'order-a') as unknown as { id: string };
+      const bRow = bProps.find((p) => p.property_id === 'order-b') as unknown as { id: string };
+      // Authorize Y first (alphabetically later) to verify ORDER BY,
+      // not insertion order, drives the result.
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_Y,
+        property_id: bRow.id,
+      });
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: bRow.id,
+      });
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_Y,
+        property_id: aRow.id,
+      });
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: aRow.id,
+      });
+
+      const matches = await fedDb.findAgentsForPropertyIdentifier(SHARED_TYPE, SHARED_VALUE);
+      expect(matches.map((m) => `${m.publisher_domain}/${m.agent_url}`)).toEqual([
+        `${PUB_A}/${AGENT_X}`,
+        `${PUB_A}/${AGENT_Y}`,
+        `${PUB_B}/${AGENT_X}`,
+        `${PUB_B}/${AGENT_Y}`,
+      ]);
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────
@@ -256,6 +329,39 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
         'mobile_app/Pinnacle Mobile',
         'website/Pinnacle Homepage',
         'website/Pinnacle News',
+      ]);
+    });
+
+    it('getPropertiesForAgent orders by (publisher_domain, property_type, name)', async () => {
+      // Authorize AGENT_X for PUB_B properties + one PUB_A property so
+      // the cross-publisher ordering contract gets exercised.
+      const pubBProps = await fedDb.getPropertiesForDomain(PUB_B);
+      for (const p of pubBProps) {
+        await fedDb.upsertAgentPropertyAuthorization({
+          agent_url: AGENT_X,
+          property_id: (p as unknown as { id: string }).id,
+        });
+      }
+      await fedDb.upsertProperty({
+        property_id: 'acme-home',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Acme Homepage',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+      });
+      const pubAProps = await fedDb.getPropertiesForDomain(PUB_A);
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: (pubAProps[0] as unknown as { id: string }).id,
+      });
+
+      const ordered = await fedDb.getPropertiesForAgent(AGENT_X);
+      // PUB_A < PUB_B alphabetically (`prop-acme...` < `prop-pinnacle...`).
+      expect(ordered.map((p) => `${p.publisher_domain}/${p.property_type}/${p.name}`)).toEqual([
+        `${PUB_A}/website/Acme Homepage`,
+        `${PUB_B}/mobile_app/Pinnacle Mobile`,
+        `${PUB_B}/website/Pinnacle Homepage`,
+        `${PUB_B}/website/Pinnacle News`,
       ]);
     });
   });

--- a/server/tests/integration/registry-reader-baseline-properties.test.ts
+++ b/server/tests/integration/registry-reader-baseline-properties.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Baseline coverage for property/publisher reader functions ahead of the
+ * property registry unification (issue #3177). PR 1 (#3195) shipped the
+ * empty `publishers` + `adagents_authorization_overrides` schema; PR 4
+ * will swap readers to consult that schema. These tests pin the I/O of
+ * the current readers — same fixtures, identical assertions must pass
+ * before and after the cutover.
+ *
+ * What this file covers:
+ *   - PropertyDatabase.getDiscoveredPropertiesByDomain
+ *   - PropertyDatabase.getAllPropertiesForRegistry
+ *   - PropertyDatabase.getPropertyRegistryStats
+ *   - FederatedIndexDatabase.getPropertiesForDomain (publisher-side reader)
+ *   - FederatedIndexDatabase.getPropertiesForAgent
+ *   - FederatedIndexDatabase.getPublisherDomainsForAgent
+ *   - FederatedIndexDatabase.findAgentsForPropertyIdentifier
+ *   - FederatedIndexDatabase.hasValidAdagents
+ *   - FederatedIndexDatabase.getStats (lower-bound assertions only)
+ *
+ * Authorization-side readers (getAgentsForDomain, validateAgentForProduct,
+ * etc.) live in registry-reader-baseline-authorizations.test.ts.
+ *
+ * Fixtures use the *.registry-baseline.example domain suffix so a parallel
+ * run of registry-feed/registry-search/etc. cannot trample our seed data.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+
+// `prop-` prefix scopes this file's fixtures away from the sibling
+// baseline files (auth-, endpoint-, mcp-) so concurrent file execution
+// can't trample state via shared LIKE patterns.
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const DOMAIN_PREFIX = 'prop-';
+const AGENT_PREFIX = 'https://prop-';
+const PUB_A = `${DOMAIN_PREFIX}acme${DOMAIN_SUFFIX}`;
+const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
+const PUB_C = `${DOMAIN_PREFIX}nova${DOMAIN_SUFFIX}`;
+const HOSTED_DOMAIN = `${DOMAIN_PREFIX}meridian${DOMAIN_SUFFIX}`;
+const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
+const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
+
+describe('Registry reader baseline — properties + publisher-side reads', () => {
+  let pool: Pool;
+  let fedDb: FederatedIndexDatabase;
+  let propDb: PropertyDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    fedDb = new FederatedIndexDatabase();
+    propDb = new PropertyDatabase();
+  });
+
+  // Cleanup keyed strictly to this file's `prop-` prefix. The sibling
+  // baseline files (auth-, endpoint-, mcp-) use disjoint prefixes so
+  // concurrent file execution can't trample state.
+  const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
+  const AGENT_LIKE = `${AGENT_PREFIX}%${DOMAIN_SUFFIX}`;
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE property_id IN (
+         SELECT id FROM discovered_properties WHERE publisher_domain LIKE $1
+       )
+          OR agent_url LIKE $2`,
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM agent_publisher_authorizations WHERE publisher_domain LIKE $1 OR agent_url LIKE $2',
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_publishers WHERE domain LIKE $1 OR discovered_by_agent LIKE $2',
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_agents WHERE agent_url LIKE $1 OR source_domain LIKE $2',
+      [AGENT_LIKE, DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM hosted_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Empty registry — every reader must tolerate a cold DB shape.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('empty registry (no fixtures for this suffix)', () => {
+    it('getPropertiesForDomain returns []', async () => {
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      expect(props).toEqual([]);
+    });
+
+    it('getDiscoveredPropertiesByDomain returns []', async () => {
+      const props = await propDb.getDiscoveredPropertiesByDomain(PUB_A);
+      expect(props).toEqual([]);
+    });
+
+    it('getPropertiesForAgent returns [] for an unknown agent', async () => {
+      const props = await fedDb.getPropertiesForAgent(AGENT_X);
+      expect(props).toEqual([]);
+    });
+
+    it('getPublisherDomainsForAgent returns [] for an unknown agent', async () => {
+      const domains = await fedDb.getPublisherDomainsForAgent(AGENT_X);
+      expect(domains).toEqual([]);
+    });
+
+    it('findAgentsForPropertyIdentifier returns [] when no property matches', async () => {
+      const agents = await fedDb.findAgentsForPropertyIdentifier(
+        'domain',
+        `unknown${DOMAIN_SUFFIX}`
+      );
+      expect(agents).toEqual([]);
+    });
+
+    it('hasValidAdagents returns null for a domain never discovered', async () => {
+      const result = await fedDb.hasValidAdagents(`unseen${DOMAIN_SUFFIX}`);
+      expect(result).toBeNull();
+    });
+
+    it('getAllPropertiesForRegistry filtered to our prefix returns []', async () => {
+      const rows = await propDb.getAllPropertiesForRegistry({ search: DOMAIN_PREFIX });
+      expect(rows).toEqual([]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Single publisher / single property / single agent.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('single publisher + property + agent', () => {
+    beforeEach(async () => {
+      await fedDb.upsertProperty({
+        property_id: 'prop-a-website',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Acme Homepage',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+        tags: ['news'],
+      });
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      const propRow = props[0] as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propRow.id,
+        authorized_for: 'all',
+      });
+    });
+
+    it('getPropertiesForDomain returns the seeded property with parsed identifiers', async () => {
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      expect(props.length).toBe(1);
+      expect(props[0].publisher_domain).toBe(PUB_A);
+      expect(props[0].name).toBe('Acme Homepage');
+      expect(props[0].property_type).toBe('website');
+      expect(props[0].identifiers).toEqual([{ type: 'domain', value: PUB_A }]);
+      expect(props[0].tags).toEqual(['news']);
+    });
+
+    it('getDiscoveredPropertiesByDomain returns the seeded row with the same fields', async () => {
+      const props = await propDb.getDiscoveredPropertiesByDomain(PUB_A);
+      expect(props.length).toBe(1);
+      expect(props[0].publisher_domain).toBe(PUB_A);
+      expect(props[0].name).toBe('Acme Homepage');
+      expect(props[0].identifiers).toEqual([{ type: 'domain', value: PUB_A }]);
+    });
+
+    it('getPropertiesForAgent returns properties via the join', async () => {
+      const props = await fedDb.getPropertiesForAgent(AGENT_X);
+      expect(props.length).toBe(1);
+      expect(props[0].publisher_domain).toBe(PUB_A);
+      expect(props[0].name).toBe('Acme Homepage');
+    });
+
+    it('getPublisherDomainsForAgent returns the publisher', async () => {
+      const domains = await fedDb.getPublisherDomainsForAgent(AGENT_X);
+      expect(domains).toEqual([PUB_A]);
+    });
+
+    it('findAgentsForPropertyIdentifier matches on (type, value)', async () => {
+      const matches = await fedDb.findAgentsForPropertyIdentifier('domain', PUB_A);
+      expect(matches.length).toBe(1);
+      expect(matches[0].agent_url).toBe(AGENT_X);
+      expect(matches[0].publisher_domain).toBe(PUB_A);
+      expect(matches[0].property.name).toBe('Acme Homepage');
+    });
+
+    it('findAgentsForPropertyIdentifier does not match on a partial type/value', async () => {
+      const wrongType = await fedDb.findAgentsForPropertyIdentifier('ios_bundle', PUB_A);
+      expect(wrongType).toEqual([]);
+      const wrongValue = await fedDb.findAgentsForPropertyIdentifier(
+        'domain',
+        `other${DOMAIN_SUFFIX}`
+      );
+      expect(wrongValue).toEqual([]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Multiple properties per publisher + ORDER BY contract.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('multiple properties per publisher', () => {
+    beforeEach(async () => {
+      // Seeded out of final ORDER BY so we can assert sorting actually applies.
+      await fedDb.upsertProperty({
+        property_id: 'pin-mobile',
+        publisher_domain: PUB_B,
+        property_type: 'mobile_app',
+        name: 'Pinnacle Mobile',
+        identifiers: [{ type: 'ios_bundle', value: 'com.pinnacle.app' }],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'pin-web-news',
+        publisher_domain: PUB_B,
+        property_type: 'website',
+        name: 'Pinnacle News',
+        identifiers: [{ type: 'domain', value: `news.${PUB_B}` }],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'pin-web-home',
+        publisher_domain: PUB_B,
+        property_type: 'website',
+        name: 'Pinnacle Homepage',
+        identifiers: [{ type: 'domain', value: PUB_B }],
+      });
+    });
+
+    it('getPropertiesForDomain orders by (property_type, name)', async () => {
+      const props = await fedDb.getPropertiesForDomain(PUB_B);
+      expect(props.map((p) => `${p.property_type}/${p.name}`)).toEqual([
+        'mobile_app/Pinnacle Mobile',
+        'website/Pinnacle Homepage',
+        'website/Pinnacle News',
+      ]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Multiple agents per property — both surface through the readers.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('multiple agents per property', () => {
+    beforeEach(async () => {
+      await fedDb.upsertProperty({
+        property_id: 'shared-prop',
+        publisher_domain: PUB_C,
+        property_type: 'website',
+        name: 'Nova Shared Site',
+        identifiers: [{ type: 'domain', value: PUB_C }],
+      });
+      const props = await fedDb.getPropertiesForDomain(PUB_C);
+      const propRow = props[0] as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propRow.id,
+      });
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_Y,
+        property_id: propRow.id,
+      });
+    });
+
+    it('findAgentsForPropertyIdentifier returns both agents', async () => {
+      const matches = await fedDb.findAgentsForPropertyIdentifier('domain', PUB_C);
+      const urls = matches.map((m) => m.agent_url).sort();
+      expect(urls).toEqual([AGENT_X, AGENT_Y]);
+    });
+
+    it('getPropertiesForAgent works independently for each agent', async () => {
+      const xProps = await fedDb.getPropertiesForAgent(AGENT_X);
+      const yProps = await fedDb.getPropertiesForAgent(AGENT_Y);
+      expect(xProps.length).toBe(1);
+      expect(yProps.length).toBe(1);
+      expect(xProps[0].name).toBe('Nova Shared Site');
+      expect(yProps[0].name).toBe('Nova Shared Site');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // hasValidAdagents — three states: null (unseen), false, true.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('hasValidAdagents three-state contract', () => {
+    it('returns false when discovered_publishers row exists with has_valid_adagents=false', async () => {
+      await fedDb.upsertPublisher({
+        domain: PUB_A,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: false,
+      });
+      const result = await fedDb.hasValidAdagents(PUB_A);
+      expect(result).toBe(false);
+    });
+
+    it('returns true once any record reports has_valid_adagents=true', async () => {
+      await fedDb.upsertPublisher({
+        domain: PUB_B,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: false,
+      });
+      await fedDb.upsertPublisher({
+        domain: PUB_B,
+        discovered_by_agent: AGENT_Y,
+        has_valid_adagents: true,
+      });
+      const result = await fedDb.hasValidAdagents(PUB_B);
+      expect(result).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Registry view (hosted + discovered union).
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('getAllPropertiesForRegistry / getPropertyRegistryStats', () => {
+    beforeEach(async () => {
+      // One discovered property (adagents_json source).
+      await fedDb.upsertProperty({
+        property_id: 'reg-discovered',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Acme Homepage',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+      });
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      const propRow = props[0] as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propRow.id,
+      });
+
+      // One hosted (community) property — public + approved.
+      await propDb.createHostedProperty({
+        publisher_domain: HOSTED_DOMAIN,
+        adagents_json: {
+          authorized_agents: [{ url: AGENT_X }],
+          properties: [{ name: 'Meridian Site', property_type: 'website' }],
+        },
+        source_type: 'community',
+        is_public: true,
+        review_status: 'approved',
+      });
+    });
+
+    it('returns one row per source for our prefix, with the hosted row marked as community', async () => {
+      const rows = await propDb.getAllPropertiesForRegistry({ search: DOMAIN_PREFIX });
+      const byDomain = new Map(rows.map((r) => [r.domain, r]));
+
+      const hosted = byDomain.get(HOSTED_DOMAIN);
+      expect(hosted).toBeTruthy();
+      expect(hosted!.source).toBe('community');
+      expect(hosted!.property_count).toBe(1);
+      expect(hosted!.agent_count).toBe(1);
+
+      const discovered = byDomain.get(PUB_A);
+      expect(discovered).toBeTruthy();
+      expect(discovered!.source).toBe('adagents_json');
+      expect(discovered!.property_count).toBe(1);
+      expect(discovered!.agent_count).toBe(1);
+    });
+
+    it('rows are returned ordered by domain ascending', async () => {
+      const rows = await propDb.getAllPropertiesForRegistry({ search: DOMAIN_PREFIX });
+      const domains = rows.map((r) => r.domain);
+      const sorted = [...domains].sort();
+      expect(domains).toEqual(sorted);
+    });
+
+    it('getPropertyRegistryStats counts at least both seeded sources for our prefix', async () => {
+      const stats = await propDb.getPropertyRegistryStats(DOMAIN_PREFIX);
+      expect(stats.community).toBeGreaterThanOrEqual(1);
+      expect(stats.adagents_json).toBeGreaterThanOrEqual(1);
+      // total is the sum of all source buckets and must reconcile with
+      // the per-bucket counts.
+      expect(stats.total).toBeGreaterThanOrEqual(stats.community + stats.adagents_json);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Stats — lower-bound assertions to survive cross-suite contamination.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('getStats lower-bounds', () => {
+    it('reflects at least the rows seeded in this test', async () => {
+      await fedDb.upsertAgent({
+        agent_url: AGENT_X,
+        source_type: 'adagents_json',
+        source_domain: PUB_A,
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        source: 'adagents_json',
+      });
+      await fedDb.upsertProperty({
+        property_id: 'stats-prop',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Acme Stats Site',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+      });
+      await fedDb.upsertPublisher({
+        domain: PUB_A,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: true,
+      });
+
+      const stats = await fedDb.getStats();
+      expect(stats.discovered_agents).toBeGreaterThanOrEqual(1);
+      expect(stats.discovered_publishers).toBeGreaterThanOrEqual(1);
+      expect(stats.discovered_properties).toBeGreaterThanOrEqual(1);
+      expect(stats.authorizations).toBeGreaterThanOrEqual(1);
+      expect(stats.authorizations_by_source.adagents_json).toBeGreaterThanOrEqual(1);
+      expect(stats.properties_by_type.website).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/server/tests/integration/registry-reader-baseline-properties.test.ts
+++ b/server/tests/integration/registry-reader-baseline-properties.test.ts
@@ -219,6 +219,41 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
       expect(wrongValue).toEqual([]);
     });
 
+    it('findAgentsForPropertyIdentifier matches a property whose identifier carries extra fields beyond {type,value} (JSONB containment)', async () => {
+      // PR 4 may move identifiers from a JSONB array to a normalized
+      // (property_id, type, value) table. JSONB `@>` containment today
+      // is element-wise — `[{type, value}]` is contained by
+      // `[{type, value, region}]`. Pinning that the reader still surfaces
+      // a property whose stored identifier carries an extra key catches
+      // a normalization that silently drops extras.
+      const EXTRA_DOMAIN = `prop-extra${DOMAIN_SUFFIX}`;
+      await fedDb.upsertProperty({
+        property_id: 'extra-prop',
+        publisher_domain: EXTRA_DOMAIN,
+        property_type: 'website',
+        name: 'Extra-Field Site',
+        identifiers: [
+          // Cast through unknown to get past the PropertyIdentifier
+          // {type, value} type — the stored JSONB carries the extra key.
+          { type: 'domain', value: EXTRA_DOMAIN, region: 'us' } as unknown as {
+            type: string;
+            value: string;
+          },
+        ],
+      });
+      const props = await fedDb.getPropertiesForDomain(EXTRA_DOMAIN);
+      const propRow = props[0] as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: propRow.id,
+      });
+
+      const matches = await fedDb.findAgentsForPropertyIdentifier('domain', EXTRA_DOMAIN);
+      expect(matches.length).toBe(1);
+      expect(matches[0].agent_url).toBe(AGENT_X);
+      expect(matches[0].publisher_domain).toBe(EXTRA_DOMAIN);
+    });
+
     it('findAgentsForPropertyIdentifier returns [] when the property has no agent_property_authorizations row (INNER JOIN contract)', async () => {
       // Insert a property with the same identifier under a *different*
       // publisher and no authorization. The current implementation uses
@@ -503,6 +538,43 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
       // total is the sum of all source buckets and must reconcile with
       // the per-bucket counts.
       expect(stats.total).toBeGreaterThanOrEqual(stats.community + stats.adagents_json);
+    });
+
+    it('a domain with both a public hosted row AND discovered_properties surfaces ONCE, sourced from hosted (precedence carve-out)', async () => {
+      // The current SQL carve-out (NOT IN public hosted_properties) is
+      // the single piece of non-trivial logic in this reader. PR 4 could
+      // remove or invert it — produce two rows, flip precedence to
+      // discovered, etc. — and a fixture with disjoint hosted+discovered
+      // domains would not catch the regression. Seed a third domain
+      // with both sides.
+      const DUAL = `${DOMAIN_PREFIX}dual${DOMAIN_SUFFIX}`;
+      await fedDb.upsertProperty({
+        property_id: 'dual-discovered',
+        publisher_domain: DUAL,
+        property_type: 'website',
+        name: 'Dual Discovered Site',
+        identifiers: [{ type: 'domain', value: DUAL }],
+      });
+      await propDb.createHostedProperty({
+        publisher_domain: DUAL,
+        adagents_json: {
+          authorized_agents: [{ url: AGENT_X }, { url: AGENT_Y }],
+          properties: [{ name: 'Dual Hosted Site', property_type: 'website' }],
+        },
+        source_type: 'community',
+        is_public: true,
+        review_status: 'approved',
+      });
+
+      const rows = await propDb.getAllPropertiesForRegistry({ search: DOMAIN_PREFIX });
+      const dualRows = rows.filter((r) => r.domain === DUAL);
+      expect(dualRows.length).toBe(1);
+      expect(dualRows[0].source).toBe('community');
+      // Hosted's agent_count comes from the adagents_json `authorized_agents`
+      // array length (2), not the discovered apa rows (0). Pinning this
+      // confirms the row was sourced from the hosted side, not the
+      // discovered side.
+      expect(dualRows[0].agent_count).toBe(2);
     });
   });
 

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Baseline coverage for the public registry HTTP endpoints ahead of the
+ * property registry unification (issue #3177). PR 4 will swap the
+ * federated-index readers under these endpoints to the new publishers /
+ * adagents_authorization_overrides schema (#3195). Same fixtures must
+ * produce the same response shapes before and after the cutover.
+ *
+ * Endpoints covered:
+ *   - GET /api/registry/agents (with and without ?properties=true)
+ *   - GET /api/registry/publishers
+ *   - GET /api/registry/publisher?domain=X
+ *   - GET /api/registry/operator?domain=X
+ *   - GET /api/registry/stats
+ *   - GET /api/registry/feed       (smoke test: 200 + envelope shape)
+ *
+ * Assertion discipline: response shapes, presence of our seeded entities,
+ * counts/identities scoped to our test fixtures. We explicitly do NOT
+ * assert top-level totals because the shared test DB carries other suites'
+ * residue.
+ *
+ * Fixtures use the *.registry-baseline.example domain suffix with an
+ * `endpoint-` prefix to keep us from colliding with the sibling baseline
+ * files or any parallel registry-* test.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+// Bypass WorkOS auth — the registry feed requires `requireAuth`. Stamp
+// every request with a fixed test user. Other public registry endpoints
+// use `optAuth` (no-op without a session), so the pass-through here is
+// only load-bearing for /registry/feed.
+const TEST_USER_ID = 'user_test_registry_baseline_endpoints';
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/auth.js'
+  );
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: TEST_USER_ID, email: 'registry-baseline@test.com' };
+    next();
+  };
+  return {
+    ...actual,
+    requireAuth: pass,
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/csrf.js'
+  );
+  return {
+    ...actual,
+    csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+// Stop Stripe init from hitting the network on HTTPServer construction.
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+
+// `endpoint-` prefix scopes this file's fixtures away from the sibling
+// baseline files (prop-, auth-, mcp-) so concurrent file execution can't
+// trample state.
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const DOMAIN_PREFIX = 'endpoint-';
+const AGENT_PREFIX = 'https://endpoint-';
+const PUB_A = `${DOMAIN_PREFIX}acme${DOMAIN_SUFFIX}`;
+const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
+const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
+const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
+
+describe('Registry reader baseline — public endpoints', () => {
+  let server: HTTPServer;
+  // server.app is a private Express instance; we read it via `unknown` so
+  // the test can hand it to supertest without depending on internal types.
+  let app: unknown;
+  let pool: Pool;
+  let fedDb: FederatedIndexDatabase;
+
+  const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
+  const AGENT_LIKE = `${AGENT_PREFIX}%${DOMAIN_SUFFIX}`;
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE property_id IN (
+         SELECT id FROM discovered_properties WHERE publisher_domain LIKE $1
+       )
+          OR agent_url LIKE $2`,
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM agent_publisher_authorizations WHERE publisher_domain LIKE $1 OR agent_url LIKE $2',
+      [DOMAIN_LIKE, AGENT_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_publishers WHERE domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+    await pool.query(
+      'DELETE FROM discovered_agents WHERE agent_url LIKE $1',
+      [AGENT_LIKE]
+    );
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    fedDb = new FederatedIndexDatabase();
+    server = new HTTPServer();
+    await server.start(0);
+    // server.app is private; unknown-typed handoff to supertest.
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clearFixtures();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Empty-suffix world: our seeded entities don't exist yet.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('with an empty suffix', () => {
+    it('GET /api/registry/publisher returns null member + empty arrays for an unseen domain', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        domain: PUB_A,
+        member: null,
+        properties: [],
+        authorized_agents: [],
+      });
+      // adagents_valid is null when domain has never been crawled.
+      expect(res.body.adagents_valid).toBeNull();
+    });
+
+    it('GET /api/registry/operator returns null member + empty agents for an unseen domain', async () => {
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        domain: PUB_A,
+        member: null,
+        agents: [],
+      });
+    });
+
+    it('GET /api/registry/publisher returns 400 when domain query is missing', async () => {
+      const res = await request(app).get('/api/registry/publisher');
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Seeded fixtures: properties + agents + authorizations.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('with seeded fixtures', () => {
+    beforeEach(async () => {
+      // Two properties under PUB_A.
+      await fedDb.upsertProperty({
+        property_id: 'endpoint-home',
+        publisher_domain: PUB_A,
+        property_type: 'website',
+        name: 'Endpoint Home',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+        tags: ['flagship'],
+      });
+      await fedDb.upsertProperty({
+        property_id: 'endpoint-mobile',
+        publisher_domain: PUB_A,
+        property_type: 'mobile_app',
+        name: 'Endpoint Mobile',
+        identifiers: [{ type: 'ios_bundle', value: 'com.endpoint.app' }],
+      });
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      const home = props.find((p) => p.name === 'Endpoint Home') as unknown as { id: string };
+      const mobile = props.find((p) => p.name === 'Endpoint Mobile') as unknown as { id: string };
+
+      // Discovered agents (so /registry/agents listAllAgents returns them).
+      await fedDb.upsertAgent({
+        agent_url: AGENT_X,
+        source_type: 'adagents_json',
+        source_domain: PUB_A,
+        agent_type: 'sales',
+        protocol: 'mcp',
+        name: 'Endpoint Sales X',
+      });
+      await fedDb.upsertAgent({
+        agent_url: AGENT_Y,
+        source_type: 'adagents_json',
+        source_domain: PUB_B,
+        agent_type: 'sales',
+        protocol: 'mcp',
+        name: 'Endpoint Sales Y',
+      });
+
+      // Publisher-level authorizations (drives /registry/publisher and
+      // /registry/operator).
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_X,
+        publisher_domain: PUB_A,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+      await fedDb.upsertAuthorization({
+        agent_url: AGENT_Y,
+        publisher_domain: PUB_A,
+        source: 'agent_claim',
+      });
+
+      // Property-level authorization for AGENT_X on home only (not mobile).
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_X,
+        property_id: home.id,
+      });
+      // AGENT_Y has property-level auth on mobile only.
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: AGENT_Y,
+        property_id: mobile.id,
+      });
+
+      // Discovered publisher row so hasValidAdagents resolves true.
+      await fedDb.upsertPublisher({
+        domain: PUB_A,
+        discovered_by_agent: AGENT_X,
+        has_valid_adagents: true,
+      });
+    });
+
+    // ── /registry/publisher ────────────────────────────────────────
+
+    it('GET /api/registry/publisher returns properties + authorized agents for a seeded domain', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.domain).toBe(PUB_A);
+      expect(res.body.adagents_valid).toBe(true);
+
+      // Properties: the route projects {id, type, name, identifiers, tags}.
+      const propsByName = new Map(
+        res.body.properties.map((p: { name: string }) => [p.name, p])
+      );
+      expect(propsByName.size).toBe(2);
+      expect(propsByName.get('Endpoint Home')).toMatchObject({
+        id: 'endpoint-home',
+        type: 'website',
+        name: 'Endpoint Home',
+        identifiers: [{ type: 'domain', value: PUB_A }],
+      });
+      expect(propsByName.get('Endpoint Mobile')).toMatchObject({
+        id: 'endpoint-mobile',
+        type: 'mobile_app',
+      });
+
+      // Authorized agents: includes both adagents_json and agent_claim
+      // sources, projected as {url, authorized_for, source}.
+      const agentsByUrl = new Map(
+        res.body.authorized_agents.map((a: { url: string }) => [a.url, a])
+      );
+      expect(agentsByUrl.get(AGENT_X)).toMatchObject({
+        url: AGENT_X,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+      expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
+        url: AGENT_Y,
+        source: 'agent_claim',
+      });
+    });
+
+    // ── /registry/publishers ───────────────────────────────────────
+
+    it('GET /api/registry/publishers includes our seeded publisher with discovered source', async () => {
+      const res = await request(app).get('/api/registry/publishers');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.publishers)).toBe(true);
+      expect(res.body.sources).toMatchObject({
+        registered: expect.any(Number),
+        discovered: expect.any(Number),
+      });
+
+      const ours = res.body.publishers.find(
+        (p: { domain: string }) => p.domain === PUB_A
+      );
+      expect(ours).toBeTruthy();
+      expect(ours.source).toBe('discovered');
+      expect(ours.has_valid_adagents).toBe(true);
+    });
+
+    // ── /registry/operator ─────────────────────────────────────────
+
+    it('GET /api/registry/operator returns null member when no profile owns the domain', async () => {
+      // No member_profile seeded for PUB_A, so the operator endpoint
+      // returns the empty agent list (the agents array is sourced from
+      // the member profile's agents[], not federated discoveries).
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        domain: PUB_A,
+        member: null,
+        agents: [],
+      });
+    });
+
+    // ── /registry/stats ────────────────────────────────────────────
+
+    it('GET /api/registry/stats reflects at least our seeded counts', async () => {
+      const res = await request(app).get('/api/registry/stats');
+      expect(res.status).toBe(200);
+      // Lower-bounds: our seed adds ≥2 agents, ≥1 publisher, ≥2 properties,
+      // ≥2 authorizations (one each in adagents_json + agent_claim).
+      expect(res.body.discovered_agents).toBeGreaterThanOrEqual(2);
+      expect(res.body.discovered_publishers).toBeGreaterThanOrEqual(1);
+      expect(res.body.discovered_properties).toBeGreaterThanOrEqual(2);
+      expect(res.body.authorizations).toBeGreaterThanOrEqual(2);
+      expect(res.body.authorizations_by_source.adagents_json).toBeGreaterThanOrEqual(1);
+      expect(res.body.authorizations_by_source.agent_claim).toBeGreaterThanOrEqual(1);
+      expect(res.body.properties_by_type.website).toBeGreaterThanOrEqual(1);
+      expect(res.body.properties_by_type.mobile_app).toBeGreaterThanOrEqual(1);
+    });
+
+    // ── /registry/agents ───────────────────────────────────────────
+
+    it('GET /api/registry/agents includes our seeded agents (no enrichment)', async () => {
+      const res = await request(app).get('/api/registry/agents');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.agents)).toBe(true);
+      expect(res.body.sources).toMatchObject({
+        registered: expect.any(Number),
+        discovered: expect.any(Number),
+      });
+
+      const x = res.body.agents.find((a: { url: string }) => a.url === AGENT_X);
+      const y = res.body.agents.find((a: { url: string }) => a.url === AGENT_Y);
+      expect(x).toBeTruthy();
+      expect(y).toBeTruthy();
+      expect(x.source).toBe('discovered');
+      expect(x.type).toBe('sales');
+    });
+
+    it('GET /api/registry/agents?properties=true enriches buying agents only', async () => {
+      // Seed an additional buyer-typed agent so we exercise the
+      // properties-enrichment branch. The current readers attach
+      // property_summary + publisher_domains for type=buying.
+      const BUYER_URL = 'https://endpoint-buyer.registry-baseline.example';
+      await fedDb.upsertAgent({
+        agent_url: BUYER_URL,
+        source_type: 'adagents_json',
+        source_domain: PUB_B,
+        agent_type: 'buying',
+        protocol: 'mcp',
+        name: 'Endpoint Buyer',
+      });
+      // Authorize the buyer on the existing PUB_A home property.
+      const props = await fedDb.getPropertiesForDomain(PUB_A);
+      const home = props.find((p) => p.name === 'Endpoint Home') as unknown as { id: string };
+      await fedDb.upsertAgentPropertyAuthorization({
+        agent_url: BUYER_URL,
+        property_id: home.id,
+      });
+
+      const res = await request(app).get('/api/registry/agents?properties=true');
+      expect(res.status).toBe(200);
+
+      const buyer = res.body.agents.find((a: { url: string }) => a.url === BUYER_URL);
+      expect(buyer).toBeTruthy();
+      expect(buyer.publisher_domains).toEqual([PUB_A]);
+      expect(buyer.property_summary).toMatchObject({
+        total_count: 1,
+        publisher_count: 1,
+        count_by_type: { website: 1 },
+      });
+
+      // Sales-typed agents must NOT receive property enrichment, even
+      // when ?properties=true is set.
+      const x = res.body.agents.find((a: { url: string }) => a.url === AGENT_X);
+      expect(x).toBeTruthy();
+      expect(x.publisher_domains).toBeUndefined();
+      expect(x.property_summary).toBeUndefined();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // /registry/feed — change feed smoke test. The feed itself reads
+  // catalog_events (not the property/publisher tables under cutover)
+  // but is listed in #3177 because cross-instance pollers depend on it
+  // staying stable across the migration.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('/registry/feed envelope', () => {
+    it('returns events array + has_more flag (auth pass-through under test mock)', async () => {
+      const res = await request(app).get('/api/registry/feed?limit=1');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.events)).toBe(true);
+      expect(typeof res.body.has_more).toBe('boolean');
+    });
+
+    it('rejects an invalid cursor format with 400', async () => {
+      const res = await request(app).get('/api/registry/feed?cursor=not-a-uuid');
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -80,6 +80,8 @@ const PUB_A = `${DOMAIN_PREFIX}acme${DOMAIN_SUFFIX}`;
 const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
 const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
 const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
+const ORG_ID = 'org_endpoint_registry_baseline';
+const MEMBER_SLUG = 'endpoint-acme-baseline';
 
 describe('Registry reader baseline — public endpoints', () => {
   let server: HTTPServer;
@@ -117,6 +119,8 @@ describe('Registry reader baseline — public endpoints', () => {
       'DELETE FROM discovered_agents WHERE agent_url LIKE $1',
       [AGENT_LIKE]
     );
+    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [ORG_ID]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG_ID]);
   }
 
   beforeAll(async () => {
@@ -335,6 +339,69 @@ describe('Registry reader baseline — public endpoints', () => {
       });
     });
 
+    it('GET /api/registry/operator projects the member profile + per-agent authorized_by array', async () => {
+      // Seed a profile claiming PUB_A as its primary brand domain. The
+      // operator endpoint pulls agents from the profile's public
+      // agents[] and enriches each with authorized_by drawn from
+      // getAuthorizationsForAgent. PR 4 swaps that reader, so the
+      // per-agent projection (publisher_domain, authorized_for, source)
+      // is exactly what the cutover must preserve. The seeded fixtures
+      // already have AGENT_X authorized to PUB_A via adagents_json.
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES ($1, 'Endpoint Baseline Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [ORG_ID]
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, primary_brand_domain, is_public,
+           created_at, updated_at
+         ) VALUES ($1, 'Endpoint Baseline Org', $2, $3::jsonb, $4, true, NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO UPDATE SET
+           agents = EXCLUDED.agents,
+           primary_brand_domain = EXCLUDED.primary_brand_domain,
+           is_public = EXCLUDED.is_public,
+           updated_at = NOW()`,
+        [
+          ORG_ID,
+          MEMBER_SLUG,
+          JSON.stringify([
+            { url: AGENT_X, name: 'Endpoint Sales X', type: 'sales', visibility: 'public' },
+          ]),
+          PUB_A,
+        ]
+      );
+
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.domain).toBe(PUB_A);
+      expect(res.body.member).toMatchObject({
+        slug: MEMBER_SLUG,
+        display_name: 'Endpoint Baseline Org',
+      });
+      expect(res.body.agents).toHaveLength(1);
+      expect(res.body.agents[0]).toMatchObject({
+        url: AGENT_X,
+        name: 'Endpoint Sales X',
+        type: 'sales',
+      });
+      // The authorized_by array shape is what publisher-ops UIs render
+      // and what PR 4 must not silently rename or drop.
+      expect(Array.isArray(res.body.agents[0].authorized_by)).toBe(true);
+      const pubAEntry = res.body.agents[0].authorized_by.find(
+        (a: { publisher_domain: string }) => a.publisher_domain === PUB_A
+      );
+      expect(pubAEntry).toMatchObject({
+        publisher_domain: PUB_A,
+        authorized_for: 'all',
+        source: 'adagents_json',
+      });
+    });
+
     // ── /registry/stats ────────────────────────────────────────────
 
     it('GET /api/registry/stats reflects at least our seeded counts', async () => {
@@ -354,7 +421,7 @@ describe('Registry reader baseline — public endpoints', () => {
 
     // ── /registry/agents ───────────────────────────────────────────
 
-    it('GET /api/registry/agents includes our seeded agents (no enrichment)', async () => {
+    it('GET /api/registry/agents includes our seeded agents with full DSP-discovery projection', async () => {
       const res = await request(app).get('/api/registry/agents');
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body.agents)).toBe(true);
@@ -369,6 +436,15 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(y).toBeTruthy();
       expect(x.source).toBe('discovered');
       expect(x.type).toBe('sales');
+      expect(x.protocol).toBe('mcp');
+      // discovered_from is the DSP-discovery breadcrumb — sourced from
+      // the bulk-auth join via discovered_agents.source_domain. PR 4
+      // must not drop or rename this field.
+      expect(x.discovered_from).toMatchObject({ publisher_domain: PUB_A });
+      // added_date is sourced from discovered_at; pin presence as a
+      // non-empty string but not an exact value.
+      expect(typeof x.added_date).toBe('string');
+      expect(x.added_date.length).toBeGreaterThan(0);
     });
 
     it('GET /api/registry/agents?properties=true enriches buying agents only', async () => {


### PR DESCRIPTION
## Summary

PR 3 of the property registry unification (tracking issue [#3177](https://github.com/adcontextprotocol/adcp/issues/3177)). Tests-only, **no production code changes**.

PR 1 ([#3195](https://github.com/adcontextprotocol/adcp/pull/3195)) shipped the empty `publishers` + `adagents_authorization_overrides` schema. PR 4 will swap the federated-index + property-registry readers to consult that schema. This PR pins the I/O of the *current* readers — same fixtures, same response shapes, identities, counts, ordering — so PR 4 will fail loudly if the cutover changes any caller-visible behavior.

## Coverage

Four new files under `server/tests/integration/`, all integration tests against a real Postgres at `process.env.DATABASE_URL` (default `postgresql://adcp:localdev@localhost:5432/adcp_test`).

- **`registry-reader-baseline-properties.test.ts`** — `getPropertiesForDomain`, `getDiscoveredPropertiesByDomain`, `getPropertiesForAgent`, `getPublisherDomainsForAgent`, `findAgentsForPropertyIdentifier`, `hasValidAdagents` three-state contract, `getAllPropertiesForRegistry` source-projection + ORDER BY, `getPropertyRegistryStats`, `FederatedIndexDatabase.getStats` lower-bounds.
- **`registry-reader-baseline-authorizations.test.ts`** — `getAgentsForDomain` / `getDomainsForAgent` ordering contract, `getAgentAuthorizationsForDomain`, `bulkGetFirstAuthForAgents` (incl. `adagents_json > agent_claim` source preference), `validateAgentForProduct` for `selection_type` ∈ {`all`, `by_id`, `by_tag`} with source reporting (`adagents_json` / `agent_claim` / `none`), wildcard-agent (`'*'`) literal handling.
- **`registry-reader-baseline-public-endpoints.test.ts`** — supertest against `GET /api/registry/agents` (with and without `?properties=true`, asserting the `buying`-only enrichment branch), `/registry/publishers`, `/registry/publisher?domain=X`, `/registry/operator?domain=X`, `/registry/stats`, plus a smoke test for `/registry/feed` envelope shape.
- **`registry-reader-baseline-mcp.test.ts`** — `lookup_domain` (separates `adagents_json` authorized agents from `agent_claim` sales claims) and `list_publishers` (dedupes by domain across multiple discovering agents). `list_authorized_properties` is the upstream sales-agent tool name and intentionally out of scope.

## Assertion discipline

Behavior only — response shape, returned counts, returned identities, ordering contracts. No assertions on internal types or implementation details. PR 4 must be able to swap implementations and these tests still pass with identical I/O.

## Parallelism

Each file uses a disjoint domain prefix (`prop-` / `auth-` / `endpoint-` / `mcp-`) under `*.registry-baseline.example` so the four can run concurrently with each other and with sibling `registry-*` tests without trampling state. Stats and registry-view assertions use lower-bounds where shared-DB residue would otherwise cause flakes.

## Test plan

- [x] All 4 new files pass against current `main` behavior, individually
- [x] All 4 pass when run together (60 tests)
- [x] All 4 pass alongside `registry-feed.test.ts`, `registry-search.test.ts`, `registry-overlay-schema.test.ts` in the same vitest run (100 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)