### PR TITLE
docs: add AdCP vs RTB one-minute explainer page

### DIFF
--- a/.changeset/adcp-vs-rtb-comparison-page.md
+++ b/.changeset/adcp-vs-rtb-comparison-page.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add top-of-funnel "AdCP vs RTB" one-minute explainer page at /docs/adcp-vs-rtb. Surfaces alongside the homepage "Where do you want to start?" card group. Includes nav entries in both v3.0 and latest versions, and a cross-link callout from the existing technical adcp-vs-openrtb page. Driven by Addie weekly insights showing ~90 "What is AdCP vs RTB?" questions per week from discovery-mode users. Closes #2573.

--- a/docs.json
+++ b/docs.json
@@ -74,6 +74,7 @@
             "group": "Documentation",
             "pages": [
               "docs/intro",
+              "docs/adcp-vs-rtb",
               "docs/quickstart",
               {
                 "group": "Building with AdCP",
@@ -579,6 +580,7 @@
             "group": "Getting Started",
             "pages": [
               "docs/intro",
+              "docs/adcp-vs-rtb",
               "docs/quickstart"
             ]
           },

--- a/docs/adcp-vs-rtb.mdx
+++ b/docs/adcp-vs-rtb.mdx
@@ -1,0 +1,50 @@
+---
+title: AdCP vs OpenRTB — One-Minute Explainer
+sidebarTitle: AdCP vs RTB
+description: "AdCP vs RTB: how Ad Context Protocol and OpenRTB differ and work together. One-minute explainer for anyone familiar with real-time bidding."
+"og:title": "AdCP — How AdCP and RTB Fit Together"
+---
+
+RTB runs in milliseconds inside the auction. AdCP runs before and after — how agents find inventory, agree on terms, move creative, and read back results. They solve different problems.
+
+Neither replaces the other. A platform that already uses OpenRTB can add AdCP without touching the auction layer. A platform with no auction at all (a direct-sold publisher, a commerce media network) can use AdCP on its own.
+
+## What each one does
+
+| | OpenRTB | AdCP |
+|---|---|---|
+| **What it handles** | Single impression auctions | End-to-end campaign workflows |
+| **Participants** | DSPs and SSPs | AI agents and advertising platforms |
+| **Timing** | Real-time (milliseconds) | Asynchronous (seconds to days) |
+| **Maintained by** | IAB Tech Lab | AgenticAdvertising.org |
+
+## How they fit together
+
+An AI buyer agent uses AdCP to plan and execute the campaign — brief, negotiation, budget, creatives, governance. The publisher's ad server can use OpenRTB internally to run the impression-level auction. Both run on the same platform — AdCP before and after the auction, OpenRTB inside it.
+
+Three signals that clarify this:
+
+- AdCP's `create_media_buy` might generate thousands of OpenRTB bid requests over the campaign's lifetime. AdCP owns the deal; OpenRTB owns each auction.
+- Publishers without real-time bidding (direct-sold, commerce media, AI assistants) use AdCP alone. No OpenRTB required.
+- The [Trusted Match Protocol](/docs/trusted-match) is AdCP's real-time bridge when impression-time decisions matter — contextual and identity matching without turning AdCP into an auction.
+
+## Three questions people ask
+
+**Does AdCP replace OpenRTB?** No. They handle different parts of the workflow and are complementary. AdCP runs around the auction; OpenRTB runs inside it.
+
+**Do I need OpenRTB to use AdCP?** No. AdCP works independently. Publishers and platforms that don't use real-time bidding can implement AdCP on their own.
+
+**Can a platform implement both?** Yes, and most will. AdCP handles the buyer/seller workflow; OpenRTB handles impression-level execution where applicable.
+
+## Go deeper
+
+<CardGroup cols={2}>
+  <Card title="Academy Basics (free)" icon="graduation-cap" href="/docs/learning/overview">
+    Three modules, no prerequisites. Start understanding AdCP through hands-on chat with Addie.
+  </Card>
+  <Card title="Ask Addie" icon="message-bot" href="https://adcontextprotocol.org/chat">
+    Ask any follow-up question about AdCP and how it fits your platform.
+  </Card>
+</CardGroup>
+
+For the technical details — TMP integration, full comparison table, and how OpenRTB and AdCP share the serving layer — see [AdCP and OpenRTB](/docs/building/understanding/adcp-vs-openrtb).

--- a/docs/building/understanding/adcp-vs-openrtb.mdx
+++ b/docs/building/understanding/adcp-vs-openrtb.mdx
@@ -5,6 +5,10 @@ description: "AdCP vs OpenRTB: how they differ and work together. AdCP handles a
 "og:title": "AdCP — AdCP and OpenRTB"
 ---
 
+<Note>
+New to AdCP? [AdCP vs RTB — One-Minute Explainer](/docs/adcp-vs-rtb) is written for readers coming from real-time bidding. This page is the technical deep dive for implementers.
+</Note>
+
 AdCP and OpenRTB are complementary standards that operate at different layers of the advertising stack. They are not competing — a platform can (and often will) implement both.
 
 One of the most important connection points is **cross-publisher frequency capping**. AdCP enables it the same way OpenRTB enables programmatic buying: by exposing each impression to a buyer-controlled real-time decision layer before the ad server serves. In AdCP, that integration point is the **[Trusted Match Protocol (TMP)](/docs/trusted-match)**.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -600,12 +600,15 @@ Governance isn't a gate that slows things down. It's the safety net that lets yo
 
 ## Where do you want to start?
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="I want to buy on AI platforms" icon="cart-shopping" href="/docs/sponsored-intelligence/monetizing-ai">
     For brands, agencies, and businesses who want to advertise on AI surfaces
   </Card>
   <Card title="I want to build with AdCP" icon="code" href="/docs/building">
     For platforms, publishers, and developers implementing the protocol
+  </Card>
+  <Card title="AdCP vs RTB" icon="arrows-left-right" href="/docs/adcp-vs-rtb">
+    If you know real-time bidding, here's how AdCP fits alongside it — one minute read.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Closes #2573

Adds a top-of-funnel "AdCP vs RTB" comparison page at `/docs/adcp-vs-rtb`, driven by Addie weekly insights showing ~90 foundational "What is AdCP / how does it differ from RTB?" questions per week. The existing `adcp-vs-openrtb.mdx` targets implementers; this page targets the pre-enrollment, discovery-mode audience.

## Changes

- **`docs/adcp-vs-rtb.mdx`** — new one-minute explainer: 4-row comparison table, "how they fit together" section (before/after the auction framing), inline FAQ (no accordions so the content is skim-visible), Academy Basics + Ask Addie CTAs
- **`docs.json`** — nav entry in both `3.0` and `latest` version groups, immediately after `docs/intro`
- **`docs/intro.mdx`** — Card added to "Where do you want to start?" `CardGroup` (updated to `cols={3}`)
- **`docs/building/understanding/adcp-vs-openrtb.mdx`** — `<Note>` cross-link callout at the top routing discovery-mode readers to the new page
- **`.changeset/adcp-vs-rtb-comparison-page.md`** — empty changeset (docs-only, no protocol impact)

## Non-breaking justification

Adds new MDX page and nav entries; no existing pages or schema fields modified in a breaking way. Homepage card and technical-page cross-link are purely additive.

## Pre-PR review

- **code-reviewer:** approved — no CI-impacting blockers; nits surfaced: `og:title` redundancy (fixed), pronoun agreement (fixed), `cols={2}→cols={3}` orphan card (fixed), TMP link path convention (fixed)
- **docs-expert:** approved — factual accuracy confirmed against FAQ and technical page; "layers" framing replaced with "before/after the auction" throughout; "Scope"+"Operations" table row overlap resolved by collapsing to "What it handles"; Note callout framing updated from "short version" to audience-routing

**Nits surfaced (not fixed — for reviewer awareness):**
- "Academy Basics (free)" card title uses parenthetical — can remove `(free)` qualifier if preferred
- `<Note>` on `adcp-vs-openrtb.mdx` uses "coming from real-time bidding" — reviewers may prefer different phrasing

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/cse_01HULrqPhn8kLM76nSmcpj4d

---
_Generated by [Claude Code](https://claude.ai/code/session_017KQc5D5hf8ngWH9W2duhga)_