### PR TITLE
docs(certification): add S6 security specialist module scaffold (#2369)

### DIFF
--- a/.changeset/s6-security-specialist-scaffold.md
+++ b/.changeset/s6-security-specialist-scaffold.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add S6: Security specialist module scaffold — MDX page, specialist table row in overview, and docs.json nav entries. Sandbox exercises and Addie teaching flow wiring are follow-up work pending criterion ID design.

--- a/docs.json
+++ b/docs.json
@@ -549,7 +549,8 @@
                       "docs/learning/specialist/creative",
                       "docs/learning/specialist/signals",
                       "docs/learning/specialist/governance",
-                      "docs/learning/specialist/sponsored-intelligence"
+                      "docs/learning/specialist/sponsored-intelligence",
+                      "docs/learning/specialist/security"
                     ]
                   },
                   {
@@ -1024,7 +1025,8 @@
                   "docs/learning/specialist/creative",
                   "docs/learning/specialist/signals",
                   "docs/learning/specialist/governance",
-                  "docs/learning/specialist/sponsored-intelligence"
+                  "docs/learning/specialist/sponsored-intelligence",
+                  "docs/learning/specialist/security"
                 ]
               },
               {

--- a/docs/learning/overview.mdx
+++ b/docs/learning/overview.mdx
@@ -105,6 +105,7 @@ Each specialist module combines a hands-on lab with an adaptive exam in a specif
 | [S3: Signals](/docs/learning/specialist/signals) | Signal discovery, activation, privacy, optimization loops | 45 min |
 | [S4: Governance](/docs/learning/specialist/governance) | Brand safety, supply chain compliance, content standards | 45 min |
 | [S5: Sponsored Intelligence](/docs/learning/specialist/sponsored-intelligence) | Conversational brand experiences, session lifecycle | 45 min |
+| [S6: Security](/docs/learning/specialist/security) | Threat model, 5-layer defense, idempotency semantics, governance verification, SSRF discipline | 60 min |
 
 ## Get started
 

--- a/docs/learning/specialist/security.mdx
+++ b/docs/learning/specialist/security.mdx
@@ -1,0 +1,103 @@
+---
+title: "S6: Security"
+sidebarTitle: "S6: Security"
+description: "AdCP specialist module S6: Security mastery. Threat model, 5-layer defense model, idempotency semantics, governance token verification, SSRF discipline, and operational incident response."
+"og:title": "AdCP — S6: Security"
+---
+
+# S6: Security
+
+<Info>
+**Members only** — Requires Practitioner credential. ~60 minutes with Addie. Combines hands-on lab and adaptive exam.
+</Info>
+
+This specialist module tests your mastery of AdCP's security model. You'll work with sandbox agents to demonstrate the protocol's five-layer defense in practice: identity verification, tenant isolation, idempotency semantics, signed governance verification, and SSRF discipline. Addie evaluates both hands-on execution and your ability to reason about threat scenarios and incident response.
+
+Passing earns the **AdCP specialist — Security** credential.
+
+<Warning>
+This module is in development and not yet available via Addie. The curriculum, sandbox exercises, and teaching flow are being finalized. Check back soon.
+</Warning>
+
+<Note>
+This module covers AdCP-specific controls — the threat model, layered defenses, and operational response patterns specific to agentic advertising systems. It is not a replacement for a general security program. Certified specialists can reason about how AdCP's controls compose; for OWASP Top 10 or general security engineering, see your organization's security training.
+</Note>
+
+## Specialisms this track prepares you to validate
+
+The following `specialisms` fall under the security domain. Each has its own compliance storyboard — see the [Compliance Catalog](/docs/building/compliance-catalog) for the full taxonomy.
+
+| Specialism | Status | What it covers |
+|---|---|---|
+| `security` | stable | Authentication baseline — unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |
+| `signed-requests` | stable | RFC 9421 transport-layer request-signing verification |
+
+## What you'll demonstrate
+
+- Explain the agentic advertising threat model: credential theft, replay attacks, cross-tenant data leakage, SSRF on outbound fetches, spoofed agent identity, unauthorized governance token use, and audit log tampering
+- Walk through AdCP's 5-layer defense model — identity, isolation, idempotency, signed governance, auditability — and name the specific attack each layer closes
+- Mint an idempotency key and demonstrate all four outcomes against a sandbox: successful first call, idempotent replay (`replayed: true`), conflict on payload change, and expiry on TTL lapse. Explain the side-effect implications of each outcome.
+- Verify a signed governance token against a JWKS endpoint: walk the 15-step verification checklist (`alg` allowlist, `typ` match, SSRF-validated JWKS fetch, `aud`/`sub`/`phase` binding, `jti` replay dedup, revocation list check), tamper with a claim and observe rejection, trace the revocation mechanics
+- Implement the 6-point SSRF check on an outbound fetch: HTTPS-only enforcement, reserved-IP deny list (including cloud metadata endpoints), IP-pin validation, redirect suppression, size and timeout caps, and suppressed error detail in responses
+- Design an operational runbook covering credential compromise, webhook secret rotation, governance key revocation, and cross-party incident communication
+- Given an incident description, identify which defense layer failed and what specific control to harden
+
+<Note>
+S4 (Governance) covers the 15-step JWS seller verification from the **seller's** perspective — how a seller validates a governance token issued by a buyer's governance agent. S6 covers it from the **security operator's** perspective — verifying your own token issuance implementation is correct and reasoning about what each step closes. Overlap is intentional; the framing is different.
+</Note>
+
+## Prerequisite reading
+
+<CardGroup cols={2}>
+  <Card title="Security model" icon="shield" href="/docs/building/understanding/security-model">
+    AdCP's five-layer defense model: identity, isolation, idempotency, signed governance, and auditability.
+  </Card>
+  <Card title="Security implementation" icon="lock" href="/docs/building/implementation/security">
+    Implementation reference: idempotency enforcement, webhook HMAC verification, SSRF discipline, signed governance, principal isolation, and insert-rate ceiling.
+  </Card>
+  <Card title="Campaign governance specification" icon="file-code" href="/docs/governance/campaign/specification">
+    Governance token structure, the JWS verification model, and the correlation model for multi-party lifecycle tracking.
+  </Card>
+  <Card title="Operating an agent" icon="server" href="/docs/building/operating-an-agent">
+    Security as an operating concern: credential management, rotation cadences, and incident response.
+  </Card>
+  <Card title="Accounts and security" icon="key" href="/docs/media-buy/advanced-topics/accounts-and-security">
+    Principal isolation, account-scoped access, and multi-tenant separation.
+  </Card>
+  <Card title="Authentication" icon="fingerprint" href="/docs/building/integration/authentication">
+    API key enforcement, OAuth discovery, RFC 9728 audience binding, and the authentication baseline specialism.
+  </Card>
+</CardGroup>
+
+## Connecting to the test agent
+
+Lab exercises run against the public test agent. Use the shared token — no signup required:
+
+```bash
+export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+```
+
+See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.
+
+## Lab exercises
+
+1. **Threat model walkthrough** — Map each threat (credential theft, replay, cross-tenant leakage, SSRF, spoofed identity, unauthorized governance, audit tampering) to the specific AdCP control that closes it. Explain why no single layer is sufficient alone.
+2. **Idempotency lifecycle** — Submit four requests to a sandbox endpoint using the same idempotency key: (a) first call — observe success; (b) identical replay — observe `replayed: true` and confirm no side effect; (c) same key, different payload — observe conflict error; (d) after TTL lapse — observe expiry. Reason about what a missing idempotency key means for the seller's safety guarantees.
+3. **Governance token verification** — Fetch a signed governance token from the sandbox governance agent. Walk the 15-step verification checklist. Tamper with the `aud` claim and observe rejection. Check the revocation list for a pre-revoked key (`test-revoked-2026`) and confirm the token is rejected before signature verification completes. Explain what each step closes.
+4. **SSRF defense implementation** — Given a skeleton outbound-fetch function, add the 6-point SSRF check. Verify that a request to a cloud metadata endpoint (`169.254.169.254`) is blocked, that a redirect to a reserved IP is caught at the IP-pin step, and that error detail is suppressed in the response.
+5. **Principal isolation probe** — Use two sandbox principals on the same seller. Attempt to read resources scoped to the other principal. Confirm isolation. Explain the separation model and what would break if account-scoped tokens were not enforced.
+6. **Incident runbook design** — Given a credential compromise scenario (API key leaked in a public repo), design the response: which keys to rotate and in what order, how to notify counterparties, what audit events to review, and how to verify the compromise window.
+7. **Defense layer diagnosis** — Given three incident descriptions (replay attack succeeded, cross-tenant data returned, governance token accepted after key revocation), identify which layer failed in each case and what specific control to harden.
+
+## Assessment
+
+| Dimension | Weight | What Addie evaluates |
+|-----------|--------|---------------------|
+| Threat model fluency | 20% | Can you name an attack and the specific layer that closes it? |
+| Hands-on idempotency | 20% | Can you produce all four idempotency outcomes on demand and explain their implications? |
+| Governance verification | 25% | Can you walk the 15-step checklist and explain what each step prevents? |
+| SSRF discipline | 15% | Can you implement the 6-point check correctly? |
+| Operational design | 20% | Can you design a runbook for credential compromise, including rotation order and cross-party communication? |
+
+Passing threshold: 70%.


### PR DESCRIPTION
Refs #2369

Adds the S6: Security specialist module page, specialist table row in `docs/learning/overview.mdx`, and nav entries in `docs.json`. The module page is marked as in-development via a Warning callout — no Addie wiring or sandbox exercises are included in this PR.

**Non-breaking justification:** new optional docs pages and nav entries; no schema, wire format, task definition, or Addie tool changes.

## What's in scope

- `docs/learning/specialist/security.mdx` — full module page with learning objectives, specialism table (`security`, `signed-requests`), prerequisite reading cards, 7 lab exercises, assessment dimensions, connecting-to-test-agent block, and Warning that the module is in development
- `docs/learning/overview.mdx` — S6 row added to specialist table
- `docs.json` — `docs/learning/specialist/security` added in both nav version groups
- `.changeset/s6-security-specialist-scaffold.md` — empty changeset (docs-only, no protocol version bump)

## What's deferred (follow-up to #2369)

- Addie teaching flow wiring (`certification-tools.ts` — `begin_specialist_module` enum, credential name map, module metadata)
- Sandbox exercises for idempotency, JWKS verification, and SSRF (requires sandbox infrastructure decision: dedicated sandbox vs. existing test kits)
- Criterion ID assignment for LOs 1–2 and LO 6 (conversational LOs that need a stable required-demonstration ID before Addie can grade them)

## Nits surfaced in pre-PR review (not fixed — PR body only)

- S6 is listed at 60 min in `overview.mdx` while S1–S5 show 45 min. The issue spec says ~60 min and `governance.mdx` already says ~60 min in its callout while showing 45 min in the table — there's a pre-existing table vs. callout mismatch. Recommend correcting the overview table to 60 min for S4 and S6 in a follow-up pass.

**Pre-PR review:**
- code-reviewer: approved — broken idempotency link fixed, certification-tools.ts gap documented as deferred, docs.json updated in both nav locations
- docs-expert: approved — S4 overlap note added, specialism table added, sandbox auth block added, CTA replaced with in-development Warning

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RXrSE3dZQ2Zu2mwZnN2JVM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXrSE3dZQ2Zu2mwZnN2JVM)_