### PR TITLE
feat(admin): subscription dedup history on org detail page (#3245 part 3)

### DIFF
--- a/.changeset/admin-dedup-history.md
+++ b/.changeset/admin-dedup-history.md
@@ -1,0 +1,4 @@
+---
+---
+
+Persists webhook-side dedup decisions to `registry_audit_log` (action: `subscription_dedup`) and adds a "Dedup Events" button + modal on the admin org detail page so admins can retroactively see which subscriptions the helper canceled, when, and why. Closes the admin-UI sub-item of #3245.

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -849,6 +849,7 @@
                 Sync from Stripe
               </button>
               <button class="btn btn-sm btn-secondary" onclick="openPaymentHistory()">Payment History</button>
+              <button class="btn btn-sm btn-secondary" onclick="openDedupHistory()">Dedup Events</button>
               <button class="btn btn-sm btn-danger" onclick="openDeleteWorkspaceModal()" style="margin-left: auto;">
                 Delete Workspace
               </button>
@@ -1398,6 +1399,19 @@
       </div>
       <div id="paymentHistoryBody" style="padding: var(--space-4);">
         <div class="empty-state">Loading payment history...</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Dedup Events Modal — webhook-side duplicate-subscription guard history -->
+  <div id="dedupHistoryModal" class="modal">
+    <div class="modal-content" style="max-width: 760px;">
+      <div class="modal-header">
+        <h2 id="dedupHistoryTitle">Subscription Dedup Events</h2>
+        <button class="modal-close" onclick="closeModal('dedupHistoryModal')">&times;</button>
+      </div>
+      <div id="dedupHistoryBody" style="padding: var(--space-4);">
+        <div class="empty-state">Loading dedup events...</div>
       </div>
     </div>
   </div>
@@ -2874,6 +2888,101 @@
               </div>
               ${p.product_name ? `<div style="font-size: var(--text-sm); color: var(--color-text-secondary); margin-top: var(--space-1);">${escapeHtml(p.product_name)}</div>` : ''}
               ${p.stripe_invoice_id ? `<div style="font-size: var(--text-xs); color: var(--color-text-muted);">Invoice: ${escapeHtml(p.stripe_invoice_id)}</div>` : ''}
+            </div>
+          `;
+        }).join('');
+      } catch (err) {
+        body.innerHTML = `<div class="empty-state" style="color: var(--color-error-600);">${escapeHtml(err.message)}</div>`;
+      }
+    }
+
+    async function openDedupHistory() {
+      const modal = document.getElementById('dedupHistoryModal');
+      const body = document.getElementById('dedupHistoryBody');
+      const title = document.getElementById('dedupHistoryTitle');
+      title.textContent = `Subscription Dedup Events - ${accountData?.name || 'Account'}`;
+      body.innerHTML = '<div class="empty-state">Loading dedup events...</div>';
+      modal.classList.add('show');
+
+      try {
+        const params = new URLSearchParams({
+          organization_id: accountId,
+          action: 'subscription_dedup',
+          limit: '50',
+        });
+        const response = await fetch(`/api/admin/audit-logs?${params}`);
+        if (!response.ok) throw new Error('Failed to load dedup events');
+        const result = await response.json();
+        const entries = result.entries || [];
+
+        if (entries.length === 0) {
+          body.innerHTML = `
+            <div class="empty-state">
+              <p>No subscription dedup events recorded for this org.</p>
+              <p style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-2);">
+                Events are written when the webhook helper auto-cancels a duplicate or escalates a duplicate to manual review.
+              </p>
+            </div>`;
+          return;
+        }
+
+        const kindLabels = {
+          canceled_new: 'Canceled new (duplicate intake)',
+          canceled_existing: 'Canceled existing (swap to new)',
+          manual_review: 'Manual review (could not auto-decide)',
+        };
+        const kindColors = {
+          canceled_new: 'var(--color-warning-300)',
+          canceled_existing: 'var(--color-success-500)',
+          manual_review: 'var(--color-error-300)',
+        };
+
+        body.innerHTML = entries.map((e) => {
+          const d = e.details || {};
+          const kind = d.kind || 'unknown';
+          const label = kindLabels[kind] || kind;
+          const color = kindColors[kind] || 'var(--color-gray-300)';
+          const date = new Date(e.created_at).toLocaleString();
+          const facts = d.canceled_facts || {};
+          const amountStr = typeof facts.amountCents === 'number'
+            ? `$${(facts.amountCents / 100).toFixed(2)}`
+            : '—';
+          const cancelOk = facts.cancelSucceeded === false
+            ? '<span style="color: var(--color-error-600); font-weight: 600;">⚠ Stripe cancel FAILED — manual cleanup needed</span>'
+            : '';
+
+          let detailRows = '';
+          if (kind === 'canceled_new') {
+            detailRows = `
+              <div>Canceled new sub: <code>${escapeHtml(d.new_sub_id || '')}</code> (${amountStr}, ${escapeHtml(facts.lookupKey || 'no lookup_key')})</div>
+              <div>Surviving existing sub${(d.existing_live_sub_ids || []).length > 1 ? 's' : ''}: ${(d.existing_live_sub_ids || []).map((id) => `<code>${escapeHtml(id)}</code>`).join(', ') || '—'}</div>
+              ${d.surviving_tier_label ? `<div>Surviving tier: <strong>${escapeHtml(d.surviving_tier_label)}</strong></div>` : ''}
+            `;
+          } else if (kind === 'canceled_existing') {
+            detailRows = `
+              <div>Canceled existing sub: <code>${escapeHtml(d.canceled_sub_id || '')}</code> (${amountStr}, ${escapeHtml(facts.lookupKey || 'no lookup_key')})</div>
+              <div>Surviving new sub: <code>${escapeHtml(d.surviving_new_sub_id || '')}</code></div>
+              ${d.surviving_tier_label ? `<div>Surviving tier: <strong>${escapeHtml(d.surviving_tier_label)}</strong></div>` : ''}
+            `;
+          } else if (kind === 'manual_review') {
+            detailRows = `
+              <div>New sub: <code>${escapeHtml(d.new_sub_id || '')}</code></div>
+              <div>All live sub IDs: ${(d.all_live_sub_ids || []).map((id) => `<code>${escapeHtml(id)}</code>`).join(', ') || '—'}</div>
+              <div style="color: var(--color-text-secondary); font-style: italic;">Reason: ${escapeHtml(d.reason || '')}</div>
+            `;
+          }
+
+          return `
+            <div style="padding: var(--space-3); margin-bottom: var(--space-2); border-left: 3px solid ${color}; background: var(--color-gray-50); border-radius: var(--radius-sm);">
+              <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: var(--space-2);">
+                <div style="font-weight: 600;">${escapeHtml(label)}</div>
+                <div style="font-size: var(--text-xs); color: var(--color-text-secondary);">${escapeHtml(date)}</div>
+              </div>
+              <div style="font-size: var(--text-sm);">${detailRows}</div>
+              ${cancelOk ? `<div style="margin-top: var(--space-2); font-size: var(--text-sm);">${cancelOk}</div>` : ''}
+              <div style="margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-text-muted);">
+                Customer: <code>${escapeHtml(d.customer_id || '')}</code>
+              </div>
             </div>
           `;
         }).join('');

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -214,12 +214,6 @@ const workosUserCache = new Map<string, CacheEntry<{ displayName: string }>>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Fire-and-forget customer notification when the webhook dedup helper
- * canceled a duplicate subscription on this org. We always send to the
- * full set of org admins (typically a single founder/owner). All failures
- * are logged but never thrown — the dedup itself is the primary action.
- */
-/**
  * Shape the dedup helper outcome into a serializable JSON object for the
  * registry_audit_log details field. The admin UI reads this back to render
  * the dedup history panel.
@@ -263,6 +257,12 @@ function dedupAuditDetails(
   }
 }
 
+/**
+ * Fire-and-forget customer notification when the webhook dedup helper
+ * canceled a duplicate subscription on this org. We always send to the
+ * full set of org admins (typically a single founder/owner). All failures
+ * are logged but never thrown — the dedup itself is the primary action.
+ */
 function fireDedupNotice(args: {
   org: { workos_organization_id: string; name: string | null };
   workos: WorkOS;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -219,6 +219,50 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * full set of org admins (typically a single founder/owner). All failures
  * are logged but never thrown — the dedup itself is the primary action.
  */
+/**
+ * Shape the dedup helper outcome into a serializable JSON object for the
+ * registry_audit_log details field. The admin UI reads this back to render
+ * the dedup history panel.
+ */
+function dedupAuditDetails(
+  outcome: Awaited<ReturnType<typeof dedupOnSubscriptionCreated>>,
+  newSub: Stripe.Subscription,
+  customerId: string,
+): Record<string, unknown> {
+  const base = {
+    kind: outcome.kind,
+    customer_id: customerId,
+    new_sub_id: newSub.id,
+  };
+  switch (outcome.kind) {
+    case 'canceled_new':
+      return {
+        ...base,
+        existing_live_sub_ids: outcome.existingLiveSubIds,
+        canceled_facts: outcome.canceledFacts,
+        surviving_tier_label: outcome.survivingTierLabel,
+      };
+    case 'canceled_existing':
+      return {
+        ...base,
+        canceled_sub_id: outcome.canceledSubId,
+        surviving_new_sub_id: outcome.survivingNewSubId,
+        canceled_facts: outcome.canceledFacts,
+        surviving_tier_label: outcome.survivingTierLabel,
+      };
+    case 'manual_review':
+      return {
+        ...base,
+        all_live_sub_ids: outcome.allLiveSubIds,
+        reason: outcome.reason,
+      };
+    default:
+      // Caller already filters to the three above; this is a defensive
+      // fallthrough so a future outcome variant doesn't write nothing.
+      return base;
+  }
+}
+
 function fireDedupNotice(args: {
   org: { workos_organization_id: string; name: string | null };
   workos: WorkOS;
@@ -3599,6 +3643,35 @@ export class HTTPServer {
                     });
                   }
                   break;
+              }
+
+              // Persist the dedup decision to the audit log so admins can
+              // retroactively see what happened on this org. We only record
+              // the cases where the helper actually decided something; the
+              // common no_duplicate / retry_skip paths are uninteresting and
+              // would drown the log. Failure here is logged but never
+              // throws — the dedup itself is the primary action.
+              if (
+                org &&
+                (dedup.kind === 'canceled_new' ||
+                  dedup.kind === 'canceled_existing' ||
+                  dedup.kind === 'manual_review')
+              ) {
+                try {
+                  await orgDb.recordAuditLog({
+                    workos_organization_id: org.workos_organization_id,
+                    workos_user_id: SYSTEM_USER_ID,
+                    action: 'subscription_dedup',
+                    resource_type: 'subscription',
+                    resource_id: subscription.id,
+                    details: dedupAuditDetails(dedup, subscription, customerId),
+                  });
+                } catch (auditErr) {
+                  logger.error(
+                    { err: auditErr, orgId: org.workos_organization_id, dedupKind: dedup.kind },
+                    'Failed to persist dedup audit log entry',
+                  );
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

Closes the admin-UI sub-item of #3245. Two parts:

1. **Persist dedup decisions** to `registry_audit_log` (action: `subscription_dedup`) so we have a queryable record beyond the ops Slack alert.
2. **Add a "Dedup Events" button + modal** on the admin org detail page so operators can retroactively see what the helper did on a given org.

### What gets recorded

Only the consequential outcomes (\`canceled_new\`, \`canceled_existing\`, \`manual_review\`). The two boring outcomes (\`no_duplicate\`, \`retry_skip\`) fire on every normal sub creation and would drown the log.

Audit row details JSON captures:

| Field | All | canceled_new | canceled_existing | manual_review |
|---|---|---|---|---|
| `kind`, `customer_id`, `new_sub_id` | ✓ | | | |
| `existing_live_sub_ids[]` | | ✓ | | |
| `canceled_sub_id`, `surviving_new_sub_id` | | | ✓ | |
| `canceled_facts` (cancelSucceeded, amountCents, lookupKey) | | ✓ | ✓ | |
| `surviving_tier_label` | | ✓ | ✓ | |
| `all_live_sub_ids[]`, `reason` | | | | ✓ |

### UI

New button in the billing section next to "Payment History." Modal hits the existing `/api/admin/audit-logs?organization_id=X&action=subscription_dedup` route — no new API surface needed. Each event renders as a color-coded card (warning/success/error) with sub IDs as `<code>`, surviving tier label, and an explicit "⚠ Stripe cancel FAILED" warning when the Stripe API rejected the cancel.

### Failure semantics

Audit-write failure is logged but never throws. The dedup itself remains the primary action, matching the same defensive pattern as the customer apology email in #3252.

## Out of scope

- No backfill of historical dedup events — the empty-history audit script (#3245-related) confirmed zero auto-cancels happened in the brief cancel-newer window before #3250 deployed, so there's nothing to backfill anyway.
- No tests for the new HTML/JS (repo doesn't unit-test the admin pages).
- No test for `dedupAuditDetails` shape — pure shaping function in http.ts; would need a giant import surface for low value. Trust review + the runtime contract.

## Test plan

- [x] `npm run typecheck` clean

Manual verification (after deploy):
- Trigger a duplicate intake on a test org → see a row appear in the dedup-events modal showing the canceled sub ID, surviving sub ID, surviving tier label.
- `manual_review` case (two paid concurrent subs) → modal shows the reason and all sub IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)