### PR TITLE
fix(fly): auto_start workers — rolling deploys were leaving them stopped

### DIFF
--- a/.changeset/fly-worker-auto-start.md
+++ b/.changeset/fly-worker-auto-start.md
@@ -1,0 +1,16 @@
+---
+---
+
+Fix Fly worker process group lifecycle — rolling deploys were leaving worker
+machines in `stopped` state forever because the worker pgroup had no
+auto_start_machines path (only `[http_service]` had it, scoped to web).
+Replace the bare `[[checks]]` block with a `[[services]]` block targeting
+`processes=["worker"]` with `auto_start_machines=true` and
+`min_machines_running=2`. No external ports — workers stay private; the
+internal_port is only used by the http_check.
+
+Symptom this fixes: the periodic catalog crawler (every 30 min) and the
+buying-agents crawler (every 6h) only run on workers. Workers being
+stopped meant the property-registry-unification chain (#3274/#3314/#3312/#3352)
+was unexercised in production until manual `/api/registry/crawl-request`
+calls fired it.

--- a/fly.toml
+++ b/fly.toml
@@ -48,17 +48,32 @@ primary_region = 'iad'
     [http_service.checks.headers]
       User-Agent = "Fly Health Check"
 
-# Worker health check (no public traffic, just keeps Fly from killing it)
-[[checks]]
-  name = "worker-health"
-  port = 8080
-  type = "http"
-  interval = "15s"
-  timeout = "20s"
-  grace_period = "60s"
-  method = "GET"
-  path = "/health"
+# Worker process group config.
+#
+# `[[services]]` (rather than a bare `[[checks]]`) opts the worker process
+# group into Fly's auto_start_machines + min_machines_running lifecycle —
+# the same mechanism `[http_service]` uses for web. Without this, workers
+# created by a rolling deploy stay in `stopped` state forever (no
+# auto_start path) and the periodic crawler / scheduled jobs don't run.
+#
+# No `[[services.ports]]` block: no external traffic. The internal_port
+# is only used by the health check below.
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
   processes = ["worker"]
+  auto_start_machines = true
+  auto_stop_machines = "off"
+  min_machines_running = 2
+
+  [[services.http_checks]]
+    interval = "15s"
+    timeout = "20s"
+    grace_period = "60s"
+    method = "GET"
+    path = "/health"
+    protocol = "http"
+    tls_skip_verify = false
 
 [[vm]]
   processes = ["web"]


### PR DESCRIPTION
## Summary

Production workers on adcp-docs have been sitting in `stopped` state with check status `\"the machine hasn't started\"` since the readers PR (#3352) deploy. The worker process group's lifecycle was never opted into Fly's auto_start_machines path the way `[http_service]` is for web — so a rolling deploy creates new worker machines but never starts them.

This is what prevented the full property-registry-unification chain (#3274/#3314/#3312/#3352) from being exercised in production: the periodic crawler that calls `PublisherDatabase.upsertAdagentsCache` only runs on workers (every 30 min for the catalog queue, every 6h for buying agents), and workers were dead.

Verified by manually firing `POST /api/registry/crawl-request` for `mamamia.com.au`: writer projected one row, trigger emitted `authorization.granted`, UNION reader returned the catalog row through `/api/registry/lookup/agent/.../domains`. Full chain works — workers just weren't running it.

## Change

Replace the bare `[[checks]]` block for worker-health with a `[[services]]` block:
- `processes = [\"worker\"]` — scopes to the worker process group
- `auto_start_machines = true` — same lifecycle hook `[http_service]` uses for web
- `min_machines_running = 2` — Fly will keep two workers alive
- No `[[services.ports]]` block — no external traffic; the internal_port is only used by the http_check
- `[[services.http_checks]]` replaces the prior bare check

`fly config validate` passes (warning about missing ports is stale documentation about a Feb 2024 deprecation that didn't actually hard-fail).

## Test plan

- [ ] Merge → next deploy creates worker machines that auto-start (no manual `fly machine start` needed).
- [ ] Periodic catalog crawl resumes (logs: \"Periodic catalog domain crawl started\").
- [ ] After 30 min, `/api/registry/feed?types=authorization.*` shows new events from the queue draining.
- [ ] If a deploy fails health checks, workers don't get stuck in `stopped`.

## Rollback

Revert this PR; workers fall back to manual start. Either run `fly machine start <id>` for each, or `fly scale count worker=2 --process=worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)