### PR TITLE
chore: formalize validation error issues field (#3059)

### DIFF
--- a/docs/protocol/calling-an-agent.mdx
+++ b/docs/protocol/calling-an-agent.mdx
@@ -115,11 +115,15 @@ Every validation failure produces an envelope shaped like:
 }
 ```
 
+- `field` — legacy single-path summary for the first error found; uses the older field-path notation and remains for compatibility while clients transition to `issues[]`
 - `issues[].pointer` — RFC 6901 JSON Pointer to the offending field
-- `issues[].keyword` — Ajv keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`)
-- `issues[].variants` — when `keyword` is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`
+- `issues[].keyword` — optional Ajv-style keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`) when the implementation can provide one
+- `issues[].schemaPath` — optional schema-internal path; sellers should normally omit this in production responses
+- `issues[].variants` — optional implementation-specific extension. When present for `oneOf` or `anyOf`, each entry can list one variant's `required` + declared `properties`
 
-**For `oneOf` failures, pick ONE variant from `variants[]` and send only its `required` fields.** This is the fastest recovery path when you didn't know the field was a union.
+`issues[]` may be present on any error code and may be empty when structured issue details do not apply.
+
+**For `oneOf` failures, pick ONE variant from `variants[]` only if the seller provided that extension.** Otherwise, use `pointer`, `keyword`, and the task schema to repair the payload.
 
 `recovery` values:
 
@@ -131,7 +135,7 @@ Every validation failure produces an envelope shaped like:
 
 | Symptom | What it means | Fix |
 |---|---|---|
-| `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| `keyword: 'oneOf'` with `variants[]` present | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
 | 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |

--- a/issue-3059-issues-array-plan.md
+++ b/issue-3059-issues-array-plan.md
@@ -1,0 +1,150 @@
+# Issue 3059: normalize `adcp_error.issues[]` into `core/error.json`
+
+## Confirmed interpretation
+
+Yes: the issue's core claim is supported by the current repo state.
+
+- The authoritative schema source at `static/schemas/source/core/error.json` does **not** currently define a top-level `issues` field.
+- The released copy at `dist/schemas/3.0.0/core/error.json` also does **not** define it.
+- Buyer-facing protocol docs already instruct buyers to read top-level `adcp_error.issues[]`, including `issues[].pointer`, `issues[].keyword`, and `issues[].variants[]`.
+- Agent skill docs also already teach the same recovery flow from `adcp_error.issues[]`.
+
+That means `issues[]` is already acting as a de facto extension in the ecosystem and in this repo's agent guidance, while the normative schema still omits it. Normalizing it into `core/error.json` is the right shape of change if the goal is to align the spec with current buyer behavior before implementations diverge.
+
+## Important nuance
+
+The repo does **not** show this as an already-normalized schema field. What exists today is:
+
+- normative omission in the source schema
+- buyer guidance that already depends on the field
+- an open triage thread on issue #3059 that explicitly leaves several details unresolved
+
+So the implementation should be treated as a spec/schema alignment change, not a no-op codification.
+
+## Evidence checked
+
+- `static/schemas/source/core/error.json`
+- `dist/schemas/3.0.0/core/error.json`
+- `docs/protocol/calling-an-agent.mdx`
+- `skills/call-adcp-agent/SKILL.md`
+- `docs/building/implementation/security.mdx`
+- `static/schemas/source/enums/error-code.json`
+
+## Proposed implementation plan
+
+### 1. Resolve the blocking spec decisions first
+
+The key design choices are now resolved.
+
+- `issues[].pointer` should use RFC 6901 JSON Pointer.
+- `issues[].keyword` should be optional so non-Ajv implementations do not need placeholder values.
+- Top-level `issues` should be available for all error codes, with an empty array allowed when structured issues do not apply to a particular case.
+- `schemaPath` may be included in the schema, but production guidance should say sellers `SHOULD NOT` populate it in production.
+
+### 2. Update the authoritative schema source
+
+Edit `static/schemas/source/core/error.json` to add a normative top-level `issues` property.
+
+Expected shape, subject to triage:
+
+- `issues`: array
+- item fields:
+  - `pointer` (RFC 6901 JSON Pointer)
+  - `message`
+  - `keyword` (optional)
+  - `schemaPath` (optional, with guidance that production systems SHOULD NOT populate it)
+  - `variants` if the repo wants the currently documented `oneOf`/`anyOf` recovery helper to be schema-recognized rather than just implementation-specific
+
+Related schema text to update at the same time:
+
+- `field` description, because it should reflect the first error found for now and be positioned as a compatibility field that may later be deprecated in favor of `issues`
+- `details` description only if needed to clarify that top-level `issues` is the normalized location and `details.issues` is not part of the recommended contract
+
+### 3. Decide whether `variants[]` is part of the normalized contract
+
+This repo's docs and skills already teach `issues[].variants[]` as the recovery mechanism for `oneOf`/`anyOf` failures, but issue #3059's text as fetched emphasizes `pointer`, `message`, `keyword`, and `schemaPath`.
+
+Decision:
+
+- Standardize only `issues[]` with core validation metadata and leave `variants[]` as an implementation-specific extension.
+
+Buyer docs and skills should keep mentioning `variants[]` as an optional extension hint, but should not present it as a normative cross-implementation contract.
+
+### 4. Align docs and agent skills with the final schema contract
+
+After the schema decision is locked, update at least:
+
+- `docs/protocol/calling-an-agent.mdx`
+- `skills/call-adcp-agent/SKILL.md`
+
+Likely edits:
+
+- pointer encoding wording
+- that `issues` is available across error codes and may be empty when not applicable
+- whether `keyword` is guaranteed vs optional
+- that `schemaPath` exists but SHOULD NOT be populated in production
+- that `variants[]` remains documented as an implementation-specific extension rather than normative
+- compatibility wording around `field`, including its current role as the first error found and likely future deprecation in favor of `issues`
+
+### 5. Add or update security guidance
+
+If `schemaPath` remains in the schema, add normative language in the docs to avoid schema-shape fingerprinting leakage, state that production systems SHOULD NOT populate it, and cross-reference the existing security discussion in `docs/building/implementation/security.mdx`.
+
+Because `issues[].pointer` will use RFC 6901 while `field` remains a compatibility field, the docs should avoid telling implementers to copy one into the other literally.
+
+### 6. Regenerate derived artifacts
+
+After source-schema edits:
+
+- run `npm run build:schemas`
+
+This should refresh generated outputs under `dist/schemas/` and any bundled schema artifacts that inline `core/error.json`.
+
+### 7. Run focused validation
+
+Add or update tests explicitly, not just validation commands.
+
+Minimum test work after the change:
+
+- update any existing schema or error-envelope tests that currently assert the old shape
+- add a regression test that accepts top-level `issues` with RFC 6901 `pointer`, optional `keyword`, optional `schemaPath`, and an empty `issues` array
+- add a backward-compatibility test that keeps `field` populated with the first error found while `issues` is present
+- add an extensibility test that confirms additional non-normative fields on issue objects do not break validation or brittle exact-shape assertions
+- add or update docs/example validation so buyer-facing examples using `issues[]` are checked against the updated schema contract
+
+Minimum command validation after the change:
+
+- `npm run build:schemas`
+- `npm run test:error-codes`
+
+Then run the narrowest additional checks affected by the doc/spec changes:
+
+- the schema/example tests that rely on `/schemas/core/error.json`
+- any docs or unit tests that assert the buyer-facing error envelope shape
+- the new backward-compatibility and extensibility tests added for `issues[]`
+
+## Recommended execution order
+
+1. Update `static/schemas/source/core/error.json` with top-level `issues`, RFC 6901 `pointer`, optional `keyword`, optional `schemaPath`, and wording that allows empty `issues` arrays when structured issues do not apply.
+2. Update the `field` description so it reflects the first error found for now and clearly signals planned deprecation in favor of `issues`.
+3. Update buyer docs and skill docs to match the chosen contract.
+4. Add the production guidance for `schemaPath` and cross-reference the existing security notes.
+5. Add or update tests for the new schema shape, backward compatibility of `field`, and extensibility for additional non-normative issue fields.
+6. Regenerate `dist/schemas/*`.
+7. Run focused validation.
+8. If this becomes a PR, add a changeset that matches whether the repo treats this as a protocol spec change.
+
+## Resolved decisions
+
+1. `issues[].pointer` uses RFC 6901 JSON Pointer.
+2. `issues[].keyword` is optional.
+3. Top-level `issues` is available across all error codes, with an empty array allowed when structured issues do not apply.
+4. `schemaPath` is allowed in the schema, but production guidance should say sellers SHOULD NOT populate it.
+5. Top-level `issues` is the intended normalized location; `details.issues` mirroring is not part of the recommended contract.
+6. `issues[].variants[]` is not standardized and remains implementation-specific.
+7. `field` should reflect the first error found for now, with eventual deprecation in favor of `issues`.
+8. Test coverage should explicitly preserve backward compatibility and extensibility, including allowing additional non-normative issue fields without brittle failures.
+
+## Working hypothesis for implementation
+
+If the answers above converge, this looks like a straightforward source-schema change plus buyer-doc alignment, with the main risk being accidental documentation/spec drift if the repo keeps documenting richer recovery fields than the schema actually standardizes.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -115,11 +115,15 @@ Every validation failure produces:
 }
 ```
 
+- `field` — legacy single-path summary for the first error found; uses the older field-path notation and remains for compatibility while clients transition to `issues[]`.
 - `issues[].pointer` — RFC 6901 JSON Pointer to the field.
-- `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
-- `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
+- `issues[].keyword` — optional AJV-style keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`) when the implementation can provide one.
+- `issues[].schemaPath` — optional schema-internal path. Sellers should normally omit it in production responses.
+- `issues[].variants` — optional implementation-specific extension. When present for `oneOf` or `anyOf`, each entry can list one variant's `required` + declared `properties`. **Pick ONE variant** only when the seller provides this extension.
 
-Patch the pointers, don't re-guess what the skill or the `variants` already told you, resend. Three attempts should cover every field.
+`issues[]` may be present on any error code and may be empty when structured issue details do not apply.
+
+Patch the pointers, don't re-guess what the issue list already told you, resend. If `variants[]` is present, use it as an extension hint. Three attempts should cover every field.
 
 ## Minimal working examples
 
@@ -224,7 +228,7 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 
 | Symptom | What it means | Fix |
 |---|---|---|
-| `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| `keyword: 'oneOf'` with `variants[]` present | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
 | 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -17,7 +17,37 @@
     },
     "field": {
       "type": "string",
-      "description": "Field path associated with the error (e.g., 'packages[0].targeting')"
+      "description": "Legacy single-path summary associated with the first error found, retained for compatibility while clients transition to top-level issues. Uses the existing field-path notation (e.g., 'packages[0].targeting'), not RFC 6901 JSON Pointer."
+    },
+    "issues": {
+      "type": "array",
+      "description": "Structured list of error issues. May be empty when structured issue details do not apply to a particular error.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "type": "string",
+            "description": "RFC 6901 JSON Pointer to the offending field or object."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the issue."
+          },
+          "keyword": {
+            "type": "string",
+            "description": "Optional validator keyword describing the failed rule when the implementation can provide one."
+          },
+          "schemaPath": {
+            "type": "string",
+            "description": "Optional path inside the schema that rejected the payload. Sellers SHOULD normally omit this in production responses."
+          }
+        },
+        "required": [
+          "pointer",
+          "message"
+        ],
+        "additionalProperties": true
+      }
     },
     "suggestion": {
       "type": "string",

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -151,6 +151,58 @@ async function runTests() {
     await validateExample(example.data, example.schema, example.description);
   }
 
+  await validateExample(
+    {
+      "code": "ACCOUNT_SUSPENDED",
+      "message": "Account requires manual review",
+      "field": "account.status",
+      "issues": []
+    },
+    '/schemas/core/error.json',
+    'Error example with empty issues[] and legacy field summary'
+  );
+
+  await validateExample(
+    {
+      "code": "VALIDATION_ERROR",
+      "message": "Request validation failed",
+      "field": "brand.domain",
+      "recovery": "correctable",
+      "issues": [
+        {
+          "pointer": "/brand/domain",
+          "message": "must have required property 'domain'"
+        }
+      ]
+    },
+    '/schemas/core/error.json',
+    'Error example with minimal issue item and optional keyword omitted'
+  );
+
+  await validateExample(
+    {
+      "code": "VALIDATION_ERROR",
+      "message": "Request validation failed",
+      "field": "account",
+      "recovery": "correctable",
+      "issues": [
+        {
+          "pointer": "/account",
+          "keyword": "oneOf",
+          "message": "must match exactly one schema in oneOf",
+          "schemaPath": "#/properties/account/oneOf",
+          "variants": [
+            { "index": 0, "required": ["account_id"] },
+            { "index": 1, "required": ["brand", "operator"] }
+          ],
+          "vendor_hint": "choose one account identity shape"
+        }
+      ]
+    },
+    '/schemas/core/error.json',
+    'Error example allows non-normative issue extensions including variants[]'
+  );
+
   // Test request/response examples
   await validateExample(
     {

--- a/tests/extension-fields.test.cjs
+++ b/tests/extension-fields.test.cjs
@@ -171,6 +171,36 @@ async function runTests() {
     return true;
   });
 
+  await test('Error issues accept implementation-specific extension fields', async () => {
+    const validate = await loadAndCompileSchema(path.join(SCHEMA_BASE_DIR, 'core/error.json'));
+
+    const errorEnvelope = {
+      code: 'VALIDATION_ERROR',
+      message: 'Request validation failed',
+      field: 'account',
+      issues: [
+        {
+          pointer: '/account',
+          message: 'must match exactly one schema in oneOf',
+          keyword: 'oneOf',
+          variants: [
+            { index: 0, required: ['account_id'] },
+            { index: 1, required: ['brand', 'operator'] }
+          ],
+          seller_debug: {
+            attempted_variant_count: 2
+          }
+        }
+      ]
+    };
+
+    const valid = validate(errorEnvelope);
+    if (!valid) {
+      throw new Error(`Validation failed: ${JSON.stringify(validate.errors)}`);
+    }
+    return true;
+  });
+
   // Test 3: Validate objects with extension fields
   await test('Product validates with string extension field', async () => {
     const validate = await loadAndCompileSchema(path.join(SCHEMA_BASE_DIR, 'core/product.json'));


### PR DESCRIPTION
## Summary

Adds `issues[]` to the core error schema as a formal optional field for structured validation errors.

This formalizes behavior that could already appear as an extension and aligns the schema with current buyer-facing guidance, while preserving compatibility for existing consumers.

## Approach

The change is additive and compatibility-focused:

- `issues[]` is optional
- `field` remains present for existing consumers
- `issues[].pointer` uses JSON Pointer format, matching current documented guidance
- `issues[].keyword` is optional so implementations are not forced to invent placeholder values
- `issues[].schemaPath` is optional debug metadata, with guidance against exposing it in production responses by default

## Rationale

Because the error schema already allowed additional properties, `issues[]` could already appear as an extension. Defining it explicitly in `core/error.json` makes that shape documented and interoperable for clients that want structured validation details.

The goal is to standardize the schema contract, not redesign validation behavior.

## Validation

- [x] JSON schema parses successfully
- [x] Targeted schema/example/extensibility tests pass locally
- [x] Full pre-commit passes locally in my current environment

## Notes

Also updates buyer-facing docs/skill guidance and adds regression coverage for empty `issues[]`, optional `keyword`, compatibility of `field`, and non-normative issue extensions.