### PR TITLE
fix(addie): sanitize step.error / validation.error / narrative in MCP output

### DIFF
--- a/.changeset/sanitize-storyboard-error-rendering.md
+++ b/.changeset/sanitize-storyboard-error-rendering.md
@@ -1,0 +1,8 @@
+---
+---
+
+Addie: sanitize agent-controlled error and narrative strings before interpolating them into MCP tool output. Closes #3219.
+
+The hint fix-plan formatter (adcp#3084 / #3220) carefully sanitized every seller-controlled field at its boundary, but sibling renders on the same `StoryboardStepResult` (`step.error`, `validation.error`, `result.next.narrative`) and adjacent tools (`evaluate_agent_quality` scenario errors, `compare_media_kit` per-brief errors, `test_io_execution` failure messages, `get_storyboard_detail` narratives) emitted runner/agent strings raw — letting a hostile or compromised seller bypass the formatter's prompt-injection protection through a sibling field on the same Claude-bound output.
+
+This pass runs every such site through `sanitizeAgentField` with a documented 400-char cap (`RUNNER_ERROR_MAX_LEN`) — explicitly framed as a prompt-injection budget, not a UX choice. Defense in depth; no current attack.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -28,7 +28,7 @@ import { loadRules } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.4';
+export const CODE_VERSION = '2026.04.5';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -322,6 +322,20 @@ function sanitizeAgentField(value: unknown, maxLen = 200): string {
 }
 
 /**
+ * Length cap for runner-emitted / agent-emitted error and narrative
+ * strings rendered into MCP tool output. This is an explicit prompt-
+ * injection budget — not a UX choice. It bounds how much agent-
+ * controlled prose can compete with the surrounding tool-output
+ * structure for LLM attention. Don't raise without thinking about the
+ * blast radius; mirrors the per-cap rationale in
+ * `storyboard-fix-plan.ts` (`MAX_VALUE_LEN`, `MAX_REQUEST_FIELD_LEN`,
+ * etc.). 400 chars covers legitimate AdCP error envelopes (`code` +
+ * `message` + a short `details` reference) with margin; legitimate
+ * storyboard step narratives are typically under 200.
+ */
+const RUNNER_ERROR_MAX_LEN = 400;
+
+/**
  * Wrap an untrusted agent-reported value in quotes, explicitly marking it as
  * agent-provided so the LLM is less likely to treat it as authoritative.
  * Returns the empty string if the value is empty after sanitization.
@@ -3382,7 +3396,7 @@ export function createMemberToolHandlers(
               output += `  - FAILED: ${scenario.scenario}\n`;
               const failedSteps = (scenario.steps ?? []).filter(s => !s.passed);
               for (const step of failedSteps.slice(0, 3)) {
-                output += `    - ${step.step}${step.error ? `: ${step.error}` : ''}\n`;
+                output += `    - ${step.step}${step.error ? `: ${sanitizeAgentField(step.error, RUNNER_ERROR_MAX_LEN)}` : ''}\n`;
               }
               if (failedSteps.length > 3) {
                 output += `    - ... and ${failedSteps.length - 3} more\n`;
@@ -3658,12 +3672,12 @@ export function createMemberToolHandlers(
     output += `**Track:** ${sb.track || 'general'}\n`;
     output += `**Summary:** ${sb.summary}\n\n`;
     if (sb.narrative) {
-      output += `${sb.narrative}\n\n`;
+      output += `${sanitizeAgentField(sb.narrative, RUNNER_ERROR_MAX_LEN)}\n\n`;
     }
 
     for (const phase of sb.phases) {
       output += `### ${phase.title}\n`;
-      if (phase.narrative) output += `${phase.narrative}\n`;
+      if (phase.narrative) output += `${sanitizeAgentField(phase.narrative, RUNNER_ERROR_MAX_LEN)}\n`;
       output += '\n';
 
       for (const step of phase.steps) {
@@ -3671,7 +3685,7 @@ export function createMemberToolHandlers(
         output += `  Task: \`${step.task}\`\n`;
         if (step.requires_tool) output += `  Requires: \`${step.requires_tool}\`\n`;
         if (step.expect_error) output += `  Expects: error response\n`;
-        if (step.narrative) output += `  ${step.narrative}\n`;
+        if (step.narrative) output += `  ${sanitizeAgentField(step.narrative, RUNNER_ERROR_MAX_LEN)}\n`;
         if (step.expected) output += `  Expected: ${step.expected}\n`;
         if (step.validations?.length) {
           output += `  Validations:\n`;
@@ -3729,10 +3743,10 @@ export function createMemberToolHandlers(
 
           if (!step.passed && !step.skipped) {
             if (step.error) {
-              output += `  Error: ${step.error}\n`;
+              output += `  Error: ${sanitizeAgentField(step.error, RUNNER_ERROR_MAX_LEN)}\n`;
             }
             for (const v of step.validations.filter(v => !v.passed)) {
-              output += `  Failed: ${v.description}${v.error ? ` — ${v.error}` : ''}\n`;
+              output += `  Failed: ${v.description}${v.error ? ` — ${sanitizeAgentField(v.error, RUNNER_ERROR_MAX_LEN)}` : ''}\n`;
             }
           }
           // Hints are diagnostic-only and don't flip pass/fail per the
@@ -3840,12 +3854,12 @@ export function createMemberToolHandlers(
         if (result.validations.length > 0) {
           output += `\n**Validations:**\n`;
           for (const v of result.validations) {
-            output += `- ${v.passed ? 'PASS' : 'FAIL'}: ${v.description}${v.error ? ` — ${v.error}` : ''}\n`;
+            output += `- ${v.passed ? 'PASS' : 'FAIL'}: ${v.description}${v.error ? ` — ${sanitizeAgentField(v.error, RUNNER_ERROR_MAX_LEN)}` : ''}\n`;
           }
         }
 
         if (result.error) {
-          output += `\n**Error:** ${result.error}\n`;
+          output += `\n**Error:** ${sanitizeAgentField(result.error, RUNNER_ERROR_MAX_LEN)}\n`;
         }
 
         // Hints are diagnostic-only and don't flip pass/fail per the
@@ -3875,7 +3889,7 @@ export function createMemberToolHandlers(
       if (result.next) {
         output += `\n### Next step\n`;
         output += `**${result.next.title}** (\`${result.next.step_id}\`) — \`${result.next.task}\`\n`;
-        if (result.next.narrative) output += `${result.next.narrative}\n`;
+        if (result.next.narrative) output += `${sanitizeAgentField(result.next.narrative, RUNNER_ERROR_MAX_LEN)}\n`;
         output += `\nTo continue, call \`run_storyboard_step\` with \`step_id: "${result.next.step_id}"\` and pass the context below.\n`;
       } else {
         output += `\nThis was the last step in the storyboard.\n`;
@@ -4096,7 +4110,7 @@ export function createMemberToolHandlers(
       output += `### Per-brief results\n\n`;
       for (const br of briefResults) {
         if (br.error) {
-          output += `- **${br.name}:** ERROR — ${br.error}\n`;
+          output += `- **${br.name}:** ERROR — ${sanitizeAgentField(br.error, RUNNER_ERROR_MAX_LEN)}\n`;
         } else {
           output += `- **${br.name}:** ${br.products_count} products`;
           if (br.channels_found.length > 0) output += ` | channels: ${br.channels_found.join(', ')}`;
@@ -4703,7 +4717,7 @@ export function createMemberToolHandlers(
           output += `**Success** — Media buy created: ${executeResult.media_buy_id}\n`;
           output += `**Status:** ${executeResult.status} | **Packages:** ${executeResult.packages_created}\n\n`;
         } else {
-          output += `**Failed** — ${executeResult.error}\n\n`;
+          output += `**Failed** — ${sanitizeAgentField(executeResult.error, RUNNER_ERROR_MAX_LEN)}\n\n`;
         }
       }
 


### PR DESCRIPTION
Closes #3219.

The hint fix-plan formatter (adcp#3084 / #3220) sanitized every seller-controlled field at its boundary. But sibling renders on the same \`StoryboardStepResult\` (\`step.error\`, \`validation.error\`, \`result.next.narrative\`) and adjacent tools (\`evaluate_agent_quality\`, \`compare_media_kit\`, \`test_io_execution\`, \`get_storyboard_detail\`) emitted runner/agent strings raw, letting a hostile or compromised seller bypass the formatter's prompt-injection protection through a sibling field on the same Claude-bound output.

This pass routes every such site through \`sanitizeAgentField\`. Defense in depth; no current attack.

## Sites covered

Per the triage on #3219 (eight original sites + three additional narrative renders for consistency, since they're on the same trust path and same LLM-bound output):

| Site | Source | Field |
|---|---|---|
| line 3399 | \`evaluate_agent_quality\` per-step error | \`step.error\` |
| line 3746 | \`run_storyboard\` step error | \`step.error\` |
| line 3749 | \`run_storyboard\` validation error | \`v.error\` |
| line 3857 | \`run_storyboard_step\` validation error | \`v.error\` |
| line 3861 | \`run_storyboard_step\` step error | \`result.error\` |
| line 3892 | \`run_storyboard_step\` next-step preview | \`result.next.narrative\` |
| line 4113 | \`compare_media_kit\` per-brief | \`br.error\` |
| line 4720 | \`test_io_execution\` failure | \`executeResult.error\` |
| line 3675 | \`get_storyboard_detail\` (consistency) | \`sb.narrative\` |
| line 3680 | \`get_storyboard_detail\` (consistency) | \`phase.narrative\` |
| line 3688 | \`get_storyboard_detail\` (consistency) | \`step.narrative\` |

## New constant

\`RUNNER_ERROR_MAX_LEN = 400\` with a docstring explicitly framing the cap as a prompt-injection budget — not a UX choice. Mirrors the per-cap rationale in \`storyboard-fix-plan.ts\` (\`MAX_VALUE_LEN\`, \`MAX_REQUEST_FIELD_LEN\`, etc.). 400 chars covers legitimate AdCP error envelopes (\`code\` + \`message\` + a short \`details\` reference) with margin; legitimate storyboard step narratives are typically under 200.

## Reviews from triage

- **security-reviewer:** fix is correct for the four named sites; flagged the three additional \`.error\` interpolations at 3385, 4099, 4706 (now 3399, 4113, 4720 after the constant insertion) — all included in this PR
- **prompt-engineer:** \`maxLen=400\` cap should be documented as an explicit injection-budget decision — done via the \`RUNNER_ERROR_MAX_LEN\` docstring

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:server-unit\` — 2249 passed (no regressions; pre-existing DB-init log noise from \`addie-router.test.ts\` unchanged)
- [x] Existing \`storyboard-fix-plan.test.ts\` (which exercises the same sanitizer regex via \`sanitizeAgentString\`) — 58/58 still green
- [ ] CI passes on this PR

Note on test coverage — the changes are mechanical \`\${value}\` → \`\${sanitizeAgentField(value, RUNNER_ERROR_MAX_LEN)}\` wraps at 11 enumerated sites. The sanitizer regex is shared with \`sanitizeAgentString\` in \`storyboard-fix-plan.ts\`, which has a dedicated injection-regression test covering U+2028 / U+2029 / NEL / backtick / control-char stripping.

CODE_VERSION bumped 2026.04.4 → 2026.04.5 (MCP tool output behavior change, per playbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)