### PR TITLE
feat(training-agent): add /mcp-strict-required and /mcp-strict-forbidden conformance routes

### DIFF
--- a/.changeset/add-mcp-strict-required-forbidden-routes.md
+++ b/.changeset/add-mcp-strict-required-forbidden-routes.md
@@ -1,0 +1,15 @@
+---
+---
+
+feat(training-agent): add /mcp-strict-required and /mcp-strict-forbidden conformance routes
+
+Adds two grader-targeted MCP routes that expose `covers_content_digest='required'` and `'forbidden'` modes for the request-signing conformance grader:
+
+- `/mcp-strict-required` — advertises and enforces `covers_content_digest: 'required'`. Enables grader vector neg/007 (`missing-content-digest`): rejects signatures that omit content-digest coverage.
+- `/mcp-strict-forbidden` — advertises and enforces `covers_content_digest: 'forbidden'`. Enables grader vector neg/018 (`digest-covered-when-forbidden`): rejects signatures that include content-digest coverage.
+
+Previously, `/mcp-strict` advertised `'either'` (correct for the sandbox) so neg/007 and neg/018 could never fire — the verifier correctly accepted both probe shapes, leaving buyers with no endpoint to test required-mode and forbidden-mode rejection paths.
+
+**Implementation:** refactors the internal `buildStrictAuthenticator` into a `buildStrictModeAuthenticator(lazyAuth)` factory that accepts a lazy signing authenticator, allowing each route to hold its own capability instance baked at init time (per-request capability swap is unsafe because `verifySignatureAsAuthenticator` captures the capability at construction). Adds `digestMode` to `TrainingContext` so `selectSigningCapability(ctx)` can pick the right capability for the `get_adcp_capabilities` advertisement.
+
+Server-only change. No schema modifications. Closes #3339.

--- a/server/src/training-agent/framework-server.ts
+++ b/server/src/training-agent/framework-server.ts
@@ -31,7 +31,7 @@ import { z } from 'zod';
 import type { TrainingContext, ToolArgs, AccountRef, BrandRef } from './types.js';
 import { getIdempotencyStore, scopedPrincipal } from './idempotency.js';
 import { getWebhookSigningMaterial, maybeEmitCompletionWebhook } from './webhooks.js';
-import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
+import { selectSigningCapability } from './request-signing.js';
 import { PUBLISHERS } from './publishers.js';
 import { getSession, runWithSessionContext, flushDirtySessions, sessionKeyFromArgs } from './state.js';
 import { createLogger } from '../logger.js';
@@ -309,7 +309,7 @@ function scopedWebhookPrincipal(ctx: HandlerContext, params: Record<string, unkn
  * escape our module boundary.
  */
 export function createFrameworkTrainingAgentServer(ctx: TrainingContext): AdcpServer {
-  const signingCap = ctx.strict ? getStrictRequestSigningCapability() : getRequestSigningCapability();
+  const signingCap = selectSigningCapability(ctx);
 
   // ── Custom tools outside AdcpToolMap ─────────────────────────
   // Registered through the framework's `customTools` config (5.4).

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -33,6 +33,8 @@ import { SIGNAL_PROVIDERS } from './signal-providers.js';
 import { getPublicJwks } from './webhooks.js';
 import {
   buildRequestSigningAuthenticator,
+  buildStrictRequiredRequestSigningAuthenticator,
+  buildStrictForbiddenRequestSigningAuthenticator,
   enforceSigningWhenWebhookAuthPresent,
   STRICT_REQUIRED_FOR,
 } from './request-signing.js';
@@ -127,6 +129,22 @@ function lazySigningAuth(): Authenticator {
   };
 }
 
+let _strictRequiredSigningAuth: Authenticator | null = null;
+function lazyStrictRequiredSigningAuth(): Authenticator {
+  return (req) => {
+    if (!_strictRequiredSigningAuth) _strictRequiredSigningAuth = buildStrictRequiredRequestSigningAuthenticator();
+    return _strictRequiredSigningAuth(req);
+  };
+}
+
+let _strictForbiddenSigningAuth: Authenticator | null = null;
+function lazyStrictForbiddenSigningAuth(): Authenticator {
+  return (req) => {
+    if (!_strictForbiddenSigningAuth) _strictForbiddenSigningAuth = buildStrictForbiddenRequestSigningAuthenticator();
+    return _strictForbiddenSigningAuth(req);
+  };
+}
+
 /**
  * Default `/mcp` route: presence-gated signature composition. Callers with no
  * `Signature-Input` header fall through to bearer auth (sandbox backward
@@ -150,19 +168,19 @@ function buildDefaultAuthenticator(): Authenticator | null {
 }
 
 /**
- * Strict `/mcp-strict` route (grader target): presence-gated signature
- * with `required_for: ['create_media_buy']`. Delegates to the SDK's
- * `requireAuthenticatedOrSigned` (5.7) — presence-gated signing, bypass
- * on valid bearer, `request_signature_required` thrown as an
- * `AuthError(cause: RequestSignatureError)` when the op requires signing
- * and no other credential verifies. `serve()` / the handler below auto-
- * detect the signature-layer error via `signatureErrorCodeFromCause`.
+ * Presence-gated authenticator for all `/mcp-strict*` routes. Accepts a lazy
+ * signing authenticator so each route uses its own capability instance
+ * (covers_content_digest varies per route and is baked at init time).
+ *
+ * Delegates to `requireAuthenticatedOrSigned` (5.7): bypass on valid bearer,
+ * `request_signature_required` on unsigned required-op, `signatureErrorCodeFromCause`
+ * surfaces RFC 9421 error codes on bad signatures.
  */
-function buildStrictAuthenticator(): Authenticator | null {
+function buildStrictModeAuthenticator(lazyAuth: () => Authenticator): Authenticator | null {
   const bearerAuth = buildBearerAuthenticator();
   if (!bearerAuth) return null;
   return enforceSigningWhenWebhookAuthPresent(requireAuthenticatedOrSigned({
-    signature: lazySigningAuth(),
+    signature: lazyAuth(),
     fallback: bearerAuth,
     requiredFor: STRICT_REQUIRED_FOR,
     resolveOperation: (req) => {
@@ -188,7 +206,9 @@ function buildStrictAuthenticator(): Authenticator | null {
 }
 
 const defaultAuthenticator = buildDefaultAuthenticator();
-const strictAuthenticator = buildStrictAuthenticator();
+const strictAuthenticator = buildStrictModeAuthenticator(lazySigningAuth);
+const strictRequiredAuthenticator = buildStrictModeAuthenticator(lazyStrictRequiredSigningAuth);
+const strictForbiddenAuthenticator = buildStrictModeAuthenticator(lazyStrictForbiddenSigningAuth);
 
 function buildRequireToken(authenticator: Authenticator | null) {
   return async function requireToken(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -240,6 +260,8 @@ function buildRequireToken(authenticator: Authenticator | null) {
 
 const requireTokenDefault = buildRequireToken(defaultAuthenticator);
 const requireTokenStrict = buildRequireToken(strictAuthenticator);
+const requireTokenStrictRequired = buildRequireToken(strictRequiredAuthenticator);
+const requireTokenStrictForbidden = buildRequireToken(strictForbiddenAuthenticator);
 
 /**
  * Capture the response body as it's written by the MCP transport, redact any
@@ -425,12 +447,14 @@ export function createTrainingAgentRouter(): Router {
     },
   });
 
-  // MCP endpoint factory. Two routes share the same body:
-  //   /mcp — sandbox. anyOf(bearers, signing). required_for=[].
-  //   /mcp-strict — grader target. presence-gated signing. required_for=['create_media_buy'].
-  // The `strict` flag flows into TrainingContext so get_adcp_capabilities
+  // MCP endpoint factory. Routes share the same body:
+  //   /mcp                — sandbox. anyOf(bearers, signing). required_for=[].
+  //   /mcp-strict         — grader target. covers_content_digest='either'.
+  //   /mcp-strict-required  — grader target. covers_content_digest='required'. Fires neg/007.
+  //   /mcp-strict-forbidden — grader target. covers_content_digest='forbidden'. Fires neg/018.
+  // The `strict` + `digestMode` flags flow into TrainingContext so get_adcp_capabilities
   // advertises the correct request_signing block per route.
-  function mcpHandler(strict: boolean) {
+  function mcpHandler(strict: boolean, digestMode?: 'either' | 'required' | 'forbidden') {
     return async (req: Request, res: Response) => {
       setCORSHeaders(res);
 
@@ -444,7 +468,7 @@ export function createTrainingAgentRouter(): Router {
         // Principal is set by requireToken; defaults to 'anonymous' in dev mode
         // when no tokens are configured.
         const principal = (res.locals.trainingPrincipal as string | undefined) ?? 'anonymous';
-        const ctx: TrainingContext = { mode: 'open', principal, strict };
+        const ctx: TrainingContext = { mode: 'open', principal, strict, digestMode };
 
         server = useFrameworkServer()
           ? createFrameworkTrainingAgentServer(ctx)
@@ -546,6 +570,37 @@ export function createTrainingAgentRouter(): Router {
       error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
     });
   });
+
+  // Grader-only targets for covers_content_digest='required' and 'forbidden' modes.
+  // Enables grader vectors neg/007 (missing-content-digest) and neg/018
+  // (digest-covered-when-forbidden) that can't fire against /mcp-strict because
+  // that route advertises 'either' — correct for the sandbox but untestable for
+  // those specific negative paths. Buyers smoke-testing their signing implementation
+  // can use these to verify their code handles required-mode and forbidden-mode
+  // rejections.
+  function mcpStrictModeGet(_req: Request, res: Response): void {
+    setCORSHeaders(res);
+    res.setHeader('Allow', 'POST, OPTIONS');
+    res.status(405).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
+    });
+  }
+
+  router.options('/mcp-strict-required', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.status(204).end();
+  });
+  router.post('/mcp-strict-required', mcpRateLimiter, requireTokenStrictRequired, mcpHandler(true, 'required'));
+  router.get('/mcp-strict-required', mcpStrictModeGet);
+
+  router.options('/mcp-strict-forbidden', (_req: Request, res: Response) => {
+    setCORSHeaders(res);
+    res.status(204).end();
+  });
+  router.post('/mcp-strict-forbidden', mcpRateLimiter, requireTokenStrictForbidden, mcpHandler(true, 'forbidden'));
+  router.get('/mcp-strict-forbidden', mcpStrictModeGet);
 
   // GET/DELETE not supported in stateless mode
   router.get('/mcp', (_req: Request, res: Response) => {

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -51,6 +51,8 @@ export const STRICT_REQUIRED_FOR: readonly string[] = ['create_media_buy'];
 
 let defaultCapability: VerifierCapability | null = null;
 let strictCapability: VerifierCapability | null = null;
+let strictRequiredCapability: VerifierCapability | null = null;
+let strictForbiddenCapability: VerifierCapability | null = null;
 
 function loadTestJwks(): AdcpJsonWebKey[] {
   const path = join(getComplianceCacheDir(), 'test-vectors', 'request-signing', 'keys.json');
@@ -110,15 +112,52 @@ export function getStrictRequestSigningCapability(): VerifierCapability {
 }
 
 /**
- * Build the Authenticator that verifies RFC 9421 signatures. Composed
- * into the main auth chain via `anyOf(verifyApiKey(...), this)` so the
- * endpoint accepts either bearer OR a valid signature.
- *
- * Returns `null` (fall-through) on unsigned requests. Throws `AuthError`
- * on signature-present-but-invalid. Returns a principal
- * `signing:<keyid>` on success.
+ * Capability for `/mcp-strict-required`: verifier rejects signatures that
+ * omit `content-digest` coverage. Enables grader vectors neg/007
+ * (`missing-content-digest`) and any other vector requiring `'required'` mode.
  */
-export function buildRequestSigningAuthenticator(): Authenticator {
+export function getStrictRequiredRequestSigningCapability(): VerifierCapability {
+  if (!strictRequiredCapability) {
+    strictRequiredCapability = {
+      supported: true,
+      covers_content_digest: 'required',
+      required_for: [...STRICT_REQUIRED_FOR],
+      supported_for: [...MUTATING_TOOLS],
+    };
+  }
+  return strictRequiredCapability;
+}
+
+/**
+ * Capability for `/mcp-strict-forbidden`: verifier rejects signatures that
+ * include `content-digest` coverage. Enables grader vector neg/018
+ * (`digest-covered-when-forbidden`) and any other vector requiring `'forbidden'` mode.
+ */
+export function getStrictForbiddenRequestSigningCapability(): VerifierCapability {
+  if (!strictForbiddenCapability) {
+    strictForbiddenCapability = {
+      supported: true,
+      covers_content_digest: 'forbidden',
+      required_for: [...STRICT_REQUIRED_FOR],
+      supported_for: [...MUTATING_TOOLS],
+    };
+  }
+  return strictForbiddenCapability;
+}
+
+/**
+ * Select the right `VerifierCapability` for a training-agent context. The
+ * default (`!ctx.strict`) is the sandbox capability. Strict routes use
+ * `digestMode` to pick among `'either'` / `'required'` / `'forbidden'`.
+ */
+export function selectSigningCapability(ctx: { strict?: boolean; digestMode?: 'either' | 'required' | 'forbidden' }): VerifierCapability {
+  if (!ctx.strict) return getRequestSigningCapability();
+  if (ctx.digestMode === 'required') return getStrictRequiredRequestSigningCapability();
+  if (ctx.digestMode === 'forbidden') return getStrictForbiddenRequestSigningCapability();
+  return getStrictRequestSigningCapability();
+}
+
+function buildAuthenticatorWithCapability(capability: VerifierCapability): Authenticator {
   const keys = loadTestJwks();
   const jwks = new StaticJwksResolver(keys);
   const replayStore = new InMemoryReplayStore();
@@ -133,13 +172,8 @@ export function buildRequestSigningAuthenticator(): Authenticator {
     revoked_jtis: [],
   });
 
-  logger.info(
-    { kids: keys.map(k => k.kid), required_for_count: getRequestSigningCapability().required_for.length },
-    'Request-signing authenticator initialised from compliance test JWKS',
-  );
-
   return verifySignatureAsAuthenticator({
-    capability: getRequestSigningCapability(),
+    capability,
     jwks,
     replayStore,
     revocationStore,
@@ -170,6 +204,33 @@ export function buildRequestSigningAuthenticator(): Authenticator {
       return undefined;
     },
   });
+}
+
+/**
+ * Build the Authenticator that verifies RFC 9421 signatures. Composed
+ * into the main auth chain via `anyOf(verifyApiKey(...), this)` so the
+ * endpoint accepts either bearer OR a valid signature.
+ *
+ * Returns `null` (fall-through) on unsigned requests. Throws `AuthError`
+ * on signature-present-but-invalid. Returns a principal
+ * `signing:<keyid>` on success.
+ */
+export function buildRequestSigningAuthenticator(): Authenticator {
+  logger.info(
+    { required_for_count: getRequestSigningCapability().required_for.length },
+    'Request-signing authenticator initialised from compliance test JWKS',
+  );
+  return buildAuthenticatorWithCapability(getRequestSigningCapability());
+}
+
+/** Authenticator for `/mcp-strict-required`: enforces `covers_content_digest='required'`. */
+export function buildStrictRequiredRequestSigningAuthenticator(): Authenticator {
+  return buildAuthenticatorWithCapability(getStrictRequiredRequestSigningCapability());
+}
+
+/** Authenticator for `/mcp-strict-forbidden`: enforces `covers_content_digest='forbidden'`. */
+export function buildStrictForbiddenRequestSigningAuthenticator(): Authenticator {
+  return buildAuthenticatorWithCapability(getStrictForbiddenRequestSigningCapability());
 }
 
 function headerFirst(value: string | string[] | undefined): string | undefined {
@@ -288,4 +349,6 @@ export function enforceSigningWhenWebhookAuthPresent(inner: Authenticator): Auth
 export function resetRequestSigning(): void {
   defaultCapability = null;
   strictCapability = null;
+  strictRequiredCapability = null;
+  strictForbiddenCapability = null;
 }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -244,7 +244,7 @@ import {
   getIdempotencyStore,
 } from './idempotency.js';
 import { maybeEmitCompletionWebhook } from './webhooks.js';
-import { getRequestSigningCapability, getStrictRequestSigningCapability } from './request-signing.js';
+import { selectSigningCapability } from './request-signing.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
 const MAX_PACKAGES_PER_BUY = 50;
@@ -2495,7 +2495,7 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
     .filter(name => name !== 'get_adcp_capabilities');
   const channels = [...new Set(PUBLISHERS.flatMap(p => p.channels))].sort();
   const publisherDomains = PUBLISHERS.map(p => p.domain);
-  const signingCap = ctx.strict ? getStrictRequestSigningCapability() : getRequestSigningCapability();
+  const signingCap = selectSigningCapability(ctx);
   return {
     adcp: {
       major_versions: [...SUPPORTED_MAJOR_VERSIONS],

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -29,6 +29,12 @@ export interface TrainingContext {
    *  presence-gated signing at the auth layer. Default `/mcp` leaves
    *  `required_for` empty so unsigned bearer callers keep working. */
   strict?: boolean;
+  /**
+   * `covers_content_digest` mode advertised by this route. Only meaningful
+   * when `strict` is true. Defaults to `'either'` (the `/mcp-strict` route).
+   * `/mcp-strict-required` uses `'required'`; `/mcp-strict-forbidden` uses `'forbidden'`.
+   */
+  digestMode?: 'either' | 'required' | 'forbidden';
 }
 
 export interface ShowSpecial {

--- a/server/tests/integration/training-agent-strict.test.ts
+++ b/server/tests/integration/training-agent-strict.test.ts
@@ -26,13 +26,14 @@ vi.mock('../../src/logger.js', () => ({
 
 const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
 const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+const { resetRequestSigning } = await import('../../src/training-agent/request-signing.js');
 
 const AUTH = 'Bearer test-token-for-strict';
 
 /** Call a tool via MCP JSON-RPC and return the parsed inner response. */
 async function callTool(
   app: express.Application,
-  route: '/mcp' | '/mcp-strict',
+  route: '/mcp' | '/mcp-strict' | '/mcp-strict-required' | '/mcp-strict-forbidden',
   tool: string,
   args: Record<string, unknown>,
   opts: { auth?: boolean } = { auth: true },
@@ -190,6 +191,80 @@ describe('Training Agent /mcp-strict route', () => {
 
     it('POST /mcp-strict without auth returns 401', async () => {
       const res = await callTool(app, '/mcp-strict', 'get_adcp_capabilities', {}, { auth: false });
+      expect(res.status).toBe(401);
+    });
+  });
+});
+
+describe('Training Agent /mcp-strict-required and /mcp-strict-forbidden routes', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    resetRequestSigning();
+    app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8');
+      },
+    }));
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  describe('capability declaration — covers_content_digest mode', () => {
+    it('/mcp-strict-required advertises covers_content_digest: required', async () => {
+      const res = await callTool(app, '/mcp-strict-required', 'get_adcp_capabilities', {});
+      expect(res.status).toBe(200);
+      const inner = innerResponse(res) as {
+        request_signing: { supported: boolean; covers_content_digest: string; required_for: string[] };
+      };
+      expect(inner.request_signing.covers_content_digest).toBe('required');
+      expect(inner.request_signing.required_for).toEqual(['create_media_buy']);
+    });
+
+    it('/mcp-strict-forbidden advertises covers_content_digest: forbidden', async () => {
+      const res = await callTool(app, '/mcp-strict-forbidden', 'get_adcp_capabilities', {});
+      expect(res.status).toBe(200);
+      const inner = innerResponse(res) as {
+        request_signing: { supported: boolean; covers_content_digest: string; required_for: string[] };
+      };
+      expect(inner.request_signing.covers_content_digest).toBe('forbidden');
+      expect(inner.request_signing.required_for).toEqual(['create_media_buy']);
+    });
+
+    it('/mcp-strict still advertises covers_content_digest: either (unchanged)', async () => {
+      const res = await callTool(app, '/mcp-strict', 'get_adcp_capabilities', {});
+      expect(res.status).toBe(200);
+      const inner = innerResponse(res) as {
+        request_signing: { covers_content_digest: string };
+      };
+      expect(inner.request_signing.covers_content_digest).toBe('either');
+    });
+  });
+
+  describe('route contract', () => {
+    it('GET /mcp-strict-required returns 405', async () => {
+      const res = await request(app).get('/api/training-agent/mcp-strict-required');
+      expect(res.status).toBe(405);
+      expect(res.headers['allow']).toMatch(/POST/);
+    });
+
+    it('GET /mcp-strict-forbidden returns 405', async () => {
+      const res = await request(app).get('/api/training-agent/mcp-strict-forbidden');
+      expect(res.status).toBe(405);
+      expect(res.headers['allow']).toMatch(/POST/);
+    });
+
+    it('POST /mcp-strict-required without auth returns 401', async () => {
+      const res = await callTool(app, '/mcp-strict-required', 'get_adcp_capabilities', {}, { auth: false });
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /mcp-strict-forbidden without auth returns 401', async () => {
+      const res = await callTool(app, '/mcp-strict-forbidden', 'get_adcp_capabilities', {}, { auth: false });
       expect(res.status).toBe(401);
     });
   });


### PR DESCRIPTION
Closes #3339

Grader vectors neg/007 (`missing-content-digest`) and neg/018 (`digest-covered-when-forbidden`) can't fire against `/mcp-strict` because it advertises `covers_content_digest='either'` — correct for the sandbox, but it means the verifier accepts both probe shapes and the negative paths are silently untestable. Buyers smoke-testing their signing implementation have no endpoint to verify their code handles required-mode and forbidden-mode rejection paths.

This PR adds two dedicated grader-target routes:

- **`/mcp-strict-required`** — advertises and enforces `covers_content_digest: 'required'`. Rejects signatures that omit content-digest coverage → fires neg/007.
- **`/mcp-strict-forbidden`** — advertises and enforces `covers_content_digest: 'forbidden'`. Rejects signatures that include content-digest coverage → fires neg/018.

`/mcp-strict` is unchanged (`covers_content_digest: 'either'`).

**Implementation:** the internal `buildStrictAuthenticator` is refactored into a `buildStrictModeAuthenticator(lazyAuth)` factory so each route holds its own `Authenticator` instance with its capability baked at init time (per-request capability swap is unsafe — `verifySignatureAsAuthenticator` captures capability at construction). `digestMode` is added to `TrainingContext` so `selectSigningCapability(ctx)` can pick the right capability for both the verifier and the `get_adcp_capabilities` advertisement.

**Note on the grader bug (Option 1 from the issue):** the grader's `black_box (contract loaded)` harness should ideally skip neg/007 and neg/018 when the verifier under test advertises `'either'` — firing them unconditionally is a grader bug per the AdCP spec's capability-gating rule. That fix belongs in adcp-client and should be tracked as a follow-on issue there.

**Non-breaking justification:** adds new routes, new capability getter functions, and a new optional field on `TrainingContext`. No existing routes, schemas, or API contracts are changed. Existing consumers are unaffected.

**Pre-PR review:**
- code-reviewer: approved — both blockers (`resetRequestSigning` incomplete, no integration tests) fixed; nit (hermetic `beforeAll`) addressed by adding `resetRequestSigning()` call
- ad-tech-protocol-expert: approved — route-per-mode pattern is correct; `required_for: ['create_media_buy']` on new routes is sound for existing vector set; non-breaking confirmed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RX1tXNkZQXs6TaZEFKdb2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RX1tXNkZQXs6TaZEFKdb2d)_