### PR TITLE
feat(training-agent): GCP KMS-backed webhook signing

### DIFF
--- a/.changeset/kms-webhook-signing.md
+++ b/.changeset/kms-webhook-signing.md
@@ -1,0 +1,32 @@
+---
+---
+
+feat(training-agent): GCP KMS-backed webhook signing
+
+Routes the training-agent's outbound webhook signing through a GCP KMS
+`SigningProvider` (added in `@adcp/client@5.21.0` per #1020 / PR
+adcp-client#1021). Private webhook-signing key material no longer enters
+process memory in production.
+
+AdCP requires distinct key material per signing purpose
+(`docs/guides/SIGNING-GUIDE.md` § Key separation), so this lands a second
+KMS cryptoKeyVersion separate from the request-signing key. New Fly secret:
+`GCP_KMS_WEBHOOK_KEY_VERSION` pointing at the webhook cryptoKeyVersion path.
+The shared `GCP_SA_JSON` covers IAM for both.
+
+Refactors `server/src/security/gcp-kms-signer.ts` into a factory pattern
+with two named exports — `getRequestSigningProvider()` and
+`getWebhookSigningProvider()` — sharing init / tripwire / lazy-singleton /
+in-flight-dedup logic.
+
+`server/src/security/expected-public-key.ts` now exports both committed
+PEMs and KIDs (`aao-signing-2026-04` for requests, `aao-webhook-2026-04`
+for webhooks). The published JWKS at `/.well-known/jwks.json` advertises
+both keys with their respective `adcp_use` values; receivers enforce
+purpose at that field.
+
+Dev fallback unchanged: when `GCP_KMS_WEBHOOK_KEY_VERSION` is unset,
+`webhooks.ts` still loads `WEBHOOK_SIGNING_KEY_JWK` (stable JWK env) or
+generates an ephemeral key.
+
+Bumps `@adcp/client` 5.20.0 → 5.21.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0",
       "dependencies": {
-        "@adcp/client": "5.20.0",
+        "@adcp/client": "5.21.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.20.0.tgz",
-      "integrity": "sha512-AVZkWtO+G1Q76QT5Fe4JNNxNpGWZCl1hkC0Giu19VAfaPAeFLbgnmvpxf/tchM6HSeLPA6oFlvTk8N4CtgN4QA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.0.tgz",
+      "integrity": "sha512-2I2dfAlxReadkO+j4CdtNtPQ9X9xqaYDK/b3/gVqn8+KuYktFDBPXHCVjGK56Cs15FrOFLGjhupwgLxX/Sv7oQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "5.20.0",
+    "@adcp/client": "5.21.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -679,7 +679,7 @@ export function createAdcpToolHandlers(
 
     try {
       const { AdCPClient } = await import('@adcp/client');
-      const { getGcpKmsSigningProvider } = await import('../../security/gcp-kms-signer.js');
+      const { getRequestSigningProvider } = await import('../../security/gcp-kms-signer.js');
 
       // Sign outbound AdCP requests with the GCP KMS-backed Ed25519 key
       // when configured. Verifiers fetch the public key from
@@ -693,7 +693,7 @@ export function createAdcpToolHandlers(
       // result rendered to the end user.
       let signingProvider;
       try {
-        signingProvider = await getGcpKmsSigningProvider();
+        signingProvider = await getRequestSigningProvider();
       } catch (kmsErr) {
         logger.error({ err: kmsErr, agentUrl, task }, 'GCP KMS signing provider init failed');
         return '**Error:** Outbound AdCP signing is misconfigured. Operator: check structured logs for KMS init failure (gcp-kms-signer module).';

--- a/server/src/security/expected-public-key.ts
+++ b/server/src/security/expected-public-key.ts
@@ -1,27 +1,41 @@
 /**
- * The Ed25519 public key the GCP KMS signer is expected to return, plus
- * the wire identity (`kid`, `alg`) it's published under.
+ * Public keys the GCP KMS signers are expected to return, plus the wire
+ * identities (`kid`, `alg`) they're published under.
  *
- * Committed to the repo as a tripwire: if KMS returns a different key
- * (rotation, IAM swap, hostile substitution), the signer init fails loudly
- * rather than emitting signatures verifiers — fetching the JWKS published
- * from this same constant — would reject.
+ * AdCP requires distinct key material per signing purpose
+ * (`docs/guides/SIGNING-GUIDE.md` § Key separation). One Ed25519 key for
+ * outbound RFC 9421 request signing, a separate one for webhook signing.
  *
- * On rotation: generate the new version in GCP, update `EXPECTED_PUBLIC_KEY_PEM`
- * and `KID`, set `GCP_KMS_KEY_VERSION` to the new version path, deploy.
+ * Committed as a tripwire: if KMS returns a different key (rotation, IAM
+ * swap, hostile substitution), signer init fails loudly rather than
+ * emitting signatures verifiers — fetching the JWKS published from this
+ * same constant — would reject.
  *
- * Key version pinned by `GCP_KMS_KEY_VERSION` secret. Current logical key:
- * projects/adcp-production/locations/us-east4/keyRings/aao_signing/cryptoKeys/addie_request_signing/cryptoKeyVersions/1
+ * Rotation: generate a new version in GCP, update the matching constant
+ * here and the `KID`, set the matching Fly secret to the new version
+ * path, deploy.
  *
- * `KID` is the wire identifier published in `Signature-Input`'s `keyid`
- * parameter and at `${BASE_URL}/.well-known/jwks.json`. The date-suffix
- * pattern lets a future rotation publish both old and new under different
- * `kid` values during the cutover window.
+ * Both keys live under the same `aao_signing` keyring; the version path
+ * pins which one each provider uses. The shared service account
+ * (`GCP_SA_JSON`) has `roles/cloudkms.signer` scoped per version.
+ *
+ * Key versions:
+ *   request-signing: projects/adcp-production/locations/us-east4/keyRings/aao_signing/cryptoKeys/addie_request_signing/cryptoKeyVersions/1
+ *   webhook-signing: projects/adcp-production/locations/us-east4/keyRings/aao_signing/cryptoKeys/addie_request_signing/cryptoKeyVersions/2
  */
-export const EXPECTED_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+
+export const ALGORITHM = 'ed25519' as const;
+
+/** RFC 9421 request signing — Addie's outbound AdCP calls. */
+export const REQUEST_SIGNING_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEASRYr8eSvjkZF6dAUquI1sKuU4YGZkoGH+2jwkz4dRJg=
 -----END PUBLIC KEY-----
 `;
+export const REQUEST_SIGNING_KID = 'aao-signing-2026-04';
 
-export const KID = 'aao-signing-2026-04';
-export const ALGORITHM = 'ed25519' as const;
+/** RFC 9421 webhook signing — outbound webhook deliveries. */
+export const WEBHOOK_SIGNING_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAlHJI+IvBwCE36heDNOyBmCk5UMKRIs4b4BAWJRgao+M=
+-----END PUBLIC KEY-----
+`;
+export const WEBHOOK_SIGNING_KID = 'aao-webhook-2026-04';

--- a/server/src/security/gcp-kms-signer.ts
+++ b/server/src/security/gcp-kms-signer.ts
@@ -1,92 +1,124 @@
 /**
- * GCP KMS-backed RFC 9421 SigningProvider for Addie's outbound AdCP requests.
+ * GCP KMS-backed RFC 9421 SigningProviders for Addie.
  *
- * Reads two Fly secrets:
- *   - GCP_SA_JSON: service-account credentials JSON (IAM identity)
- *   - GCP_KMS_KEY_VERSION: full resource name
- *     `projects/.../keyRings/.../cryptoKeys/.../cryptoKeyVersions/N`
+ * Two providers, one per AdCP signing purpose (request vs webhook). AdCP
+ * requires distinct key material per purpose; both providers wrap a
+ * different `cryptoKeyVersion` under the same KMS keyring with the shared
+ * service account.
  *
- * On first call, builds a `KeyManagementServiceClient`, fetches the public
- * key, asserts it's Ed25519, and asserts it matches `EXPECTED_PUBLIC_KEY_PEM`.
- * Mismatch fails loudly — tripwire against an out-of-band key swap in GCP
- * that would otherwise silently re-sign with an unexpected key.
+ * Reads three Fly secrets:
+ *   - GCP_SA_JSON: service-account credentials JSON (shared IAM identity)
+ *   - GCP_KMS_KEY_VERSION: cryptoKeyVersion for outbound AdCP request signing
+ *   - GCP_KMS_WEBHOOK_KEY_VERSION: cryptoKeyVersion for webhook signing
  *
- * Singleton — one provider per process. The KMS client is fetched lazily so
- * boot doesn't fail in dev where the secrets aren't set; production callers
- * can opt into eager init via `eagerInitGcpKmsSigningProvider()`.
+ * On first call per provider, fetches the public key, asserts it's
+ * Ed25519, and asserts it matches the committed PEM. Mismatch fails
+ * loudly — tripwire against an out-of-band key swap in GCP that would
+ * silently re-sign with an unexpected key.
+ *
+ * Singleton per purpose. Lazy init so dev (no env) boots; production
+ * pays the `getPublicKey` round-trip on the first signed call.
  */
 
 import { createPublicKey } from 'node:crypto';
 import { KeyManagementServiceClient } from '@google-cloud/kms';
 import type { SigningProvider } from '@adcp/client/signing';
 import { createLogger } from '../logger.js';
-import { EXPECTED_PUBLIC_KEY_PEM, KID, ALGORITHM } from './expected-public-key.js';
+import {
+  ALGORITHM,
+  REQUEST_SIGNING_KID,
+  REQUEST_SIGNING_PUBLIC_KEY_PEM,
+  WEBHOOK_SIGNING_KID,
+  WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
+} from './expected-public-key.js';
 
 const logger = createLogger('gcp-kms-signer');
 
 const KMS_ALG_ED25519 = 'EC_SIGN_ED25519';
 
-let cached: SigningProvider | null = null;
-let initInFlight: Promise<SigningProvider> | null = null;
+interface SignerSpec {
+  /** Logical name for logs. */
+  purpose: 'request-signing' | 'webhook-signing';
+  /** Fly secret holding the cryptoKeyVersion path. */
+  keyVersionEnvVar: 'GCP_KMS_KEY_VERSION' | 'GCP_KMS_WEBHOOK_KEY_VERSION';
+  /** Wire `kid` published in `Signature-Input` and at the JWKS endpoint. */
+  kid: string;
+  /** Committed PEM the signer must match at init. */
+  expectedPem: string;
+}
+
+const REQUEST_SPEC: SignerSpec = {
+  purpose: 'request-signing',
+  keyVersionEnvVar: 'GCP_KMS_KEY_VERSION',
+  kid: REQUEST_SIGNING_KID,
+  expectedPem: REQUEST_SIGNING_PUBLIC_KEY_PEM,
+};
+
+const WEBHOOK_SPEC: SignerSpec = {
+  purpose: 'webhook-signing',
+  keyVersionEnvVar: 'GCP_KMS_WEBHOOK_KEY_VERSION',
+  kid: WEBHOOK_SIGNING_KID,
+  expectedPem: WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
+};
+
+interface ProviderState {
+  cached: SigningProvider | null;
+  initInFlight: Promise<SigningProvider> | null;
+}
+
+const requestState: ProviderState = { cached: null, initInFlight: null };
+const webhookState: ProviderState = { cached: null, initInFlight: null };
 
 /**
- * Returns the GCP KMS-backed signing provider, or null if env vars are
- * unset (dev / non-signing deployments). Throws if env is set but
- * misconfigured — fail-fast so a half-configured production deploy
- * doesn't silently fall through to unsigned requests.
- *
- * Only successful init is cached. Transient KMS errors (network blip
- * during `getPublicKey`) are retried on the next call rather than
- * permanently sticking the process. Concurrent callers share one
- * in-flight init promise so a thundering herd doesn't fan out into
- * many `getPublicKey` calls.
+ * Returns the GCP KMS-backed signing provider for outbound AdCP request
+ * signing, or null if env vars are unset (dev / non-signing deployments).
+ * Throws if env is set but misconfigured.
  */
-export async function getGcpKmsSigningProvider(): Promise<SigningProvider | null> {
-  if (cached) return cached;
+export function getRequestSigningProvider(): Promise<SigningProvider | null> {
+  return getProvider(REQUEST_SPEC, requestState);
+}
+
+/**
+ * Returns the GCP KMS-backed signing provider for webhook signing, or
+ * null if env vars are unset. Distinct key material from the
+ * request-signing provider per AdCP's key-separation requirement.
+ */
+export function getWebhookSigningProvider(): Promise<SigningProvider | null> {
+  return getProvider(WEBHOOK_SPEC, webhookState);
+}
+
+async function getProvider(spec: SignerSpec, state: ProviderState): Promise<SigningProvider | null> {
+  if (state.cached) return state.cached;
 
   const saJson = process.env.GCP_SA_JSON;
-  const keyVersion = process.env.GCP_KMS_KEY_VERSION;
+  const keyVersion = process.env[spec.keyVersionEnvVar];
 
   if (!saJson && !keyVersion) {
     return null;
   }
   if (!saJson || !keyVersion) {
     throw new Error(
-      'GCP KMS signing partially configured: both GCP_SA_JSON and GCP_KMS_KEY_VERSION must be set, or neither.'
+      `GCP KMS ${spec.purpose} partially configured: both GCP_SA_JSON and ${spec.keyVersionEnvVar} must be set, or neither.`
     );
   }
 
-  if (!initInFlight) {
-    // Set `cached` inside the IIFE *before* the .finally clears
-    // initInFlight. If a third caller arrives between the .finally
-    // microtask and the outer await resume, they'll see `cached` already
-    // populated and skip init entirely.
-    initInFlight = (async () => {
+  if (!state.initInFlight) {
+    state.initInFlight = (async () => {
       const credentials = parseServiceAccountJson(saJson);
       const client = new KeyManagementServiceClient({ credentials });
-      const provider = await buildProvider(client, keyVersion);
-      cached = provider;
+      const provider = await buildProvider(client, spec, keyVersion);
+      state.cached = provider;
       logger.info(
-        { kid: KID, algorithm: ALGORITHM, keyVersion: redactKeyVersion(keyVersion) },
+        { purpose: spec.purpose, kid: spec.kid, algorithm: ALGORITHM, keyVersion: redactKeyVersion(keyVersion) },
         'GCP KMS signing provider initialized'
       );
       return provider;
     })().finally(() => {
-      initInFlight = null;
+      state.initInFlight = null;
     });
   }
 
-  return initInFlight;
-}
-
-/**
- * Boot-path eager init. Call from the server startup if KMS env is set so
- * deploy fails before traffic is taken (rather than every tool-call
- * failing post-rollout). Silent no-op when env is unset.
- */
-export async function eagerInitGcpKmsSigningProvider(): Promise<void> {
-  if (!process.env.GCP_SA_JSON && !process.env.GCP_KMS_KEY_VERSION) return;
-  await getGcpKmsSigningProvider();
+  return state.initInFlight;
 }
 
 interface ServiceAccountCredentials {
@@ -117,24 +149,25 @@ function parseServiceAccountJson(raw: string): ServiceAccountCredentials {
 
 async function buildProvider(
   client: KeyManagementServiceClient,
+  spec: SignerSpec,
   keyVersion: string
 ): Promise<SigningProvider> {
   const [pubResp] = await client.getPublicKey({ name: keyVersion });
   const kmsAlgorithm = pubResp.algorithm ?? '';
   const pem = pubResp.pem ?? '';
   if (!pem) {
-    throw new Error(`GCP KMS getPublicKey returned no PEM for ${redactKeyVersion(keyVersion)}`);
+    throw new Error(`GCP KMS getPublicKey returned no PEM for ${spec.purpose} (${redactKeyVersion(keyVersion)})`);
   }
   if (kmsAlgorithm !== KMS_ALG_ED25519) {
     throw new Error(
-      `GCP KMS key ${redactKeyVersion(keyVersion)} has algorithm '${kmsAlgorithm}', expected '${KMS_ALG_ED25519}'`
+      `GCP KMS ${spec.purpose} key ${redactKeyVersion(keyVersion)} has algorithm '${kmsAlgorithm}', expected '${KMS_ALG_ED25519}'`
     );
   }
 
-  assertPublicKeyMatchesCommitted(pem, keyVersion);
+  assertPublicKeyMatchesCommitted(pem, spec, keyVersion);
 
   return {
-    keyid: KID,
+    keyid: spec.kid,
     algorithm: ALGORITHM,
     fingerprint: keyVersion,
     async sign(payload: Uint8Array): Promise<Uint8Array> {
@@ -161,21 +194,21 @@ function coerceSignature(value: Buffer | Uint8Array | string | null | undefined)
 }
 
 /**
- * Tripwire: compare the KMS-returned PEM to the one committed in this repo.
- * Different bytes mean the GCP key was rotated or replaced without a
- * corresponding code change — refuse to sign rather than emit signatures
- * verifiers (looking at the published JWKS) will reject.
+ * Tripwire: compare the KMS-returned PEM to the one committed in this repo
+ * for the given purpose. Different bytes mean the GCP key was rotated or
+ * replaced without a corresponding code change — refuse to sign rather than
+ * emit signatures verifiers (looking at the published JWKS) will reject.
  *
  * Comparison is on the SPKI public-key bytes, not the raw PEM string, so
  * formatting differences (line endings, header capitalization) don't
  * trigger false positives.
  */
-function assertPublicKeyMatchesCommitted(actualPem: string, keyVersion: string): void {
+function assertPublicKeyMatchesCommitted(actualPem: string, spec: SignerSpec, keyVersion: string): void {
   const actualSpki = createPublicKey(actualPem).export({ type: 'spki', format: 'der' }) as Buffer;
-  const expectedSpki = createPublicKey(EXPECTED_PUBLIC_KEY_PEM).export({ type: 'spki', format: 'der' }) as Buffer;
+  const expectedSpki = createPublicKey(spec.expectedPem).export({ type: 'spki', format: 'der' }) as Buffer;
   if (!actualSpki.equals(expectedSpki)) {
     throw new Error(
-      `GCP KMS public key for ${redactKeyVersion(keyVersion)} does not match the committed expected key. ` +
+      `GCP KMS ${spec.purpose} public key for ${redactKeyVersion(keyVersion)} does not match the committed expected key. ` +
         `If the key was rotated, update server/src/security/expected-public-key.ts and redeploy.`
     );
   }
@@ -187,8 +220,10 @@ function redactKeyVersion(keyVersion: string): string {
   return keyVersion.replace(/projects\/[^/]+/, 'projects/<redacted>');
 }
 
-/** Test-only — drop the cached provider so a subsequent call re-initializes. */
+/** Test-only — drop both cached providers so subsequent calls re-initialize. */
 export function resetGcpKmsSignerForTests(): void {
-  cached = null;
-  initInFlight = null;
+  requestState.cached = null;
+  requestState.initInFlight = null;
+  webhookState.cached = null;
+  webhookState.initInFlight = null;
 }

--- a/server/src/security/jwks.ts
+++ b/server/src/security/jwks.ts
@@ -1,14 +1,24 @@
 /**
- * Public JWKS for Addie's request-signing key.
+ * Public JWKS for Addie's signing keys.
  *
- * Derived from the committed `EXPECTED_PUBLIC_KEY_PEM` so the published key
- * and the signer's tripwire always reference the same source of truth —
- * rotation is a one-line edit to that file plus a `GCP_KMS_KEY_VERSION`
- * secret update.
+ * Two entries — one per AdCP signing purpose. AdCP receivers enforce key
+ * purpose at the JWK's `adcp_use` field (`docs/guides/SIGNING-GUIDE.md` §
+ * Key separation), so request-signing and webhook-signing keys must
+ * appear as distinct JWK entries with their respective `adcp_use` values.
+ *
+ * Both derived from the committed PEM constants so the published JWKS
+ * and each signer's tripwire reference the same source of truth —
+ * rotation is a one-line edit to `expected-public-key.ts` plus a
+ * `GCP_KMS_*_KEY_VERSION` secret update.
  */
 
 import { createPublicKey } from 'node:crypto';
-import { EXPECTED_PUBLIC_KEY_PEM, KID } from './expected-public-key.js';
+import {
+  REQUEST_SIGNING_PUBLIC_KEY_PEM,
+  REQUEST_SIGNING_KID,
+  WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
+  WEBHOOK_SIGNING_KID,
+} from './expected-public-key.js';
 
 interface PublicJwk {
   kty: string;
@@ -25,29 +35,37 @@ let cached: { keys: PublicJwk[] } | null = null;
 
 export function getPublicSigningJwks(): { keys: PublicJwk[] } {
   if (cached) return cached;
-  const raw = createPublicKey(EXPECTED_PUBLIC_KEY_PEM).export({ format: 'jwk' }) as {
+  cached = {
+    keys: [
+      pemToAdcpJwk(REQUEST_SIGNING_PUBLIC_KEY_PEM, REQUEST_SIGNING_KID, 'request-signing'),
+      pemToAdcpJwk(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID, 'webhook-signing'),
+    ],
+  };
+  return cached;
+}
+
+function pemToAdcpJwk(pem: string, kid: string, adcpUse: 'request-signing' | 'webhook-signing'): PublicJwk {
+  const raw = createPublicKey(pem).export({ format: 'jwk' }) as {
     kty?: string;
     crv?: string;
     x?: string;
   };
   if (raw.kty !== 'OKP' || raw.crv !== 'Ed25519' || typeof raw.x !== 'string') {
     throw new Error(
-      `Expected public key is not Ed25519 OKP (got kty=${raw.kty}, crv=${raw.crv}). ` +
+      `Expected public key for ${adcpUse} is not Ed25519 OKP (got kty=${raw.kty}, crv=${raw.crv}). ` +
         'Update expected-public-key.ts.'
     );
   }
-  const jwk: PublicJwk = {
+  return {
     kty: 'OKP',
     crv: 'Ed25519',
     x: raw.x,
-    kid: KID,
+    kid,
     alg: 'EdDSA',
     use: 'sig',
-    adcp_use: 'request-signing',
+    adcp_use: adcpUse,
     key_ops: ['verify'],
   };
-  cached = { keys: [jwk] };
-  return cached;
 }
 
 export function resetJwksForTests(): void {

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -30,7 +30,7 @@ import type { Product } from '@adcp/client';
 import { z } from 'zod';
 import type { TrainingContext, ToolArgs, AccountRef, BrandRef } from './types.js';
 import { getIdempotencyStore, scopedPrincipal } from './idempotency.js';
-import { getWebhookSigningKey, maybeEmitCompletionWebhook } from './webhooks.js';
+import { getWebhookSigningMaterial, maybeEmitCompletionWebhook } from './webhooks.js';
 import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
 import { PUBLISHERS } from './publishers.js';
 import { getSession, runWithSessionContext, flushDirtySessions, sessionKeyFromArgs } from './state.js';
@@ -478,7 +478,7 @@ export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpSe
     version: '1.0.0',
 
     idempotency: getIdempotencyStore(),
-    webhooks: { signerKey: getWebhookSigningKey() },
+    webhooks: getWebhookSigningMaterial(),
 
     // Only `static:public` is account-scoped: it's the shared sandbox token,
     // so unscoped idempotency keys would collide across callers. Other

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -3,12 +3,19 @@
  *
  * Uses `@adcp/client/server`'s `createWebhookEmitter` to post RFC 9421-signed
  * completion webhooks with stable `idempotency_key` per logical event and
- * retry/backoff on 5xx/429. The signer uses a single Ed25519 keypair sourced
- * from `WEBHOOK_SIGNING_KEY_JWK` (a private JWK) when configured, or a
- * freshly-generated key at startup for dev mode.
+ * retry/backoff on 5xx/429.
  *
- * Public key is published at `/.well-known/jwks.json` on the training agent
- * router so buyers can verify incoming webhooks against a real JWKS endpoint.
+ * Production (`GCP_KMS_WEBHOOK_KEY_VERSION` set): routes signing through a
+ * GCP KMS-backed `SigningProvider`. Private key material never enters
+ * process memory. Key separation per AdCP spec — a distinct
+ * `cryptoKeyVersion` from the request-signing path.
+ *
+ * Dev (env unset): falls back to either `WEBHOOK_SIGNING_KEY_JWK` (a
+ * stable private JWK) or a freshly-generated key at startup.
+ *
+ * Public key is published at the root `/.well-known/jwks.json` (with
+ * `adcp_use: "webhook-signing"`) and at the training-agent's own
+ * `/api/training-agent/.well-known/jwks.json` for legacy callers.
  */
 
 import { createHash, generateKeyPairSync, randomUUID } from 'node:crypto';
@@ -17,10 +24,15 @@ import {
   memoryWebhookKeyStore,
   type WebhookEmitter,
 } from '@adcp/client/server';
-import type { SignerKey } from '@adcp/client/signing';
+import type { SignerKey, SigningProvider } from '@adcp/client/signing';
 import type { AdcpJsonWebKey } from '@adcp/client/signing';
 import { createLogger } from '../logger.js';
 import { createWebhookFetch } from './webhook-fetch.js';
+import { getWebhookSigningProvider } from '../security/gcp-kms-signer.js';
+import {
+  WEBHOOK_SIGNING_KID,
+  WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
+} from '../security/expected-public-key.js';
 
 const logger = createLogger('training-agent-webhooks');
 
@@ -56,100 +68,54 @@ export const TOOL_TO_TASK_TYPE = {
   get_brand_identity: 'get_brand_identity',
   get_rights: 'get_rights',
   acquire_rights: 'acquire_rights',
-} as const satisfies Record<string, WebhookTaskType>;
+} as const;
 
-type WebhookEmittingTool = keyof typeof TOOL_TO_TASK_TYPE;
+export type WebhookEmittingTool = keyof typeof TOOL_TO_TASK_TYPE;
 
-/** AdCP protocol domain for each webhook-emitting tool. Values are the kebab-case
- *  enum from `enums/adcp-protocol.json`. Matches the spec's operational grouping:
- *  creative operations bundled into a media-buy seller stamp as `media-buy`
- *  (see `core/mcp-webhook-payload.json` example where `sync_creatives` → `media-buy`);
- *  dedicated brand / signals / governance tools stamp their own domain. The
- *  `Record<WebhookEmittingTool, ...>` type forces this map to stay in sync with
- *  `TOOL_TO_TASK_TYPE` — adding a tool there without a protocol here fails tsc. */
-type WebhookProtocol = 'media-buy' | 'signals' | 'governance' | 'creative' | 'brand' | 'sponsored-intelligence';
-
-const TOOL_TO_PROTOCOL: Readonly<Record<WebhookEmittingTool, WebhookProtocol>> = {
-  create_media_buy: 'media-buy',
-  update_media_buy: 'media-buy',
-  sync_creatives: 'media-buy',
-  get_creative_delivery: 'media-buy',
-  sync_event_sources: 'media-buy',
-  sync_audiences: 'media-buy',
-  sync_catalogs: 'media-buy',
-  log_event: 'media-buy',
-  sync_accounts: 'governance',
-  get_account_financials: 'governance',
-  activate_signal: 'signals',
-  get_signals: 'signals',
-  create_property_list: 'governance',
-  update_property_list: 'governance',
-  get_property_list: 'governance',
-  list_property_lists: 'governance',
-  delete_property_list: 'governance',
-  get_brand_identity: 'brand',
-  get_rights: 'brand',
-  acquire_rights: 'brand',
+export const TOOL_TO_PROTOCOL: Record<WebhookEmittingTool, 'mcp' | 'a2a'> = {
+  create_media_buy: 'mcp', update_media_buy: 'mcp', sync_creatives: 'mcp',
+  activate_signal: 'mcp', get_signals: 'mcp', create_property_list: 'mcp',
+  update_property_list: 'mcp', get_property_list: 'mcp', list_property_lists: 'mcp',
+  delete_property_list: 'mcp', sync_accounts: 'mcp', get_account_financials: 'mcp',
+  get_creative_delivery: 'mcp', sync_event_sources: 'mcp', sync_audiences: 'mcp',
+  sync_catalogs: 'mcp', log_event: 'mcp', get_brand_identity: 'mcp',
+  get_rights: 'mcp', acquire_rights: 'mcp',
 };
 
+/**
+ * Extract the webhook URL from tool arguments. Caller drops the optional
+ * `push_notification_config.{url,authentication}` fields onto the request;
+ * we sign only the URL.
+ */
 function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
-  const pnc = args.push_notification_config as { url?: unknown } | undefined;
+  const pnc = args.push_notification_config;
   if (!pnc || typeof pnc !== 'object') return undefined;
-  return typeof pnc.url === 'string' && pnc.url.length > 0 ? pnc.url : undefined;
+  const url = (pnc as { url?: unknown }).url;
+  return typeof url === 'string' && url.length > 0 ? url : undefined;
 }
 
-/** Derive a stable logical event id for webhook idempotency. Two emissions
- *  with the same operation_id reuse the same `idempotency_key` across retries.
- *  Prefers a buyer-facing entity id from the response so retries from the same
- *  buyer collapse; falls back to the request's idempotency_key.
- *
- *  Scoped by the caller's principal so two buyers sharing the public sandbox
- *  token who happen to land on the same deterministic response entity id
- *  (e.g. both get `mb_abc123`) produce distinct webhook idempotency_keys.
- *  Without the prefix, a receiver that dedupes across tenants on
- *  `idempotency_key` would drop the second buyer's event as a duplicate of
- *  the first. The principal is the same scoped string the request-side
- *  idempotency cache uses (`scopedPrincipal(auth, accountScope)`), so both
- *  caches partition identically. */
+/** A stable, deterministic key for the operation a webhook represents. */
 export function deriveWebhookOperationId(
   toolName: string,
   response: Record<string, unknown>,
   requestIdempotencyKey: string | undefined,
   principal: string,
 ): string {
-  for (const field of ['media_buy_id', 'creative_id', 'activation_id', 'signal_activation_id', 'task_id', 'list_id', 'account_id']) {
-    const v = response[field];
-    if (typeof v === 'string' && v.length > 0) return `${principal}|${toolName}.${v}`;
-  }
-  if (requestIdempotencyKey) return `${principal}|${toolName}.${requestIdempotencyKey}`;
-  return `${principal}|${toolName}.${randomUUID()}`;
+  const taskId = typeof response.task_id === 'string' ? response.task_id : null;
+  const seed = taskId ?? requestIdempotencyKey ?? randomUUID();
+  return createHash('sha256').update(principal).update('').update(toolName).update('').update(seed).digest('hex').slice(0, 32);
 }
 
-/**
- * Fire a completion webhook for a successful tool call if the buyer supplied
- * `push_notification_config.url` and the tool maps to a webhook task type.
- *
- * Fire-and-forget: the emitter handles RFC 9421 signing, `idempotency_key`
- * stability across retries, and retry/backoff on 5xx/429 internally. Any
- * delivery failure is logged but never surfaces to the caller — the sync
- * response has already been returned.
- *
- * Shared between legacy dispatch (`task-handlers.ts`) and the framework
- * adapter (`framework-server.ts`) so both paths emit byte-identical envelopes.
- */
+/** Fire-and-forget completion webhook emission. The `toolName` is `string`
+ *  (not `WebhookEmittingTool`) because callers — `task-handlers.ts:3750`
+ *  and `framework-server.ts:265` — operate on the AdCP server's full tool
+ *  surface, not just the webhook-emitting subset. The runtime guard below
+ *  filters to the subset before dispatching. */
 export function maybeEmitCompletionWebhook(opts: {
   toolName: string;
   args: Record<string, unknown>;
   response: Record<string, unknown>;
   requestIdempotencyKey?: string;
-  /** Caller-uniqueness key for webhook idempotency. Pass the same value the
-   *  request-side idempotency store uses for this caller (legacy dispatch
-   *  passes `scopedPrincipal(auth, accountScope)`; the framework path passes
-   *  `auth` directly except for `static:public` where it scopes by account).
-   *  Two distinct callers MUST produce distinct strings here, otherwise
-   *  receivers that dedupe across tenants on `idempotency_key` may drop one
-   *  caller's webhook as a duplicate of another's. Empty strings are rejected
-   *  fail-fast — they would silently degrade scoping to "no partitioning". */
   principal: string;
 }): void {
   if (!opts.principal) {
@@ -176,9 +142,13 @@ export function maybeEmitCompletionWebhook(opts: {
 }
 
 const ENV_KEY = 'WEBHOOK_SIGNING_KEY_JWK';
+const KMS_WEBHOOK_ENV = 'GCP_KMS_WEBHOOK_KEY_VERSION';
 
-let signerKey: SignerKey | null = null;
-let publicJwk: AdcpJsonWebKey | null = null;
+type WebhookMaterial =
+  | { kind: 'kms'; signerProvider: SigningProvider; publicJwk: AdcpJsonWebKey }
+  | { kind: 'inline'; signerKey: SignerKey; publicJwk: AdcpJsonWebKey };
+
+let material: WebhookMaterial | null = null;
 let emitter: WebhookEmitter | null = null;
 
 function generateEphemeralKey(): { signer: SignerKey; publicJwk: AdcpJsonWebKey } {
@@ -223,7 +193,6 @@ function loadConfiguredKey(raw: string): { signer: SignerKey; publicJwk: AdcpJso
       key_ops: ['sign'],
     },
   };
-  // Public JWK is the private JWK minus `d`.
   const { d: _drop, ...publicOnly } = jwk;
   const pubJwk: AdcpJsonWebKey = {
     ...publicOnly,
@@ -235,40 +204,101 @@ function loadConfiguredKey(raw: string): { signer: SignerKey; publicJwk: AdcpJso
   return { signer, publicJwk: pubJwk };
 }
 
-function ensureKey(): { signer: SignerKey; publicJwk: AdcpJsonWebKey } {
-  if (signerKey && publicJwk) return { signer: signerKey, publicJwk };
+/**
+ * Synchronous SigningProvider wrapper around the lazy KMS-backed
+ * webhook-signing provider. The wire identity (`keyid`, `algorithm`,
+ * `fingerprint`) is known statically from committed constants, so we can
+ * hand a fully-shaped provider to `createWebhookEmitter` without waiting
+ * for the KMS round-trip. The first `sign()` call resolves the underlying
+ * KMS provider (cached singleton in `gcp-kms-signer.ts`) and delegates;
+ * the tripwire / algorithm assertion fires there.
+ */
+function buildKmsWebhookProviderWrapper(keyVersion: string): SigningProvider {
+  return {
+    keyid: WEBHOOK_SIGNING_KID,
+    algorithm: 'ed25519',
+    fingerprint: keyVersion,
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      const provider = await getWebhookSigningProvider();
+      if (!provider) {
+        throw new Error(
+          'GCP KMS webhook signing unavailable at sign-time despite env being set. Check structured logs for init failure.'
+        );
+      }
+      return provider.sign(payload);
+    },
+  };
+}
+
+function ensureMaterial(): WebhookMaterial {
+  if (material) return material;
+  const kmsKeyVersion = process.env[KMS_WEBHOOK_ENV];
+  if (kmsKeyVersion) {
+    const publicJwk = buildPublicJwkFromPem(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID);
+    material = {
+      kind: 'kms',
+      signerProvider: buildKmsWebhookProviderWrapper(kmsKeyVersion),
+      publicJwk,
+    };
+    logger.info({ kid: WEBHOOK_SIGNING_KID }, 'Webhook signing routes through GCP KMS');
+    return material;
+  }
   const raw = process.env[ENV_KEY];
-  const material = raw ? loadConfiguredKey(raw) : generateEphemeralKey();
-  signerKey = material.signer;
-  publicJwk = material.publicJwk;
+  const m = raw ? loadConfiguredKey(raw) : generateEphemeralKey();
   if (!raw) {
     logger.warn(
-      { kid: signerKey.keyid },
-      `Training agent webhook signing key generated ephemerally. Set ${ENV_KEY} for stable keys across restarts.`,
+      { kid: m.signer.keyid },
+      `Training agent webhook signing key generated ephemerally. Set ${ENV_KEY} or ${KMS_WEBHOOK_ENV} for stable keys across restarts.`,
     );
   }
+  material = { kind: 'inline', signerKey: m.signer, publicJwk: m.publicJwk };
   return material;
 }
 
-export function getPublicJwks(): { keys: AdcpJsonWebKey[] } {
-  const { publicJwk: pub } = ensureKey();
-  return { keys: [pub] };
+function buildPublicJwkFromPem(pem: string, kid: string): AdcpJsonWebKey {
+  // Inline import to keep this module's own surface lean.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createPublicKey } = require('node:crypto') as typeof import('node:crypto');
+  const raw = createPublicKey(pem).export({ format: 'jwk' }) as { kty?: string; crv?: string; x?: string };
+  if (raw.kty !== 'OKP' || raw.crv !== 'Ed25519' || typeof raw.x !== 'string') {
+    throw new Error('Webhook public key is not Ed25519 OKP');
+  }
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: raw.x,
+    kid,
+    alg: 'EdDSA',
+    adcp_use: 'webhook-signing',
+    key_ops: ['verify'],
+    use: 'sig',
+  } as AdcpJsonWebKey;
 }
 
-/** Expose the webhook signer to framework-server config (`webhooks: { signerKey }`). */
-export function getWebhookSigningKey(): SignerKey {
-  return ensureKey().signer;
+export function getPublicJwks(): { keys: AdcpJsonWebKey[] } {
+  return { keys: [ensureMaterial().publicJwk] };
+}
+
+/** Material handed to `createAdcpServer({ webhooks })` — exactly one of
+ *  `signerKey` or `signerProvider` per the SDK's discriminated config. */
+export function getWebhookSigningMaterial():
+  | { signerKey: SignerKey }
+  | { signerProvider: SigningProvider } {
+  const m = ensureMaterial();
+  return m.kind === 'kms'
+    ? { signerProvider: m.signerProvider }
+    : { signerKey: m.signerKey };
 }
 
 export function getWebhookEmitter(): WebhookEmitter {
   if (emitter) return emitter;
-  const { signer } = ensureKey();
+  const m = ensureMaterial();
   // Production (`NODE_ENV=production`, i.e. fly.io) refuses webhook delivery
   // to private/loopback/metadata addresses. Dev and CI need loopback for
   // conformance storyboards using `http://127.0.0.1:<port>` receivers.
   const allowPrivateIp = process.env.NODE_ENV !== 'production';
   emitter = createWebhookEmitter({
-    signerKey: signer,
+    ...(m.kind === 'kms' ? { signerProvider: m.signerProvider } : { signerKey: m.signerKey }),
     idempotencyKeyStore: memoryWebhookKeyStore(),
     userAgent: 'adcp-training-agent/1.0',
     fetch: createWebhookFetch({ allowPrivateIp }),
@@ -278,7 +308,6 @@ export function getWebhookEmitter(): WebhookEmitter {
 
 /** Reset state — tests only. */
 export function resetWebhookSigning(): void {
-  signerKey = null;
-  publicJwk = null;
+  material = null;
   emitter = null;
 }

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -3,22 +3,15 @@
  *
  * Uses `@adcp/client/server`'s `createWebhookEmitter` to post RFC 9421-signed
  * completion webhooks with stable `idempotency_key` per logical event and
- * retry/backoff on 5xx/429.
+ * retry/backoff on 5xx/429. The signer uses a single Ed25519 keypair sourced
+ * from `WEBHOOK_SIGNING_KEY_JWK` (a private JWK) when configured, or a
+ * freshly-generated key at startup for dev mode.
  *
- * Production (`GCP_KMS_WEBHOOK_KEY_VERSION` set): routes signing through a
- * GCP KMS-backed `SigningProvider`. Private key material never enters
- * process memory. Key separation per AdCP spec — a distinct
- * `cryptoKeyVersion` from the request-signing path.
- *
- * Dev (env unset): falls back to either `WEBHOOK_SIGNING_KEY_JWK` (a
- * stable private JWK) or a freshly-generated key at startup.
- *
- * Public key is published at the root `/.well-known/jwks.json` (with
- * `adcp_use: "webhook-signing"`) and at the training-agent's own
- * `/api/training-agent/.well-known/jwks.json` for legacy callers.
+ * Public key is published at `/.well-known/jwks.json` on the training agent
+ * router so buyers can verify incoming webhooks against a real JWKS endpoint.
  */
 
-import { createHash, generateKeyPairSync, randomUUID } from 'node:crypto';
+import { createHash, createPublicKey, generateKeyPairSync, randomUUID } from 'node:crypto';
 import {
   createWebhookEmitter,
   memoryWebhookKeyStore,
@@ -68,54 +61,100 @@ export const TOOL_TO_TASK_TYPE = {
   get_brand_identity: 'get_brand_identity',
   get_rights: 'get_rights',
   acquire_rights: 'acquire_rights',
-} as const;
+} as const satisfies Record<string, WebhookTaskType>;
 
-export type WebhookEmittingTool = keyof typeof TOOL_TO_TASK_TYPE;
+type WebhookEmittingTool = keyof typeof TOOL_TO_TASK_TYPE;
 
-export const TOOL_TO_PROTOCOL: Record<WebhookEmittingTool, 'mcp' | 'a2a'> = {
-  create_media_buy: 'mcp', update_media_buy: 'mcp', sync_creatives: 'mcp',
-  activate_signal: 'mcp', get_signals: 'mcp', create_property_list: 'mcp',
-  update_property_list: 'mcp', get_property_list: 'mcp', list_property_lists: 'mcp',
-  delete_property_list: 'mcp', sync_accounts: 'mcp', get_account_financials: 'mcp',
-  get_creative_delivery: 'mcp', sync_event_sources: 'mcp', sync_audiences: 'mcp',
-  sync_catalogs: 'mcp', log_event: 'mcp', get_brand_identity: 'mcp',
-  get_rights: 'mcp', acquire_rights: 'mcp',
+/** AdCP protocol domain for each webhook-emitting tool. Values are the kebab-case
+ *  enum from `enums/adcp-protocol.json`. Matches the spec's operational grouping:
+ *  creative operations bundled into a media-buy seller stamp as `media-buy`
+ *  (see `core/mcp-webhook-payload.json` example where `sync_creatives` → `media-buy`);
+ *  dedicated brand / signals / governance tools stamp their own domain. The
+ *  `Record<WebhookEmittingTool, ...>` type forces this map to stay in sync with
+ *  `TOOL_TO_TASK_TYPE` — adding a tool there without a protocol here fails tsc. */
+type WebhookProtocol = 'media-buy' | 'signals' | 'governance' | 'creative' | 'brand' | 'sponsored-intelligence';
+
+const TOOL_TO_PROTOCOL: Readonly<Record<WebhookEmittingTool, WebhookProtocol>> = {
+  create_media_buy: 'media-buy',
+  update_media_buy: 'media-buy',
+  sync_creatives: 'media-buy',
+  get_creative_delivery: 'media-buy',
+  sync_event_sources: 'media-buy',
+  sync_audiences: 'media-buy',
+  sync_catalogs: 'media-buy',
+  log_event: 'media-buy',
+  sync_accounts: 'governance',
+  get_account_financials: 'governance',
+  activate_signal: 'signals',
+  get_signals: 'signals',
+  create_property_list: 'governance',
+  update_property_list: 'governance',
+  get_property_list: 'governance',
+  list_property_lists: 'governance',
+  delete_property_list: 'governance',
+  get_brand_identity: 'brand',
+  get_rights: 'brand',
+  acquire_rights: 'brand',
 };
 
-/**
- * Extract the webhook URL from tool arguments. Caller drops the optional
- * `push_notification_config.{url,authentication}` fields onto the request;
- * we sign only the URL.
- */
 function extractWebhookUrl(args: Record<string, unknown>): string | undefined {
-  const pnc = args.push_notification_config;
+  const pnc = args.push_notification_config as { url?: unknown } | undefined;
   if (!pnc || typeof pnc !== 'object') return undefined;
-  const url = (pnc as { url?: unknown }).url;
-  return typeof url === 'string' && url.length > 0 ? url : undefined;
+  return typeof pnc.url === 'string' && pnc.url.length > 0 ? pnc.url : undefined;
 }
 
-/** A stable, deterministic key for the operation a webhook represents. */
+/** Derive a stable logical event id for webhook idempotency. Two emissions
+ *  with the same operation_id reuse the same `idempotency_key` across retries.
+ *  Prefers a buyer-facing entity id from the response so retries from the same
+ *  buyer collapse; falls back to the request's idempotency_key.
+ *
+ *  Scoped by the caller's principal so two buyers sharing the public sandbox
+ *  token who happen to land on the same deterministic response entity id
+ *  (e.g. both get `mb_abc123`) produce distinct webhook idempotency_keys.
+ *  Without the prefix, a receiver that dedupes across tenants on
+ *  `idempotency_key` would drop the second buyer's event as a duplicate of
+ *  the first. The principal is the same scoped string the request-side
+ *  idempotency cache uses (`scopedPrincipal(auth, accountScope)`), so both
+ *  caches partition identically. */
 export function deriveWebhookOperationId(
   toolName: string,
   response: Record<string, unknown>,
   requestIdempotencyKey: string | undefined,
   principal: string,
 ): string {
-  const taskId = typeof response.task_id === 'string' ? response.task_id : null;
-  const seed = taskId ?? requestIdempotencyKey ?? randomUUID();
-  return createHash('sha256').update(principal).update('').update(toolName).update('').update(seed).digest('hex').slice(0, 32);
+  for (const field of ['media_buy_id', 'creative_id', 'activation_id', 'signal_activation_id', 'task_id', 'list_id', 'account_id']) {
+    const v = response[field];
+    if (typeof v === 'string' && v.length > 0) return `${principal}|${toolName}.${v}`;
+  }
+  if (requestIdempotencyKey) return `${principal}|${toolName}.${requestIdempotencyKey}`;
+  return `${principal}|${toolName}.${randomUUID()}`;
 }
 
-/** Fire-and-forget completion webhook emission. The `toolName` is `string`
- *  (not `WebhookEmittingTool`) because callers — `task-handlers.ts:3750`
- *  and `framework-server.ts:265` — operate on the AdCP server's full tool
- *  surface, not just the webhook-emitting subset. The runtime guard below
- *  filters to the subset before dispatching. */
+/**
+ * Fire a completion webhook for a successful tool call if the buyer supplied
+ * `push_notification_config.url` and the tool maps to a webhook task type.
+ *
+ * Fire-and-forget: the emitter handles RFC 9421 signing, `idempotency_key`
+ * stability across retries, and retry/backoff on 5xx/429 internally. Any
+ * delivery failure is logged but never surfaces to the caller — the sync
+ * response has already been returned.
+ *
+ * Shared between legacy dispatch (`task-handlers.ts`) and the framework
+ * adapter (`framework-server.ts`) so both paths emit byte-identical envelopes.
+ */
 export function maybeEmitCompletionWebhook(opts: {
   toolName: string;
   args: Record<string, unknown>;
   response: Record<string, unknown>;
   requestIdempotencyKey?: string;
+  /** Caller-uniqueness key for webhook idempotency. Pass the same value the
+   *  request-side idempotency store uses for this caller (legacy dispatch
+   *  passes `scopedPrincipal(auth, accountScope)`; the framework path passes
+   *  `auth` directly except for `static:public` where it scopes by account).
+   *  Two distinct callers MUST produce distinct strings here, otherwise
+   *  receivers that dedupe across tenants on `idempotency_key` may drop one
+   *  caller's webhook as a duplicate of another's. Empty strings are rejected
+   *  fail-fast — they would silently degrade scoping to "no partitioning". */
   principal: string;
 }): void {
   if (!opts.principal) {
@@ -193,6 +232,7 @@ function loadConfiguredKey(raw: string): { signer: SignerKey; publicJwk: AdcpJso
       key_ops: ['sign'],
     },
   };
+  // Public JWK is the private JWK minus `d`.
   const { d: _drop, ...publicOnly } = jwk;
   const pubJwk: AdcpJsonWebKey = {
     ...publicOnly,
@@ -207,11 +247,11 @@ function loadConfiguredKey(raw: string): { signer: SignerKey; publicJwk: AdcpJso
 /**
  * Synchronous SigningProvider wrapper around the lazy KMS-backed
  * webhook-signing provider. The wire identity (`keyid`, `algorithm`,
- * `fingerprint`) is known statically from committed constants, so we can
- * hand a fully-shaped provider to `createWebhookEmitter` without waiting
- * for the KMS round-trip. The first `sign()` call resolves the underlying
- * KMS provider (cached singleton in `gcp-kms-signer.ts`) and delegates;
- * the tripwire / algorithm assertion fires there.
+ * `fingerprint`) is known statically from committed constants, so we
+ * hand a fully-shaped provider to `createWebhookEmitter` without
+ * blocking on a KMS round-trip at startup. The first `sign()` call
+ * resolves the underlying KMS singleton in `gcp-kms-signer.ts`; the
+ * tripwire / algorithm assertion fires there.
  */
 function buildKmsWebhookProviderWrapper(keyVersion: string): SigningProvider {
   return {
@@ -230,35 +270,7 @@ function buildKmsWebhookProviderWrapper(keyVersion: string): SigningProvider {
   };
 }
 
-function ensureMaterial(): WebhookMaterial {
-  if (material) return material;
-  const kmsKeyVersion = process.env[KMS_WEBHOOK_ENV];
-  if (kmsKeyVersion) {
-    const publicJwk = buildPublicJwkFromPem(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID);
-    material = {
-      kind: 'kms',
-      signerProvider: buildKmsWebhookProviderWrapper(kmsKeyVersion),
-      publicJwk,
-    };
-    logger.info({ kid: WEBHOOK_SIGNING_KID }, 'Webhook signing routes through GCP KMS');
-    return material;
-  }
-  const raw = process.env[ENV_KEY];
-  const m = raw ? loadConfiguredKey(raw) : generateEphemeralKey();
-  if (!raw) {
-    logger.warn(
-      { kid: m.signer.keyid },
-      `Training agent webhook signing key generated ephemerally. Set ${ENV_KEY} or ${KMS_WEBHOOK_ENV} for stable keys across restarts.`,
-    );
-  }
-  material = { kind: 'inline', signerKey: m.signer, publicJwk: m.publicJwk };
-  return material;
-}
-
-function buildPublicJwkFromPem(pem: string, kid: string): AdcpJsonWebKey {
-  // Inline import to keep this module's own surface lean.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { createPublicKey } = require('node:crypto') as typeof import('node:crypto');
+function publicJwkFromPem(pem: string, kid: string): AdcpJsonWebKey {
   const raw = createPublicKey(pem).export({ format: 'jwk' }) as { kty?: string; crv?: string; x?: string };
   if (raw.kty !== 'OKP' || raw.crv !== 'Ed25519' || typeof raw.x !== 'string') {
     throw new Error('Webhook public key is not Ed25519 OKP');
@@ -275,11 +287,35 @@ function buildPublicJwkFromPem(pem: string, kid: string): AdcpJsonWebKey {
   } as AdcpJsonWebKey;
 }
 
+function ensureMaterial(): WebhookMaterial {
+  if (material) return material;
+  const kmsKeyVersion = process.env[KMS_WEBHOOK_ENV];
+  if (kmsKeyVersion) {
+    material = {
+      kind: 'kms',
+      signerProvider: buildKmsWebhookProviderWrapper(kmsKeyVersion),
+      publicJwk: publicJwkFromPem(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID),
+    };
+    logger.info({ kid: WEBHOOK_SIGNING_KID }, 'Webhook signing routes through GCP KMS');
+    return material;
+  }
+  const raw = process.env[ENV_KEY];
+  const m = raw ? loadConfiguredKey(raw) : generateEphemeralKey();
+  if (!raw) {
+    logger.warn(
+      { kid: m.signer.keyid },
+      `Training agent webhook signing key generated ephemerally. Set ${ENV_KEY} or ${KMS_WEBHOOK_ENV} for stable keys across restarts.`,
+    );
+  }
+  material = { kind: 'inline', signerKey: m.signer, publicJwk: m.publicJwk };
+  return material;
+}
+
 export function getPublicJwks(): { keys: AdcpJsonWebKey[] } {
   return { keys: [ensureMaterial().publicJwk] };
 }
 
-/** Material handed to `createAdcpServer({ webhooks })` — exactly one of
+/** Expose the webhook signer to framework-server config — exactly one of
  *  `signerKey` or `signerProvider` per the SDK's discriminated config. */
 export function getWebhookSigningMaterial():
   | { signerKey: SignerKey }

--- a/server/tests/unit/gcp-kms-signer.test.ts
+++ b/server/tests/unit/gcp-kms-signer.test.ts
@@ -1,85 +1,132 @@
 /**
- * Tests for the GCP KMS-backed RFC 9421 signing provider.
- *
- * The signer module reads two Fly secrets (GCP_SA_JSON, GCP_KMS_KEY_VERSION).
- * These tests cover the env-handling paths and the JWKS publication that
+ * Tests for the GCP KMS-backed RFC 9421 signing providers (request +
+ * webhook). Covers the env-handling paths and the JWKS publication that
  * doesn't need a real KMS — full KMS round-trips need a mocked client and
  * are out of scope for unit tests.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createPublicKey } from 'node:crypto';
 
-import { getGcpKmsSigningProvider, resetGcpKmsSignerForTests } from '../../src/security/gcp-kms-signer.js';
+import {
+  getRequestSigningProvider,
+  getWebhookSigningProvider,
+  resetGcpKmsSignerForTests,
+} from '../../src/security/gcp-kms-signer.js';
 import { getPublicSigningJwks, resetJwksForTests } from '../../src/security/jwks.js';
-import { EXPECTED_PUBLIC_KEY_PEM, KID } from '../../src/security/expected-public-key.js';
+import {
+  REQUEST_SIGNING_PUBLIC_KEY_PEM,
+  REQUEST_SIGNING_KID,
+  WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
+  WEBHOOK_SIGNING_KID,
+} from '../../src/security/expected-public-key.js';
 
-describe('gcp-kms-signer env handling', () => {
+describe('gcp-kms-signer env handling — request signing', () => {
   const originalSa = process.env.GCP_SA_JSON;
-  const originalKey = process.env.GCP_KMS_KEY_VERSION;
+  const originalReq = process.env.GCP_KMS_KEY_VERSION;
+  const originalWh = process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
 
   beforeEach(() => {
     delete process.env.GCP_SA_JSON;
     delete process.env.GCP_KMS_KEY_VERSION;
+    delete process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
     resetGcpKmsSignerForTests();
   });
 
   afterEach(() => {
     if (originalSa === undefined) delete process.env.GCP_SA_JSON;
     else process.env.GCP_SA_JSON = originalSa;
-    if (originalKey === undefined) delete process.env.GCP_KMS_KEY_VERSION;
-    else process.env.GCP_KMS_KEY_VERSION = originalKey;
+    if (originalReq === undefined) delete process.env.GCP_KMS_KEY_VERSION;
+    else process.env.GCP_KMS_KEY_VERSION = originalReq;
+    if (originalWh === undefined) delete process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
+    else process.env.GCP_KMS_WEBHOOK_KEY_VERSION = originalWh;
     resetGcpKmsSignerForTests();
   });
 
   it('returns null when neither secret is set (dev default)', async () => {
-    const provider = await getGcpKmsSigningProvider();
-    expect(provider).toBeNull();
+    expect(await getRequestSigningProvider()).toBeNull();
   });
 
   it('throws when GCP_SA_JSON is set but GCP_KMS_KEY_VERSION is not', async () => {
     process.env.GCP_SA_JSON = '{"client_email":"x@example.com","private_key":"x"}';
-    await expect(getGcpKmsSigningProvider()).rejects.toThrow(/partially configured/i);
+    await expect(getRequestSigningProvider()).rejects.toThrow(/partially configured/i);
   });
 
   it('throws when GCP_KMS_KEY_VERSION is set but GCP_SA_JSON is not', async () => {
     process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1';
-    await expect(getGcpKmsSigningProvider()).rejects.toThrow(/partially configured/i);
+    await expect(getRequestSigningProvider()).rejects.toThrow(/partially configured/i);
   });
 
   it('throws when GCP_SA_JSON is not valid JSON', async () => {
     process.env.GCP_SA_JSON = 'not json';
     process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1';
-    await expect(getGcpKmsSigningProvider()).rejects.toThrow(/not valid JSON/i);
+    await expect(getRequestSigningProvider()).rejects.toThrow(/not valid JSON/i);
   });
 
   it('throws when GCP_SA_JSON lacks client_email or private_key', async () => {
     process.env.GCP_SA_JSON = '{"client_email":"x@example.com"}';
     process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1';
-    await expect(getGcpKmsSigningProvider()).rejects.toThrow(/client_email.*private_key|private_key.*client_email/i);
+    await expect(getRequestSigningProvider()).rejects.toThrow(/client_email.*private_key|private_key.*client_email/i);
   });
 
   it('JSON.parse error message does NOT include parser detail (parser offset can quote secret bytes)', async () => {
     process.env.GCP_SA_JSON = '{"private_key":"-----BEGIN ROOT_OF_TRUST_BYTES-----';
     process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1';
-    await expect(getGcpKmsSigningProvider()).rejects.toThrow(/^GCP_SA_JSON is not valid JSON$/);
-    // Negative assertion: the rejected error must not echo the malformed payload.
+    await expect(getRequestSigningProvider()).rejects.toThrow(/^GCP_SA_JSON is not valid JSON$/);
     await expect(
-      getGcpKmsSigningProvider().catch((e: Error) => e.message)
+      getRequestSigningProvider().catch((e: Error) => e.message)
     ).resolves.not.toMatch(/ROOT_OF_TRUST_BYTES|position \d+|Unexpected/);
   });
 
   it('concurrent first calls share one in-flight init (env-rejection path)', async () => {
     process.env.GCP_SA_JSON = '{"client_email":"x@example.com"}';
     process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1';
-    // Both should reject for the same reason (missing private_key) — and the
-    // race-fix guarantees they don't fan out to two independent KMS clients
-    // even when the rejection is synchronous-ish.
     const [a, b] = await Promise.allSettled([
-      getGcpKmsSigningProvider(),
-      getGcpKmsSigningProvider(),
+      getRequestSigningProvider(),
+      getRequestSigningProvider(),
     ]);
     expect(a.status).toBe('rejected');
     expect(b.status).toBe('rejected');
+  });
+});
+
+describe('gcp-kms-signer env handling — webhook signing', () => {
+  const originalSa = process.env.GCP_SA_JSON;
+  const originalReq = process.env.GCP_KMS_KEY_VERSION;
+  const originalWh = process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
+
+  beforeEach(() => {
+    delete process.env.GCP_SA_JSON;
+    delete process.env.GCP_KMS_KEY_VERSION;
+    delete process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
+    resetGcpKmsSignerForTests();
+  });
+
+  afterEach(() => {
+    if (originalSa === undefined) delete process.env.GCP_SA_JSON;
+    else process.env.GCP_SA_JSON = originalSa;
+    if (originalReq === undefined) delete process.env.GCP_KMS_KEY_VERSION;
+    else process.env.GCP_KMS_KEY_VERSION = originalReq;
+    if (originalWh === undefined) delete process.env.GCP_KMS_WEBHOOK_KEY_VERSION;
+    else process.env.GCP_KMS_WEBHOOK_KEY_VERSION = originalWh;
+    resetGcpKmsSignerForTests();
+  });
+
+  it('returns null when neither secret is set', async () => {
+    expect(await getWebhookSigningProvider()).toBeNull();
+  });
+
+  it('throws when GCP_SA_JSON is set but GCP_KMS_WEBHOOK_KEY_VERSION is not', async () => {
+    process.env.GCP_SA_JSON = '{"client_email":"x@example.com","private_key":"x"}';
+    await expect(getWebhookSigningProvider()).rejects.toThrow(/webhook-signing partially configured/i);
+  });
+
+  it('request and webhook caches are independent', async () => {
+    process.env.GCP_SA_JSON = '{"client_email":"x@example.com"}';
+    process.env.GCP_KMS_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/req/cryptoKeyVersions/1';
+    process.env.GCP_KMS_WEBHOOK_KEY_VERSION = 'projects/p/locations/l/keyRings/r/cryptoKeys/wh/cryptoKeyVersions/1';
+    // Both reject (missing private_key in SA), independently.
+    await expect(getRequestSigningProvider()).rejects.toThrow(/client_email.*private_key|private_key.*client_email/i);
+    await expect(getWebhookSigningProvider()).rejects.toThrow(/client_email.*private_key|private_key.*client_email/i);
   });
 });
 
@@ -88,24 +135,43 @@ describe('getPublicSigningJwks', () => {
     resetJwksForTests();
   });
 
-  it('publishes one Ed25519 JWK with the expected kid', () => {
+  it('publishes two JWKs — one per AdCP signing purpose', () => {
     const jwks = getPublicSigningJwks();
-    expect(jwks.keys).toHaveLength(1);
-    const jwk = jwks.keys[0];
+    expect(jwks.keys).toHaveLength(2);
+    const purposes = jwks.keys.map(k => k.adcp_use).sort();
+    expect(purposes).toEqual(['request-signing', 'webhook-signing']);
+  });
+
+  it('request-signing JWK shape', () => {
+    const jwk = getPublicSigningJwks().keys.find(k => k.adcp_use === 'request-signing')!;
     expect(jwk.kty).toBe('OKP');
     expect(jwk.crv).toBe('Ed25519');
     expect(jwk.alg).toBe('EdDSA');
     expect(jwk.use).toBe('sig');
-    expect(jwk.adcp_use).toBe('request-signing');
-    expect(jwk.kid).toBe(KID);
+    expect(jwk.kid).toBe(REQUEST_SIGNING_KID);
     expect(jwk.key_ops).toEqual(['verify']);
+    const pemDerived = createPublicKey(REQUEST_SIGNING_PUBLIC_KEY_PEM).export({ format: 'jwk' }) as { x?: string };
+    expect(jwk.x).toBe(pemDerived.x);
   });
 
-  it('JWK x parameter matches the committed PEM public key', () => {
-    const jwks = getPublicSigningJwks();
-    const jwk = jwks.keys[0];
-    const pemDerived = createPublicKey(EXPECTED_PUBLIC_KEY_PEM).export({ format: 'jwk' }) as { x?: string };
+  it('webhook-signing JWK shape', () => {
+    const jwk = getPublicSigningJwks().keys.find(k => k.adcp_use === 'webhook-signing')!;
+    expect(jwk.kty).toBe('OKP');
+    expect(jwk.crv).toBe('Ed25519');
+    expect(jwk.alg).toBe('EdDSA');
+    expect(jwk.use).toBe('sig');
+    expect(jwk.kid).toBe(WEBHOOK_SIGNING_KID);
+    expect(jwk.key_ops).toEqual(['verify']);
+    const pemDerived = createPublicKey(WEBHOOK_SIGNING_PUBLIC_KEY_PEM).export({ format: 'jwk' }) as { x?: string };
     expect(jwk.x).toBe(pemDerived.x);
+  });
+
+  it('request and webhook keys have distinct material (per AdCP key-separation)', () => {
+    const jwks = getPublicSigningJwks();
+    const req = jwks.keys.find(k => k.adcp_use === 'request-signing')!;
+    const webhook = jwks.keys.find(k => k.adcp_use === 'webhook-signing')!;
+    expect(req.x).not.toBe(webhook.x);
+    expect(req.kid).not.toBe(webhook.kid);
   });
 
   it('returns the same object on repeated calls (cache)', () => {


### PR DESCRIPTION
## Summary

Routes the training-agent's outbound webhook signing through a GCP KMS `SigningProvider` (5.21.0 surface, [#1020](https://github.com/adcontextprotocol/adcp-client/issues/1020) / PR [adcp-client#1021](https://github.com/adcontextprotocol/adcp-client/pull/1021)). Private webhook-signing key material no longer enters process memory in production.

Bumps `@adcp/client` 5.20.0 → 5.21.0.

## Why a second KMS key (and not the request-signing one)

AdCP's spec requires distinct key material per signing purpose (`docs/guides/SIGNING-GUIDE.md` § Key separation). This PR follows that — provisions a second `cryptoKeyVersion` for webhook signing, surfaced via a new Fly secret `GCP_KMS_WEBHOOK_KEY_VERSION`. Shared `GCP_SA_JSON` covers IAM for both.

## Surface

**`server/src/security/gcp-kms-signer.ts`** — refactored into a factory pattern with two named exports:
- `getRequestSigningProvider()` — outbound AdCP request signing (was `getGcpKmsSigningProvider`)
- `getWebhookSigningProvider()` — webhook signing

Shared init / tripwire / lazy-singleton / in-flight-dedup. Each provider has its own cached state.

**`server/src/security/expected-public-key.ts`** — both committed PEMs and KIDs:
- `aao-signing-2026-04` (request-signing)
- `aao-webhook-2026-04` (webhook-signing)

**`server/src/security/jwks.ts`** — `/.well-known/jwks.json` now advertises both keys with their respective `adcp_use` values. Receivers enforce purpose at that field per [adcp#2423](https://github.com/adcontextprotocol/adcp/issues/2423).

**`server/src/training-agent/webhooks.ts`** — new synchronous `SigningProvider` wrapper that exposes the static wire identity (keyid/algorithm/fingerprint from constants) immediately and defers the KMS round-trip to first `sign()` call. Lets `createAdcpServer`'s sync `webhooks` config accept a provider whose KMS init hasn't happened yet. Dev fallback unchanged: ephemeral key generation or `WEBHOOK_SIGNING_KEY_JWK` when KMS env unset.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 15 unit tests in `server/tests/unit/gcp-kms-signer.test.ts` covering env handling for both providers + JWKS shape (request + webhook entries, distinct material)

## Verification post-deploy

```
curl https://agenticadvertising.org/.well-known/jwks.json | jq '.keys | map({kid, adcp_use, x: (.x[0:8] + "...")})'
```

Expected: two entries, distinct `x` values, one `adcp_use: "request-signing"` (kid `aao-signing-2026-04`), one `adcp_use: "webhook-signing"` (kid `aao-webhook-2026-04`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)