### PR TITLE
feat(billing): webhook-side subscription dedup (#3184)

### DIFF
--- a/.changeset/webhook-side-subscription-dedup.md
+++ b/.changeset/webhook-side-subscription-dedup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Webhook-side dedup on `customer.subscription.created`: cancel a duplicate subscription with proration and skip the org-row UPDATE when the customer already has another live sub. Closes the cross-path race the intake-side guards (active-subscription guard, advisory lock) can't catch — Stripe Checkout creates a session URL, not a subscription, so two concurrent intake paths can both pass guards before either mints a sub. Logs and alerts ops; failures fall through (audit invariant catches misses).

--- a/server/src/billing/dedup-on-subscription-created.ts
+++ b/server/src/billing/dedup-on-subscription-created.ts
@@ -53,13 +53,30 @@ export interface DedupResult {
 export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<DedupResult> {
   const { subscription, customerId, orgId, stripe, logger, notifySystemError } = args;
 
+  // Stripe retries `customer.subscription.created` on 5xx / slow handlers.
+  // On retry the new sub will already be canceled by the prior invocation;
+  // skip cleanly so we don't try to cancel-again (returns 400) and re-alert.
+  if (!(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)) {
+    return { duplicate: false, existingLiveSubIds: [] };
+  }
+
   let liveSubs: Stripe.Subscription[];
   try {
+    // limit: 100 is Stripe's max per page. A customer with >100 historical
+    // subs would still have all live ones returned: Stripe lists in
+    // most-recent-first order, and the live ones include the just-created
+    // one, so they're at the head. We log when has_more so ops can confirm.
     const list = await stripe.subscriptions.list({
       customer: customerId,
       status: 'all',
-      limit: 20,
+      limit: 100,
     });
+    if (list.has_more) {
+      logger.warn(
+        { customerId, newSubId: subscription.id, orgId },
+        'dedup-on-subscription-created: subscriptions.list paginated — only first 100 inspected',
+      );
+    }
     liveSubs = list.data;
   } catch (err) {
     logger.warn(
@@ -89,8 +106,10 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
     'Duplicate subscription detected on customer.subscription.created — canceling new sub',
   );
 
+  let canceled = false;
   try {
     await stripe.subscriptions.cancel(subscription.id, { prorate: true });
+    canceled = true;
   } catch (cancelErr) {
     logger.error(
       { err: cancelErr, customerId, newSubId: subscription.id, orgId },
@@ -99,11 +118,23 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
     // Continue with the alert; ops needs to know either way.
   }
 
+  // Enrich the alert so ops can triage without clicking into Stripe.
+  const newSubItem = subscription.items?.data?.[0];
+  const newSubAmount = newSubItem?.price?.unit_amount ?? null;
+  const newSubLookupKey = newSubItem?.price?.lookup_key ?? null;
+  const newSubCollection = subscription.collection_method ?? null;
+
+  const cancelStatus = canceled
+    ? 'was canceled with proration'
+    : 'COULD NOT be canceled (Stripe error) — cancel manually in Stripe';
+
   notifySystemError({
     source: 'stripe-subscription-dedup',
     errorMessage:
       `Duplicate subscription ${subscription.id} on customer ${customerId} ` +
-      `(org ${orgId ?? 'unknown'}) was canceled with proration. ` +
+      `(org ${orgId ?? 'unknown'}) ${cancelStatus}. ` +
+      `New sub: amount=${newSubAmount ?? 'unknown'} lookup_key=${newSubLookupKey ?? 'unknown'} ` +
+      `collection=${newSubCollection ?? 'unknown'}. ` +
       `Existing live subs kept: ${otherIds.join(', ')}.`,
   });
 

--- a/server/src/billing/dedup-on-subscription-created.ts
+++ b/server/src/billing/dedup-on-subscription-created.ts
@@ -1,0 +1,111 @@
+/**
+ * Webhook-side defense against duplicate subscriptions on a single Stripe
+ * customer. Closes the cross-path race the intake-side guards (#3171
+ * blockIfActiveSubscription, #3183 advisory lock) leave open: Stripe Checkout
+ * creates a session URL, not a subscription — the sub gets minted only when
+ * the user completes the hosted page. So two concurrent intake paths (e.g.,
+ * admin invite + member checkout) can both pass their guards before either
+ * mints a sub, and the user can complete both within seconds.
+ *
+ * On `customer.subscription.created` we look at the customer's full live-sub
+ * inventory. If there's another live sub besides this new one, we cancel the
+ * new one with proration refund, alert ops, and tell the caller to suppress
+ * the org-row UPDATE so the existing surviving sub's state stays intact.
+ */
+import type Stripe from 'stripe';
+import type { Logger } from 'pino';
+import { TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
+
+export interface DedupArgs {
+  /** The just-created subscription from the webhook event. */
+  subscription: Stripe.Subscription;
+  /** Stripe customer id (extracted from `subscription.customer`). */
+  customerId: string;
+  /** Org id we resolved for this customer; used in alert messaging. */
+  orgId?: string | null;
+  stripe: Stripe;
+  logger: Logger;
+  notifySystemError: (ctx: { source: string; errorMessage: string }) => void;
+}
+
+export interface DedupResult {
+  /**
+   * True when the new sub was identified as a duplicate and canceled.
+   * Caller must skip the org-row UPDATE so the surviving sub's state stays.
+   */
+  duplicate: boolean;
+  /** When `duplicate`, the IDs of the *other* live subs we kept. */
+  existingLiveSubIds: string[];
+}
+
+/**
+ * Returns `{ duplicate: false }` to let the normal webhook flow proceed.
+ * Returns `{ duplicate: true, existingLiveSubIds }` after canceling the new
+ * sub when the customer already has another live one.
+ *
+ * Lookup or cancel failures are logged and treated as "don't know" — we fall
+ * through to `duplicate: false`, accepting that a missed duplicate will be
+ * caught by the periodic integrity audit (#3193 invariant
+ * `one-active-stripe-sub-per-org`). Failing closed (refusing the sub) on a
+ * transient Stripe error would be worse: it would block legitimate first-time
+ * subscriptions during a Stripe blip.
+ */
+export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<DedupResult> {
+  const { subscription, customerId, orgId, stripe, logger, notifySystemError } = args;
+
+  let liveSubs: Stripe.Subscription[];
+  try {
+    const list = await stripe.subscriptions.list({
+      customer: customerId,
+      status: 'all',
+      limit: 20,
+    });
+    liveSubs = list.data;
+  } catch (err) {
+    logger.warn(
+      { err, customerId, newSubId: subscription.id, orgId },
+      'dedup-on-subscription-created: subscriptions.list failed — proceeding without dedup check',
+    );
+    return { duplicate: false, existingLiveSubIds: [] };
+  }
+
+  const otherLive = liveSubs.filter(
+    (s) =>
+      s.id !== subscription.id &&
+      (TIER_PRESERVING_STATUSES as readonly string[]).includes(s.status),
+  );
+  if (otherLive.length === 0) {
+    return { duplicate: false, existingLiveSubIds: [] };
+  }
+
+  const otherIds = otherLive.map((s) => s.id);
+  logger.error(
+    {
+      newSubId: subscription.id,
+      customerId,
+      orgId,
+      existingLiveSubIds: otherIds,
+    },
+    'Duplicate subscription detected on customer.subscription.created — canceling new sub',
+  );
+
+  try {
+    await stripe.subscriptions.cancel(subscription.id, { prorate: true });
+  } catch (cancelErr) {
+    logger.error(
+      { err: cancelErr, customerId, newSubId: subscription.id, orgId },
+      'Failed to cancel duplicate subscription — manual intervention needed',
+    );
+    // Continue with the alert; ops needs to know either way.
+  }
+
+  notifySystemError({
+    source: 'stripe-subscription-dedup',
+    errorMessage:
+      `Duplicate subscription ${subscription.id} on customer ${customerId} ` +
+      `(org ${orgId ?? 'unknown'}) was canceled with proration. ` +
+      `Existing live subs kept: ${otherIds.join(', ')}.`,
+  });
+
+  return { duplicate: true, existingLiveSubIds: otherIds };
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3506,6 +3506,35 @@ export class HTTPServer {
               }
             }
 
+            // For `.updated`/`.deleted` events, ignore the event when its
+            // subscription id is not the one we currently track for this org
+            // AND the event's status is non-live. That covers two cases:
+            // (a) the dedup helper just canceled a duplicate, and Stripe is
+            // now firing the follow-up `.updated`/`.deleted` for that
+            // canceled duplicate — without this guard, those events would
+            // overwrite the surviving sub's row state. (b) a customer's
+            // long-canceled standby sub gets a webhook event by some Stripe
+            // path; we shouldn't reset the org's tracked sub.
+            // `.created` is exempt because that's how we *learn* about a new
+            // sub the org row doesn't yet point to.
+            const isStaleNonLiveEvent =
+              event.type !== 'customer.subscription.created' &&
+              org !== null &&
+              org.stripe_subscription_id !== null &&
+              org.stripe_subscription_id !== subscription.id &&
+              !(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status);
+
+            if (isStaleNonLiveEvent) {
+              logger.info({
+                eventType: event.type,
+                eventSubId: subscription.id,
+                trackedSubId: org!.stripe_subscription_id,
+                eventStatus: subscription.status,
+                orgId: org!.workos_organization_id,
+              }, 'Ignoring webhook event for non-tracked sub in non-live status');
+              break;
+            }
+
             // Update database with subscription status, period end, and pricing details
             // This allows admin dashboard to display data without querying Stripe API
             try {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -28,6 +28,7 @@ import type { Server } from "http";
 import { stripe, STRIPE_WEBHOOK_SECRET, createStripeCustomer, createCustomerPortalSession, createCustomerSession, fetchAllPaidInvoices, fetchAllRefunds, getPendingInvoices, type RevenueEvent } from "./billing/stripe-client.js";
 import { handleSubscriptionCreated, type ActivationAdminContext } from "./billing/handle-subscription-created.js";
 import { resolveOrgForStripeCustomer } from "./billing/webhook-helpers.js";
+import { dedupOnSubscriptionCreated } from "./billing/dedup-on-subscription-created.js";
 import Stripe from "stripe";
 import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";
@@ -3473,25 +3474,42 @@ export class HTTPServer {
             // until the organizations row reflects the activated membership.
             let activationAdminContext: ActivationAdminContext | undefined;
 
-            if (event.type === 'customer.subscription.created' && org) {
-              activationAdminContext = await handleSubscriptionCreated({
+            // When the just-created sub is a duplicate that we cancel,
+            // skip the org-row UPDATE so the surviving sub's state stays.
+            let suppressOrgUpdate = false;
+
+            if (event.type === 'customer.subscription.created') {
+              const dedup = await dedupOnSubscriptionCreated({
                 subscription,
                 customerId,
-                org,
+                orgId: org?.workos_organization_id,
                 stripe,
-                workos: workos!,
-                orgDb,
-                pool,
                 logger,
                 notifySystemError,
-                notifyNewSubscription,
               });
+
+              if (dedup.duplicate) {
+                suppressOrgUpdate = true;
+              } else if (org) {
+                activationAdminContext = await handleSubscriptionCreated({
+                  subscription,
+                  customerId,
+                  org,
+                  stripe,
+                  workos: workos!,
+                  orgDb,
+                  pool,
+                  logger,
+                  notifySystemError,
+                  notifyNewSubscription,
+                });
+              }
             }
 
             // Update database with subscription status, period end, and pricing details
             // This allows admin dashboard to display data without querying Stripe API
             try {
-              if (org) {
+              if (org && !suppressOrgUpdate) {
                 const subUpdate = buildSubscriptionUpdate(subscription as any, org.is_personal);
 
                 // Capture current tier before update for change detection

--- a/server/tests/unit/dedup-on-subscription-created.test.ts
+++ b/server/tests/unit/dedup-on-subscription-created.test.ts
@@ -12,8 +12,31 @@ import type Stripe from 'stripe';
 import type { Logger } from 'pino';
 import { dedupOnSubscriptionCreated } from '../../src/billing/dedup-on-subscription-created.js';
 
-function makeSub(id: string, status: Stripe.Subscription.Status): Stripe.Subscription {
-  return { id, status, customer: 'cus_test' } as unknown as Stripe.Subscription;
+function makeSub(
+  id: string,
+  status: Stripe.Subscription.Status,
+  extras?: {
+    unit_amount?: number;
+    lookup_key?: string;
+    collection_method?: 'charge_automatically' | 'send_invoice';
+  },
+): Stripe.Subscription {
+  return {
+    id,
+    status,
+    customer: 'cus_test',
+    collection_method: extras?.collection_method ?? 'charge_automatically',
+    items: {
+      data: [
+        {
+          price: {
+            unit_amount: extras?.unit_amount ?? 300000,
+            lookup_key: extras?.lookup_key ?? 'aao_membership_builder_3000',
+          },
+        },
+      ],
+    },
+  } as unknown as Stripe.Subscription;
 }
 
 function makeStripe(opts: {
@@ -195,6 +218,118 @@ describe('dedupOnSubscriptionCreated', () => {
     expect(result.existingLiveSubIds).toEqual(['sub_existing']);
     expect(notifySystemError).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns duplicate=false without listing when the new sub is already canceled (Stripe webhook retry)', async () => {
+    const newSub = makeSub('sub_new', 'canceled');
+    const list = vi.fn().mockResolvedValue({ data: [] });
+    const cancel = vi.fn();
+    const stripe = makeStripe({ list, cancel });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(list).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('returns duplicate=false when the new sub is incomplete_expired (no live status)', async () => {
+    const newSub = makeSub('sub_new', 'incomplete_expired');
+    const list = vi.fn().mockResolvedValue({ data: [] });
+    const stripe = makeStripe({ list });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('warns when subscriptions.list returns has_more (page overflow)', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+        has_more: true,
+      }),
+    });
+
+    await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('alert message reflects cancel failure (no false "was canceled" claim)', async () => {
+    const newSub = makeSub('sub_new', 'active', { unit_amount: 300000, lookup_key: 'aao_membership_builder_3000' });
+    const cancel = vi.fn().mockRejectedValue(new Error('cannot cancel'));
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+      }),
+      cancel,
+    });
+
+    await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    const msg = notifySystemError.mock.calls[0][0].errorMessage;
+    expect(msg).toContain('COULD NOT be canceled');
+    expect(msg).toContain('cancel manually');
+    expect(msg).not.toContain('was canceled with proration');
+  });
+
+  it('alert message includes new sub amount, lookup_key, and collection_method', async () => {
+    const newSub = makeSub('sub_new', 'active', {
+      unit_amount: 300000,
+      lookup_key: 'aao_membership_builder_3000',
+      collection_method: 'send_invoice',
+    });
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+      }),
+    });
+
+    await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    const msg = notifySystemError.mock.calls[0][0].errorMessage;
+    expect(msg).toContain('amount=300000');
+    expect(msg).toContain('lookup_key=aao_membership_builder_3000');
+    expect(msg).toContain('collection=send_invoice');
   });
 
   it('handles missing orgId in the alert message', async () => {

--- a/server/tests/unit/dedup-on-subscription-created.test.ts
+++ b/server/tests/unit/dedup-on-subscription-created.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the webhook-side duplicate-subscription guard.
+ *
+ * Closes the cross-path race the intake-side guards leave open: Stripe
+ * Checkout creates a session URL, not a subscription — the sub mints only
+ * when the user completes the hosted page. Two concurrent intake paths
+ * (admin invite + member checkout) can both pass their guards before
+ * either mints a sub, so we re-check at `customer.subscription.created`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type Stripe from 'stripe';
+import type { Logger } from 'pino';
+import { dedupOnSubscriptionCreated } from '../../src/billing/dedup-on-subscription-created.js';
+
+function makeSub(id: string, status: Stripe.Subscription.Status): Stripe.Subscription {
+  return { id, status, customer: 'cus_test' } as unknown as Stripe.Subscription;
+}
+
+function makeStripe(opts: {
+  list?: () => Promise<{ data: Stripe.Subscription[] }>;
+  cancel?: () => Promise<Stripe.Subscription>;
+}): Stripe {
+  return {
+    subscriptions: {
+      list: opts.list ?? vi.fn().mockResolvedValue({ data: [] }),
+      cancel: opts.cancel ?? vi.fn().mockResolvedValue({} as Stripe.Subscription),
+    },
+  } as unknown as Stripe;
+}
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Logger;
+}
+
+describe('dedupOnSubscriptionCreated', () => {
+  let logger: Logger;
+  let notifySystemError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    notifySystemError = vi.fn();
+  });
+
+  it('returns duplicate=false when the customer has only the new sub', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({ data: [newSub] }),
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.existingLiveSubIds).toEqual([]);
+    expect(notifySystemError).not.toHaveBeenCalled();
+    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+  });
+
+  it('returns duplicate=false when other subs exist but are all canceled/incomplete', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [
+          newSub,
+          makeSub('sub_old1', 'canceled'),
+          makeSub('sub_old2', 'incomplete_expired'),
+          makeSub('sub_old3', 'incomplete'),
+        ],
+      }),
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.existingLiveSubIds).toEqual([]);
+    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+  });
+
+  it('cancels the new sub and alerts ops when another active sub exists', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+      }),
+      cancel,
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(result.existingLiveSubIds).toEqual(['sub_existing']);
+    expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+    expect(notifySystemError).toHaveBeenCalledTimes(1);
+    expect(notifySystemError.mock.calls[0][0].source).toBe('stripe-subscription-dedup');
+    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('sub_new');
+    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('sub_existing');
+  });
+
+  it('treats trialing and past_due as live and triggers cancel', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [
+          newSub,
+          makeSub('sub_trial', 'trialing'),
+          makeSub('sub_past_due', 'past_due'),
+        ],
+      }),
+      cancel,
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(result.existingLiveSubIds).toEqual(['sub_trial', 'sub_past_due']);
+    expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+  });
+
+  it('falls through to duplicate=false when subscriptions.list throws (transient Stripe blip)', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const stripe = makeStripe({
+      list: vi.fn().mockRejectedValue(new Error('Stripe API down')),
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.existingLiveSubIds).toEqual([]);
+    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    expect(notifySystemError).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('still alerts ops when cancel fails — manual intervention is needed', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const cancel = vi.fn().mockRejectedValue(new Error('cannot cancel'));
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+      }),
+      cancel,
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: 'org_test',
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(result.existingLiveSubIds).toEqual(['sub_existing']);
+    expect(notifySystemError).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('handles missing orgId in the alert message', async () => {
+    const newSub = makeSub('sub_new', 'active');
+    const stripe = makeStripe({
+      list: vi.fn().mockResolvedValue({
+        data: [newSub, makeSub('sub_existing', 'active')],
+      }),
+    });
+
+    const result = await dedupOnSubscriptionCreated({
+      subscription: newSub,
+      customerId: 'cus_test',
+      orgId: null,
+      stripe,
+      logger,
+      notifySystemError,
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('org unknown');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cross-path race that the intake-side guards (#3171 `blockIfActiveSubscription`, #3179/#3183 advisory lock) leave open. Stripe Checkout creates a session URL — the subscription gets minted only when the user completes the hosted page. Two concurrent intake paths (e.g., admin invite + member checkout) can both pass their guards before either mints a sub. Triton hit this in April 2026.

On `customer.subscription.created`, re-check the customer's full live-sub inventory. If another live sub (`active`/`trialing`/`past_due`) exists, cancel the new one with proration refund, alert ops via `notifySystemError`, and skip the org-row UPDATE so the surviving sub's state stays intact.

- New helper: `server/src/billing/dedup-on-subscription-created.ts`
- Wiring: `server/src/http.ts` webhook handler, gated by a `suppressOrgUpdate` flag

Failure semantics (intentional):
- `subscriptions.list` failure → fall through (don't know). Refusing to process the webhook would block legitimate first-time subs during a Stripe blip.
- `subscriptions.cancel` failure → still alert ops; manual intervention.
- A missed duplicate is caught by the periodic integrity invariant `one-active-stripe-sub-per-org` (#3193).

Closes #3184.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/unit/dedup-on-subscription-created.test.ts` — 7 tests pass
  - no other live subs → no-op
  - other subs all canceled/incomplete → no-op
  - one other active sub → cancel + alert
  - trialing/past_due treated as live
  - `subscriptions.list` throws → fall through, no cancel
  - `subscriptions.cancel` throws → still alert ops
  - missing `orgId` renders as "org unknown" in alert
- [x] Pre-commit hook (`test:unit` + `test:test-dynamic-imports` + `typecheck`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)