### PR TITLE
feat(membership): track provisioning source on each org membership

### DIFF
--- a/.changeset/provisioning-source-attribution.md
+++ b/.changeset/provisioning-source-attribution.md
@@ -1,0 +1,20 @@
+---
+---
+
+feat(membership): track provisioning source on each org membership
+
+Each row in `organization_memberships` now carries a `provisioning_source` tag identifying how it came to exist:
+
+- `verified_domain` — `autoLinkByVerifiedDomain` matched the user's email domain to a verified org with auto-provision on
+- `invited` — accepted via `POST /:orgId/invitations` or `/members/by-email` Path 1
+- `admin_added` — created via `/members/by-email` Path 2 (admin/owner direct add)
+- `webhook` — surfaced by an `organization_membership.created` event with no staged source (e.g. someone added the membership directly in the WorkOS dashboard)
+- `null` — pre-existing rows that haven't been touched since this migration
+
+The originating endpoint stages source + seat_type into `invitation_seat_types` (a new `source` column there). The `organization_membership.created` webhook handler reads both back via `consumeInvitationSeatType` and writes `provisioning_source` on the local cache row. The upsert preserves an existing source on conflict, so a subsequent webhook upsert can't wipe a more-specific origin.
+
+Sets up the new-member digest in the auto-provision notification feature so org owners can see which auto-joined members showed up via verified-domain vs. were explicitly invited.
+
+## Migration
+
+`436_organization_membership_provisioning_source.sql` adds the columns and an index keyed on `(workos_organization_id, provisioning_source, created_at DESC)` for the digest query.

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -13,6 +13,14 @@ const logger = createLogger('membership-db');
 
 // ── Types ────────────────────────────────────────────────────────────
 
+/** Tracks how each organization_memberships row came to exist. */
+export type ProvisioningSource =
+  | 'verified_domain'  // autoLinkByVerifiedDomain
+  | 'invited'          // POST /:orgId/invitations or /members/by-email Path 1
+  | 'admin_added'      // /members/by-email Path 2 direct add
+  | 'webhook'          // organization_membership.created with no staged source
+  | 'unknown';
+
 export interface MembershipUpsertParams {
   user_id: string;
   organization_id: string;
@@ -23,6 +31,13 @@ export interface MembershipUpsertParams {
   role: string;          // raw role slug from WorkOS (e.g. 'member', 'admin', 'owner')
   seat_type: string;     // resolved seat type ('contributor' | 'community_only')
   has_explicit_seat_type: boolean;
+  /**
+   * Provisioning source to record on the local cache row. Only written when
+   * the row is being inserted (or when the existing row has NULL/'unknown'
+   * source) — once a membership is tagged, subsequent webhook upserts don't
+   * overwrite the original attribution.
+   */
+  provisioning_source?: ProvisioningSource;
 }
 
 export interface MembershipUpsertResult {
@@ -57,6 +72,7 @@ export async function upsertOrganizationMembership(
       last_name,
       role,
       seat_type,
+      provisioning_source,
       synced_at
     ) VALUES (
       $1, $2, $3, $4, $5, $6,
@@ -70,7 +86,7 @@ export async function upsertOrganizationMembership(
         WHEN $7 = '__auto__' THEN 'member'
         ELSE $7
       END,
-      $8, NOW()
+      $8, $10, NOW()
     )
     ON CONFLICT (workos_user_id, workos_organization_id)
     DO UPDATE SET
@@ -83,6 +99,9 @@ export async function upsertOrganizationMembership(
         WHEN $9::boolean THEN EXCLUDED.seat_type
         ELSE organization_memberships.seat_type
       END,
+      -- Don't overwrite an existing attribution; later webhooks would be the
+      -- 'webhook' source and would otherwise wipe a more specific origin.
+      provisioning_source = COALESCE(organization_memberships.provisioning_source, EXCLUDED.provisioning_source),
       synced_at = NOW(),
       updated_at = NOW()
     RETURNING role`,
@@ -96,6 +115,7 @@ export async function upsertOrganizationMembership(
       effectiveRole,
       params.seat_type,
       params.has_explicit_seat_type,
+      params.provisioning_source ?? null,
     ],
   );
 
@@ -136,23 +156,28 @@ export async function deleteOrganizationMembership(
 // ── Invitation seat type ─────────────────────────────────────────────
 
 /**
- * Consume any pending seat_type assignment from an invitation.
- * Returns the seat type if one was found, or null.
+ * Consume any pending seat_type and provisioning_source staged by the endpoint
+ * that triggered the membership creation. Returns both fields when a row is
+ * found; null when no staging row exists.
  */
 export async function consumeInvitationSeatType(
   organizationId: string,
   email: string,
-): Promise<string | null> {
+): Promise<{ seat_type: string; source: ProvisioningSource | null } | null> {
   const pool = getPool();
 
-  const result = await pool.query<{ seat_type: string }>(
+  const result = await pool.query<{ seat_type: string; source: string | null }>(
     `DELETE FROM invitation_seat_types
      WHERE workos_organization_id = $1 AND lower(email) = lower($2)
-     RETURNING seat_type`,
+     RETURNING seat_type, source`,
     [organizationId, email],
   );
 
-  return result.rows[0]?.seat_type ?? null;
+  if (!result.rows[0]) return null;
+  return {
+    seat_type: result.rows[0].seat_type,
+    source: (result.rows[0].source as ProvisioningSource | null) ?? null,
+  };
 }
 
 // ── Successor promotion query ────────────────────────────────────────
@@ -260,6 +285,23 @@ export async function autoLinkByVerifiedDomain(
 
   if (userAlreadyMember) return null;
 
+  // Stage the provisioning source so the organization_membership.created
+  // webhook handler can record 'verified_domain' on the local cache row.
+  // Clear any stale (org, email) staging row first; consumeInvitationSeatType
+  // matches by (org, email) and we don't want a leftover row from a prior
+  // failed attempt to win.
+  const stagingKey = `verified_domain_${orgId}_${userId}`;
+  await pool.query(
+    'DELETE FROM invitation_seat_types WHERE workos_organization_id = $1 AND lower(email) = lower($2)',
+    [orgId, email],
+  );
+  await pool.query(
+    `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+     VALUES ($1, $2, $3, 'community_only', 'verified_domain')
+     ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type, source = EXCLUDED.source`,
+    [stagingKey, orgId, email],
+  );
+
   // Always create as member. Auto-promotion to owner for ownerless orgs is
   // handled atomically by upsertOrganizationMembership when the
   // organization_membership.created webhook fires — that path uses a NOT EXISTS
@@ -279,6 +321,19 @@ export async function autoLinkByVerifiedDomain(
       // Membership exists but wasn't returned by list — return as success
       logger.info({ userId, orgId }, 'Auto-link skipped: membership already exists in WorkOS');
       return { organizationId: orgId, organizationName: orgName, role: 'member' };
+    }
+    // Roll back the staging row so a stale 'verified_domain' source can't be
+    // consumed by an unrelated future invite for the same (org, email) pair.
+    try {
+      await pool.query(
+        'DELETE FROM invitation_seat_types WHERE workos_invitation_id = $1',
+        [stagingKey],
+      );
+    } catch (rollbackErr) {
+      logger.error(
+        { err: rollbackErr, userId, orgId, email, stagingKey },
+        'CRITICAL: failed to rollback verified_domain staging row after createOrganizationMembership failure — manually delete row to avoid source leak',
+      );
     }
     logger.warn({ err, userId, orgId }, 'Failed to auto-link user to organization');
     return null;

--- a/server/src/db/migrations/436_organization_membership_provisioning_source.sql
+++ b/server/src/db/migrations/436_organization_membership_provisioning_source.sql
@@ -1,0 +1,30 @@
+-- Track how each organization membership came to exist.
+--
+-- Existing rows are NULL ('unknown'). New rows are tagged at creation by the
+-- code path that triggered them: autoLinkByVerifiedDomain → 'verified_domain',
+-- /members/by-email Path 1 → 'invited', Path 2 → 'admin_added',
+-- POST /:orgId/invitations → 'invited', everything else (sync from WorkOS,
+-- webhook for an externally-created membership) → 'webhook'.
+--
+-- Used by the new-member digest in the auto-provision notification feature so
+-- org owners can see which auto-joined members showed up via verified-domain
+-- vs. were explicitly invited.
+
+ALTER TABLE organization_memberships
+  ADD COLUMN IF NOT EXISTS provisioning_source VARCHAR(32);
+
+COMMENT ON COLUMN organization_memberships.provisioning_source IS
+  'How this membership was created: verified_domain, invited, admin_added, webhook, unknown';
+
+CREATE INDEX IF NOT EXISTS idx_organization_memberships_provisioning_source
+  ON organization_memberships(workos_organization_id, provisioning_source, created_at DESC)
+  WHERE provisioning_source IS NOT NULL;
+
+-- Mirror on the invitation_seat_types staging table so the webhook handler can
+-- read the source set by the originating endpoint and apply it to the local
+-- cache row when the membership.created event arrives.
+ALTER TABLE invitation_seat_types
+  ADD COLUMN IF NOT EXISTS source VARCHAR(32);
+
+COMMENT ON COLUMN invitation_seat_types.source IS
+  'Provisioning source to apply to the membership when this staging row is consumed';

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -2400,11 +2400,11 @@ export function createOrganizationsRouter(): Router {
         roleSlug: role || 'member',
       });
 
-      // Persist seat_type intent for when the invitation is accepted
+      // Persist seat_type intent + provisioning source for when the invitation is accepted
       await query(
-        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-         VALUES ($1, $2, $3, $4)
-         ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type`,
+        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+         VALUES ($1, $2, $3, $4, 'invited')
+         ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type, source = EXCLUDED.source`,
         [invitation.id, orgId, email, seatType]
       );
 
@@ -2575,10 +2575,10 @@ export function createOrganizationsRouter(): Router {
         roleSlug: 'member',
       });
 
-      // Persist seat_type intent for the new invitation
+      // Persist seat_type intent + provisioning source for the new invitation
       await query(
-        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-         VALUES ($1, $2, $3, $4)`,
+        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+         VALUES ($1, $2, $3, $4, 'invited')`,
         [newInvitation.id, orgId, invitation.email, preservedSeatType]
       );
 
@@ -2751,12 +2751,13 @@ export function createOrganizationsRouter(): Router {
           roleSlug: 'member',
         });
 
-        // Persist seat_type intent so the webhook handler picks it up when the
-        // invitee accepts (mirrors the existing /invitations endpoint).
+        // Persist seat_type intent + provisioning source so the webhook
+        // handler picks them up when the invitee accepts (mirrors the
+        // existing /invitations endpoint).
         await query(
-          `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-           VALUES ($1, $2, $3, $4)
-           ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type`,
+          `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+           VALUES ($1, $2, $3, $4, 'invited')
+           ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type, source = EXCLUDED.source`,
           [invitation.id, orgId, normalizedEmail, seatType],
         );
 
@@ -2835,9 +2836,9 @@ export function createOrganizationsRouter(): Router {
         );
         const stagingKey = `direct_${orgId}_${targetUserId}`;
         await query(
-          `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-           VALUES ($1, $2, $3, $4)
-           ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type`,
+          `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+           VALUES ($1, $2, $3, $4, 'admin_added')
+           ON CONFLICT (workos_invitation_id) DO UPDATE SET seat_type = EXCLUDED.seat_type, source = EXCLUDED.source`,
           [stagingKey, orgId, normalizedEmail, seatType],
         );
 

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -122,10 +122,14 @@ async function upsertMembership(
 
   const role = membership.role?.slug || 'member';
 
-  // Consume any pending seat_type assignment from the invitation
-  const consumedSeatType = await consumeInvitationSeatType(membership.organization_id, userData.email);
-  const hasExplicitSeatType = consumedSeatType !== null;
-  const seatType = consumedSeatType || 'community_only';
+  // Consume any pending seat_type + provisioning_source staged by the
+  // endpoint that triggered this membership creation. Falls back to defaults
+  // when no row was staged (e.g. someone added the membership directly in
+  // WorkOS rather than through one of our endpoints).
+  const consumed = await consumeInvitationSeatType(membership.organization_id, userData.email);
+  const hasExplicitSeatType = consumed !== null;
+  const seatType = consumed?.seat_type || 'community_only';
+  const provisioningSource = consumed?.source || 'webhook';
 
   const { assigned_role } = await upsertOrganizationMembership({
     user_id: membership.user_id,
@@ -137,6 +141,7 @@ async function upsertMembership(
     role,
     seat_type: seatType,
     has_explicit_seat_type: hasExplicitSeatType,
+    provisioning_source: provisioningSource,
   });
 
   // If the DB promoted this member to owner, sync the change to WorkOS

--- a/server/tests/integration/membership-webhook.test.ts
+++ b/server/tests/integration/membership-webhook.test.ts
@@ -264,15 +264,15 @@ describe('Membership webhook DB operations', () => {
   // =========================================================================
 
   describe('consumeInvitationSeatType', () => {
-    it('returns and deletes the pending seat type', async () => {
+    it('returns and deletes the pending seat type and source', async () => {
       await pool.query(
-        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-         VALUES ($1, $2, $3, $4)`,
-        ['inv_test_1', TEST_ORG_ID, 'invited@test.com', 'contributor'],
+        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+         VALUES ($1, $2, $3, $4, $5)`,
+        ['inv_test_1', TEST_ORG_ID, 'invited@test.com', 'contributor', 'invited'],
       );
 
       const result = await consumeInvitationSeatType(TEST_ORG_ID, 'invited@test.com');
-      expect(result).toBe('contributor');
+      expect(result).toEqual({ seat_type: 'contributor', source: 'invited' });
 
       // Should be consumed (deleted)
       const second = await consumeInvitationSeatType(TEST_ORG_ID, 'invited@test.com');
@@ -281,13 +281,26 @@ describe('Membership webhook DB operations', () => {
 
     it('matches case-insensitively', async () => {
       await pool.query(
-        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
-         VALUES ($1, $2, $3, $4)`,
-        ['inv_test_2', TEST_ORG_ID, 'CamelCase@Test.com', 'contributor'],
+        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+         VALUES ($1, $2, $3, $4, $5)`,
+        ['inv_test_2', TEST_ORG_ID, 'CamelCase@Test.com', 'contributor', 'invited'],
       );
 
       const result = await consumeInvitationSeatType(TEST_ORG_ID, 'camelcase@test.com');
-      expect(result).toBe('contributor');
+      expect(result?.seat_type).toBe('contributor');
+      expect(result?.source).toBe('invited');
+    });
+
+    it('returns null source when staging row predates the source column', async () => {
+      // Backward compatibility: rows written before migration 436 have NULL source.
+      await pool.query(
+        `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type)
+         VALUES ($1, $2, $3, $4)`,
+        ['inv_test_legacy', TEST_ORG_ID, 'legacy@test.com', 'community_only'],
+      );
+
+      const result = await consumeInvitationSeatType(TEST_ORG_ID, 'legacy@test.com');
+      expect(result).toEqual({ seat_type: 'community_only', source: null });
     });
 
     it('returns null when no invitation exists', async () => {
@@ -570,6 +583,86 @@ describe('Membership webhook DB operations', () => {
       await pool.query(
         `DELETE FROM organization_memberships WHERE workos_organization_id = 'org_personal_autolink_user'`,
       );
+    });
+
+    it('stages provisioning_source=verified_domain so the webhook can record it', async () => {
+      await seedOrgWithVerifiedDomain('autolink.com');
+      const workos = makeWorkOSMock();
+
+      const result = await autoLinkByVerifiedDomain(workos, AUTOLINK_USER, 'matt@autolink.com');
+      expect(result).not.toBeNull();
+
+      // The staging row should now exist for the org+email pair so the
+      // organization_membership.created webhook can consume it.
+      const staged = await pool.query<{ seat_type: string; source: string | null }>(
+        `SELECT seat_type, source FROM invitation_seat_types
+         WHERE workos_organization_id = $1 AND lower(email) = lower($2)`,
+        [TEST_AUTOLINK_ORG_ID, 'matt@autolink.com'],
+      );
+      expect(staged.rows[0]).toBeDefined();
+      expect(staged.rows[0].seat_type).toBe('community_only');
+      expect(staged.rows[0].source).toBe('verified_domain');
+    });
+  });
+
+  describe('upsertOrganizationMembership provisioning_source', () => {
+    it('writes provisioning_source on insert', async () => {
+      await upsertOrganizationMembership({
+        user_id: TEST_USER_1,
+        organization_id: TEST_ORG_ID,
+        membership_id: 'om_source_test',
+        email: 'src@test.com',
+        first_name: 'Src',
+        last_name: 'Test',
+        role: 'member',
+        seat_type: 'community_only',
+        has_explicit_seat_type: false,
+        provisioning_source: 'verified_domain',
+      });
+
+      const row = await pool.query<{ provisioning_source: string | null }>(
+        'SELECT provisioning_source FROM organization_memberships WHERE workos_user_id = $1 AND workos_organization_id = $2',
+        [TEST_USER_1, TEST_ORG_ID],
+      );
+      expect(row.rows[0].provisioning_source).toBe('verified_domain');
+    });
+
+    it('preserves an existing provisioning_source on subsequent upserts', async () => {
+      // Initial insert tags the row.
+      await upsertOrganizationMembership({
+        user_id: TEST_USER_1,
+        organization_id: TEST_ORG_ID,
+        membership_id: 'om_pres_1',
+        email: 'pres@test.com',
+        first_name: null,
+        last_name: null,
+        role: 'member',
+        seat_type: 'community_only',
+        has_explicit_seat_type: false,
+        provisioning_source: 'admin_added',
+      });
+
+      // Subsequent webhook upsert with a less-specific source must not overwrite.
+      await upsertOrganizationMembership({
+        user_id: TEST_USER_1,
+        organization_id: TEST_ORG_ID,
+        membership_id: 'om_pres_1',
+        email: 'pres@test.com',
+        first_name: null,
+        last_name: null,
+        role: 'admin',
+        seat_type: 'community_only',
+        has_explicit_seat_type: false,
+        provisioning_source: 'webhook',
+      });
+
+      const row = await pool.query<{ provisioning_source: string | null; role: string }>(
+        'SELECT provisioning_source, role FROM organization_memberships WHERE workos_user_id = $1 AND workos_organization_id = $2',
+        [TEST_USER_1, TEST_ORG_ID],
+      );
+      expect(row.rows[0].provisioning_source).toBe('admin_added');
+      // Role still updates normally.
+      expect(row.rows[0].role).toBe('admin');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `organization_memberships.provisioning_source` so we can answer "how did this person become a member?" for every row. Sets up the new-member digest in #2 (next PR) — an org owner needs the source to distinguish auto-joined members from explicit invites in the consent receipt.

## Sources

| Value | Originating path |
|---|---|
| `verified_domain` | `autoLinkByVerifiedDomain` matched a verified-domain email |
| `invited` | `POST /:orgId/invitations` or `/members/by-email` Path 1 |
| `admin_added` | `/members/by-email` Path 2 (admin/owner direct add) |
| `webhook` | `organization_membership.created` with no staged source (e.g. WorkOS-dashboard add) |
| `null` | rows that pre-date this migration |

## Mechanism

The originating endpoint stages source + seat_type into `invitation_seat_types` (new `source` column there). The `organization_membership.created` webhook reads both back via `consumeInvitationSeatType` and writes the source on the local cache row.

The upsert preserves an existing source on conflict — so a later "webhook" upsert can't wipe a more-specific origin (`verified_domain` → `webhook` would otherwise lose the attribution).

`autoLinkByVerifiedDomain` rolls back the staging row if `createOrganizationMembership` fails, so a transient WorkOS error can't leak a `verified_domain` source onto an unrelated future invite for the same `(org, email)` pair.

## Tests

- `server/tests/integration/membership-webhook.test.ts` — 27 → 31 tests. New cases for source propagation through the staging table, source preservation on conflict, autoLink staging the source, and backward compatibility with NULL `source` rows from pre-migration data.

## Migration

`436_organization_membership_provisioning_source.sql` adds the columns and an index keyed on `(workos_organization_id, provisioning_source, created_at DESC)` for the digest query that #2 will run.

## Test plan

- [x] `npm run typecheck` clean
- [x] 31/31 integration tests pass
- [ ] CI green
- [ ] Migration applies on a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)