### PR TITLE
fix(admin): add Preview/View links and status vs visibility help text

### DIFF
--- a/.changeset/fix-admin-event-draft-preview-link.md
+++ b/.changeset/fix-admin-event-draft-preview-link.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(admin): add Preview link for draft events and visibility/status help text
+
+Adds a "Preview" link to draft events in the admin event list so admins can navigate to `/events/{slug}` and see the existing draft-preview banner. Also adds a "View" link for published/completed events. Adds `<small>` help text beneath the Status and Visibility dropdowns to explain that status=Published (not visibility) is what makes an event publicly accessible — the root cause of the visibility-vs-status confusion reported in #2536.

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -458,6 +458,7 @@
               <option value="cancelled">Cancelled</option>
               <option value="completed">Completed</option>
             </select>
+            <small>Set to <strong>Published</strong> to make the event publicly visible. Use the Preview link to check a draft before publishing.</small>
           </div>
         </div>
 
@@ -667,6 +668,7 @@
             <option value="invite_listed">Invite only, listed — shown in listings; registration restricted</option>
             <option value="invite_unlisted">Invite only, unlisted — hidden from public listing</option>
           </select>
+          <small>Controls who can register once the event is published. This does not make a draft event live — use Status for that.</small>
         </div>
 
         <div id="accessRulesSection" style="display: none;">
@@ -968,7 +970,10 @@
             <div class="event-actions">
               <button class="btn btn-secondary btn-small" onclick="editEvent('${event.id}')">Edit</button>
               ${event.status === 'draft' ? `
+                <a class="btn btn-secondary btn-small" href="/events/${escapeHtml(event.slug)}" target="_blank" rel="noopener noreferrer">Preview</a>
                 <button class="btn btn-primary btn-small" onclick="publishEvent('${event.id}')">Publish</button>
+              ` : (event.status === 'published' || event.status === 'completed') ? `
+                <a class="btn btn-secondary btn-small" href="/events/${escapeHtml(event.slug)}" target="_blank" rel="noopener noreferrer">View</a>
               ` : ''}
               <button class="btn btn-secondary btn-small" onclick="viewRegistrations('${event.id}')">Registrations</button>
               <button class="btn btn-danger btn-small" onclick="showDeleteModal('${event.id}')">Delete</button>

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -580,8 +580,8 @@
 
     <div id="loading" class="loading">Loading event...</div>
     <div id="error" class="error-state" style="display: none;">
-      <h2>Event Not Found</h2>
-      <p>The event you're looking for doesn't exist or has been removed.</p>
+      <h2>Event Not Available</h2>
+      <p>This event isn't currently available. It may not be published yet, or the link may be incorrect.</p>
       <a href="/events" class="btn btn-primary">View All Events</a>
     </div>
     <div id="draftBanner" style="display: none; background: var(--color-warning-100, #fef3c7); border: 1px solid var(--color-warning-300, #fcd34d); color: var(--color-warning-800, #92400e); padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px;">


### PR DESCRIPTION
Refs #2536

Admins editing a draft event had no discoverable path to the existing admin-preview feature at `/events/:slug`. The event list now shows a **Preview** link for draft events (opens in a new tab, shows the existing "Draft preview — not yet published" banner that was already implemented server-side) and a **View** link for published/completed events. Cancelled events get no link since the page would be misleading. Two `<small>` help texts are added beneath the Status and Visibility dropdowns to prevent recurrence: status=Published is what makes an event live; visibility controls audience gating for a published event.

**Non-breaking justification:** Additive HTML only — new anchor tags and `<small>` hint elements. No schema, API, or server-side changes. Existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on `escapeHtml` null-slug edge case (slug is `NOT NULL` in schema, so unreachable in practice)
- internal-tools-strategist: approved — copy is accurate and minimal; "View" correctly scoped to published/completed after blocker fix

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

**Note:** Track 2 of #2536 (speaker headshots + bios on event editor) is tracked separately in #2552. This PR covers Track 1 only — the visibility-vs-status confusion fix.

**Pre-existing build state:** The repo has 3964 TypeScript errors in unrelated files (missing `@types/node` env — confirmed by reverting and re-checking). This change is pure HTML and does not affect TypeScript compilation.

Session: https://claude.ai/code/session_01Xape4dBpbX3P4JNHHx6qby

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xape4dBpbX3P4JNHHx6qby)_