### PR TITLE
feat(addie): response post-process pipeline — strip end_turn fix, length cap, empty-response guard

### DIFF
--- a/.changeset/addie-length-postprocessor.md
+++ b/.changeset/addie-length-postprocessor.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds a deterministic length post-processor that fires on responses to short user questions. Sonnet's instinct toward thoroughness produces 250–350 word answers to 7–12 word challenges (priv-1, acct-1, acct-2, gap-1 in the redteam suite) even with response-style.md teaching it to match the conversational register. The teaching reduces mean length but doesn't enforce a ceiling — this is the floor. Fires when the user's question is ≤15 words AND the assistant response is >160 words; truncates at the nearest sentence boundary at or before 130 words and appends *"Happy to go deeper on any of this if useful."* Code blocks are kept whole, never cut mid-fence. Same shape as the existing `stripBannedRituals` post-processor — applied at the same four return sites in `claude-client.ts`. Idempotent.

--- a/.changeset/addie-strip-end-turn-textblocks.md
+++ b/.changeset/addie-strip-end-turn-textblocks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixes a missed code path in the banned-ritual stripper. Prod redteam against the just-deployed Sonnet+stripper combo showed 3 ritual-phrase leaks ("the honest answer is", "that's a fair question", "here's the honest answer") despite the stripper being in place. Tracing showed the strip was applied at three response-emission sites in `claude-client.ts` but missed a fourth: the `end_turn` path at line 763 that handles multi-text-block responses (used by web-search-returning answers). That path returned `text` unstripped to the caller. Now consistent with the other three return points — collect rawText, run through `stripBannedRituals`, return the cleaned form. No semantic change to non-end_turn paths.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -763,10 +763,11 @@ export class AddieClaudeClient {
       if (response.stop_reason === 'end_turn') {
         // Collect ALL text blocks (web search responses have multiple text blocks)
         const textBlocks = response.content.filter((c) => c.type === 'text');
-        const text = textBlocks
+        const rawText = textBlocks
           .map(block => block.type === 'text' ? block.text : '')
           .join('\n\n')
           .trim();
+        const text = stripBannedRituals(rawText);
 
         // Calculate total tool execution time from tool_executions
         totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -19,7 +19,7 @@ import { formatTokenCount, getConversationTokenLimit, buildDroppedMessagesSummar
 import { notifyToolError } from './error-notifier.js';
 import { ToolError } from './tool-error.js';
 import { checkCostCap, recordCost, formatCapExceededMessage } from './claude-cost-tracker.js';
-import { stripBannedRituals, truncateLongResponseToShortQuestion } from './response-postprocess.js';
+import { applyResponsePipeline } from './response-postprocess.js';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
@@ -767,7 +767,7 @@ export class AddieClaudeClient {
           .map(block => block.type === 'text' ? block.text : '')
           .join('\n\n')
           .trim();
-        const text = truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(rawText));
+        const text = applyResponsePipeline(userMessage, rawText);
 
         // Calculate total tool execution time from tool_executions
         totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
@@ -898,7 +898,7 @@ export class AddieClaudeClient {
         if (toolUseBlocks.length === 0 && serverToolBlocks.length === 0) {
           const textContent = response.content.find((c) => c.type === 'text');
           const rawText = textContent && textContent.type === 'text' ? textContent.text : "I'm not sure how to help with that.";
-          const text = truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(rawText));
+          const text = applyResponsePipeline(userMessage, rawText);
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
           return {
             text,
@@ -1420,7 +1420,7 @@ export class AddieClaudeClient {
           yield {
             type: 'done',
             response: {
-              text: truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(fullText)),
+              text: applyResponsePipeline(userMessage, fullText),
               tools_used: toolsUsed,
               tool_executions: toolExecutions,
               flagged: !!hallucinationReason,
@@ -1451,7 +1451,7 @@ export class AddieClaudeClient {
             yield {
               type: 'done',
               response: {
-                text: truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(fullText)),
+                text: applyResponsePipeline(userMessage, fullText),
                 tools_used: toolsUsed,
                 tool_executions: toolExecutions,
                 flagged: false,

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -19,7 +19,7 @@ import { formatTokenCount, getConversationTokenLimit, buildDroppedMessagesSummar
 import { notifyToolError } from './error-notifier.js';
 import { ToolError } from './tool-error.js';
 import { checkCostCap, recordCost, formatCapExceededMessage } from './claude-cost-tracker.js';
-import { stripBannedRituals } from './response-postprocess.js';
+import { stripBannedRituals, truncateLongResponseToShortQuestion } from './response-postprocess.js';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
@@ -767,7 +767,7 @@ export class AddieClaudeClient {
           .map(block => block.type === 'text' ? block.text : '')
           .join('\n\n')
           .trim();
-        const text = stripBannedRituals(rawText);
+        const text = truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(rawText));
 
         // Calculate total tool execution time from tool_executions
         totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
@@ -898,7 +898,7 @@ export class AddieClaudeClient {
         if (toolUseBlocks.length === 0 && serverToolBlocks.length === 0) {
           const textContent = response.content.find((c) => c.type === 'text');
           const rawText = textContent && textContent.type === 'text' ? textContent.text : "I'm not sure how to help with that.";
-          const text = stripBannedRituals(rawText);
+          const text = truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(rawText));
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
           return {
             text,
@@ -1420,7 +1420,7 @@ export class AddieClaudeClient {
           yield {
             type: 'done',
             response: {
-              text: stripBannedRituals(fullText),
+              text: truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(fullText)),
               tools_used: toolsUsed,
               tool_executions: toolExecutions,
               flagged: !!hallucinationReason,
@@ -1451,7 +1451,7 @@ export class AddieClaudeClient {
             yield {
               type: 'done',
               response: {
-                text: stripBannedRituals(fullText),
+                text: truncateLongResponseToShortQuestion(userMessage, stripBannedRituals(fullText)),
                 tools_used: toolsUsed,
                 tool_executions: toolExecutions,
                 flagged: false,

--- a/server/src/addie/response-postprocess.ts
+++ b/server/src/addie/response-postprocess.ts
@@ -112,3 +112,151 @@ export function stripBannedRituals(text: string): string {
  * that every literal would actually be stripped by the regex.
  */
 export const __test_BANNED_RITUAL_LITERALS = BANNED_RITUAL_LITERALS;
+
+// ---------------------------------------------------------------------------
+// Length post-processor: trim verbose responses to short questions
+// ---------------------------------------------------------------------------
+
+/**
+ * Word-count thresholds for the length post-processor.
+ *
+ * Sonnet's instinct toward thoroughness produces 250–350-word answers to
+ * 7–12-word challenges even with response-style.md teaching it to match
+ * the conversational register. Direct redteam confirmation across
+ * priv-1 / acct-1 / acct-2 / gap-1: the rule reduces mean length but
+ * doesn't enforce a ceiling. This module is the deterministic floor.
+ *
+ * Why these numbers:
+ * - 15-word user question: empirically the line where conversational
+ *   yes/no challenges and short open questions sit. Above this the
+ *   user is asking for something multi-part and length is justified.
+ * - 160-word response cap: matches the existing redteam shortQuestion
+ *   length_cap check, so the post-processor enforces what the suite
+ *   measures.
+ * - 130-word truncation target: leaves a buffer below the 160 cap so
+ *   the truncated form (plus the "go deeper?" suffix) lands well under.
+ */
+const SHORT_QUESTION_MAX_WORDS = 15;
+const RESPONSE_CAP_WORDS = 160;
+const TRUNCATION_TARGET_WORDS = 130;
+
+const TRUNCATION_SUFFIX = '\n\n*Happy to go deeper on any of this if useful.*';
+
+/** Count words in a string by whitespace splits, ignoring empty tokens. */
+function countWords(text: string): number {
+  if (!text) return 0;
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * If the question is short and the response runs long, truncate the response
+ * at the sentence boundary nearest TRUNCATION_TARGET_WORDS and append a
+ * "go deeper?" suffix. Otherwise return the response unchanged.
+ *
+ * Truncation behavior:
+ *
+ * - Splits the response into chunks alternating between [prose, code-fence,
+ *   prose, code-fence, ...]. Code fences are kept whole — never cut inside
+ *   ```fenced``` content; if including a fence would push us over the
+ *   target, we stop before the fence rather than mid-block.
+ * - For prose chunks, splits on sentence terminators (.!?) followed by
+ *   whitespace. Accumulates sentences until adding the next one would
+ *   exceed TRUNCATION_TARGET_WORDS, then stops.
+ * - If even the first sentence of the response already exceeds the target,
+ *   we keep that one sentence rather than returning empty — a single long
+ *   sentence is still better than no answer.
+ *
+ * Idempotent: running on already-truncated text leaves it unchanged
+ * (the truncated form is below the response cap by construction).
+ *
+ * @param question The user's most recent message text.
+ * @param text The assistant's response text (post-strip).
+ * @returns The original text, or a truncated form with a "go deeper?" suffix.
+ */
+export function truncateLongResponseToShortQuestion(
+  question: string,
+  text: string,
+): string {
+  if (!question || !text) return text;
+  const questionWords = countWords(question);
+  if (questionWords > SHORT_QUESTION_MAX_WORDS) return text;
+  const responseWords = countWords(text);
+  if (responseWords <= RESPONSE_CAP_WORDS) return text;
+
+  // Split on fenced code blocks so we never truncate inside one.
+  const parts = text.split(/(```[\s\S]*?```)/g);
+
+  let cumulativeWords = 0;
+  const kept: string[] = [];
+  let stopped = false;
+
+  for (let i = 0; i < parts.length && !stopped; i++) {
+    const part = parts[i];
+    const isCode = i % 2 === 1;
+
+    if (isCode) {
+      const blockWords = countWords(part);
+      if (kept.length === 0 || cumulativeWords + blockWords <= TRUNCATION_TARGET_WORDS) {
+        kept.push(part);
+        cumulativeWords += blockWords;
+      } else {
+        // Including this fence would push us over — stop before it.
+        stopped = true;
+      }
+      continue;
+    }
+
+    // Prose segment. Split into sentences and add until we hit the target.
+    const sentences = splitProseIntoSentences(part);
+    const proseKept: string[] = [];
+    for (const sentence of sentences) {
+      const w = countWords(sentence);
+      if (kept.length === 0 && proseKept.length === 0) {
+        // Always keep the first sentence even if it's already over budget —
+        // a one-sentence answer beats no answer.
+        proseKept.push(sentence);
+        cumulativeWords += w;
+        continue;
+      }
+      if (cumulativeWords + w > TRUNCATION_TARGET_WORDS) {
+        stopped = true;
+        break;
+      }
+      proseKept.push(sentence);
+      cumulativeWords += w;
+    }
+    if (proseKept.length > 0) {
+      kept.push(proseKept.join(' '));
+    }
+  }
+
+  const truncated = kept.join('').trimEnd();
+  return truncated + TRUNCATION_SUFFIX;
+}
+
+/**
+ * Split prose into sentences, preserving original whitespace separators
+ * so the rejoined output reads naturally.
+ *
+ * Splits on `[.!?]` followed by whitespace, but keeps the terminator with
+ * the preceding sentence so reassembly is just `.join(' ')`.
+ */
+function splitProseIntoSentences(prose: string): string[] {
+  if (!prose) return [];
+  // Match: text up to and including a sentence terminator + trailing whitespace.
+  // Final segment may not end in a terminator; capture it separately.
+  const matches = prose.match(/[^.!?]+[.!?]+\s*/g) || [];
+  const consumed = matches.join('');
+  const trailing = prose.slice(consumed.length).trim();
+  const out = matches.map(s => s.trim()).filter(Boolean);
+  if (trailing) out.push(trailing);
+  return out;
+}
+
+/** Test-only exports for the unit test. */
+export const __test_lengthThresholds = {
+  SHORT_QUESTION_MAX_WORDS,
+  RESPONSE_CAP_WORDS,
+  TRUNCATION_TARGET_WORDS,
+  TRUNCATION_SUFFIX,
+};

--- a/server/src/addie/response-postprocess.ts
+++ b/server/src/addie/response-postprocess.ts
@@ -260,3 +260,46 @@ export const __test_lengthThresholds = {
   TRUNCATION_TARGET_WORDS,
   TRUNCATION_SUFFIX,
 };
+
+// ---------------------------------------------------------------------------
+// Combined response pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Fallback shown when the model returns an empty assistant message. Two
+ * redteam-flagged turns produced rating=1 "Response is empty" responses on
+ * short follow-up prompts ("?", "what happened?"). Substituting a clarifying
+ * line is better than shipping the void.
+ */
+const EMPTY_RESPONSE_FALLBACK =
+  "Sorry, I lost the thread there. Could you rephrase or give me a bit more context?";
+
+/**
+ * Apply the full assistant-text post-processing chain in order:
+ *
+ * 1. `stripBannedRituals` — remove ritual phrases the model leaks despite
+ *    response-style.md banning them.
+ * 2. Empty-response guard — substitute a clarifying fallback if the model
+ *    returned no content (or only ritual phrases that all got stripped).
+ * 3. `truncateLongResponseToShortQuestion` — for short user questions,
+ *    cap response length at the sentence boundary near 130 words and append
+ *    a "go deeper?" suffix.
+ *
+ * Used at every assistant-text return site in `claude-client.ts` so the
+ * pipeline is consistent across non-streaming, multi-textblock, and
+ * streaming `done` paths.
+ *
+ * @param question The user's most recent message.
+ * @param rawText The raw assistant text from the model (post-tool-use).
+ * @returns The post-processed text safe to return to the caller.
+ */
+export function applyResponsePipeline(question: string, rawText: string): string {
+  const stripped = stripBannedRituals(rawText);
+  if (stripped.trim().length === 0) {
+    return EMPTY_RESPONSE_FALLBACK;
+  }
+  return truncateLongResponseToShortQuestion(question, stripped);
+}
+
+/** Test-only export of the empty-response fallback. */
+export const __test_EMPTY_RESPONSE_FALLBACK = EMPTY_RESPONSE_FALLBACK;

--- a/server/tests/unit/addie/response-postprocess.test.ts
+++ b/server/tests/unit/addie/response-postprocess.test.ts
@@ -6,8 +6,10 @@ import { describe, it, expect } from 'vitest';
 import {
   stripBannedRituals,
   truncateLongResponseToShortQuestion,
+  applyResponsePipeline,
   __test_BANNED_RITUAL_LITERALS,
   __test_lengthThresholds,
+  __test_EMPTY_RESPONSE_FALLBACK,
 } from '../../../src/addie/response-postprocess.js';
 
 describe('stripBannedRituals', () => {
@@ -182,5 +184,40 @@ describe('truncateLongResponseToShortQuestion', () => {
   it('handles empty inputs gracefully', () => {
     expect(truncateLongResponseToShortQuestion('', 'something')).toBe('something');
     expect(truncateLongResponseToShortQuestion('what?', '')).toBe('');
+  });
+});
+
+describe('applyResponsePipeline', () => {
+  it('substitutes the empty-response fallback when the model returns empty text', () => {
+    expect(applyResponsePipeline('?', '')).toBe(__test_EMPTY_RESPONSE_FALLBACK);
+    expect(applyResponsePipeline('what happened?', '   ')).toBe(__test_EMPTY_RESPONSE_FALLBACK);
+  });
+
+  it('substitutes the fallback when stripBannedRituals leaves an empty result', () => {
+    // A response that's nothing but ritual phrases.
+    const ritualOnly = "Great question. The honest answer is, sharp question.";
+    expect(applyResponsePipeline('?', ritualOnly)).toBe(__test_EMPTY_RESPONSE_FALLBACK);
+  });
+
+  it('passes substantive responses through both strip and truncate', () => {
+    const q = "What is X?";
+    // 50 short sentences of 6 words each = 300 words total, with real
+    // sentence boundaries so the truncator can find a stop point.
+    const sentences: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      sentences.push(`This is sentence ${i} content.`);
+    }
+    const longRitual = "Great question. " + sentences.join(' ');
+    const out = applyResponsePipeline(q, longRitual);
+    expect(out).not.toMatch(/great question/i);
+    expect(out).toContain(__test_lengthThresholds.TRUNCATION_SUFFIX.trim());
+    // Should not contain all 50 sentences.
+    expect(out.split(/\bsentence \d+\b/).length - 1).toBeLessThan(50);
+  });
+
+  it('passes short clean responses through unchanged', () => {
+    const q = "What is X?";
+    const short = "X is the protocol.";
+    expect(applyResponsePipeline(q, short)).toBe(short);
   });
 });

--- a/server/tests/unit/addie/response-postprocess.test.ts
+++ b/server/tests/unit/addie/response-postprocess.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   stripBannedRituals,
+  truncateLongResponseToShortQuestion,
   __test_BANNED_RITUAL_LITERALS,
+  __test_lengthThresholds,
 } from '../../../src/addie/response-postprocess.js';
 
 describe('stripBannedRituals', () => {
@@ -92,5 +94,93 @@ describe('stripBannedRituals', () => {
     expect(output).not.toMatch(/to be clear/i);
     expect(output).not.toMatch(/sharp question/i);
     expect(output).toContain("AdCP is a campaign-layer protocol");
+  });
+});
+
+describe('truncateLongResponseToShortQuestion', () => {
+  const { SHORT_QUESTION_MAX_WORDS, RESPONSE_CAP_WORDS, TRUNCATION_SUFFIX } = __test_lengthThresholds;
+
+  // Build a deterministic prose string of N words made of N short sentences.
+  function makeProse(words: number): string {
+    const sentences: string[] = [];
+    let used = 0;
+    let i = 0;
+    while (used < words) {
+      const w = Math.min(8, words - used);
+      // Each sentence has `w` tokens — w-1 word tokens + 1 trailing terminator-included token.
+      const tokens: string[] = [];
+      for (let j = 0; j < w - 1; j++) tokens.push(`word${i++}`);
+      tokens.push(`final${i++}.`);
+      sentences.push(tokens.join(' '));
+      used += w;
+    }
+    return sentences.join(' ');
+  }
+
+  it('returns text unchanged when the question is long', () => {
+    const longQ = Array.from({ length: SHORT_QUESTION_MAX_WORDS + 5 }, (_, i) => `q${i}`).join(' ');
+    const longResp = makeProse(RESPONSE_CAP_WORDS + 50);
+    expect(truncateLongResponseToShortQuestion(longQ, longResp)).toBe(longResp);
+  });
+
+  it('returns text unchanged when the response is at or below the cap', () => {
+    const q = "What is X?";
+    const resp = makeProse(RESPONSE_CAP_WORDS); // exactly at cap
+    expect(truncateLongResponseToShortQuestion(q, resp)).toBe(resp);
+  });
+
+  it('truncates and appends the suffix when question is short and response is long', () => {
+    const q = "What does AdCP not do?"; // 5 words
+    const resp = makeProse(300);
+    const out = truncateLongResponseToShortQuestion(q, resp);
+    expect(out).not.toBe(resp);
+    expect(out).toContain(TRUNCATION_SUFFIX.trim());
+    // Word count of body should be at or below the truncation target plus the
+    // suffix (a handful of words).
+    const bodyWords = out.replace(TRUNCATION_SUFFIX, '').trim().split(/\s+/).length;
+    expect(bodyWords).toBeLessThanOrEqual(150);
+  });
+
+  it('preserves complete sentences at the truncation boundary', () => {
+    const q = "What is X?";
+    const resp = makeProse(250);
+    const out = truncateLongResponseToShortQuestion(q, resp);
+    // Body should end with a sentence terminator before the suffix.
+    const body = out.slice(0, out.length - TRUNCATION_SUFFIX.length).trim();
+    expect(body).toMatch(/[.!?]$/);
+  });
+
+  it('keeps the first sentence even if it alone exceeds the target', () => {
+    const q = "What is X?";
+    // One giant sentence of 200 words.
+    const giant = Array.from({ length: 199 }, (_, i) => `word${i}`).join(' ') + ' end.';
+    const out = truncateLongResponseToShortQuestion(q, giant);
+    expect(out).toContain('end.');
+    expect(out).toContain(TRUNCATION_SUFFIX.trim());
+  });
+
+  it('does not truncate inside fenced code blocks', () => {
+    const q = "What is X?";
+    const codeBlock = '```\n' + Array.from({ length: 100 }, (_, i) => `line ${i}`).join('\n') + '\n```';
+    const resp = makeProse(50) + '\n\n' + codeBlock + '\n\n' + makeProse(80);
+    const out = truncateLongResponseToShortQuestion(q, resp);
+    if (out !== resp) {
+      // If we truncated, the code block should appear whole or be excluded entirely.
+      const fenceCount = (out.match(/```/g) || []).length;
+      expect(fenceCount % 2).toBe(0); // matched pairs only
+    }
+  });
+
+  it('idempotent on already-truncated text', () => {
+    const q = "What is X?";
+    const resp = makeProse(300);
+    const once = truncateLongResponseToShortQuestion(q, resp);
+    const twice = truncateLongResponseToShortQuestion(q, once);
+    expect(twice).toBe(once);
+  });
+
+  it('handles empty inputs gracefully', () => {
+    expect(truncateLongResponseToShortQuestion('', 'something')).toBe('something');
+    expect(truncateLongResponseToShortQuestion('what?', '')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Three response post-processor changes from the prod redteam follow-up, factored into a single `applyResponsePipeline(question, rawText)` helper used at all four assistant-text return sites in `claude-client.ts`.

### 1. Bug fix: missed code path in the banned-ritual stripper

Prod redteam against the deployed Sonnet+stripper combo (PR #3273) showed 3 ritual-phrase leaks ("the honest answer is", "that's a fair question", "here's the honest answer") despite the stripper being in place. The strip was applied at three of four return sites in `claude-client.ts` but missed the `end_turn` path that joins multi-text-block responses (used by web-search-returning answers).

### 2. Feature: deterministic length post-processor

Both prompt-engineer and docs-expert reviews of PR #3290 converged: rule-based teaching reduces mean length but doesn't enforce a ceiling on Sonnet's verbosity. Prod redteam confirmed:

- priv-1 ("surveillance capitalism?"): 254 words
- acct-1 ("$500K on garbage inventory"): 304 words
- acct-2 ("AI screws up"): 227 words
- gap-1 ("what AdCP not do"): 173 words

New `truncateLongResponseToShortQuestion(question, text)`:
- **Fires when** question ≤15 words AND response >160 words
- **Truncates at** the nearest sentence boundary at or before 130 words
- **Appends** *"Happy to go deeper on any of this if useful."*
- **Code blocks** kept whole — never cut mid-fence
- **First-sentence fallback** — keeps the first sentence even if alone over target
- **Idempotent**

### 3. Empty-response guard

Two redteam-flagged turns produced rating=1 "Response is empty" responses on short follow-up prompts ("?", "what happened?"). The model returned an assistant message with empty text. Now substitutes a clarifying fallback rather than ship the void.

### Single pipeline

All three live behind `applyResponsePipeline(question, rawText)`:

```
stripBannedRituals → empty-response guard → truncateLongResponseToShortQuestion
```

Used at the four assistant-text return sites in `claude-client.ts` (lines 770, 901, 1423, 1454). The chain is the same everywhere; future additions slot into one helper.

## Verification

- 25/25 unit tests on the postprocess module
- `npm run typecheck` clean
- Pre-commit (test:unit + dynamic-imports + typecheck) green

## Expected redteam impact

| Failure mode | Before | After (expected) |
|---|---|---|
| `ritual-phrase hits` | 3 | 0 |
| `length_cap` | 4 | 0 |
| Empty assistant text on short prompts | silent rating=1 | clarifying fallback |
| **Aggregate prod pass rate** | **25/33 (76%)** | **~32/33** |

Remaining failures (out of scope, separate followups):
- priv-1 `"adcp is more private"` banned_marker
- priv-2 `"proven secure"` banned_marker

Both are overclaim phrases the truncator/stripper don't catch (they appear within otherwise valid body text). Right fix: promote per-scenario `bannedMarkers` to a global ban list. Small followup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)