### PR TITLE
fix(training-agent): reject creative_assignments: [] on active/paused buys

### DIFF
--- a/.changeset/fix-creative-assignment-clear-regression.md
+++ b/.changeset/fix-creative-assignment-clear-regression.md
@@ -1,0 +1,10 @@
+---
+---
+
+Reject creative_assignments: [] on active/paused/pending_start media buys in the training agent.
+
+Calling update_media_buy with an empty creative_assignments array on a live buy caused
+deriveStatus to return pending_creatives (hasCreatives === false), an off-graph transition from
+active not in MEDIA_BUY_TRANSITIONS. Now validated in the pre-pass: if the buy is in
+active, paused, or pending_start status, clearing all assignments returns VALIDATION_ERROR
+before any mutation occurs. Server-only change; no protocol schema impact.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2396,6 +2396,14 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       const assignments = (update as PackageUpdate & { creative_assignments?: Array<{ creative_id: string }> }).creative_assignments;
       if (assignments === undefined) continue;
       const pkgId = update.package_id || '';
+      if (assignments.length === 0) {
+        const currentStatus = deriveStatus(mb);
+        if (['active', 'paused', 'pending_start'].includes(currentStatus)) {
+          return {
+            errors: [{ code: 'VALIDATION_ERROR', message: `creative_assignments cannot be cleared on a buy in "${currentStatus}" status`, field: `packages[${pkgId}].creative_assignments` }] as TaskError[],
+          };
+        }
+      }
       for (const assignment of assignments) {
         const cid = assignment.creative_id;
         if (!cid) {
@@ -2465,8 +2473,8 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       }
 
       // Replacement semantics: the provided array replaces pkg.creativeAssignments
-      // entirely. An empty array clears assignments and may regress the buy to
-      // pending_creatives. Validity of creative_ids was checked in the pre-pass.
+      // entirely. Empty arrays are rejected in the pre-pass for active/paused/pending_start buys;
+      // validity of creative_ids was also checked in the pre-pass.
       const creativeAssignments = (update as PackageUpdate & { creative_assignments?: Array<{ creative_id: string }> }).creative_assignments;
       if (creativeAssignments !== undefined) {
         const creativeIds = creativeAssignments.map(a => a.creative_id);

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -2773,7 +2773,7 @@ describe('update_media_buy handler', () => {
     expect((postBuy.media_buys as Array<Record<string, unknown>>)[0].status).toBe('pending_start');
   });
 
-  it('clears creative_assignments when given an empty array, regressing to pending_creatives', async () => {
+  it('rejects creative_assignments: [] on a buy in pending_start', async () => {
     const catalog = buildCatalog();
     const product = catalog[0].product;
     const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
@@ -2815,6 +2815,144 @@ describe('update_media_buy handler', () => {
       media_buy_id: mediaBuyId,
       packages: [{ package_id: pkgId, creative_assignments: [] }],
     });
+    expect(updateResult.code).toBe('VALIDATION_ERROR');
+    expect(updateResult.message).toBe('creative_assignments cannot be cleared on a buy in "pending_start" status');
+    expect(updateResult.field).toBe(`packages[${pkgId}].creative_assignments`);
+  });
+
+  it('rejects creative_assignments: [] on a buy in active', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'assign-clear-active.example' }, operator: 'assign-clear-active.example' };
+
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'assign-clear-active.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2027-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 10000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+    const pkgId = ((createResult.packages as Array<Record<string, unknown>>)[0]).package_id as string;
+
+    await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'sync_creatives', {
+      account,
+      creatives: [{
+        creative_id: 'cr_active_clear',
+        format_id: { agent_url: TEST_AGENT_URL, id: 'display_300x250' },
+        name: 'Active Clear',
+      }],
+      assignments: [{ media_buy_id: mediaBuyId, package_id: pkgId, creative_id: 'cr_active_clear' }],
+    });
+
+    const { result: afterAdd } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    expect((afterAdd.media_buys as Array<Record<string, unknown>>)[0].status).toBe('active');
+
+    const { result: updateResult } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: pkgId, creative_assignments: [] }],
+    });
+    expect(updateResult.code).toBe('VALIDATION_ERROR');
+    expect(updateResult.message).toBe('creative_assignments cannot be cleared on a buy in "active" status');
+    expect(updateResult.field).toBe(`packages[${pkgId}].creative_assignments`);
+  });
+
+  it('rejects creative_assignments: [] on a buy in paused', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'assign-clear-paused.example' }, operator: 'assign-clear-paused.example' };
+
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'assign-clear-paused.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2027-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 10000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+    const pkgId = ((createResult.packages as Array<Record<string, unknown>>)[0]).package_id as string;
+
+    await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'sync_creatives', {
+      account,
+      creatives: [{
+        creative_id: 'cr_paused_clear',
+        format_id: { agent_url: TEST_AGENT_URL, id: 'display_300x250' },
+        name: 'Paused Clear',
+      }],
+      assignments: [{ media_buy_id: mediaBuyId, package_id: pkgId, creative_id: 'cr_paused_clear' }],
+    });
+
+    await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      paused: true,
+    });
+
+    const { result: afterPause } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    expect((afterPause.media_buys as Array<Record<string, unknown>>)[0].status).toBe('paused');
+
+    const { result: updateResult } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: pkgId, creative_assignments: [] }],
+    });
+    expect(updateResult.code).toBe('VALIDATION_ERROR');
+    expect(updateResult.message).toBe('creative_assignments cannot be cleared on a buy in "paused" status');
+    expect(updateResult.field).toBe(`packages[${pkgId}].creative_assignments`);
+  });
+
+  it('allows creative_assignments: [] on a buy still in pending_creatives (no-op)', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'assign-clear-pc.example' }, operator: 'assign-clear-pc.example' };
+
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'assign-clear-pc.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 10000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+    const pkgId = ((createResult.packages as Array<Record<string, unknown>>)[0]).package_id as string;
+
+    const { result: pre } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    expect((pre.media_buys as Array<Record<string, unknown>>)[0].status).toBe('pending_creatives');
+
+    const { result: updateResult } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: pkgId, creative_assignments: [] }],
+    });
+    expect(updateResult.code).toBeUndefined();
     expect(updateResult.status).toBe('pending_creatives');
   });
 


### PR DESCRIPTION
Closes #2835

`update_media_buy` with `creative_assignments: []` on a package of an active buy caused `deriveStatus` to return `pending_creatives` (because `hasCreatives === false`), emitting an `active → pending_creatives` transition that is not in `MEDIA_BUY_TRANSITIONS`. The `status.monotonic` invariant assertion would reject this transition the moment any storyboard exercises the "buyer replaces all creatives" path.

**Fix:** Validation guard added in the pre-validation pass (`handleUpdateMediaBuy`, pre-pass loop). If the buy's derived status is `active`, `paused`, or `pending_start`, clearing all assignments on any package returns `VALIDATION_ERROR` before any mutation occurs. This is Option 2 from the issue — cleaner than the `creaturesWereAttached` bit (Option 1) because it keeps `deriveStatus` and `MEDIA_BUY_TRANSITIONS` untouched and produces a clear API error the agent under test can observe.

**Non-breaking justification:** Server-only change in `task-handlers.ts`; no protocol schema, task definition, or published API surface touched. Changeset `--empty`.

**Pre-PR review:**
- code-reviewer: approved — Option 2 confirmed cleaner; guard placement in pre-pass (before any mutation) correct; comment at mutation site updated to remove the stale "may regress to pending_creatives" language; no schema impact

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01M768hMCssKxU5oDyTbW7iV)_