### PR TITLE
fix(boot): drop GCP KMS eager-init at boot

### DIFF
--- a/.changeset/revert-kms-eager-init.md
+++ b/.changeset/revert-kms-eager-init.md
@@ -1,0 +1,17 @@
+---
+---
+
+fix(boot): drop GCP KMS eager-init at boot
+
+The eager-init added in #3283 took down the prod deploy: when KMS auth is
+misconfigured, the gRPC client retries forever inside `getPublicKey`, the app
+never binds port 8080, and Fly's health-check times out without surfacing the
+underlying KMS error.
+
+Lazy init in `getGcpKmsSigningProvider()` is the safer default — a broken
+signing path fails per-call (logged + generic message to LLM via the
+call-site try/catch in `adcp-tools.ts`) while the rest of the server boots
+normally so operators can SSH in and inspect.
+
+Re-enabling eager init needs either a hard timeout on the `getPublicKey`
+round-trip or a deploy-time probe outside the boot critical path.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,19 +25,11 @@ async function main() {
     }
   }
 
-  // Eager-init the GCP KMS signing provider before binding the port. If the
-  // KMS env is set (production), a misconfiguration (bad SA, unreachable
-  // KMS, wrong algorithm, public-key tripwire mismatch) crashes the boot
-  // here — Fly never sees a healthy machine, the deploy rolls back. No-op
-  // when env is unset (dev). Lazy fallback in `getGcpKmsSigningProvider`
-  // still applies if anything bypasses this path.
-  try {
-    const { eagerInitGcpKmsSigningProvider } = await import('./security/gcp-kms-signer.js');
-    await eagerInitGcpKmsSigningProvider();
-  } catch (error) {
-    logger.fatal({ err: error }, 'GCP KMS signing provider failed eager init at boot');
-    process.exit(1);
-  }
+  // GCP KMS signing provider initializes lazily on first signed AdCP call
+  // (see security/gcp-kms-signer.ts). Eager-init at boot was tried and
+  // pulled — when KMS auth is misconfigured, the gRPC client retries
+  // forever and the app never binds port 8080, taking down the whole
+  // deploy instead of just the signing path. Lazy is the safer default.
 
   // Start HTTP server first, then initialize Addie in the background.
   // initializeAddieBolt uses execSync (git clone) which blocks the event loop,


### PR DESCRIPTION
Hotfix for #3283 deploy failure. Eager-init at boot took down prod: KMS auth misconfig caused gRPC to retry forever inside getPublicKey, app never bound port 8080, Fly health-check timed out. Reverts only the eager-init block; all other review fixes stay. Lazy init is safer default — server boots, signing path fails per-call with structured log + generic message.