### PR TITLE
fix(brand-claim): hide adopt-prior checkbox when manifest empty + neutralize copy

### DIFF
--- a/.changeset/brand-claim-adopt-copy-fix.md
+++ b/.changeset/brand-claim-adopt-copy-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix brand-claim adoption copy: hide the adopt-prior checkbox unless the prior manifest actually exists, neutralize "inherit" framing that primed hostile-takeover users (e.g. brand reclaiming from a squatter) toward keeping assets they don't want.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1009,9 +1009,9 @@
                     <span style="font-size: var(--text-xs); color: var(--color-text-muted);">Self-contained text block to paste into a ticket.</span>
                   </div>
 
-                  <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-3); font-size: var(--text-sm); color: var(--color-text-secondary);">
+                  <label id="domain-claim-adopt-prior-label" style="display: none; align-items: center; gap: var(--space-2); margin-bottom: var(--space-3); font-size: var(--text-sm); color: var(--color-text-secondary);">
                     <input type="checkbox" id="domain-claim-adopt-prior" style="margin: 0;">
-                    Inherit prior brand identity (only check if a previous owner relinquished this domain and you want their logos / colors / agents as a starting point — typical for acquisitions).
+                    Start from the existing brand record (only check if you want to keep the prior org's logos and colors — most reclaims should leave this unchecked).
                   </label>
 
                   <div style="display: flex; gap: var(--space-3); align-items: center;">
@@ -1842,6 +1842,17 @@
       var toggle = document.getElementById('domain-claim-toggle');
       panel.style.display = _domainClaimOpen ? 'block' : 'none';
       toggle.textContent = _domainClaimOpen ? 'Cancel' : 'Start';
+      // Reset adopt-prior state on every open. Without this, a stale tick
+      // from a prior session (when prior_manifest_exists was true) could
+      // persist across panel close/reopen even though the next issue may
+      // not return prior_manifest_exists. requestDomainChallenge will
+      // re-show the label if the next issue actually has a prior manifest.
+      if (_domainClaimOpen) {
+        var adoptLabel = document.getElementById('domain-claim-adopt-prior-label');
+        var adoptCheckbox = document.getElementById('domain-claim-adopt-prior');
+        if (adoptLabel) adoptLabel.style.display = 'none';
+        if (adoptCheckbox) adoptCheckbox.checked = false;
+      }
     }
 
     function setDomainClaimError(msg) {
@@ -1887,6 +1898,18 @@
         document.getElementById('domain-claim-record-value').textContent = token;
         document.getElementById('domain-claim-instructions').style.display = 'block';
         document.getElementById('domain-claim-status').textContent = '';
+        // Only surface the adopt-prior checkbox when a relinquished prior
+        // manifest actually exists. Showing it for every claim primes
+        // hostile-takeover users (e.g. brand reclaiming from a squatter)
+        // toward inheriting assets they don't want.
+        var adoptLabel = document.getElementById('domain-claim-adopt-prior-label');
+        var adoptCheckbox = document.getElementById('domain-claim-adopt-prior');
+        if (data.prior_manifest_exists) {
+          if (adoptLabel) adoptLabel.style.display = 'flex';
+        } else {
+          if (adoptLabel) adoptLabel.style.display = 'none';
+          if (adoptCheckbox) adoptCheckbox.checked = false;
+        }
       } catch (err) {
         setDomainClaimError(err.message || 'Failed to issue challenge.');
       } finally {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -736,7 +736,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         },
         adopt_prior_manifest: {
           type: 'boolean',
-          description: 'Set true ONLY when the issue response had prior_manifest_exists=true and the user explicitly asked to inherit the prior brand identity (logos, colors, agents). Default false starts fresh. Do not set true on a clean claim or hostile takeover.',
+          description: 'Set true ONLY when the issue response had prior_manifest_exists=true AND the user explicitly asked to keep the existing brand record (logos, colors, agents). Default false starts fresh — this is the right choice for most claims, including reclaiming a domain from a squatter or first-time registration.',
         },
       },
       required: ['domain'],
@@ -2316,7 +2316,7 @@ export function createMemberToolHandlers(
     if (result.prior_manifest_exists) {
       lines.push(
         ``,
-        `Note: a previous organization had this domain registered and left a brand identity (logos / colors / agents) in place. After verification you can either inherit that prior identity (typical for acquisitions or rebrands) or start fresh. If you want to inherit, mention "adopt prior identity" before I run verify; otherwise I'll start fresh.`,
+        `Note: a previous organization had this domain registered and left brand assets (logos / colors / agents) in place. After verification you can either keep the existing brand record (typical for acquisitions or rebrands) or start fresh. **Most claims should start fresh** — only mention "keep the existing brand record" if you specifically want the prior assets (e.g., this is an acquisition where you actually inherited the brand).`,
       );
     }
     return lines.join('\n');


### PR DESCRIPTION
Closes #3229.

## Summary

The `adopt_prior_manifest` checkbox and surrounding copy in the brand-claim flow primed users wrong for hostile-takeover cases (e.g. a brand reclaiming a domain from a squatter). The "Inherit prior brand identity" label, defaulting visible on every claim, made non-acquisition users pause: most reclaims want to start clean, not inherit the squatter's logo.

## Changes

**UI** (`server/public/member-profile.html`):
- The adopt-prior label now defaults to `display: none` and is only revealed when `data.prior_manifest_exists === true` (already returned by `/brand-claim/issue` from #3224).
- Renamed: "Inherit prior brand identity" → "Start from the existing brand record (only check if you want to keep the prior org's logos and colors — most reclaims should leave this unchecked)."
- When prior manifest is absent, the checkbox is force-unchecked so a stale tick from a prior session can't slip through.

**Chat tool** (`server/src/addie/mcp/member-tools.ts`):
- The conditional adoption-note in `request_brand_domain_challenge` markdown switches to neutral framing: "Most claims should start fresh — only mention 'keep the existing brand record' if you specifically want the prior assets."
- The `adopt_prior_manifest` parameter description on `verify_brand_domain_challenge` now spells out that "Default false starts fresh — this is the right choice for most claims, including reclaiming a domain from a squatter or first-time registration."

No service or DB changes. Existing service tests cover `prior_manifest_exists`.

## Test plan

- [x] Type-check clean
- [x] Pre-commit hooks (test:unit + test-dynamic-imports + typecheck) green
- [ ] Manual smoke: claim a domain with no prior manifest → checkbox hidden; claim one with orphaned non-empty manifest → checkbox visible
- [ ] Manual smoke: chat — verify the adoption note only appears when relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)