### PR TITLE
fix(billing): cancel-unpaid dedup policy (#3245 part 1)

### DIFF
--- a/.changeset/dedup-cancel-unpaid-policy.md
+++ b/.changeset/dedup-cancel-unpaid-policy.md
@@ -1,0 +1,4 @@
+---
+---
+
+Replaces the dedup helper's "always cancel newer" policy with "cancel the unpaid one when exactly one is unpaid." Determines paid/unpaid via `latest_invoice.status === 'paid'`. When zero or multiple subs are unpaid, the helper now refuses to auto-cancel and emits a `manual_review` outcome with full context for ops. Webhook handler updated to handle the new four-way outcome (`no_duplicate` | `canceled_new` | `canceled_existing` | `manual_review`). Closes the cancel-newer sub-item of #3245.

--- a/server/src/billing/dedup-on-subscription-created.ts
+++ b/server/src/billing/dedup-on-subscription-created.ts
@@ -40,6 +40,9 @@ export interface DedupArgs {
  * Outcome of the dedup decision. Caller (http.ts) uses `kind` to wire the
  * downstream behavior:
  *   - `no_duplicate`        → normal flow (handleSubscriptionCreated + org UPDATE)
+ *   - `retry_skip`          → skip UPDATE and activation hooks. Fires on
+ *                              webhook retries where the sub arg is already
+ *                              non-live (we canceled it on a prior invocation).
  *   - `canceled_new`        → skip UPDATE so the surviving sub's row state stays
  *   - `canceled_existing`   → let UPDATE run (the new sub becomes the tracked
  *                              one), but don't fire fresh-activation hooks —
@@ -49,6 +52,7 @@ export interface DedupArgs {
  */
 export type DedupOutcome =
   | { kind: 'no_duplicate' }
+  | { kind: 'retry_skip' }
   | { kind: 'canceled_new'; existingLiveSubIds: string[] }
   | { kind: 'canceled_existing'; canceledSubId: string; survivingNewSubId: string }
   | { kind: 'manual_review'; allLiveSubIds: string[]; reason: string };
@@ -75,8 +79,10 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
   // Stripe retries `customer.subscription.created` on 5xx / slow handlers.
   // On retry the new sub will already be canceled by the prior invocation;
   // skip cleanly so we don't try to cancel-again (returns 400) and re-alert.
+  // Caller must ALSO skip the org-row UPDATE — running it would overwrite
+  // the surviving sub's state with the canceled retry's `status: 'canceled'`.
   if (!(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)) {
-    return { kind: 'no_duplicate' };
+    return { kind: 'retry_skip' };
   }
 
   let liveSubs: Stripe.Subscription[];
@@ -196,6 +202,15 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
   };
 }
 
+/**
+ * Strict "money actually moved" check. Returns true only for `status: 'paid'`.
+ * Stripe's other invoice statuses are intentionally treated as unpaid:
+ *   - `null`               → no invoice yet (timing of webhook event)
+ *   - `'draft'` / `'open'` → not collected yet
+ *   - `'uncollectible'`    → Stripe wrote it off after retries
+ *   - `'void'`             → invoice was canceled
+ *   - unexpanded string id → can't tell; safer to treat as unpaid
+ */
 function isLatestInvoicePaid(
   latestInvoice: Stripe.Subscription['latest_invoice'],
 ): boolean {

--- a/server/src/billing/dedup-on-subscription-created.ts
+++ b/server/src/billing/dedup-on-subscription-created.ts
@@ -7,10 +7,18 @@
  * admin invite + member checkout) can both pass their guards before either
  * mints a sub, and the user can complete both within seconds.
  *
- * On `customer.subscription.created` we look at the customer's full live-sub
- * inventory. If there's another live sub besides this new one, we cancel the
- * new one with proration refund, alert ops, and tell the caller to suppress
- * the org-row UPDATE so the existing surviving sub's state stays intact.
+ * Policy (#3245 update, replaced earlier "always cancel newer"):
+ *   - Look at every live (active/trialing/past_due) sub on the customer.
+ *   - Determine paid/unpaid via `latest_invoice.status === 'paid'`.
+ *   - If exactly one is unpaid: cancel that one, keep the paid survivor.
+ *   - If zero or multiple are unpaid: don't auto-cancel — alert ops for
+ *     manual review (covers two-paid edge case and the rare both-open one).
+ *
+ * Why this beats cancel-newer: the typical AAO duplicate is one paid (the
+ * legit member) plus one unpaid open invoice (the wrong-tier intake). The
+ * cancel-newer rule worked for the Triton case by luck — it would have
+ * canceled a legitimate higher-tier upgrade if the member had paid the
+ * upgrade after the duplicate-old-sub appeared.
  */
 import type Stripe from 'stripe';
 import type { Logger } from 'pino';
@@ -28,48 +36,58 @@ export interface DedupArgs {
   notifySystemError: (ctx: { source: string; errorMessage: string }) => void;
 }
 
-export interface DedupResult {
-  /**
-   * True when the new sub was identified as a duplicate and canceled.
-   * Caller must skip the org-row UPDATE so the surviving sub's state stays.
-   */
-  duplicate: boolean;
-  /** When `duplicate`, the IDs of the *other* live subs we kept. */
-  existingLiveSubIds: string[];
+/**
+ * Outcome of the dedup decision. Caller (http.ts) uses `kind` to wire the
+ * downstream behavior:
+ *   - `no_duplicate`        → normal flow (handleSubscriptionCreated + org UPDATE)
+ *   - `canceled_new`        → skip UPDATE so the surviving sub's row state stays
+ *   - `canceled_existing`   → let UPDATE run (the new sub becomes the tracked
+ *                              one), but don't fire fresh-activation hooks —
+ *                              the customer was already a member
+ *   - `manual_review`       → skip UPDATE; don't fire activation hooks; ops
+ *                              alerted to resolve manually
+ */
+export type DedupOutcome =
+  | { kind: 'no_duplicate' }
+  | { kind: 'canceled_new'; existingLiveSubIds: string[] }
+  | { kind: 'canceled_existing'; canceledSubId: string; survivingNewSubId: string }
+  | { kind: 'manual_review'; allLiveSubIds: string[]; reason: string };
+
+interface SubPaidStatus {
+  sub: Stripe.Subscription;
+  /** True iff `latest_invoice.status === 'paid'`. Null/draft/open all count as unpaid. */
+  paid: boolean;
 }
 
 /**
- * Returns `{ duplicate: false }` to let the normal webhook flow proceed.
- * Returns `{ duplicate: true, existingLiveSubIds }` after canceling the new
- * sub when the customer already has another live one.
+ * Returns a `DedupOutcome` describing what the helper did.
  *
  * Lookup or cancel failures are logged and treated as "don't know" — we fall
- * through to `duplicate: false`, accepting that a missed duplicate will be
+ * through to `no_duplicate`, accepting that a missed duplicate will be
  * caught by the periodic integrity audit (#3193 invariant
  * `one-active-stripe-sub-per-org`). Failing closed (refusing the sub) on a
  * transient Stripe error would be worse: it would block legitimate first-time
  * subscriptions during a Stripe blip.
  */
-export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<DedupResult> {
+export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<DedupOutcome> {
   const { subscription, customerId, orgId, stripe, logger, notifySystemError } = args;
 
   // Stripe retries `customer.subscription.created` on 5xx / slow handlers.
   // On retry the new sub will already be canceled by the prior invocation;
   // skip cleanly so we don't try to cancel-again (returns 400) and re-alert.
   if (!(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)) {
-    return { duplicate: false, existingLiveSubIds: [] };
+    return { kind: 'no_duplicate' };
   }
 
   let liveSubs: Stripe.Subscription[];
   try {
-    // limit: 100 is Stripe's max per page. A customer with >100 historical
-    // subs would still have all live ones returned: Stripe lists in
-    // most-recent-first order, and the live ones include the just-created
-    // one, so they're at the head. We log when has_more so ops can confirm.
+    // Expand latest_invoice so we can read its status without a per-sub
+    // round trip. limit: 100 is Stripe's max per page.
     const list = await stripe.subscriptions.list({
       customer: customerId,
       status: 'all',
       limit: 100,
+      expand: ['data.latest_invoice'],
     });
     if (list.has_more) {
       logger.warn(
@@ -77,66 +95,159 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
         'dedup-on-subscription-created: subscriptions.list paginated — only first 100 inspected',
       );
     }
-    liveSubs = list.data;
+    liveSubs = list.data.filter((s) =>
+      (TIER_PRESERVING_STATUSES as readonly string[]).includes(s.status),
+    );
   } catch (err) {
     logger.warn(
       { err, customerId, newSubId: subscription.id, orgId },
       'dedup-on-subscription-created: subscriptions.list failed — proceeding without dedup check',
     );
-    return { duplicate: false, existingLiveSubIds: [] };
+    return { kind: 'no_duplicate' };
   }
 
-  const otherLive = liveSubs.filter(
-    (s) =>
-      s.id !== subscription.id &&
-      (TIER_PRESERVING_STATUSES as readonly string[]).includes(s.status),
-  );
-  if (otherLive.length === 0) {
-    return { duplicate: false, existingLiveSubIds: [] };
+  if (liveSubs.length <= 1) {
+    return { kind: 'no_duplicate' };
   }
 
-  const otherIds = otherLive.map((s) => s.id);
-  logger.error(
-    {
-      newSubId: subscription.id,
+  // Compute paid status for each live sub. `latest_invoice` may be:
+  //   - an expanded Stripe.Invoice with .status set
+  //   - a string id (if expand failed silently for some reason)
+  //   - null (no invoice yet — counts as unpaid)
+  const statuses: SubPaidStatus[] = liveSubs.map((s) => ({
+    sub: s,
+    paid: isLatestInvoicePaid(s.latest_invoice),
+  }));
+
+  const unpaid = statuses.filter((s) => !s.paid);
+  const paid = statuses.filter((s) => s.paid);
+
+  // Exactly one unpaid → cancel it. Only safe auto-action.
+  if (unpaid.length === 1) {
+    const target = unpaid[0].sub;
+    const survivors = liveSubs.filter((s) => s.id !== target.id);
+
+    const canceled = await tryCancel({
+      subId: target.id,
+      stripe,
+      logger,
       customerId,
       orgId,
-      existingLiveSubIds: otherIds,
-    },
-    'Duplicate subscription detected on customer.subscription.created — canceling new sub',
-  );
+    });
 
-  let canceled = false;
-  try {
-    await stripe.subscriptions.cancel(subscription.id, { prorate: true });
-    canceled = true;
-  } catch (cancelErr) {
-    logger.error(
-      { err: cancelErr, customerId, newSubId: subscription.id, orgId },
-      'Failed to cancel duplicate subscription — manual intervention needed',
-    );
-    // Continue with the alert; ops needs to know either way.
+    notifyDedupAction({
+      notifySystemError,
+      customerId,
+      orgId,
+      action: canceled ? 'canceled_unpaid' : 'cancel_failed',
+      canceledSub: target,
+      survivors,
+    });
+
+    if (target.id === subscription.id) {
+      return {
+        kind: 'canceled_new',
+        existingLiveSubIds: survivors.map((s) => s.id),
+      };
+    }
+    return {
+      kind: 'canceled_existing',
+      canceledSubId: target.id,
+      survivingNewSubId: subscription.id,
+    };
   }
 
-  // Enrich the alert so ops can triage without clicking into Stripe.
-  const newSubItem = subscription.items?.data?.[0];
-  const newSubAmount = newSubItem?.price?.unit_amount ?? null;
-  const newSubLookupKey = newSubItem?.price?.lookup_key ?? null;
-  const newSubCollection = subscription.collection_method ?? null;
+  // Multiple paid (rare; legit upgrade race) or multiple unpaid (two
+  // concurrent send_invoice flows in flight). Don't auto-cancel — too easy
+  // to discard real revenue or the wrong intake. Alert ops with full
+  // context so they can resolve manually.
+  const reason =
+    unpaid.length === 0
+      ? `${paid.length} live subs, all paid — possible legit upgrade race or duplicate payment`
+      : `${unpaid.length} live subs, all unpaid — concurrent intake flows`;
 
-  const cancelStatus = canceled
-    ? 'was canceled with proration'
-    : 'COULD NOT be canceled (Stripe error) — cancel manually in Stripe';
+  logger.error(
+    {
+      customerId,
+      orgId,
+      newSubId: subscription.id,
+      allLiveSubIds: liveSubs.map((s) => s.id),
+      paidSubIds: paid.map((s) => s.sub.id),
+      unpaidSubIds: unpaid.map((s) => s.sub.id),
+    },
+    'Duplicate subscription detected — manual review required',
+  );
 
   notifySystemError({
     source: 'stripe-subscription-dedup',
     errorMessage:
-      `Duplicate subscription ${subscription.id} on customer ${customerId} ` +
-      `(org ${orgId ?? 'unknown'}) ${cancelStatus}. ` +
-      `New sub: amount=${newSubAmount ?? 'unknown'} lookup_key=${newSubLookupKey ?? 'unknown'} ` +
-      `collection=${newSubCollection ?? 'unknown'}. ` +
-      `Existing live subs kept: ${otherIds.join(', ')}.`,
+      `Duplicate subscriptions on customer ${customerId} (org ${orgId ?? 'unknown'}) ` +
+      `require manual review: ${reason}. ` +
+      `New sub: ${subscription.id}. ` +
+      `paid=${paid.map((s) => s.sub.id).join(',') || '(none)'}; ` +
+      `unpaid=${unpaid.map((s) => s.sub.id).join(',') || '(none)'}. ` +
+      `Resolve in Stripe Dashboard, then run /sync.`,
   });
 
-  return { duplicate: true, existingLiveSubIds: otherIds };
+  return {
+    kind: 'manual_review',
+    allLiveSubIds: liveSubs.map((s) => s.id),
+    reason,
+  };
+}
+
+function isLatestInvoicePaid(
+  latestInvoice: Stripe.Subscription['latest_invoice'],
+): boolean {
+  if (!latestInvoice) return false;
+  if (typeof latestInvoice === 'string') return false;
+  return latestInvoice.status === 'paid';
+}
+
+async function tryCancel(args: {
+  subId: string;
+  stripe: Stripe;
+  logger: Logger;
+  customerId: string;
+  orgId?: string | null;
+}): Promise<boolean> {
+  try {
+    await args.stripe.subscriptions.cancel(args.subId, { prorate: true });
+    return true;
+  } catch (err) {
+    args.logger.error(
+      { err, customerId: args.customerId, subId: args.subId, orgId: args.orgId },
+      'Failed to cancel duplicate subscription — manual intervention needed',
+    );
+    return false;
+  }
+}
+
+function notifyDedupAction(args: {
+  notifySystemError: (ctx: { source: string; errorMessage: string }) => void;
+  customerId: string;
+  orgId?: string | null;
+  action: 'canceled_unpaid' | 'cancel_failed';
+  canceledSub: Stripe.Subscription;
+  survivors: Stripe.Subscription[];
+}) {
+  const item = args.canceledSub.items?.data?.[0];
+  const amount = item?.price?.unit_amount ?? null;
+  const lookupKey = item?.price?.lookup_key ?? null;
+  const collection = args.canceledSub.collection_method ?? null;
+
+  const cancelStatus =
+    args.action === 'canceled_unpaid'
+      ? 'was canceled (it was the unpaid duplicate)'
+      : 'COULD NOT be canceled (Stripe error) — cancel manually in Stripe';
+
+  args.notifySystemError({
+    source: 'stripe-subscription-dedup',
+    errorMessage:
+      `Duplicate subscription ${args.canceledSub.id} on customer ${args.customerId} ` +
+      `(org ${args.orgId ?? 'unknown'}) ${cancelStatus}. ` +
+      `Canceled sub: amount=${amount ?? 'unknown'} lookup_key=${lookupKey ?? 'unknown'} ` +
+      `collection=${collection ?? 'unknown'}. ` +
+      `Survivors: ${args.survivors.map((s) => s.id).join(', ') || '(none)'}.`,
+  });
 }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3474,8 +3474,14 @@ export class HTTPServer {
             // until the organizations row reflects the activated membership.
             let activationAdminContext: ActivationAdminContext | undefined;
 
-            // When the just-created sub is a duplicate that we cancel,
-            // skip the org-row UPDATE so the surviving sub's state stays.
+            // Dedup outcome controls two things:
+            //   - suppressOrgUpdate: skip the row UPDATE when we want a
+            //     different sub (the existing one, or none) to remain
+            //     tracked instead of this newly-created one.
+            //   - whether to fire fresh-activation hooks (welcome email,
+            //     listing autopublish): only on `no_duplicate`. The
+            //     `canceled_existing` case is a swap, not an activation —
+            //     the customer was already a member.
             let suppressOrgUpdate = false;
 
             if (event.type === 'customer.subscription.created') {
@@ -3488,21 +3494,39 @@ export class HTTPServer {
                 notifySystemError,
               });
 
-              if (dedup.duplicate) {
-                suppressOrgUpdate = true;
-              } else if (org) {
-                activationAdminContext = await handleSubscriptionCreated({
-                  subscription,
-                  customerId,
-                  org,
-                  stripe,
-                  workos: workos!,
-                  orgDb,
-                  pool,
-                  logger,
-                  notifySystemError,
-                  notifyNewSubscription,
-                });
+              switch (dedup.kind) {
+                case 'canceled_new':
+                  // We canceled the just-created sub (it was the unpaid
+                  // duplicate). Keep the org row pointing at the surviving
+                  // existing sub.
+                  suppressOrgUpdate = true;
+                  break;
+                case 'manual_review':
+                  // Don't change tracking — ops will resolve in Stripe and
+                  // run /sync to reconcile.
+                  suppressOrgUpdate = true;
+                  break;
+                case 'canceled_existing':
+                  // The new sub becomes the org's tracked sub. Let the
+                  // UPDATE block below run, but skip handleSubscriptionCreated
+                  // — this is a tier swap, not a fresh activation.
+                  break;
+                case 'no_duplicate':
+                  if (org) {
+                    activationAdminContext = await handleSubscriptionCreated({
+                      subscription,
+                      customerId,
+                      org,
+                      stripe,
+                      workos: workos!,
+                      orgDb,
+                      pool,
+                      logger,
+                      notifySystemError,
+                      notifyNewSubscription,
+                    });
+                  }
+                  break;
               }
             }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3501,6 +3501,13 @@ export class HTTPServer {
                   // existing sub.
                   suppressOrgUpdate = true;
                   break;
+                case 'retry_skip':
+                  // Stripe retried `customer.subscription.created` after a
+                  // prior invocation already canceled this sub. The event's
+                  // status is non-live now; running UPDATE would overwrite
+                  // the surviving sub's row state with `status: 'canceled'`.
+                  suppressOrgUpdate = true;
+                  break;
                 case 'manual_review':
                   // Don't change tracking — ops will resolve in Stripe and
                   // run /sync to reconcile.

--- a/server/tests/unit/dedup-on-subscription-created.test.ts
+++ b/server/tests/unit/dedup-on-subscription-created.test.ts
@@ -128,7 +128,10 @@ describe('dedupOnSubscriptionCreated', () => {
       expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
     });
 
-    it('returns no_duplicate without listing when the new sub is already canceled (webhook retry)', async () => {
+    it('returns retry_skip without listing when the new sub is already canceled (webhook retry)', async () => {
+      // Critical: must not return no_duplicate here — that would let the
+      // webhook handler run UPDATE on the canceled sub and overwrite the
+      // surviving sub's row state with `status: 'canceled'`.
       const newSub = makeSub('sub_new', 'canceled');
       const list = vi.fn().mockResolvedValue({ data: [] });
       const cancel = vi.fn();
@@ -143,10 +146,28 @@ describe('dedupOnSubscriptionCreated', () => {
         notifySystemError,
       });
 
-      expect(result.kind).toBe('no_duplicate');
+      expect(result.kind).toBe('retry_skip');
       expect(list).not.toHaveBeenCalled();
       expect(cancel).not.toHaveBeenCalled();
       expect(notifySystemError).not.toHaveBeenCalled();
+    });
+
+    it('returns retry_skip when the new sub is incomplete_expired (treats as already-handled)', async () => {
+      const newSub = makeSub('sub_new', 'incomplete_expired');
+      const list = vi.fn().mockResolvedValue({ data: [] });
+      const stripe = makeStripe({ list });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('retry_skip');
+      expect(list).not.toHaveBeenCalled();
     });
 
     it('falls through to no_duplicate when subscriptions.list throws (transient Stripe blip)', async () => {
@@ -391,6 +412,105 @@ describe('dedupOnSubscriptionCreated', () => {
       const msg = notifySystemError.mock.calls[0][0].errorMessage;
       expect(msg).toContain('paid=(none)');
       expect(msg).toContain('unpaid=sub_new,sub_other');
+    });
+
+    it('returns manual_review when 3+ live subs are all paid', async () => {
+      // Three concurrent paid subs is rare but possible; auto-canceling
+      // any of them risks discarding real revenue.
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'paid' });
+      const a = makeSub('sub_a', 'active', { latest_invoice_status: 'paid' });
+      const b = makeSub('sub_b', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn();
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, a, b] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('manual_review');
+      if (result.kind === 'manual_review') {
+        expect(result.allLiveSubIds).toEqual(['sub_new', 'sub_a', 'sub_b']);
+        expect(result.reason).toContain('all paid');
+      }
+      expect(cancel).not.toHaveBeenCalled();
+    });
+
+    it('returns manual_review when 3+ live subs are all unpaid', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const a = makeSub('sub_a', 'active', { latest_invoice_status: 'open' });
+      const b = makeSub('sub_b', 'active', { latest_invoice_status: 'draft' });
+      const cancel = vi.fn();
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, a, b] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('manual_review');
+      if (result.kind === 'manual_review') {
+        expect(result.reason).toContain('all unpaid');
+      }
+      expect(cancel).not.toHaveBeenCalled();
+    });
+
+    it('treats latest_invoice = uncollectible as unpaid (Stripe wrote it off after retries)', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'uncollectible' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+      expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+    });
+
+    it('treats latest_invoice = void as unpaid (Stripe canceled the invoice)', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'void' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+      expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
     });
 
     it('returns manual_review when 3+ live subs and ambiguous payment state', async () => {

--- a/server/tests/unit/dedup-on-subscription-created.test.ts
+++ b/server/tests/unit/dedup-on-subscription-created.test.ts
@@ -1,11 +1,9 @@
 /**
  * Tests for the webhook-side duplicate-subscription guard.
  *
- * Closes the cross-path race the intake-side guards leave open: Stripe
- * Checkout creates a session URL, not a subscription — the sub mints only
- * when the user completes the hosted page. Two concurrent intake paths
- * (admin invite + member checkout) can both pass their guards before
- * either mints a sub, so we re-check at `customer.subscription.created`.
+ * Policy (#3245): cancel the unpaid sub when exactly one is unpaid.
+ * Otherwise (zero unpaid, or multiple unpaid) → manual_review with no
+ * auto-cancel. Identifies paid via `latest_invoice.status === 'paid'`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type Stripe from 'stripe';
@@ -19,13 +17,27 @@ function makeSub(
     unit_amount?: number;
     lookup_key?: string;
     collection_method?: 'charge_automatically' | 'send_invoice';
+    /** When omitted, latest_invoice is null → treated as unpaid. */
+    latest_invoice_status?: Stripe.Invoice.Status | null;
+    latest_invoice_id?: string;
   },
 ): Stripe.Subscription {
+  const latestInvoice =
+    extras?.latest_invoice_status === undefined
+      ? null
+      : extras.latest_invoice_status === null
+        ? null
+        : ({
+            id: extras.latest_invoice_id ?? `in_${id}`,
+            status: extras.latest_invoice_status,
+          } as Stripe.Invoice);
+
   return {
     id,
     status,
     customer: 'cus_test',
     collection_method: extras?.collection_method ?? 'charge_automatically',
+    latest_invoice: latestInvoice,
     items: {
       data: [
         {
@@ -40,7 +52,7 @@ function makeSub(
 }
 
 function makeStripe(opts: {
-  list?: () => Promise<{ data: Stripe.Subscription[] }>;
+  list?: () => Promise<{ data: Stripe.Subscription[]; has_more?: boolean }>;
   cancel?: () => Promise<Stripe.Subscription>;
 }): Stripe {
   return {
@@ -69,287 +81,415 @@ describe('dedupOnSubscriptionCreated', () => {
     notifySystemError = vi.fn();
   });
 
-  it('returns duplicate=false when the customer has only the new sub', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({ data: [newSub] }),
+  describe('no-duplicate fast paths', () => {
+    it('returns no_duplicate when the customer has only the new sub', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub] }),
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('no_duplicate');
+      expect(notifySystemError).not.toHaveBeenCalled();
+      expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
     });
 
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
+    it('returns no_duplicate when other subs exist but are all canceled/incomplete', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({
+          data: [
+            newSub,
+            makeSub('sub_old1', 'canceled'),
+            makeSub('sub_old2', 'incomplete_expired'),
+            makeSub('sub_old3', 'incomplete'),
+          ],
+        }),
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('no_duplicate');
+      expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
     });
 
-    expect(result.duplicate).toBe(false);
-    expect(result.existingLiveSubIds).toEqual([]);
-    expect(notifySystemError).not.toHaveBeenCalled();
-    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    it('returns no_duplicate without listing when the new sub is already canceled (webhook retry)', async () => {
+      const newSub = makeSub('sub_new', 'canceled');
+      const list = vi.fn().mockResolvedValue({ data: [] });
+      const cancel = vi.fn();
+      const stripe = makeStripe({ list, cancel });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('no_duplicate');
+      expect(list).not.toHaveBeenCalled();
+      expect(cancel).not.toHaveBeenCalled();
+      expect(notifySystemError).not.toHaveBeenCalled();
+    });
+
+    it('falls through to no_duplicate when subscriptions.list throws (transient Stripe blip)', async () => {
+      const newSub = makeSub('sub_new', 'active');
+      const stripe = makeStripe({
+        list: vi.fn().mockRejectedValue(new Error('Stripe API down')),
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('no_duplicate');
+      expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+      expect(notifySystemError).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
   });
 
-  it('returns duplicate=false when other subs exist but are all canceled/incomplete', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [
-          newSub,
-          makeSub('sub_old1', 'canceled'),
-          makeSub('sub_old2', 'incomplete_expired'),
-          makeSub('sub_old3', 'incomplete'),
-        ],
-      }),
+  describe('cancel-unpaid policy', () => {
+    it('cancels the new sub when it is the unpaid one (Triton-shape with new=unpaid)', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+      if (result.kind === 'canceled_new') {
+        expect(result.existingLiveSubIds).toEqual(['sub_existing']);
+      }
+      expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+      expect(notifySystemError).toHaveBeenCalledTimes(1);
     });
 
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
+    it('cancels an existing sub when the new sub is paid and the existing is unpaid', async () => {
+      // Reviewer's hypothetical flipped: customer paid for new bigger
+      // tier (e.g., $50K Leader) while a smaller open invoice was sitting
+      // around. New sub wins; we cancel the unpaid existing one.
+      const newSub = makeSub('sub_new_leader', 'active', { latest_invoice_status: 'paid' });
+      const oldUnpaid = makeSub('sub_old_pro', 'active', { latest_invoice_status: 'open' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, oldUnpaid] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_existing');
+      if (result.kind === 'canceled_existing') {
+        expect(result.canceledSubId).toBe('sub_old_pro');
+        expect(result.survivingNewSubId).toBe('sub_new_leader');
+      }
+      expect(cancel).toHaveBeenCalledWith('sub_old_pro', { prorate: true });
     });
 
-    expect(result.duplicate).toBe(false);
-    expect(result.existingLiveSubIds).toEqual([]);
-    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    it('treats latest_invoice = null as unpaid', async () => {
+      // Some sub-creation paths fire the webhook before the first invoice
+      // exists; null latest_invoice still counts as unpaid.
+      const newSub = makeSub('sub_new', 'active'); // no latest_invoice
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+      expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+    });
+
+    it('treats latest_invoice = open/draft as unpaid', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'draft' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+      expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
+    });
+
+    it('treats latest_invoice as a string id (unexpanded) as unpaid', async () => {
+      // Defensive: if expand silently fails, latest_invoice is just the
+      // id string. We can't tell whether it's paid, so treat as unpaid
+      // — better to err on the side of canceling the one with no signal.
+      const newSub = makeSub('sub_new', 'active');
+      (newSub as unknown as { latest_invoice: string }).latest_invoice = 'in_unknown';
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('canceled_new');
+    });
+
+    it('alert message identifies which sub was canceled and why', async () => {
+      const newSub = makeSub('sub_new', 'active', {
+        latest_invoice_status: 'open',
+        unit_amount: 300000,
+        lookup_key: 'aao_membership_builder_3000',
+        collection_method: 'send_invoice',
+      });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+      });
+
+      await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      const msg = notifySystemError.mock.calls[0][0].errorMessage;
+      expect(msg).toContain('sub_new');
+      expect(msg).toContain('was canceled (it was the unpaid duplicate)');
+      expect(msg).toContain('amount=300000');
+      expect(msg).toContain('lookup_key=aao_membership_builder_3000');
+      expect(msg).toContain('collection=send_invoice');
+      expect(msg).toContain('sub_existing');
+    });
   });
 
-  it('cancels the new sub and alerts ops when another active sub exists', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-      }),
-      cancel,
+  describe('manual_review (refuses to auto-decide)', () => {
+    it('returns manual_review when both live subs are paid', async () => {
+      // Both customers have paid charges → either could be the legit one.
+      // Auto-canceling either risks discarding real revenue. Alert ops.
+      const newSub = makeSub('sub_new_leader', 'active', { latest_invoice_status: 'paid' });
+      const existing = makeSub('sub_existing_pro', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn();
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('manual_review');
+      if (result.kind === 'manual_review') {
+        expect(result.allLiveSubIds).toEqual(['sub_new_leader', 'sub_existing_pro']);
+        expect(result.reason).toContain('all paid');
+      }
+      expect(cancel).not.toHaveBeenCalled();
+      expect(notifySystemError).toHaveBeenCalled();
+      const msg = notifySystemError.mock.calls[0][0].errorMessage;
+      expect(msg).toContain('manual review');
+      expect(msg).toContain('paid=sub_new_leader,sub_existing_pro');
+      expect(msg).toContain('unpaid=(none)');
     });
 
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
+    it('returns manual_review when both live subs are unpaid', async () => {
+      // Two concurrent send_invoice intake flows in flight; can't tell
+      // which one the customer "meant" so escalate.
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const existing = makeSub('sub_other', 'active', { latest_invoice_status: 'open' });
+      const cancel = vi.fn();
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(result.kind).toBe('manual_review');
+      if (result.kind === 'manual_review') {
+        expect(result.reason).toContain('all unpaid');
+      }
+      expect(cancel).not.toHaveBeenCalled();
+      const msg = notifySystemError.mock.calls[0][0].errorMessage;
+      expect(msg).toContain('paid=(none)');
+      expect(msg).toContain('unpaid=sub_new,sub_other');
     });
 
-    expect(result.duplicate).toBe(true);
-    expect(result.existingLiveSubIds).toEqual(['sub_existing']);
-    expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
-    expect(notifySystemError).toHaveBeenCalledTimes(1);
-    expect(notifySystemError.mock.calls[0][0].source).toBe('stripe-subscription-dedup');
-    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('sub_new');
-    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('sub_existing');
+    it('returns manual_review when 3+ live subs and ambiguous payment state', async () => {
+      // Three live subs, two paid + one unpaid. Cancel-unpaid is technically
+      // unambiguous here, so we DO cancel the unpaid one.
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'paid' });
+      const paidExisting = makeSub('sub_paid', 'active', { latest_invoice_status: 'paid' });
+      const unpaidExisting = makeSub('sub_unpaid', 'active', { latest_invoice_status: 'open' });
+      const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, paidExisting, unpaidExisting] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      // Exactly one unpaid → cancel that one. The two-paid subs case
+      // remains a separate problem the audit invariants will flag.
+      expect(result.kind).toBe('canceled_existing');
+      if (result.kind === 'canceled_existing') {
+        expect(result.canceledSubId).toBe('sub_unpaid');
+      }
+    });
   });
 
-  it('treats trialing and past_due as live and triggers cancel', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const cancel = vi.fn().mockResolvedValue({} as Stripe.Subscription);
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [
-          newSub,
-          makeSub('sub_trial', 'trialing'),
-          makeSub('sub_past_due', 'past_due'),
-        ],
-      }),
-      cancel,
+  describe('failure modes', () => {
+    it('still alerts ops when cancel fails — manual intervention is needed', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const cancel = vi.fn().mockRejectedValue(new Error('cannot cancel'));
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+        cancel,
+      });
+
+      const result = await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      // We still return canceled_new — the survivor still wins; ops
+      // handles the actual cancel manually.
+      expect(result.kind).toBe('canceled_new');
+      expect(notifySystemError).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalled();
+      const msg = notifySystemError.mock.calls[0][0].errorMessage;
+      expect(msg).toContain('COULD NOT be canceled');
+      expect(msg).not.toContain('was canceled (it was the unpaid duplicate)');
     });
 
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
+    it('warns when subscriptions.list returns has_more (page overflow)', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({
+          data: [newSub, makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' })],
+          has_more: true,
+        }),
+      });
+
+      await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: 'org_test',
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(logger.warn).toHaveBeenCalled();
     });
 
-    expect(result.duplicate).toBe(true);
-    expect(result.existingLiveSubIds).toEqual(['sub_trial', 'sub_past_due']);
-    expect(cancel).toHaveBeenCalledWith('sub_new', { prorate: true });
-  });
+    it('handles missing orgId in the alert message', async () => {
+      const newSub = makeSub('sub_new', 'active', { latest_invoice_status: 'open' });
+      const existing = makeSub('sub_existing', 'active', { latest_invoice_status: 'paid' });
+      const stripe = makeStripe({
+        list: vi.fn().mockResolvedValue({ data: [newSub, existing] }),
+      });
 
-  it('falls through to duplicate=false when subscriptions.list throws (transient Stripe blip)', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const stripe = makeStripe({
-      list: vi.fn().mockRejectedValue(new Error('Stripe API down')),
+      await dedupOnSubscriptionCreated({
+        subscription: newSub,
+        customerId: 'cus_test',
+        orgId: null,
+        stripe,
+        logger,
+        notifySystemError,
+      });
+
+      expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('org unknown');
     });
-
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(result.duplicate).toBe(false);
-    expect(result.existingLiveSubIds).toEqual([]);
-    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
-    expect(notifySystemError).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalled();
-  });
-
-  it('still alerts ops when cancel fails — manual intervention is needed', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const cancel = vi.fn().mockRejectedValue(new Error('cannot cancel'));
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-      }),
-      cancel,
-    });
-
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(result.duplicate).toBe(true);
-    expect(result.existingLiveSubIds).toEqual(['sub_existing']);
-    expect(notifySystemError).toHaveBeenCalledTimes(1);
-    expect(logger.error).toHaveBeenCalled();
-  });
-
-  it('returns duplicate=false without listing when the new sub is already canceled (Stripe webhook retry)', async () => {
-    const newSub = makeSub('sub_new', 'canceled');
-    const list = vi.fn().mockResolvedValue({ data: [] });
-    const cancel = vi.fn();
-    const stripe = makeStripe({ list, cancel });
-
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(result.duplicate).toBe(false);
-    expect(list).not.toHaveBeenCalled();
-    expect(cancel).not.toHaveBeenCalled();
-    expect(notifySystemError).not.toHaveBeenCalled();
-  });
-
-  it('returns duplicate=false when the new sub is incomplete_expired (no live status)', async () => {
-    const newSub = makeSub('sub_new', 'incomplete_expired');
-    const list = vi.fn().mockResolvedValue({ data: [] });
-    const stripe = makeStripe({ list });
-
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(result.duplicate).toBe(false);
-    expect(list).not.toHaveBeenCalled();
-  });
-
-  it('warns when subscriptions.list returns has_more (page overflow)', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-        has_more: true,
-      }),
-    });
-
-    await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(logger.warn).toHaveBeenCalled();
-  });
-
-  it('alert message reflects cancel failure (no false "was canceled" claim)', async () => {
-    const newSub = makeSub('sub_new', 'active', { unit_amount: 300000, lookup_key: 'aao_membership_builder_3000' });
-    const cancel = vi.fn().mockRejectedValue(new Error('cannot cancel'));
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-      }),
-      cancel,
-    });
-
-    await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    const msg = notifySystemError.mock.calls[0][0].errorMessage;
-    expect(msg).toContain('COULD NOT be canceled');
-    expect(msg).toContain('cancel manually');
-    expect(msg).not.toContain('was canceled with proration');
-  });
-
-  it('alert message includes new sub amount, lookup_key, and collection_method', async () => {
-    const newSub = makeSub('sub_new', 'active', {
-      unit_amount: 300000,
-      lookup_key: 'aao_membership_builder_3000',
-      collection_method: 'send_invoice',
-    });
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-      }),
-    });
-
-    await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: 'org_test',
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    const msg = notifySystemError.mock.calls[0][0].errorMessage;
-    expect(msg).toContain('amount=300000');
-    expect(msg).toContain('lookup_key=aao_membership_builder_3000');
-    expect(msg).toContain('collection=send_invoice');
-  });
-
-  it('handles missing orgId in the alert message', async () => {
-    const newSub = makeSub('sub_new', 'active');
-    const stripe = makeStripe({
-      list: vi.fn().mockResolvedValue({
-        data: [newSub, makeSub('sub_existing', 'active')],
-      }),
-    });
-
-    const result = await dedupOnSubscriptionCreated({
-      subscription: newSub,
-      customerId: 'cus_test',
-      orgId: null,
-      stripe,
-      logger,
-      notifySystemError,
-    });
-
-    expect(result.duplicate).toBe(true);
-    expect(notifySystemError.mock.calls[0][0].errorMessage).toContain('org unknown');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the dedup helper's "always cancel newer" rule with **"cancel the unpaid one when exactly one is unpaid."** Closes the cancel-newer sub-item of #3245.

### Why

The cancel-newer rule worked for the Triton case **by luck** — both the legit-paid sub and the wrong-tier-unpaid sub also happened to be old vs. new. But the rule fails when the bigger purchase lands second:

- Existing \$250 Pro (paid first, older) + new \$50K Leader (paid by card, newer) → cancel-newer wrongly cancels the Leader.

The cancel-unpaid rule handles all four cases correctly:

| Case | Action |
|---|---|
| One paid + one unpaid | Cancel the unpaid one |
| Two paid (legit upgrade race or double-payment) | `manual_review` — alert ops, don't auto-cancel |
| Two unpaid (concurrent intake flows in flight) | `manual_review` — alert ops, don't auto-cancel |
| Only one live sub | `no_duplicate` (existing fast path) |

### Implementation

**Paid detection.** Helper now expands `data.latest_invoice` on the `subscriptions.list` call and checks `latest_invoice.status === 'paid'`. `null` / `'open'` / `'draft'` / unexpanded-string-id all count as unpaid (defensive — better to err toward canceling the one we have no payment signal for).

**Discriminated-union outcome.** Helper return type changed from `{ duplicate: boolean }` to a `kind` union:

```ts
type DedupOutcome =
  | { kind: 'no_duplicate' }
  | { kind: 'canceled_new'; existingLiveSubIds: string[] }
  | { kind: 'canceled_existing'; canceledSubId: string; survivingNewSubId: string }
  | { kind: 'manual_review'; allLiveSubIds: string[]; reason: string };
```

**Webhook handler wiring** (`http.ts`) updated with a switch:

- `canceled_new` → `suppressOrgUpdate = true` (existing sub stays tracked)
- `canceled_existing` → let UPDATE run (new sub becomes tracked) but skip `handleSubscriptionCreated` — this is a tier swap, not a fresh activation, so no welcome email
- `manual_review` → `suppressOrgUpdate = true` (don't change tracking; ops resolves)
- `no_duplicate` → unchanged

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run --dir server/tests/unit/` — 2,373 tests pass (1 file skipped, 34 skipped — all pre-existing)
- [x] `npx vitest run tests/unit/dedup-on-subscription-created.test.ts` — 16 tests pass

New test cases:
- cancels existing sub when new=paid + existing=unpaid (the reviewer hypothetical)
- `latest_invoice = null` treated as unpaid
- `latest_invoice = open/draft` treated as unpaid  
- `latest_invoice` as unexpanded string id treated as unpaid
- both paid → `manual_review` (no auto-cancel)
- both unpaid → `manual_review` (no auto-cancel)
- 3 live subs with exactly one unpaid → cancels the unpaid

## Out of scope (still open under #3245)

- Customer apology email when dedup fires (templated; mentions refund only when one happened)
- Admin UI dedup history showing recent dedup events on the org page

🤖 Generated with [Claude Code](https://claude.com/claude-code)