### PR TITLE
fix(training-agent): PostgresReplayStore so vector 016 catches cross-instance replays

### DIFF
--- a/.changeset/postgres-replay-store-3338.md
+++ b/.changeset/postgres-replay-store-3338.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(training-agent): swap to PostgresReplayStore so vector 016 catches cross-instance replays
+
+The per-route fix in #3346 closed the cross-route bug but vector 016 still failed in prod. Root cause: Fly runs `min_machines_running = 2` web machines and the per-process `InMemoryReplayStore` can't see across machines. Probe 1 hits machine A and consumes the nonce; probe 2 gets routed to machine B by the LB, machine B has never seen the nonce locally, accepts it.
+
+Swaps `InMemoryReplayStore` for `PostgresReplayStore` from `@adcp/client/signing/server` (5.21.0+, [adcp-client#1018](https://github.com/adcontextprotocol/adcp-client/pull/1018)). All instances share one `adcp_replay_cache` table, so the replay window holds across the LB.
+
+Adds:
+- Migration `447_adcp_replay_cache.sql` — schema mirrors the SDK's `getReplayStoreMigration()` output: `(keyid, scope, nonce)` PK + `expires_at` TTL column, two indexes for the lookup and sweep paths.
+- `startReplayCacheSweeper()` in `request-signing.ts` and `index.ts` boot wiring — runs `sweepExpiredReplays(pool)` every 60s. Postgres has no native TTL; without sweeping the table grows unboundedly.
+
+Singleton replay store across the per-route authenticators (default / strict / strict-required / strict-forbidden) — the (keyid, scope, nonce) primary key already partitions by route via the `@target-uri`-derived scope, so a shared table is safe and avoids four separate connections.
+
+Closes the remaining piece of #3338. Once deployed, grader vector 016 should pass against `/mcp-strict`, completing 33/33 graded vectors across the four strict-mode routes.

--- a/server/src/db/migrations/447_adcp_replay_cache.sql
+++ b/server/src/db/migrations/447_adcp_replay_cache.sql
@@ -1,0 +1,27 @@
+-- RFC 9421 nonce-replay cache, shared across all training-agent instances.
+--
+-- Replaces the per-process `InMemoryReplayStore` from `@adcp/client`. With
+-- Fly running >= 2 web machines, in-memory replay state can't catch
+-- cross-instance replays — a captured signature replayed against a sibling
+-- machine that hasn't seen the nonce locally would be accepted (#3338,
+-- grader vector neg/016).
+--
+-- Schema mirrors the SDK's `getReplayStoreMigration()` output (5.21.0+):
+-- `(keyid, scope, nonce)` PK serializes concurrent inserts; `expires_at`
+-- carries the per-row TTL since Postgres has no native TTL. The
+-- `sweepExpiredReplays` helper scheduled in the boot path deletes
+-- expired rows on a 60s interval.
+
+CREATE TABLE IF NOT EXISTS adcp_replay_cache (
+  keyid       TEXT NOT NULL,
+  scope       TEXT NOT NULL,
+  nonce       TEXT NOT NULL,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (keyid, scope, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_replay_cache_expires_at
+  ON adcp_replay_cache(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_replay_cache_keyid_scope_active
+  ON adcp_replay_cache(keyid, scope, expires_at);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,13 @@ async function main() {
   const port = parseInt(process.env.PORT || process.env.CONDUCTOR_PORT || "3000", 10);
   await httpServer.start(port);
 
+  // Periodic sweep of expired RFC 9421 nonce-cache rows. Postgres has no
+  // native TTL, so the replay-store table grows unboundedly without this.
+  // Safe after `httpServer.start` because the underlying pool is initialized
+  // by then; sweep failures log-warn but never crash.
+  const { startReplayCacheSweeper } = await import('./training-agent/request-signing.js');
+  startReplayCacheSweeper();
+
   // Log memory usage every 60s so PostHog/OTEL can chart heap trends.
   // On 1GB Fly machines this is critical for spotting leaks early.
   setInterval(() => {

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -23,11 +23,10 @@ import { join } from 'node:path';
 import type { IncomingMessage } from 'node:http';
 import {
   StaticJwksResolver,
-  InMemoryReplayStore,
   InMemoryRevocationStore,
   RequestSignatureError,
 } from '@adcp/client/signing';
-import type { AdcpJsonWebKey, VerifierCapability } from '@adcp/client/signing';
+import type { AdcpJsonWebKey, ReplayStore, VerifierCapability } from '@adcp/client/signing';
 import {
   verifySignatureAsAuthenticator,
   AuthError,
@@ -35,9 +34,11 @@ import {
   tagAuthenticatorPresenceGated,
   isAuthenticatorPresenceGated,
 } from '@adcp/client/server';
+import { PostgresReplayStore, sweepExpiredReplays } from '@adcp/client/signing/server';
 import type { Authenticator } from '@adcp/client/server';
 import { getComplianceCacheDir } from '@adcp/client/testing';
 import { createLogger } from '../logger.js';
+import { getPool } from '../db/client.js';
 import { MUTATING_TOOLS } from './idempotency.js';
 
 const logger = createLogger('training-agent-request-signing');
@@ -157,10 +158,55 @@ export function selectSigningCapability(ctx: { strict?: boolean; digestMode?: 'e
   return getStrictRequestSigningCapability();
 }
 
+/**
+ * Replay store backed by Postgres so all training-agent instances share
+ * one cache. Per-process `InMemoryReplayStore` can't catch cross-instance
+ * replays — Fly's load balancer routes consecutive probes to different
+ * machines, and the second machine has no record of the first nonce
+ * (#3338, grader vector neg/016).
+ *
+ * Singleton across all per-route authenticators so they all hit the same
+ * `adcp_replay_cache` table; the (keyid, scope, nonce) primary key
+ * partitions by route automatically via the `@target-uri`-derived scope.
+ */
+let _replayStore: ReplayStore | null = null;
+function getReplayStore(): ReplayStore {
+  if (_replayStore) return _replayStore;
+  const store = new PostgresReplayStore(getPool());
+  _replayStore = store;
+  return store;
+}
+
+/**
+ * Schedule periodic deletion of expired rows from `adcp_replay_cache`.
+ * Postgres has no native TTL — without this, the table grows unboundedly.
+ * Called from the server boot path (index.ts).
+ */
+let _sweepInterval: NodeJS.Timeout | null = null;
+export function startReplayCacheSweeper(): void {
+  if (_sweepInterval) return;
+  _sweepInterval = setInterval(() => {
+    sweepExpiredReplays(getPool())
+      .then((result: { deleted: number }) => {
+        if (result.deleted > 0) logger.info({ deleted: result.deleted }, 'Swept expired replay-cache rows');
+      })
+      .catch((err: unknown) => logger.warn({ err }, 'Replay-cache sweep failed'));
+  }, 60_000);
+  // Don't keep the event loop alive for the sweeper alone.
+  _sweepInterval.unref?.();
+}
+
+export function stopReplayCacheSweeper(): void {
+  if (_sweepInterval) {
+    clearInterval(_sweepInterval);
+    _sweepInterval = null;
+  }
+}
+
 function buildAuthenticatorWithCapability(capability: VerifierCapability): Authenticator {
   const keys = loadTestJwks();
   const jwks = new StaticJwksResolver(keys);
-  const replayStore = new InMemoryReplayStore();
+  const replayStore = getReplayStore();
 
   // Pre-revoke the test-kit's revocation vector key so vector 017 fires
   // the expected `request_signature_revoked` error instead of passing.


### PR DESCRIPTION
## What and why

#3346 closed the cross-route replay bug but `adcp grade request-signing` vector 016 (`replayed-nonce`) still failed in prod. Root cause: Fly runs `min_machines_running = 2` web machines and the per-process `InMemoryReplayStore` can't see across machines. Probe 1 hits machine A and consumes the nonce; probe 2 gets routed to machine B by Fly's LB, machine B has never seen the nonce locally, accepts.

Swaps to `PostgresReplayStore` from `@adcp/client/signing/server` (shipped in [adcp-client#1018](https://github.com/adcontextprotocol/adcp-client/pull/1018), 5.21.0+). All instances share one `adcp_replay_cache` table; the (keyid, scope, nonce) primary key serializes concurrent inserts and `ON CONFLICT DO NOTHING` returns `'replayed'` on the second submission.

## What's in this PR

- **Migration 447_adcp_replay_cache.sql** — `(keyid, scope, nonce)` PK + `expires_at` TTL column + two supporting indexes. Schema mirrors the SDK's `getReplayStoreMigration()` exactly.
- **`getReplayStore()` singleton** in `request-signing.ts` shared across all per-route authenticators (default / strict / strict-required / strict-forbidden). Safe to share because `(keyid, scope, nonce)` already partitions by route via the `@target-uri`-derived scope.
- **`startReplayCacheSweeper()`** wired in `index.ts` boot path — runs `sweepExpiredReplays(pool)` every 60s with an unref'd interval (won't keep the loop alive on shutdown). Postgres has no native TTL; without sweeping the table grows unboundedly.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `server/tests/integration/training-agent-strict.test.ts` 15/15 pass (no regression)
- [ ] Post-deploy: `npx adcp grade request-signing https://agenticadvertising.org/api/training-agent/mcp-strict --transport mcp --skip-rate-abuse --only 016-replayed-nonce` → expect PASS

## Closes

#3338 (the remaining cross-instance piece). #3346 closed the cross-route piece earlier.

## Sibling work

Upstream [adcp-client#1018](https://github.com/adcontextprotocol/adcp-client/pull/1018) is the SDK side that made this trivial — three months of in-flight work landed in 5.21.0 just before we needed it.