### PR TITLE
feat(addie): prompt-rule decay and suppression (#3282)

### DIFF
--- a/.changeset/addie-prompt-decay.md
+++ b/.changeset/addie-prompt-decay.md
@@ -1,0 +1,13 @@
+---
+---
+
+Implements #3282: decay/suppression for Addie's suggested-prompts rules engine. Without this, every activation rule fires indefinitely until the gating signal flips — owners who deliberately ignore the "List my company in the directory" prompt see it forever.
+
+- New migration `436_addie_prompt_telemetry.sql` creates `addie_prompt_telemetry (workos_user_id, rule_id, shown_count, last_shown_at, suppressed_until)` keyed on `(workos_user_id, rule_id)`.
+- New DB layer `server/src/db/addie-prompt-telemetry-db.ts` exposes `getTelemetryForUser` (read into a Map) and `recordPromptsShown` (upsert with auto-suppression: 5 shows → 30-day suppress).
+- `MemberContext.prompt_telemetry` hydrated in both Slack and web flows so the evaluator stays sync and benefits from the existing 30-min cache.
+- Evaluator skips rules whose `suppressed_until > now` before running their predicate — no behaviour change for users without telemetry rows.
+- New `pickPrompts()` returns parallel `{prompts, ruleIds}`; existing `buildSuggestedPrompts()` kept as a thin wrapper.
+- All 4 call sites (Slack Assistant, Slack App Home, Web Home, plus the legacy `getDynamicSuggestedPrompts` wrappers) record telemetry fire-and-forget after picking.
+- 6 new tests for suppression behaviour and the `pickPrompts` API. No "acted on" tracking — when the gating signal flips, the rule's `when()` returns false naturally.
+- Out of scope: dismissal UI (no Slack/web button surfaces yet), per-rule decay configurations.

--- a/.changeset/addie-prompt-decay.md
+++ b/.changeset/addie-prompt-decay.md
@@ -4,10 +4,12 @@
 Implements #3282: decay/suppression for Addie's suggested-prompts rules engine. Without this, every activation rule fires indefinitely until the gating signal flips — owners who deliberately ignore the "List my company in the directory" prompt see it forever.
 
 - New migration `436_addie_prompt_telemetry.sql` creates `addie_prompt_telemetry (workos_user_id, rule_id, shown_count, last_shown_at, suppressed_until)` keyed on `(workos_user_id, rule_id)`.
-- New DB layer `server/src/db/addie-prompt-telemetry-db.ts` exposes `getTelemetryForUser` (read into a Map) and `recordPromptsShown` (upsert with auto-suppression: 5 shows → 30-day suppress).
-- `MemberContext.prompt_telemetry` hydrated in both Slack and web flows so the evaluator stays sync and benefits from the existing 30-min cache.
-- Evaluator skips rules whose `suppressed_until > now` before running their predicate — no behaviour change for users without telemetry rows.
-- New `pickPrompts()` returns parallel `{prompts, ruleIds}`; existing `buildSuggestedPrompts()` kept as a thin wrapper.
-- All 4 call sites (Slack Assistant, Slack App Home, Web Home, plus the legacy `getDynamicSuggestedPrompts` wrappers) record telemetry fire-and-forget after picking.
-- 6 new tests for suppression behaviour and the `pickPrompts` API. No "acted on" tracking — when the gating signal flips, the rule's `when()` returns false naturally.
-- Out of scope: dismissal UI (no Slack/web button surfaces yet), per-rule decay configurations.
+- New DB layer `server/src/db/addie-prompt-telemetry-db.ts`: `getTelemetryForUser` reads into a Map; `recordPromptsShown` does one bulk upsert via `unnest($2::text[])` for all rules in the batch.
+- **Counting is bucketed by UTC day**: shown_count only increments if `last_shown_at < CURRENT_DATE`. Without this a Slack user who opens App Home and starts a few Assistant threads in one workday would burn through the suppression threshold without ever consciously reading the prompt.
+- Default thresholds: 5 distinct days of shows → 30-day suppression. Tunable via `recordPromptsShown` options.
+- **Persona prompts are exempt** (`decay: false` on `PromptRule`). Personas are stable entry points, not nudges — suppressing "Prove the outcomes" for a `data_decoder` would leave them with strictly worse fallbacks. Their rule IDs are excluded from `recordPromptsShown` so no telemetry is written.
+- `MemberContext.prompt_telemetry` hydrated in both Slack and web flows; benefits from the existing 30-min context cache so the evaluator stays synchronous. Cache means in-memory `suppressed_until` can be up to 30 min stale, which is fine given suppression is 30 days.
+- New `pickPrompts()` returns parallel `{prompts, ruleIds}` for telemetry recording; existing `buildSuggestedPrompts()` kept as a thin wrapper. All 4 call sites (Slack Assistant, App Home, Web Home, legacy wrappers) record fire-and-forget after picking.
+- 8 new tests covering suppression behaviour, the `pickPrompts` API, and persona-exempt logic.
+
+Out of scope: dismissal UI (no Slack/web button surface yet), per-rule decay configurations, "acted on" tracking (when the gating signal flips, the rule's `when()` returns false naturally).

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -79,7 +79,8 @@ import {
   canScheduleMeetings,
 } from './mcp/meeting-tools.js';
 import { SUGGESTED_PROMPTS, HISTORY_UNAVAILABLE_NOTE } from './prompts.js';
-import { buildSuggestedPrompts } from './home/builders/suggested-prompts.js';
+import { pickPrompts } from './home/builders/suggested-prompts.js';
+import { recordPromptsShown } from '../db/addie-prompt-telemetry-db.js';
 import { AddieModelConfig, ModelConfig } from '../config/models.js';
 import { getMemberContext, formatMemberContextForPrompt, type MemberContext } from './member-context.js';
 import {
@@ -777,7 +778,12 @@ async function getDynamicSuggestedPrompts(userId: string): Promise<SuggestedProm
   try {
     const memberContext = await getMemberContext(userId);
     const userIsAdmin = await isSlackUserAAOAdmin(userId);
-    return buildSuggestedPrompts(memberContext, userIsAdmin).map((p) => ({
+    const { prompts, ruleIds } = pickPrompts(memberContext, userIsAdmin);
+    const workosUserId = memberContext?.workos_user?.workos_user_id;
+    if (workosUserId && ruleIds.length > 0) {
+      void recordPromptsShown(workosUserId, ruleIds);
+    }
+    return prompts.map((p) => ({
       title: p.label,
       message: p.prompt,
     }));

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -99,7 +99,8 @@ import {
 } from './mcp/image-tools.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SUGGESTED_PROMPTS, STATUS_MESSAGES } from './prompts.js';
-import { buildSuggestedPrompts } from './home/builders/suggested-prompts.js';
+import { pickPrompts } from './home/builders/suggested-prompts.js';
+import { recordPromptsShown } from '../db/addie-prompt-telemetry-db.js';
 import { AddieModelConfig } from '../config/models.js';
 import { getMemberContext, formatMemberContextForPrompt, type MemberContext } from './member-context.js';
 import { checkForSensitiveTopics } from './sensitive-topics.js';
@@ -475,7 +476,12 @@ async function getDynamicSuggestedPrompts(userId: string): Promise<SuggestedProm
   try {
     const memberContext = await getMemberContext(userId);
     const userIsAdmin = await isSlackUserAAOAdmin(userId);
-    return buildSuggestedPrompts(memberContext, userIsAdmin).map((p) => ({
+    const { prompts, ruleIds } = pickPrompts(memberContext, userIsAdmin);
+    const workosUserId = memberContext?.workos_user?.workos_user_id;
+    if (workosUserId && ruleIds.length > 0) {
+      void recordPromptsShown(workosUserId, ruleIds);
+    }
+    return prompts.map((p) => ({
       title: p.label,
       message: p.prompt,
     }));

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -119,9 +119,13 @@ export const MEMBER_RULES: PromptRule[] = [
     label: 'Join AgenticAdvertising.org',
     prompt: 'How do I join, and what do I get?',
   },
+  // Persona rules use decay: false because they're not nudges — they're
+  // a stable entry point reflecting who the user is. Suppressing them
+  // would leave the user with strictly worse fallbacks for their persona.
   {
     id: 'persona.molecule_builder',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) && persona(memberContext) === 'molecule_builder',
     label: 'Build a sales agent',
@@ -130,6 +134,7 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'persona.pragmatic_builder',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) && persona(memberContext) === 'pragmatic_builder',
     label: 'Fastest path to AdCP',
@@ -138,6 +143,7 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'persona.data_decoder',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) => isMember(memberContext) && persona(memberContext) === 'data_decoder',
     label: 'Prove the outcomes',
     prompt: 'How do I measure agentic vs. traditional and prove AdCP improves outcomes?',
@@ -145,6 +151,7 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'persona.resops_integrator',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) && persona(memberContext) === 'resops_integrator',
     label: 'Fit AdCP into my stack',
@@ -153,6 +160,7 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'persona.ladder_or_simple_starter',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) &&
       (persona(memberContext) === 'ladder_climber' ||
@@ -163,6 +171,7 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'persona.pureblood_protector',
     priority: 90,
+    decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) && persona(memberContext) === 'pureblood_protector',
     label: 'Brand safety controls',

--- a/server/src/addie/home/builders/rules/types.ts
+++ b/server/src/addie/home/builders/rules/types.ts
@@ -11,4 +11,11 @@ export interface PromptRule {
   when: (ctx: PromptRuleContext) => boolean;
   label: string;
   prompt: string;
+  /**
+   * When false, this rule is exempt from auto-suppression — it can fire
+   * on every render even if the user has seen it many times. Use for
+   * persona-anchored prompts where the user expects a stable entry
+   * point rather than a one-time nudge.
+   */
+  decay?: boolean;
 }

--- a/server/src/addie/home/builders/suggested-prompts.ts
+++ b/server/src/addie/home/builders/suggested-prompts.ts
@@ -5,22 +5,44 @@ import type { PromptRule } from './rules/types.js';
 
 const MAX_PROMPTS = 4;
 
+/**
+ * Pick the top N rules to show this user. Returns both the rendered
+ * prompts and the rule IDs so callers can record telemetry for the
+ * suppression layer.
+ */
+export function pickPrompts(
+  memberContext: MemberContext | null,
+  isAdmin: boolean,
+): { prompts: SuggestedPrompt[]; ruleIds: string[] } {
+  const rules = isAdmin ? ADMIN_RULES : MEMBER_RULES;
+  return evaluate(rules, { memberContext, isAdmin });
+}
+
+/**
+ * Convenience wrapper for callers that only need the rendered prompts.
+ */
 export function buildSuggestedPrompts(
   memberContext: MemberContext | null,
-  isAdmin: boolean
+  isAdmin: boolean,
 ): SuggestedPrompt[] {
-  if (isAdmin) {
-    return evaluate(ADMIN_RULES, { memberContext, isAdmin });
-  }
-  return evaluate(MEMBER_RULES, { memberContext, isAdmin });
+  return pickPrompts(memberContext, isAdmin).prompts;
 }
 
 function evaluate(
   rules: PromptRule[],
-  ctx: { memberContext: MemberContext | null; isAdmin: boolean }
-): SuggestedPrompt[] {
+  ctx: { memberContext: MemberContext | null; isAdmin: boolean },
+): { prompts: SuggestedPrompt[]; ruleIds: string[] } {
+  const now = Date.now();
+  const telemetry = ctx.memberContext?.prompt_telemetry;
+
   const matched = rules
     .filter((r) => {
+      // Skip suppressed rules first — cheap check, avoids running the
+      // rule's predicate when we know we won't pick it anyway.
+      const t = telemetry?.get(r.id);
+      if (t?.suppressed_until && t.suppressed_until.getTime() > now) {
+        return false;
+      }
       try {
         return r.when(ctx);
       } catch {
@@ -29,15 +51,20 @@ function evaluate(
     })
     .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id));
 
-  const seen = new Set<string>();
-  const picked: SuggestedPrompt[] = [];
+  const seenLabels = new Set<string>();
+  const prompts: SuggestedPrompt[] = [];
+  const ruleIds: string[] = [];
   for (const rule of matched) {
-    if (seen.has(rule.label)) continue;
-    seen.add(rule.label);
-    picked.push({ label: rule.label, prompt: rule.prompt });
-    if (picked.length >= MAX_PROMPTS) break;
+    if (seenLabels.has(rule.label)) continue;
+    seenLabels.add(rule.label);
+    prompts.push({ label: rule.label, prompt: rule.prompt });
+    ruleIds.push(rule.id);
+    if (prompts.length >= MAX_PROMPTS) break;
   }
   // Web home renders these in a 2-column grid; an odd count leaves a stray cell.
-  if (picked.length % 2 !== 0) picked.pop();
-  return picked;
+  if (prompts.length % 2 !== 0) {
+    prompts.pop();
+    ruleIds.pop();
+  }
+  return { prompts, ruleIds };
 }

--- a/server/src/addie/home/builders/suggested-prompts.ts
+++ b/server/src/addie/home/builders/suggested-prompts.ts
@@ -38,10 +38,13 @@ function evaluate(
   const matched = rules
     .filter((r) => {
       // Skip suppressed rules first — cheap check, avoids running the
-      // rule's predicate when we know we won't pick it anyway.
-      const t = telemetry?.get(r.id);
-      if (t?.suppressed_until && t.suppressed_until.getTime() > now) {
-        return false;
+      // rule's predicate when we know we won't pick it anyway. Rules
+      // with decay: false are exempt and never get suppressed.
+      if (r.decay !== false) {
+        const t = telemetry?.get(r.id);
+        if (t?.suppressed_until && t.suppressed_until.getTime() > now) {
+          return false;
+        }
       }
       try {
         return r.when(ctx);
@@ -52,19 +55,19 @@ function evaluate(
     .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id));
 
   const seenLabels = new Set<string>();
-  const prompts: SuggestedPrompt[] = [];
-  const ruleIds: string[] = [];
+  const picked: PromptRule[] = [];
   for (const rule of matched) {
     if (seenLabels.has(rule.label)) continue;
     seenLabels.add(rule.label);
-    prompts.push({ label: rule.label, prompt: rule.prompt });
-    ruleIds.push(rule.id);
-    if (prompts.length >= MAX_PROMPTS) break;
+    picked.push(rule);
+    if (picked.length >= MAX_PROMPTS) break;
   }
   // Web home renders these in a 2-column grid; an odd count leaves a stray cell.
-  if (prompts.length % 2 !== 0) {
-    prompts.pop();
-    ruleIds.pop();
-  }
+  if (picked.length % 2 !== 0) picked.pop();
+
+  // ruleIds returned to callers excludes decay: false rules — those should
+  // not be recorded in telemetry, since they're exempt from suppression.
+  const prompts = picked.map((r) => ({ label: r.label, prompt: r.prompt }));
+  const ruleIds = picked.filter((r) => r.decay !== false).map((r) => r.id);
   return { prompts, ruleIds };
 }

--- a/server/src/addie/home/home-service.ts
+++ b/server/src/addie/home/home-service.ts
@@ -14,7 +14,8 @@ import { buildQuickActions } from './builders/quick-actions.js';
 import { buildActivityFeed } from './builders/activity.js';
 import { buildStats } from './builders/stats.js';
 import { buildAdminPanel } from './builders/admin.js';
-import { buildSuggestedPrompts } from './builders/suggested-prompts.js';
+import { pickPrompts } from './builders/suggested-prompts.js';
+import { recordPromptsShown } from '../../db/addie-prompt-telemetry-db.js';
 import { logger } from '../../logger.js';
 
 export interface GetHomeContentOptions {
@@ -61,8 +62,14 @@ export async function getHomeContent(
   // Build synchronous sections
   const greeting = buildGreeting(memberContext);
   const quickActions = buildQuickActions(memberContext, isAAOAdmin);
-  const suggestedPrompts = buildSuggestedPrompts(memberContext, isAAOAdmin);
+  const { prompts: suggestedPrompts, ruleIds: shownRuleIds } = pickPrompts(memberContext, isAAOAdmin);
   const stats = buildStats(memberContext);
+
+  // Fire-and-forget: increment shown_count for the rules we just picked.
+  const workosUserId = memberContext.workos_user?.workos_user_id;
+  if (workosUserId && shownRuleIds.length > 0) {
+    void recordPromptsShown(workosUserId, shownRuleIds);
+  }
 
   const content: HomeContent = {
     greeting,

--- a/server/src/addie/home/web-home-service.ts
+++ b/server/src/addie/home/web-home-service.ts
@@ -13,7 +13,8 @@ import { buildQuickActions } from './builders/quick-actions.js';
 import { buildActivityFeed } from './builders/activity.js';
 import { buildStats } from './builders/stats.js';
 import { buildAdminPanel } from './builders/admin.js';
-import { buildSuggestedPrompts } from './builders/suggested-prompts.js';
+import { pickPrompts } from './builders/suggested-prompts.js';
+import { recordPromptsShown } from '../../db/addie-prompt-telemetry-db.js';
 import { logger } from '../../logger.js';
 
 /**
@@ -41,8 +42,13 @@ export async function getWebHomeContent(workosUserId: string): Promise<HomeConte
   // Build synchronous sections
   const greeting = buildGreeting(memberContext);
   const quickActions = buildQuickActions(memberContext, userIsAdmin);
-  const suggestedPrompts = buildSuggestedPrompts(memberContext, userIsAdmin);
+  const { prompts: suggestedPrompts, ruleIds: shownRuleIds } = pickPrompts(memberContext, userIsAdmin);
   const stats = buildStats(memberContext);
+
+  // Fire-and-forget telemetry for the suppression layer.
+  if (shownRuleIds.length > 0) {
+    void recordPromptsShown(workosUserId, shownRuleIds);
+  }
 
   const content: HomeContent = {
     greeting,

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -13,6 +13,7 @@ import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { JoinRequestDatabase } from '../db/join-request-db.js';
 import { OrgKnowledgeDatabase } from '../db/org-knowledge-db.js';
+import { getTelemetryForUser } from '../db/addie-prompt-telemetry-db.js';
 import { getThreadService } from './thread-service.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { isDevModeEnabled, DEV_USERS } from '../middleware/auth.js';
@@ -342,6 +343,17 @@ export interface MemberContext {
     /** Fraction (0–1) of org members who belong to at least one working group. */
     team_wg_coverage: number;
   };
+
+  /**
+   * Per-rule telemetry for the suggested-prompts evaluator. Lets rules
+   * suppress themselves after being shown without action. Map is keyed
+   * by rule_id; absent keys mean the rule has never been shown.
+   */
+  prompt_telemetry?: Map<string, {
+    shown_count: number;
+    last_shown_at: Date | null;
+    suppressed_until: Date | null;
+  }>;
 }
 
 /**
@@ -557,6 +569,13 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
       logger.warn({ error, organizationId }, 'Addie: Failed to compute adoption signals');
     }
 
+    // Per-rule telemetry for the prompt evaluator's suppression layer.
+    try {
+      context.prompt_telemetry = await getTelemetryForUser(workosUserId);
+    } catch (error) {
+      logger.warn({ error, workosUserId }, 'Addie: Failed to load prompt telemetry');
+    }
+
     // Process subscription info
     if (subscriptionInfo && subscriptionInfo.status !== 'none') {
       context.subscription = {
@@ -753,6 +772,12 @@ async function resolveContextFromLocalDb(
     };
   } catch (error) {
     logger.warn({ error, organizationId }, 'Addie Web: Failed to compute adoption signals');
+  }
+
+  try {
+    context.prompt_telemetry = await getTelemetryForUser(workosUserId);
+  } catch (error) {
+    logger.warn({ error, workosUserId }, 'Addie Web: Failed to load prompt telemetry');
   }
 
   try {

--- a/server/src/db/addie-prompt-telemetry-db.ts
+++ b/server/src/db/addie-prompt-telemetry-db.ts
@@ -1,0 +1,102 @@
+/**
+ * Addie suggested-prompts telemetry.
+ *
+ * Tracks how many times each rule has been shown to each user so the
+ * evaluator can suppress rules that have been ignored. The actual
+ * suppression decision is made in the application layer; this module
+ * only persists the counters.
+ */
+
+import { query } from './client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('addie-prompt-telemetry-db');
+
+export interface PromptTelemetryRow {
+  rule_id: string;
+  shown_count: number;
+  last_shown_at: Date | null;
+  suppressed_until: Date | null;
+}
+
+/**
+ * Read all telemetry rows for a single user. Returned as a map keyed by
+ * rule_id for cheap lookup in the evaluator.
+ */
+export async function getTelemetryForUser(
+  workosUserId: string,
+): Promise<Map<string, PromptTelemetryRow>> {
+  const result = await query<PromptTelemetryRow>(
+    `SELECT rule_id, shown_count, last_shown_at, suppressed_until
+       FROM addie_prompt_telemetry
+       WHERE workos_user_id = $1`,
+    [workosUserId],
+  );
+  const map = new Map<string, PromptTelemetryRow>();
+  for (const row of result.rows) {
+    map.set(row.rule_id, {
+      rule_id: row.rule_id,
+      shown_count: Number(row.shown_count),
+      last_shown_at: row.last_shown_at ? new Date(row.last_shown_at) : null,
+      suppressed_until: row.suppressed_until ? new Date(row.suppressed_until) : null,
+    });
+  }
+  return map;
+}
+
+/**
+ * Increment shown_count for a batch of rules just shown to the user.
+ * Sets last_shown_at to NOW(). When shown_count crosses the suppression
+ * threshold, sets suppressed_until.
+ *
+ * Fire-and-forget: callers don't await the result.
+ */
+export async function recordPromptsShown(
+  workosUserId: string,
+  ruleIds: string[],
+  options: {
+    /** Suppress the rule once it's been shown this many times. */
+    suppressAfterShows?: number;
+    /** How long to suppress for once the threshold is hit. */
+    suppressForDays?: number;
+  } = {},
+): Promise<void> {
+  if (!workosUserId || ruleIds.length === 0) return;
+  const suppressAfterShows = options.suppressAfterShows ?? 5;
+  const suppressForDays = options.suppressForDays ?? 30;
+
+  try {
+    // Upsert each rule's row. We don't bulk-insert because the suppression
+    // calc needs the prior shown_count to decide whether to set
+    // suppressed_until on this write.
+    await Promise.all(
+      ruleIds.map((ruleId) =>
+        query(
+          `INSERT INTO addie_prompt_telemetry
+             (workos_user_id, rule_id, shown_count, last_shown_at)
+           VALUES ($1, $2, 1, NOW())
+           ON CONFLICT (workos_user_id, rule_id) DO UPDATE SET
+             shown_count = addie_prompt_telemetry.shown_count + 1,
+             last_shown_at = NOW(),
+             suppressed_until = CASE
+               WHEN addie_prompt_telemetry.shown_count + 1 >= $3
+                 THEN NOW() + ($4 || ' days')::interval
+               ELSE addie_prompt_telemetry.suppressed_until
+             END`,
+          [workosUserId, ruleId, suppressAfterShows, String(suppressForDays)],
+        ),
+      ),
+    );
+  } catch (error) {
+    logger.warn({ error, workosUserId, ruleIds }, 'Failed to record prompt telemetry');
+  }
+}
+
+/**
+ * Reset telemetry for a user — used by tests and for admin debugging.
+ */
+export async function resetTelemetryForUser(workosUserId: string): Promise<void> {
+  await query(`DELETE FROM addie_prompt_telemetry WHERE workos_user_id = $1`, [
+    workosUserId,
+  ]);
+}

--- a/server/src/db/addie-prompt-telemetry-db.ts
+++ b/server/src/db/addie-prompt-telemetry-db.ts
@@ -46,8 +46,15 @@ export async function getTelemetryForUser(
 
 /**
  * Increment shown_count for a batch of rules just shown to the user.
- * Sets last_shown_at to NOW(). When shown_count crosses the suppression
- * threshold, sets suppressed_until.
+ *
+ * Counting is bucketed by UTC day: the same rule shown to the same user
+ * multiple times in one day counts once. Without this, a Slack user who
+ * opens App Home and starts a few Assistant threads in a workday would
+ * burn through the suppression threshold without ever consciously
+ * reading the prompt.
+ *
+ * When shown_count crosses the suppression threshold (counted in days,
+ * not impressions), sets suppressed_until to NOW() + suppressForDays.
  *
  * Fire-and-forget: callers don't await the result.
  */
@@ -55,7 +62,7 @@ export async function recordPromptsShown(
   workosUserId: string,
   ruleIds: string[],
   options: {
-    /** Suppress the rule once it's been shown this many times. */
+    /** Suppress the rule once it's been shown on this many distinct days. */
     suppressAfterShows?: number;
     /** How long to suppress for once the threshold is hit. */
     suppressForDays?: number;
@@ -66,26 +73,32 @@ export async function recordPromptsShown(
   const suppressForDays = options.suppressForDays ?? 30;
 
   try {
-    // Upsert each rule's row. We don't bulk-insert because the suppression
-    // calc needs the prior shown_count to decide whether to set
-    // suppressed_until on this write.
-    await Promise.all(
-      ruleIds.map((ruleId) =>
-        query(
-          `INSERT INTO addie_prompt_telemetry
-             (workos_user_id, rule_id, shown_count, last_shown_at)
-           VALUES ($1, $2, 1, NOW())
-           ON CONFLICT (workos_user_id, rule_id) DO UPDATE SET
-             shown_count = addie_prompt_telemetry.shown_count + 1,
-             last_shown_at = NOW(),
-             suppressed_until = CASE
-               WHEN addie_prompt_telemetry.shown_count + 1 >= $3
-                 THEN NOW() + ($4 || ' days')::interval
-               ELSE addie_prompt_telemetry.suppressed_until
-             END`,
-          [workosUserId, ruleId, suppressAfterShows, String(suppressForDays)],
-        ),
-      ),
+    // One bulk upsert via unnest — turns N rule writes into a single
+    // round trip. The CASE expressions implement per-day bucketing:
+    // shown_count only increments if last_shown_at is NULL or before
+    // today (UTC). last_shown_at always advances so callers can tell
+    // when the prompt was last surfaced.
+    await query(
+      `INSERT INTO addie_prompt_telemetry
+         (workos_user_id, rule_id, shown_count, last_shown_at)
+       SELECT $1, rule_id, 1, NOW()
+       FROM unnest($2::text[]) AS rule_id
+       ON CONFLICT (workos_user_id, rule_id) DO UPDATE SET
+         shown_count = CASE
+           WHEN addie_prompt_telemetry.last_shown_at IS NULL
+             OR addie_prompt_telemetry.last_shown_at < CURRENT_DATE
+           THEN addie_prompt_telemetry.shown_count + 1
+           ELSE addie_prompt_telemetry.shown_count
+         END,
+         last_shown_at = NOW(),
+         suppressed_until = CASE
+           WHEN (addie_prompt_telemetry.last_shown_at IS NULL
+             OR addie_prompt_telemetry.last_shown_at < CURRENT_DATE)
+             AND addie_prompt_telemetry.shown_count + 1 >= $3
+           THEN NOW() + make_interval(days => $4)
+           ELSE addie_prompt_telemetry.suppressed_until
+         END`,
+      [workosUserId, ruleIds, suppressAfterShows, suppressForDays],
     );
   } catch (error) {
     logger.warn({ error, workosUserId, ruleIds }, 'Failed to record prompt telemetry');

--- a/server/src/db/migrations/436_addie_prompt_telemetry.sql
+++ b/server/src/db/migrations/436_addie_prompt_telemetry.sql
@@ -1,0 +1,25 @@
+-- Telemetry for Addie's suggested-prompt rules engine.
+--
+-- Without per-user-per-rule history, every activation rule fires
+-- indefinitely until the underlying signal flips. An owner who
+-- intentionally doesn't list their company in the directory still sees
+-- "List my company in the directory" forever. The rules engine reads
+-- this table to suppress prompts that have been shown enough times
+-- without action.
+--
+-- One row per (user, rule). Updated on every render that picks the
+-- rule. Suppression is computed in the application layer based on
+-- shown_count and last_shown_at; suppressed_until is the cached
+-- decision so the evaluator stays fast.
+
+CREATE TABLE IF NOT EXISTS addie_prompt_telemetry (
+  workos_user_id   VARCHAR(255) NOT NULL,
+  rule_id          VARCHAR(255) NOT NULL,
+  shown_count      INTEGER      NOT NULL DEFAULT 0,
+  last_shown_at    TIMESTAMPTZ,
+  suppressed_until TIMESTAMPTZ,
+  PRIMARY KEY (workos_user_id, rule_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_addie_prompt_telemetry_user
+  ON addie_prompt_telemetry (workos_user_id);

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -424,6 +424,29 @@ describe('buildSuggestedPrompts', () => {
       expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Complete my profile');
     });
 
+    it('does not suppress persona prompts even with high shown_count', () => {
+      const ctx = makeMember({
+        persona: { persona: 'data_decoder', aspiration_persona: null, source: 'assessment', journey_stage: null },
+        prompt_telemetry: new Map([
+          ['persona.data_decoder', {
+            shown_count: 100,
+            last_shown_at: DAYS_AGO(1),
+            suppressed_until: new Date(NOW.getTime() + 365 * 24 * 60 * 60 * 1000),
+          }],
+        ]),
+      });
+      // Persona rules have decay: false, so suppressed_until is ignored.
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Prove the outcomes');
+    });
+
+    it('persona ruleIds are excluded from telemetry recording', () => {
+      const ctx = makeMember({
+        persona: { persona: 'data_decoder', aspiration_persona: null, source: 'assessment', journey_stage: null },
+      });
+      const { ruleIds } = pickPrompts(ctx, false);
+      expect(ruleIds.every((id) => !id.startsWith('persona.'))).toBe(true);
+    });
+
     it('suppression of a high-priority rule lets the next-priority rule fire', () => {
       const ctx = makeMember({
         community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildSuggestedPrompts } from '../../src/addie/home/builders/suggested-prompts.js';
+import { buildSuggestedPrompts, pickPrompts } from '../../src/addie/home/builders/suggested-prompts.js';
 import type { MemberContext } from '../../src/addie/member-context.js';
 
 const NOW = new Date('2026-04-23T12:00:00Z');
@@ -384,6 +384,75 @@ describe('buildSuggestedPrompts', () => {
       });
       const prompts = buildSuggestedPrompts(ctx, false);
       expect(prompts.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('suppression via prompt_telemetry', () => {
+    it('suppresses a rule whose suppressed_until is in the future', () => {
+      const ctx = makeMember({
+        community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
+        prompt_telemetry: new Map([
+          ['profile.incomplete', {
+            shown_count: 5,
+            last_shown_at: DAYS_AGO(1),
+            suppressed_until: new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1000),
+          }],
+        ]),
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Complete my profile');
+    });
+
+    it('does not suppress a rule whose suppressed_until is in the past', () => {
+      const ctx = makeMember({
+        community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
+        prompt_telemetry: new Map([
+          ['profile.incomplete', {
+            shown_count: 5,
+            last_shown_at: DAYS_AGO(60),
+            suppressed_until: DAYS_AGO(1),
+          }],
+        ]),
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Complete my profile');
+    });
+
+    it('does not suppress when telemetry is missing', () => {
+      const ctx = makeMember({
+        community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
+        prompt_telemetry: undefined,
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Complete my profile');
+    });
+
+    it('suppression of a high-priority rule lets the next-priority rule fire', () => {
+      const ctx = makeMember({
+        community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
+        working_groups: [],
+        prompt_telemetry: new Map([
+          ['profile.incomplete', {
+            shown_count: 5,
+            last_shown_at: DAYS_AGO(1),
+            suppressed_until: new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1000),
+          }],
+        ]),
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      expect(labels).not.toContain('Complete my profile');
+      // Find a working group fires once profile is suppressed.
+      expect(labels).toContain('Find a working group');
+    });
+  });
+
+  describe('pickPrompts', () => {
+    it('returns parallel prompts and ruleIds arrays', () => {
+      const { prompts, ruleIds } = pickPrompts(makeMember(), false);
+      expect(prompts).toHaveLength(ruleIds.length);
+      ruleIds.forEach((id) => expect(typeof id).toBe('string'));
+    });
+
+    it('admin path returns admin rule IDs', () => {
+      const { ruleIds } = pickPrompts(makeMember(), true);
+      expect(ruleIds.every((id) => id.startsWith('admin.'))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds per-user-per-rule telemetry so activation prompts can suppress themselves after being shown without action — closes #3282.
- Counting is **bucketed by UTC day** so a Slack user opening App Home a few times in a workday doesn't burn the threshold without ever consciously reading the prompt.
- **Persona rules are exempt** (\`decay: false\`) — they're stable entry points, not nudges.
- All 4 surfaces (Slack Assistant, App Home, Web Home, legacy wrappers) use the new \`pickPrompts()\` and record telemetry fire-and-forget.

## Reviews applied
- **Code reviewer**: bulk upsert via \`unnest(\$2::text[])\` (4 round trips → 1), \`make_interval(days => \$4)\` instead of string concat.
- **Product reviewer**: per-day bucketing fixes the \"5 raw shows in one workday\" trap; persona rules exempted from suppression.

## What's in
- Migration 436: \`addie_prompt_telemetry\` keyed on \`(workos_user_id, rule_id)\`.
- DB layer: \`getTelemetryForUser\` + bulk \`recordPromptsShown\`.
- \`MemberContext.prompt_telemetry\` hydrated in both Slack and web flows; benefits from existing 30-min context cache.
- Evaluator skips suppressed rules before running their predicate; \`PromptRule.decay\` flag controls whether a rule participates.
- 8 new tests covering suppression, persona-exempt, and \`pickPrompts\` API.

## Out of scope
- Dismissal UI (no Slack/web button surface yet)
- Per-rule decay configuration (single global default for now)
- \"Acted on\" tracking — when the gating signal flips, the rule's \`when()\` returns false naturally.

## Test plan
- [x] 52 unit tests pass (was 44 before, +8 covering decay)
- [x] Pre-commit hooks pass (unit + typecheck)
- [x] DB layer reviewed for SQL injection / race conditions (bulk upsert with \`ON CONFLICT DO UPDATE\` is concurrency-safe)
- [ ] Verify in staging: open Addie home 6 days in a row without acting on a non-persona prompt → confirm it disappears on day 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)