### PR TITLE
fix(training-agent): fall back to InMemoryReplayStore when no DB initialized

### DIFF
--- a/.changeset/fix-training-agent-replay-store-no-db-fallback.md
+++ b/.changeset/fix-training-agent-replay-store-no-db-fallback.md
@@ -1,0 +1,17 @@
+---
+---
+
+fix(training-agent): fall back to InMemoryReplayStore when no DB is initialized
+
+The storyboard CI runner starts the training-agent without a Postgres database,
+so `getPool()` threw "Database not initialized" on every signed request, causing
+all 28 positive `signed_requests` storyboard vectors to return 401.
+
+Restores pre-#3351 CI behavior: each authenticator gets its own `InMemoryReplayStore`
+when no DB is present, preserving per-route replay isolation without requiring Postgres.
+In production (DB initialized), the shared `PostgresReplayStore` singleton is unchanged.
+
+Also guards `startReplayCacheSweeper()` to no-op when no DB is available.
+
+Fixes the `signed_requests` storyboard regression introduced by #3351; unblocks
+all PRs against main including #3373 (3.0.1 release prep).

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -119,10 +119,11 @@ function buildBearerAuthenticator(): Authenticator | null {
   return authenticators.length === 1 ? authenticators[0] : anyOf(...authenticators);
 }
 
-// Per-route lazy signing authenticators. Each route MUST own its own
-// `InMemoryReplayStore` — sharing one store lets a nonce consumed on
-// one route falsely fire `request_signature_replayed` on another (#3338).
-// Lazy so the compliance test JWKS isn't read at module import time.
+// Per-route lazy signing authenticators. Built on first signed request, cached
+// thereafter. In production each authenticator shares the singleton Postgres
+// replay store (scope-keyed by @target-uri, so routes are isolated). In CI
+// (no DB) each gets its own InMemoryReplayStore, preserving the same isolation
+// guarantee. Lazy so the compliance test JWKS isn't read at module import time.
 let _signingAuth: Authenticator | null = null;
 function lazySigningAuth(): Authenticator {
   return (req) => {

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -276,9 +276,10 @@ export function buildRequestSigningAuthenticator(): Authenticator {
 
 /** Authenticator for `/mcp-strict`: presence-gated signing with
  *  `required_for: ['create_media_buy']` and `'either'` content-digest mode.
- *  Distinct from the default authenticator so each route owns an isolated
- *  `InMemoryReplayStore` — sharing one store lets a nonce consumed on `/mcp`
- *  falsely fire `request_signature_replayed` on `/mcp-strict` (#3338). */
+ *  Distinct from the default authenticator so each route gets its own scoped
+ *  store entry — in production via the `@target-uri`-derived scope column of
+ *  the Postgres singleton; in CI via a per-authenticator `InMemoryReplayStore`
+ *  (#3338). */
 export function buildStrictRequestSigningAuthenticator(): Authenticator {
   return buildAuthenticatorWithCapability(getStrictRequestSigningCapability());
 }

--- a/server/src/training-agent/request-signing.ts
+++ b/server/src/training-agent/request-signing.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import type { IncomingMessage } from 'node:http';
 import {
   StaticJwksResolver,
+  InMemoryReplayStore,
   InMemoryRevocationStore,
   RequestSignatureError,
 } from '@adcp/client/signing';
@@ -38,7 +39,7 @@ import { PostgresReplayStore, sweepExpiredReplays } from '@adcp/client/signing/s
 import type { Authenticator } from '@adcp/client/server';
 import { getComplianceCacheDir } from '@adcp/client/testing';
 import { createLogger } from '../logger.js';
-import { getPool } from '../db/client.js';
+import { getPool, isDatabaseInitialized } from '../db/client.js';
 import { MUTATING_TOOLS } from './idempotency.js';
 
 const logger = createLogger('training-agent-request-signing');
@@ -159,15 +160,14 @@ export function selectSigningCapability(ctx: { strict?: boolean; digestMode?: 'e
 }
 
 /**
- * Replay store backed by Postgres so all training-agent instances share
- * one cache. Per-process `InMemoryReplayStore` can't catch cross-instance
- * replays — Fly's load balancer routes consecutive probes to different
- * machines, and the second machine has no record of the first nonce
- * (#3338, grader vector neg/016).
+ * Shared Postgres replay store for production. Singleton across all per-route
+ * authenticators — the `adcp_replay_cache` table's (keyid, scope, nonce) PK
+ * partitions by route via the `@target-uri`-derived scope, so sharing one
+ * pool connection is safe and avoids four separate pool entries.
  *
- * Singleton across all per-route authenticators so they all hit the same
- * `adcp_replay_cache` table; the (keyid, scope, nonce) primary key
- * partitions by route automatically via the `@target-uri`-derived scope.
+ * Not used when the database has not been initialized (CI/storyboard runner).
+ * In that case `buildAuthenticatorWithCapability` creates a per-authenticator
+ * `InMemoryReplayStore` instead — see below.
  */
 let _replayStore: ReplayStore | null = null;
 function getReplayStore(): ReplayStore {
@@ -186,6 +186,7 @@ let _sweepInterval: NodeJS.Timeout | null = null;
 export function startReplayCacheSweeper(): void {
   if (_sweepInterval) return;
   _sweepInterval = setInterval(() => {
+    if (!isDatabaseInitialized()) return;
     sweepExpiredReplays(getPool())
       .then((result: { deleted: number }) => {
         if (result.deleted > 0) logger.info({ deleted: result.deleted }, 'Swept expired replay-cache rows');
@@ -206,7 +207,11 @@ export function stopReplayCacheSweeper(): void {
 function buildAuthenticatorWithCapability(capability: VerifierCapability): Authenticator {
   const keys = loadTestJwks();
   const jwks = new StaticJwksResolver(keys);
-  const replayStore = getReplayStore();
+  // In production (DB initialized): shared Postgres store catches cross-instance replays.
+  // In CI/storyboard runner (no DB): per-authenticator InMemoryReplayStore restores the
+  // pre-#3351 behavior; each route owns its own store so cross-route false positives
+  // can't occur (#3338).
+  const replayStore = isDatabaseInitialized() ? getReplayStore() : new InMemoryReplayStore();
 
   // Pre-revoke the test-kit's revocation vector key so vector 017 fires
   // the expected `request_signature_revoked` error instead of passing.


### PR DESCRIPTION
Closes #3376

## Summary

PR #3351 swapped `InMemoryReplayStore` for `PostgresReplayStore` to fix cross-instance replay detection on Fly's multi-machine deployment. The storyboard CI runner (`run-storyboards.ts`) starts the training-agent without Postgres — no `DATABASE_URL`, no `initializeDatabase()` call — so `getPool()` threw `"Database not initialized"` on every signed request. All 28 positive `signed_requests` storyboard vectors returned 401 instead of 2xx; every PR against main has been failing CI since `2bb3dcd8`.

**Fix:** check `isDatabaseInitialized()` before choosing the store in `buildAuthenticatorWithCapability()`:
- **Production** (DB always initialized before `listen()` per `http.ts:8531` vs `8641`): unchanged — shared `PostgresReplayStore` singleton, cross-instance replay protection.
- **CI / storyboard runner** (no DB): per-authenticator `InMemoryReplayStore`, restoring exact pre-#3351 behavior. Each route gets its own store, so cross-route false positives can't occur (#3338).

Also guards `startReplayCacheSweeper()`'s interval callback with `if (!isDatabaseInitialized()) return` to prevent tick-level `getPool()` throws if the sweeper is ever started in a no-DB context.

**Note on neg/016 in CI:** The per-authenticator `InMemoryReplayStore` correctly handles the intra-run replay vector via white-box harness injection (documented in `negative/016-replayed-nonce.json`). Cross-instance replay (the scenario #3351 was solving for) is only validated in production against the Postgres-backed verifier — CI tests the single-process guarantee only.

## Non-breaking justification

Server-side infrastructure change only. No schema fields, task definitions, or `@adcp/*` package API changed. In production the Postgres store path is unaffected. Changeset: `--empty`.

## Pre-PR review

- **code-reviewer**: approved — no blockers; fixed stale JSDoc on `buildStrictRequestSigningAuthenticator` per reviewer's issue flag; nits surfaced (missing unit test for `isDatabaseInitialized()` branch, sweeper guard is defensive dead-code in current call sites)
- **ad-tech-protocol-expert**: approved — `isDatabaseInitialized()` guard is safe per boot sequence; non-breaking per spec definition; changeset classification correct; neg/016 CI scope documented

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015vh3dBv4iAKcoWj4a16ygU

---
_Generated by [Claude Code](https://claude.ai/code/session_015vh3dBv4iAKcoWj4a16ygU)_