### PR TITLE
fix(test): unskip user-context integration tests — fix WorkOS mock shape (#3319)

### DIFF
--- a/.changeset/fix-workos-mock-unskip-user-context-tests.md
+++ b/.changeset/fix-workos-mock-unskip-user-context-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix WorkOS mock shape in user-context integration tests and narrow `getWebMemberContext` error handling so non-existent users return 404 instead of empty 200, while transient WorkOS errors leave authenticated sessions unaffected. Unskips all 10 tests in `user-context.test.ts`.

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1045,8 +1045,13 @@ export async function getWebMemberContext(workosUserId: string): Promise<MemberC
         first_name: workosUser.firstName ?? undefined,
         last_name: workosUser.lastName ?? undefined,
       };
-    } catch (error) {
+    } catch (error: any) {
       logger.warn({ error, workosUserId }, 'Addie Web: Failed to get WorkOS user');
+      // Only mark unmapped when the user genuinely doesn't exist (WorkOS 404).
+      // Transient errors leave is_mapped: true so authenticated sessions degrade
+      // gracefully rather than being treated as anonymous.
+      const isNotFound = error?.status === 404 || error?.code === 'entity_not_found';
+      if (isNotFound) context.is_mapped = false;
       return context;
     }
 

--- a/server/tests/integration/user-context.test.ts
+++ b/server/tests/integration/user-context.test.ts
@@ -31,60 +31,72 @@ vi.mock('../../src/middleware/csrf.js', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
 
-// Mock WorkOS client to avoid external API calls
-vi.mock('../../src/auth/workos-client.js', () => ({
-  workos: {
-    userManagement: {
-      getUser: vi.fn().mockImplementation((userId: string) => {
-        if (userId === 'user_test_workos') {
-          return Promise.resolve({
-            id: 'user_test_workos',
-            email: 'test@example.com',
-            firstName: 'Test',
-            lastName: 'User',
-            emailVerified: true,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          });
-        }
-        if (userId === 'user_nonexistent') {
-          return Promise.reject(new Error('User not found'));
-        }
+// Mock WorkOS client to avoid external API calls.
+// workos-client.ts exports getWorkos() (a function), not a `workos` singleton —
+// so we export both: `workos` for any direct property access and `getWorkos` for
+// the call sites in member-context.ts (getWorkos().userManagement.*).
+vi.mock('../../src/auth/workos-client.js', () => {
+  const mockUserManagement = {
+    getUser: vi.fn().mockImplementation((userId: string) => {
+      if (userId === 'user_test_workos') {
         return Promise.resolve({
-          id: userId,
-          email: `${userId}@example.com`,
-          firstName: 'Unknown',
+          id: 'user_test_workos',
+          email: 'test@example.com',
+          firstName: 'Test',
           lastName: 'User',
           emailVerified: true,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         });
-      }),
-      listOrganizationMemberships: vi.fn().mockImplementation(({ userId, organizationId }: any) => {
-        if (userId === 'user_test_workos') {
-          return Promise.resolve({
-            data: [
-              {
-                organizationId: 'org_test_context',
-                role: { slug: 'admin' },
-                createdAt: new Date().toISOString(),
-              },
-            ],
-          });
-        }
-        if (organizationId === 'org_test_context') {
-          return Promise.resolve({
-            data: [
-              { organizationId: 'org_test_context', userId: 'user_test_workos' },
-              { organizationId: 'org_test_context', userId: 'user_test_2' },
-            ],
-          });
-        }
-        return Promise.resolve({ data: [] });
-      }),
-    },
-  },
-}));
+      }
+      if (userId === 'user_nonexistent') {
+        const err: any = new Error('User not found');
+        err.status = 404;
+        return Promise.reject(err);
+      }
+      return Promise.resolve({
+        id: userId,
+        email: `${userId}@example.com`,
+        firstName: 'Unknown',
+        lastName: 'User',
+        emailVerified: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }),
+    // getWebMemberContext calls this twice: once with { userId } for the user's own
+    // memberships, and once with { organizationId } for the org's full member list.
+    listOrganizationMemberships: vi.fn().mockImplementation(({ userId, organizationId }: any) => {
+      if (userId === 'user_test_workos') {
+        return Promise.resolve({
+          data: [
+            {
+              organizationId: 'org_test_context',
+              userId: 'user_test_workos',
+              role: { slug: 'admin' },
+              status: 'active',
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        });
+      }
+      if (organizationId === 'org_test_context') {
+        return Promise.resolve({
+          data: [
+            { organizationId: 'org_test_context', userId: 'user_test_workos', status: 'active', role: { slug: 'admin' } },
+            { organizationId: 'org_test_context', userId: 'user_test_2', status: 'active', role: { slug: 'member' } },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    }),
+  };
+  const mockInstance = { userManagement: mockUserManagement };
+  return {
+    workos: mockInstance,
+    getWorkos: () => mockInstance,
+  };
+});
 
 // Mock Stripe client
 vi.mock('../../src/billing/stripe-client.js', () => ({
@@ -97,11 +109,7 @@ vi.mock('../../src/billing/stripe-client.js', () => ({
   }),
 }));
 
-// Skipped: see #3289 — Slack-path tests pass, but the WorkOS-path tests fail
-// because the route's user-lookup chain (auth/workos-client.js → various
-// db helpers) returns different shape than what the mock supplies. Needs
-// a closer look at the lookup chain or a richer WorkOS-side mock.
-describe.skip('User Context API Tests', () => {
+describe('User Context API Tests', () => {
   let server: HTTPServer;
   let app: any;
   let pool: Pool;


### PR DESCRIPTION
Closes #3319

## Summary

`server/tests/integration/user-context.test.ts` was `describe.skip` because all 10 WorkOS-path tests failed with `expected undefined to be defined`. Three root causes, three fixes:

**1. Wrong mock export shape (core fix)**
`vi.mock('workos-client.js')` exported `{ workos: { userManagement: ... } }` but `workos-client.ts` only exports named functions. `member-context.ts` calls `getWorkos().userManagement.*`, so `getWorkos` was `undefined`. Fix: export `getWorkos: () => mockInstance` from the mock factory.

**2. Missing `status: 'active'` on membership mock data**
`getWebMemberContext` filters with `.find(m => m.status === 'active')` and `resolveUserRole` skips memberships where `status !== 'active'`. Without the field, `organizationId` stayed `null` and the function returned early before building any org/membership context. Fix: add `status: 'active'` (and `userId`) to all membership objects in the mock.

**3. 404 never triggered for non-existent WorkOS users**
`getWebMemberContext` initializes `is_mapped: true` (correct for authenticated sessions). On `getUser` failure it returned that partial context, so the route's `!is_mapped && !slack_user && !workos_user` guard never fired. Fix: set `context.is_mapped = false` only when the WorkOS error is a genuine 404 (`error.status === 404 || error.code === 'entity_not_found'`) — transient failures leave `is_mapped: true` so authenticated sessions degrade gracefully rather than being treated as anonymous. The test mock now throws a 404-shaped error for `user_nonexistent`.

**Non-breaking justification:** the `getWebMemberContext` change only affects the `is_mapped` flag when WorkOS returns a hard 404 for a user ID that doesn't exist. All callers that check `organization` (agent-oauth.ts) or wrap in try/catch (addie-chat.ts) are unaffected. For the admin debug endpoint, the behavior is now correct: non-existent user ID → 404.

## Pre-PR review

- **code-reviewer:** approved — no blockers on final diff; `error.status === 404 || error.code === 'entity_not_found'` narrowing correctly avoids transient-error demotion; mock shape matches module exports
- **dx-expert:** approved — simpler mock approach (no `@workos-inc/node` class mock needed) confirmed safe since no code path in this test instantiates `WorkOS` directly; dual-discriminant `listOrganizationMemberships` mock is idiomatic for mutually-exclusive WorkOS call patterns

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01S4yASsF6fSh3gqWGjoJ2mq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4yASsF6fSh3gqWGjoJ2mq)_