### PR TITLE
docs(security): fix three stale /docs/reference/security URLs that 404 in 3.0

### DIFF
--- a/.changeset/fix-security-md-stale-urls.md
+++ b/.changeset/fix-security-md-stale-urls.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix three stale `/docs/reference/security` links in SECURITY.md that 404 in 3.0. Replace with the canonical 3.0 security content at `/docs/building/implementation/security` and add a cross-link to the threat-model page.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 The Advertising Context Protocol (AdCP) handles financial commitments and potentially sensitive campaign data. Security is a critical concern for all implementations.
 
-For comprehensive security guidance, see our [Security Documentation](https://docs.adcontextprotocol.org/docs/reference/security).
+For comprehensive security guidance, see our [Security Documentation](https://docs.adcontextprotocol.org/docs/building/implementation/security).
 
 ## Supported Versions
 
@@ -60,13 +60,13 @@ For detailed guidance on implementing secure AdCP systems, including:
 - **Compliance**: GDPR, CCPA, SOC 2, and other regulatory requirements
 - **Implementation Checklists**: Role-specific security requirements
 
-See our comprehensive [Security Documentation](https://docs.adcontextprotocol.org/docs/reference/security).
+See our comprehensive [Security Documentation](https://docs.adcontextprotocol.org/docs/building/implementation/security). For the threat model and narrative, see the [Security Model](https://docs.adcontextprotocol.org/docs/building/understanding/security-model).
 
 ## Security Questions & Discussion
 
 For security questions that are not sensitive vulnerability reports:
 
-- **Documentation**: https://docs.adcontextprotocol.org/docs/reference/security
+- **Documentation**: https://docs.adcontextprotocol.org/docs/building/implementation/security
 - **GitHub Discussions**: Security category
 - **Email**: security@adcontextprotocol.org
 - **Slack**: https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg


### PR DESCRIPTION
Closes #2812

SECURITY.md at repo root pointed to `https://docs.adcontextprotocol.org/docs/reference/security` in three places; that path does not exist in 3.0 and 404s. This PR replaces all three occurrences with the canonical 3.0 location (`/docs/building/implementation/security`) and adds a cross-link to the threat-model page (`/docs/building/understanding/security-model`) from the Security Best Practices section. The old path was not caught by the Mintlify broken-links pre-push hook because that hook scans `docs/**` MDX files, not repo-root markdown.

**Non-breaking justification:** URL-only update in a root markdown file; no schema, task definition, or wire-format change.

**Pre-PR review:**
- code-reviewer: approved — all 3 stale URLs replaced correctly; changeset `--empty` (docs-only, correct); nit: `/docs/reference/v2-sunset` link in version table is out of scope for this PR but may also need checking.
- docs-expert: approved — cross-link placement in Security Best Practices section is appropriate; nit: appended sentence is slightly run-on (prose only, not a blocker).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0156uh5mfdvVz4Y2zP8JwbRw

---
_Generated by [Claude Code](https://claude.ai/code/session_0156uh5mfdvVz4Y2zP8JwbRw)_