### PR TITLE
feat(addie): surface CTA context blocks in Addie's system prompt

### DIFF
--- a/.changeset/addie-context-coverage-for-cta-blocks.md
+++ b/.changeset/addie-context-coverage-for-cta-blocks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Surface the CTA-producing context blocks to Addie's reasoning, not just her rules engine. `formatMemberContextForPrompt` now renders sections for `certification`, `agent_testing`, `perspectives`, `next_event`, and `adoption` — five blocks that were hydrated onto MemberContext for the suggested-prompts engine but had been invisible to Addie's system prompt. After this change, when a learner clicks "Continue A1" Addie's system prompt already says "Currently working on: A1 (in progress, started 7 days ago)" instead of forcing a tool round-trip to figure out what they're working on. Same for stale agent tests, upcoming events, the user's perspectives footprint, and missing public company listings.

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1504,6 +1504,7 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
 
   // Certification — surface in-progress attempts so Addie can route the
   // conversation back to the right module without a tool round-trip.
+  // Only facts here; response policy lives in server/src/addie/rules/*.md.
   if (context.certification) {
     const cert = context.certification;
     const id = cert.module_id ?? cert.track_id;
@@ -1515,44 +1516,40 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
     if (cert.status === 'in_progress') {
       lines.push(`Currently working on: ${id} (in progress, started ${startedDays} days ago).`);
       if (startedDays > 45) {
-        lines.push('Note: this attempt is older than 45 days — the user may have moved on.');
+        lines.push('This attempt is older than 45 days (stale).');
       }
     } else if (cert.status === 'passed') {
       lines.push(`Most recent attempt: ${id} — passed.`);
     } else if (cert.status === 'failed') {
-      lines.push(`Most recent attempt: ${id} — failed. Be encouraging if they want to retry.`);
+      lines.push(`Most recent attempt: ${id} — failed.`);
     }
   }
 
-  // Agent testing — surface stale-test signal for builders so Addie can
-  // suggest a fresh evaluation without re-querying agent_test_history.
+  // Agent testing — last-run signal for builders. Facts only.
   if (context.agent_testing) {
     const at = context.agent_testing;
+    lines.push('');
+    lines.push('### Agent Testing');
     if (at.last_test_at) {
       const days = Math.floor(
         (Date.now() - at.last_test_at.getTime()) / (24 * 60 * 60 * 1000)
       );
-      lines.push('');
-      lines.push('### Agent Testing');
       lines.push(`Last agent test: ${days} days ago (${at.last_outcome ?? 'unknown'}).`);
       if (days > 14) {
-        lines.push('Note: tests older than 14 days are stale — gently suggest a fresh evaluation if the conversation goes near agent setup.');
+        lines.push('Last test is older than 14 days (stale).');
       }
     } else {
-      lines.push('');
-      lines.push('### Agent Testing');
-      lines.push('No agent tests on record. If they discuss building or running an agent, suggest `evaluate_agent_quality` to verify it works.');
+      lines.push('No agent tests on record.');
     }
   }
 
-  // Perspectives — surface zero-or-many footprint so Addie can encourage
-  // contribution without re-querying.
+  // Perspectives — published-count footprint. Facts only.
   if (context.perspectives) {
     const p = context.perspectives;
     lines.push('');
     lines.push('### Perspectives');
     if (p.published_count === 0) {
-      lines.push('Has not published any perspectives yet. If they share interesting ideas, gently offer to help them turn one into a perspective.');
+      lines.push('Has not published any perspectives yet.');
     } else {
       lines.push(`Has published ${p.published_count} perspective(s).`);
       if (p.last_published_at) {

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1502,6 +1502,104 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
     lines.push('Note: This user\'s Slack account is not yet linked to their AgenticAdvertising.org account.');
   }
 
+  // Certification — surface in-progress attempts so Addie can route the
+  // conversation back to the right module without a tool round-trip.
+  if (context.certification) {
+    const cert = context.certification;
+    const id = cert.module_id ?? cert.track_id;
+    const startedDays = Math.floor(
+      (Date.now() - cert.started_at.getTime()) / (24 * 60 * 60 * 1000)
+    );
+    lines.push('');
+    lines.push('### Certification');
+    if (cert.status === 'in_progress') {
+      lines.push(`Currently working on: ${id} (in progress, started ${startedDays} days ago).`);
+      if (startedDays > 45) {
+        lines.push('Note: this attempt is older than 45 days — the user may have moved on.');
+      }
+    } else if (cert.status === 'passed') {
+      lines.push(`Most recent attempt: ${id} — passed.`);
+    } else if (cert.status === 'failed') {
+      lines.push(`Most recent attempt: ${id} — failed. Be encouraging if they want to retry.`);
+    }
+  }
+
+  // Agent testing — surface stale-test signal for builders so Addie can
+  // suggest a fresh evaluation without re-querying agent_test_history.
+  if (context.agent_testing) {
+    const at = context.agent_testing;
+    if (at.last_test_at) {
+      const days = Math.floor(
+        (Date.now() - at.last_test_at.getTime()) / (24 * 60 * 60 * 1000)
+      );
+      lines.push('');
+      lines.push('### Agent Testing');
+      lines.push(`Last agent test: ${days} days ago (${at.last_outcome ?? 'unknown'}).`);
+      if (days > 14) {
+        lines.push('Note: tests older than 14 days are stale — gently suggest a fresh evaluation if the conversation goes near agent setup.');
+      }
+    } else {
+      lines.push('');
+      lines.push('### Agent Testing');
+      lines.push('No agent tests on record. If they discuss building or running an agent, suggest `evaluate_agent_quality` to verify it works.');
+    }
+  }
+
+  // Perspectives — surface zero-or-many footprint so Addie can encourage
+  // contribution without re-querying.
+  if (context.perspectives) {
+    const p = context.perspectives;
+    lines.push('');
+    lines.push('### Perspectives');
+    if (p.published_count === 0) {
+      lines.push('Has not published any perspectives yet. If they share interesting ideas, gently offer to help them turn one into a perspective.');
+    } else {
+      lines.push(`Has published ${p.published_count} perspective(s).`);
+      if (p.last_published_at) {
+        const days = Math.floor(
+          (Date.now() - p.last_published_at.getTime()) / (24 * 60 * 60 * 1000)
+        );
+        lines.push(`Last published: ${days} days ago.`);
+      }
+    }
+  }
+
+  // Upcoming registered event — context for time-bound discussions.
+  if (context.next_event) {
+    const e = context.next_event;
+    const days = Math.floor(
+      (e.starts_at.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+    );
+    lines.push('');
+    lines.push('### Upcoming Event');
+    lines.push(`Registered for: ${e.title} (in ${days} days).`);
+  }
+
+  // Adoption signals — public listing + team WG coverage. Lets Addie
+  // give org-aware suggestions when the conversation drifts toward
+  // setup or community participation.
+  if (context.adoption) {
+    const a = context.adoption;
+    const adoptionLines: string[] = [];
+    if (!a.has_company_listing && context.organization && !context.organization.is_personal) {
+      adoptionLines.push('Their organization does not yet have a public company listing in the directory.');
+    }
+    if (
+      context.org_membership &&
+      context.org_membership.member_count >= 3 &&
+      a.team_wg_coverage < 0.5
+    ) {
+      adoptionLines.push(
+        `Less than half their team (${Math.round(a.team_wg_coverage * 100)}%) is in any working group.`
+      );
+    }
+    if (adoptionLines.length > 0) {
+      lines.push('');
+      lines.push('### Org Adoption');
+      for (const l of adoptionLines) lines.push(l);
+    }
+  }
+
   // Pending content notifications (for committee leads and admins)
   if (context.pending_content && context.pending_content.total > 0) {
     lines.push('');

--- a/server/tests/unit/member-context.test.ts
+++ b/server/tests/unit/member-context.test.ts
@@ -708,4 +708,140 @@ describe('community_profile formatting', () => {
     expect(result).toContain('GitHub: Not linked');
     expect(result).toContain('/account');
   });
+
+  describe('coverage of CTA-producing context blocks', () => {
+    const baseMember: MemberContext = {
+      is_mapped: true,
+      is_member: true,
+      slack_linked: true,
+      workos_user: { workos_user_id: 'user_x', email: 'x@y.co' },
+      organization: {
+        workos_organization_id: 'org_x',
+        name: 'Acme',
+        subscription_status: 'active',
+        is_personal: false,
+        membership_tier: 'company_standard',
+      },
+    };
+
+    it('renders in-progress certification with module id and started-days', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'in_progress',
+          started_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+          last_activity_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('### Certification');
+      expect(out).toContain('A1');
+      expect(out).toContain('in progress');
+      expect(out).toContain('started 7 days ago');
+    });
+
+    it('flags stale (>45d) cert attempts', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        certification: {
+          track_id: 'A',
+          module_id: 'A1',
+          status: 'in_progress',
+          started_at: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+          last_activity_at: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+        },
+      };
+      expect(formatMemberContextForPrompt(ctx)).toContain('older than 45 days');
+    });
+
+    it('renders agent_testing with last-test-age and stale flag', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        agent_testing: {
+          last_test_at: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000),
+          last_outcome: 'passed',
+        },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('### Agent Testing');
+      expect(out).toContain('20 days ago');
+      expect(out).toContain('stale');
+    });
+
+    it('renders agent_testing "no tests on record" when never tested', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        agent_testing: { last_test_at: null, last_outcome: null },
+      };
+      expect(formatMemberContextForPrompt(ctx)).toContain('No agent tests on record');
+    });
+
+    it('renders perspectives zero-state with a writing nudge', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        perspectives: { published_count: 0, last_published_at: null },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('### Perspectives');
+      expect(out).toContain('Has not published');
+    });
+
+    it('renders perspectives footprint when user has shipped some', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        perspectives: {
+          published_count: 3,
+          last_published_at: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000),
+        },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('Has published 3 perspective');
+      expect(out).toContain('14 days ago');
+    });
+
+    it('renders next_event with title and days-until', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        next_event: {
+          title: 'Cannes Lions',
+          slug: 'cannes-2026',
+          starts_at: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
+        },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('### Upcoming Event');
+      expect(out).toContain('Cannes Lions');
+      expect(out).toContain('in 5 days');
+    });
+
+    it('renders adoption signals when company has no public listing', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        adoption: { has_company_listing: false, team_wg_coverage: 1 },
+      };
+      expect(formatMemberContextForPrompt(ctx)).toContain('does not yet have a public company listing');
+    });
+
+    it('renders adoption signals when team WG coverage is low and team >= 3', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        org_membership: { role: 'owner', member_count: 5, joined_at: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) },
+        adoption: { has_company_listing: true, team_wg_coverage: 0.2 },
+      };
+      const out = formatMemberContextForPrompt(ctx);
+      expect(out).toContain('### Org Adoption');
+      expect(out).toContain('Less than half their team');
+      expect(out).toContain('20%');
+    });
+
+    it('omits adoption section when nothing notable to say', () => {
+      const ctx: MemberContext = {
+        ...baseMember,
+        adoption: { has_company_listing: true, team_wg_coverage: 0.9 },
+      };
+      expect(formatMemberContextForPrompt(ctx)).not.toContain('### Org Adoption');
+    });
+  });
 });


### PR DESCRIPTION
## Why
When we built the suggested-prompts engine we hydrated five new \`MemberContext\` blocks (\`certification\`, \`agent_testing\`, \`perspectives\`, \`next_event\`, \`adoption\`) — but \`formatMemberContextForPrompt\` (the function that injects user context into Addie's system prompt) was never updated to read them.

Result: Addie has been blind to all this state when reasoning. A learner clicks "Continue A1" → Addie sees the message but her system prompt has no idea they have an in-progress A1 attempt. Best case: she calls a cert tool to find out. Common case: generic response.

## What changed
\`formatMemberContextForPrompt\` now renders sections for all five blocks. Specific signals surfaced:

- **Certification**: in-progress with module id + started-days, flagged stale past 45 days; passed/failed summarized
- **Agent Testing**: last test age + outcome, stale flag past 14 days; "no tests on record" nudge for builders who haven't tested yet
- **Perspectives**: zero-state writing nudge or count + last-published-days
- **Upcoming Event**: registered title + days-until
- **Org Adoption**: missing public company listing, low team WG coverage

## Why this matters beyond this PR
This is a small fix but a meaningful invariant: **any new MemberContext field must be surfaced to both the rules engine AND Addie's prompt.** Otherwise we end up with two parallel data planes — one for picking prompts, one for reasoning about them — and they drift.

## Test plan
- [x] 9 new tests covering each rendered section + negative case (adoption section omitted when nothing notable)
- [x] 125 unit tests pass total across member-context + suggested-prompts files
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)