### PR TITLE
feat(addie): dynamic per-context labels for suggested prompts (closes #3304)

### DIFF
--- a/.changeset/addie-dynamic-prompt-labels.md
+++ b/.changeset/addie-dynamic-prompt-labels.md
@@ -1,0 +1,4 @@
+---
+---
+
+Closes #3304: dynamic per-context labels and prompts for Addie's suggested-prompts engine. `PromptRule.label` and `.prompt` now accept `string | (ctx) => string`. Resolves at evaluation time. Dynamic-prompt rules opt into a `matchClick` callback for click telemetry since the static reverse-index can't represent function strings. Cert continuation now renders "Continue A1" / "Let's keep going with A1. Where did we leave off?" when module_id is known, falling back to track_id ("Continue A") and the original generic phrasing when neither is present.

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -56,6 +56,18 @@ function hasFreshInProgressCertification(ctx: MemberContext | null): boolean {
   return age < 45 * 24 * 60 * 60 * 1000;
 }
 
+/**
+ * Most-specific identifier we have for the user's current certification
+ * attempt — module_id when we know it (e.g. 'A1'), else track_id (e.g.
+ * 'A'), else null. Used by the cert continuation rule to personalize
+ * its label and prompt without baking in track-specific copy.
+ */
+function certModuleLabel(ctx: MemberContext | null): string | null {
+  const cert = ctx?.certification;
+  if (!cert) return null;
+  return cert.module_id ?? cert.track_id ?? null;
+}
+
 function isLowLoginActive(ctx: MemberContext | null): boolean {
   const last = lastLoginMs(ctx);
   if (last === null) return false;
@@ -220,8 +232,21 @@ export const MEMBER_RULES: PromptRule[] = [
     decay: false,
     when: ({ memberContext }) =>
       isMember(memberContext) && hasFreshInProgressCertification(memberContext),
-    label: 'Continue certification',
-    prompt: 'Pick up where I left off in certification.',
+    label: ({ memberContext }) => {
+      const id = certModuleLabel(memberContext);
+      return id ? `Continue ${id}` : 'Continue certification';
+    },
+    prompt: ({ memberContext }) => {
+      const id = certModuleLabel(memberContext);
+      return id
+        ? `Let's keep going with ${id}. Where did we leave off?`
+        : 'Pick up where I left off in certification.';
+    },
+    // Dynamic prompt → can't live in the static reverse-index. Match
+    // against either the module-specific or the generic phrasing.
+    matchClick: (msg) =>
+      /^Let's keep going with [A-Za-z0-9-]+\. Where did we leave off\?$/.test(msg) ||
+      msg === 'Pick up where I left off in certification.',
   },
   {
     id: 'profile.incomplete',
@@ -348,16 +373,30 @@ export const ALL_RULES: PromptRule[] = [...ADMIN_RULES, ...MEMBER_RULES];
  * positives (a user paraphrases the same idea) would inflate the CTR
  * for popular rules. We accept a few false negatives (a user manually
  * retypes the prompt with a different period) for cleaner data.
+ *
+ * Rules with dynamic (function) `prompt` are not in the static index —
+ * they must provide a `matchClick` callback instead.
  */
 const PROMPT_TO_RULE_ID = new Map<string, string>(
-  ALL_RULES.map((r) => [r.prompt.trim(), r.id]),
+  ALL_RULES
+    .filter((r): r is PromptRule & { prompt: string } => typeof r.prompt === 'string')
+    .map((r) => [r.prompt.trim(), r.id]),
 );
+
+const RULES_WITH_MATCH_CLICK = ALL_RULES.filter((r) => typeof r.matchClick === 'function');
 
 /**
  * Look up the rule_id whose prompt text matches the given user message
- * verbatim. Returns null when there is no match.
+ * verbatim. Falls back to per-rule `matchClick` callbacks for rules
+ * with dynamic prompts. Returns null when there is no match.
  */
 export function matchRuleIdFromMessage(message: string | null | undefined): string | null {
   if (!message) return null;
-  return PROMPT_TO_RULE_ID.get(message.trim()) ?? null;
+  const trimmed = message.trim();
+  const staticHit = PROMPT_TO_RULE_ID.get(trimmed);
+  if (staticHit) return staticHit;
+  for (const rule of RULES_WITH_MATCH_CLICK) {
+    if (rule.matchClick!(trimmed)) return rule.id;
+  }
+  return null;
 }

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -243,9 +243,12 @@ export const MEMBER_RULES: PromptRule[] = [
         : 'Pick up where I left off in certification.';
     },
     // Dynamic prompt → can't live in the static reverse-index. Match
-    // against either the module-specific or the generic phrasing.
+    // against either the module-specific or the generic phrasing. The
+    // character class stays in sync with certModuleLabel's output (the
+    // module_id or track_id from the certification schema) — \w lets
+    // future ids like 'A1_intro' still register as a click on this rule.
     matchClick: (msg) =>
-      /^Let's keep going with [A-Za-z0-9-]+\. Where did we leave off\?$/.test(msg) ||
+      /^Let's keep going with [\w-]+\. Where did we leave off\?$/.test(msg) ||
       msg === 'Pick up where I left off in certification.',
   },
   {

--- a/server/src/addie/home/builders/rules/types.ts
+++ b/server/src/addie/home/builders/rules/types.ts
@@ -5,12 +5,19 @@ export interface PromptRuleContext {
   isAdmin: boolean;
 }
 
+/**
+ * A rule's display strings can be either static or a function of context.
+ * Use functions when the prompt should reflect specific user state
+ * (e.g. "Continue A1" instead of a generic "Continue certification").
+ */
+export type PromptString = string | ((ctx: PromptRuleContext) => string);
+
 export interface PromptRule {
   id: string;
   priority: number;
   when: (ctx: PromptRuleContext) => boolean;
-  label: string;
-  prompt: string;
+  label: PromptString;
+  prompt: PromptString;
   /**
    * When false, this rule is exempt from auto-suppression — it can fire
    * on every render even if the user has seen it many times. Use for
@@ -18,4 +25,21 @@ export interface PromptRule {
    * point rather than a one-time nudge.
    */
   decay?: boolean;
+  /**
+   * Optional override for click detection. Required for rules whose
+   * `prompt` is a function — the static reverse-index can't represent
+   * dynamic strings. Return true when the incoming user message looks
+   * like a click on this rule.
+   */
+  matchClick?: (message: string) => boolean;
+}
+
+/**
+ * Resolve a PromptString to its string value at evaluation time.
+ */
+export function resolvePromptString(
+  s: PromptString,
+  ctx: PromptRuleContext,
+): string {
+  return typeof s === 'function' ? s(ctx) : s;
 }

--- a/server/src/addie/home/builders/suggested-prompts.ts
+++ b/server/src/addie/home/builders/suggested-prompts.ts
@@ -1,7 +1,8 @@
 import type { SuggestedPrompt } from '../types.js';
 import type { MemberContext } from '../../member-context.js';
 import { ADMIN_RULES, MEMBER_RULES } from './rules/prompt-rules.js';
-import type { PromptRule } from './rules/types.js';
+import { resolvePromptString } from './rules/types.js';
+import type { PromptRule, PromptRuleContext } from './rules/types.js';
 
 const MAX_PROMPTS = 4;
 
@@ -54,12 +55,17 @@ function evaluate(
     })
     .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id));
 
+  // Resolve dynamic labels/prompts once per rule so dedup-by-label
+  // operates on the rendered text, not the function reference.
+  const ruleCtx: PromptRuleContext = ctx;
   const seenLabels = new Set<string>();
-  const picked: PromptRule[] = [];
+  const picked: { rule: PromptRule; label: string; prompt: string }[] = [];
   for (const rule of matched) {
-    if (seenLabels.has(rule.label)) continue;
-    seenLabels.add(rule.label);
-    picked.push(rule);
+    const label = resolvePromptString(rule.label, ruleCtx);
+    const prompt = resolvePromptString(rule.prompt, ruleCtx);
+    if (seenLabels.has(label)) continue;
+    seenLabels.add(label);
+    picked.push({ rule, label, prompt });
     if (picked.length >= MAX_PROMPTS) break;
   }
   // Web home renders these in a 2-column grid; an odd count leaves a stray cell.
@@ -67,7 +73,7 @@ function evaluate(
 
   // ruleIds returned to callers excludes decay: false rules — those should
   // not be recorded in telemetry, since they're exempt from suppression.
-  const prompts = picked.map((r) => ({ label: r.label, prompt: r.prompt }));
-  const ruleIds = picked.filter((r) => r.decay !== false).map((r) => r.id);
+  const prompts = picked.map(({ label, prompt }) => ({ label, prompt }));
+  const ruleIds = picked.filter(({ rule }) => rule.decay !== false).map(({ rule }) => rule.id);
   return { prompts, ruleIds };
 }

--- a/server/src/addie/home/builders/suggested-prompts.ts
+++ b/server/src/addie/home/builders/suggested-prompts.ts
@@ -56,7 +56,10 @@ function evaluate(
     .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id));
 
   // Resolve dynamic labels/prompts once per rule so dedup-by-label
-  // operates on the rendered text, not the function reference.
+  // operates on the rendered text, not the function reference. If a
+  // dynamic rule ever renders to the same label as a higher-priority
+  // static rule, the higher-priority rule wins (priority sort above
+  // runs first); the dynamic rule is dropped from this render.
   const ruleCtx: PromptRuleContext = ctx;
   const seenLabels = new Set<string>();
   const picked: { rule: PromptRule; label: string; prompt: string }[] = [];

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -334,7 +334,7 @@ describe('buildSuggestedPrompts', () => {
           last_activity_at: DAYS_AGO(2),
         },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Continue certification');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Continue A1');
     });
 
     it('does not show the cert prompt when the latest attempt is passed', () => {
@@ -347,7 +347,7 @@ describe('buildSuggestedPrompts', () => {
           last_activity_at: DAYS_AGO(20),
         },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue A1');
     });
 
     it('does not show the cert prompt when the latest attempt is failed', () => {
@@ -360,12 +360,12 @@ describe('buildSuggestedPrompts', () => {
           last_activity_at: DAYS_AGO(20),
         },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue A1');
     });
 
     it('does not show the cert prompt when there is no attempt', () => {
       const ctx = makeMember({ certification: undefined });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue A1');
     });
 
     it('does not show the cert prompt when the attempt is older than 45 days (stale)', () => {
@@ -378,7 +378,7 @@ describe('buildSuggestedPrompts', () => {
           last_activity_at: DAYS_AGO(60),
         },
       });
-      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue certification');
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Continue A1');
     });
 
     it('cert continuation outranks profile completeness', () => {
@@ -390,7 +390,7 @@ describe('buildSuggestedPrompts', () => {
         community_profile: { is_public: false, slug: null, completeness: 30, github_username: null },
       });
       const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
-      const certIdx = labels.indexOf('Continue certification');
+      const certIdx = labels.indexOf('Continue A1');
       const profileIdx = labels.indexOf('Complete my profile');
       expect(certIdx).toBeGreaterThanOrEqual(0);
       expect(profileIdx).toBeGreaterThanOrEqual(0);
@@ -406,7 +406,7 @@ describe('buildSuggestedPrompts', () => {
         engagement: { login_count_30d: 0, last_login: DAYS_AGO(60), working_group_count: 0, email_click_count_30d: 0, interest_level: null },
       });
       const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
-      const certIdx = labels.indexOf('Continue certification');
+      const certIdx = labels.indexOf('Continue A1');
       const lapsedIdx = labels.indexOf("What's new since you were last here?");
       expect(certIdx).toBeGreaterThanOrEqual(0);
       expect(lapsedIdx).toBeGreaterThanOrEqual(0);
@@ -422,7 +422,7 @@ describe('buildSuggestedPrompts', () => {
         },
       });
       const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
-      expect(labels).toContain('Continue certification');
+      expect(labels).toContain('Continue A1');
       expect(labels).not.toContain('Start with the Academy');
     });
 
@@ -593,10 +593,10 @@ describe('buildSuggestedPrompts', () => {
   });
 
   describe('matchRuleIdFromMessage (heuristic click detection)', () => {
-    it('matches a known prompt verbatim', () => {
-      const certRule = ALL_RULES.find((r) => r.id === 'cert.continue_in_progress');
-      expect(certRule).toBeDefined();
-      expect(matchRuleIdFromMessage(certRule!.prompt)).toBe('cert.continue_in_progress');
+    it('matches a known static prompt verbatim', () => {
+      const fallback = ALL_RULES.find((r) => r.id === 'fallback.whats_new')!;
+      expect(typeof fallback.prompt).toBe('string');
+      expect(matchRuleIdFromMessage(fallback.prompt as string)).toBe('fallback.whats_new');
     });
 
     it('matches with surrounding whitespace trimmed', () => {
@@ -615,14 +615,63 @@ describe('buildSuggestedPrompts', () => {
     });
 
     it('does not match a paraphrase (intentional false-negative)', () => {
-      const rule = ALL_RULES.find((r) => r.id === 'cert.continue_in_progress')!;
-      const paraphrased = rule.prompt.replace(/\.$/, '!');
+      const fallback = ALL_RULES.find((r) => r.id === 'fallback.whats_new')!;
+      const paraphrased = (fallback.prompt as string).replace(/\?$/, '!');
       expect(matchRuleIdFromMessage(paraphrased)).toBeNull();
     });
 
-    it('every rule has a unique prompt string (so the reverse index is unambiguous)', () => {
-      const prompts = ALL_RULES.map((r) => r.prompt);
-      expect(new Set(prompts).size).toBe(prompts.length);
+    it('matches the cert continuation rule via its module-specific phrasing', () => {
+      expect(matchRuleIdFromMessage("Let's keep going with A1. Where did we leave off?"))
+        .toBe('cert.continue_in_progress');
+      expect(matchRuleIdFromMessage("Let's keep going with B2. Where did we leave off?"))
+        .toBe('cert.continue_in_progress');
+    });
+
+    it('matches the cert continuation rule via the generic fallback phrasing', () => {
+      expect(matchRuleIdFromMessage('Pick up where I left off in certification.'))
+        .toBe('cert.continue_in_progress');
+    });
+
+    it('every rule with a static prompt has a unique prompt string', () => {
+      const staticPrompts = ALL_RULES
+        .filter((r) => typeof r.prompt === 'string')
+        .map((r) => r.prompt as string);
+      expect(new Set(staticPrompts).size).toBe(staticPrompts.length);
+    });
+  });
+
+  describe('dynamic prompt rendering', () => {
+    it('renders module-specific label when module_id is present', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A', module_id: 'A1', status: 'in_progress',
+          started_at: DAYS_AGO(2), last_activity_at: DAYS_AGO(2),
+        },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      expect(labels).toContain('Continue A1');
+    });
+
+    it('falls back to track_id when module_id is null', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'C', module_id: null, status: 'in_progress',
+          started_at: DAYS_AGO(2), last_activity_at: DAYS_AGO(2),
+        },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      expect(labels).toContain('Continue C');
+    });
+
+    it('renders the module-specific prompt body alongside the label', () => {
+      const ctx = makeMember({
+        certification: {
+          track_id: 'A', module_id: 'A1', status: 'in_progress',
+          started_at: DAYS_AGO(2), last_activity_at: DAYS_AGO(2),
+        },
+      });
+      const cert = buildSuggestedPrompts(ctx, false).find((p) => p.label === 'Continue A1');
+      expect(cert?.prompt).toBe("Let's keep going with A1. Where did we leave off?");
     });
   });
 });

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -627,6 +627,16 @@ describe('buildSuggestedPrompts', () => {
         .toBe('cert.continue_in_progress');
     });
 
+    it('matches cert clicks via track-only phrasing when no module_id', () => {
+      expect(matchRuleIdFromMessage("Let's keep going with C. Where did we leave off?"))
+        .toBe('cert.continue_in_progress');
+    });
+
+    it('matches cert clicks for ids with underscores (future-proof)', () => {
+      expect(matchRuleIdFromMessage("Let's keep going with A1_intro. Where did we leave off?"))
+        .toBe('cert.continue_in_progress');
+    });
+
     it('matches the cert continuation rule via the generic fallback phrasing', () => {
       expect(matchRuleIdFromMessage('Pick up where I left off in certification.'))
         .toBe('cert.continue_in_progress');


### PR DESCRIPTION
## Summary
- \`PromptRule.label\` / \`.prompt\` now accept \`string | (ctx) => string\`. Resolves at evaluation time.
- Cert continuation now renders \"Continue A1\" / \"Let's keep going with A1. Where did we leave off?\" when module_id is known. Falls back to track_id, then to the original generic phrasing.
- Optional \`matchClick: (msg) => boolean\` callback lets dynamic-prompt rules participate in heuristic click telemetry (the static reverse-index can't enumerate function strings).

## Test plan
- [x] 72 unit tests pass (was 67; added 5 for dynamic label, track-id fallback, prompt body rendering, both matchClick variants)
- [x] tsc clean on changed files; pre-commit hooks pass after \`npm install\` to refresh @adcp/client 5.20 → 5.21
- [ ] Verify in staging: a learner mid-A1 sees "Continue A1" not "Continue certification"
- [ ] Verify click on the rendered prompt registers in the metrics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)