### PR TITLE
feat(billing): detect duplicate Stripe customers by email/name (#3200)

### DIFF
--- a/.changeset/dup-customer-detection-by-email-name.md
+++ b/.changeset/dup-customer-detection-by-email-name.md
@@ -1,0 +1,4 @@
+---
+---
+
+Extends `findStripeCustomerMismatches` (and `GET /api/admin/stripe-mismatches`) to detect duplicate Stripe customers by shared email or shared name+active-sub, in addition to the existing metadata-based detection. Each mismatch carries `match_reason: 'metadata' | 'email' | 'name'`. Closes #3200, the ResponsiveAds case where two customers shared an email and the orphan generated a duplicate $2,500 invoice.

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -384,7 +384,12 @@
         <button class="btn btn-secondary" id="auto-resolve-btn" style="display: none;" onclick="autoResolveAll()">Auto-Resolve Safe</button>
       </div>
       <div class="conflict-info-box">
-        A mismatch occurs when an organization has a Stripe customer in our database, but a <strong>different</strong> Stripe customer's metadata claims to belong to that same organization. This typically means the org has multiple Stripe customers (duplicate accounts).<br><br>
+        A mismatch occurs when an organization has multiple Stripe customers. Detected via three signals (the badge on each duplicate shows which):
+        <ul style="margin: 6px 0 6px 18px;">
+          <li><strong>Metadata</strong> — orphan's <code>metadata.workos_organization_id</code> points at this org</li>
+          <li><strong>Email</strong> — orphan shares the linked customer's email</li>
+          <li><strong>Name + active sub</strong> — orphan shares the linked customer's name and has a live subscription</li>
+        </ul>
         <strong>Auto-resolve:</strong> If only one customer has activity (invoices/subscriptions), the inactive one can be safely archived.
       </div>
       <table class="conflicts-table">
@@ -392,7 +397,7 @@
           <tr>
             <th>Organization</th>
             <th>DB Customer</th>
-            <th>Metadata Customer</th>
+            <th>Duplicate Customer</th>
             <th>Suggested Action</th>
           </tr>
         </thead>
@@ -919,6 +924,18 @@
       }
     }
 
+    function matchReasonLabel(reason) {
+      if (reason === 'email') return 'Match: email';
+      if (reason === 'name') return 'Match: name + active sub';
+      return 'Match: metadata';
+    }
+
+    function matchReasonTooltip(reason) {
+      if (reason === 'email') return "This duplicate shares the linked customer's email.";
+      if (reason === 'name') return "This duplicate shares the linked customer's name and has a live subscription.";
+      return "This duplicate's metadata.workos_organization_id points at this org.";
+    }
+
     function renderCustomerActivity(customer, isActive) {
       if (!customer) return '<span style="color: var(--color-text-muted);">Unable to fetch</span>';
       const badges = [];
@@ -1030,7 +1047,7 @@
             <td style="border-left: 3px solid ${metadataIsKeep ? 'var(--color-success-500)' : 'var(--color-gray-200)'};">
               <div style="margin-bottom: 4px;">
                 <strong>${mismatch.stripe_metadata_customer_id}</strong>
-                <span class="badge badge-gray">Metadata</span>
+                <span class="badge badge-gray" title="${matchReasonTooltip(mismatch.match_reason)}">${matchReasonLabel(mismatch.match_reason)}</span>
                 ${metadataActivity?.has_activity ? '<span class="badge badge-warning">Has Activity</span>' : ''}
               </div>
               <div style="font-size: 11px; margin-bottom: 4px;">

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -626,34 +626,97 @@ export async function createCustomerSession(
 }
 
 /**
- * List all Stripe customers with their WorkOS organization IDs
- * Used for syncing Stripe data to local database on startup
+ * Backward-compatible filter: every customer that has a
+ * `metadata.workos_organization_id` set.
  */
 export async function listCustomersWithOrgIds(): Promise<
   Array<{ stripeCustomerId: string; workosOrgId: string }>
 > {
+  const all = await listAllStripeCustomers();
+  return all
+    .filter((c) => c.metadataWorkosOrgId !== null)
+    .map((c) => ({
+      stripeCustomerId: c.id,
+      workosOrgId: c.metadataWorkosOrgId!,
+    }));
+}
+
+export interface StripeCustomerSummary {
+  id: string;
+  email: string | null;
+  name: string | null;
+  /** Set when `customer.metadata.workos_organization_id` is present. */
+  metadataWorkosOrgId: string | null;
+  /** True when Stripe has marked this customer deleted. */
+  deleted: boolean;
+}
+
+/**
+ * Walk every Stripe customer and return the fields needed for cross-customer
+ * duplicate detection: id, email, name, metadata-linked org id, deleted flag.
+ *
+ * Replaces the old `listCustomersWithOrgIds` which only returned customers
+ * that already had a `workos_organization_id` metadata pointer — that filter
+ * hid orphan duplicates whose only signal was a shared email or name (the
+ * ResponsiveAds case in #3200).
+ */
+export async function listAllStripeCustomers(): Promise<StripeCustomerSummary[]> {
   if (!stripe) {
     return [];
   }
 
-  const results: Array<{ stripeCustomerId: string; workosOrgId: string }> = [];
+  const results: StripeCustomerSummary[] = [];
 
   try {
-    // Iterate through all customers (auto-pagination)
     for await (const customer of stripe.customers.list({ limit: 100 })) {
-      const workosOrgId = customer.metadata?.workos_organization_id;
-      if (workosOrgId) {
-        results.push({
-          stripeCustomerId: customer.id,
-          workosOrgId,
-        });
-      }
+      results.push({
+        id: customer.id,
+        email: customer.email ?? null,
+        name: customer.name ?? null,
+        metadataWorkosOrgId: customer.metadata?.workos_organization_id ?? null,
+        deleted: (customer as { deleted?: boolean }).deleted === true,
+      });
     }
 
     return results;
   } catch (error) {
     logger.error({ err: error }, 'Error listing Stripe customers');
     return [];
+  }
+}
+
+/**
+ * Returns the set of customer IDs that have at least one live (active /
+ * trialing / past_due) subscription. Stripe's subscriptions.list filters by
+ * a single status at a time, so this issues three paginated calls. The total
+ * row count is bounded by live subs (small), not all subs.
+ */
+export async function listCustomerIdsWithLiveSubscriptions(): Promise<Set<string>> {
+  const ids = new Set<string>();
+  if (!stripe) {
+    return ids;
+  }
+
+  const liveStatuses: Array<'active' | 'trialing' | 'past_due'> = [
+    'active',
+    'trialing',
+    'past_due',
+  ];
+
+  try {
+    for (const status of liveStatuses) {
+      for await (const sub of stripe.subscriptions.list({ status, limit: 100 })) {
+        const customerId =
+          typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
+        if (customerId) {
+          ids.add(customerId);
+        }
+      }
+    }
+    return ids;
+  } catch (error) {
+    logger.error({ err: error }, 'Error listing live Stripe subscriptions');
+    return ids;
   }
 }
 

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1,6 +1,12 @@
 import type { PoolClient } from 'pg';
 import { getPool, query } from './client.js';
-import { getStripeSubscriptionInfo, listCustomersWithOrgIds } from '../billing/stripe-client.js';
+import {
+  getStripeSubscriptionInfo,
+  listCustomersWithOrgIds,
+  listAllStripeCustomers,
+  listCustomerIdsWithLiveSubscriptions,
+  type StripeCustomerSummary,
+} from '../billing/stripe-client.js';
 import { WorkOS } from '@workos-inc/node';
 import { createLogger } from '../logger.js';
 import { CompanyTypeValue } from '../config/company-types.js';
@@ -1266,44 +1272,130 @@ export class OrganizationDatabase {
   }
 
   /**
-   * Find Stripe customer mismatches where an org has a different customer ID in the DB
-   * than what Stripe metadata says it should have.
+   * Find Stripe customers that look like duplicates of an org's linked customer.
    *
-   * This detects the case where:
-   * - Org has stripe_customer_id = cus_X in the database
-   * - But a different Stripe customer (cus_Y) has metadata saying it belongs to that org
+   * Three signals, in priority order:
+   *   1. metadata — orphan customer's `metadata.workos_organization_id`
+   *      points at the org (the original signal).
+   *   2. email    — orphan customer shares email (case-insensitive) with the
+   *      org's linked customer.
+   *   3. name     — orphan customer shares name (trimmed, lower-cased) with
+   *      the org's linked customer AND has a live (active/trialing/past_due)
+   *      subscription.
    *
-   * This often indicates an org has multiple Stripe customers (e.g., someone created
-   * a new customer instead of using the existing one).
+   * The ResponsiveAds case (#3200) had two customers with identical name and
+   * email: one linked + one orphan with an active sub generating a duplicate
+   * \$2,500 invoice. Metadata-only detection didn't surface it.
+   *
+   * Each mismatch carries `match_reason` so the resolver can pick the right
+   * unwind (metadata-linked orphans typically merge cleanly; email/name
+   * orphans may need manual sub cancel + invoice void in Stripe first).
+   *
+   * One mismatch per (org, orphan) pair — if the same orphan matches by
+   * multiple signals, the first signal in priority order wins.
    */
   async findStripeCustomerMismatches(): Promise<Array<{
     org_id: string;
     org_name: string;
     db_customer_id: string;
     stripe_metadata_customer_id: string;
+    match_reason: 'metadata' | 'email' | 'name';
   }>> {
-    const mismatches: Array<{
+    type Mismatch = {
       org_id: string;
       org_name: string;
       db_customer_id: string;
       stripe_metadata_customer_id: string;
-    }> = [];
+      match_reason: 'metadata' | 'email' | 'name';
+    };
 
-    // Get all Stripe customers with org metadata
-    const stripeCustomers = await listCustomersWithOrgIds();
+    const allCustomers = await listAllStripeCustomers();
+    const liveSubCustomerIds = await listCustomerIdsWithLiveSubscriptions();
 
-    for (const { stripeCustomerId, workosOrgId } of stripeCustomers) {
-      const localOrg = await this.getOrganization(workosOrgId);
+    const customerById = new Map<string, StripeCustomerSummary>();
+    for (const c of allCustomers) customerById.set(c.id, c);
 
-      // Check if org exists and has a DIFFERENT customer ID than Stripe metadata suggests
-      if (localOrg && localOrg.stripe_customer_id && localOrg.stripe_customer_id !== stripeCustomerId) {
-        // Mismatch: Org has cus_X in DB, but Stripe customer cus_Y claims to belong to this org
-        mismatches.push({
-          org_id: workosOrgId,
-          org_name: localOrg.name,
-          db_customer_id: localOrg.stripe_customer_id,
-          stripe_metadata_customer_id: stripeCustomerId,
-        });
+    // For each org with a linked Stripe customer, collect candidate orphans
+    // by metadata, email, and name and emit one mismatch per (org, orphan)
+    // pair. `seenPairs` keys "<orgId>:<orphanId>" so we don't emit duplicates
+    // when an orphan matches by multiple signals.
+    const linkedOrgsResult = await getPool().query<{
+      workos_organization_id: string;
+      name: string;
+      stripe_customer_id: string;
+    }>(
+      `SELECT workos_organization_id, name, stripe_customer_id
+       FROM organizations
+       WHERE stripe_customer_id IS NOT NULL`
+    );
+
+    const mismatches: Mismatch[] = [];
+    const seenPairs = new Set<string>();
+
+    const recordPair = (
+      org: { workos_organization_id: string; name: string; stripe_customer_id: string },
+      orphan: StripeCustomerSummary,
+      reason: 'metadata' | 'email' | 'name',
+    ) => {
+      const key = `${org.workos_organization_id}:${orphan.id}`;
+      if (seenPairs.has(key)) return;
+      seenPairs.add(key);
+      mismatches.push({
+        org_id: org.workos_organization_id,
+        org_name: org.name,
+        db_customer_id: org.stripe_customer_id,
+        stripe_metadata_customer_id: orphan.id,
+        match_reason: reason,
+      });
+    };
+
+    for (const org of linkedOrgsResult.rows) {
+      const linkedCustomer = customerById.get(org.stripe_customer_id);
+
+      // Pass 1: metadata — orphan customer's metadata points at this org.
+      // This pass runs even when the linked customer is missing from Stripe
+      // (e.g., deleted) — the legacy detector worked that way too.
+      for (const candidate of allCustomers) {
+        if (
+          candidate.metadataWorkosOrgId === org.workos_organization_id &&
+          candidate.id !== org.stripe_customer_id
+        ) {
+          recordPair(org, candidate, 'metadata');
+        }
+      }
+
+      // Email/name passes need the linked customer's profile — without it
+      // we can't look for shared email/name. Skip cleanly.
+      if (!linkedCustomer || linkedCustomer.deleted) continue;
+
+      const linkedEmail = linkedCustomer.email?.toLowerCase().trim() ?? null;
+      const linkedName = linkedCustomer.name?.toLowerCase().trim() ?? null;
+
+      for (const candidate of allCustomers) {
+        if (candidate.id === linkedCustomer.id || candidate.deleted) continue;
+
+        // Pass 2: email match (case-insensitive, trimmed).
+        if (
+          linkedEmail &&
+          candidate.email &&
+          candidate.email.toLowerCase().trim() === linkedEmail
+        ) {
+          recordPair(org, candidate, 'email');
+          continue;
+        }
+
+        // Pass 3: name match + candidate has a live subscription. We require
+        // the active-sub signal here because shared names are far more common
+        // than shared emails (e.g., two unrelated personal orgs both named
+        // "Test"), so we'd false-positive without it.
+        if (
+          linkedName &&
+          candidate.name &&
+          candidate.name.toLowerCase().trim() === linkedName &&
+          liveSubCustomerIds.has(candidate.id)
+        ) {
+          recordPair(org, candidate, 'name');
+        }
       }
     }
 

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1326,7 +1326,16 @@ export class OrganizationDatabase {
     }>(
       `SELECT workos_organization_id, name, stripe_customer_id
        FROM organizations
-       WHERE stripe_customer_id IS NOT NULL`
+       WHERE stripe_customer_id IS NOT NULL
+       ORDER BY workos_organization_id`
+    );
+
+    // Set of every Stripe customer that is some org's linked customer.
+    // We use this to avoid reporting another org's linked customer as an
+    // "orphan" of *this* org — that situation is a metadata conflict, not
+    // a duplicate, and is already surfaced by findStripeCustomerConflicts.
+    const allLinkedCustomerIds = new Set(
+      linkedOrgsResult.rows.map((r) => r.stripe_customer_id),
     );
 
     const mismatches: Mismatch[] = [];
@@ -1355,10 +1364,14 @@ export class OrganizationDatabase {
       // Pass 1: metadata — orphan customer's metadata points at this org.
       // This pass runs even when the linked customer is missing from Stripe
       // (e.g., deleted) — the legacy detector worked that way too.
+      // Skip candidates that are another org's linked customer; that's a
+      // metadata conflict (handled by findStripeCustomerConflicts), not a
+      // duplicate, and reporting it here would double-flag the row.
       for (const candidate of allCustomers) {
         if (
           candidate.metadataWorkosOrgId === org.workos_organization_id &&
-          candidate.id !== org.stripe_customer_id
+          candidate.id !== org.stripe_customer_id &&
+          !allLinkedCustomerIds.has(candidate.id)
         ) {
           recordPair(org, candidate, 'metadata');
         }
@@ -1373,6 +1386,9 @@ export class OrganizationDatabase {
 
       for (const candidate of allCustomers) {
         if (candidate.id === linkedCustomer.id || candidate.deleted) continue;
+        // Same exclusion as the metadata pass: another org's linked customer
+        // is not an orphan of this org.
+        if (allLinkedCustomerIds.has(candidate.id)) continue;
 
         // Pass 2: email match (case-insensitive, trimmed).
         if (

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -1157,11 +1157,17 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
 
   /**
    * GET /api/admin/stripe-mismatches
-   * List Stripe customer mismatches where an org has a different customer ID in the DB
-   * than what Stripe metadata says it should have.
+   * List Stripe customer mismatches where an org has a duplicate customer in
+   * Stripe. Three detection signals (see findStripeCustomerMismatches):
+   *   - metadata: orphan customer's metadata.workos_organization_id points
+   *     at the org
+   *   - email:    orphan shares the linked customer's email (case-insensitive)
+   *   - name:     orphan shares the linked customer's name AND has a live
+   *     subscription
    *
-   * This detects orgs that appear to have multiple Stripe customers.
-   * Returns activity data for both customers and suggests which one to keep.
+   * Each entry carries `match_reason` so admins see why the duplicate
+   * surfaced. Returns activity data for both customers and suggests which
+   * one to keep (manual review when both have activity).
    */
   apiRouter.get("/stripe-mismatches", requireAuth, requireAdmin, async (_req, res) => {
     try {

--- a/server/tests/unit/find-stripe-customer-mismatches.test.ts
+++ b/server/tests/unit/find-stripe-customer-mismatches.test.ts
@@ -281,6 +281,85 @@ describe('findStripeCustomerMismatches', () => {
     });
   });
 
+  it("does not flag another org's linked customer as an orphan even when its metadata points at this org (would be a metadata conflict, not a duplicate)", async () => {
+    // cus_B is org_B's linked customer, but its metadata says it belongs to
+    // org_A. The legacy duplicate detector would have reported this as an
+    // orphan of org_A. That's wrong — it's a metadata-conflict (handled by
+    // findStripeCustomerConflicts), not a duplicate.
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_A', email: 'a@x.com', name: 'Org A' }),
+      makeCustomer({
+        id: 'cus_B',
+        email: 'b@y.com',
+        name: 'Org B',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        { workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_A' },
+        { workos_organization_id: 'org_B', name: 'Org B', stripe_customer_id: 'cus_B' },
+      ],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes another org's linked customer from email/name passes too", async () => {
+    // cus_legit_B is the legit linked customer for org_B but happens to
+    // share an email/name with org_A's linked customer (e.g., founder runs
+    // both orgs on the same email). It must NOT be reported as an orphan
+    // of org_A.
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_legit_A', email: 'shared@x.com', name: 'Shared Co' }),
+      makeCustomer({ id: 'cus_legit_B', email: 'shared@x.com', name: 'Shared Co' }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(
+      new Set(['cus_legit_A', 'cus_legit_B']),
+    );
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        { workos_organization_id: 'org_A', name: 'Shared Co A', stripe_customer_id: 'cus_legit_A' },
+        { workos_organization_id: 'org_B', name: 'Shared Co B', stripe_customer_id: 'cus_legit_B' },
+      ],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it('flags a deleted orphan with stale metadata (admins still want to see and clean these)', async () => {
+    // The metadata pass intentionally does not skip deleted candidates —
+    // a deleted customer with stale metadata pointing at an org is still
+    // useful to surface so admins can confirm the cleanup is complete.
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Org A' }),
+      makeCustomer({
+        id: 'cus_deleted_orphan',
+        email: 'a@x.com',
+        name: 'Org A',
+        metadataWorkosOrgId: 'org_A',
+        deleted: true,
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      stripe_metadata_customer_id: 'cus_deleted_orphan',
+      match_reason: 'metadata',
+    });
+  });
+
   it('returns multiple orphans when one org has several duplicates', async () => {
     mockListAllStripeCustomers.mockResolvedValue([
       makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Org A' }),

--- a/server/tests/unit/find-stripe-customer-mismatches.test.ts
+++ b/server/tests/unit/find-stripe-customer-mismatches.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for OrganizationDatabase.findStripeCustomerMismatches.
+ *
+ * The detector surfaces Stripe customers that look like duplicates of an
+ * org's linked customer. Three signals (metadata, email, name+active-sub)
+ * with priority ordering — the first signal in priority order wins per pair.
+ *
+ * The ResponsiveAds case (#3200) had two customers with identical name and
+ * email: one linked + one orphan with an active sub generating a duplicate
+ * $2,500 invoice. Metadata-only detection didn't surface it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StripeCustomerSummary } from '../../src/billing/stripe-client.js';
+
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const {
+  mockListAllStripeCustomers,
+  mockListLiveSubCustomerIds,
+  mockPoolQuery,
+} = vi.hoisted(() => ({
+  mockListAllStripeCustomers: vi.fn<any>(),
+  mockListLiveSubCustomerIds: vi.fn<any>(),
+  mockPoolQuery: vi.fn<any>(),
+}));
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  listAllStripeCustomers: () => mockListAllStripeCustomers(),
+  listCustomerIdsWithLiveSubscriptions: () => mockListLiveSubCustomerIds(),
+  // listCustomersWithOrgIds is unused by the detector but imported elsewhere
+  listCustomersWithOrgIds: vi.fn().mockResolvedValue([]),
+  getStripeSubscriptionInfo: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({
+    query: (...args: unknown[]) => mockPoolQuery(...args),
+  }),
+}));
+
+const { OrganizationDatabase } = await import('../../src/db/organization-db.js');
+
+function makeCustomer(overrides: Partial<StripeCustomerSummary> & { id: string }): StripeCustomerSummary {
+  return {
+    id: overrides.id,
+    email: overrides.email ?? null,
+    name: overrides.name ?? null,
+    metadataWorkosOrgId: overrides.metadataWorkosOrgId ?? null,
+    deleted: overrides.deleted ?? false,
+  };
+}
+
+describe('findStripeCustomerMismatches', () => {
+  let db: InstanceType<typeof OrganizationDatabase>;
+
+  beforeEach(() => {
+    mockListAllStripeCustomers.mockReset();
+    mockListLiveSubCustomerIds.mockReset();
+    mockPoolQuery.mockReset();
+    db = new OrganizationDatabase();
+  });
+
+  it('returns nothing when no orgs have a linked Stripe customer', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it('detects metadata-based mismatch (orphan metadata points at org)', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Org A' }),
+      makeCustomer({
+        id: 'cus_orphan',
+        email: 'b@x.com',
+        name: 'Different Name',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([
+      {
+        org_id: 'org_A',
+        org_name: 'Org A',
+        db_customer_id: 'cus_linked',
+        stripe_metadata_customer_id: 'cus_orphan',
+        match_reason: 'metadata',
+      },
+    ]);
+  });
+
+  it('detects email-based mismatch (case-insensitive)', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'matt@responsiveads.com', name: 'ResponsiveAds' }),
+      makeCustomer({ id: 'cus_orphan', email: 'MATT@RESPONSIVEADS.COM', name: 'Different Name' }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_R', name: 'ResponsiveAds', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      org_id: 'org_R',
+      stripe_metadata_customer_id: 'cus_orphan',
+      match_reason: 'email',
+    });
+  });
+
+  it('detects name-based mismatch only when the orphan has a live subscription', async () => {
+    // Two customers share a name. Without an active sub, the candidate
+    // doesn't qualify (shared names are common; would false-positive).
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Acme Inc' }),
+      makeCustomer({ id: 'cus_inert', email: 'b@y.com', name: 'Acme Inc' }),
+      makeCustomer({ id: 'cus_active', email: 'c@z.com', name: 'Acme Inc' }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set(['cus_active']));
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_acme', name: 'Acme Inc', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    // Only cus_active surfaces; cus_inert is filtered out by the live-sub gate.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      stripe_metadata_customer_id: 'cus_active',
+      match_reason: 'name',
+    });
+  });
+
+  it('responsiveads-shape: linked + orphan share both name and email; reports as email (priority)', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({
+        id: 'cus_UFKmlsAXbHz0XZ',
+        email: 'matt@responsiveads.com',
+        name: 'ResponsiveAds',
+      }),
+      makeCustomer({
+        id: 'cus_Tma6KyBEy5EJWG',
+        email: 'matt@responsiveads.com',
+        name: 'ResponsiveAds',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set(['cus_Tma6KyBEy5EJWG']));
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          workos_organization_id: 'org_responsiveads',
+          name: 'ResponsiveAds',
+          stripe_customer_id: 'cus_UFKmlsAXbHz0XZ',
+        },
+      ],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    // One mismatch — email match wins over name match per priority order.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      org_id: 'org_responsiveads',
+      db_customer_id: 'cus_UFKmlsAXbHz0XZ',
+      stripe_metadata_customer_id: 'cus_Tma6KyBEy5EJWG',
+      match_reason: 'email',
+    });
+  });
+
+  it('priority: metadata wins over email when both signals match the same orphan', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'shared@x.com', name: 'Same Co' }),
+      makeCustomer({
+        id: 'cus_orphan',
+        email: 'shared@x.com',
+        name: 'Same Co',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set(['cus_orphan']));
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Same Co', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].match_reason).toBe('metadata');
+  });
+
+  it('does not match itself when an org\'s own linked customer has its own metadata pointer', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({
+        id: 'cus_linked',
+        email: 'a@x.com',
+        name: 'Org A',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not match by email when one or both customers have no email', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: null, name: 'Org A' }),
+      makeCustomer({ id: 'cus_other', email: null, name: 'Other Co' }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it('skips deleted Stripe customers (both as linked and as candidate)', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Org A', deleted: true }),
+      makeCustomer({ id: 'cus_other', email: 'a@x.com', name: 'Org A' }),
+      makeCustomer({ id: 'cus_deleted_dup', email: 'b@y.com', name: 'Org B', deleted: true }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        { workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' },
+        { workos_organization_id: 'org_B', name: 'Org B', stripe_customer_id: 'cus_normal_b' },
+      ],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    // Linked customer for org_A is deleted → email/name passes skip.
+    // Candidate cus_deleted_dup is deleted → not considered.
+    // No metadata match, no other signal → empty.
+    expect(result).toEqual([]);
+  });
+
+  it('detects metadata mismatch even when the linked Stripe customer is missing (deleted in Stripe)', async () => {
+    // Legacy compat: the old detector ran metadata pass without requiring
+    // the linked customer to be present. Keep that behavior so cleanup
+    // tooling can still surface orphan metadata after a customer delete.
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({
+        id: 'cus_orphan',
+        email: 'a@x.com',
+        name: 'Org A',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_missing' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      stripe_metadata_customer_id: 'cus_orphan',
+      match_reason: 'metadata',
+    });
+  });
+
+  it('returns multiple orphans when one org has several duplicates', async () => {
+    mockListAllStripeCustomers.mockResolvedValue([
+      makeCustomer({ id: 'cus_linked', email: 'a@x.com', name: 'Org A' }),
+      makeCustomer({ id: 'cus_orphan_email', email: 'a@x.com', name: 'X' }),
+      makeCustomer({
+        id: 'cus_orphan_meta',
+        email: 'unrelated@y.com',
+        name: 'Y',
+        metadataWorkosOrgId: 'org_A',
+      }),
+    ]);
+    mockListLiveSubCustomerIds.mockResolvedValue(new Set());
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_A', name: 'Org A', stripe_customer_id: 'cus_linked' }],
+    });
+
+    const result = await db.findStripeCustomerMismatches();
+
+    expect(result).toHaveLength(2);
+    const reasons = result.map((m) => m.match_reason).sort();
+    expect(reasons).toEqual(['email', 'metadata']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3200. Extends `findStripeCustomerMismatches` to detect duplicate Stripe customers via three signals (priority order):

1. **`metadata`** — orphan's `metadata.workos_organization_id` points at the org (existing behavior)
2. **`email`** — orphan shares the linked customer's email (case-insensitive, trimmed)
3. **`name`** — orphan shares the linked customer's name AND has a live (active/trialing/past_due) subscription

The active-sub gate on name matches prevents false-positives from common shared names ("Test", personal-org duplicates).

Each mismatch carries `match_reason: 'metadata' | 'email' | 'name'` so admins on `/admin/stripe-mismatches` see why the duplicate surfaced. Existing `suggested_action` / `can_auto_resolve` logic is unchanged — `manual_review` still applies when both have activity (the ResponsiveAds shape).

### ResponsiveAds case (the trigger)

`cus_UFKmlsAXbHz0XZ` (linked, $2,500 paid) and `cus_Tma6KyBEy5EJWG` (orphan, active sub generating duplicate $2,500 invoice) shared email `matt@responsiveads.com`. Metadata-only didn't find it. Now matched as `email`.

### New stripe-client helpers

- `listAllStripeCustomers()` — full summary (id, email, name, metadata, deleted)
- `listCustomerIdsWithLiveSubscriptions()` — `Set<string>` of customer IDs with live subs
- `listCustomersWithOrgIds()` retained as a backward-compat filter for existing callers

### Out of scope

Per the issue's "Stretch": no admin endpoint for canceling Stripe subscriptions yet. Operators still need to manually cancel/void in Stripe before re-running resolve when both customers have activity.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/unit/find-stripe-customer-mismatches.test.ts` — 11 tests pass
  - empty case, metadata, email (case-insensitive), name+active-sub
  - ResponsiveAds shape (email + name overlap, email wins per priority)
  - metadata wins over email when both signals match same orphan
  - own customer doesn't self-match
  - empty/null email handled
  - deleted customers skipped (both as linked and as candidate)
  - metadata still surfaces when linked customer is missing in Stripe
  - multiple orphans per org

🤖 Generated with [Claude Code](https://claude.com/claude-code)