### PR TITLE
feat(addie): agent-test staleness prompt for builder personas (closes #3254)

### DIFF
--- a/.changeset/addie-agent-test-staleness.md
+++ b/.changeset/addie-agent-test-staleness.md
@@ -1,0 +1,4 @@
+---
+---
+
+Closes #3254: agent test staleness signal feeding a new builder-persona prompt rule. Reuses the existing `agent_test_history` table (no new schema) and adds a `getLatestTestForUser` query. Hydrates `agent_testing.{last_test_at, last_outcome}` onto MemberContext. New rule `agent.stale_test` (priority 91, decay enabled) fires for `molecule_builder` and `pragmatic_builder` personas when the last test is older than 14 days or never run, with label "Run a fresh agent test." Generic `member.test_my_agent` (priority 50) now suppresses when the high-priority stale rule is firing to avoid duplicate-intent prompts in the top 4. Storyboard runner (`run_storyboard`) now records to `agent_test_history` so its runs count toward the staleness signal alongside `evaluate_agent_quality`.

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -68,6 +68,21 @@ function certModuleLabel(ctx: MemberContext | null): string | null {
   return cert.module_id ?? cert.track_id ?? null;
 }
 
+/**
+ * True for builder personas whose last agent test was either never run
+ * or older than 14 days. Gates the agent-staleness rule so builders
+ * actively iterating (last test < 14d) don't get nagged.
+ */
+function hasStaleAgentTest(ctx: MemberContext | null): boolean {
+  if (!isMember(ctx)) return false;
+  const p = persona(ctx);
+  if (p !== 'molecule_builder' && p !== 'pragmatic_builder') return false;
+  const last = ctx?.agent_testing?.last_test_at;
+  if (!last) return true; // never tested → definitely worth a nudge
+  const age = Date.now() - new Date(last).getTime();
+  return age > 14 * 24 * 60 * 60 * 1000;
+}
+
 function isLowLoginActive(ctx: MemberContext | null): boolean {
   const last = lastLoginMs(ctx);
   if (last === null) return false;
@@ -224,6 +239,13 @@ export const MEMBER_RULES: PromptRule[] = [
     prompt: 'What do I get if I upgrade from Explorer?',
   },
   {
+    id: 'agent.stale_test',
+    priority: 91,
+    when: ({ memberContext }) => hasStaleAgentTest(memberContext),
+    label: 'Run a fresh agent test',
+    prompt: 'When did I last test my agent, and can we run a fresh evaluation?',
+  },
+  {
     id: 'cert.continue_in_progress',
     priority: 93,
     // Never auto-suppress: re-engaging a stalled learner is exactly the
@@ -334,7 +356,11 @@ export const MEMBER_RULES: PromptRule[] = [
   {
     id: 'member.test_my_agent',
     priority: 50,
-    when: ({ memberContext }) => isMember(memberContext),
+    // The high-priority agent.stale_test rule (id: 'agent.stale_test')
+    // is more accurate for builder personas with stale agents — duplicating
+    // the generic "Test my agent" filler in the same render is redundant.
+    when: ({ memberContext }) =>
+      isMember(memberContext) && !hasStaleAgentTest(memberContext),
     label: 'Test my agent',
     prompt: 'Can you check if my agent is set up correctly?',
   },

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3890,6 +3890,31 @@ export function createMemberToolHandlers(
         ...(authOption && { auth: authOption }),
       });
 
+      // Record the run in agent_test_history when we have a saved
+      // agent_context for this org+url. Mirrors evaluate_agent_quality's
+      // pattern; powers the "agent not tested in 14d" prompt rule.
+      if (organizationId) {
+        try {
+          const context = await agentContextDb.getByOrgAndUrl(organizationId, resolved.resolvedUrl);
+          if (context) {
+            await agentContextDb.recordTest({
+              agent_context_id: context.id,
+              scenario: `storyboard:${sb.id}`,
+              overall_passed: result.overall_passed,
+              steps_passed: result.passed_count,
+              steps_failed: result.failed_count,
+              total_duration_ms: result.total_duration_ms,
+              summary: result.storyboard_title,
+              dry_run: dryRun,
+              triggered_by: 'user',
+              user_id: memberContext?.workos_user?.workos_user_id,
+            });
+          }
+        } catch (error) {
+          logger.debug({ error }, 'Could not record storyboard run');
+        }
+      }
+
       let output = '';
       if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3893,6 +3893,9 @@ export function createMemberToolHandlers(
       // Record the run in agent_test_history when we have a saved
       // agent_context for this org+url. Mirrors evaluate_agent_quality's
       // pattern; powers the "agent not tested in 14d" prompt rule.
+      // Storyboard runs don't carry a structured agent_profile (only
+      // evaluate_agent_quality probes get_adcp_capabilities), so we
+      // omit agent_profile_json — readers tolerate null.
       if (organizationId) {
         try {
           const context = await agentContextDb.getByOrgAndUrl(organizationId, resolved.resolvedUrl);

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -15,6 +15,7 @@ import { JoinRequestDatabase } from '../db/join-request-db.js';
 import { OrgKnowledgeDatabase } from '../db/org-knowledge-db.js';
 import { getTelemetryForUser } from '../db/addie-prompt-telemetry-db.js';
 import { getLatestAttempt } from '../db/certification-db.js';
+import { AgentContextDatabase } from '../db/agent-context-db.js';
 import { getThreadService } from './thread-service.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { isDevModeEnabled, DEV_USERS } from '../middleware/auth.js';
@@ -45,6 +46,7 @@ const emailPrefsDb = new EmailPreferencesDatabase();
 const addieDb = new AddieDatabase();
 const joinRequestDb = new JoinRequestDatabase();
 const orgKnowledgeDb = new OrgKnowledgeDatabase();
+const agentContextDb = new AgentContextDatabase();
 
 /**
  * Get pending content count for a user
@@ -115,6 +117,22 @@ async function getPendingContentForUser(
  * which is why the cert prompt rule uses a 45-day freshness guard against
  * `started_at` rather than trying to infer engagement from this field.
  */
+/**
+ * Fetch the most recent agent_test_history row for the user. Powers
+ * the builder-persona "test your agent" prompt rule for builders whose
+ * last test run is stale.
+ */
+async function fetchAgentTesting(
+  workosUserId: string,
+): Promise<MemberContext['agent_testing']> {
+  const latest = await agentContextDb.getLatestTestForUser(workosUserId);
+  if (!latest) return { last_test_at: null, last_outcome: null };
+  return {
+    last_test_at: new Date(latest.started_at),
+    last_outcome: latest.overall_passed ? 'passed' : 'failed',
+  };
+}
+
 async function fetchCertification(
   workosUserId: string,
 ): Promise<MemberContext['certification']> {
@@ -390,6 +408,20 @@ export interface MemberContext {
   };
 
   /**
+   * Most recent agent test the user has run against any of their saved
+   * agents. Powers the builder-persona "test your agent" prompt for
+   * builders whose last test is stale.
+   *
+   * Tests against the public test agent or unsaved URLs are not
+   * recorded — they don't count here either, which matches the rule's
+   * audience (builders who have already saved their seller agent).
+   */
+  agent_testing?: {
+    last_test_at: Date | null;
+    last_outcome: 'passed' | 'failed' | null;
+  };
+
+  /**
    * Per-rule telemetry for the suggested-prompts evaluator. Lets rules
    * suppress themselves after being shown without action. Map is keyed
    * by rule_id; absent keys mean the rule has never been shown.
@@ -628,6 +660,13 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
       logger.warn({ error, workosUserId }, 'Addie: Failed to load certification context');
     }
 
+    // Latest agent test — drives the "test your agent" prompt for builders.
+    try {
+      context.agent_testing = await fetchAgentTesting(workosUserId);
+    } catch (error) {
+      logger.warn({ error, workosUserId }, 'Addie: Failed to load agent testing context');
+    }
+
     // Process subscription info
     if (subscriptionInfo && subscriptionInfo.status !== 'none') {
       context.subscription = {
@@ -836,6 +875,12 @@ async function resolveContextFromLocalDb(
     context.certification = await fetchCertification(workosUserId);
   } catch (error) {
     logger.warn({ error, workosUserId }, 'Addie Web: Failed to load certification context');
+  }
+
+  try {
+    context.agent_testing = await fetchAgentTesting(workosUserId);
+  } catch (error) {
+    logger.warn({ error, workosUserId }, 'Addie Web: Failed to load agent testing context');
   }
 
   try {

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -959,6 +959,32 @@ export class AgentContextDatabase {
   }
 
   /**
+   * Most recent agent test the user has run, across all of their saved
+   * agents. Powers the "agent not tested in X days" suggested-prompts
+   * rule for builder personas.
+   *
+   * Returns null if the user has never tested any registered agent.
+   * Tests against the public test agent or unsaved URLs are not
+   * recorded in agent_test_history (they don't have an agent_context),
+   * so they don't count here either — which is the right semantic for
+   * the rule's audience (builders with their own seller agent).
+   */
+  async getLatestTestForUser(workosUserId: string): Promise<{
+    started_at: Date;
+    overall_passed: boolean;
+  } | null> {
+    const result = await query<{ started_at: Date; overall_passed: boolean }>(
+      `SELECT started_at, overall_passed
+         FROM agent_test_history
+         WHERE user_id = $1
+         ORDER BY started_at DESC
+         LIMIT 1`,
+      [workosUserId]
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /**
    * Infer agent type from discovered tools
    */
   inferAgentType(tools: string[]): AgentType {

--- a/server/src/db/migrations/443_agent_test_history_user_id_index.sql
+++ b/server/src/db/migrations/443_agent_test_history_user_id_index.sql
@@ -1,0 +1,8 @@
+-- Add a covering index for getLatestTestForUser, called on every Addie
+-- member-context hydration (Slack and web flows) by the agent-test
+-- staleness prompt rule. Without this index the query falls back to
+-- the agent_context_id index + filter, which is fine for small data
+-- but degrades as agent_test_history grows.
+
+CREATE INDEX IF NOT EXISTS idx_agent_test_history_user_started
+  ON agent_test_history(user_id, started_at DESC);

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -350,6 +350,15 @@ describe('buildSuggestedPrompts', () => {
       expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Run a fresh agent test');
     });
 
+    it('does not fire for unlinked / non-member users with builder persona on context', () => {
+      const ctx = makeMember({
+        is_member: false,
+        persona: builderPersona,
+        agent_testing: { last_test_at: null, last_outcome: null },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Run a fresh agent test');
+    });
+
     it('does not fire for non-builder personas even when stale', () => {
       const ctx = makeMember({
         persona: { persona: 'data_decoder', aspiration_persona: null, source: 'assessment', journey_stage: null },

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -323,6 +323,55 @@ describe('buildSuggestedPrompts', () => {
     });
   });
 
+  describe('agent stale-test rule', () => {
+    const builderPersona = { persona: 'molecule_builder', aspiration_persona: null, source: 'assessment', journey_stage: null };
+
+    it('fires for a molecule_builder who has never tested an agent', () => {
+      const ctx = makeMember({
+        persona: builderPersona,
+        agent_testing: { last_test_at: null, last_outcome: null },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Run a fresh agent test');
+    });
+
+    it('fires for a pragmatic_builder whose last test is older than 14 days', () => {
+      const ctx = makeMember({
+        persona: { persona: 'pragmatic_builder', aspiration_persona: null, source: 'assessment', journey_stage: null },
+        agent_testing: { last_test_at: DAYS_AGO(20), last_outcome: 'passed' },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Run a fresh agent test');
+    });
+
+    it('does not fire for a builder who tested recently', () => {
+      const ctx = makeMember({
+        persona: builderPersona,
+        agent_testing: { last_test_at: DAYS_AGO(5), last_outcome: 'passed' },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Run a fresh agent test');
+    });
+
+    it('does not fire for non-builder personas even when stale', () => {
+      const ctx = makeMember({
+        persona: { persona: 'data_decoder', aspiration_persona: null, source: 'assessment', journey_stage: null },
+        agent_testing: { last_test_at: DAYS_AGO(60), last_outcome: 'passed' },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain('Run a fresh agent test');
+    });
+
+    it('outranks the persona prompt for the same builder', () => {
+      const ctx = makeMember({
+        persona: builderPersona,
+        agent_testing: { last_test_at: null, last_outcome: null },
+      });
+      const labels = buildSuggestedPrompts(ctx, false).map((p) => p.label);
+      const staleIdx = labels.indexOf('Run a fresh agent test');
+      const personaIdx = labels.indexOf('Build a sales agent');
+      expect(staleIdx).toBeGreaterThanOrEqual(0);
+      expect(personaIdx).toBeGreaterThanOrEqual(0);
+      expect(staleIdx).toBeLessThan(personaIdx);
+    });
+  });
+
   describe('certification continuation', () => {
     it('shows Continue certification when a fresh attempt is in_progress', () => {
       const ctx = makeMember({


### PR DESCRIPTION
## Summary
- New \"Run a fresh agent test\" prompt rule (priority 91, decay enabled) for \`molecule_builder\` and \`pragmatic_builder\` personas whose most recent agent test is older than 14 days (or never run).
- No new schema. Reuses \`agent_test_history\` (migration #109) — already records \`user_id\` from \`evaluate_agent_quality\`. Added the same \`recordTest\` call to \`run_storyboard\` so storyboard runs count too.
- New \`agent_testing\` block on MemberContext (\`last_test_at\`, \`last_outcome\`).
- Generic \`member.test_my_agent\` (priority 50) suppresses when the high-priority stale rule fires to prevent duplicate-intent prompts.

Closes #3254. The original issue proposed a new \`agent_test_runs\` table; reusing \`agent_test_history\` is tighter and gives us 100% of the audience (builders with saved seller agents — exactly who gets recorded today).

## Test plan
- [x] 79 unit tests pass (was 74; added 5 covering never-tested, recent-test, stale-test for both builder variants, non-builder negative, priority ordering vs persona prompt)
- [x] tsc clean on changed files
- [ ] Verify in staging: a molecule_builder with no agent_test_history rows sees \"Run a fresh agent test\" at the top
- [ ] Verify a builder who runs a storyboard sees the rule suppress for 14 days afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)