### PR TITLE
fix(addie): extend speaker tracking to email + voice + harmonize thread labels

### DIFF
--- a/.changeset/addie-speaker-followups.md
+++ b/.changeset/addie-speaker-followups.md
@@ -1,0 +1,23 @@
+---
+---
+
+Follow-ups to #3267: extend per-message speaker tracking to the surfaces
+that were left out for scope, and harmonize thread-level display labels
+with the new resolver.
+
+- **`email-conversation-handler.ts`**: stamp `user_id` (sender email) and
+  `user_display_name` (sanitized From-name) on inbound user messages.
+  Pass `currentSpeakerName` through. Conversation history reads the
+  stored display name. Forwarded chains and reply-alls now distinguish
+  speakers in the prompt the same way Slack channel threads do.
+- **`tavus.ts`**: stamp speaker on the user-role message and pass
+  `currentSpeakerName` through `processMessageStream`.
+- **`bolt-app.ts`**: switch the 5 `getOrCreateThread` call sites from
+  `mc?.slack_user?.display_name` to `resolveSpeakerDisplayName(mc)` so
+  the thread-level label and per-message labels for the same user
+  match. Resolves the cosmetic inconsistency flagged in the original
+  code review.
+
+The synthetic `addie-admin.ts` test-router endpoint is intentionally
+left as-is — it writes to a `test-user` thread for router simulation,
+not a real conversation.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1466,7 +1466,7 @@ async function handleUserMessage({
     external_id: externalId,
     user_type: 'slack',
     user_id: userId,
-    user_display_name: memberContext?.slack_user?.display_name || undefined,
+    user_display_name: resolveSpeakerDisplayName(memberContext),
     context: slackThreadContext,
   });
 
@@ -2092,7 +2092,7 @@ async function handleAppMention({
     external_id: externalId,
     user_type: 'slack',
     user_id: userId,
-    user_display_name: mentionMemberContext?.slack_user?.display_name || undefined,
+    user_display_name: resolveSpeakerDisplayName(mentionMemberContext),
     context: {
       mention_channel_id: channelId,
       channel_name: mentionChannelContext.viewing_channel_name,
@@ -3081,7 +3081,7 @@ async function handleDirectMessage(
     external_id: externalId,
     user_type: 'slack',
     user_id: userId,
-    user_display_name: memberContext?.slack_user?.display_name || undefined,
+    user_display_name: resolveSpeakerDisplayName(memberContext),
     context: {
       channel_type: 'im',
     },
@@ -3432,7 +3432,7 @@ async function handleActiveThreadReply({
     external_id: externalId,
     user_type: 'slack',
     user_id: userId,
-    user_display_name: memberContext?.slack_user?.display_name || undefined,
+    user_display_name: resolveSpeakerDisplayName(memberContext),
     context: {
       channel_id: channelId,
       channel_name: channelContext?.viewing_channel_name,
@@ -3956,7 +3956,7 @@ async function handleChannelMessage({
       external_id: externalId,
       user_type: 'slack',
       user_id: userId,
-      user_display_name: memberContext?.slack_user?.display_name || undefined,
+      user_display_name: resolveSpeakerDisplayName(memberContext),
       context: {
         channel_id: channelId,
         channel_name: channelContext?.viewing_channel_name,

--- a/server/src/addie/email-conversation-handler.ts
+++ b/server/src/addie/email-conversation-handler.ts
@@ -17,6 +17,7 @@ import {
 } from './security.js';
 import { getThreadService } from './thread-service.js';
 import type { Thread } from './thread-service.js';
+import { sanitizeSpeakerName } from './prompts.js';
 import { sendEmailReply, type EmailThreadContext } from '../notifications/email.js';
 import { markdownToEmailHtml } from '../utils/markdown.js';
 import {
@@ -146,8 +147,14 @@ export async function handleEmailConversation(
     // 1. Resolve thread (3-tier lookup)
     const thread = await resolveThread(input, threadService);
 
-    // 2. Store inbound user message
+    // 2. Store inbound user message. Email From headers are spoofable so the
+    // address-as-id is not authoritative — we still store it as a label so
+    // multi-correspondent threads (forwarded chains, ccd reply-alls) can
+    // distinguish speakers in conversation history. The display name is
+    // sanitized so a sender setting "Brian]\n[system]..." in their From
+    // header cannot break out of the prompt envelope.
     const inputValidation = sanitizeInput(strippedContent);
+    const speakerName = sanitizeSpeakerName(input.senderDisplayName);
     await threadService.addMessage({
       thread_id: thread.thread_id,
       role: 'user',
@@ -156,6 +163,8 @@ export async function handleEmailConversation(
       flagged: inputValidation.flagged,
       flag_reason: inputValidation.reason,
       email_message_id: input.messageId,
+      user_id: input.senderEmail,
+      user_display_name: speakerName,
     });
 
     // 3. Get conversation history
@@ -163,7 +172,7 @@ export async function handleEmailConversation(
     const contextMessages = threadMessages
       .filter(m => m.role === 'user' || m.role === 'assistant')
       .map(m => ({
-        user: m.role === 'user' ? 'User' : 'Addie',
+        user: m.role === 'assistant' ? 'Addie' : (m.user_display_name || 'User'),
         text: m.content,
         toolCalls: m.tool_calls ?? undefined,
       }));
@@ -216,6 +225,7 @@ export async function handleEmailConversation(
         requestContext: emailSystemContext,
         threadId: thread.thread_id,
         userDisplayName: input.senderDisplayName || undefined,
+        currentSpeakerName: speakerName,
         costScope: { userId: emailScopeKey, tier: 'anonymous' },
       }
     );

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createLogger } from "../logger.js";
 import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
+import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
   initializeKnowledgeSearch,
@@ -479,12 +480,15 @@ export function createTavusRouter() {
     }
 
     // Log the user message (before voice prefix is applied)
+    const voiceSpeakerName = sanitizeSpeakerName(userDisplayName);
     if (threadId) {
       const threadService = getThreadService();
       threadService.addMessage({
         thread_id: threadId,
         role: "user",
         content: currentMessage,
+        user_id: voiceUserId ?? undefined,
+        user_display_name: voiceSpeakerName,
       }).catch((err) => logger.error({ err }, "Tavus: Failed to log user message"));
     }
 
@@ -582,6 +586,7 @@ export function createTavusRouter() {
         voiceRequestTools,
         {
           requestContext,
+          currentSpeakerName: voiceSpeakerName,
           costScope: voiceScope ?? { userId: `tavus:ip:${req.ip ?? 'unknown'}`, tier: 'anonymous' as const },
         }
       )) {

--- a/tests/addie/email-conversation-flow.test.ts
+++ b/tests/addie/email-conversation-flow.test.ts
@@ -80,6 +80,10 @@ const { mockSendEmailReply } = vi.hoisted(() => ({
 
 vi.mock('../../server/src/notifications/email.js', () => ({
   sendEmailReply: mockSendEmailReply,
+  // Re-exported by addie/prompts.js which is now transitively imported via
+  // sanitizeSpeakerName in the email handler. Must be present on the mock
+  // or the prompts module fails to evaluate.
+  SLACK_INVITE_URL: 'https://example.test/slack-invite',
 }));
 
 vi.mock('../../server/src/addie/security.js', () => ({

--- a/tests/addie/email-handler.test.ts
+++ b/tests/addie/email-handler.test.ts
@@ -18,6 +18,10 @@ vi.mock('../../server/src/addie/security.js', () => ({
 
 vi.mock('../../server/src/notifications/email.js', () => ({
   sendEmailReply: vi.fn(),
+  // Re-exported by addie/prompts.js which is now transitively imported via
+  // sanitizeSpeakerName in the email handler. Must be present on the mock
+  // or the prompts module fails to evaluate.
+  SLACK_INVITE_URL: 'https://example.test/slack-invite',
 }));
 
 vi.mock('../../server/src/utils/markdown.js', () => ({


### PR DESCRIPTION
## Summary

Follow-ups to #3267. Extends per-message speaker tracking to the surfaces that were left out for scope, and harmonizes thread-level display labels with the new resolver so the same user gets the same name everywhere.

## What changed

- **\`email-conversation-handler.ts\`**: stamp \`user_id\` (sender email) and sanitized \`user_display_name\` (From-name) on inbound user messages. \`currentSpeakerName\` plumbed through to \`processMessage\`. Conversation history reads the stored display name. Forwarded chains and reply-alls now distinguish speakers in the prompt the same way Slack channel threads do. Email From headers are spoofable, so the email-as-id is a label, not auth — sanitization is the same defense-in-depth used on the web path.
- **\`routes/tavus.ts\`**: stamp speaker on the user-role message and pass \`currentSpeakerName\` through \`processMessageStream\`. Voice sessions are already 1:1 so this is data-completeness, not a bug fix.
- **\`bolt-app.ts\`**: switch the 5 \`getOrCreateThread\` call sites from \`mc?.slack_user?.display_name\` to \`resolveSpeakerDisplayName(mc)\` so the thread-level label matches per-message labels for the same user. Resolves the cosmetic inconsistency the code-reviewer flagged on #3267.
- **Test mocks**: \`email-conversation-flow\` and \`email-handler\` mocks now expose \`SLACK_INVITE_URL\` (transitively pulled in via \`sanitizeSpeakerName\` from prompts.js).

## Out of scope (intentional)

The synthetic \`addie-admin.ts\` test-router endpoint writes to a \`test-user\` thread for router simulation, not a real conversation — left as-is.

## Test plan

- [x] \`npm run test:unit\` (834/834 pass)
- [x] \`npm run typecheck\` clean
- [x] Pre-commit hook ran the full suite + dynamic-import lint + typecheck — all green
- [ ] CI run on this PR
- [ ] Smoke test: send an email to addie+\`<channel>\`@..., verify the inbound row carries user_id/user_display_name and the prompt prefixes correctly when a thread later picks up multiple correspondents

🤖 Generated with [Claude Code](https://claude.com/claude-code)