### PR TITLE
fix(admin): edit button silently fails for items in All Content tab

### DIFF
--- a/.changeset/fix-admin-edit-content-lookup.md
+++ b/.changeset/fix-admin-edit-content-lookup.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix admin "Edit" button silently doing nothing on blog posts in the All Content tab.
+
+`editContent` looked up items only in `myContent` (the user's own posts), but admin items rendered from the All Content tab come from `adminContent`, so the lookup always returned undefined and returned early. Fix: fall back to `adminContent` with type-safe String comparison, fetch full content/tags from `/api/admin/content/:id` before opening the modal (the list endpoint omits these fields), and handle the flat `committee_slug` field that admin list items carry instead of the nested `collection.committee_slug` shape.

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -1293,9 +1293,18 @@
       document.getElementById('contentModal').style.display = 'flex';
     }
 
-    function editContent(id) {
-      const item = myContent.find(c => c.id === id);
-      if (!item) return;
+    async function editContent(id) {
+      const ownItem = myContent.find(c => c.id === id);
+      let item = ownItem;
+      if (!item) {
+        item = adminContent.find(c => String(c.id) === String(id));
+        if (!item) return;
+        // Admin list items lack content/tags — fetch the full record before opening the edit modal
+        try {
+          const res = await fetch(`/api/admin/content/${encodeURIComponent(item.id)}`, { credentials: 'include' });
+          if (res.ok) { const full = await res.json(); item.content = full.content; item.tags = full.tags; }
+        } catch (e) { console.error('Failed to load full content for edit:', e); }
+      }
       editingContent = item;
       document.getElementById('modalTitle').textContent = 'Edit Content';
       document.getElementById('contentId').value = item.id;
@@ -1316,7 +1325,8 @@
       else if (st === 'pending_review') document.getElementById('statusSelect').value = 'pending_review';
       else document.getElementById('statusSelect').value = 'draft';
 
-      const colSlug = item.collection?.committee_slug || item.collection?.slug;
+      // Admin list items carry committee_slug as a flat field; myContent items nest it under collection
+      const colSlug = item.collection?.committee_slug || item.collection?.slug || item.committee_slug;
       if (colSlug) document.getElementById('collection').value = colSlug;
       setContentType(item.content_type || 'article');
       updatePreview();


### PR DESCRIPTION
Closes #2692

Admin users clicking "Edit" on blog posts in the All Content tab got no response — the button appeared to do nothing across all browsers.

**Root cause:** `editContent(id)` searched only `myContent` (the user's own posts). Items displayed in the All Content tab come from `adminContent` (a separate array populated by `GET /api/admin/content`). When the ID wasn't in `myContent`, the function returned early silently.

**Fix:** Three changes in `editContent`:
1. Fall back to `adminContent` with `String(c.id) === String(id)` (matching the type-safe comparison already used in `openDetailModal`)
2. When item comes from `adminContent`, async-fetch the full record from `/api/admin/content/:id` before opening the modal — the admin list endpoint omits `content` and `tags`, which would otherwise render the body editor blank and overwrite the article body on save
3. Resolve committee slug from `item.committee_slug` (flat field on admin list items) as fallback to `item.collection?.committee_slug` (nested shape on `myContent` items)

**Non-breaking justification:** Client-side JS fix for a broken UI path; no API, schema, or protocol changes.

**Pre-PR review:**
- code-reviewer: approved — all three blockers (missing `content` field, collection field shape mismatch, ID type coercion) addressed; save path via `PUT /api/me/content/:id` confirmed admin-permissive at server level
- internal-tools-strategist: approved — async fetch pattern mirrors `openDetailModal`; `editFromDetailModal` path unaffected; no new duplicate pathways

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01M768hMCssKxU5oDyTbW7iV)_