### PR TITLE
chore(server): bump @adcp/client 5.18.0 → 5.19.0 + probe idempotency backend at boot

### DIFF
--- a/.changeset/sdk-5-19-and-idempotency-probe.md
+++ b/.changeset/sdk-5-19-and-idempotency-probe.md
@@ -1,0 +1,13 @@
+---
+---
+
+chore(server): bump @adcp/client 5.18.0 → 5.19.0 and probe idempotency backend at boot
+
+Wires the new `IdempotencyStore.probe()` (5.19.0) into the main HTTP boot path right after `runMigrations()`. A misconfigured pool — typo in `DATABASE_URL`, missing migration, deprovisioned DB, wrong credentials — now fails the process at deploy time with a descriptive error naming the table and remediation, rather than silently passing every mutating call to a broken backend until the first 5xx in production.
+
+`probe?.()` is optional on the store interface — when the lazy backend selection in `training-agent/idempotency.ts` falls back to `memoryBackend` (no DB initialized), the call is a no-op and boot proceeds normally.
+
+5.19.0 also ships:
+- `AgentClient.fromMCPClient()` — in-process MCP transport for compliance fleets (adcp-client#1008)
+- Storyboard runner: `$generate:opaque_id` + `context_outputs[generate]` for runner-minted task IDs threaded through multi-step lifecycle storyboards (adcp-client#1006)
+- `get_media_buys` extractor guard for mid-walk pagination pages (adcp-client#999)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0",
       "dependencies": {
-        "@adcp/client": "5.18.0",
+        "@adcp/client": "5.19.0",
         "@anthropic-ai/sdk": "^0.90.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.18.0.tgz",
-      "integrity": "sha512-Rg+7saZescCp9T+Is9OI90pTi8ppm/K6YTxPPIXYznUGgMLPVaGCabBmGNexAVhrjR6Ub87txU6re3ssT6jqTg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.19.0.tgz",
+      "integrity": "sha512-u+5jGZDcqOVK3aAvqIfH2GSj6+GnCmya9F1qTXpnvE8vURp5Kfh9ixvMTc7IGEw6ybYXCyhapvdWATL9DtMfSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "5.18.0",
+    "@adcp/client": "5.19.0",
     "@anthropic-ai/sdk": "^0.90.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -8308,6 +8308,28 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
     await runMigrations();
 
+    // Validate the idempotency backend can actually query its table — fails
+    // fast on a stale pool, missing migration, or wrong-credentials boot
+    // rather than silently passing every mutating call to a broken backend.
+    // No-ops when the store falls back to memoryBackend.
+    //
+    // Bounded with a 10s deadline because the pg pool has connectionTimeoutMillis=5000
+    // but no statement_timeout — without this race, a hung query (e.g., DB starting
+    // up, replica failover) would stall boot indefinitely and starve Fly's TCP healthcheck.
+    const { getIdempotencyStore } = await import("./training-agent/idempotency.js");
+    const probe = getIdempotencyStore().probe?.();
+    if (probe) {
+      await Promise.race([
+        probe,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Idempotency backend probe timed out after 10s — check DATABASE_URL and pool reachability")),
+            10_000,
+          ),
+        ),
+      ]);
+    }
+
     // Sync organizations from WorkOS and Stripe to local database (dev environment support)
     if (AUTH_ENABLED && workos) {
       const orgDb = new OrganizationDatabase();


### PR DESCRIPTION
## Summary

- Bumps `@adcp/client` 5.18.0 → 5.19.0 (release notes: https://github.com/adcontextprotocol/adcp-client/blob/main/CHANGELOG.md#5190)
- Wires the new `IdempotencyStore.probe()` into the HTTP boot path right after `runMigrations()` and before `app.listen()` — a misconfigured pool (typo'd `DATABASE_URL`, missing migration, deprovisioned DB, wrong creds) now fails the deploy with a descriptive error rather than silently passing every mutating call to a broken backend until the first 5xx in production
- Bounds the probe with a 10s `Promise.race` deadline — the pg pool has `connectionTimeoutMillis=5000` but no `statement_timeout`, so without the race a hung query (DB starting up, replica failover) would stall boot indefinitely and starve Fly's TCP healthcheck

## Why now

5.19.0 ships three things this repo cares about:

| adcp-client PR | Surface | Why it matters here |
|---|---|---|
| #1008 | `AgentClient.fromMCPClient()` | In-process MCP transport — useful for future compliance fleets |
| #1007 | `pgBackend.probe()` + `serve({ readinessCheck })` | **Wired in this PR** |
| #1006 | `$generate:opaque_id` + `context_outputs[generate]` | Future storyboard work needing runner-minted task IDs |
| #999 | `get_media_buys` extractor mid-walk pagination guard | Already-filed pagination issue |

## Expert review

- **code-reviewer**: clean bill of health — boot positioning correct (after migrations, before listen), lazy import pattern matches surrounding code, `probe?.()` optional form is right, no blockers
- **debugger**: flagged the unbounded probe (could stall boot indefinitely on hung query) — **addressed** with `Promise.race` 10s deadline. Other concerns (flapping deploys on transient pgBouncer issues, partial-init test paths) judged speculative for now — fail-fast is the whole point of the probe; the 10s bound is the real production safety knob

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Precommit hook (unit tests + dynamic-imports + typecheck) passed
- [ ] CI: full test suite + changeset check
- [ ] Smoke-test on a deploy where `DATABASE_URL` is reachable but the idempotency table doesn't exist — confirm boot fails fast with descriptive error
- [ ] Smoke-test memoryBackend path (no DB env) — confirm probe is a no-op and boot proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)