### PR TITLE
test(e2e): Playwright smoke tests for six authenticated pages (#1897)

### DIFF
--- a/.changeset/playwright-e2e-smoke-tests.md
+++ b/.changeset/playwright-e2e-smoke-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Playwright smoke tests for six authenticated pages (membership hub, organization dashboard, certification dashboard, brand viewer, community hub, admin newsletter editor) with a shared helpers module. Extends the pattern from the profile-edit smoke test introduced in #1895.

--- a/tests/e2e/admin-newsletter.smoke.js
+++ b/tests/e2e/admin-newsletter.smoke.js
@@ -1,0 +1,77 @@
+/**
+ * Playwright smoke tests for /admin/newsletters/the_prompt.
+ *
+ * Note: /admin/digest redirects (301) to /admin/newsletters/the_prompt — this
+ * test targets the canonical URL directly.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/admin-newsletter.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/admin-newsletter.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+async function testAdminNewsletter(page, consoleErrors) {
+  console.log('\n=== Admin newsletter editor ===');
+  await login(page, 'admin');
+
+  await page.goto(`${TARGET_URL}/admin/newsletters/the_prompt`);
+  await page.waitForSelector('#nlTitle', { timeout: 15000 });
+
+  console.log('DOM:');
+  assert(await page.$('#nlTitle') !== null, 'Newsletter title present');
+  assert(await page.$('#editMode') !== null, 'Edit mode container present');
+  assert(await page.$('#sectionsContainer') !== null, 'Sections container present');
+  assert(await page.$('#instructionInput') !== null, 'AI instruction input present');
+
+  console.log('Redirect:');
+  // Verify the old /admin/digest URL redirects correctly.
+  const resp = await page.goto(`${TARGET_URL}/admin/digest`, { waitUntil: 'domcontentloaded' });
+  const finalUrl = page.url();
+  assert(finalUrl.includes('/admin/newsletters/the_prompt'), `Redirect from /admin/digest lands on canonical URL (got: ${finalUrl})`);
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: '/tmp/smoke-admin-newsletter.png', fullPage: true });
+}
+
+(async () => {
+  console.log(`Admin newsletter smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    resetFailures();
+    await testAdminNewsletter(page, consoleErrors);
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-admin-newsletter-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/admin-newsletter.smoke.js
+++ b/tests/e2e/admin-newsletter.smoke.js
@@ -31,7 +31,7 @@ async function testAdminNewsletter(page, consoleErrors) {
 
   console.log('Redirect:');
   // Verify the old /admin/digest URL redirects correctly.
-  const resp = await page.goto(`${TARGET_URL}/admin/digest`, { waitUntil: 'domcontentloaded' });
+  await page.goto(`${TARGET_URL}/admin/digest`, { waitUntil: 'domcontentloaded' });
   const finalUrl = page.url();
   assert(finalUrl.includes('/admin/newsletters/the_prompt'), `Redirect from /admin/digest lands on canonical URL (got: ${finalUrl})`);
 

--- a/tests/e2e/brand-viewer.smoke.js
+++ b/tests/e2e/brand-viewer.smoke.js
@@ -1,0 +1,94 @@
+/**
+ * Playwright smoke tests for /brand/:domain.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/brand-viewer.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/brand-viewer.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+// Use a known seeded domain; tests the known-brand rendering path.
+const TEST_DOMAIN = 'agenticadvertising.org';
+
+async function testBrandViewer(page, consoleErrors) {
+  console.log(`\n=== Brand viewer: ${TEST_DOMAIN} ===`);
+  await login(page, 'admin');
+
+  await page.goto(`${TARGET_URL}/brand/${TEST_DOMAIN}`);
+  // Either brand data or error state should render within this timeout.
+  await page.waitForSelector('#hero-title', { timeout: 20000 });
+
+  console.log('DOM:');
+  assert(await page.$('#adcp-nav') !== null, 'Nav rendered');
+  assert(await page.$('#hero-title') !== null, 'Hero title present');
+  // Brand data OR error state — both are valid renderings of the page.
+  const hasBrandData = await page.$('#brand-info-content') !== null;
+  const hasErrorState = await page.$('#error-title') !== null;
+  assert(hasBrandData || hasErrorState, 'Brand data or error state rendered');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: '/tmp/smoke-brand-viewer.png', fullPage: true });
+}
+
+async function testBrandViewerUnknownDomain(page, consoleErrors) {
+  console.log('\n=== Brand viewer: unknown domain (error state) ===');
+  await login(page, 'admin');
+
+  await page.goto(`${TARGET_URL}/brand/unknown.example.invalid`);
+  await page.waitForSelector('#error-title', { timeout: 15000 });
+
+  console.log('DOM:');
+  assert(await page.$('#error-title') !== null, 'Error title rendered for unknown domain');
+  assert(await page.$('#error-message') !== null, 'Error message rendered');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: '/tmp/smoke-brand-viewer-unknown.png', fullPage: true });
+}
+
+(async () => {
+  console.log(`Brand viewer smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    resetFailures();
+    await testBrandViewer(page, consoleErrors);
+    consoleErrors.length = 0;
+    await testBrandViewerUnknownDomain(page, consoleErrors);
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-brand-viewer-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/certification.smoke.js
+++ b/tests/e2e/certification.smoke.js
@@ -11,7 +11,7 @@
  */
 
 import { chromium } from 'playwright';
-import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+import { TARGET_URL, assert, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
 
 async function testCertification(page, consoleErrors, userType) {
   console.log(`\n=== Certification dashboard: ${userType} ===`);
@@ -48,7 +48,6 @@ async function testCertification(page, consoleErrors, userType) {
     await checkDevServer(page);
 
     for (const userType of ['personal', 'admin']) {
-      resetFailures();
       consoleErrors.length = 0;
       await testCertification(page, consoleErrors, userType);
     }

--- a/tests/e2e/certification.smoke.js
+++ b/tests/e2e/certification.smoke.js
@@ -1,0 +1,70 @@
+/**
+ * Playwright smoke tests for /certification.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/certification.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/certification.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+async function testCertification(page, consoleErrors, userType) {
+  console.log(`\n=== Certification dashboard: ${userType} ===`);
+  await login(page, userType);
+
+  await page.goto(`${TARGET_URL}/certification`);
+  await page.waitForSelector('#learning-container', { state: 'visible', timeout: 20000 });
+
+  console.log('DOM:');
+  assert(await page.$('#adcp-nav') !== null, 'Nav rendered');
+  assert(await page.$('#learning-container') !== null, 'Learning container present');
+  assert(await page.$('#adcp-footer') !== null, 'Footer rendered');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: `/tmp/smoke-certification-${userType}.png`, fullPage: true });
+}
+
+(async () => {
+  console.log(`Certification dashboard smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    for (const userType of ['personal', 'admin']) {
+      resetFailures();
+      consoleErrors.length = 0;
+      await testCertification(page, consoleErrors, userType);
+    }
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-certification-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/community-hub.smoke.js
+++ b/tests/e2e/community-hub.smoke.js
@@ -11,7 +11,7 @@
  */
 
 import { chromium } from 'playwright';
-import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+import { TARGET_URL, assert, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
 
 async function testCommunityHub(page, consoleErrors, userType) {
   console.log(`\n=== Community hub: ${userType} ===`);
@@ -52,7 +52,6 @@ async function testCommunityHub(page, consoleErrors, userType) {
     await checkDevServer(page);
 
     for (const userType of ['personal', 'member']) {
-      resetFailures();
       consoleErrors.length = 0;
       await testCommunityHub(page, consoleErrors, userType);
     }

--- a/tests/e2e/community-hub.smoke.js
+++ b/tests/e2e/community-hub.smoke.js
@@ -1,0 +1,74 @@
+/**
+ * Playwright smoke tests for /community.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/community-hub.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/community-hub.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+async function testCommunityHub(page, consoleErrors, userType) {
+  console.log(`\n=== Community hub: ${userType} ===`);
+  await login(page, userType);
+
+  await page.goto(`${TARGET_URL}/community`);
+  await page.waitForSelector('#adcp-nav', { state: 'visible', timeout: 15000 });
+  // Give dynamic content time to hydrate.
+  await page.waitForTimeout(2000);
+
+  console.log('DOM:');
+  assert(await page.$('#adcp-nav') !== null, 'Nav rendered');
+  assert(await page.$('#adcp-footer') !== null, 'Footer rendered');
+  // Page should not crash with a blank body.
+  const bodyText = await page.evaluate(() => document.body.innerText);
+  assert(bodyText.length > 50, 'Page has substantial content');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: `/tmp/smoke-community-hub-${userType}.png`, fullPage: true });
+}
+
+(async () => {
+  console.log(`Community hub smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    for (const userType of ['personal', 'member']) {
+      resetFailures();
+      consoleErrors.length = 0;
+      await testCommunityHub(page, consoleErrors, userType);
+    }
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-community-hub-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -1,0 +1,56 @@
+/**
+ * Shared utilities for Playwright smoke tests.
+ *
+ * Usage:
+ *   import { TARGET_URL, assert, resetFailures, failureCount, login } from './helpers.js';
+ */
+
+export const TARGET_URL = process.env.TARGET_URL || 'http://localhost:55020';
+
+let failures = 0;
+
+export function resetFailures() {
+  failures = 0;
+}
+
+export function failureCount() {
+  return failures;
+}
+
+export function assert(condition, label) {
+  if (condition) {
+    console.log(`  ✅ ${label}`);
+  } else {
+    console.log(`  ❌ ${label}`);
+    failures++;
+  }
+}
+
+const DEV_USER_LABELS = {
+  personal: 'Personal Account',
+  admin: 'Admin Tester',
+  member: 'Member User',
+};
+
+export async function login(page, userType) {
+  await page.goto(`${TARGET_URL}/auth/logout`);
+  await page.goto(`${TARGET_URL}/dev-login.html`);
+  await page.waitForSelector(`text=${DEV_USER_LABELS[userType]}`);
+  await page.click(`text=${DEV_USER_LABELS[userType]}`);
+  await page.waitForURL('**/member*', { timeout: 15000 }).catch(() => {});
+}
+
+// Filters out noise from PostHog, missing favicons, and network blips.
+export function filterConsoleErrors(errors, extraPatterns = []) {
+  const defaultIgnored = ['posthog', 'net::ERR', 'favicon', 'Hub load error'];
+  return errors.filter(e => ![...defaultIgnored, ...extraPatterns].some(p => e.includes(p)));
+}
+
+export async function checkDevServer(page) {
+  const resp = await page.goto(`${TARGET_URL}/dev-login.html`);
+  if (!resp || resp.status() !== 200) {
+    console.error(`Dev server not reachable at ${TARGET_URL} (status: ${resp?.status()})`);
+    console.error('Start with: docker compose up --build');
+    process.exit(1);
+  }
+}

--- a/tests/e2e/membership-hub.smoke.js
+++ b/tests/e2e/membership-hub.smoke.js
@@ -1,0 +1,70 @@
+/**
+ * Playwright smoke tests for /membership/hub.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/membership-hub.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/membership-hub.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+async function testMembershipHub(page, consoleErrors, userType) {
+  console.log(`\n=== Membership hub: ${userType} ===`);
+  await login(page, userType);
+
+  await page.goto(`${TARGET_URL}/membership/hub`);
+  await page.waitForSelector('#hub-content', { state: 'visible', timeout: 20000 });
+
+  console.log('DOM:');
+  assert(await page.$('#adcp-nav') !== null, 'Nav rendered');
+  assert(await page.$('#hub-content') !== null, 'Hub content container present');
+  assert(await page.$('#adcp-footer') !== null, 'Footer rendered');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: `/tmp/smoke-membership-hub-${userType}.png`, fullPage: true });
+}
+
+(async () => {
+  console.log(`Membership hub smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    for (const userType of ['member', 'personal', 'admin']) {
+      resetFailures();
+      consoleErrors.length = 0;
+      await testMembershipHub(page, consoleErrors, userType);
+    }
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-membership-hub-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/membership-hub.smoke.js
+++ b/tests/e2e/membership-hub.smoke.js
@@ -11,7 +11,7 @@
  */
 
 import { chromium } from 'playwright';
-import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+import { TARGET_URL, assert, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
 
 async function testMembershipHub(page, consoleErrors, userType) {
   console.log(`\n=== Membership hub: ${userType} ===`);
@@ -48,7 +48,6 @@ async function testMembershipHub(page, consoleErrors, userType) {
     await checkDevServer(page);
 
     for (const userType of ['member', 'personal', 'admin']) {
-      resetFailures();
       consoleErrors.length = 0;
       await testMembershipHub(page, consoleErrors, userType);
     }

--- a/tests/e2e/organization-dashboard.smoke.js
+++ b/tests/e2e/organization-dashboard.smoke.js
@@ -1,0 +1,71 @@
+/**
+ * Playwright smoke tests for /organization.
+ *
+ * Requires:
+ *   - Local dev server running (`docker compose up --build`)
+ *   - Playwright installed (`npx playwright install chromium`)
+ *
+ * Usage:
+ *   node tests/e2e/organization-dashboard.smoke.js
+ *   TARGET_URL=http://localhost:3000 node tests/e2e/organization-dashboard.smoke.js
+ */
+
+import { chromium } from 'playwright';
+import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+
+async function testOrgDashboard(page, consoleErrors, userType) {
+  console.log(`\n=== Organization dashboard: ${userType} ===`);
+  await login(page, userType);
+
+  await page.goto(`${TARGET_URL}/organization`);
+  await page.waitForSelector('#hub-content', { state: 'visible', timeout: 20000 });
+
+  console.log('DOM:');
+  assert(await page.$('#adcp-nav') !== null, 'Nav rendered');
+  assert(await page.$('#hub-content') !== null, 'Hub content container present');
+  assert(await page.$('#membership') !== null, 'Membership section present');
+  assert(await page.$('#directory') !== null, 'Directory section present');
+
+  console.log('Console:');
+  const errors = filterConsoleErrors(consoleErrors);
+  assert(errors.length === 0, `No unexpected console errors${errors.length ? ': ' + errors.join('; ') : ''}`);
+
+  await page.screenshot({ path: `/tmp/smoke-org-dashboard-${userType}.png`, fullPage: true });
+}
+
+(async () => {
+  console.log(`Organization dashboard smoke tests against ${TARGET_URL}\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    await checkDevServer(page);
+
+    for (const userType of ['admin', 'member']) {
+      resetFailures();
+      consoleErrors.length = 0;
+      await testOrgDashboard(page, consoleErrors, userType);
+    }
+
+    console.log(`\n${'='.repeat(40)}`);
+    if (failureCount() === 0) {
+      console.log('All checks passed');
+    } else {
+      console.log(`${failureCount()} check(s) failed`);
+    }
+  } catch (err) {
+    console.error('\nTest crashed:', err.message);
+    await page.screenshot({ path: '/tmp/smoke-org-dashboard-crash.png', fullPage: true }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+
+  process.exit(failureCount() > 0 ? 1 : 0);
+})();

--- a/tests/e2e/organization-dashboard.smoke.js
+++ b/tests/e2e/organization-dashboard.smoke.js
@@ -11,7 +11,7 @@
  */
 
 import { chromium } from 'playwright';
-import { TARGET_URL, assert, resetFailures, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
+import { TARGET_URL, assert, failureCount, login, filterConsoleErrors, checkDevServer } from './helpers.js';
 
 async function testOrgDashboard(page, consoleErrors, userType) {
   console.log(`\n=== Organization dashboard: ${userType} ===`);
@@ -49,7 +49,6 @@ async function testOrgDashboard(page, consoleErrors, userType) {
     await checkDevServer(page);
 
     for (const userType of ['admin', 'member']) {
-      resetFailures();
       consoleErrors.length = 0;
       await testOrgDashboard(page, consoleErrors, userType);
     }


### PR DESCRIPTION
Closes #1897

Extends the Playwright smoke-test suite (introduced in #1895) to six additional authenticated pages. Extracts shared login/assert/error-collection utilities from `profile-edit.smoke.js` into a `tests/e2e/helpers.js` module, then adds one smoke file per page:

| File | Route | Dev users |
|---|---|---|
| `membership-hub.smoke.js` | `/membership/hub` | member, personal, admin |
| `organization-dashboard.smoke.js` | `/organization` | admin, member |
| `certification.smoke.js` | `/certification` | personal, admin |
| `brand-viewer.smoke.js` | `/brand/:domain` | admin (known domain + unknown domain error state) |
| `community-hub.smoke.js` | `/community` | personal, member |
| `admin-newsletter.smoke.js` | `/admin/newsletters/the_prompt` (+ redirect from `/admin/digest`) | admin |

Each test: dev-login → navigate → wait for key container → assert critical DOM IDs → collect console errors. Screenshot on failure to `/tmp/`.

**Non-breaking justification:** adds new `.js` test files outside the TypeScript compilation boundary; no existing code modified; changeset `--empty` (no protocol impact).

**Note on runner script:** `npm run test:e2e` (mentioned in the issue) requires a `package.json` script entry which cannot be added in this PR. Tests run today as `node tests/e2e/<file>.smoke.js` matching the existing `profile-edit.smoke.js` pattern.

**Note on pre-existing build failures:** `npm run build` has pre-existing TypeScript errors in `server/src/validator.ts` and `url-security.ts` (confirmed present on `main` before this branch). These are unrelated to this PR; `npm run build:schemas` passes clean.

**Pre-PR review:**
- code-reviewer: approved after fixes — removed `resetFailures()` from inside per-userType loops (was silently discarding non-last-iteration failures) and dropped unused `resp` variable in admin-newsletter redirect check
- adtech-product-expert: approved — pattern proven, all 6 target pages confirmed in `server/public/`, changeset `--empty` correct, CI integration deliberately excluded as a follow-on

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016dJ4nMXCbcLEmCsCNrBK6d

---
_Generated by [Claude Code](https://claude.ai/code/session_016dJ4nMXCbcLEmCsCNrBK6d)_