### PR TITLE
feat(brand-claim): copy-all DNS instructions for IT handoff

### DIFF
--- a/.changeset/copy-all-dns-instructions.md
+++ b/.changeset/copy-all-dns-instructions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a "Copy all (for IT)" button to the brand-claim DNS panel that emits a self-contained text block (domain, FQDN, type, value, TTL, propagation note, verification URL) the user can paste into a Jira/Linear ticket for their IT team. CMOs and CTOs typically don't publish DNS themselves; this gives them a hand-off block their IT team can act on without bouncing back for clarification.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1004,6 +1004,11 @@
                     <button type="button" onclick="copyDomainClaimField('value', this)" style="padding: 4px 10px; background: var(--color-gray-700); color: white; border: none; border-radius: var(--radius-sm); font-size: 11px; cursor: pointer;">Copy</button>
                   </div>
 
+                  <div style="margin-bottom: var(--space-3); display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap;">
+                    <button type="button" onclick="copyDomainClaimAll(this)" style="padding: var(--space-2) var(--space-3); background: var(--color-bg-card); color: var(--color-text); border: 1px solid var(--color-border); border-radius: var(--radius-sm); font-size: var(--text-sm); cursor: pointer;">Copy all (for IT)</button>
+                    <span style="font-size: var(--text-xs); color: var(--color-text-muted);">Self-contained text block to paste into a ticket.</span>
+                  </div>
+
                   <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-3); font-size: var(--text-sm); color: var(--color-text-secondary);">
                     <input type="checkbox" id="domain-claim-adopt-prior" style="margin: 0;">
                     Inherit prior brand identity (only check if a previous owner relinquished this domain and you want their logos / colors / agents as a starting point — typical for acquisitions).
@@ -1944,6 +1949,32 @@
       if (!text || !btn) return;
       var original = btn.textContent;
       navigator.clipboard.writeText(text).then(function() {
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = original; }, 2000);
+      });
+    }
+
+    // Self-contained DNS instructions an admin can paste into an IT ticket.
+    // CMOs / CTOs typically don't publish DNS themselves; this gives them a
+    // hand-off block their IT team can act on without bouncing back for
+    // clarification.
+    function copyDomainClaimAll(btn) {
+      var domain = (currentProfile && currentProfile.primary_brand_domain) || '';
+      var fqdn = document.getElementById('domain-claim-record-name').textContent || '';
+      var token = document.getElementById('domain-claim-record-value').textContent || '';
+      if (!fqdn || !token || !btn) return;
+      var block =
+        'Domain: ' + domain + '\n' +
+        'Add a DNS TXT record:\n' +
+        '  Name:  ' + fqdn + '\n' +
+        '  Type:  TXT\n' +
+        '  Value: ' + token + '\n' +
+        '  TTL:   300 (or your registrar\'s minimum)\n' +
+        '\n' +
+        'Once published, propagation is usually 5-15 minutes (sometimes longer with slow registrars). The brand admin will run verification at:\n' +
+        '  https://agenticadvertising.org/member-profile\n';
+      var original = btn.textContent;
+      navigator.clipboard.writeText(block).then(function() {
         btn.textContent = 'Copied!';
         setTimeout(function() { btn.textContent = original; }, 2000);
       });


### PR DESCRIPTION
Closes #3230 (partial). Followup #3239 covers expiration / reissue (deferred — WorkOS doesn't expose TTL).

## Summary

Adds a "Copy all (for IT)" button to the brand-claim DNS panel that emits a self-contained text block:

\`\`\`
Domain: nike.com
Add a DNS TXT record:
  Name:  _workos-challenge.nike.com
  Type:  TXT
  Value: <token>
  TTL:   300 (or your registrar's minimum)

Once published, propagation is usually 5-15 minutes (sometimes longer with slow registrars). The brand admin will run verification at:
  https://agenticadvertising.org/member-profile
\`\`\`

CMOs and CTOs typically don't publish DNS themselves — they Slack their IT team. This gives them a hand-off block IT can act on without bouncing back for clarification.

## Punted to #3239

WorkOS's `OrganizationDomain` exposes `createdAt` + `state` but **no TTL or expiration field** (verified against `@workos-inc/node` SDK types). Expiration surfacing ("issued N hours ago") is mechanical but uninformative; reissue (delete+create) needs a design pass for the "your previous DNS record is now invalid" UX. Both deferred to #3239.

## Test plan

- [x] HTML script smoke check: `node -e "..."` parses cleanly
- [x] Pre-commit hooks green
- [ ] Manual smoke: click "Copy all" → paste shows the full block

🤖 Generated with [Claude Code](https://claude.com/claude-code)