### PR TITLE
feat(compliance): add signals-specific universal storyboards for error_handling and core tracks

### DIFF
--- a/.changeset/signals-error-schema-storyboards.md
+++ b/.changeset/signals-error-schema-storyboards.md
@@ -1,0 +1,13 @@
+---
+---
+
+feat(compliance): add signals-specific universal storyboards for error_handling and core tracks
+
+Adds `error-compliance-signals.yaml` and `schema-validation-signals.yaml` to
+`static/compliance/source/universal/`, restoring error handling and schema
+compliance coverage for signals-only agents. Fixes the regression from 5.13
+where both tracks produced 0 steps for agents with `supported_protocols:
+["signals"]` because the existing storyboards gate on `required_tools:
+[get_products]`.
+
+Related: #3350

--- a/docs/building/compliance-catalog.mdx
+++ b/docs/building/compliance-catalog.mdx
@@ -23,8 +23,10 @@ Every agent runs every storyboard in `/compliance/{version}/universal/` regardle
 |-----------|---------|
 | `capability-discovery` | `get_adcp_capabilities` shape, protocol/specialism declarations, version advertising |
 | `schema-validation` | Request and response schema conformance, ISO 8601 timestamps, temporal invariants |
+| `schema-validation-signals` | Response schema compliance for signals — required fields on every signal; gated on `get_signals` |
 | `v3-envelope-integrity` | v3 protocol envelopes MUST NOT carry the v2 legacy `task_status` or `response_status` fields — `status` is the single canonical lifecycle field in v3. |
 | `error-compliance` | Structured error shape, published error codes, transport binding, no existence leaks across tenants |
+| `error-compliance-signals` | Error handling for signals protocol — nonexistent signal IDs, missing fields, VERSION_UNSUPPORTED, transport binding; gated on `get_signals` + `activate_signal` |
 | `idempotency` | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
 | `security` | **Authentication baseline — unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding.** See [Authentication](/docs/building/integration/authentication). |
 | `webhook-emission` | Outbound webhook conformance — stable `idempotency_key` across retries; RFC 9421 webhook signing (or HMAC fallback if the buyer opted in). Runs for any agent that accepts `push_notification_config` on any operation. |

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -62,8 +62,10 @@ Every agent MUST pass every storyboard below.
 |------------|------------------|
 | [`capability_discovery`](https://adcontextprotocol.org/compliance/latest/universal/capability-discovery) | `get_adcp_capabilities` shape, protocol/specialism declarations, version advertising |
 | [`schema_validation`](https://adcontextprotocol.org/compliance/latest/universal/schema-validation) | Request and response schema conformance, ISO 8601 timestamps, temporal invariants |
+| [`schema_validation_signals`](https://adcontextprotocol.org/compliance/latest/universal/schema-validation-signals) | Response schema compliance for signals — required fields on every signal; gated on `get_signals` |
 | [`v3_envelope_integrity`](https://adcontextprotocol.org/compliance/latest/universal/v3-envelope-integrity) | v3 protocol envelopes MUST NOT carry the v2 legacy `task_status` or `response_status` fields — `status` is the single canonical lifecycle field in v3 |
 | [`error_compliance`](https://adcontextprotocol.org/compliance/latest/universal/error-compliance) | Structured error shape, published error codes, transport binding, no existence leaks across tenants |
+| [`error_compliance_signals`](https://adcontextprotocol.org/compliance/latest/universal/error-compliance-signals) | Error handling for signals protocol — nonexistent signal IDs, missing fields, VERSION_UNSUPPORTED, transport binding; gated on `get_signals` + `activate_signal` |
 | [`idempotency`](https://adcontextprotocol.org/compliance/latest/universal/idempotency) | `idempotency_key` scoping, replay semantics, `IDEMPOTENCY_CONFLICT`, `replayed: true`, declared TTL |
 | [`security_baseline`](https://adcontextprotocol.org/compliance/latest/universal/security) | Unauth rejection, API key enforcement, OAuth discovery + RFC 9728 audience binding |
 | [`webhook_emission`](https://adcontextprotocol.org/compliance/latest/universal/webhook-emission) | Outbound webhook conformance — stable `idempotency_key` across retries, RFC 9421 webhook signing (or opt-in HMAC fallback) on every delivery. Runs for any agent accepting `push_notification_config`. |

--- a/static/compliance/source/universal/error-compliance-signals.yaml
+++ b/static/compliance/source/universal/error-compliance-signals.yaml
@@ -1,0 +1,377 @@
+id: error_compliance_signals
+version: "1.0.0"
+title: "Error handling — signals protocol"
+category: error_compliance
+summary: "Validates that signals agents return properly structured AdCP errors with correct codes, recovery hints, and transport bindings."
+track: error_handling
+required_tools:
+  - get_signals
+  - activate_signal
+
+narrative: |
+  Every AdCP agent must handle invalid input gracefully. When a buyer sends a
+  nonexistent signal ID, an activation request with a missing required field, or
+  a protocol version the agent cannot support, the agent should return a structured
+  error response — not a stack trace or a generic 500.
+
+  AdCP defines three compliance levels for error responses:
+  - L1: isError flag set on the MCP response
+  - L2: JSON text fallback with adcp_error object in content
+  - L3: structuredContent.adcp_error binding (full compliance)
+
+  This storyboard sends intentionally bad input to a signals agent and validates
+  that the agent rejects it with the correct error code, recovery classification,
+  and transport binding. Agents that use the adcpError() helper from @adcp/client
+  get L3 compliance automatically.
+
+  Context echo is required on error responses — the correlation ID is even more
+  important for error diagnosis than for success cases. Every error response must
+  include the caller's context object unchanged. This contract applies to
+  application-level errors (your tool handler returns an error). MCP transport
+  errors (unknown tool, malformed request) are outside the agent's control and do
+  not carry AdCP context.
+
+agent:
+  interaction_model: owned_signals
+  capabilities: []
+  examples:
+    - "Any AdCP signals agent (owned or marketplace)"
+
+caller:
+  role: buyer_agent
+  example: "Compliance test harness"
+
+prerequisites:
+  description: |
+    No special prerequisites. The storyboard sends intentionally invalid requests
+    to test error handling.
+  test_kit: "test-kits/nova-motors.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent supports the
+      signals protocol before testing error handling.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares the expected protocol support before
+          proceeding with domain-specific operations.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring signals in supported_protocols, confirming
+          the agent exposes get_signals and activate_signal.
+        sample_request:
+          context:
+            correlation_id: "error_compliance_signals--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: error_responses
+    title: "Error responses for invalid input"
+    narrative: |
+      The buyer sends activation requests with intentionally invalid data — a
+      nonexistent signal ID and an activation request missing a required field.
+      Each request should be rejected with a structured error containing an
+      appropriate AdCP error code.
+
+    steps:
+      - id: nonexistent_signal
+        title: "Reject nonexistent signal_agent_segment_id"
+        narrative: |
+          The buyer references a signal_agent_segment_id that does not exist on
+          this platform. REFERENCE_NOT_FOUND is the canonical code for a typed
+          parameter with no dedicated error code that fails to resolve. INVALID_REQUEST
+          is accepted as an alternative. SIGNAL_NOT_FOUND is reserved for unresolvable
+          signal_id (data-provider catalog references), not for opaque agent-internal
+          segment IDs.
+        task: activate_signal
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: error_handling
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject the request with:
+          - code: REFERENCE_NOT_FOUND or INVALID_REQUEST
+          - recovery: correctable
+
+        sample_request:
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+          signal_agent_segment_id: "nonexistent-signal-id-xyz"
+          destinations:
+            - type: "agent"
+              agent_url: "https://test-dsp.example"
+          idempotency_key: "error-test-signals-nonexistent"
+          context:
+            correlation_id: "error_compliance_signals--nonexistent_signal"
+        validations:
+          - check: error_code
+            allowed_values: ["REFERENCE_NOT_FOUND", "INVALID_REQUEST"]
+            description: "Error code is REFERENCE_NOT_FOUND or INVALID_REQUEST for unresolvable signal_agent_segment_id"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--nonexistent_signal"
+            description: "Context correlation_id returned unchanged"
+
+      - id: missing_required_field
+        title: "Reject activation missing signal_agent_segment_id"
+        narrative: |
+          Send an activate_signal request without the required
+          signal_agent_segment_id field. The agent must reject this malformed
+          request with a structured error.
+        task: activate_signal
+        expect_error: true
+        negative_path: schema_invalid
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: error_handling
+        stateful: false
+        # signal_agent_segment_id is required per the schema — this request
+        # intentionally omits it to verify the agent's validation response.
+        sample_request_skip_schema: true
+        expected: |
+          Reject the request with:
+          - code: INVALID_REQUEST or VALIDATION_ERROR
+          - recovery: correctable
+
+        sample_request:
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+          destinations:
+            - type: "agent"
+              agent_url: "https://test-dsp.example"
+          idempotency_key: "error-test-signals-missing-field"
+          context:
+            correlation_id: "error_compliance_signals--missing_required_field"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST", "VALIDATION_ERROR"]
+            description: "Error code is INVALID_REQUEST or VALIDATION_ERROR"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--missing_required_field"
+            description: "Context correlation_id returned unchanged"
+
+  - id: error_structure
+    title: "Error structure compliance"
+    narrative: |
+      Validates that error responses follow the AdCP error structure with required
+      and optional fields.
+
+    steps:
+      - id: validate_error_shape
+        title: "Validate error response structure"
+        narrative: |
+          Trigger an error and inspect the response structure. The adcp_error object
+          must have code and message. Optional fields include recovery, retry_after,
+          field, and suggestion.
+        task: activate_signal
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: error_codes
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Error response with:
+          - code: a recognized AdCP error code
+          - message: human-readable description
+          - recovery: correctable, transient, or fatal (optional)
+
+        sample_request:
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+          signal_agent_segment_id: "nonexistent-signal-error-structure"
+          destinations:
+            - type: "agent"
+              agent_url: "https://test-dsp.example"
+          idempotency_key: "error-structure-signals-test"
+          context:
+            correlation_id: "error_compliance_signals--validate_error_shape"
+        validations:
+          - check: error_code
+            description: "Response surfaces a typed error code via either adcp_error (envelope) or errors[] (payload)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--validate_error_shape"
+            description: "Context correlation_id returned unchanged"
+
+  - id: version_negotiation
+    title: "Protocol version validation"
+    narrative: |
+      Every AdCP request may carry adcp_major_version. Agents validate against their
+      declared supported_major_versions (from get_adcp_capabilities) and return
+      VERSION_UNSUPPORTED when the buyer asks for a version the agent does not speak.
+      When omitted, the agent assumes its highest supported version — so version
+      validation only fires when the buyer explicitly declares an unsupported number.
+
+    steps:
+      - id: unsupported_major_version
+        title: "Reject unsupported adcp_major_version"
+        narrative: |
+          Send a get_signals request asserting a future major version the agent
+          cannot support. The agent must reject with VERSION_UNSUPPORTED and
+          indicate which versions are supported so the buyer can retry.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: error_handling
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with:
+          - code: VERSION_UNSUPPORTED
+          - recovery: fatal
+          - message referencing the buyer's requested version and the agent's supported set
+
+        sample_request:
+          adcp_major_version: 99
+          signal_spec: "Version negotiation probe"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+
+          context:
+            correlation_id: "error_compliance_signals--unsupported_major_version"
+        validations:
+          - check: error_code
+            value: "VERSION_UNSUPPORTED"
+            description: "Error code is VERSION_UNSUPPORTED"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--unsupported_major_version"
+            description: "Context correlation_id returned unchanged"
+
+      - id: supported_major_version
+        title: "Accept supported adcp_major_version"
+        narrative: |
+          Send a get_signals request with the current major version (3). The agent
+          must accept the request normally — version negotiation only rejects
+          mismatched versions, not explicit declarations of a supported one.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: signals_flow
+        stateful: false
+        expected: |
+          Return signals normally — adcp_major_version: 3 is a supported version.
+
+        sample_request:
+          adcp_major_version: 3
+          signal_spec: "Adults interested in electric vehicles"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+
+          context:
+            correlation_id: "error_compliance_signals--supported_major_version"
+        validations:
+          - check: response_schema
+            description: "Response matches get-signals-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--supported_major_version"
+            description: "Context correlation_id returned unchanged"
+
+  - id: error_transport
+    title: "Error transport bindings"
+    narrative: |
+      Validates that errors are transported correctly via MCP. The isError flag must
+      be set, and the error should be available in both JSON text content (L2) and
+      structuredContent (L3) bindings.
+
+    steps:
+      - id: validate_transport_binding
+        title: "Validate error transport binding"
+        narrative: |
+          Trigger an error and verify the MCP transport binding: isError flag must
+          be set to true, and the error content should include the adcp_error object.
+        task: activate_signal
+        schema_ref: "signals/activate-signal-request.json"
+        response_schema_ref: "signals/activate-signal-response.json"
+        doc_ref: "/signals/tasks/activate_signal"
+        comply_scenario: error_transport
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          MCP response with:
+          - isError: true
+          - content containing adcp_error (L2: JSON text, L3: structuredContent)
+
+        sample_request:
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+          signal_agent_segment_id: "nonexistent-signal-transport-test"
+          destinations:
+            - type: "agent"
+              agent_url: "https://test-dsp.example"
+          idempotency_key: "error-transport-signals-test"
+          context:
+            correlation_id: "error_compliance_signals--validate_transport_binding"
+        validations:
+          - check: error_code
+            description: "Transport binding surfaces a typed error code via either adcp_error (envelope) or errors[] (payload)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance_signals--validate_transport_binding"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/universal/error-compliance-signals.yaml
+++ b/static/compliance/source/universal/error-compliance-signals.yaml
@@ -281,7 +281,7 @@ phases:
             correlation_id: "error_compliance_signals--unsupported_major_version"
         validations:
           - check: error_code
-            value: "VERSION_UNSUPPORTED"
+            allowed_values: ["VERSION_UNSUPPORTED"]
             description: "Error code is VERSION_UNSUPPORTED"
           - check: field_present
             path: "context"

--- a/static/compliance/source/universal/schema-validation-signals.yaml
+++ b/static/compliance/source/universal/schema-validation-signals.yaml
@@ -1,0 +1,182 @@
+id: schema_validation_signals
+version: "1.0.0"
+title: "Schema compliance — signals protocol"
+category: schema_validation
+summary: "Validates that signals agent responses conform to AdCP schemas with all required fields present and correctly typed."
+track: core
+required_tools:
+  - get_signals
+
+narrative: |
+  Every AdCP agent must return responses that match the published JSON schemas.
+  For signals agents, this means get_signals responses must carry the required
+  fields on every signal: signal_id, signal_agent_segment_id, name, description,
+  signal_type, data_provider, coverage_percentage, deployments, and
+  pricing_options.
+
+  This storyboard validates schema compliance on get_signals responses —
+  confirming that each signal contains the fields buyers need to proceed to
+  activation and reporting. A signals agent that omits required fields forces
+  buyers to fail at activate_signal or report_usage with no clear error signal.
+
+agent:
+  interaction_model: owned_signals
+  capabilities: []
+  examples:
+    - "Any AdCP signals agent (owned or marketplace)"
+
+caller:
+  role: buyer_agent
+  example: "Compliance test harness"
+
+prerequisites:
+  description: |
+    The caller needs a brand identity for signal discovery requests.
+  test_kit: "test-kits/nova-motors.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to confirm the agent supports the
+      signals protocol before validating response schemas.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares the expected protocol support before
+          proceeding with domain-specific operations.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring signals in supported_protocols, confirming
+          the agent supports get_signals.
+        sample_request:
+          context:
+            correlation_id: "schema_validation_signals--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation_signals--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: schema_compliance
+    title: "Response schema compliance"
+    narrative: |
+      The buyer sends a standard get_signals request and validates that the
+      response matches the published schema. Each signal must have the required
+      fields defined in the AdCP spec.
+
+    steps:
+      - id: get_signals_schema
+        title: "Validate get_signals response schema"
+        narrative: |
+          Send a signal_spec and validate the response structure. Every signal in
+          the response must conform to the get-signals-response.json schema with
+          all required fields present.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: schema_compliance
+        stateful: false
+        expected: |
+          Return signals matching the spec. Each signal must have all required fields:
+          - signal_id: reference to the data provider's catalog
+          - signal_agent_segment_id: opaque identifier used for activation
+          - name: human-readable signal name
+          - description: detailed signal description
+          - signal_type: marketplace, custom, or owned
+          - data_provider: human-readable name of the data provider
+          - coverage_percentage: audience coverage percentage (0–100)
+          - deployments: array of deployment targets
+          - pricing_options: array (minItems: 1) with pricing_option_id
+
+          Responses missing any of these fields fail schema validation.
+
+        sample_request:
+          signal_spec: "Show all available signals"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+
+          context:
+            correlation_id: "schema_validation_signals--get_signals_schema"
+        validations:
+          - check: response_schema
+            description: "Response matches get-signals-response.json schema"
+          - check: field_present
+            path: "signals"
+            description: "Response contains a signals array"
+          - check: field_present
+            path: "signals[0].signal_agent_segment_id"
+            description: "Each signal carries a signal_agent_segment_id for activation"
+          - check: field_present
+            path: "signals[0].signal_type"
+            description: "Each signal declares marketplace, custom, or owned type"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation_signals--get_signals_schema"
+            description: "Context correlation_id returned unchanged"
+
+      - id: pricing_options_present
+        title: "Validate pricing options structure"
+        narrative: |
+          Verify that signals include pricing_options with the required fields.
+          Buyers pass pricing_option_id in report_usage for billing verification;
+          missing or malformed pricing options break the downstream reporting flow.
+        task: get_signals
+        schema_ref: "signals/get-signals-request.json"
+        response_schema_ref: "signals/get-signals-response.json"
+        doc_ref: "/signals/tasks/get_signals"
+        comply_scenario: schema_compliance
+        stateful: false
+        expected: |
+          Signals include pricing_options with:
+          - pricing_option_id: unique identifier for the pricing option
+          - model: pricing model discriminator (cpm, percent_of_media, flat_fee,
+            per_unit, or custom)
+
+        sample_request:
+          signal_spec: "Premium audience signals with pricing details"
+          account:
+            brand:
+              domain: "novamotors.example"
+            operator: "pinnacle-agency.example"
+
+          context:
+            correlation_id: "schema_validation_signals--pricing_options_present"
+        validations:
+          - check: field_present
+            path: "signals[0].pricing_options[0].pricing_option_id"
+            description: "Pricing options have a pricing_option_id"
+          - check: field_present
+            path: "signals[0].pricing_options[0].model"
+            description: "Pricing options declare a pricing model discriminator"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation_signals--pricing_options_present"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
Refs #3350

## Summary

Signals-only agents (`supported_protocols: ["signals"]`, no `get_products` tool) get 0 steps from the `error_handling` and `core` compliance tracks in the 5.13 runner. Root cause: `error-compliance.yaml` and `schema-validation.yaml` both carry `required_tools: [get_products]` at the storyboard root — the runner interprets this as an applicability gate and emits `missing_tool` / skips the storyboard entirely for agents that lack `get_products`.

This PR adds two new universal storyboards targeting signals agents:

- **`error-compliance-signals.yaml`** (`track: error_handling`, `required_tools: [get_signals, activate_signal]`) — 5 phases: capability discovery, error responses (nonexistent segment ID, missing required field), error structure validation, VERSION_UNSUPPORTED / version negotiation, MCP transport binding
- **`schema-validation-signals.yaml`** (`track: core`, `required_tools: [get_signals]`) — 2 phases: capability discovery, schema compliance (required fields on signals, pricing options structure)

Updates `docs/building/conformance.mdx` and `docs/building/compliance-catalog.mdx` per the doc-parity lint requirement.

**Non-breaking justification:** adds new storyboards; no existing storyboard is modified; media-buy agents are unaffected. Signals agents gain new required compliance coverage — this was always the spec intent (universal tracks must run for all agents), so this restores correct behavior rather than expanding requirements.

**Note:** The existing `error-compliance.yaml` and `schema-validation.yaml` still have `required_tools: [get_products]` at the root, which means they remain scoped to media-buy agents. A complementary fix in the `adcp-client` runner (using `supported_protocols` for track applicability rather than `required_tools` as a proxy) would be the complete solution. That fix is in `adcp-client`, not this repo.

## Pre-PR review

- **code-reviewer**: approved — all 6 structural checks pass (idempotency keys on all `activate_signal` steps, `sample_request_skip_schema` on intentionally-malformed step, `REFERENCE_NOT_FOUND` correct error code for unresolvable `signal_agent_segment_id`, `model` field correct for signals pricing)
- **ad-tech-protocol-expert**: approved — error codes correct per spec's "not-found precedence" rule (`REFERENCE_NOT_FOUND` for opaque `signal_agent_segment_id`, not `SIGNAL_NOT_FOUND` which is for `signal_id` catalog references); VERSION_UNSUPPORTED pattern via `get_signals` is sound; coverage sufficient to restore zero-step agents to participation

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01J2r8RXmLEsooTH82Q3XyY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2r8RXmLEsooTH82Q3XyY9)_