### PR TITLE
docs(compliance): document v3_envelope_integrity in universal-storyboards tables

### DIFF
--- a/.changeset/v3-envelope-doc-parity.md
+++ b/.changeset/v3-envelope-doc-parity.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(compliance): document v3_envelope_integrity in universal-storyboards tables
+
+Adds the `v3_envelope_integrity` storyboard (introduced by #3045) to the two universal-storyboards tables in the docs. The doc-parity lint at `scripts/lint-universal-storyboard-doc-parity.cjs` was failing on main because #3045 added the YAML but didn't update the tables — every branch built off main has been failing `Build Check` / `Release` / `Deploy` since.

--- a/docs/building/compliance-catalog.mdx
+++ b/docs/building/compliance-catalog.mdx
@@ -23,6 +23,7 @@ Every agent runs every storyboard in `/compliance/{version}/universal/` regardle
 |-----------|---------|
 | `capability-discovery` | `get_adcp_capabilities` shape, protocol/specialism declarations, version advertising |
 | `schema-validation` | Request and response schema conformance, ISO 8601 timestamps, temporal invariants |
+| `v3-envelope-integrity` | v3 envelope MUST carry the canonical `status` field and MUST NOT carry the v2 legacy `task_status` / `response_status` fields at the envelope root. Schema-level enforcement is immediate via `protocol-envelope.json`; the storyboard's `field_absent` checks await runner support in `@adcp/client`. |
 | `error-compliance` | Structured error shape, published error codes, transport binding, no existence leaks across tenants |
 | `idempotency` | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
 | `security` | **Authentication baseline — unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding.** See [Authentication](/docs/building/integration/authentication). |

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -54,6 +54,7 @@ Every agent MUST pass every storyboard below.
 |------------|------------------|
 | [`capability_discovery`](https://adcontextprotocol.org/compliance/latest/universal/capability-discovery) | `get_adcp_capabilities` shape, protocol/specialism declarations, version advertising |
 | [`schema_validation`](https://adcontextprotocol.org/compliance/latest/universal/schema-validation) | Request and response schema conformance, ISO 8601 timestamps, temporal invariants |
+| [`v3_envelope_integrity`](https://adcontextprotocol.org/compliance/latest/universal/v3-envelope-integrity) | v3 envelope MUST carry the canonical `status` field and MUST NOT carry the v2 legacy `task_status` / `response_status` fields at the envelope root. Schema-level enforcement is immediate via `protocol-envelope.json`; the storyboard's `field_absent` checks await runner support in `@adcp/client`. |
 | [`error_compliance`](https://adcontextprotocol.org/compliance/latest/universal/error-compliance) | Structured error shape, published error codes, transport binding, no existence leaks across tenants |
 | [`idempotency`](https://adcontextprotocol.org/compliance/latest/universal/idempotency) | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
 | [`security_baseline`](https://adcontextprotocol.org/compliance/latest/universal/security) | Unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |


### PR DESCRIPTION
## Summary

Unblocks main — `Build Check`, `Release`, and `Deploy` have been red since #3045 merged because the `v3_envelope_integrity` storyboard was added to `static/compliance/source/universal/` but the two universal-storyboards tables in `docs/building/` weren't updated. The doc-parity lint at `scripts/lint-universal-storyboard-doc-parity.cjs` enforces this synchronization and fails on every branch built off main.

This PR adds the missing rows:

- `docs/building/conformance.mdx` — snake_case YAML id form (`v3_envelope_integrity`), per the lint comment on line 51
- `docs/building/compliance-catalog.mdx` — kebab-case slug form (`v3-envelope-integrity`), per the lint comment on line 20

Description copied from the storyboard YAML and the original changeset for #3045: schema-level enforcement is immediate via `protocol-envelope.json`; the storyboard's `field_absent` checks await runner support in `@adcp/client`.

## Test plan

- [x] `npm run build` passes locally (compliance, schemas, tarball — all green)
- [x] `npm run test:unit && npm run typecheck` (pre-commit hook) — green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)