### PR TITLE
feat(admin): POST /api/admin/accounts/:orgId/reset-subscription-state

### DIFF
--- a/.changeset/admin-reset-subscription-state.md
+++ b/.changeset/admin-reset-subscription-state.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `POST /api/admin/accounts/:orgId/reset-subscription-state` — admin-only endpoint that atomically clears all subscription fields to NULL for orgs whose Stripe state is gone but whose DB rows are stale. Includes live-subscription safety guard, org-name confirmation, required reason field, and before-state snapshot in registry_audit_log.

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -435,4 +435,156 @@ export function setupAccountsBillingRoutes(
       }
     }
   );
+
+  // POST /api/admin/accounts/:orgId/reset-subscription-state
+  // Atomically clears all subscription-related fields to NULL.
+  // Use when Stripe state is gone but the DB row is stale (e.g., post-audit cleanup,
+  // unlinked customer with orphaned stripe_subscription_id blocking a unique constraint).
+  apiRouter.post(
+    "/accounts/:orgId/reset-subscription-state",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const { confirmation, reason } = req.body;
+
+      try {
+        const pool = getPool();
+
+        const orgResult = await pool.query(
+          `SELECT workos_organization_id, name, stripe_customer_id,
+                  subscription_status, stripe_subscription_id,
+                  subscription_amount, subscription_currency, subscription_interval,
+                  subscription_current_period_end, subscription_canceled_at,
+                  subscription_product_id, subscription_product_name,
+                  subscription_price_id, subscription_price_lookup_key,
+                  membership_tier, subscription_metadata
+           FROM organizations WHERE workos_organization_id = $1`,
+          [orgId]
+        );
+
+        if (orgResult.rows.length === 0) {
+          return res.status(404).json({
+            error: "Organization not found",
+            message: "The specified organization does not exist",
+          });
+        }
+
+        const org = orgResult.rows[0];
+
+        if (!reason || reason.trim().length < 10) {
+          return res.status(400).json({
+            error: "Reason required",
+            message:
+              "A reason of at least 10 characters is required for the audit record.",
+          });
+        }
+
+        if (!confirmation || confirmation !== org.name) {
+          return res.status(400).json({
+            error: "Confirmation required",
+            message: `To reset subscription state, provide the exact organization name "${org.name}" in the confirmation field.`,
+            requires_confirmation: true,
+            organization_name: org.name,
+          });
+        }
+
+        // Refuse if the org has live Stripe subscriptions — caller should /sync or cancel first.
+        if (org.stripe_customer_id && stripe) {
+          const customer = await stripe.customers.retrieve(
+            org.stripe_customer_id,
+            { expand: ["subscriptions"] }
+          );
+
+          if (!customer.deleted) {
+            const liveStatuses = ["active", "trialing", "past_due", "incomplete"];
+            const liveSubs =
+              (customer as Stripe.Customer).subscriptions?.data.filter(
+                (sub: any) => liveStatuses.includes(sub.status)
+              ) ?? [];
+
+            if (liveSubs.length > 0) {
+              return res.status(400).json({
+                error: "Live subscriptions exist",
+                message: `Organization has ${liveSubs.length} live Stripe subscription(s). Run /sync or cancel the subscription before resetting.`,
+                live_subscription_ids: liveSubs.map((s: any) => s.id),
+              });
+            }
+          }
+        }
+
+        const beforeState = {
+          subscription_status: org.subscription_status,
+          stripe_subscription_id: org.stripe_subscription_id,
+          subscription_amount: org.subscription_amount,
+          subscription_currency: org.subscription_currency,
+          subscription_interval: org.subscription_interval,
+          subscription_current_period_end: org.subscription_current_period_end,
+          subscription_canceled_at: org.subscription_canceled_at,
+          subscription_product_id: org.subscription_product_id,
+          subscription_product_name: org.subscription_product_name,
+          subscription_price_id: org.subscription_price_id,
+          subscription_price_lookup_key: org.subscription_price_lookup_key,
+          membership_tier: org.membership_tier,
+          subscription_metadata: org.subscription_metadata,
+        };
+
+        await pool.query(
+          `UPDATE organizations
+           SET subscription_status = NULL,
+               stripe_subscription_id = NULL,
+               subscription_amount = NULL,
+               subscription_currency = NULL,
+               subscription_interval = NULL,
+               subscription_current_period_end = NULL,
+               subscription_canceled_at = NULL,
+               subscription_product_id = NULL,
+               subscription_product_name = NULL,
+               subscription_price_id = NULL,
+               subscription_price_lookup_key = NULL,
+               membership_tier = NULL,
+               subscription_metadata = NULL,
+               updated_at = NOW()
+           WHERE workos_organization_id = $1`,
+          [orgId]
+        );
+
+        const orgDb = new OrganizationDatabase();
+        await orgDb.recordAuditLog({
+          workos_organization_id: orgId,
+          workos_user_id: req.user!.id,
+          action: "subscription_state_reset",
+          resource_type: "organization",
+          resource_id: orgId,
+          details: {
+            org_name: org.name,
+            admin_email: req.user!.email,
+            reason: reason.trim(),
+            before_state: beforeState,
+          },
+        });
+
+        logger.info(
+          { orgId, orgName: org.name, adminEmail: req.user?.email },
+          "Reset subscription state for organization"
+        );
+
+        res.json({
+          success: true,
+          message: `Subscription state reset for ${org.name}`,
+          org_id: orgId,
+          org_name: org.name,
+          cleared_fields: Object.entries(beforeState)
+            .filter(([, v]) => v !== null)
+            .map(([k]) => k),
+        });
+      } catch (error) {
+        logger.error({ err: error, orgId }, "Error resetting subscription state");
+        res.status(500).json({
+          error: "Internal server error",
+          message: "Unable to reset subscription state",
+        });
+      }
+    }
+  );
 }

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -13,7 +13,7 @@ import Stripe from "stripe";
 import { getPool } from "../../db/client.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
-import { OrganizationDatabase } from "../../db/organization-db.js";
+import { OrganizationDatabase, TIER_PRESERVING_STATUSES } from "../../db/organization-db.js";
 import { stripe } from "../../billing/stripe-client.js";
 
 const logger = createLogger("admin-accounts-billing");
@@ -506,17 +506,23 @@ export function setupAccountsBillingRoutes(
           );
 
           if (!customer.deleted) {
-            const liveStatuses = ["active", "trialing", "past_due", "incomplete"];
+            // Reuse the canonical "live subscription" set (active/trialing/past_due)
+            // from organization-db.ts so this endpoint's safety check stays in
+            // sync with blockIfActiveSubscription. `incomplete` is intentionally
+            // not blocking — Stripe is still trying the initial charge; if it
+            // succeeds later, the customer.subscription.updated webhook will
+            // re-populate the cleared fields.
             const liveSubs =
               (customer as Stripe.Customer).subscriptions?.data.filter(
-                (sub: any) => liveStatuses.includes(sub.status)
+                (sub: Stripe.Subscription) =>
+                  (TIER_PRESERVING_STATUSES as readonly string[]).includes(sub.status)
               ) ?? [];
 
             if (liveSubs.length > 0) {
               return res.status(400).json({
                 error: "Live subscriptions exist",
                 message: `Organization has ${liveSubs.length} live Stripe subscription(s). Run /sync or cancel the subscription before resetting.`,
-                live_subscription_ids: liveSubs.map((s: any) => s.id),
+                live_subscription_ids: liveSubs.map((s: Stripe.Subscription) => s.id),
               });
             }
           }
@@ -542,40 +548,60 @@ export function setupAccountsBillingRoutes(
           subscription_metadata: org.subscription_metadata,
         };
 
-        await pool.query(
-          `UPDATE organizations
-           SET subscription_status = NULL,
-               stripe_subscription_id = NULL,
-               subscription_amount = NULL,
-               subscription_currency = NULL,
-               subscription_interval = NULL,
-               subscription_current_period_end = NULL,
-               subscription_canceled_at = NULL,
-               subscription_product_id = NULL,
-               subscription_product_name = NULL,
-               subscription_price_id = NULL,
-               subscription_price_lookup_key = NULL,
-               membership_tier = NULL,
-               subscription_metadata = NULL,
-               updated_at = NOW()
-           WHERE workos_organization_id = $1`,
-          [orgId]
-        );
-
-        const orgDb = new OrganizationDatabase();
-        await orgDb.recordAuditLog({
-          workos_organization_id: orgId,
-          workos_user_id: req.user!.id,
-          action: "subscription_state_reset",
-          resource_type: "organization",
-          resource_id: orgId,
-          details: {
-            org_name: org.name,
-            admin_email: req.user!.email,
-            reason: reason.trim(),
-            before_state: beforeState,
-          },
-        });
+        // Wrap the UPDATE and audit-log INSERT in a single transaction so
+        // either both succeed or neither does. Without this, a crash or
+        // connection drop between the two writes could leave subscription
+        // state cleared with no audit trail of who did it.
+        const txClient = await pool.connect();
+        try {
+          await txClient.query("BEGIN");
+          await txClient.query(
+            `UPDATE organizations
+             SET subscription_status = NULL,
+                 stripe_subscription_id = NULL,
+                 subscription_amount = NULL,
+                 subscription_currency = NULL,
+                 subscription_interval = NULL,
+                 subscription_current_period_end = NULL,
+                 subscription_canceled_at = NULL,
+                 subscription_product_id = NULL,
+                 subscription_product_name = NULL,
+                 subscription_price_id = NULL,
+                 subscription_price_lookup_key = NULL,
+                 membership_tier = NULL,
+                 subscription_metadata = NULL,
+                 updated_at = NOW()
+             WHERE workos_organization_id = $1`,
+            [orgId]
+          );
+          // Mirrors OrganizationDatabase.recordAuditLog inline so it shares the
+          // transaction. Same table + columns; just executed via the locked
+          // client instead of a fresh pool query.
+          await txClient.query(
+            `INSERT INTO registry_audit_log
+             (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+             VALUES ($1, $2, $3, $4, $5, $6)`,
+            [
+              orgId,
+              req.user!.id,
+              "subscription_state_reset",
+              "organization",
+              orgId,
+              JSON.stringify({
+                org_name: org.name,
+                admin_email: req.user!.email,
+                reason: reason.trim(),
+                before_state: beforeState,
+              }),
+            ]
+          );
+          await txClient.query("COMMIT");
+        } catch (txErr) {
+          try { await txClient.query("ROLLBACK"); } catch { /* swallow */ }
+          throw txErr;
+        } finally {
+          txClient.release();
+        }
 
         logger.info(
           { orgId, orgName: org.name, adminEmail: req.user!.email },

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -472,7 +472,7 @@ export function setupAccountsBillingRoutes(
 
         const org = orgResult.rows[0];
 
-        if (!reason || reason.trim().length < 10) {
+        if (!reason || typeof reason !== 'string' || reason.trim().length < 10) {
           return res.status(400).json({
             error: "Reason required",
             message:
@@ -490,7 +490,16 @@ export function setupAccountsBillingRoutes(
         }
 
         // Refuse if the org has live Stripe subscriptions — caller should /sync or cancel first.
-        if (org.stripe_customer_id && stripe) {
+        // If stripe_customer_id is set but Stripe is unconfigured we can't verify — block the reset.
+        if (org.stripe_customer_id) {
+          if (!stripe) {
+            return res.status(503).json({
+              error: "Stripe not configured",
+              message:
+                "Cannot verify live subscription status — Stripe is not configured. Unlink the customer first or configure Stripe.",
+            });
+          }
+
           const customer = await stripe.customers.retrieve(
             org.stripe_customer_id,
             { expand: ["subscriptions"] }
@@ -513,7 +522,11 @@ export function setupAccountsBillingRoutes(
           }
         }
 
+        // stripe_customer_id is intentionally not cleared — it is managed by the
+        // separate /stripe-customer/unlink endpoint. Included in beforeState for
+        // audit completeness only.
         const beforeState = {
+          stripe_customer_id: org.stripe_customer_id,
           subscription_status: org.subscription_status,
           stripe_subscription_id: org.stripe_subscription_id,
           subscription_amount: org.subscription_amount,
@@ -565,7 +578,7 @@ export function setupAccountsBillingRoutes(
         });
 
         logger.info(
-          { orgId, orgName: org.name, adminEmail: req.user?.email },
+          { orgId, orgName: org.name, adminEmail: req.user!.email },
           "Reset subscription state for organization"
         );
 
@@ -575,7 +588,7 @@ export function setupAccountsBillingRoutes(
           org_id: orgId,
           org_name: org.name,
           cleared_fields: Object.entries(beforeState)
-            .filter(([, v]) => v !== null)
+            .filter(([k, v]) => k !== 'stripe_customer_id' && v !== null)
             .map(([k]) => k),
         });
       } catch (error) {


### PR DESCRIPTION
Closes #3217

## Summary

Adds `POST /api/admin/accounts/:orgId/reset-subscription-state` — an admin-only endpoint that atomically clears all 13 subscription-related fields to NULL for orgs whose Stripe state is gone but whose DB rows are stale.

The immediate use cases are the two orgs surfaced by the Apr 25 2026 audit cleanup:
- **WPP Media** — `subscription_status=active` with zero Stripe billing history; sync has no state to write from, so the row stays stale.
- **Personal Workspace / HYPD** — `stripe_customer_id=null` but `stripe_subscription_id` still set, blocking the HYPD org from picking up the same subscription via the unique constraint `idx_organizations_stripe_subscription_id`.

## Fields cleared (all set to NULL)

`subscription_status`, `stripe_subscription_id`, `subscription_amount`, `subscription_currency`, `subscription_interval`, `subscription_current_period_end`, `subscription_canceled_at`, `subscription_product_id`, `subscription_product_name`, `subscription_price_id`, `subscription_price_lookup_key`, `membership_tier`, `subscription_metadata`

`stripe_customer_id` is **not** cleared — it is managed separately by `POST /api/admin/stripe-customer/unlink`. It is included in the `beforeState` audit snapshot for forensic completeness.

## Safeguards

| Check | Behaviour |
|---|---|
| `reason` missing or < 10 chars | 400 |
| `confirmation` ≠ `org.name` | 400 with `organization_name` hint (same pattern as DELETE /accounts/:orgId) |
| `stripe_customer_id` non-null but Stripe unconfigured | 503 — can't verify live-sub status |
| `stripe_customer_id` non-null + live Stripe subscription exists | 400 with `live_subscription_ids` list |
| None of the above | proceeds |

## Audit

Writes to `registry_audit_log` with `action: "subscription_state_reset"` and `details` containing `{ reason, admin_email, before_state }` — same mechanism used by the delete-workspace endpoint.

## Non-breaking justification

Adds a new endpoint. No existing fields, types, or endpoints are changed; no consumers need to update to keep working.

## Pre-PR review

- **code-reviewer:** approved — blockers fixed: added `typeof reason !== 'string'` guard, 503 when `stripe_customer_id` set but Stripe unconfigured, `stripe_customer_id` in beforeState for audit completeness. Nit (no tests for new endpoint) surfaced below.
- **internal-tools-strategist:** approved — 13-field list confirmed complete including `subscription_metadata`; `liveStatuses` set consistent with rest of codebase; `cleared_fields` filtered to non-null keys.

**Nit (not fixed in this PR):** No unit tests cover the new endpoint. Happy-path + error-path coverage (`404`, `400` on missing reason, `400` on wrong confirmation, `400` on live-sub present, `503` on unconfigured Stripe) should be added in a follow-up.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01W2MEXUk2GfBPwNcUKCrdeF

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2MEXUk2GfBPwNcUKCrdeF)_