### PR TITLE
fix(my-content): unlock status dropdown for non-leads + toast on demotion (#2719)

### DIFF
--- a/.changeset/my-content-status-toast-and-enabled-dropdown.md
+++ b/.changeset/my-content-status-toast-and-enabled-dropdown.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `/my-content` status dropdown for non-leads (#2719). Before this change `updateStatusHint()` force-set the dropdown to `draft` and disabled it, so a member submitting to a committee they were a member of could not actually pick "Submit for Review" — the option existed in the markup but was unreachable. The dropdown is now always enabled with `Submit for Review` as the default for non-leads, and the hint text explains what each option does. After a successful submit, `saveContent()` compares the requested status against the server-resolved `status` field and surfaces a toast — most importantly, when a non-lead picks "Publish Now" and the propose endpoint demotes the request to `pending_review`, the user sees "Submitted for review — a committee lead will approve before publishing. Track it in the Pending tab." instead of a silent demotion.

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -1224,15 +1224,19 @@
 
       const collection = committees.find(c => c.slug === collectionSlug);
 
+      // Dropdown is always enabled — non-leads can still pick Submit for
+      // Review or Save as Draft. The server demotes a Publish Now request
+      // to pending_review for non-leads (see proposeContentForUser); we
+      // surface that with a post-submit toast in saveContent().
+      statusSelect.disabled = false;
+
       if (collection?.canPublishDirectly || isAdmin) {
         hint.textContent = collection?.type === 'committee'
           ? 'As a lead, you can publish directly.'
           : 'You can publish directly.';
-        statusSelect.disabled = false;
       } else {
-        hint.textContent = 'Will be submitted for review.';
-        statusSelect.value = 'draft';
-        statusSelect.disabled = true;
+        const reviewer = collection?.type === 'committee' ? 'a committee lead' : 'an admin';
+        hint.textContent = `Submit for Review sends it to ${reviewer}. Save as Draft keeps it private. Publish Now will be routed to review since you are not a lead.`;
       }
     }
 
@@ -1311,9 +1315,12 @@
           throw new Error(err.message || 'Failed to save');
         }
 
+        const result = await response.json();
         closeModal();
         await loadMyContent();
         if (canReview) await loadPendingContent();
+
+        showStatusOutcomeToast(statusValue, result.status);
       } catch (error) {
         console.error('Save error:', error);
         alert('Failed to save: ' + error.message);
@@ -1321,6 +1328,58 @@
 
       btn.disabled = false;
       btn.textContent = 'Save';
+    }
+
+    // Compare requested vs server-resolved status and announce the outcome.
+    // The propose endpoint demotes a non-lead's "published" request to
+    // pending_review (see proposeContentForUser in server/src/routes/content.ts);
+    // without this toast that demotion is silent.
+    function showStatusOutcomeToast(requested, actual) {
+      if (!actual) {
+        console.warn('Save response missing status — toast suppressed', { requested });
+        return;
+      }
+      if (requested === 'published' && actual === 'pending_review') {
+        const collection = committees.find(c => c.slug === document.getElementById('collection').value);
+        const reviewer = collection?.type === 'committee' ? 'a committee lead' : 'an admin';
+        showToast(`Submitted for review — ${reviewer} will approve before publishing. Track it in the Pending tab.`);
+        return;
+      }
+      if (actual === 'pending_review') {
+        showToast('Submitted for review.');
+      } else if (actual === 'published') {
+        showToast('Published.');
+      } else if (actual === 'draft') {
+        showToast('Saved as draft.');
+      }
+    }
+
+    function showToast(message, type = 'success') {
+      const toast = document.createElement('div');
+      const bg = type === 'error' ? 'var(--color-error-600)' : 'var(--color-success-600)';
+      toast.style.cssText = `
+        position: fixed;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 12px 24px;
+        background: ${bg};
+        color: white;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 500;
+        max-width: 480px;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        z-index: 10000;
+      `;
+      toast.textContent = message;
+      document.body.appendChild(toast);
+      setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transition = 'opacity 0.3s';
+        setTimeout(() => toast.remove(), 300);
+      }, 4000);
     }
 
     // Show review modal

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -14,7 +14,7 @@ if (!STRIPE_SECRET_KEY) {
 
 export const stripe = STRIPE_SECRET_KEY
   ? new Stripe(STRIPE_SECRET_KEY, {
-      apiVersion: '2026-03-25.dahlia',
+      apiVersion: '2026-04-22.dahlia',
     })
   : null;
 

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -331,6 +331,10 @@ describe('My Content — body, admin scope, status, delete', () => {
         })
         .expect(201);
 
+      // Server demotes non-lead `published` requests to `pending_review`.
+      // The my-content.html UI compares the requested vs returned status to
+      // surface this with a toast (see #2719); keep `status` in the response
+      // body so the client can detect the demotion.
       expect(response.body.status).toBe('pending_review');
     });
 


### PR DESCRIPTION
Closes #2719.

## Summary

PR #2766 added the three-option `Submit for Review / Save as Draft / Publish Now` dropdown to `my-content.html`, but a bug in `updateStatusHint()` was force-disabling the dropdown and overwriting its value to `draft` for non-leads — so a member submitting to a committee they were a member of (but not lead of) could not actually pick "Submit for Review" via the UI. The option existed in the markup but was unreachable.

This PR closes the two remaining gaps versus the issue's acceptance criteria:

1. **`updateStatusHint()` always enables the dropdown.** Default stays `pending_review` from the markup. For non-leads, the hint text now describes each option and conditions on collection type so non-committee collections correctly say "an admin" will approve (committee collections still say "a committee lead").

2. **`saveContent()` shows a status-outcome toast.** After a successful save, the client compares the requested status against the server-resolved `result.status`. When `proposeContentForUser` demotes a non-lead's `published` request to `pending_review` (server contract at `server/src/routes/content.ts:485-495`), the toast surfaces the demotion explicitly:
   > Submitted for review — a committee lead/admin will approve before publishing. Track it in the Pending tab.

   Other outcomes get short confirmation toasts. Toast helper is copied from the `dashboard.html:2974` pattern, with the broken `slideUp` keyframe ref dropped (the keyframe lives only in `chat.html`, not the design system).

## Drive-by

`server/src/billing/stripe-client.ts` had a stale `apiVersion: '2026-03-25.dahlia'` pin that didn't match the Stripe SDK shipped in #3275. Bumped to `'2026-04-22.dahlia'` so the precommit typecheck passes — unrelated to #2719 but it was blocking the commit.

## Tests

- The server contract that drives the toast is already covered by the existing `'non-leads cannot self-publish by sending status=published'` integration test at `server/tests/integration/content-my-content.test.ts:318-340`. Added a comment there pointing to #2719 so future contributors don't inadvertently weaken the contract.
- Browser smoke test (Playwright, member dev user, `localhost:55020/my-content`):
  - Page loads with no console errors or page errors
  - `#statusSelect` enabled, default `pending_review`, three correct options
  - `#statusHint` text adapts to collection type (`an admin` for non-committee, `a committee lead` for committee)
  - `showStatusOutcomeToast('published', 'pending_review')` produces a toast with the expected demotion message

## Test plan

- [x] Typecheck clean (after Stripe bump)
- [x] Precommit `test:unit` + `typecheck` green
- [x] Browser smoke test — dropdown enabled, default `pending_review`, toast appears with correct message
- [ ] Production smoke after deploy: member submits via `/my-content` choosing "Publish Now", confirms they see the demotion toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)