### PR TITLE
fix(registry): writer anchor-adopt promotes contributed rid to authoritative

### DIFF
--- a/.changeset/writer-anchor-adopt-promotion.md
+++ b/.changeset/writer-anchor-adopt-promotion.md
@@ -1,0 +1,15 @@
+---
+---
+
+Fix writer anchor-adopt promotion — when a publisher's adagents.json claims a
+property whose rid was previously created by community/enrichment/contributed
+flows AND anchors via a domain identifier under their own host, promote
+`source` → `'authoritative'` and rebind `created_by` →
+`'adagents_json:<publisher>'`. Without this, the auth projection's
+`WHERE created_by = 'adagents_json:<pub>' AND property_id = ANY(...)` returns
+zero rows for properties already in the catalog under a different pipeline,
+silently dropping the manifest's `authorized_agents[]` entries.
+
+Found via escalation #287 (wheelrandom.com): valid adagents.json with a
+correctly anchored inline property, but registry showed 0 authorizations
+because a pre-existing `contributed` catalog row blocked the auth projection.

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -368,14 +368,34 @@ export class PublisherDatabase {
       }
 
       propertyRid = ownRids[0];
+      // Anchor-adopt promotion: when a publisher's adagents.json claims a rid
+      // previously created by community/enrichment/contributed flows AND
+      // anchors via a domain identifier under their own host, the publisher
+      // is now the source-of-truth pipeline for this property. Promote
+      // source → 'authoritative' and rebind created_by →
+      // 'adagents_json:<publisher>' so downstream queries that filter by
+      // created_by (auth projection in projectAuthorizationToCatalog,
+      // publisher_domain derivation in v_effective_agent_authorizations)
+      // see this row as a publisher-owned authoritative entry. Without
+      // this rebind, the auth projection's
+      // `WHERE created_by = 'adagents_json:<pub>' AND property_id = ANY(...)`
+      // returns 0 rows for properties that were already in the catalog
+      // under a different pipeline — silently dropping the manifest's
+      // authorized_agents[] entries on the floor.
+      //
+      // Own re-crawls (matchedCreatedBy === expectedCreatedBy) re-set
+      // source_updated_at without changing created_by; the SET below is
+      // idempotent for that case.
       await client.query(
         `UPDATE catalog_properties SET
            source_updated_at = NOW(),
            updated_at = NOW(),
            adagents_url = COALESCE(adagents_url, $2),
-           property_id = COALESCE(property_id, $3)
+           property_id = COALESCE(property_id, $3),
+           source = 'authoritative',
+           created_by = $4
          WHERE property_rid = $1`,
-        [propertyRid, adagentsUrl, property.property_id ?? null]
+        [propertyRid, adagentsUrl, property.property_id ?? null, expectedCreatedBy]
       );
     } else {
       propertyRid = uuidv7();

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -280,6 +280,85 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows.map((r) => r.property_id_slug)).toEqual(['known']);
     });
 
+    it('anchor-adopt promotes a contributed/community catalog row to authoritative so the auth lands', async () => {
+      // Pre-seed a catalog row for TEST_PUB's domain identifier with a
+      // non-adagents created_by (mirrors community/enrichment seeding).
+      // The publisher's manifest then arrives with the same domain
+      // identifier — it MUST adopt the rid (Rule 4 anchor) AND promote
+      // the row's source / created_by so the auth projection's
+      // `WHERE created_by = 'adagents_json:TEST_PUB'` filter matches.
+      // Regression for wheelrandom.com (escalation #287).
+      const { rows: seedRows } = await pool.query<{ property_rid: string }>(
+        `INSERT INTO catalog_properties
+           (property_rid, property_id, classification, source, status, created_by)
+         VALUES (gen_random_uuid(), NULL, 'property', 'contributed', 'active',
+                 'community:' || $1)
+         RETURNING property_rid`,
+        [TEST_PUB]
+      );
+      const seedRid = seedRows[0].property_rid;
+      await pool.query(
+        `INSERT INTO catalog_identifiers
+           (id, property_rid, identifier_type, identifier_value, evidence, confidence)
+         VALUES (gen_random_uuid(), $1, 'domain', $2, 'community', 'medium')`,
+        [seedRid, TEST_PUB]
+      );
+
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'property_ids',
+              property_ids: ['flagship'],
+            },
+          ],
+          [
+            {
+              property_id: 'flagship',
+              property_type: 'website',
+              name: 'Flagship Site',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+
+      // Catalog row promoted: same rid (no duplicate row), now
+      // source='authoritative' + created_by='adagents_json:TEST_PUB' +
+      // property_id='flagship'.
+      const { rows: cpRows } = await pool.query<{
+        property_rid: string;
+        source: string;
+        created_by: string;
+        property_id: string | null;
+      }>(
+        `SELECT property_rid, source, created_by, property_id
+           FROM catalog_properties
+          WHERE property_rid = $1`,
+        [seedRid]
+      );
+      expect(cpRows).toHaveLength(1);
+      expect(cpRows[0].source).toBe('authoritative');
+      expect(cpRows[0].created_by).toBe(`adagents_json:${TEST_PUB}`);
+      expect(cpRows[0].property_id).toBe('flagship');
+
+      // Auth projection lands a CAA row referencing the promoted rid.
+      const { rows: caaRows } = await pool.query<{
+        property_rid: string;
+        property_id_slug: string;
+      }>(
+        `SELECT property_rid, property_id_slug
+           FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(caaRows).toHaveLength(1);
+      expect(caaRows[0].property_rid).toBe(seedRid);
+      expect(caaRows[0].property_id_slug).toBe('flagship');
+    });
+
     it('does not resolve slugs owned by another publisher', async () => {
       // Pre-seed VICTIM_PUB's `home` slug. The attacker's manifest
       // references the same string but the slug-resolution query is


### PR DESCRIPTION
## Summary

Found via escalation #287 (wheelrandom.com): the publisher's adagents.json is valid and anchored, but the registry resolves 0 authorizations.

## Root cause

When `projectPropertyToCatalog` adopts a foreign rid via Rule 4 (publisher anchors via a domain identifier under their own host), the UPDATE refreshes `adagents_url` and `property_id` via COALESCE — but leaves `source='contributed'` and `created_by='community:<pub>'` (or whatever pipeline previously owned the rid).

The auth projection's slug-resolution query then looks up:
```sql
WHERE created_by = 'adagents_json:<pub>' AND property_id = ANY([...])
```

It returns zero rows for the just-adopted rid → `targets.length === 0` → no CAA insert → no `authorization.granted` event. The `authorized_agents[]` entries silently drop.

This is exactly what wheelrandom.com hit: a `contributed` row from earlier enrichment was sitting at `domain:wheelrandom.com`, the manifest came in with a clean property + slug + auth, the property got the slug COALESCE'd in but the auth never landed.

## Fix

Two extra columns on the adopt-path UPDATE:
- `source = 'authoritative'`
- `created_by = expectedCreatedBy` (= `'adagents_json:<pub>'`)

Idempotent for own re-crawls (when `matchedCreatedBy === expectedCreatedBy` it's a no-op).

## Test

`registry-catalog-agent-auth-writer.test.ts`:
- Pre-seed catalog row with `source='contributed'` and `created_by='community:<pub>'`
- Pre-seed identifier `domain:<pub>` pointing at the row
- Crawl adagents.json with same domain identifier + a property slug + an auth referencing the slug
- Assert: rid is reused (no duplicate row), `source` promoted to `'authoritative'`, `created_by` rebound, auth projection lands a CAA row referencing the promoted rid.

61/61 tests pass across writer + reader baseline + reader cutover.

## Test plan
- [ ] Merge → deploy → re-trigger `POST /api/registry/crawl-request {domain: wheelrandom.com}`
- [ ] Watch `/api/registry/feed?types=authorization.*` for the `authorization.granted` event
- [ ] Confirm `resolve_property` for `domain:wheelrandom.com` returns the property + the agent

Refs #3177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)