### PR TITLE
fix(server): raise storyboard eval/step rate limits for member dev iteration

### DIFF
--- a/.changeset/relax-storyboard-eval-rate-limits.md
+++ b/.changeset/relax-storyboard-eval-rate-limits.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(server): raise storyboard eval/step rate limits for member dev iteration (closes #3277)
+
+Bumps `storyboardEvalRateLimiter` from 5→10/hr and `storyboardStepRateLimiter` from 30→60/hr so
+members can complete a typical 4–5 cycle debug session without hitting the wall. Admin bypass
+added in #2729 is unchanged. Also fixes both handlers to use the real `Retry-After` window
+position instead of a hardcoded full-hour fallback — matching the pattern already used by
+`agentReadRateLimiter` in the same file.
+
+Non-protocol server change; no schema or task-definition impact.

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -194,12 +194,12 @@ export const notificationRateLimiter = rateLimit({
 
 /**
  * Rate limiter for storyboard evaluation endpoints.
- * Limits: 5 evaluations per hour per user (each eval makes real HTTP calls to external agents).
+ * Limits: 10 evaluations per hour per user (each eval makes real HTTP calls to external agents).
  * AAO platform admins bypass this limit so they can debug and curate without hitting it.
  */
 export const storyboardEvalRateLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 5,
+  max: 10,
   skipFailedRequests: true,
   skip: skipForAdmins,
   standardHeaders: true,
@@ -214,21 +214,22 @@ export const storyboardEvalRateLimiter = rateLimit({
       path: req.path,
     }, 'Rate limit exceeded for storyboard evaluation');
 
+    const retryAfter = parseRetryAfterSeconds(res.getHeader('Retry-After'));
     res.status(429).json({
       error: 'Too many requests',
-      message: 'Storyboard evaluation limit exceeded (5 per hour). Please try again later.',
-      retryAfter: Math.ceil(60 * 60),
+      message: 'Storyboard evaluation limit exceeded (10 per hour). Please try again later.',
+      ...(retryAfter !== undefined ? { retryAfter } : {}),
     });
   },
 });
 
 /**
  * Rate limiter for step-by-step storyboard execution.
- * More generous than full evaluation (30/hour vs 5/hour) since each step is one MCP call.
+ * More generous than full evaluation (60/hour vs 10/hour) since each step is one MCP call.
  */
 export const storyboardStepRateLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 30,
+  max: 60,
   skipFailedRequests: true,
   skip: skipForAdmins,
   standardHeaders: true,
@@ -243,10 +244,11 @@ export const storyboardStepRateLimiter = rateLimit({
       path: req.path,
     }, 'Rate limit exceeded for storyboard step execution');
 
+    const retryAfter = parseRetryAfterSeconds(res.getHeader('Retry-After'));
     res.status(429).json({
       error: 'Too many requests',
-      message: 'Step execution limit exceeded (30 per hour). Please try again later.',
-      retryAfter: Math.ceil(60 * 60),
+      message: 'Step execution limit exceeded (60 per hour). Please try again later.',
+      ...(retryAfter !== undefined ? { retryAfter } : {}),
     });
   },
 });


### PR DESCRIPTION
Closes #3277

Storyboard eval rate limits were too tight for member developer iteration: 5 evals/hr = roughly 2 debug cycles before hitting the wall on a single agent. This PR implements Option B from the issue (the author's recommendation): raise the caps to match a realistic iteration cadence.

**Changes:**
- `storyboardEvalRateLimiter`: max 5 → 10/hr
- `storyboardStepRateLimiter`: max 30 → 60/hr
- Both 429 handlers: fix `retryAfter` to use the real window-position value from the `Retry-After` header via `parseRetryAfterSeconds` (was hardcoded `Math.ceil(60 * 60)` = always 3600s regardless of elapsed time). Pattern matches `agentReadRateLimiter` in the same file.
- Error message strings updated to reflect new limits

**Non-breaking justification:** server-side config change only; no protocol schema, task definition, or API contract changes. Admin bypass (`skipForAdmins`) and `skipFailedRequests: true` behavior unchanged.

**Option A (per-agent keying) deferred:** the issue author recommends "only do A if non-admin reports keep coming." Option A also has an open design question (multiply-vs-fixed ceiling) and the correct key source is `req.params.encodedUrl` not `req.body.agent_url` — needs owner input before implementation.

**Pre-PR review:**
- code-reviewer: approved — one blocker (missing changeset) fixed; retryAfter pattern is correct; no new security surface
- internal-tools-strategist: approved — `standardHeaders: true` sets the `Retry-After` header before the handler fires so `res.getHeader('Retry-After')` is always available; window-transition behavior (users at 5/5 before deploy get 5 more in-place) is intentional

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01SPJGvJCxD961HSCvtwyj3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPJGvJCxD961HSCvtwyj3D)_