### PR TITLE
feat(addie): Continue certification prompt for in-progress learners

### DIFF
--- a/.changeset/addie-cert-continuation.md
+++ b/.changeset/addie-cert-continuation.md
@@ -1,0 +1,13 @@
+---
+---
+
+Stage 2 of persona-driven Addie suggested prompts (#2299) — Piia's flagship example: a learner mid-certification gets a "Continue certification" prompt at the top of Addie's home.
+
+- Adds `MemberContext.certification` (track_id, module_id, status, started_at, last_activity_at) hydrated in both Slack and web flows.
+- New `getLatestAttempt(userId)` query (LIMIT 1, prefers in-progress) replaces a full-scan call to `getUserAttempts`.
+- New rule `cert.continue_in_progress` at priority **93** (above lapsed at 92 — a concrete unfinished thing beats generic re-engagement when both signals are present).
+- **Decay-exempt** like persona prompts: re-engaging a stalled learner is exactly the high-value case; don't auto-suppress.
+- **Freshness guard**: only fires when `started_at` is within the last 45 days. Past that, the learner has likely moved on and the lapsed-re-engagement rule (or low-login) handles re-entry better than nudging about an abandoned artifact.
+- Gates `persona.ladder_or_simple_starter` ("Start with the Academy") to skip when the learner is already mid-cert — "Continue certification" is the more accurate prompt at that point.
+
+Out of scope (filed for follow-up): dynamic per-module label like "Continue A1" — needs `PromptRule.label`/`prompt` to accept a function, which is a broader refactor.

--- a/server/scripts/prompt-scenarios.ts
+++ b/server/scripts/prompt-scenarios.ts
@@ -85,6 +85,10 @@ show('Compound: lapsed Explorer owner, persona, no WG, incomplete profile', base
   persona: { persona: 'data_decoder', aspiration_persona: null, source: 'assessment', journey_stage: null },
   engagement: { login_count_30d: 0, last_login: ago(60), working_group_count: 0, email_click_count_30d: 0, interest_level: null },
 }));
+show('Learner mid-certification', base({
+  certification: { track_id: 'A', module_id: 'A1', status: 'in_progress', started_at: ago(7), last_activity_at: ago(2) },
+  community_profile: { is_public: false, slug: null, completeness: 40, github_username: null },
+}));
 show('Brand new member, day 2, no persona', base({
   working_groups: [],
   community_profile: { is_public: false, slug: null, completeness: 10, github_username: null },

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -43,6 +43,19 @@ function isLapsed(ctx: MemberContext | null): boolean {
   return sinceLogin > THIRTY_DAYS_MS && sinceLogin < 3 * THIRTY_DAYS_MS;
 }
 
+/**
+ * True when the user has an in-progress certification attempt that's
+ * fresh enough to "continue." Started >45 days ago without completion
+ * usually means the learner has moved on; nudging them about it is
+ * stale-state behaviour, not re-engagement.
+ */
+function hasFreshInProgressCertification(ctx: MemberContext | null): boolean {
+  const cert = ctx?.certification;
+  if (!cert || cert.status !== 'in_progress') return false;
+  const age = Date.now() - new Date(cert.started_at).getTime();
+  return age < 45 * 24 * 60 * 60 * 1000;
+}
+
 function isLowLoginActive(ctx: MemberContext | null): boolean {
   const last = lastLoginMs(ctx);
   if (last === null) return false;
@@ -161,10 +174,15 @@ export const MEMBER_RULES: PromptRule[] = [
     id: 'persona.ladder_or_simple_starter',
     priority: 90,
     decay: false,
-    when: ({ memberContext }) =>
-      isMember(memberContext) &&
-      (persona(memberContext) === 'ladder_climber' ||
-        persona(memberContext) === 'simple_starter'),
+    when: ({ memberContext }) => {
+      if (!isMember(memberContext)) return false;
+      const p = persona(memberContext);
+      if (p !== 'ladder_climber' && p !== 'simple_starter') return false;
+      // Once the learner is in a certification, "Continue certification"
+      // (id: cert.continue_in_progress) is more accurate than "Start with
+      // the Academy."
+      return !hasFreshInProgressCertification(memberContext);
+    },
     label: 'Start with the Academy',
     prompt: 'Which Academy module should I start with?',
   },
@@ -192,6 +210,18 @@ export const MEMBER_RULES: PromptRule[] = [
       memberContext?.organization?.membership_tier === 'individual_academic',
     label: 'Upgrade for Slack & working group access',
     prompt: 'What do I get if I upgrade from Explorer?',
+  },
+  {
+    id: 'cert.continue_in_progress',
+    priority: 93,
+    // Never auto-suppress: re-engaging a stalled learner is exactly the
+    // high-value case. The 45-day freshness guard inside `when` handles
+    // genuinely abandoned attempts.
+    decay: false,
+    when: ({ memberContext }) =>
+      isMember(memberContext) && hasFreshInProgressCertification(memberContext),
+    label: 'Continue certification',
+    prompt: 'Pick up where I left off in certification.',
   },
   {
     id: 'profile.incomplete',

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -14,6 +14,7 @@ import { AddieDatabase } from '../db/addie-db.js';
 import { JoinRequestDatabase } from '../db/join-request-db.js';
 import { OrgKnowledgeDatabase } from '../db/org-knowledge-db.js';
 import { getTelemetryForUser } from '../db/addie-prompt-telemetry-db.js';
+import { getLatestAttempt } from '../db/certification-db.js';
 import { getThreadService } from './thread-service.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { isDevModeEnabled, DEV_USERS } from '../middleware/auth.js';
@@ -101,6 +102,32 @@ async function getPendingContentForUser(
   }
 
   return { total, by_committee: byCommittee };
+}
+
+/**
+ * Fetch the most recent certification attempt for the user — prefer a
+ * still-in-progress attempt so the "Continue certification" prompt
+ * always points at unfinished work; fall back to the most recent
+ * completed attempt for context.
+ *
+ * `last_activity_at` here means "started_at, or completed_at if completed."
+ * It's not a true last-touch timestamp (the schema doesn't track that),
+ * which is why the cert prompt rule uses a 45-day freshness guard against
+ * `started_at` rather than trying to infer engagement from this field.
+ */
+async function fetchCertification(
+  workosUserId: string,
+): Promise<MemberContext['certification']> {
+  const latest = await getLatestAttempt(workosUserId);
+  if (!latest) return undefined;
+  const lastActivityIso = latest.completed_at ?? latest.started_at;
+  return {
+    track_id: latest.track_id,
+    module_id: latest.module_id,
+    status: latest.status,
+    started_at: new Date(latest.started_at),
+    last_activity_at: new Date(lastActivityIso),
+  };
 }
 
 /**
@@ -345,6 +372,24 @@ export interface MemberContext {
   };
 
   /**
+   * Most recent certification attempt for this user, if any. Used by the
+   * "Continue certification" suggested-prompt rule and by Addie's tools
+   * to anchor learner conversations on the right module.
+   */
+  certification?: {
+    /** Track id (e.g. 'A', 'B') of the latest attempt. */
+    track_id: string;
+    /** Module id of the latest attempt (may be null for old rows). */
+    module_id: string | null;
+    /** Status of that attempt. */
+    status: 'in_progress' | 'passed' | 'failed';
+    /** When that attempt was started. */
+    started_at: Date;
+    /** When the user last touched the attempt — last completed_at if any, else started_at. */
+    last_activity_at: Date;
+  };
+
+  /**
    * Per-rule telemetry for the suggested-prompts evaluator. Lets rules
    * suppress themselves after being shown without action. Map is keyed
    * by rule_id; absent keys mean the rule has never been shown.
@@ -576,6 +621,13 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
       logger.warn({ error, workosUserId }, 'Addie: Failed to load prompt telemetry');
     }
 
+    // Latest certification attempt — drives the "Continue certification" prompt.
+    try {
+      context.certification = await fetchCertification(workosUserId);
+    } catch (error) {
+      logger.warn({ error, workosUserId }, 'Addie: Failed to load certification context');
+    }
+
     // Process subscription info
     if (subscriptionInfo && subscriptionInfo.status !== 'none') {
       context.subscription = {
@@ -778,6 +830,12 @@ async function resolveContextFromLocalDb(
     context.prompt_telemetry = await getTelemetryForUser(workosUserId);
   } catch (error) {
     logger.warn({ error, workosUserId }, 'Addie Web: Failed to load prompt telemetry');
+  }
+
+  try {
+    context.certification = await fetchCertification(workosUserId);
+  } catch (error) {
+    logger.warn({ error, workosUserId }, 'Addie Web: Failed to load certification context');
   }
 
   try {

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -347,6 +347,23 @@ export async function getUserAttempts(userId: string): Promise<CertificationAtte
   return result.rows;
 }
 
+/**
+ * Latest attempt for a user, preferring in-progress over completed when both
+ * exist. Used to power the "Continue certification" suggested-prompt rule —
+ * we want the unfinished thing if there is one, else the most recent attempt
+ * for context.
+ */
+export async function getLatestAttempt(userId: string): Promise<CertificationAttempt | null> {
+  const result = await query<CertificationAttempt>(
+    `SELECT * FROM certification_attempts
+     WHERE workos_user_id = $1
+     ORDER BY (status = 'in_progress')::int DESC, created_at DESC
+     LIMIT 1`,
+    [userId]
+  );
+  return result.rows[0] ?? null;
+}
+
 export async function getUserCertifications(userId: string): Promise<CertificationAttempt[]> {
   const result = await query<CertificationAttempt>(
     `SELECT * FROM certification_attempts

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -322,6 +322,118 @@ describe('buildSuggestedPrompts', () => {
     });
   });
 
+  describe('certification continuation', () => {
+    it('shows Continue certification when a fresh attempt is in_progress', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'in_progress',
+          started_at: DAYS_AGO(7),
+          last_activity_at: DAYS_AGO(2),
+        },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Continue certification');
+    });
+
+    it('does not show the cert prompt when the latest attempt is passed', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'passed',
+          started_at: DAYS_AGO(30),
+          last_activity_at: DAYS_AGO(20),
+        },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+    });
+
+    it('does not show the cert prompt when the latest attempt is failed', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'failed',
+          started_at: DAYS_AGO(30),
+          last_activity_at: DAYS_AGO(20),
+        },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+    });
+
+    it('does not show the cert prompt when there is no attempt', () => {
+      const ctx = makeMember({ certification: undefined });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+    });
+
+    it('does not show the cert prompt when the attempt is older than 45 days (stale)', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'in_progress',
+          started_at: DAYS_AGO(60),
+          last_activity_at: DAYS_AGO(60),
+        },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+    });
+
+    it('cert continuation outranks profile completeness', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A', module_id: 'A1', status: 'in_progress',
+          started_at: DAYS_AGO(7), last_activity_at: DAYS_AGO(2),
+        },
+        community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      const certIdx = labels.indexOf('Continue certification');
+      const profileIdx = labels.indexOf('Complete my profile');
+      expect(certIdx).toBeGreaterThanOrEqual(0);
+      expect(profileIdx).toBeGreaterThanOrEqual(0);
+      expect(certIdx).toBeLessThan(profileIdx);
+    });
+
+    it('cert continuation outranks lapsed re-engagement (concrete unfinished thing wins)', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A', module_id: 'A1', status: 'in_progress',
+          started_at: DAYS_AGO(7), last_activity_at: DAYS_AGO(2),
+        },
+        engagement: { login_count_30d: 0, last_login: DAYS_AGO(60), working_group_count: 0, email_click_count_30d: 0, interest_level: null },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      const certIdx = labels.indexOf('Continue certification');
+      const lapsedIdx = labels.indexOf("What's new since you were last here?");
+      expect(certIdx).toBeGreaterThanOrEqual(0);
+      expect(lapsedIdx).toBeGreaterThanOrEqual(0);
+      expect(certIdx).toBeLessThan(lapsedIdx);
+    });
+
+    it('suppresses Start with the Academy persona prompt when learner is mid-cert', () => {
+      const ctx = makeMember({
+        persona: { persona: 'ladder_climber', aspiration_persona: null, source: 'assessment', journey_stage: null },
+        certification: {
+          track_id: 'A', module_id: 'A1', status: 'in_progress',
+          started_at: DAYS_AGO(7), last_activity_at: DAYS_AGO(2),
+        },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      expect(labels).toContain('Continue certification');
+      expect(labels).not.toContain('Start with the Academy');
+    });
+
+    it('still shows Start with the Academy when ladder_climber has no in-progress cert', () => {
+      const ctx = makeMember({
+        persona: { persona: 'ladder_climber', aspiration_persona: null, source: 'assessment', journey_stage: null },
+        certification: undefined,
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Start with the Academy');
+    });
+  });
+
   describe('profile and working groups', () => {
     it('shows Complete my profile when completeness < 80', () => {
       const ctx = makeMember({


### PR DESCRIPTION
## Summary
- Stage 2 of #2299, Piia's flagship example: a learner mid-cert sees "Continue certification" at the top of Addie's home.
- New \`MemberContext.certification\` block hydrated from \`certification_attempts\` (single \`LIMIT 1\` query that prefers in-progress).
- New rule \`cert.continue_in_progress\` at priority **93** — above lapsed re-engagement (92), because a concrete unfinished thing beats generic "what's new" when both signals fire.
- **Decay-exempt** + **45-day freshness guard**: never auto-suppresses (re-engaging a stalled learner is the high-value case), but doesn't fire for genuinely abandoned (>45-day-old) attempts — the lapsed and low-login rules handle re-entry better than nudging about an old artifact.
- **Persona override**: \`persona.ladder_or_simple_starter\` ("Start with the Academy") is gated off when the learner is mid-cert — "Continue certification" is the accurate prompt at that point.

## Reviews applied
- **Code reviewer**: replaced full-scan \`getUserAttempts\` with new \`getLatestAttempt\` (\`LIMIT 1\`), added \`failed\` status test, set \`decay: false\`.
- **Product expert**: added freshness guard for stale attempts; bumped priority 82 → 93 above lapsed; added persona override.
- **Education expert**: voice + dynamic-label feedback ("Continue A1" with track/module surfaced) deferred — needs \`PromptRule\` to support function labels, broader refactor; will file as follow-up.

## Test plan
- [x] 61 unit tests pass (was 56 pre-review; +5 covering freshness, failed status, persona override, lapsed-vs-cert priority)
- [x] Pre-commit hooks pass after \`npm install --safe-chain-skip-minimum-package-age\` (deps were stale)
- [x] Manual scenario walkthrough — \`Learner mid-certification\` correctly produces Continue cert → Profile → WG → Test agent
- [ ] Verify in staging: a real A1 learner sees the prompt; an abandoned 60-day-old attempt does not

## Out of scope (follow-up)
Dynamic per-module label ("Continue A1" instead of "Continue certification") — needs \`PromptRule.label\` and \`prompt\` to accept functions of context. Will file as a small refactor issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)