### PR TITLE
feat(addie): adoption prompt rules — company listing + team WG coverage

### DIFF
--- a/.changeset/addie-adoption-prompt-rules.md
+++ b/.changeset/addie-adoption-prompt-rules.md
@@ -1,4 +1,9 @@
 ---
 ---
 
-Stage 1.5 of persona-driven Addie suggested prompts (#2299): add the two deferred adoption rules. Adds `adoption.has_company_listing` (derived from existing fetched profile, free) and `adoption.team_wg_coverage` (one DB query against `working_group_memberships`, reusing the WorkOS membership list already fetched) to MemberContext. Two new rules: "Set up your company listing" for non-personal owners without a public listing (priority 76), and "Get your team into working groups" for owners of 5+ teams with <30% WG coverage (priority 73). API key count rule is still deferred — needs a cheaper signal source than per-request WorkOS API calls.
+Stage 1.5 of persona-driven Addie suggested prompts (#2299): add the two deferred adoption rules. Adds `adoption.has_company_listing` (derived from existing fetched profile, free) and `adoption.team_wg_coverage` (one DB query against `working_group_memberships`, reusing the WorkOS membership list already fetched) to MemberContext. Two new rules:
+
+- **List my company in the directory** (priority 76): non-personal org with no public listing, fires for org owners and admins.
+- **Find working groups for my team** (priority 73): owner/admin of a 3+ team with less than half in any working group.
+
+API key count rule is still deferred — needs a cheaper signal source than per-request WorkOS API calls.

--- a/.changeset/addie-adoption-prompt-rules.md
+++ b/.changeset/addie-adoption-prompt-rules.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stage 1.5 of persona-driven Addie suggested prompts (#2299): add the two deferred adoption rules. Adds `adoption.has_company_listing` (derived from existing fetched profile, free) and `adoption.team_wg_coverage` (one DB query against `working_group_memberships`, reusing the WorkOS membership list already fetched) to MemberContext. Two new rules: "Set up your company listing" for non-personal owners without a public listing (priority 76), and "Get your team into working groups" for owners of 5+ teams with <30% WG coverage (priority 73). API key count rule is still deferred — needs a cheaper signal source than per-request WorkOS API calls.

--- a/server/scripts/prompt-scenarios.ts
+++ b/server/scripts/prompt-scenarios.ts
@@ -65,6 +65,14 @@ show('Owner of 5-person team, Builder tier, profile incomplete', base({
   org_membership: { role: 'owner', member_count: 5, joined_at: ago(120) },
   community_profile: { is_public: false, slug: null, completeness: 50, github_username: null },
 }));
+show('Owner of company without a public listing', base({
+  org_membership: { role: 'owner', member_count: 3, joined_at: ago(60) },
+  adoption: { has_company_listing: false, team_wg_coverage: 0.5 },
+}));
+show('Owner of 8-person team with low WG coverage', base({
+  org_membership: { role: 'owner', member_count: 8, joined_at: ago(180) },
+  adoption: { has_company_listing: true, team_wg_coverage: 0.1 },
+}));
 show('WG leader (Creative)', base({
   working_groups: [{ name: 'Creative', is_leader: true }],
 }));

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -11,6 +11,16 @@ function isMember(ctx: MemberContext | null): boolean {
   return !!ctx?.is_member;
 }
 
+/**
+ * True for users who can act on org-level setup (owner or admin in WorkOS).
+ * Day-to-day org operations at most companies are run by admins, not the
+ * original owner — gating only on 'owner' would miss them.
+ */
+function isOrgOperator(ctx: MemberContext | null): boolean {
+  const role = ctx?.org_membership?.role;
+  return role === 'owner' || role === 'admin';
+}
+
 function isLinkedNonMember(ctx: MemberContext | null): boolean {
   return isMapped(ctx) && !isMember(ctx);
 }
@@ -198,24 +208,26 @@ export const MEMBER_RULES: PromptRule[] = [
     priority: 76,
     when: ({ memberContext }) =>
       isMember(memberContext) &&
-      memberContext?.org_membership?.role === 'owner' &&
+      isOrgOperator(memberContext) &&
       memberContext?.organization?.is_personal === false &&
       memberContext?.adoption?.has_company_listing === false,
-    label: 'Set up your company listing',
-    prompt: "Help me set up my organization's public listing in the directory.",
+    label: 'List my company in the directory',
+    prompt: 'Help me add my company to the directory.',
   },
   {
     id: 'org.owner_team_wg_coverage_low',
     priority: 73,
     when: ({ memberContext }) => {
       if (!isMember(memberContext)) return false;
-      if (memberContext?.org_membership?.role !== 'owner') return false;
-      if ((memberContext?.org_membership?.member_count ?? 0) <= 5) return false;
+      if (!isOrgOperator(memberContext)) return false;
+      // Fire for any team of 3+ where less than half are in working groups.
+      // Below 3 people, coverage math is too noisy to act on.
+      if ((memberContext?.org_membership?.member_count ?? 0) < 3) return false;
       const coverage = memberContext?.adoption?.team_wg_coverage;
-      return coverage !== undefined && coverage < 0.3;
+      return (coverage ?? 1) < 0.5;
     },
-    label: 'Get your team into working groups',
-    prompt: 'Help me get my team active in working groups.',
+    label: 'Find working groups for my team',
+    prompt: 'Which working groups should my team join?',
   },
   {
     id: 'wg.find_groups',

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -194,6 +194,30 @@ export const MEMBER_RULES: PromptRule[] = [
     prompt: 'Help me invite my team to the organization.',
   },
   {
+    id: 'org.owner_set_company_listing',
+    priority: 76,
+    when: ({ memberContext }) =>
+      isMember(memberContext) &&
+      memberContext?.org_membership?.role === 'owner' &&
+      memberContext?.organization?.is_personal === false &&
+      memberContext?.adoption?.has_company_listing === false,
+    label: 'Set up your company listing',
+    prompt: "Help me set up my organization's public listing in the directory.",
+  },
+  {
+    id: 'org.owner_team_wg_coverage_low',
+    priority: 73,
+    when: ({ memberContext }) => {
+      if (!isMember(memberContext)) return false;
+      if (memberContext?.org_membership?.role !== 'owner') return false;
+      if ((memberContext?.org_membership?.member_count ?? 0) <= 5) return false;
+      const coverage = memberContext?.adoption?.team_wg_coverage;
+      return coverage !== undefined && coverage < 0.3;
+    },
+    label: 'Get your team into working groups',
+    prompt: 'Help me get my team active in working groups.',
+  },
+  {
     id: 'wg.find_groups',
     priority: 75,
     when: ({ memberContext }) =>

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -103,6 +103,23 @@ async function getPendingContentForUser(
 }
 
 /**
+ * Compute the fraction of org members who belong to ≥1 working group.
+ * Returns 0 when there are no org members in the input list.
+ */
+async function computeTeamWgCoverage(orgMemberUserIds: string[]): Promise<number> {
+  if (orgMemberUserIds.length === 0) return 0;
+  const result = await query<{ count: string }>(
+    `SELECT COUNT(DISTINCT workos_user_id)::text as count
+       FROM working_group_memberships
+       WHERE workos_user_id = ANY($1::text[])
+         AND status = 'active'`,
+    [orgMemberUserIds]
+  );
+  const inWgs = parseInt(result.rows[0]?.count || '0', 10);
+  return inWgs / orgMemberUserIds.length;
+}
+
+/**
  * Fetch community profile data for a user.
  * Shared between getMemberContext (Slack) and getWebMemberContext (web chat).
  */
@@ -317,6 +334,14 @@ export interface MemberContext {
 
   /** Pending join requests for the organization (admins only) */
   pending_join_requests_count?: number;
+
+  /** Adoption signals for the organization (used by suggested-prompts rules) */
+  adoption?: {
+    /** True when the org has a public company listing in the directory. */
+    has_company_listing: boolean;
+    /** Fraction (0–1) of org members who belong to at least one working group. */
+    team_wg_coverage: number;
+  };
 }
 
 /**
@@ -413,11 +438,13 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
 
     // Step 4b: Get org member count from WorkOS
     let memberCount = 0;
+    let orgMemberUserIds: string[] = [];
     try {
       const orgMemberships = await getWorkos().userManagement.listOrganizationMemberships({
         organizationId: organizationId,
       });
       memberCount = orgMemberships.data?.length || 0;
+      orgMemberUserIds = (orgMemberships.data ?? []).map(m => m.userId).filter(Boolean);
     } catch (error) {
       logger.warn({ error, organizationId }, 'Addie: Failed to get org member count');
     }
@@ -517,6 +544,17 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
         headquarters: profile.headquarters,
         listing_type: org?.is_personal ? 'personal' : 'company',
       };
+    }
+
+    // Adoption signals for the suggested-prompts rules.
+    try {
+      const teamWgCoverage = await computeTeamWgCoverage(orgMemberUserIds);
+      context.adoption = {
+        has_company_listing: !!(org && !org.is_personal && profile?.is_public),
+        team_wg_coverage: teamWgCoverage,
+      };
+    } catch (error) {
+      logger.warn({ error, organizationId }, 'Addie: Failed to compute adoption signals');
     }
 
     // Process subscription info
@@ -671,6 +709,7 @@ async function resolveContextFromLocalDb(
   context: MemberContext,
   organizationId: string,
   workosUserId: string,
+  orgMemberUserIds: string[] = [],
 ): Promise<MemberContext> {
   const org = await orgDb.getOrganization(organizationId);
   if (org) {
@@ -703,6 +742,16 @@ async function resolveContextFromLocalDb(
       headquarters: profile.headquarters,
       listing_type: org?.is_personal ? 'personal' : 'company',
     };
+  }
+
+  try {
+    const teamWgCoverage = await computeTeamWgCoverage(orgMemberUserIds);
+    context.adoption = {
+      has_company_listing: !!(org && !org.is_personal && profile?.is_public),
+      team_wg_coverage: teamWgCoverage,
+    };
+  } catch (error) {
+    logger.warn({ error, organizationId }, 'Addie Web: Failed to compute adoption signals');
   }
 
   try {
@@ -975,11 +1024,13 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
 
     // Step 4: Get org member count from WorkOS
     let memberCount = 0;
+    let webOrgMemberUserIds: string[] = [];
     try {
       const orgMemberships = await getWorkos().userManagement.listOrganizationMemberships({
         organizationId: organizationId,
       });
       memberCount = orgMemberships.data?.length || 0;
+      webOrgMemberUserIds = (orgMemberships.data ?? []).map(m => m.userId).filter(Boolean);
     } catch (error) {
       logger.warn({ error, organizationId }, 'Addie Web: Failed to get org member count');
     }
@@ -990,7 +1041,7 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
       joined_at: userJoinedAt,
     };
 
-    return await resolveContextFromLocalDb(context, organizationId, workosUserId);
+    return await resolveContextFromLocalDb(context, organizationId, workosUserId, webOrgMemberUserIds);
   } catch (error) {
     logger.error({ error, workosUserId }, 'Addie Web: Error getting member context');
     return context;

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -699,11 +699,12 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
 }
 
 /**
- * Look up member context from a WorkOS user ID (for web chat)
- *
-/**
  * Resolve organization, profile, subscription, engagement, and other context
  * from the local database. Used by both dev-mode and production paths.
+ *
+ * `orgMemberUserIds` is used to compute team_wg_coverage. The dev-mode caller
+ * passes [] (no WorkOS lookup), so coverage is 0 in dev — fine for testing
+ * since the team-WG rule also requires member_count >= 3.
  */
 async function resolveContextFromLocalDb(
   context: MemberContext,

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -250,23 +250,39 @@ describe('buildSuggestedPrompts', () => {
       expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Invite your team');
     });
 
-    it('shows Set up your company listing for non-personal owners without a public listing', () => {
+    it('shows List my company in the directory for non-personal owners without a public listing', () => {
       const ctx = makeMember({
         org_membership: { role: 'owner', member_count: 3, joined_at: DAYS_AGO(60) },
-        adoption: { has_company_listing: false, team_wg_coverage: 0.5 },
+        adoption: { has_company_listing: false, team_wg_coverage: 0.6 },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Set up your company listing');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('List my company in the directory');
     });
 
-    it('does not show Set up your company listing when listing already public', () => {
+    it('also shows the listing prompt for org admins (not just owners)', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'admin', member_count: 3, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: false, team_wg_coverage: 0.6 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('List my company in the directory');
+    });
+
+    it('does not show the listing prompt for plain members', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'member', member_count: 3, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: false, team_wg_coverage: 0.6 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('List my company in the directory');
+    });
+
+    it('does not show listing prompt when listing already public', () => {
       const ctx = makeMember({
         org_membership: { role: 'owner', member_count: 3, joined_at: DAYS_AGO(60) },
-        adoption: { has_company_listing: true, team_wg_coverage: 0.5 },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.6 },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Set up your company listing');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('List my company in the directory');
     });
 
-    it('does not show Set up your company listing for personal orgs', () => {
+    it('does not show listing prompt for personal orgs', () => {
       const ctx = makeMember({
         organization: {
           workos_organization_id: 'org_123',
@@ -278,31 +294,31 @@ describe('buildSuggestedPrompts', () => {
         org_membership: { role: 'owner', member_count: 1, joined_at: DAYS_AGO(60) },
         adoption: { has_company_listing: false, team_wg_coverage: 0 },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Set up your company listing');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('List my company in the directory');
     });
 
-    it('shows Get your team into working groups when coverage is low and team > 5', () => {
-      const ctx = makeMember({
-        org_membership: { role: 'owner', member_count: 8, joined_at: DAYS_AGO(60) },
-        adoption: { has_company_listing: true, team_wg_coverage: 0.1 },
-      });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Get your team into working groups');
-    });
-
-    it('does not show team WG prompt when coverage is healthy', () => {
-      const ctx = makeMember({
-        org_membership: { role: 'owner', member_count: 8, joined_at: DAYS_AGO(60) },
-        adoption: { has_company_listing: true, team_wg_coverage: 0.5 },
-      });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Get your team into working groups');
-    });
-
-    it('does not show team WG prompt for small teams (≤5)', () => {
+    it('shows Find working groups for my team when coverage is below 50% and team >= 3', () => {
       const ctx = makeMember({
         org_membership: { role: 'owner', member_count: 4, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.2 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Find working groups for my team');
+    });
+
+    it('does not show team WG prompt when coverage is healthy (≥ 50%)', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 8, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.6 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Find working groups for my team');
+    });
+
+    it('does not show team WG prompt for tiny teams (< 3)', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 2, joined_at: DAYS_AGO(60) },
         adoption: { has_company_listing: true, team_wg_coverage: 0 },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Get your team into working groups');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Find working groups for my team');
     });
   });
 

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -249,6 +249,61 @@ describe('buildSuggestedPrompts', () => {
       });
       expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Invite your team');
     });
+
+    it('shows Set up your company listing for non-personal owners without a public listing', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 3, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: false, team_wg_coverage: 0.5 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Set up your company listing');
+    });
+
+    it('does not show Set up your company listing when listing already public', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 3, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.5 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Set up your company listing');
+    });
+
+    it('does not show Set up your company listing for personal orgs', () => {
+      const ctx = makeMember({
+        organization: {
+          workos_organization_id: 'org_123',
+          name: 'Acme',
+          subscription_status: 'active',
+          is_personal: true,
+          membership_tier: 'individual_professional',
+        },
+        org_membership: { role: 'owner', member_count: 1, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: false, team_wg_coverage: 0 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Set up your company listing');
+    });
+
+    it('shows Get your team into working groups when coverage is low and team > 5', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 8, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.1 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Get your team into working groups');
+    });
+
+    it('does not show team WG prompt when coverage is healthy', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 8, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.5 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Get your team into working groups');
+    });
+
+    it('does not show team WG prompt for small teams (≤5)', () => {
+      const ctx = makeMember({
+        org_membership: { role: 'owner', member_count: 4, joined_at: DAYS_AGO(60) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0 },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Get your team into working groups');
+    });
   });
 
   describe('profile and working groups', () => {


### PR DESCRIPTION
## Summary
- Stage 1.5 of #2299 — ships the two deferred adoption rules from the original Stage 1 PR (#3272).
- Adds two new signals to \`MemberContext.adoption\`: \`has_company_listing\` (free, derived from already-fetched profile) and \`team_wg_coverage\` (one DB query reusing the WorkOS member list we already fetch).
- Adds two new prompt rules: \"Set up your company listing\" (priority 76) for non-personal owners without a public listing, and \"Get your team into working groups\" (priority 73) for owners of a 5+ team with <30% WG coverage.

## What's deferred
- API key count rule — still requires a cheaper signal source than per-request WorkOS HTTP calls. Not blocking, will land in a Stage 2 follow-up.

## Test plan
- [x] 42 unit tests pass (was 36 in Stage 1; adds 6 covering the new rules and edge cases — owner-without-listing, listing-already-public, personal-org-skip, low-coverage-fires, healthy-coverage-skips, small-team-skip)
- [x] Pre-commit hooks pass (unit suite + typecheck)
- [x] Manual scenario walkthrough — added 2 new scenarios in \`server/scripts/prompt-scenarios.ts\` confirming both rules fire correctly
- [ ] Verify rules surface in staging once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)