### PR TITLE
fix(membership): centralize primary_organization_id reads, add invariant

### DIFF
--- a/.changeset/primary-org-fallback-and-invariant.md
+++ b/.changeset/primary-org-fallback-and-invariant.md
@@ -1,0 +1,12 @@
+---
+---
+
+Fix paid members being silently treated as non-members when `users.primary_organization_id` is NULL.
+
+The column is a denormalized pointer set by the `organization_membership.created` webhook and by `enrichUserWithMembership` on page load. A user.created vs membership.created webhook-order race or a fire-and-forget backfill failure can leave it NULL even when the user has memberships. Eleven read sites (Addie member tools, brand-feeds, referrals, brand-claim, registry-api, resolve-caller-org, member-profile, community sync) treated NULL as "no organization" — that's how a paid Founding member at ResponsiveAds saw "no directory listing" and "not a member" despite an active subscription.
+
+Fix:
+- New `resolvePrimaryOrganization()` helper in `users-db.ts` that does the read-with-fallback (column → organization_memberships → opportunistic backfill). All 11 direct reads now go through it.
+- `upsertUser` webhook handler now backfills the column after creating/updating the users row, closing the race where membership.created arrives first.
+- One-time migration backfills any existing NULL rows from organization_memberships.
+- New `users-have-primary-organization` integrity invariant catches new drift; visible at `/api/admin/integrity/check`.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -62,6 +62,7 @@ import { ComplianceDatabase } from '../../db/compliance-db.js';
 import { getPool, query } from '../../db/client.js';
 import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-db.js';
 import { OrganizationDatabase } from '../../db/organization-db.js';
+import { resolvePrimaryOrganization } from '../../db/users-db.js';
 import { WorkingGroupDatabase } from '../../db/working-group-db.js';
 import { checkMilestones } from '../services/journey-computation.js';
 import { PERSONA_LABELS } from '../../config/personas.js';
@@ -1988,11 +1989,7 @@ export function createMemberToolHandlers(
     }
 
     const userId = memberContext.workos_user.workos_user_id;
-    const userRow = await query<{ primary_organization_id: string | null }>(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      [userId]
-    );
-    const orgId = userRow.rows[0]?.primary_organization_id;
+    const orgId = await resolvePrimaryOrganization(userId);
     if (!orgId) {
       return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one!";
     }
@@ -2098,11 +2095,7 @@ export function createMemberToolHandlers(
     }
 
     const userId = memberContext.workos_user.workos_user_id;
-    const userRow = await query<{ primary_organization_id: string | null }>(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      [userId]
-    );
-    const orgId = userRow.rows[0]?.primary_organization_id;
+    const orgId = await resolvePrimaryOrganization(userId);
     if (!orgId) {
       return "Your organization doesn't have a directory listing yet. Visit https://agenticadvertising.org/member-profile to create one first!";
     }

--- a/server/src/audit/integrity/invariants/index.ts
+++ b/server/src/audit/integrity/invariants/index.ts
@@ -14,8 +14,11 @@ import { oneActiveStripeSubPerOrgInvariant } from './one-active-stripe-sub-per-o
 import { stripeCustomerResolvesInvariant } from './stripe-customer-resolves.js';
 import { orgRowMatchesLiveStripeSubInvariant } from './org-row-matches-live-stripe-sub.js';
 import { workosMembershipRowExistsInWorkosInvariant } from './workos-membership-row-exists-in-workos.js';
+import { usersHavePrimaryOrganizationInvariant } from './users-have-primary-organization.js';
 
 export const ALL_INVARIANTS: readonly Invariant[] = [
+  // DB-only checks first (no external API calls).
+  usersHavePrimaryOrganizationInvariant,
   stripeCustomerOrgMetadataBidirectionalInvariant,
   oneActiveStripeSubPerOrgInvariant,
   stripeCustomerResolvesInvariant,

--- a/server/src/audit/integrity/invariants/users-have-primary-organization.ts
+++ b/server/src/audit/integrity/invariants/users-have-primary-organization.ts
@@ -1,47 +1,54 @@
 /**
- * Invariant: every user with at least one organization_memberships row in a
- * non-personal org has users.primary_organization_id set.
+ * Invariant: users.primary_organization_id is coherent with the user's
+ * organization_memberships. Two failure modes:
  *
- * A NULL pointer silently breaks every read site that queries the column
- * directly without falling back to organization_memberships. This caused
- * paid Founding members to see "no directory listing" / "not a member" on
- * the member-profile page and Addie tools in April 2026.
+ *   1. Missing pointer — user has memberships but column is NULL.
+ *      Caused by user.created vs organization_membership.created webhook-order
+ *      races, fire-and-forget backfill failures, or direct DB inserts.
+ *      Read sites that gate on the column treat the user as having no org.
  *
- * Drift sources:
- *   - user.created vs organization_membership.created webhook-order race
- *     (membership webhook's backfill UPDATE no-ops if the users row doesn't
- *     exist yet)
- *   - fire-and-forget backfill failures in enrichUserWithMembership
- *   - direct DB inserts that bypass the webhook handlers
+ *   2. Stale pointer — column points at an org the user no longer belongs to.
+ *      Caused by missed delete webhooks (or pre-fix delete handlers that
+ *      didn't clear the column). Read sites continue resolving the user into
+ *      an org they were removed from — the same authorization-scope risk in
+ *      reverse.
  *
- * The remediation hint maps to the centralized helper that does the right
- * read-with-fallback in production: users-db.ts:resolvePrimaryOrganization.
+ * Production fix lives in users-db.ts:resolvePrimaryOrganization (read-with-
+ * fallback) and membership-db.ts:deleteOrganizationMembership (clears the
+ * pointer in the same step as the membership delete).
  */
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
 
 const DEFAULT_LIMIT = 1000;
 
-interface MismatchRow {
+interface MissingPointerRow {
   workos_user_id: string;
   email: string;
   inferred_org_id: string;
   inferred_org_name: string;
 }
 
+interface StalePointerRow {
+  workos_user_id: string;
+  email: string;
+  stale_org_id: string;
+}
+
 export const usersHavePrimaryOrganizationInvariant: Invariant = {
   name: 'users-have-primary-organization',
   description:
-    'Every user with at least one organization_memberships row in a non-personal ' +
-    'org has users.primary_organization_id set. Catches webhook-order races and ' +
-    'silent backfill failures that break read sites which do not fall back from ' +
-    'the column to organization_memberships.',
+    'users.primary_organization_id is coherent with organization_memberships. ' +
+    'Catches both missing pointers (column NULL despite memberships) and stale ' +
+    'pointers (column set to an org the user no longer belongs to). Either drift ' +
+    'silently broadens or narrows the read sites that gate on the column.',
   severity: 'warning',
   async check(ctx: InvariantContext): Promise<InvariantResult> {
     const { pool, options } = ctx;
     const limit = Math.min(options?.sampleSize ?? DEFAULT_LIMIT, 5000);
     const violations: Violation[] = [];
 
-    const result = await pool.query<MismatchRow>(`
+    // Failure mode 1: column NULL but memberships exist.
+    const missing = await pool.query<MissingPointerRow>(`
       SELECT DISTINCT ON (u.workos_user_id)
         u.workos_user_id,
         u.email,
@@ -59,7 +66,7 @@ export const usersHavePrimaryOrganizationInvariant: Invariant = {
       LIMIT $1
     `, [limit]);
 
-    for (const row of result.rows) {
+    for (const row of missing.rows) {
       violations.push({
         invariant: 'users-have-primary-organization',
         severity: 'warning',
@@ -71,6 +78,7 @@ export const usersHavePrimaryOrganizationInvariant: Invariant = {
           `(Addie member tools, brand-feeds, referrals, brand-claim, registry-api) ` +
           `silently treat this user as having no organization.`,
         details: {
+          drift: 'missing_pointer',
           workos_user_id: row.workos_user_id,
           email: row.email,
           inferred_org_id: row.inferred_org_id,
@@ -83,6 +91,41 @@ export const usersHavePrimaryOrganizationInvariant: Invariant = {
       });
     }
 
-    return { checked: result.rows.length, violations };
+    // Failure mode 2: column points at an org with no current membership row.
+    const stale = await pool.query<StalePointerRow>(`
+      SELECT u.workos_user_id, u.email, u.primary_organization_id AS stale_org_id
+      FROM users u
+      LEFT JOIN organization_memberships om
+        ON om.workos_user_id = u.workos_user_id
+       AND om.workos_organization_id = u.primary_organization_id
+      WHERE u.primary_organization_id IS NOT NULL
+        AND om.workos_user_id IS NULL
+      LIMIT $1
+    `, [limit]);
+
+    for (const row of stale.rows) {
+      violations.push({
+        invariant: 'users-have-primary-organization',
+        severity: 'warning',
+        subject_type: 'user',
+        subject_id: row.workos_user_id,
+        message:
+          `User ${row.workos_user_id} (${row.email}) has primary_organization_id = ` +
+          `${row.stale_org_id} but no organization_memberships row for that org. ` +
+          `Read sites continue resolving the user into the removed org.`,
+        details: {
+          drift: 'stale_pointer',
+          workos_user_id: row.workos_user_id,
+          email: row.email,
+          stale_org_id: row.stale_org_id,
+        },
+        remediation_hint:
+          'Clear the column (UPDATE users SET primary_organization_id = NULL ...) ' +
+          'and let resolvePrimaryOrganization re-derive from organization_memberships ' +
+          'on the next request.',
+      });
+    }
+
+    return { checked: missing.rows.length + stale.rows.length, violations };
   },
 };

--- a/server/src/audit/integrity/invariants/users-have-primary-organization.ts
+++ b/server/src/audit/integrity/invariants/users-have-primary-organization.ts
@@ -1,0 +1,88 @@
+/**
+ * Invariant: every user with at least one organization_memberships row in a
+ * non-personal org has users.primary_organization_id set.
+ *
+ * A NULL pointer silently breaks every read site that queries the column
+ * directly without falling back to organization_memberships. This caused
+ * paid Founding members to see "no directory listing" / "not a member" on
+ * the member-profile page and Addie tools in April 2026.
+ *
+ * Drift sources:
+ *   - user.created vs organization_membership.created webhook-order race
+ *     (membership webhook's backfill UPDATE no-ops if the users row doesn't
+ *     exist yet)
+ *   - fire-and-forget backfill failures in enrichUserWithMembership
+ *   - direct DB inserts that bypass the webhook handlers
+ *
+ * The remediation hint maps to the centralized helper that does the right
+ * read-with-fallback in production: users-db.ts:resolvePrimaryOrganization.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+const DEFAULT_LIMIT = 1000;
+
+interface MismatchRow {
+  workos_user_id: string;
+  email: string;
+  inferred_org_id: string;
+  inferred_org_name: string;
+}
+
+export const usersHavePrimaryOrganizationInvariant: Invariant = {
+  name: 'users-have-primary-organization',
+  description:
+    'Every user with at least one organization_memberships row in a non-personal ' +
+    'org has users.primary_organization_id set. Catches webhook-order races and ' +
+    'silent backfill failures that break read sites which do not fall back from ' +
+    'the column to organization_memberships.',
+  severity: 'warning',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, options } = ctx;
+    const limit = Math.min(options?.sampleSize ?? DEFAULT_LIMIT, 5000);
+    const violations: Violation[] = [];
+
+    const result = await pool.query<MismatchRow>(`
+      SELECT DISTINCT ON (u.workos_user_id)
+        u.workos_user_id,
+        u.email,
+        om.workos_organization_id AS inferred_org_id,
+        o.name AS inferred_org_name
+      FROM users u
+      JOIN organization_memberships om ON om.workos_user_id = u.workos_user_id
+      JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+      WHERE u.primary_organization_id IS NULL
+        AND COALESCE(o.is_personal, false) = false
+      ORDER BY
+        u.workos_user_id,
+        CASE WHEN o.subscription_status = 'active' THEN 0 ELSE 1 END,
+        om.created_at DESC
+      LIMIT $1
+    `, [limit]);
+
+    for (const row of result.rows) {
+      violations.push({
+        invariant: 'users-have-primary-organization',
+        severity: 'warning',
+        subject_type: 'user',
+        subject_id: row.workos_user_id,
+        message:
+          `User ${row.workos_user_id} (${row.email}) has organization_memberships but ` +
+          `users.primary_organization_id is NULL. Read sites that gate on the column ` +
+          `(Addie member tools, brand-feeds, referrals, brand-claim, registry-api) ` +
+          `silently treat this user as having no organization.`,
+        details: {
+          workos_user_id: row.workos_user_id,
+          email: row.email,
+          inferred_org_id: row.inferred_org_id,
+          inferred_org_name: row.inferred_org_name,
+        },
+        remediation_hint:
+          'Set users.primary_organization_id to inferred_org_id, or have the user ' +
+          'load any authenticated page (which calls resolvePrimaryOrganization and ' +
+          'opportunistically backfills the column).',
+      });
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -6,7 +6,7 @@
  */
 
 import type { WorkOS } from '@workos-inc/node';
-import { getPool } from './client.js';
+import { getPool, getClient } from './client.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('membership-db');
@@ -146,22 +146,31 @@ export async function deleteOrganizationMembership(
   userId: string,
   organizationId: string,
 ): Promise<string | null> {
-  const pool = getPool();
-
-  const result = await pool.query<{ role: string }>(
-    `DELETE FROM organization_memberships
-     WHERE workos_user_id = $1 AND workos_organization_id = $2
-     RETURNING role`,
-    [userId, organizationId],
-  );
-
-  await pool.query(
-    `UPDATE users SET primary_organization_id = NULL, updated_at = NOW()
-     WHERE workos_user_id = $1 AND primary_organization_id = $2`,
-    [userId, organizationId],
-  );
-
-  return result.rows[0]?.role ?? null;
+  // Atomic: DELETE membership and clear the cached pointer in one transaction.
+  // If the DELETE succeeded but the pointer-clear UPDATE failed, we'd recreate
+  // the exact stale-pointer state the integrity invariant exists to catch.
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    const result = await client.query<{ role: string }>(
+      `DELETE FROM organization_memberships
+       WHERE workos_user_id = $1 AND workos_organization_id = $2
+       RETURNING role`,
+      [userId, organizationId],
+    );
+    await client.query(
+      `UPDATE users SET primary_organization_id = NULL, updated_at = NOW()
+       WHERE workos_user_id = $1 AND primary_organization_id = $2`,
+      [userId, organizationId],
+    );
+    await client.query('COMMIT');
+    return result.rows[0]?.role ?? null;
+  } catch (err) {
+    try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 // ── Invitation seat type ─────────────────────────────────────────────

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -136,6 +136,11 @@ export async function upsertOrganizationMembership(
 /**
  * Delete an organization membership. Returns the role of the deleted
  * row (or null if the row didn't exist).
+ *
+ * Also clears users.primary_organization_id when it pointed at this org —
+ * a stale pointer would let resolvePrimaryOrganization keep returning a
+ * removed-org id, which read sites use as an authorization scope. Next
+ * read backfills via resolvePreferredOrganization.
  */
 export async function deleteOrganizationMembership(
   userId: string,
@@ -147,6 +152,12 @@ export async function deleteOrganizationMembership(
     `DELETE FROM organization_memberships
      WHERE workos_user_id = $1 AND workos_organization_id = $2
      RETURNING role`,
+    [userId, organizationId],
+  );
+
+  await pool.query(
+    `UPDATE users SET primary_organization_id = NULL, updated_at = NOW()
+     WHERE workos_user_id = $1 AND primary_organization_id = $2`,
     [userId, organizationId],
   );
 

--- a/server/src/db/migrations/448_backfill_primary_organization_id.sql
+++ b/server/src/db/migrations/448_backfill_primary_organization_id.sql
@@ -1,0 +1,30 @@
+-- One-time backfill: users.primary_organization_id from organization_memberships.
+--
+-- The column is a denormalized pointer set by the organization_membership.created
+-- webhook and by enrichUserWithMembership on page load. A user.created /
+-- membership.created webhook-order race or a fire-and-forget backfill failure
+-- can leave the column NULL even when the user has memberships. Every read
+-- site that doesn't fall back from the column to organization_memberships
+-- silently treats those users as "no organization" — that's the bug that
+-- broke directory listings for paid Founding members in April 2026.
+--
+-- Ongoing prevention: users-db.ts:resolvePrimaryOrganization (centralized
+-- read-with-fallback), upsertUser webhook backfill, and the
+-- users-have-primary-organization integrity invariant.
+
+UPDATE users u
+SET primary_organization_id = pref.org_id,
+    updated_at = NOW()
+FROM (
+  SELECT DISTINCT ON (om.workos_user_id)
+    om.workos_user_id,
+    om.workos_organization_id AS org_id
+  FROM organization_memberships om
+  JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+  ORDER BY
+    om.workos_user_id,
+    CASE WHEN o.subscription_status = 'active' THEN 0 ELSE 1 END,
+    om.created_at DESC
+) pref
+WHERE u.workos_user_id = pref.workos_user_id
+  AND u.primary_organization_id IS NULL;

--- a/server/src/db/migrations/448_backfill_primary_organization_id.sql
+++ b/server/src/db/migrations/448_backfill_primary_organization_id.sql
@@ -11,6 +11,11 @@
 -- Ongoing prevention: users-db.ts:resolvePrimaryOrganization (centralized
 -- read-with-fallback), upsertUser webhook backfill, and the
 -- users-have-primary-organization integrity invariant.
+--
+-- Scale: single statement is fine at current users-table size (low thousands
+-- as of this commit). If the table grows past ~100k rows, batch via
+-- WHERE workos_user_id IN (... LIMIT 5000) loops to avoid holding row locks
+-- across the whole table in one transaction.
 
 UPDATE users u
 SET primary_organization_id = pref.org_id,

--- a/server/src/db/users-db.ts
+++ b/server/src/db/users-db.ts
@@ -1,5 +1,8 @@
 import { query } from './client.js';
+import { createLogger } from '../logger.js';
 import type { UpdateUserLocationInput, UserLocation } from '../types.js';
+
+const logger = createLogger('users-db');
 
 /**
  * User record from the users table
@@ -227,4 +230,43 @@ export async function backfillPrimaryOrganization(workosUserId: string, orgId: s
      WHERE workos_user_id = $2 AND primary_organization_id IS NULL`,
     [orgId, workosUserId]
   );
+}
+
+/**
+ * Resolve the user's primary organization id.
+ *
+ *   1. Read users.primary_organization_id (the cached pointer).
+ *   2. If NULL, derive from organization_memberships (preferring paying orgs).
+ *   3. Best-effort backfill so the next read hits the fast path.
+ *
+ * Returns null when the user has no organization at all.
+ *
+ * Use this instead of selecting primary_organization_id directly. Direct reads
+ * silently return null for users whose backfill never completed (race between
+ * organization_membership.created and user.created webhooks, fire-and-forget
+ * backfill failures), which silently breaks every surface that gates on the
+ * column. The integrity invariant `users-have-primary-organization` catches
+ * any rows that stay NULL despite the fallback.
+ */
+export async function resolvePrimaryOrganization(workosUserId: string): Promise<string | null> {
+  const cached = await query<{ primary_organization_id: string | null }>(
+    `SELECT primary_organization_id FROM users
+       WHERE workos_user_id = $1 AND primary_organization_id IS NOT NULL`,
+    [workosUserId]
+  );
+  if (cached.rows[0]?.primary_organization_id) {
+    return cached.rows[0].primary_organization_id;
+  }
+
+  const derived = await resolvePreferredOrganization(workosUserId);
+  if (!derived) return null;
+
+  // Opportunistic backfill — failures don't block the lookup. The integrity
+  // invariant catches any row that stays NULL (e.g. because the users row
+  // doesn't exist yet, or a transient DB error swallows the UPDATE).
+  backfillPrimaryOrganization(workosUserId, derived).catch((err) => {
+    logger.warn({ err, userId: workosUserId, orgId: derived }, 'opportunistic primary_organization_id backfill failed');
+  });
+
+  return derived;
 }

--- a/server/src/db/users-db.ts
+++ b/server/src/db/users-db.ts
@@ -202,8 +202,17 @@ export class UsersDatabase {
 
 /**
  * Resolve the preferred organization for a user from their memberships.
- * Prefers paying orgs, then most recently created membership.
  * Returns null if the user has no memberships.
+ *
+ * Tie-breaker: paying orgs first (subscription_status = 'active'), then most
+ * recent membership. Note this matches on the column literal — a sub that's
+ * still 'active' but has subscription_canceled_at set ranks the same as a
+ * fully-paying one. That's looser than the org-filters MEMBER_FILTER but
+ * good enough for the "which org is this user's primary?" question.
+ *
+ * For a user with memberships in multiple paying orgs, the most-recent wins.
+ * Cross-org auth code that relies on a deterministic "primary" should
+ * tolerate the user changing primary across membership additions.
  */
 export async function resolvePreferredOrganization(workosUserId: string): Promise<string | null> {
   const result = await query<{ workos_organization_id: string }>(

--- a/server/src/routes/brand-feeds.ts
+++ b/server/src/routes/brand-feeds.ts
@@ -10,6 +10,7 @@ import { createLogger } from '../logger.js';
 import { requireAuth } from '../middleware/auth.js';
 import { query, getPool } from '../db/client.js';
 import { BrandDatabase } from '../db/brand-db.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { validateFetchUrl } from '../utils/url-security.js';
 import { fetchFeed, slugify, suggestProduct, mergeInstallments } from '../services/collection-feed-sync.js';
 import type { CollectionFromFeed } from '../services/collection-feed-sync.js';
@@ -38,11 +39,7 @@ export function createBrandFeedsRouter(config: { brandDb: BrandDatabase }) {
     if (brand.manifest_orphaned) return { error: 'This brand is awaiting adoption — claim it through the brand identity flow first', status: 409 };
 
     // Verify the user's org owns this brand (via primary_brand_domain or organization_domains)
-    const userOrg = await query<{ primary_organization_id: string | null }>(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      [userId]
-    );
-    const orgId = userOrg.rows[0]?.primary_organization_id;
+    const orgId = await resolvePrimaryOrganization(userId);
     if (!orgId) {
       return { error: 'No organization associated with your account', status: 403 };
     }

--- a/server/src/routes/community.ts
+++ b/server/src/routes/community.ts
@@ -8,6 +8,7 @@ import { MemberDatabase } from "../db/member-db.js";
 import { OrganizationDatabase } from "../db/organization-db.js";
 import { SlackDatabase } from "../db/slack-db.js";
 import { query } from "../db/client.js";
+import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { VALID_MEMBER_OFFERINGS, type MemberOffering } from "../types.js";
 import { notifyUser } from "../notifications/notification-service.js";
 
@@ -427,18 +428,19 @@ async function syncIndividualMemberProfile(
   invalidateMemberContextCache?: () => void,
 ): Promise<void> {
   // Look up user's org
-  const userRow = await query<{ primary_organization_id: string | null; first_name: string; last_name: string }>(
-    'SELECT primary_organization_id, first_name, last_name FROM users WHERE workos_user_id = $1',
+  const orgId = await resolvePrimaryOrganization(userId);
+  if (!orgId) return;
+
+  // Only sync for personal/individual orgs
+  const org = await orgDb.getOrganization(orgId);
+  if (!org?.is_personal) return;
+
+  const userRow = await query<{ first_name: string; last_name: string }>(
+    'SELECT first_name, last_name FROM users WHERE workos_user_id = $1',
     [userId]
   );
   const user = userRow.rows[0];
-  if (!user?.primary_organization_id) return;
-
-  // Only sync for personal/individual orgs
-  const org = await orgDb.getOrganization(user.primary_organization_id);
-  if (!org?.is_personal) return;
-
-  const displayName = [user.first_name, user.last_name].filter(Boolean).join(' ') || 'Member';
+  const displayName = [user?.first_name, user?.last_name].filter(Boolean).join(' ') || 'Member';
 
   // Build mapped fields for member_profiles
   const memberUpdates: Record<string, unknown> = {
@@ -452,14 +454,14 @@ async function syncIndividualMemberProfile(
   if (memberFields.contact_website !== undefined) memberUpdates.contact_website = memberFields.contact_website;
   if (memberFields.contact_phone !== undefined) memberUpdates.contact_phone = memberFields.contact_phone;
 
-  const existingProfile = await memberDb.getProfileByOrgId(user.primary_organization_id);
+  const existingProfile = await memberDb.getProfileByOrgId(orgId);
 
   // Sync is_public: turning off always syncs; turning on requires active subscription.
   // Only check subscription when actually toggling on to avoid unnecessary DB call.
   if (communityProfile.is_public === false) {
     memberUpdates.is_public = false;
   } else if (communityProfile.is_public === true && (!existingProfile || !existingProfile.is_public)) {
-    const hasSubscription = await orgDb.hasActiveSubscription(user.primary_organization_id);
+    const hasSubscription = await orgDb.hasActiveSubscription(orgId);
     if (hasSubscription) {
       memberUpdates.is_public = true;
     }
@@ -490,13 +492,13 @@ async function syncIndividualMemberProfile(
       memberUpdates.offerings = [...preserved, ...memberFields.offerings];
     }
 
-    await memberDb.updateProfileByOrgId(user.primary_organization_id, memberUpdates);
+    await memberDb.updateProfileByOrgId(orgId, memberUpdates);
   } else {
     // Auto-create member profile for personal accounts on first save
     const slug = communityProfile.slug || displayName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     const memberIsPublic = memberUpdates.is_public === true;
     await memberDb.createProfile({
-      workos_organization_id: user.primary_organization_id,
+      workos_organization_id: orgId,
       display_name: displayName,
       slug,
       tagline: communityProfile.headline || undefined,

--- a/server/src/routes/helpers/resolve-caller-org.ts
+++ b/server/src/routes/helpers/resolve-caller-org.ts
@@ -9,14 +9,15 @@
  *      integrations. Validated via the existing `validateWorkOSApiKey` helper.
  *   3. Sealed session — web/native app sessions whose cookie or bearer
  *      unsealed in `optionalAuth`, producing `req.user`. Organization is
- *      looked up via `users.primary_organization_id`.
+ *      resolved via `resolvePrimaryOrganization`, which falls back to the
+ *      user's organization_memberships when the cached column is NULL.
  */
 
 import type { Request } from 'express';
 import { createRemoteJWKSet, decodeJwt, jwtVerify, type JWTVerifyGetKey } from 'jose';
 import { isWorkOSApiKeyFormat } from '../../middleware/api-key-format.js';
 import { validateWorkOSApiKey } from '../../middleware/auth.js';
-import { query as dbQuery } from '../../db/client.js';
+import { resolvePrimaryOrganization } from '../../db/users-db.js';
 import { createLogger } from '../../logger.js';
 
 const logger = createLogger('resolve-caller-org');
@@ -93,11 +94,7 @@ export async function resolveCallerOrgId(req: MinimalReq): Promise<string | null
 
   if (req.user?.id) {
     try {
-      const row = await dbQuery<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [req.user.id],
-      );
-      return row.rows[0]?.primary_organization_id ?? null;
+      return await resolvePrimaryOrganization(req.user.id);
     } catch (err) {
       logger.warn({ err, userId: req.user.id }, 'caller org resolution failed — falling back to public-only');
     }

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -21,6 +21,7 @@ import { BrandManager } from "../brand-manager.js";
 import { OrganizationDatabase, hasApiAccess, readMembershipTierFromClient, resolveMembershipTier } from "../db/organization-db.js";
 import { OrgKnowledgeDatabase } from "../db/org-knowledge-db.js";
 import { autoLinkByVerifiedDomain } from "../db/membership-db.js";
+import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { AAO_HOST } from "../config/aao.js";
 import { VALID_MEMBER_OFFERINGS, isValidAgentVisibility } from "../types.js";
 import type { MemberBrandInfo, AgentVisibility, AgentConfig } from "../types.js";
@@ -923,11 +924,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
    * already been sent.
    */
   async function resolveUserOrgId(req: any, res: any): Promise<string | null> {
-    const userRow = await query<{ primary_organization_id: string | null }>(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      [req.user!.id]
-    );
-    const orgId = userRow.rows[0]?.primary_organization_id;
+    const orgId = await resolvePrimaryOrganization(req.user!.id);
     if (!orgId) {
       res.status(400).json({ error: 'No organization associated' });
       return null;
@@ -1102,11 +1099,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
   // POST /api/me/member-profile/verify-brand - Check if member's domain pointer is live and mark verified
   router.post('/verify-brand', requireAuth, async (req, res) => {
     try {
-      const userRow = await query<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [req.user!.id]
-      );
-      const orgId = userRow.rows[0]?.primary_organization_id;
+      const orgId = await resolvePrimaryOrganization(req.user!.id);
       if (!orgId) {
         return res.status(400).json({ error: 'No organization associated with this account' });
       }
@@ -1186,11 +1179,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
    * response and returns null. Both /issue and /verify gate through this.
    */
   async function resolveBrandClaimOrgOr401(req: import('express').Request, res: import('express').Response): Promise<string | null> {
-    const userRow = await query<{ primary_organization_id: string | null }>(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      [req.user!.id]
-    );
-    const orgId = userRow.rows[0]?.primary_organization_id;
+    const orgId = await resolvePrimaryOrganization(req.user!.id);
     if (!orgId) {
       res.status(400).json({ error: 'No organization associated with this account' });
       return null;

--- a/server/src/routes/referrals.ts
+++ b/server/src/routes/referrals.ts
@@ -4,7 +4,7 @@ import { getReferralCode, acceptReferralCode, getAcceptedReferralForOrg } from '
 import { MemberDatabase } from '../db/member-db.js';
 import { BrandDatabase, resolveBrandFromJson } from '../db/brand-db.js';
 import { requireAuth } from '../middleware/auth.js';
-import { query } from '../db/client.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { emailPrefsDb } from '../db/email-preferences-db.js';
 
 const logger = createLogger('referral-routes');
@@ -91,12 +91,7 @@ export function createReferralsRouter(): Router {
       const { marketing_opt_in } = req.body || {};
       const userId = req.user!.id;
 
-      // Look up the user's primary org
-      const userRow = await query<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [userId]
-      );
-      const orgId = userRow.rows[0]?.primary_organization_id;
+      const orgId = await resolvePrimaryOrganization(userId);
       if (!orgId) {
         return res.status(400).json({ error: 'No organization associated with your account' });
       }
@@ -165,11 +160,7 @@ export function createReferralsRouter(): Router {
     try {
       const userId = req.user!.id;
 
-      const userRow = await query<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [userId]
-      );
-      const orgId = userRow.rows[0]?.primary_organization_id;
+      const orgId = await resolvePrimaryOrganization(userId);
       if (!orgId) {
         return res.json({ referral: null });
       }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -14,6 +14,7 @@ import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
 import { query } from "../db/client.js";
+import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
 import { bulkResolveRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter } from "../middleware/rate-limit.js";
@@ -5135,11 +5136,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       // Look up the user's primary org once — used for both hosted brand creation and profile linking
-      const userRow = await query<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [req.user!.id]
-      );
-      const orgId = userRow.rows[0]?.primary_organization_id;
+      const orgId = await resolvePrimaryOrganization(req.user!.id);
 
       // Verify the requested domain belongs to this org (matches a WorkOS-verified domain or subdomain).
       // Skipped in dev mode (DEV_USER_EMAIL set) since dev orgs are not in WorkOS.

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -314,9 +314,17 @@ async function upsertUser(user: UserData): Promise<void> {
   // this row didn't exist yet. Set the pointer now from whatever memberships
   // are already on file. No-op when the user has no memberships yet — the
   // membership webhook will handle that case when it fires.
-  const preferredOrg = await resolvePreferredOrganization(user.id);
-  if (preferredOrg) {
-    await backfillPrimaryOrganization(user.id, preferredOrg);
+  //
+  // Failures here don't fail the user upsert — the integrity invariant
+  // surfaces any pointer that doesn't get set, and the next authenticated
+  // request opportunistically backfills via resolvePrimaryOrganization.
+  try {
+    const preferredOrg = await resolvePreferredOrganization(user.id);
+    if (preferredOrg) {
+      await backfillPrimaryOrganization(user.id, preferredOrg);
+    }
+  } catch (err) {
+    logger.warn({ err, userId: user.id }, 'primary_organization_id backfill failed during user upsert');
   }
 
   logger.info({ userId: user.id, email: user.email }, 'Upserted user');

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -309,6 +309,16 @@ async function upsertUser(user: UserData): Promise<void> {
     ]
   );
 
+  // Close the user.created vs organization_membership.created race: if a
+  // membership webhook fired first, its backfill UPDATE was a no-op because
+  // this row didn't exist yet. Set the pointer now from whatever memberships
+  // are already on file. No-op when the user has no memberships yet — the
+  // membership webhook will handle that case when it fires.
+  const preferredOrg = await resolvePreferredOrganization(user.id);
+  if (preferredOrg) {
+    await backfillPrimaryOrganization(user.id, preferredOrg);
+  }
+
   logger.info({ userId: user.id, email: user.email }, 'Upserted user');
 }
 

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -166,10 +166,16 @@ async function upsertMembership(
     }
   }
 
-  // Set primary_organization_id if not already set (prefer paying orgs)
-  const preferredOrg = await resolvePreferredOrganization(membership.user_id);
-  if (preferredOrg) {
-    await backfillPrimaryOrganization(membership.user_id, preferredOrg);
+  // Set primary_organization_id if not already set (prefer paying orgs).
+  // Best-effort — same rationale as upsertUser: a transient backfill failure
+  // shouldn't fail the membership webhook. Integrity invariant catches drift.
+  try {
+    const preferredOrg = await resolvePreferredOrganization(membership.user_id);
+    if (preferredOrg) {
+      await backfillPrimaryOrganization(membership.user_id, preferredOrg);
+    }
+  } catch (err) {
+    logger.warn({ err, userId: membership.user_id }, 'primary_organization_id backfill failed during membership upsert');
   }
 }
 

--- a/server/src/utils/html-config.ts
+++ b/server/src/utils/html-config.ts
@@ -9,9 +9,8 @@ import type { Request, Response } from "express";
 import { promises as fs } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { getPool } from "../db/client.js";
 import { resolveEffectiveMembership } from "../db/org-filters.js";
-import { resolvePreferredOrganization, backfillPrimaryOrganization } from "../db/users-db.js";
+import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { createLogger } from "../logger.js";
 import { isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
 
@@ -177,32 +176,7 @@ export async function enrichUserWithAdmin(user: AppUser | null | undefined): Pro
 export async function enrichUserWithMembership(user: AppUser | null | undefined): Promise<AppUser | null | undefined> {
   if (!user?.id || user.isMember !== undefined) return user;
   try {
-    const pool = getPool();
-
-    // Try primary_organization_id first (fast path)
-    const result = await pool.query(
-      `SELECT u.primary_organization_id
-       FROM users u
-       WHERE u.workos_user_id = $1
-         AND u.primary_organization_id IS NOT NULL`,
-      [user.id]
-    );
-
-    let orgId: string | null = result.rows[0]?.primary_organization_id ?? null;
-
-    // Fall back to organization_memberships if primary_organization_id is not set.
-    // This handles users who signed up after the initial backfill migration.
-    if (!orgId) {
-      orgId = await resolvePreferredOrganization(user.id);
-
-      // Backfill primary_organization_id so future lookups use the fast path
-      if (orgId) {
-        backfillPrimaryOrganization(user.id, orgId).catch((err) => {
-          logger.warn({ error: err, userId: user.id }, 'Best-effort backfill of primary_organization_id failed');
-        });
-      }
-    }
-
+    const orgId = await resolvePrimaryOrganization(user.id);
     if (orgId) {
       const membership = await resolveEffectiveMembership(orgId);
       user.isMember = membership.is_member;

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration tests for resolvePrimaryOrganization + the
+ * users-have-primary-organization invariant.
+ *
+ * Exercises the read-with-fallback path against real PostgreSQL so a refactor
+ * that re-introduces the "NULL column = no org" trap doesn't pass CI.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { resolvePrimaryOrganization } from '../../src/db/users-db.js';
+import { usersHavePrimaryOrganizationInvariant } from '../../src/audit/integrity/invariants/users-have-primary-organization.js';
+import type { Pool } from 'pg';
+import type Stripe from 'stripe';
+import type { WorkOS } from '@workos-inc/node';
+import { createLogger } from '../../src/logger.js';
+
+const TEST_USER = 'user_primary_org_test';
+const TEST_USER_2 = 'user_primary_org_test_2';
+const TEST_ORG_ACTIVE = 'org_primary_org_active';
+const TEST_ORG_INACTIVE = 'org_primary_org_inactive';
+const TEST_ORG_PERSONAL = 'org_primary_org_personal';
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)', [
+    [TEST_ORG_ACTIVE, TEST_ORG_INACTIVE, TEST_ORG_PERSONAL],
+  ]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [
+    [TEST_ORG_ACTIVE, TEST_ORG_INACTIVE, TEST_ORG_PERSONAL],
+  ]);
+  await pool.query('DELETE FROM users WHERE workos_user_id = ANY($1)', [[TEST_USER, TEST_USER_2]]);
+}
+
+async function seedOrg(pool: Pool, orgId: string, opts: { subscription_status?: string | null; is_personal?: boolean } = {}) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, subscription_status, is_personal, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET subscription_status = EXCLUDED.subscription_status,
+           is_personal = EXCLUDED.is_personal`,
+    [orgId, `Test ${orgId}`, opts.subscription_status ?? null, opts.is_personal ?? false],
+  );
+}
+
+async function seedUser(pool: Pool, userId: string, primaryOrgId: string | null = null) {
+  await pool.query(
+    `INSERT INTO users (workos_user_id, email, primary_organization_id, created_at, updated_at)
+     VALUES ($1, $2, $3, NOW(), NOW())
+     ON CONFLICT (workos_user_id) DO UPDATE SET primary_organization_id = EXCLUDED.primary_organization_id`,
+    [userId, `${userId}@test.com`, primaryOrgId],
+  );
+}
+
+async function seedMembership(pool: Pool, userId: string, orgId: string) {
+  await pool.query(
+    `INSERT INTO organization_memberships (
+       workos_user_id, workos_organization_id, workos_membership_id, email,
+       role, seat_type, synced_at, created_at, updated_at
+     ) VALUES ($1, $2, $3, $4, 'member', 'community_only', NOW(), NOW(), NOW())
+     ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+    [userId, orgId, `om_${userId}_${orgId}`, `${userId}@test.com`],
+  );
+}
+
+describe('primary_organization_id resolution', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  describe('resolvePrimaryOrganization', () => {
+    it('returns the cached column when set', async () => {
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBe(TEST_ORG_ACTIVE);
+    });
+
+    it('falls back to organization_memberships when column is NULL and backfills', async () => {
+      // Membership exists, primary_organization_id is NULL — Matt's situation.
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, null);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBe(TEST_ORG_ACTIVE);
+
+      // Backfill is fire-and-forget — give it a moment to land before checking.
+      await new Promise((r) => setTimeout(r, 100));
+      const after = await pool.query<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [TEST_USER],
+      );
+      expect(after.rows[0].primary_organization_id).toBe(TEST_ORG_ACTIVE);
+    });
+
+    it('prefers paying org when multiple memberships exist', async () => {
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: null });
+      await seedUser(pool, TEST_USER, null);
+      await seedMembership(pool, TEST_USER, TEST_ORG_INACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBe(TEST_ORG_ACTIVE);
+    });
+
+    it('returns null when the user has no memberships', async () => {
+      await seedUser(pool, TEST_USER, null);
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the user does not exist at all', async () => {
+      const result = await resolvePrimaryOrganization('user_does_not_exist_xyz');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('users-have-primary-organization invariant', () => {
+    function ctx(): { pool: Pool; stripe: Stripe; workos: WorkOS; logger: ReturnType<typeof createLogger> } {
+      // Invariant only touches pool — stripe/workos are unused for this DB-only check.
+      return {
+        pool: getPool(),
+        stripe: {} as Stripe,
+        workos: {} as WorkOS,
+        logger: createLogger('test'),
+      };
+    }
+
+    it('reports zero violations when all users with memberships have primary set', async () => {
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await usersHavePrimaryOrganizationInvariant.check(ctx());
+      const ours = result.violations.filter((v) => v.subject_id === TEST_USER);
+      expect(ours).toHaveLength(0);
+    });
+
+    it('reports a violation when a user has memberships but no primary set', async () => {
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, null);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await usersHavePrimaryOrganizationInvariant.check(ctx());
+      const ours = result.violations.find((v) => v.subject_id === TEST_USER);
+      expect(ours).toBeDefined();
+      expect(ours!.severity).toBe('warning');
+      expect(ours!.subject_type).toBe('user');
+      expect(ours!.details).toMatchObject({
+        workos_user_id: TEST_USER,
+        inferred_org_id: TEST_ORG_ACTIVE,
+      });
+    });
+
+    it('skips personal-workspace memberships (not a real org affiliation)', async () => {
+      await seedOrg(pool, TEST_ORG_PERSONAL, { is_personal: true });
+      await seedUser(pool, TEST_USER, null);
+      await seedMembership(pool, TEST_USER, TEST_ORG_PERSONAL);
+
+      const result = await usersHavePrimaryOrganizationInvariant.check(ctx());
+      const ours = result.violations.find((v) => v.subject_id === TEST_USER);
+      expect(ours).toBeUndefined();
+    });
+  });
+});

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -100,13 +100,20 @@ describe('primary_organization_id resolution', () => {
       const result = await resolvePrimaryOrganization(TEST_USER);
       expect(result).toBe(TEST_ORG_ACTIVE);
 
-      // Backfill is fire-and-forget — give it a moment to land before checking.
-      await new Promise((r) => setTimeout(r, 100));
-      const after = await pool.query<{ primary_organization_id: string | null }>(
-        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-        [TEST_USER],
-      );
-      expect(after.rows[0].primary_organization_id).toBe(TEST_ORG_ACTIVE);
+      // Backfill is fire-and-forget — poll until it lands rather than sleeping
+      // a fixed interval, which flakes under load.
+      const deadline = Date.now() + 2000;
+      let backfilled: string | null = null;
+      while (Date.now() < deadline) {
+        const after = await pool.query<{ primary_organization_id: string | null }>(
+          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+          [TEST_USER],
+        );
+        backfilled = after.rows[0]?.primary_organization_id ?? null;
+        if (backfilled) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(backfilled).toBe(TEST_ORG_ACTIVE);
     });
 
     it('prefers paying org when multiple memberships exist', async () => {
@@ -154,7 +161,7 @@ describe('primary_organization_id resolution', () => {
       expect(ours).toHaveLength(0);
     });
 
-    it('reports a violation when a user has memberships but no primary set', async () => {
+    it('reports a missing-pointer violation when a user has memberships but no primary set', async () => {
       await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
       await seedUser(pool, TEST_USER, null);
       await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
@@ -165,8 +172,26 @@ describe('primary_organization_id resolution', () => {
       expect(ours!.severity).toBe('warning');
       expect(ours!.subject_type).toBe('user');
       expect(ours!.details).toMatchObject({
+        drift: 'missing_pointer',
         workos_user_id: TEST_USER,
         inferred_org_id: TEST_ORG_ACTIVE,
+      });
+    });
+
+    it('reports a stale-pointer violation when primary points at a removed-membership org', async () => {
+      // User's primary points at an org, but the membership row was deleted
+      // (e.g. missed/late delete webhook). Helper would still resolve them
+      // into the removed org via the cached column.
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      // Note: NO seedMembership — pointer is set but no membership row.
+
+      const result = await usersHavePrimaryOrganizationInvariant.check(ctx());
+      const ours = result.violations.find((v) => v.subject_id === TEST_USER);
+      expect(ours).toBeDefined();
+      expect(ours!.details).toMatchObject({
+        drift: 'stale_pointer',
+        stale_org_id: TEST_ORG_ACTIVE,
       });
     });
 
@@ -178,6 +203,41 @@ describe('primary_organization_id resolution', () => {
       const result = await usersHavePrimaryOrganizationInvariant.check(ctx());
       const ours = result.violations.find((v) => v.subject_id === TEST_USER);
       expect(ours).toBeUndefined();
+    });
+  });
+
+  describe('deleteOrganizationMembership clears stale primary_organization_id', () => {
+    it('clears the column when it pointed at the deleted org', async () => {
+      const { deleteOrganizationMembership } = await import('../../src/db/membership-db.js');
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      await deleteOrganizationMembership(TEST_USER, TEST_ORG_ACTIVE);
+
+      const after = await pool.query<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [TEST_USER],
+      );
+      expect(after.rows[0].primary_organization_id).toBeNull();
+    });
+
+    it('leaves the column alone when it pointed at a different org', async () => {
+      const { deleteOrganizationMembership } = await import('../../src/db/membership-db.js');
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE); // primary = active
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_INACTIVE);
+
+      // Delete the OTHER membership; primary pointer should be untouched.
+      await deleteOrganizationMembership(TEST_USER, TEST_ORG_INACTIVE);
+
+      const after = await pool.query<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [TEST_USER],
+      );
+      expect(after.rows[0].primary_organization_id).toBe(TEST_ORG_ACTIVE);
     });
   });
 });

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the five Phase-1 integrity invariants.
+ * Tests for the registered integrity invariants.
  *
  * Each test covers the happy path (no violations) and the failure mode the
  * invariant exists to detect. Mocks the DB pool, Stripe, and WorkOS through
@@ -13,6 +13,8 @@ import { orgRowMatchesLiveStripeSubInvariant } from '../../../src/audit/integrit
 import { workosMembershipRowExistsInWorkosInvariant } from '../../../src/audit/integrity/invariants/workos-membership-row-exists-in-workos.js';
 import { ALL_INVARIANTS, getInvariantByName } from '../../../src/audit/integrity/invariants/index.js';
 import type { InvariantContext } from '../../../src/audit/integrity/types.js';
+
+const EXPECTED_INVARIANT_COUNT = 6;
 
 const mockPoolQuery = vi.fn();
 const mockStripeCustomersRetrieve = vi.fn();
@@ -51,10 +53,10 @@ beforeEach(() => {
 // ─────────────────────────────────────────────────────────────────────────
 
 describe('invariants registry', () => {
-  it('registers all five Phase-1 invariants under unique names', () => {
-    expect(ALL_INVARIANTS).toHaveLength(5);
+  it('registers all invariants under unique names', () => {
+    expect(ALL_INVARIANTS).toHaveLength(EXPECTED_INVARIANT_COUNT);
     const names = ALL_INVARIANTS.map((i) => i.name);
-    expect(new Set(names).size).toBe(5);
+    expect(new Set(names).size).toBe(EXPECTED_INVARIANT_COUNT);
   });
 
   it('resolves invariants by name', () => {

--- a/server/tests/unit/resolve-caller-org.test.ts
+++ b/server/tests/unit/resolve-caller-org.test.ts
@@ -145,20 +145,23 @@ describe('resolveCallerOrgId', () => {
 
   it('falls back to users.primary_organization_id when only req.user is set', async () => {
     validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
+    // resolvePrimaryOrganization: fast-path read returns the cached column.
     dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: 'org_from_session' }] });
 
     const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_session' }));
 
     expect(orgId).toBe('org_from_session');
-    expect(dbQueryMock).toHaveBeenCalledWith(
-      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-      ['user_session'],
-    );
+    // Assert the fast-path SQL — the WHERE filter is what makes it the fast path.
+    expect(dbQueryMock.mock.calls[0][0]).toMatch(/SELECT primary_organization_id FROM users[\s\S]*workos_user_id\s*=\s*\$1[\s\S]*primary_organization_id IS NOT NULL/);
+    expect(dbQueryMock.mock.calls[0][1]).toEqual(['user_session']);
   });
 
-  it('returns null when session user has no primary_organization_id', async () => {
+  it('returns null when session user has no primary org and no memberships', async () => {
     validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
-    dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: null }] });
+    // Fast-path: no row (column was NULL or user row missing).
+    dbQueryMock.mockResolvedValueOnce({ rows: [] });
+    // Fallback: resolvePreferredOrganization finds no memberships.
+    dbQueryMock.mockResolvedValueOnce({ rows: [] });
 
     const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_no_org' }));
 


### PR DESCRIPTION
## Summary

Eleven read sites silently treat `users.primary_organization_id IS NULL` as "no organization". That's how a paid Founding member at ResponsiveAds saw "no directory listing" and "not a member" despite an active subscription — escalations #289, #231.

The column is a denormalized pointer that drifts when:
- `user.created` races ahead of `organization_membership.created` (the membership webhook's backfill UPDATE no-ops because the users row doesn't exist yet)
- the fire-and-forget backfill in `enrichUserWithMembership` swallows a transient error

## Fix

- **Centralize the read** through `resolvePrimaryOrganization()` in `users-db.ts` — column → `organization_memberships` → opportunistic backfill. All 11 direct reads now go through it (member-tools, brand-feeds, referrals, brand-claim, registry-api, resolve-caller-org, member-profile, community sync). `enrichUserWithMembership` collapses to a single helper call.
- **Close the race** — `upsertUser` webhook handler now backfills the column after creating/updating the users row.
- **Backfill existing rows** — migration `448_backfill_primary_organization_id.sql` sets the column from `organization_memberships` for any user where it's currently NULL.
- **Catch new drift** — new integrity invariant `users-have-primary-organization`. Visible at `/api/admin/integrity/check/users-have-primary-organization`.

After this lands, a one-line UPDATE will unblock Matt at ResponsiveAds (escalation #289):
```sql
UPDATE users SET primary_organization_id = 'org_01KD1W61R3SK2KNE7E51G7G1CG'
WHERE workos_user_id = 'user_01KCW48SANHB1SNZZ4TRYTRT2X' AND primary_organization_id IS NULL;
```
…or the migration handles it automatically on deploy.

## Test plan

- [x] `npm run typecheck` clean
- [x] New integration test `primary-organization-resolution.test.ts` covers the helper (cached column, fallback path with backfill, paying-org preference, null cases) and the invariant (zero violations when set, violation when missing, skip personal workspaces)
- [x] Updated `resolve-caller-org.test.ts` mocks for the new fast-path SQL
- [x] Updated `integrity/invariants.test.ts` count assertion for the new 6th invariant
- [x] Server unit suite: 2519 passed
- [x] Membership-webhook integration tests still pass (refactored handler covered)
- [ ] After deploy: hit `/api/admin/integrity/check/users-have-primary-organization` to see the count of currently-broken users

🤖 Generated with [Claude Code](https://claude.com/claude-code)