### PR TITLE
fix(training-agent): InMemoryReplayStore fallback when no Postgres pool

### DIFF
--- a/.changeset/replay-store-fallback.md
+++ b/.changeset/replay-store-fallback.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(training-agent): InMemoryReplayStore fallback when no Postgres pool (test/dev only)
+
+#3351 swapped to `PostgresReplayStore` to close the cross-instance replay gap. That worked in production but broke the storyboard runner: CI runs the full server in-process without initializing a Postgres pool, and `getReplayStore()` was unconditionally calling `getPool()` which throws.
+
+Symptom: `signed_requests` storyboard regressed from `31P / 9S / 0N/A` to `3P / 28F / 9S` — every positive vector returned 401 because `PostgresReplayStore.insert` rejected on the unavailable pool, and the verifier failed closed.
+
+Fix: `getReplayStore()` now falls back to `InMemoryReplayStore` when `getPool()` throws — gated on `NODE_ENV !== 'production'` so a misconfigured prod still fails loudly. The sweeper is a silent no-op when no pool is initialized. Reset hook in `resetRequestSigning()` clears the cached store so test suites that swap process state stay coherent.
+
+Production unaffected: prod always has a Postgres pool, so `PostgresReplayStore` is used and cross-instance replay protection holds. Verified via `adcp grade request-signing https://agenticadvertising.org/api/training-agent/mcp-strict --only 016-replayed-nonce` → still PASS.

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import type { IncomingMessage } from 'node:http';
 import {
   StaticJwksResolver,
+  InMemoryReplayStore,
   InMemoryRevocationStore,
   RequestSignatureError,
 } from '@adcp/client/signing';
@@ -168,25 +169,59 @@ export function selectSigningCapability(ctx: { strict?: boolean; digestMode?: 'e
  * Singleton across all per-route authenticators so they all hit the same
  * `adcp_replay_cache` table; the (keyid, scope, nonce) primary key
  * partitions by route automatically via the `@target-uri`-derived scope.
+ *
+ * Falls back to `InMemoryReplayStore` in test/dev environments where
+ * `getPool()` throws because the DB isn't initialized (CI storyboard
+ * runner, vitest unit suites, local CLI tools). The fallback is gated on
+ * `NODE_ENV !== 'production'` so a misconfigured prod doesn't silently
+ * lose cross-instance replay protection — production must have a pool.
  */
 let _replayStore: ReplayStore | null = null;
 function getReplayStore(): ReplayStore {
   if (_replayStore) return _replayStore;
-  const store = new PostgresReplayStore(getPool());
-  _replayStore = store;
-  return store;
+  try {
+    _replayStore = new PostgresReplayStore(getPool());
+    return _replayStore;
+  } catch (err) {
+    if (process.env.NODE_ENV === 'production') {
+      // Production must have a Postgres pool. Don't paper over a real
+      // misconfig — let the verifier fail loudly and the operator fix it.
+      throw err;
+    }
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'No Postgres pool available — falling back to InMemoryReplayStore (test/dev only; not cross-instance safe)'
+    );
+    _replayStore = new InMemoryReplayStore();
+    return _replayStore;
+  }
 }
 
 /**
  * Schedule periodic deletion of expired rows from `adcp_replay_cache`.
  * Postgres has no native TTL — without this, the table grows unboundedly.
  * Called from the server boot path (index.ts).
+ *
+ * Silent no-op when no pool is initialized (test/dev environments). The
+ * `getReplayStore()` fallback handles the runtime path; the sweeper has
+ * nothing to sweep without a real Postgres table.
  */
 let _sweepInterval: NodeJS.Timeout | null = null;
 export function startReplayCacheSweeper(): void {
   if (_sweepInterval) return;
+  try {
+    getPool(); // probe — throws if not initialized
+  } catch {
+    return; // no DB to sweep
+  }
   _sweepInterval = setInterval(() => {
-    sweepExpiredReplays(getPool())
+    let pool;
+    try {
+      pool = getPool();
+    } catch {
+      return; // pool was torn down; skip this tick
+    }
+    sweepExpiredReplays(pool)
       .then((result: { deleted: number }) => {
         if (result.deleted > 0) logger.info({ deleted: result.deleted }, 'Swept expired replay-cache rows');
       })
@@ -406,4 +441,6 @@ export function resetRequestSigning(): void {
   strictCapability = null;
   strictRequiredCapability = null;
   strictForbiddenCapability = null;
+  _replayStore = null;
+  stopReplayCacheSweeper();
 }


### PR DESCRIPTION
## What this fixes

[#3351](https://github.com/adcontextprotocol/adcp/pull/3351) swapped to `PostgresReplayStore` to close the cross-instance replay gap (#3338). Worked in production but broke the storyboard runner: CI runs the full server in-process without initializing a Postgres pool, and `getReplayStore()` was unconditionally calling `getPool()` which throws "Database not initialized."

Symptom (visible on [#3373](https://github.com/adcontextprotocol/adcp/pull/3373) CI):

```
signed_requests  ✗ 3P / 28F / 9S
```

Every positive vector returned 401 because `PostgresReplayStore.insert` rejected on the unavailable pool, and the verifier failed closed.

## Fix

Three small changes to `server/src/training-agent/request-signing.ts`:

1. **`getReplayStore()` falls back to `InMemoryReplayStore` when `getPool()` throws** — gated on `NODE_ENV !== 'production'` so a misconfigured prod still fails loudly (preserves the multi-instance protection on production).
2. **`startReplayCacheSweeper()` is a silent no-op** when no pool is initialized — nothing to sweep.
3. **`resetRequestSigning()` clears the cached `_replayStore`** and stops the sweeper so test suites that swap process state stay coherent.

## Verified locally

Before fix:
```
signed_requests  ✗ 3P / 28F / 9S / 0N/A
```

After fix:
```
signed_requests  ✓ 31P / 9S / 0N/A
```

(Other 12 storyboard failures are pre-existing fixture issues in `sales_broadcast_tv`/`sales_guaranteed` — unrelated.)

## Production unaffected

Prod always has a Postgres pool initialized before the verifier ever runs, so `PostgresReplayStore` is used and cross-instance replay protection holds. Confirmed:

```
npx adcp grade request-signing https://agenticadvertising.org/api/training-agent/mcp-strict --transport mcp --skip-rate-abuse --only 016-replayed-nonce
→ PASS  401 request_signature_replayed
```

Owe a correction on my last response in #3351 — the post-deploy verification check there was on the grader against prod (which passed), but the storyboard runner is a separate test surface that I missed. The feedback flagging the regression was correct in mechanism; I just misread which test surface it was talking about.