### PR TITLE
chore: bump @adcp/client 5.21.0 → 5.21.1

### DIFF
--- a/.changeset/bump-adcp-client-5-21-1.md
+++ b/.changeset/bump-adcp-client-5-21-1.md
@@ -1,0 +1,16 @@
+---
+---
+
+chore: bump @adcp/client 5.21.0 → 5.21.1
+
+Patch bump picks up the grader fix from
+[adcontextprotocol/adcp-client#1026](https://github.com/adcontextprotocol/adcp-client/pull/1026)
+— `adcp grade request-signing` against Cloudflare-fronted endpoints
+(closing my-filed [#1025](https://github.com/adcontextprotocol/adcp-client/issues/1025)).
+
+Validated end-to-end: the grader now reaches `/api/training-agent/mcp-strict`
+on prod and runs all 39 vectors. 30 pass, 3 fail (verifier-side conformance
+gaps unrelated to this PR), 6 are mcp-mode skips.
+
+Runtime API surface unchanged. No code changes in this repo other than the
+version pin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.0",
       "dependencies": {
-        "@adcp/client": "5.21.0",
+        "@adcp/client": "5.21.1",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.0.tgz",
-      "integrity": "sha512-2I2dfAlxReadkO+j4CdtNtPQ9X9xqaYDK/b3/gVqn8+KuYktFDBPXHCVjGK56Cs15FrOFLGjhupwgLxX/Sv7oQ==",
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.1.tgz",
+      "integrity": "sha512-6/bATc7xCv4QCBSTeyTgCtdMrr8w/eSC2dB76rXgyJ6Ovecwc6LJN5AwBhcrt7cXNotC5C7xMETJlxWNdR1YDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "check:images": "bash scripts/check-image-quality.sh"
   },
   "dependencies": {
-    "@adcp/client": "5.21.0",
+    "@adcp/client": "5.21.1",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",


### PR DESCRIPTION
Patch picks up the grader fix from [adcontextprotocol/adcp-client#1026](https://github.com/adcontextprotocol/adcp-client/pull/1026) (closes my-filed [#1025](https://github.com/adcontextprotocol/adcp-client/issues/1025) — undici lookup callback shape broke against Cloudflare-fronted endpoints).

## Validated end-to-end after this bump

```
npx adcp grade request-signing https://agenticadvertising.org/api/training-agent/mcp-strict --transport mcp --skip-rate-abuse
```

**Result: 30 passed, 3 failed, 6 skipped** (vs. 1 passed pre-fix where all 32 others returned `fetch failed`).

### Remaining 3 failures (verifier-side gaps, unrelated to this bump)

- `neg/007 missing-content-digest`: strict route advertises `covers_content_digest: 'either'`; vector expects 401 when content-digest is required and absent. The training-agent's strict capability is `'either'`, which legitimately accepts both forms — vector's expectation depends on a stricter contract.
- `neg/016 replayed-nonce`: replay store didn't reject the duplicate `(keyid, nonce)` submission. Could be the InMemoryReplayStore not seeing both probes within the window, or strict-route auth chain bypassing replay check on the second submission.
- `neg/018 digest-covered-when-forbidden`: vector expects 401 when capability is `'forbidden'` but request covers digest; we serve `'either'` so this is accepted.

Worth filing as separate issues against the training-agent verifier configuration. Not blocking this bump.

## Runtime API surface unchanged

No code changes other than the version pin and changeset.