### PR TITLE
feat(admin): replace-subscription endpoint for custom-contract tier changes (#3180)

### DIFF
--- a/.changeset/admin-replace-subscription-endpoint.md
+++ b/.changeset/admin-replace-subscription-endpoint.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds `POST /api/admin/accounts/:orgId/replace-subscription` for out-of-band tier changes on existing members (custom contracts). Uses Stripe's in-place `subscriptions.update` so `stripe_subscription_id` stays the same and the agreement audit trail is preserved. Body accepts `lookup_key` or `price_id`, optional `coupon_id`, and `proration_behavior` (default `none`). Records a `subscription_replaced` audit log row with before/after state. Closes #3180.

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -806,7 +806,10 @@ export function setupAccountsBillingRoutes(
         // Exactly one of lookup_key / price_id must be provided. Custom
         // ad-hoc prices are out of scope for v1 — operators create those in
         // the Stripe Dashboard first, then pass the resulting price_id.
-        const priceSourceCount = [lookup_key, price_id].filter(Boolean).length;
+        // Trim before counting so whitespace-only strings count as empty.
+        const trimmedLookupKey = lookup_key?.trim();
+        const trimmedPriceId = price_id?.trim();
+        const priceSourceCount = [trimmedLookupKey, trimmedPriceId].filter(Boolean).length;
         if (priceSourceCount !== 1) {
           return res.status(400).json({
             error: "Price source required",
@@ -835,11 +838,11 @@ export function setupAccountsBillingRoutes(
         // Resolve the target price.
         let targetPrice: Stripe.Price;
         try {
-          if (price_id) {
-            targetPrice = await stripe.prices.retrieve(price_id);
+          if (trimmedPriceId) {
+            targetPrice = await stripe.prices.retrieve(trimmedPriceId);
           } else {
             const list = await stripe.prices.list({
-              lookup_keys: [lookup_key!],
+              lookup_keys: [trimmedLookupKey!],
               active: true,
               limit: 2,
             });
@@ -909,6 +912,20 @@ export function setupAccountsBillingRoutes(
           });
         }
 
+        // Refuse to update a sub in a non-live state. Stripe's retrieve
+        // returns canceled subs for ~30 days, so the prior catch doesn't
+        // surface the case — we'd hit a confusing 400 from update instead.
+        if (
+          !(TIER_PRESERVING_STATUSES as readonly string[]).includes(existingSub.status)
+        ) {
+          return res.status(400).json({
+            error: "Subscription not live",
+            message:
+              `Subscription ${existingSub.id} is in status "${existingSub.status}". Replace requires a live subscription (active/trialing/past_due). Use the normal intake flow to create a new one.`,
+            current_status: existingSub.status,
+          });
+        }
+
         const existingItem = existingSub.items.data[0];
         if (!existingItem) {
           return res.status(400).json({
@@ -916,6 +933,17 @@ export function setupAccountsBillingRoutes(
             message: "The existing subscription has no price items. Manual cleanup needed.",
           });
         }
+
+        // Capture the existing discounts so the response/audit shows what
+        // was overwritten when the caller passes a new coupon. The update
+        // call below replaces all discounts when `discounts` is set, which
+        // is the documented Stripe behavior — we surface it explicitly.
+        const existingDiscounts = (
+          existingSub.discounts as Array<string | { id?: string; coupon?: { id?: string } }> | undefined
+        ) ?? [];
+        const existingDiscountIds = existingDiscounts.map((d) =>
+          typeof d === 'string' ? d : d?.coupon?.id ?? d?.id ?? null,
+        );
 
         const beforeState = {
           subscription_id: existingSub.id,
@@ -926,12 +954,19 @@ export function setupAccountsBillingRoutes(
           unit_amount: existingItem.price.unit_amount,
           interval: existingItem.price.recurring?.interval ?? null,
           collection_method: existingSub.collection_method,
+          cancel_at_period_end: existingSub.cancel_at_period_end ?? false,
+          discount_ids: existingDiscountIds,
         };
 
         // Default proration_behavior to 'none' for custom contracts — the
         // sales-side has already negotiated the dollars; auto-prorating
         // would create a confusing extra invoice.
         const effectiveProration = proration_behavior ?? 'none';
+
+        // Stripe metadata values are capped at 500 chars per value. Reason
+        // is user-controlled, so truncate before sending; the audit log
+        // captures the full untruncated text.
+        const reasonForStripe = reason.trim().slice(0, 500);
 
         let updatedSub: Stripe.Subscription;
         try {
@@ -947,7 +982,7 @@ export function setupAccountsBillingRoutes(
               replaced_by_admin: req.user!.id,
               replaced_by_email: req.user!.email,
               replaced_at: new Date().toISOString(),
-              replace_reason: reason.trim(),
+              replace_reason: reasonForStripe,
             },
           });
         } catch (err) {
@@ -1021,6 +1056,19 @@ export function setupAccountsBillingRoutes(
           "Subscription replaced via admin route",
         );
 
+        // Surface coupon-replacement explicitly. When the caller passes a
+        // new coupon, Stripe's `discounts: [{coupon}]` parameter clobbers
+        // any existing discounts on the sub — admins should see this.
+        const replacedDiscountIds = coupon_id
+          ? existingDiscountIds.filter((id) => id !== null)
+          : [];
+        const warnings: string[] = [];
+        if (replacedDiscountIds.length > 0) {
+          warnings.push(
+            `Replaced ${replacedDiscountIds.length} existing discount(s) on the subscription: ${replacedDiscountIds.join(', ')}.`,
+          );
+        }
+
         res.json({
           success: true,
           message: `Subscription updated for ${org.name}. Webhook will refresh the org row shortly.`,
@@ -1034,6 +1082,7 @@ export function setupAccountsBillingRoutes(
             coupon_id: coupon_id ?? null,
             proration_behavior: effectiveProration,
           },
+          ...(warnings.length > 0 ? { warnings } : {}),
         });
       } catch (error) {
         logger.error({ err: error, orgId }, "Error replacing subscription");

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -759,4 +759,289 @@ export function setupAccountsBillingRoutes(
       }
     }
   );
+
+  // POST /api/admin/accounts/:orgId/replace-subscription
+  // Out-of-band tier change for custom-contract pricing on an existing
+  // member's subscription. Uses Stripe's in-place subscription update
+  // (sub_id stays the same; pending_agreement_user_id and signed agreement
+  // version are untouched). Records an audit log entry with before/after
+  // state and the reason. The customer.subscription.updated webhook
+  // refreshes the org row.
+  apiRouter.post(
+    "/accounts/:orgId/replace-subscription",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const {
+        lookup_key,
+        price_id,
+        coupon_id,
+        proration_behavior,
+        reason,
+      } = req.body as {
+        lookup_key?: string;
+        price_id?: string;
+        coupon_id?: string;
+        proration_behavior?: 'none' | 'create_prorations' | 'always_invoice';
+        reason?: string;
+      };
+
+      try {
+        if (!stripe) {
+          return res.status(503).json({
+            error: "Stripe not configured",
+            message: "Subscription updates require Stripe to be configured.",
+          });
+        }
+
+        if (!reason || typeof reason !== 'string' || reason.trim().length < 10) {
+          return res.status(400).json({
+            error: "Reason required",
+            message:
+              "A reason of at least 10 characters is required for the audit record.",
+          });
+        }
+
+        // Exactly one of lookup_key / price_id must be provided. Custom
+        // ad-hoc prices are out of scope for v1 — operators create those in
+        // the Stripe Dashboard first, then pass the resulting price_id.
+        const priceSourceCount = [lookup_key, price_id].filter(Boolean).length;
+        if (priceSourceCount !== 1) {
+          return res.status(400).json({
+            error: "Price source required",
+            message:
+              "Provide exactly one of `lookup_key` or `price_id` for the new subscription price.",
+          });
+        }
+
+        const orgDb = new OrganizationDatabase();
+        const org = await orgDb.getOrganization(orgId);
+        if (!org) {
+          return res.status(404).json({
+            error: "Organization not found",
+            message: "The specified organization does not exist",
+          });
+        }
+
+        if (!org.stripe_customer_id || !org.stripe_subscription_id) {
+          return res.status(400).json({
+            error: "No active subscription",
+            message:
+              "Organization has no Stripe subscription to replace. Use the normal intake flow to create one.",
+          });
+        }
+
+        // Resolve the target price.
+        let targetPrice: Stripe.Price;
+        try {
+          if (price_id) {
+            targetPrice = await stripe.prices.retrieve(price_id);
+          } else {
+            const list = await stripe.prices.list({
+              lookup_keys: [lookup_key!],
+              active: true,
+              limit: 2,
+            });
+            if (list.data.length === 0) {
+              return res.status(400).json({
+                error: "Price not found",
+                message: `No active Stripe price with lookup_key "${lookup_key}".`,
+              });
+            }
+            if (list.data.length > 1) {
+              return res.status(400).json({
+                error: "Ambiguous lookup_key",
+                message: `Multiple active prices share lookup_key "${lookup_key}". Pass price_id to disambiguate.`,
+              });
+            }
+            targetPrice = list.data[0];
+          }
+        } catch (err) {
+          logger.warn({ err, orgId, lookup_key, price_id }, "Failed to resolve target price");
+          return res.status(400).json({
+            error: "Price lookup failed",
+            message: "Unable to resolve the target Stripe price. Verify the lookup_key/price_id.",
+          });
+        }
+
+        if (!targetPrice.active) {
+          return res.status(400).json({
+            error: "Price inactive",
+            message: `Price ${targetPrice.id} is not active in Stripe.`,
+          });
+        }
+
+        // Validate coupon if provided. Confirms it exists and is still
+        // redeemable so we surface the failure before mutating Stripe.
+        if (coupon_id) {
+          try {
+            const coupon = await stripe.coupons.retrieve(coupon_id);
+            if (!coupon.valid) {
+              return res.status(400).json({
+                error: "Coupon invalid",
+                message: `Coupon ${coupon_id} is no longer valid.`,
+              });
+            }
+          } catch (err) {
+            logger.warn({ err, orgId, coupon_id }, "Failed to resolve coupon");
+            return res.status(400).json({
+              error: "Coupon not found",
+              message: `No Stripe coupon with id "${coupon_id}".`,
+            });
+          }
+        }
+
+        // Read the existing sub so we can target the right item id and
+        // capture the before-state for the audit log.
+        let existingSub: Stripe.Subscription;
+        try {
+          existingSub = await stripe.subscriptions.retrieve(org.stripe_subscription_id);
+        } catch (err) {
+          logger.error(
+            { err, orgId, stripeSubId: org.stripe_subscription_id },
+            "Failed to retrieve subscription for replace",
+          );
+          return res.status(400).json({
+            error: "Subscription not found in Stripe",
+            message:
+              "The org's tracked subscription id was not found in Stripe. Run /sync or /reset-subscription-state first.",
+          });
+        }
+
+        const existingItem = existingSub.items.data[0];
+        if (!existingItem) {
+          return res.status(400).json({
+            error: "Subscription has no items",
+            message: "The existing subscription has no price items. Manual cleanup needed.",
+          });
+        }
+
+        const beforeState = {
+          subscription_id: existingSub.id,
+          status: existingSub.status,
+          item_id: existingItem.id,
+          price_id: existingItem.price.id,
+          price_lookup_key: existingItem.price.lookup_key ?? null,
+          unit_amount: existingItem.price.unit_amount,
+          interval: existingItem.price.recurring?.interval ?? null,
+          collection_method: existingSub.collection_method,
+        };
+
+        // Default proration_behavior to 'none' for custom contracts — the
+        // sales-side has already negotiated the dollars; auto-prorating
+        // would create a confusing extra invoice.
+        const effectiveProration = proration_behavior ?? 'none';
+
+        let updatedSub: Stripe.Subscription;
+        try {
+          updatedSub = await stripe.subscriptions.update(existingSub.id, {
+            items: [{ id: existingItem.id, price: targetPrice.id }],
+            proration_behavior: effectiveProration,
+            // Preserve the renewal cadence so the new sub bills on the same
+            // anchor the customer is already used to.
+            billing_cycle_anchor: 'unchanged',
+            ...(coupon_id ? { discounts: [{ coupon: coupon_id }] } : {}),
+            metadata: {
+              ...(existingSub.metadata ?? {}),
+              replaced_by_admin: req.user!.id,
+              replaced_by_email: req.user!.email,
+              replaced_at: new Date().toISOString(),
+              replace_reason: reason.trim(),
+            },
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          logger.error(
+            { err, orgId, subId: existingSub.id, targetPriceId: targetPrice.id },
+            "Stripe subscription update failed",
+          );
+          return res.status(502).json({
+            error: "Stripe update failed",
+            message: `Stripe rejected the subscription update: ${message}`,
+          });
+        }
+
+        // Stripe write succeeded — record the audit entry. If audit-log
+        // INSERT fails after this point we still return success because
+        // the change is real, but ops will see the audit gap in logs.
+        try {
+          const updatedItem = updatedSub.items.data[0];
+          const afterState = {
+            subscription_id: updatedSub.id,
+            status: updatedSub.status,
+            item_id: updatedItem?.id ?? null,
+            price_id: updatedItem?.price.id ?? null,
+            price_lookup_key: updatedItem?.price.lookup_key ?? null,
+            unit_amount: updatedItem?.price.unit_amount ?? null,
+            interval: updatedItem?.price.recurring?.interval ?? null,
+            collection_method: updatedSub.collection_method,
+            coupon_id: coupon_id ?? null,
+            proration_behavior: effectiveProration,
+          };
+
+          const pool = getPool();
+          await pool.query(
+            `INSERT INTO registry_audit_log
+             (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+             VALUES ($1, $2, $3, $4, $5, $6)`,
+            [
+              orgId,
+              req.user!.id,
+              "subscription_replaced",
+              "subscription",
+              updatedSub.id,
+              JSON.stringify({
+                org_name: org.name,
+                admin_email: req.user!.email,
+                reason: reason.trim(),
+                before_state: beforeState,
+                after_state: afterState,
+              }),
+            ]
+          );
+        } catch (auditErr) {
+          // Don't fail the request — the Stripe change is committed. Log
+          // loudly so ops can manually reconcile the audit trail.
+          logger.error(
+            { err: auditErr, orgId, subId: updatedSub.id },
+            "Subscription replaced in Stripe but audit log INSERT failed — manual reconciliation needed",
+          );
+        }
+
+        logger.info(
+          {
+            orgId,
+            orgName: org.name,
+            subId: updatedSub.id,
+            oldPriceId: beforeState.price_id,
+            newPriceId: targetPrice.id,
+            adminEmail: req.user!.email,
+          },
+          "Subscription replaced via admin route",
+        );
+
+        res.json({
+          success: true,
+          message: `Subscription updated for ${org.name}. Webhook will refresh the org row shortly.`,
+          subscription_id: updatedSub.id,
+          before: beforeState,
+          after: {
+            price_id: targetPrice.id,
+            price_lookup_key: targetPrice.lookup_key,
+            unit_amount: targetPrice.unit_amount,
+            interval: targetPrice.recurring?.interval ?? null,
+            coupon_id: coupon_id ?? null,
+            proration_behavior: effectiveProration,
+          },
+        });
+      } catch (error) {
+        logger.error({ err: error, orgId }, "Error replacing subscription");
+        res.status(500).json({
+          error: "Internal server error",
+          message: "Unable to replace subscription",
+        });
+      }
+    }
+  );
 }

--- a/server/tests/unit/replace-subscription.test.ts
+++ b/server/tests/unit/replace-subscription.test.ts
@@ -312,6 +312,121 @@ describe('POST /api/admin/accounts/:orgId/replace-subscription', () => {
     expect(res.body.error).toBe('Subscription not found in Stripe');
   });
 
+  it("returns 400 when the subscription is in a non-live status (canceled / incomplete_expired)", async () => {
+    // Stripe's retrieve returns canceled subs for ~30 days, so the prior
+    // catch doesn't surface the case. Without this gate, the update call
+    // would 400 with an opaque message that surfaces as 502.
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub({ status: 'canceled' }));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Subscription not live');
+    expect(res.body.current_status).toBe('canceled');
+    expect(mockStripeUpdateSub).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the existing subscription has no price items", async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(
+      makeExistingSub({
+        items: { data: [] } as Stripe.ApiList<Stripe.SubscriptionItem>,
+      }),
+    );
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Subscription has no items');
+    expect(mockStripeUpdateSub).not.toHaveBeenCalled();
+  });
+
+  it('truncates reason to 500 chars in Stripe metadata but stores full text in audit log', async () => {
+    const longReason = 'x'.repeat(800);
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: longReason });
+
+    const updateArgs = mockStripeUpdateSub.mock.calls[0][1] as {
+      metadata: Record<string, string>;
+    };
+    expect(updateArgs.metadata.replace_reason).toHaveLength(500);
+
+    const insertCall = mockPoolQuery.mock.calls.find((c) =>
+      String(c[0]).startsWith('INSERT INTO registry_audit_log'),
+    );
+    const details = JSON.parse(String((insertCall![1] as unknown[])[5]));
+    expect(details.reason).toBe(longReason);
+  });
+
+  it('surfaces a warning when an existing coupon is replaced', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveCoupon.mockResolvedValueOnce({ id: COUPON_ID, valid: true });
+    mockStripeRetrieveSub.mockResolvedValueOnce(
+      makeExistingSub({
+        discounts: [
+          { coupon: { id: 'old-coupon-1' } },
+          { coupon: { id: 'old-coupon-2' } },
+        ],
+      } as unknown as Partial<Stripe.Subscription>),
+    );
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        coupon_id: COUPON_ID,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeDefined();
+    expect(res.body.warnings[0]).toContain('Replaced 2 existing discount(s)');
+    expect(res.body.warnings[0]).toContain('old-coupon-1');
+    expect(res.body.warnings[0]).toContain('old-coupon-2');
+    expect(res.body.before.discount_ids).toEqual(['old-coupon-1', 'old-coupon-2']);
+  });
+
+  it('does not warn when no coupon is provided (existing discounts preserved untouched)', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(
+      makeExistingSub({
+        discounts: [{ coupon: { id: 'old-coupon-1' } }],
+      } as unknown as Partial<Stripe.Subscription>),
+    );
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeUndefined();
+    // Update call must NOT include `discounts` so Stripe leaves them alone.
+    const updateArgs = mockStripeUpdateSub.mock.calls[0][1] as Record<string, unknown>;
+    expect(updateArgs).not.toHaveProperty('discounts');
+  });
+
   it('returns 502 when stripe.subscriptions.update rejects', async () => {
     mockGetOrg.mockResolvedValueOnce(makeOrg());
     mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());

--- a/server/tests/unit/replace-subscription.test.ts
+++ b/server/tests/unit/replace-subscription.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Integration tests for POST /api/admin/accounts/:orgId/replace-subscription.
+ *
+ * The endpoint does an in-place Stripe subscription update — same sub_id,
+ * new price item (and optional coupon). Each safety guard plus the happy
+ * path plus the post-Stripe audit-log path are covered.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type Stripe from 'stripe';
+
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const {
+  mockPoolQuery,
+  mockGetOrg,
+  mockStripeRetrievePrice,
+  mockStripeListPrices,
+  mockStripeRetrieveCoupon,
+  mockStripeRetrieveSub,
+  mockStripeUpdateSub,
+  stripeMockState,
+} = vi.hoisted(() => ({
+  mockPoolQuery: vi.fn<any>(),
+  mockGetOrg: vi.fn<any>(),
+  mockStripeRetrievePrice: vi.fn<any>(),
+  mockStripeListPrices: vi.fn<any>(),
+  mockStripeRetrieveCoupon: vi.fn<any>(),
+  mockStripeRetrieveSub: vi.fn<any>(),
+  mockStripeUpdateSub: vi.fn<any>(),
+  stripeMockState: { configured: true } as { configured: boolean },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_admin_01', email: 'admin@test', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({
+    query: (...args: unknown[]) => mockPoolQuery(...args),
+  }),
+}));
+
+vi.mock('../../src/db/organization-db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/organization-db.js')>();
+  return {
+    ...actual,
+    OrganizationDatabase: class MockOrgDb {
+      getOrganization(orgId: string) {
+        return mockGetOrg(orgId);
+      }
+    },
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  get stripe() {
+    if (!stripeMockState.configured) return null;
+    return {
+      prices: {
+        retrieve: (...args: unknown[]) => mockStripeRetrievePrice(...args),
+        list: (...args: unknown[]) => mockStripeListPrices(...args),
+      },
+      coupons: {
+        retrieve: (...args: unknown[]) => mockStripeRetrieveCoupon(...args),
+      },
+      subscriptions: {
+        retrieve: (...args: unknown[]) => mockStripeRetrieveSub(...args),
+        update: (...args: unknown[]) => mockStripeUpdateSub(...args),
+      },
+    };
+  },
+  STRIPE_WEBHOOK_SECRET: 'whsec_test',
+}));
+
+const ORG_ID = 'org_test_01';
+const ORG_NAME = 'Test Org';
+const SUB_ID = 'sub_existing';
+const ITEM_ID = 'si_existing';
+const OLD_PRICE_ID = 'price_old';
+const NEW_PRICE_ID = 'price_new';
+const NEW_LOOKUP_KEY = 'aao_membership_member_25000_custom';
+const COUPON_ID = 'founder-50pct-off';
+
+function makeOrg(overrides: Record<string, unknown> = {}) {
+  return {
+    workos_organization_id: ORG_ID,
+    name: ORG_NAME,
+    stripe_customer_id: 'cus_test',
+    stripe_subscription_id: SUB_ID,
+    ...overrides,
+  };
+}
+
+function makePrice(overrides: Partial<Stripe.Price> = {}): Stripe.Price {
+  return {
+    id: NEW_PRICE_ID,
+    active: true,
+    lookup_key: NEW_LOOKUP_KEY,
+    unit_amount: 2500000,
+    currency: 'usd',
+    recurring: { interval: 'year' },
+    ...overrides,
+  } as unknown as Stripe.Price;
+}
+
+function makeExistingSub(overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  return {
+    id: SUB_ID,
+    status: 'active',
+    collection_method: 'charge_automatically',
+    metadata: { signed_agreement_version: '1.2' },
+    items: {
+      data: [
+        {
+          id: ITEM_ID,
+          price: {
+            id: OLD_PRICE_ID,
+            lookup_key: 'aao_membership_member_15000',
+            unit_amount: 1500000,
+            recurring: { interval: 'year' },
+          },
+        },
+      ],
+    },
+    ...overrides,
+  } as unknown as Stripe.Subscription;
+}
+
+async function buildApp() {
+  const { setupAccountsBillingRoutes } = await import('../../src/routes/admin/accounts-billing.js');
+  const app = express();
+  app.use(express.json());
+  const router = express.Router();
+  setupAccountsBillingRoutes(router, { workos: null });
+  app.use('/api/admin', router);
+  return app;
+}
+
+describe('POST /api/admin/accounts/:orgId/replace-subscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stripeMockState.configured = true;
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+  });
+
+  it('returns 503 when Stripe is unconfigured', async () => {
+    stripeMockState.configured = false;
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed' });
+
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 when reason is missing or short', async () => {
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'short' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Reason required');
+  });
+
+  it('returns 400 when neither lookup_key nor price_id is provided', async () => {
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Price source required');
+  });
+
+  it('returns 400 when both lookup_key and price_id are provided', async () => {
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        lookup_key: NEW_LOOKUP_KEY,
+        price_id: NEW_PRICE_ID,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Price source required');
+  });
+
+  it('returns 404 when org does not exist', async () => {
+    mockGetOrg.mockResolvedValueOnce(null);
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when org has no subscription to replace', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg({ stripe_subscription_id: null }));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No active subscription');
+  });
+
+  it('returns 400 when lookup_key matches no active price', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeListPrices.mockResolvedValueOnce({ data: [] });
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ lookup_key: NEW_LOOKUP_KEY, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Price not found');
+  });
+
+  it('returns 400 when lookup_key matches multiple active prices', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeListPrices.mockResolvedValueOnce({
+      data: [makePrice(), makePrice({ id: 'price_other' })],
+    });
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ lookup_key: NEW_LOOKUP_KEY, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Ambiguous lookup_key');
+  });
+
+  it('returns 400 when target price is inactive', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice({ active: false }));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Price inactive');
+  });
+
+  it('returns 400 when coupon does not exist', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveCoupon.mockRejectedValueOnce(new Error('No such coupon'));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        coupon_id: 'nonexistent',
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Coupon not found');
+  });
+
+  it('returns 400 when coupon is no longer valid', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveCoupon.mockResolvedValueOnce({ id: COUPON_ID, valid: false });
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        coupon_id: COUPON_ID,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Coupon invalid');
+  });
+
+  it('returns 400 when the org\'s tracked subscription is gone in Stripe', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockRejectedValueOnce(new Error('No such subscription'));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Subscription not found in Stripe');
+  });
+
+  it('returns 502 when stripe.subscriptions.update rejects', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockRejectedValueOnce(new Error('Invalid billing_cycle_anchor'));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({ price_id: NEW_PRICE_ID, reason: 'custom contract signed for member tier' });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('Stripe update failed');
+    expect(res.body.message).toContain('Invalid billing_cycle_anchor');
+  });
+
+  it('happy path: in-place update preserves sub_id, sets metadata, writes audit row', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(
+      makeExistingSub({
+        items: {
+          data: [
+            {
+              id: ITEM_ID,
+              price: {
+                id: NEW_PRICE_ID,
+                lookup_key: NEW_LOOKUP_KEY,
+                unit_amount: 2500000,
+                recurring: { interval: 'year' },
+              },
+            },
+          ],
+        } as Stripe.ApiList<Stripe.SubscriptionItem>,
+      }),
+    );
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        reason: 'custom contract signed for member tier 2026',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.subscription_id).toBe(SUB_ID);
+    expect(res.body.before.price_id).toBe(OLD_PRICE_ID);
+    expect(res.body.after.price_id).toBe(NEW_PRICE_ID);
+    expect(res.body.after.proration_behavior).toBe('none');
+
+    // Stripe update was called with the right shape:
+    expect(mockStripeUpdateSub).toHaveBeenCalledWith(SUB_ID, expect.objectContaining({
+      items: [{ id: ITEM_ID, price: NEW_PRICE_ID }],
+      proration_behavior: 'none',
+      billing_cycle_anchor: 'unchanged',
+    }));
+
+    // Metadata preserves the existing signed_agreement_version and adds
+    // the admin attribution fields.
+    const updateArgs = mockStripeUpdateSub.mock.calls[0][1] as {
+      metadata: Record<string, string>;
+    };
+    expect(updateArgs.metadata.signed_agreement_version).toBe('1.2');
+    expect(updateArgs.metadata.replaced_by_admin).toBe('user_admin_01');
+    expect(updateArgs.metadata.replace_reason).toBe('custom contract signed for member tier 2026');
+
+    // Audit log INSERT was issued with the right action + before/after.
+    const insertCall = mockPoolQuery.mock.calls.find((c) =>
+      String(c[0]).startsWith('INSERT INTO registry_audit_log'),
+    );
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as unknown[];
+    expect(params[2]).toBe('subscription_replaced');
+    expect(params[3]).toBe('subscription');
+    expect(params[4]).toBe(SUB_ID);
+    const details = JSON.parse(String(params[5]));
+    expect(details.before_state.price_id).toBe(OLD_PRICE_ID);
+    expect(details.after_state.price_id).toBe(NEW_PRICE_ID);
+  });
+
+  it('applies coupon as discounts:[{coupon}] when coupon_id provided', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveCoupon.mockResolvedValueOnce({ id: COUPON_ID, valid: true });
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        coupon_id: COUPON_ID,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(mockStripeUpdateSub).toHaveBeenCalledWith(SUB_ID, expect.objectContaining({
+      discounts: [{ coupon: COUPON_ID }],
+    }));
+  });
+
+  it('honors caller-provided proration_behavior when present', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        proration_behavior: 'create_prorations',
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(mockStripeUpdateSub).toHaveBeenCalledWith(SUB_ID, expect.objectContaining({
+      proration_behavior: 'create_prorations',
+    }));
+  });
+
+  it('resolves price by lookup_key when only lookup_key is provided', async () => {
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeListPrices.mockResolvedValueOnce({ data: [makePrice()] });
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        lookup_key: NEW_LOOKUP_KEY,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockStripeListPrices).toHaveBeenCalledWith({
+      lookup_keys: [NEW_LOOKUP_KEY],
+      active: true,
+      limit: 2,
+    });
+    expect(mockStripeRetrievePrice).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 even if audit-log INSERT fails after Stripe write succeeds', async () => {
+    // The Stripe change is the primary side effect; an audit-write failure
+    // should be logged loudly but not roll back the user's request.
+    mockGetOrg.mockResolvedValueOnce(makeOrg());
+    mockStripeRetrievePrice.mockResolvedValueOnce(makePrice());
+    mockStripeRetrieveSub.mockResolvedValueOnce(makeExistingSub());
+    mockStripeUpdateSub.mockResolvedValueOnce(makeExistingSub());
+    mockPoolQuery.mockRejectedValueOnce(new Error('audit table missing'));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${ORG_ID}/replace-subscription`)
+      .send({
+        price_id: NEW_PRICE_ID,
+        reason: 'custom contract signed for member tier',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3180. Adds `POST /api/admin/accounts/:orgId/replace-subscription` so admins can change an existing member's tier to a custom-contract price without going through cancel+re-subscribe (which would lose the agreement audit trail) or editing in the Stripe Dashboard (which leaves no programmatic record).

### Why in-place update, not cancel+create

The original issue framed this as cancel+create with "atomic rollback." That's not actually achievable across Stripe + Postgres without a Subscription Schedule, and it's not how Stripe expects you to change tiers anyway — the Stripe Dashboard's "Edit subscription" UI does an in-place `subscriptions.update`, which:

- Keeps the same `sub_id` (org row's `stripe_subscription_id` unchanged)
- Fires `customer.subscription.updated` (existing webhook handler refreshes the org row)
- Preserves the billing anchor (`billing_cycle_anchor: 'unchanged'`)
- Preserves agreement-trail fields (they're not part of the subscription)
- Works for both `charge_automatically` and `send_invoice`
- Is one Stripe call → no rollback semantics needed

Design discussion in https://github.com/adcontextprotocol/adcp/issues/3180#issuecomment-4321757576.

### Body

```json
{
  "lookup_key": "aao_membership_member_25000_custom",
  // OR
  "price_id": "price_...",

  "coupon_id": "founder-50pct-off",          // optional
  "proration_behavior": "none",               // default 'none' for custom contracts
  "reason": "Custom contract signed 2026-04-25"  // ≥ 10 chars, recorded in audit
}
```

### Validation (all pre-Stripe)

- Org exists with linked `stripe_customer_id` + `stripe_subscription_id`
- Target price resolves (404 → 400) and is active
- `lookup_key` is unambiguous (multiple actives → 400)
- Coupon exists and is valid
- Existing subscription retrievable in Stripe

### Audit log

Writes one `registry_audit_log` row (action: `subscription_replaced`) with before/after state, admin actor, and reason. Audit-write failure after Stripe success logs loudly but doesn't roll back the request — the Stripe change is the primary side effect.

### Stripe metadata stamping

Update preserves all existing subscription metadata and adds:

- `replaced_by_admin: <user_id>`
- `replaced_by_email: <admin_email>`
- `replaced_at: <iso_ts>`
- `replace_reason: <text>`

So Stripe Dashboard auditors see who changed the sub and why.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/unit/replace-subscription.test.ts` — 18 tests pass

Branches covered:
- 503: Stripe unconfigured
- 400: missing/short reason
- 400: neither / both of lookup_key, price_id
- 404: org not found
- 400: org has no subscription
- 400: lookup_key matches no active price
- 400: lookup_key ambiguous (multiple active)
- 400: target price inactive
- 400: coupon does not exist
- 400: coupon invalid
- 400: tracked subscription gone in Stripe
- 502: stripe.subscriptions.update rejects (with passthrough message)
- 200: happy path (lookup_key)
- 200: happy path (price_id) with coupon → asserts `discounts: [{ coupon }]` shape
- 200: caller-provided proration_behavior honored
- 200: metadata preserves existing fields and adds admin attribution
- 200: returns 200 even if audit-log INSERT fails after Stripe write (with logged error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)