### PR TITLE
fix(triage): drop apostrophe from MODE text that broke bash quoting

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -197,7 +197,7 @@ jobs:
               (if $is_pr == "true" then
                 "is_pr: true\n" +
                 "pr: " + $pr_block + "\n" +
-                "MODE: PR-feedback. Treat new comment as actionable feedback on the PR diff. If the comment requests a fix, apply it as a follow-up commit on the PR's head branch (do not open a new PR). If the comment asks a question, answer it as a reply comment. If the comment is conversational with no action implied, post a short acknowledgement and stop.\n"
+                "MODE: PR-feedback. Treat new comment as actionable feedback on the PR diff. If the comment requests a fix, apply it as a follow-up commit on the PR head branch — do not open a new PR. If the comment asks a question, answer it as a reply comment. If the comment is conversational with no action implied, post a short acknowledgement and stop.\n"
               else
                 "is_pr: false\n"
               end) +


### PR DESCRIPTION
PR #3316 introduced a MODE directive containing `PR's head branch`. Inside the jq filter (which is wrapped in single quotes for bash), the apostrophe closed the bash string and turned the parenthetical `(do not open a new PR)` into a subshell, producing `syntax error near unexpected token '('` on workflow run 24968657038.

Rephrase to remove the apostrophe. Local repro confirms the payload now generates cleanly.

Same fix needs porting to adcp-client / adcp-client-python / adcp-go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)