### PR TITLE
feat(addie): perspectives nudge + event-prep prompts

### DIFF
--- a/.changeset/addie-perspectives-and-event-prep.md
+++ b/.changeset/addie-perspectives-and-event-prep.md
@@ -1,0 +1,10 @@
+---
+---
+
+Two new Stage 2 prompt rules powered by community-engagement context.
+
+**`event.upcoming_registered`** (priority 89, dynamic label/prompt + matchClick) — fires for members whose next registered event starts within 14 days. Renders "Prep for Cannes Lions" / "Cannes Lions is coming up. What do I need to know?" for an event titled "Cannes Lions"; falls back to a generic "Prep for your event" when title resolution fails.
+
+**`perspectives.share_first_one`** (priority 55) — fires for active members (≥1 login in 30d) who have never published a perspective. Renders "Share what I'm building."
+
+New MemberContext blocks: `perspectives` (`{ published_count, last_published_at }`) and `next_event` (`{ title, slug, starts_at }`). Both hydrated in Slack and web flows. Single-row queries, no new schema. 89 unit tests total (was 80; added 9 covering both rules + matchClick for the dynamic event prompt).

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -69,6 +69,33 @@ function certModuleLabel(ctx: MemberContext | null): string | null {
 }
 
 /**
+ * True for active members who have never published a perspective. Gated
+ * on having logged in at least once in the last 30 days so we don't ask
+ * dormant accounts to write. The rule's audience is engaged members
+ * who have something to share but haven't shipped one yet.
+ */
+function hasZeroPerspectives(ctx: MemberContext | null): boolean {
+  if (!isMember(ctx)) return false;
+  const count = ctx?.perspectives?.published_count;
+  if (count === undefined || count > 0) return false;
+  return (ctx?.engagement?.login_count_30d ?? 0) > 0;
+}
+
+/**
+ * Days from now until the user's next registered event, or null when
+ * there's no upcoming registration. Past-the-start events shouldn't be
+ * here — fetchNextEvent filters on start_time > NOW() — but defensively
+ * return null for negative deltas.
+ */
+function daysToNextEvent(ctx: MemberContext | null): number | null {
+  const start = ctx?.next_event?.starts_at;
+  if (!start) return null;
+  const ms = new Date(start).getTime() - Date.now();
+  if (ms < 0) return null;
+  return ms / (24 * 60 * 60 * 1000);
+}
+
+/**
  * True for builder personas whose last agent test was either never run
  * or older than 14 days. Gates the agent-staleness rule so builders
  * actively iterating (last test < 14d) don't get nagged.
@@ -239,6 +266,33 @@ export const MEMBER_RULES: PromptRule[] = [
     prompt: 'What do I get if I upgrade from Explorer?',
   },
   {
+    id: 'event.upcoming_registered',
+    priority: 89,
+    when: ({ memberContext }) => {
+      if (!isMember(memberContext)) return false;
+      const days = daysToNextEvent(memberContext);
+      if (days === null) return false;
+      return days <= 14;
+    },
+    label: ({ memberContext }) => {
+      const title = memberContext?.next_event?.title;
+      return title ? `Prep for ${title}` : 'Prep for your event';
+    },
+    prompt: ({ memberContext }) => {
+      const title = memberContext?.next_event?.title;
+      return title
+        ? `${title} is coming up. What do I need to know?`
+        : 'My next event is coming up. What do I need to know?';
+    },
+    // Dynamic prompt → matchClick fallback. Match either the
+    // event-titled phrasing or the no-title fallback. Title characters
+    // are not escaped: false positives from a user happening to type a
+    // matching string are fine for telemetry purposes.
+    matchClick: (msg) =>
+      / is coming up\. What do I need to know\?$/.test(msg) ||
+      msg === 'My next event is coming up. What do I need to know?',
+  },
+  {
     id: 'agent.stale_test',
     priority: 91,
     when: ({ memberContext }) => hasStaleAgentTest(memberContext),
@@ -352,6 +406,13 @@ export const MEMBER_RULES: PromptRule[] = [
     when: ({ memberContext }) => isMember(memberContext) && isLowLoginActive(memberContext),
     label: "Here's what you missed",
     prompt: "Give me a quick catch-up on what's happened recently.",
+  },
+  {
+    id: 'perspectives.share_first_one',
+    priority: 55,
+    when: ({ memberContext }) => hasZeroPerspectives(memberContext),
+    label: "Share what I'm building",
+    prompt: "Help me draft a perspective about what I'm working on.",
   },
   {
     id: 'member.test_my_agent',

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -133,6 +133,62 @@ async function fetchAgentTesting(
   };
 }
 
+/**
+ * Count of perspectives this user has published, with the most recent
+ * publish timestamp. Drives the "share what you're building" prompt.
+ *
+ * Counts only published rows authored by this user — drafts, pending
+ * review, archived, and rejected are excluded so the rule fires for
+ * users who genuinely haven't shipped a perspective yet.
+ */
+async function fetchPerspectives(
+  workosUserId: string,
+): Promise<MemberContext['perspectives']> {
+  const result = await query<{ count: string; last_at: Date | null }>(
+    `SELECT COUNT(*)::text as count, MAX(published_at) as last_at
+       FROM perspectives
+       WHERE proposer_user_id = $1
+         AND status = 'published'`,
+    [workosUserId]
+  );
+  const row = result.rows[0];
+  return {
+    published_count: parseInt(row?.count || '0', 10),
+    last_published_at: row?.last_at ? new Date(row.last_at) : null,
+  };
+}
+
+/**
+ * The user's next upcoming registered event (start_time > now), if any.
+ * Drives the pre-event prep prompt that fires inside the ~14-day window.
+ *
+ * Joins event_registrations on workos_user_id (not email) — anonymous
+ * email-only registrations don't get prompts. The rule's audience is
+ * authenticated members whose home is being personalized.
+ */
+async function fetchNextEvent(
+  workosUserId: string,
+): Promise<MemberContext['next_event']> {
+  const result = await query<{ title: string; slug: string; start_time: Date }>(
+    `SELECT e.title, e.slug, e.start_time
+       FROM event_registrations r
+       JOIN events e ON e.id = r.event_id
+       WHERE r.workos_user_id = $1
+         AND e.start_time > NOW()
+         AND e.status = 'published'
+       ORDER BY e.start_time ASC
+       LIMIT 1`,
+    [workosUserId]
+  );
+  const row = result.rows[0];
+  if (!row) return undefined;
+  return {
+    title: row.title,
+    slug: row.slug,
+    starts_at: new Date(row.start_time),
+  };
+}
+
 async function fetchCertification(
   workosUserId: string,
 ): Promise<MemberContext['certification']> {
@@ -422,6 +478,26 @@ export interface MemberContext {
   };
 
   /**
+   * The user's published-perspectives footprint. Powers the "share
+   * what you're building" prompt for active members who haven't
+   * written one yet.
+   */
+  perspectives?: {
+    published_count: number;
+    last_published_at: Date | null;
+  };
+
+  /**
+   * The user's next upcoming registered event (if any). Powers the
+   * pre-event prep prompt within ~14 days of the start.
+   */
+  next_event?: {
+    title: string;
+    slug: string;
+    starts_at: Date;
+  };
+
+  /**
    * Per-rule telemetry for the suggested-prompts evaluator. Lets rules
    * suppress themselves after being shown without action. Map is keyed
    * by rule_id; absent keys mean the rule has never been shown.
@@ -667,6 +743,20 @@ export async function getMemberContext(slackUserId: string): Promise<MemberConte
       logger.warn({ error, workosUserId }, 'Addie: Failed to load agent testing context');
     }
 
+    // Published-perspectives footprint — drives the "share what you're building" prompt.
+    try {
+      context.perspectives = await fetchPerspectives(workosUserId);
+    } catch (error) {
+      logger.warn({ error, workosUserId }, 'Addie: Failed to load perspectives context');
+    }
+
+    // Next upcoming registered event — drives pre-event prep prompts.
+    try {
+      context.next_event = await fetchNextEvent(workosUserId);
+    } catch (error) {
+      logger.warn({ error, workosUserId }, 'Addie: Failed to load next event');
+    }
+
     // Process subscription info
     if (subscriptionInfo && subscriptionInfo.status !== 'none') {
       context.subscription = {
@@ -881,6 +971,18 @@ async function resolveContextFromLocalDb(
     context.agent_testing = await fetchAgentTesting(workosUserId);
   } catch (error) {
     logger.warn({ error, workosUserId }, 'Addie Web: Failed to load agent testing context');
+  }
+
+  try {
+    context.perspectives = await fetchPerspectives(workosUserId);
+  } catch (error) {
+    logger.warn({ error, workosUserId }, 'Addie Web: Failed to load perspectives context');
+  }
+
+  try {
+    context.next_event = await fetchNextEvent(workosUserId);
+  } catch (error) {
+    logger.warn({ error, workosUserId }, 'Addie Web: Failed to load next event');
   }
 
   try {

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -169,11 +169,16 @@ async function fetchPerspectives(
 async function fetchNextEvent(
   workosUserId: string,
 ): Promise<MemberContext['next_event']> {
+  // Only count registrations the user is actually attending —
+  // 'cancelled' and 'no_show' should never produce a prep prompt.
+  // 'waitlisted' counts because the user has expressed intent and may
+  // get a seat as the event approaches.
   const result = await query<{ title: string; slug: string; start_time: Date }>(
     `SELECT e.title, e.slug, e.start_time
        FROM event_registrations r
        JOIN events e ON e.id = r.event_id
        WHERE r.workos_user_id = $1
+         AND r.registration_status IN ('registered', 'waitlisted')
          AND e.start_time > NOW()
          AND e.status = 'published'
        ORDER BY e.start_time ASC

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -323,6 +323,74 @@ describe('buildSuggestedPrompts', () => {
     });
   });
 
+  describe('perspectives share rule', () => {
+    it('fires for an active member with zero published perspectives', () => {
+      const ctx = makeMember({
+        perspectives: { published_count: 0, last_published_at: null },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain("Share what I'm building");
+    });
+
+    it('does not fire when the user has published before', () => {
+      const ctx = makeMember({
+        perspectives: { published_count: 2, last_published_at: DAYS_AGO(30) },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain("Share what I'm building");
+    });
+
+    it('does not fire for dormant members (no logins in 30d)', () => {
+      const ctx = makeMember({
+        perspectives: { published_count: 0, last_published_at: null },
+        engagement: { login_count_30d: 0, last_login: DAYS_AGO(60), working_group_count: 0, email_click_count_30d: 0, interest_level: null },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain("Share what I'm building");
+    });
+
+    it('does not fire for non-members', () => {
+      const ctx = makeMember({
+        is_member: false,
+        perspectives: { published_count: 0, last_published_at: null },
+      });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).not.toContain("Share what I'm building");
+    });
+  });
+
+  describe('upcoming event prep rule', () => {
+    const event = (daysFromNow: number) => ({
+      title: 'Cannes Lions',
+      slug: 'cannes-2026',
+      starts_at: new Date(NOW.getTime() + daysFromNow * 24 * 60 * 60 * 1000),
+    });
+
+    it('renders an event-specific label when within 14 days', () => {
+      const ctx = makeMember({ next_event: event(7) });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label)).toContain('Prep for Cannes Lions');
+    });
+
+    it('renders the matching prompt body alongside', () => {
+      const ctx = makeMember({ next_event: event(3) });
+      const prep = buildSuggestedPrompts(ctx, false).find((p) => p.label === 'Prep for Cannes Lions');
+      expect(prep?.prompt).toBe('Cannes Lions is coming up. What do I need to know?');
+    });
+
+    it('does not fire when the event is more than 14 days out', () => {
+      const ctx = makeMember({ next_event: event(30) });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label).join(' ')).not.toContain('Prep for');
+    });
+
+    it('does not fire when no upcoming event', () => {
+      const ctx = makeMember({ next_event: undefined });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label).join(' ')).not.toContain('Prep for');
+    });
+
+    it('matchClick recognizes the dynamic event prompt', () => {
+      expect(matchRuleIdFromMessage('Cannes Lions is coming up. What do I need to know?'))
+        .toBe('event.upcoming_registered');
+      expect(matchRuleIdFromMessage('My next event is coming up. What do I need to know?'))
+        .toBe('event.upcoming_registered');
+    });
+  });
+
   describe('agent stale-test rule', () => {
     const builderPersona = { persona: 'molecule_builder', aspiration_persona: null, source: 'assessment', journey_stage: null };
 

--- a/server/tests/unit/suggested-prompts.test.ts
+++ b/server/tests/unit/suggested-prompts.test.ts
@@ -389,6 +389,11 @@ describe('buildSuggestedPrompts', () => {
       expect(matchRuleIdFromMessage('My next event is coming up. What do I need to know?'))
         .toBe('event.upcoming_registered');
     });
+
+    it('does not fire for non-members even with an upcoming event', () => {
+      const ctx = makeMember({ is_member: false, next_event: event(7) });
+      expect(buildSuggestedPrompts(ctx, false).map((p) => p.label).join(' ')).not.toContain('Prep for');
+    });
   });
 
   describe('agent stale-test rule', () => {


### PR DESCRIPTION
## Summary
Two new Stage 2 prompt rules:

- **\`event.upcoming_registered\`** (priority 89, dynamic label/prompt) — fires for members whose next registered event starts within 14 days. Renders \"Prep for Cannes Lions\" / \"Cannes Lions is coming up. What do I need to know?\" for events with a title; falls back to generic copy. matchClick covers both phrasings.
- **\`perspectives.share_first_one\`** (priority 55) — fires for active members (≥1 login in 30d) who have never published a perspective.

## Hydration
Two new \`MemberContext\` blocks (\`perspectives\`, \`next_event\`), single-row queries, no new schema. Hydrated in both Slack and web flows.

## Test plan
- [x] 89 unit tests pass (was 80; added 9 covering perspective gate variations and event-prep dynamic render + matchClick)
- [x] tsc clean on changed files
- [ ] Verify in staging: a member registered for an upcoming event sees \"Prep for {title}\" near the top
- [ ] Verify a member with zero published perspectives sees \"Share what I'm building\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)