### PR TITLE
feat(admin): cross-identifier thread search

### DIFF
--- a/.changeset/admin-thread-search-cross-identifier.md
+++ b/.changeset/admin-thread-search-cross-identifier.md
@@ -1,0 +1,20 @@
+---
+---
+
+Admin thread search now matches across every natural identifier — full
+name, Slack handle, Slack real name, WorkOS first/last name, or any
+known email address. `listThreads({ user_search })` adds two LEFT JOINs
+(slack_user_mappings, users) only when the filter is set, then
+OR-matches the term against thread display name, raw user_id (which
+carries the email for email threads), Slack mapping fields, and WorkOS
+profile fields.
+
+Without this, harmonizing `addie_threads.user_display_name` to
+`Brian O'Kelley` (full WorkOS name) in #3271 orphaned admins who
+typed a Slack handle like `bokelley` into the search box. The
+underlying mapping was always there; the query just wasn't using it.
+
+Eight new integration tests in `tests/unit/thread-service.test.ts`
+cover Slack handle, Slack real name, Slack-side email, WorkOS first
+name, WorkOS email, email-thread sender lookup, harmonized display
+name across surfaces, and the negative case.

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -632,6 +632,13 @@ export class ThreadService {
     // Determine if we need to join with messages table for search/tool filtering
     const needsMessageJoin = !!(filters.search_text || filters.tool_name);
 
+    // user_search matches across all identifiers an admin might describe a
+    // person by — full name, Slack handle, real name, WorkOS first/last
+    // name, or any of the email addresses we know about. Without these
+    // joins, harmonizing thread.user_display_name to "Brian O'Kelley"
+    // would orphan admins searching by Slack handle "bokelley".
+    const needsUserSearchJoins = !!filters.user_search;
+
     if (filters.channel) {
       conditions.push(`s.channel = $${paramIndex++}`);
       params.push(filters.channel);
@@ -668,9 +675,25 @@ export class ThreadService {
       params.push(filters.since);
     }
 
-    // User display name search (ILIKE for partial matching)
+    // Cross-identifier user search: match the term against every name and
+    // email we have for the thread's owner — thread display name, raw
+    // user_id (which carries the email for email threads), Slack mapping
+    // fields (handle/real name/Slack email), and WorkOS profile fields
+    // (email/first/last). The `sm.*` and `u.*` aliases below are valid
+    // only because `needsUserSearchJoins` adds the matching LEFT JOINs
+    // when this filter is set — keep the two in lockstep.
     if (filters.user_search) {
-      conditions.push(`s.user_display_name ILIKE $${paramIndex++}`);
+      const idx = paramIndex++;
+      conditions.push(`(
+        s.user_display_name ILIKE $${idx} OR
+        s.user_id ILIKE $${idx} OR
+        sm.slack_display_name ILIKE $${idx} OR
+        sm.slack_real_name ILIKE $${idx} OR
+        sm.slack_email ILIKE $${idx} OR
+        u.email ILIKE $${idx} OR
+        u.first_name ILIKE $${idx} OR
+        u.last_name ILIKE $${idx}
+      )`);
       params.push(`%${filters.user_search}%`);
     }
 
@@ -692,11 +715,25 @@ export class ThreadService {
 
     params.push(limit, offset);
 
+    // User-search joins: slack_user_mappings keys off the Slack thread's
+    // user_id; users keys off the WorkOS id (either the thread's own
+    // user_id when user_type='workos', or the WorkOS id resolved through
+    // the Slack mapping). Both are LEFT JOINs so threads without a
+    // matching row simply contribute NULLs and fall out of the OR match.
+    const userSearchJoins = needsUserSearchJoins
+      ? `LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = s.user_id
+         LEFT JOIN users u ON u.workos_user_id = COALESCE(
+           sm.workos_user_id,
+           CASE WHEN s.user_type = 'workos' THEN s.user_id END
+         )`
+      : '';
+
     let sql: string;
     if (needsMessageJoin) {
       // Join with messages table for text/tool search, use DISTINCT to avoid duplicates
       sql = `SELECT DISTINCT ON (s.last_message_at, s.thread_id) s.*
              FROM addie_threads_summary s
+             ${userSearchJoins}
              JOIN addie_thread_messages m ON s.thread_id = m.thread_id
              ${whereClause}
              ORDER BY s.last_message_at DESC, s.thread_id
@@ -705,6 +742,7 @@ export class ThreadService {
       // Simple query without join
       sql = `SELECT s.*
              FROM addie_threads_summary s
+             ${userSearchJoins}
              ${whereClause}
              ORDER BY s.last_message_at DESC
              LIMIT $${paramIndex++} OFFSET $${paramIndex}`;

--- a/server/tests/unit/thread-service.test.ts
+++ b/server/tests/unit/thread-service.test.ts
@@ -385,6 +385,121 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Unit Tests', () => {
     });
   });
 
+  describe('listThreads cross-identifier user_search', () => {
+    // Admin thread search needs to find a person by any natural identifier:
+    // full name, Slack handle, real name, WorkOS first/last, or email.
+    // Without the OR-join, harmonizing thread.user_display_name to a full
+    // WorkOS name orphans admins who type a Slack handle into the box.
+    const SLACK_USER_ID = 'U_SEARCH_TEST_SLACK';
+    const WORKOS_USER_ID = 'user_search_test_workos';
+    const EMAIL_SENDER = 'searchtarget@example.test';
+
+    beforeEach(async () => {
+      await pool.query(
+        `INSERT INTO users (workos_user_id, email, first_name, last_name)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (workos_user_id) DO UPDATE SET
+           email = EXCLUDED.email,
+           first_name = EXCLUDED.first_name,
+           last_name = EXCLUDED.last_name`,
+        [WORKOS_USER_ID, 'someone.workos@example.test', 'Someone', 'Workostest'],
+      );
+      await pool.query(
+        `INSERT INTO slack_user_mappings (slack_user_id, slack_email, slack_display_name, slack_real_name, workos_user_id, mapping_status)
+         VALUES ($1, $2, $3, $4, $5, 'mapped')
+         ON CONFLICT (slack_user_id) DO UPDATE SET
+           slack_email = EXCLUDED.slack_email,
+           slack_display_name = EXCLUDED.slack_display_name,
+           slack_real_name = EXCLUDED.slack_real_name,
+           workos_user_id = EXCLUDED.workos_user_id`,
+        [SLACK_USER_ID, 'someone.slack@example.test', 'someslackhandle', 'Someone Slacktest', WORKOS_USER_ID],
+      );
+
+      // Slack thread — display name is the harmonized WorkOS name; Slack
+      // handle/real name only reachable via the slack_user_mappings join.
+      await threadService.getOrCreateThread({
+        channel: 'slack',
+        external_id: 'test-search-slack',
+        user_type: 'slack',
+        user_id: SLACK_USER_ID,
+        user_display_name: 'Someone Workostest',
+      });
+      // Web (WorkOS) thread — same person, different surface.
+      await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: 'test-search-web',
+        user_type: 'workos',
+        user_id: WORKOS_USER_ID,
+        user_display_name: 'Someone Workostest',
+      });
+      // Email thread — user_id IS the sender email; display_name is the From-name.
+      await threadService.getOrCreateThread({
+        channel: 'email',
+        external_id: 'test-search-email',
+        user_type: 'anonymous',
+        user_id: EMAIL_SENDER,
+        user_display_name: 'Email Sender',
+      });
+    });
+
+    afterEach(async () => {
+      await pool.query(`DELETE FROM addie_threads WHERE external_id LIKE 'test-search-%'`);
+      await pool.query(`DELETE FROM slack_user_mappings WHERE slack_user_id = $1`, [SLACK_USER_ID]);
+      await pool.query(`DELETE FROM users WHERE workos_user_id = $1`, [WORKOS_USER_ID]);
+    });
+
+    it('matches by Slack handle through slack_user_mappings join', async () => {
+      const threads = await threadService.listThreads({ user_search: 'someslackhandle' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-slack');
+    });
+
+    it('matches by Slack real_name through slack_user_mappings join', async () => {
+      const threads = await threadService.listThreads({ user_search: 'Slacktest' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-slack');
+    });
+
+    it('matches by Slack-side email through slack_user_mappings join', async () => {
+      const threads = await threadService.listThreads({ user_search: 'someone.slack@' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-slack');
+    });
+
+    it('matches by WorkOS first_name on a workos-typed thread', async () => {
+      const threads = await threadService.listThreads({ user_search: 'Someone' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-web');
+    });
+
+    it('matches by WorkOS email on a workos-typed thread', async () => {
+      const threads = await threadService.listThreads({ user_search: 'someone.workos@' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-web');
+    });
+
+    it('matches an email thread by the sender email stored in user_id', async () => {
+      const threads = await threadService.listThreads({ user_search: 'searchtarget@' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).toContain('test-search-email');
+    });
+
+    it('matches by display_name on every surface', async () => {
+      const threads = await threadService.listThreads({ user_search: 'Workostest' });
+      const ids = threads.map(t => t.external_id);
+      // Both slack and web threads share the harmonized display name.
+      expect(ids).toEqual(expect.arrayContaining(['test-search-slack', 'test-search-web']));
+    });
+
+    it('does not match unrelated threads', async () => {
+      const threads = await threadService.listThreads({ user_search: 'completely-unrelated-token' });
+      const ids = threads.map(t => t.external_id);
+      expect(ids).not.toContain('test-search-slack');
+      expect(ids).not.toContain('test-search-web');
+      expect(ids).not.toContain('test-search-email');
+    });
+  });
+
   describe('getStats', () => {
     it('should return overall statistics', async () => {
       // Create some test data


### PR DESCRIPTION
## Summary

Admin thread search now matches by full name, Slack handle, Slack real name, WorkOS first/last name, or any known email address — every natural identifier an admin would describe a person by.

## Why

PR #3271 harmonized \`addie_threads.user_display_name\` to use the WorkOS full name (\`Brian O'Kelley\`) instead of \`slack_user.display_name\` (\`bokelley\`). That's right for the prompt-prefix path but it broke admin search-by-Slack-handle. The mapping table (slack_user_mappings) and users table were always there; the search query just wasn't using them.

Reviewers on #3271 flagged this as a follow-up — fixing here.

## What changed

\`server/src/addie/thread-service.ts\`: \`listThreads\` now adds two LEFT JOINs only when \`filters.user_search\` is set:

\`\`\`sql
LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = s.user_id
LEFT JOIN users u ON u.workos_user_id = COALESCE(
  sm.workos_user_id,
  CASE WHEN s.user_type = 'workos' THEN s.user_id END
)
\`\`\`

The user_search clause then OR-matches the term across:
- \`s.user_display_name\` (harmonized full name on every surface)
- \`s.user_id\` (raw — carries the email for email threads)
- \`sm.slack_display_name\`, \`sm.slack_real_name\`, \`sm.slack_email\` (Slack identifiers)
- \`u.email\`, \`u.first_name\`, \`u.last_name\` (WorkOS profile)

\`SELECT\` is unchanged (\`s.*\` only) so no PII from the joined tables leaks into the response payload — the joins are only for matching.

## Verification

8 integration tests in \`server/tests/unit/thread-service.test.ts\` cover Slack handle, Slack real name, Slack email, WorkOS first name, WorkOS email, email-thread sender lookup, harmonized full-name match across surfaces, and the negative case. All pass against a real Postgres locally.

Pre-commit hook: 834+8 unit tests + dynamic-import lint + typecheck all green.

Reviewers (code + security) say ship. SQL injection clean (parameterized + static columns), authorization unchanged (\`requireAdmin\` upstream), no new PII surfaced (SELECT projects \`s.*\` only).

## Test plan

- [x] Local integration tests against running Postgres
- [x] \`npm run typecheck\` clean
- [ ] CI run on this PR
- [ ] Smoke test in admin UI: search "bokelley" returns threads where Brian was the speaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)