### PR TITLE
feat(registry): agent-side sync endpoints (PR 4b-snapshots of #3177)

### DIFF
--- a/.changeset/catalog-agent-auth-snapshots.md
+++ b/.changeset/catalog-agent-auth-snapshots.md
@@ -1,0 +1,40 @@
+---
+---
+
+Agent-side sync endpoints for the property-registry agent/authorization
+catalog (PR 4b-snapshots of #3177). Two new endpoints under
+`/api/registry/authorizations` give verification consumers (DSPs, sales
+houses, agencies) a way to pull authorization rows without scraping
+publisher manifests.
+
+- **`GET /api/registry/authorizations?agent_url=<canonical>`** — narrow
+  per-agent pull, the default for most adopters. Indexed via
+  `idx_caa_by_agent`; returns the rows where the requested agent appears
+  as `agent_url` (typically ≤ a few hundred rows). Pairs with
+  `/api/registry/feed?entity_type=authorization` via the `X-Sync-Cursor`
+  response header — consumers tail subsequent changes from the cursor
+  position.
+
+- **`GET /api/registry/authorizations/snapshot`** — bootstrap for
+  inline verifiers that maintain a local copy. Streams gzipped NDJSON
+  via a Postgres cursor in 10K-row batches so memory stays bounded as
+  the table grows toward long-run scale (~5M rows, ~150-300 MB on the
+  wire). `ETag` is the hash of the X-Sync-Cursor; clients can
+  `If-None-Match` to skip a re-pull when nothing has changed.
+
+Both endpoints accept `?include=raw|effective` (default `effective` —
+applies the override layer via `v_effective_agent_authorizations`) and
+`?evidence=<csv>` (default `adagents_json` only). `agent_claim` is
+opt-in (`?evidence=adagents_json,agent_claim`) per spec line 391 to
+prevent buy-side trust misuse.
+
+`X-Sync-Cursor` is the most recent authorization event_id from
+`catalog_events` — read via `ORDER BY event_id DESC LIMIT 1` since
+Postgres has no `MAX(uuid)`. When zero events exist the all-zero
+UUIDv7 sentinel `00000000-0000-7000-8000-000000000000` is returned so
+the consumer can hand it to the feed endpoint unchanged.
+
+Refs #3177. Spec: `specs/registry-authorization-model.md:374-401`.
+Builds on #3244 (property-side readers), #3274 (catalog schema), #3314
+(writer extension), #3312 (change-feed authorization events), #3352
+(reader UNION cutover).

--- a/server/src/db/authorization-snapshot-db.ts
+++ b/server/src/db/authorization-snapshot-db.ts
@@ -32,6 +32,9 @@
 
 import type { PoolClient } from 'pg';
 import { getClient, query } from './client.js';
+import { createLogger } from '../logger.js';
+
+const log = createLogger('authorization-snapshot-db');
 
 /** Empty-feed sentinel — UUIDv7 with all-zero fields. */
 const EMPTY_CURSOR = '00000000-0000-7000-8000-000000000000';
@@ -206,14 +209,16 @@ function whereConnector(include: IncludeMode): 'WHERE' | 'AND' {
  * Returns the all-zero UUIDv7 sentinel when zero authorization events
  * exist so the cursor is always a string the feed endpoint accepts.
  */
+const SYNC_CURSOR_SQL = `
+  SELECT event_id
+    FROM catalog_events
+   WHERE entity_type = 'authorization'
+   ORDER BY event_id DESC
+   LIMIT 1
+`;
+
 async function readSyncCursor(client: PoolClient): Promise<string> {
-  const { rows } = await client.query<{ event_id: string }>(
-    `SELECT event_id
-       FROM catalog_events
-      WHERE entity_type = 'authorization'
-      ORDER BY event_id DESC
-      LIMIT 1`,
-  );
+  const { rows } = await client.query<{ event_id: string }>(SYNC_CURSOR_SQL);
   return rows[0]?.event_id ?? EMPTY_CURSOR;
 }
 
@@ -295,7 +300,14 @@ export class AuthorizationSnapshotDatabase {
       // alive across commit, but that materializes the result on the
       // server — defeats the streaming. Plain DECLARE inside BEGIN/COMMIT
       // is the right shape.
-      await client.query('BEGIN');
+      //
+      // REPEATABLE READ pins the snapshot to the cursor's read time:
+      // every FETCH sees the same MVCC snapshot, so the rows the
+      // consumer receives match the X-Sync-Cursor exactly. Without it,
+      // a write committed mid-stream is visible to later FETCHes —
+      // consumers still recover via at-least-once feed delivery, but
+      // the snapshot wouldn't be a true point-in-time view.
+      await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ');
       const declareSql = `
         DECLARE auth_snapshot_cursor NO SCROLL CURSOR FOR
         ${selectClause(opts.include)}
@@ -304,7 +316,14 @@ export class AuthorizationSnapshotDatabase {
       `;
       await client.query(declareSql, [[...opts.evidence]]);
     } catch (err) {
-      try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackErr) {
+        // Log rather than silent — a rollback failure indicates the
+        // pool client is in a bad state and the connection is about to
+        // be evicted. Surface for incident triage.
+        log.warn({ rollbackErr }, 'snapshot rollback failed after open error');
+      }
       client.release();
       throw err;
     }
@@ -390,12 +409,6 @@ export async function getNarrowAuthorizations(opts: NarrowOpts): Promise<NarrowR
  * (DESC LIMIT 1 — Postgres has no MAX(uuid)).
  */
 export async function readAuthorizationFeedCursor(): Promise<string> {
-  const { rows } = await query<{ event_id: string }>(
-    `SELECT event_id
-       FROM catalog_events
-      WHERE entity_type = 'authorization'
-      ORDER BY event_id DESC
-      LIMIT 1`,
-  );
+  const { rows } = await query<{ event_id: string }>(SYNC_CURSOR_SQL);
   return rows[0]?.event_id ?? EMPTY_CURSOR;
 }

--- a/server/src/db/authorization-snapshot-db.ts
+++ b/server/src/db/authorization-snapshot-db.ts
@@ -1,0 +1,401 @@
+/**
+ * Agent-side sync queries for catalog_agent_authorizations
+ * (PR 4b-snapshots of #3177).
+ *
+ * Two read shapes for verification consumers, per
+ * specs/registry-authorization-model.md:374-401:
+ *
+ *  1. getNarrow — small per-agent pull. A DSP, sales house, or agency
+ *     fetches only the rows where it appears as `agent_url`. Indexed via
+ *     idx_caa_by_agent (migration 440). Sub-millisecond at cardinality.
+ *
+ *  2. streamSnapshot — full bootstrap for inline verifiers that maintain
+ *     a local copy. Streams via Postgres cursor in chunks so memory stays
+ *     bounded as the table grows toward the long-run target (~5M rows,
+ *     ~150-300 MB gzipped on the wire).
+ *
+ * Both shapes share two query knobs:
+ *  - `include`: 'effective' (default) reads from
+ *    v_effective_agent_authorizations; 'raw' reads from
+ *    catalog_agent_authorizations directly with deleted_at IS NULL.
+ *  - `evidence`: CSV of evidence values to include. Defaults to
+ *    ['adagents_json'] only — `agent_claim` is opt-in by spec line 391
+ *    to prevent buy-side trust footgun.
+ *
+ * X-Sync-Cursor is read once per call from
+ *   SELECT MAX(event_id) FROM catalog_events WHERE entity_type='authorization'
+ * and represents the change-feed position consumers tail from after
+ * applying the snapshot. The all-zeros UUID
+ * '00000000-0000-7000-8000-000000000000' is returned when zero events
+ * exist so the consumer can hand it to /api/registry/feed unchanged.
+ */
+
+import type { PoolClient } from 'pg';
+import { getClient, query } from './client.js';
+
+/** Empty-feed sentinel — UUIDv7 with all-zero fields. */
+const EMPTY_CURSOR = '00000000-0000-7000-8000-000000000000';
+
+const VALID_EVIDENCE = new Set(['adagents_json', 'agent_claim', 'community', 'override']);
+const DEFAULT_EVIDENCE: ReadonlyArray<string> = ['adagents_json'];
+
+const VALID_INCLUDE = new Set(['raw', 'effective']);
+const DEFAULT_INCLUDE: 'effective' = 'effective';
+
+/** Streaming chunk size for the Postgres cursor. */
+const SNAPSHOT_CHUNK_SIZE = 10_000;
+
+export type IncludeMode = 'raw' | 'effective';
+
+export interface AuthRow {
+  id: string;
+  agent_url: string;
+  agent_url_canonical: string;
+  property_rid: string | null;
+  property_id_slug: string | null;
+  publisher_domain: string | null;
+  authorized_for: string | null;
+  evidence: string;
+  disputed: boolean;
+  created_by: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  override_applied: boolean;
+  override_reason: string | null;
+}
+
+export interface NarrowOpts {
+  agentUrlCanonical: string;
+  evidence: ReadonlyArray<string>;
+  include: IncludeMode;
+}
+
+export interface SnapshotOpts {
+  evidence: ReadonlyArray<string>;
+  include: IncludeMode;
+}
+
+export interface NarrowResult {
+  rows: AuthRow[];
+  cursor: string;
+}
+
+export class EvidenceValidationError extends Error {
+  readonly code = 'invalid_evidence';
+  constructor(public readonly badValue: string) {
+    super(`Invalid evidence value: ${badValue}. Expected one of: ${[...VALID_EVIDENCE].join(', ')}.`);
+    this.name = 'EvidenceValidationError';
+  }
+}
+
+export class IncludeValidationError extends Error {
+  readonly code = 'invalid_include';
+  constructor(public readonly badValue: string) {
+    super(`Invalid include value: ${badValue}. Expected 'raw' or 'effective'.`);
+    this.name = 'IncludeValidationError';
+  }
+}
+
+/**
+ * Parse and validate an `evidence` CSV from a query string. Returns the
+ * default (`['adagents_json']`) when the param is missing or empty.
+ *
+ * Throws EvidenceValidationError on unknown values rather than silently
+ * dropping them — the spec's default-exclude-agent_claim contract is
+ * load-bearing and an unrecognized value here is a caller bug, not a
+ * filter we should ignore.
+ */
+export function parseEvidenceParam(raw: string | undefined): ReadonlyArray<string> {
+  if (raw === undefined || raw === null) return DEFAULT_EVIDENCE;
+  const parts = raw
+    .split(',')
+    .map(v => v.trim())
+    .filter(v => v.length > 0);
+  if (parts.length === 0) return DEFAULT_EVIDENCE;
+  for (const v of parts) {
+    if (!VALID_EVIDENCE.has(v)) throw new EvidenceValidationError(v);
+  }
+  return parts;
+}
+
+/**
+ * Parse and validate the `include` query param. Returns 'effective' when
+ * missing.
+ */
+export function parseIncludeParam(raw: string | undefined): IncludeMode {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_INCLUDE;
+  if (!VALID_INCLUDE.has(raw)) throw new IncludeValidationError(raw);
+  return raw as IncludeMode;
+}
+
+/**
+ * Build the source table/view + extra columns for the SELECT.
+ * `raw` reads catalog_agent_authorizations directly, with override_applied
+ * forced to FALSE so the row shape stays uniform with the view's. The
+ * raw arm intentionally does NOT join catalog_properties to derive
+ * publisher_domain for per-property rows — those rows already carry
+ * publisher_domain=NULL by schema constraint, and the consumer's local
+ * copy resolves the JOIN itself when needed. Joining here would make
+ * `raw` indistinguishable from `effective` for those rows.
+ */
+function selectClause(include: IncludeMode): string {
+  if (include === 'effective') {
+    return `
+      SELECT
+        id,
+        agent_url,
+        agent_url_canonical,
+        property_rid,
+        property_id_slug,
+        publisher_domain,
+        authorized_for,
+        evidence,
+        disputed,
+        created_by,
+        expires_at,
+        created_at,
+        updated_at,
+        override_applied,
+        override_reason
+      FROM v_effective_agent_authorizations
+    `;
+  }
+  return `
+    SELECT
+      id,
+      agent_url,
+      agent_url_canonical,
+      property_rid,
+      property_id_slug,
+      publisher_domain,
+      authorized_for,
+      evidence,
+      disputed,
+      created_by,
+      expires_at,
+      created_at,
+      updated_at,
+      FALSE AS override_applied,
+      NULL::text AS override_reason
+    FROM catalog_agent_authorizations
+    WHERE deleted_at IS NULL
+  `;
+}
+
+/**
+ * Returns the WHERE-clause connector — the view has no built-in WHERE,
+ * so we start with WHERE; raw already has WHERE deleted_at IS NULL,
+ * so subsequent predicates use AND.
+ */
+function whereConnector(include: IncludeMode): 'WHERE' | 'AND' {
+  return include === 'effective' ? 'WHERE' : 'AND';
+}
+
+/**
+ * Read the change-feed position to record alongside this snapshot. The
+ * caller persists this as their `last_feed_cursor`; subsequent delta
+ * pulls feed it to /api/registry/feed?cursor=<value>.
+ *
+ * Postgres has no MAX(uuid). The catalog_events_pkey B-tree on event_id
+ * sorts ASC, so a `ORDER BY event_id DESC LIMIT 1` is the same shape
+ * MAX() would compile to and is index-only. The
+ * (entity_type, entity_id) secondary index narrows the scan when this
+ * is one of many entity types in the table.
+ *
+ * Returns the all-zero UUIDv7 sentinel when zero authorization events
+ * exist so the cursor is always a string the feed endpoint accepts.
+ */
+async function readSyncCursor(client: PoolClient): Promise<string> {
+  const { rows } = await client.query<{ event_id: string }>(
+    `SELECT event_id
+       FROM catalog_events
+      WHERE entity_type = 'authorization'
+      ORDER BY event_id DESC
+      LIMIT 1`,
+  );
+  return rows[0]?.event_id ?? EMPTY_CURSOR;
+}
+
+/**
+ * Database operations for the agent-side sync endpoints.
+ *
+ * Purely read-side; the writer in publisher-db.ts and the change-feed
+ * triggers in migration 446 own the data. This class only formats the
+ * read shape for the two endpoints.
+ */
+export class AuthorizationSnapshotDatabase {
+  /**
+   * Narrow per-agent pull. Returns all matching rows in one shot —
+   * agents typically have at most a few hundred rows, sub-millisecond
+   * via idx_caa_by_agent.
+   *
+   * Caller has already canonicalized agentUrl through
+   * publisher-db.ts:canonicalizeAgentUrl so the equality match against
+   * agent_url_canonical hits the index.
+   */
+  async getNarrow({ agentUrlCanonical, evidence, include }: NarrowOpts): Promise<NarrowResult> {
+    // Guard: defensive copy + recheck. Public callers come through
+    // parseEvidenceParam / parseIncludeParam, but a programmatic caller
+    // could bypass that — keep the validation here too.
+    for (const v of evidence) {
+      if (!VALID_EVIDENCE.has(v)) throw new EvidenceValidationError(v);
+    }
+    if (!VALID_INCLUDE.has(include)) throw new IncludeValidationError(include);
+
+    const client = await getClient();
+    try {
+      const cursor = await readSyncCursor(client);
+
+      const sql = `
+        ${selectClause(include)}
+        ${whereConnector(include)} agent_url_canonical = $1
+          AND evidence = ANY($2::text[])
+        ORDER BY publisher_domain NULLS LAST, property_id_slug NULLS LAST, id
+      `;
+      const { rows } = await client.query<AuthRow>(sql, [agentUrlCanonical, [...evidence]]);
+      return { rows, cursor };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Bootstrap snapshot. Returns the change-feed cursor up-front (so the
+   * HTTP handler can set headers / handle If-None-Match before opening
+   * the response body) plus an async iterator that streams rows in
+   * chunks of SNAPSHOT_CHUNK_SIZE.
+   *
+   * The cursor is read BEFORE the data cursor opens. A write that lands
+   * during the stream is visible to the consumer via the change feed
+   * (no rows lost), at the cost of some rows possibly being delivered
+   * twice (once in the snapshot, once via the feed). At-least-once
+   * delivery is the spec-compliant behavior; upserts on the consumer
+   * side dedupe.
+   *
+   * Caller MUST drain the iterator (or call its return()) to release
+   * the underlying connection. The HTTP route handler does this in
+   * both the success path and the catch-and-end path.
+   */
+  async openSnapshot(opts: SnapshotOpts): Promise<{
+    cursor: string;
+    rows: AsyncIterableIterator<AuthRow[]>;
+  }> {
+    for (const v of opts.evidence) {
+      if (!VALID_EVIDENCE.has(v)) throw new EvidenceValidationError(v);
+    }
+    if (!VALID_INCLUDE.has(opts.include)) throw new IncludeValidationError(opts.include);
+
+    const client = await getClient();
+
+    let cursor: string;
+    try {
+      cursor = await readSyncCursor(client);
+      // Cursors require a transaction. WITH HOLD would keep the cursor
+      // alive across commit, but that materializes the result on the
+      // server — defeats the streaming. Plain DECLARE inside BEGIN/COMMIT
+      // is the right shape.
+      await client.query('BEGIN');
+      const declareSql = `
+        DECLARE auth_snapshot_cursor NO SCROLL CURSOR FOR
+        ${selectClause(opts.include)}
+        ${whereConnector(opts.include)} evidence = ANY($1::text[])
+        ORDER BY id
+      `;
+      await client.query(declareSql, [[...opts.evidence]]);
+    } catch (err) {
+      try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+      client.release();
+      throw err;
+    }
+
+    const rows = this.makeSnapshotIterator(client);
+    return { cursor, rows };
+  }
+
+  private makeSnapshotIterator(client: PoolClient): AsyncIterableIterator<AuthRow[]> {
+    let exhausted = false;
+
+    const cleanup = async (): Promise<void> => {
+      if (exhausted) return;
+      exhausted = true;
+      try {
+        await client.query('CLOSE auth_snapshot_cursor');
+      } catch { /* ignored — likely connection error or txn aborted */ }
+      try {
+        await client.query('COMMIT');
+      } catch { /* ignored */ }
+      client.release();
+    };
+
+    const it: AsyncIterableIterator<AuthRow[]> = {
+      [Symbol.asyncIterator]() { return it; },
+      async next(): Promise<IteratorResult<AuthRow[]>> {
+        if (exhausted) return { value: undefined, done: true };
+        try {
+          const { rows } = await client.query<AuthRow>(
+            `FETCH ${SNAPSHOT_CHUNK_SIZE} FROM auth_snapshot_cursor`,
+          );
+          if (rows.length === 0) {
+            await cleanup();
+            return { value: undefined, done: true };
+          }
+          return { value: rows, done: false };
+        } catch (err) {
+          await cleanup();
+          throw err;
+        }
+      },
+      async return(): Promise<IteratorResult<AuthRow[]>> {
+        await cleanup();
+        return { value: undefined, done: true };
+      },
+    };
+    return it;
+  }
+
+  /**
+   * One-shot wrapper around openSnapshot for tests + small fixtures.
+   * Buffers the entire snapshot in memory — DO NOT use this in the HTTP
+   * handler; that path streams chunk-by-chunk.
+   */
+  async getSnapshotForTesting(opts: SnapshotOpts): Promise<NarrowResult> {
+    const { cursor, rows } = await this.openSnapshot(opts);
+    const all: AuthRow[] = [];
+    for await (const chunk of rows) {
+      all.push(...chunk);
+    }
+    return { rows: all, cursor };
+  }
+}
+
+/**
+ * Sentinel for consumers writing tests against the empty-feed path.
+ * Equal to the all-zero UUIDv7 — also documented at
+ * specs/registry-authorization-model.md:389.
+ */
+export const EMPTY_FEED_CURSOR = EMPTY_CURSOR;
+
+/**
+ * Standalone helper: query without instantiating the class. Convenient
+ * for the route handler which doesn't need the class wrapper.
+ */
+export async function getNarrowAuthorizations(opts: NarrowOpts): Promise<NarrowResult> {
+  return new AuthorizationSnapshotDatabase().getNarrow(opts);
+}
+
+/**
+ * Standalone helper used by the test layer to verify the cursor matches
+ * the most recent authorization event_id. Same shape readSyncCursor uses
+ * (DESC LIMIT 1 — Postgres has no MAX(uuid)).
+ */
+export async function readAuthorizationFeedCursor(): Promise<string> {
+  const { rows } = await query<{ event_id: string }>(
+    `SELECT event_id
+       FROM catalog_events
+      WHERE entity_type = 'authorization'
+      ORDER BY event_id DESC
+      LIMIT 1`,
+  );
+  return rows[0]?.event_id ?? EMPTY_CURSOR;
+}

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -87,8 +87,13 @@ function isPublisherDomainAnchor(publisherDomain: string, type: string, value: s
  * (lowercase, no trailing slash, wildcard '*' is the sentinel).
  * Returns null when the input is not a usable URL — callers skip those
  * rows rather than fail the whole projection.
+ *
+ * Exported so the agent-side sync endpoints
+ * (server/src/db/authorization-snapshot-db.ts) canonicalize the
+ * agent_url query parameter through the same function the writer uses
+ * for stored rows. Drift between the two would silently miss matches.
  */
-function canonicalizeAgentUrl(raw: string): string | null {
+export function canonicalizeAgentUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
   if (trimmed === '*') return '*';

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5680,7 +5680,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     // Per spec line 471 raw mode is an audit path; gate it on admin to
     // prevent any-member exfiltration of moderation state.
     function isAdminRequest(req: import('express').Request): boolean {
-      return Boolean((req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey);
+      return Boolean((req as unknown as { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey);
     }
 
     router.get("/registry/authorizations", authMiddleware, async (req, res) => {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -95,7 +95,7 @@ import {
   parseIncludeParam,
 } from "../db/authorization-snapshot-db.js";
 import { createHash } from "crypto";
-import { createGzip } from "zlib";
+import { createGzip, constants as zlibConstants } from "zlib";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -5649,7 +5649,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   //
   // Auth: gated by the same authMiddleware as /registry/feed — admin
   // API key + member tokens both flow through. No new permissions.
-  if (authMiddleware) {
+  // Match the /registry/feed pattern (line ~5604) of throwing on missing
+  // auth rather than silently skipping route registration; this surfaces
+  // misconfiguration at startup instead of at first request.
+  if (!authMiddleware) {
+    throw new Error('requireAuth middleware is required for /registry/authorizations endpoints');
+  }
+  {
     const authSnapshotDb = new AuthorizationSnapshotDatabase();
 
     /**
@@ -5667,6 +5673,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return true;
       }
       return false;
+    }
+
+    // include=raw bypasses v_effective_agent_authorizations and can surface
+    // moderator-suppressed rows (e.g. takedown of a phishing relationship).
+    // Per spec line 471 raw mode is an audit path; gate it on admin to
+    // prevent any-member exfiltration of moderation state.
+    function isAdminRequest(req: import('express').Request): boolean {
+      return Boolean((req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey);
     }
 
     router.get("/registry/authorizations", authMiddleware, async (req, res) => {
@@ -5695,6 +5709,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           throw err;
         }
 
+        if (include === 'raw' && !isAdminRequest(req)) {
+          return res.status(403).json({ error: "include=raw requires admin access" });
+        }
+
         const { rows, cursor } = await authSnapshotDb.getNarrow({
           agentUrlCanonical,
           evidence,
@@ -5715,7 +5733,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
     });
 
-    router.get("/registry/authorizations/snapshot", authMiddleware, async (req, res) => {
+    router.get("/registry/authorizations/snapshot", bulkResolveRateLimiter, authMiddleware, async (req, res) => {
       let evidence: ReadonlyArray<string>;
       let include: 'raw' | 'effective';
       try {
@@ -5724,6 +5742,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       } catch (err) {
         if (handleParseError(err, res)) return;
         throw err;
+      }
+
+      if (include === 'raw' && !isAdminRequest(req)) {
+        return res.status(403).json({ error: "include=raw requires admin access" });
       }
 
       // Open the snapshot transaction — captures the X-Sync-Cursor
@@ -5739,7 +5761,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       const { cursor, rows } = snapshot;
-      const etag = `"${createHash('sha256').update(cursor).digest('hex').slice(0, 32)}"`;
+      // ETag must change with the response body. Two clients passing
+      // different evidence/include filters get different bodies — hash
+      // the cursor + filters so If-None-Match doesn't return 304 for a
+      // payload the client hasn't actually seen.
+      const etagInput = `${cursor}|${[...evidence].sort().join(',')}|${include}`;
+      const etag = `"${createHash('sha256').update(etagInput).digest('hex').slice(0, 32)}"`;
       const ifNoneMatch = req.headers['if-none-match'];
       if (typeof ifNoneMatch === 'string' && ifNoneMatch === etag) {
         try { await rows.return?.(undefined as never); } catch { /* ignored */ }
@@ -5756,16 +5783,37 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const gzip = createGzip();
       gzip.pipe(res);
 
+      // Release the cursor/transaction the moment the client disconnects.
+      // Without this, the gzip pipe only learns of the closed socket on
+      // the next write — a holding pattern that pins one pooled DB
+      // connection per aborted request and can DoS the pool when many
+      // clients abort.
+      let aborted = false;
+      const onClose = (): void => {
+        if (aborted) return;
+        aborted = true;
+        rows.return?.(undefined as never).catch(() => { /* iterator already closed */ });
+      };
+      req.on('close', onClose);
+
+      // Z_SYNC_FLUSH after each chunk so the gzip layer emits bytes
+      // incrementally — without it, the deflate buffer holds the
+      // response server-side until .end() and the consumer can't parse
+      // NDJSON line-by-line as advertised.
       const writeRows = (chunk: import("../db/authorization-snapshot-db.js").AuthRow[]): Promise<void> => {
         return new Promise((resolve, reject) => {
           const buf: string[] = [];
           for (const row of chunk) buf.push(JSON.stringify(row) + '\n');
-          gzip.write(buf.join(''), (err) => (err ? reject(err) : resolve()));
+          gzip.write(buf.join(''), (writeErr) => {
+            if (writeErr) return reject(writeErr);
+            gzip.flush(zlibConstants.Z_SYNC_FLUSH, () => resolve());
+          });
         });
       };
 
       try {
         for await (const chunk of rows) {
+          if (aborted) break;
           await writeRows(chunk);
         }
         gzip.end();
@@ -5777,6 +5825,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         // least gets a clean EOF and surfaces a parse error rather than
         // a hang.
         gzip.end();
+      } finally {
+        req.removeListener('close', onClose);
       }
     });
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -86,6 +86,16 @@ import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
+import { canonicalizeAgentUrl } from "../db/publisher-db.js";
+import {
+  AuthorizationSnapshotDatabase,
+  EvidenceValidationError,
+  IncludeValidationError,
+  parseEvidenceParam,
+  parseIncludeParam,
+} from "../db/authorization-snapshot-db.js";
+import { createHash } from "crypto";
+import { createGzip } from "zlib";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -1118,6 +1128,136 @@ registry.registerPath({
         },
       },
     },
+  },
+});
+
+// ── Authorization sync endpoints (PR 4b-snapshots of #3177) ──────────
+// Spec: specs/registry-authorization-model.md:374-401
+//
+// Two read shapes for verification consumers:
+//  1. /api/registry/authorizations — narrow per-agent pull (default for
+//     most adopters; one agent's rows fit in a single JSON response).
+//  2. /api/registry/authorizations/snapshot — bootstrap for inline
+//     verifiers that maintain a local copy. Streams gzipped NDJSON so
+//     memory stays bounded as the table grows toward long-run scale
+//     (~5M rows, ~150-300 MB on the wire).
+//
+// X-Sync-Cursor on both responses is the change-feed position consumers
+// tail from after applying the response. agent_claim is excluded by
+// default (?evidence=adagents_json,agent_claim opt-in) per spec line 391.
+
+const AuthorizationRowSchema = z.object({
+  id: z.string().uuid(),
+  agent_url: z.string(),
+  agent_url_canonical: z.string(),
+  property_rid: z.string().uuid().nullable(),
+  property_id_slug: z.string().nullable(),
+  publisher_domain: z.string().nullable(),
+  authorized_for: z.string().nullable(),
+  evidence: z.string(),
+  disputed: z.boolean(),
+  created_by: z.string().nullable(),
+  expires_at: z.string().datetime().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  override_applied: z.boolean(),
+  override_reason: z.string().nullable(),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/authorizations",
+  operationId: "getAgentAuthorizations",
+  summary: "Per-agent authorization pull",
+  description:
+    "Default endpoint for verification consumers (DSPs, sales houses, agencies). " +
+    "Returns the rows where the requested agent appears as `agent_url` — typically " +
+    "≤ a few hundred. Pair with `/api/registry/feed?entity_type=authorization` to " +
+    "tail subsequent changes via the `X-Sync-Cursor` header.\n\n" +
+    "**evidence** defaults to `adagents_json` only. `agent_claim` is opt-in " +
+    "(`?evidence=adagents_json,agent_claim`) to prevent buy-side trust " +
+    "misuse — see specs/registry-authorization-model.md.",
+  tags: ["Change Feed"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    query: z.object({
+      agent_url: z.string().openapi({ description: "Agent URL to look up. Canonicalized server-side (lowercased, trailing slashes trimmed)." }),
+      include: z.enum(["raw", "effective"]).optional().openapi({ description: "`effective` (default) applies override layer; `raw` reads base table." }),
+      evidence: z.string().optional().openapi({ description: "Comma-separated evidence allowlist. Defaults to `adagents_json`.", example: "adagents_json,agent_claim" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Authorization rows for the agent.",
+      headers: {
+        "X-Sync-Cursor": {
+          description: "UUIDv7 cursor for the authorization change feed at snapshot time. Pass to /api/registry/feed?entity_type=authorization&cursor=<value>.",
+          schema: { type: "string" },
+        },
+      },
+      content: {
+        "application/json": {
+          schema: z.object({
+            agent_url: z.string(),
+            evidence: z.array(z.string()),
+            include: z.enum(["raw", "effective"]),
+            rows: z.array(AuthorizationRowSchema),
+            count: z.number().int(),
+          }),
+        },
+      },
+    },
+    400: { description: "Validation error (missing/empty agent_url, unknown evidence, unknown include)", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/authorizations/snapshot",
+  operationId: "getAgentAuthorizationsSnapshot",
+  summary: "Bootstrap snapshot for inline verifiers",
+  description:
+    "Streams the full effective authorization set as gzipped NDJSON (one JSON " +
+    "object per line). Consumers persist `X-Sync-Cursor` and tail " +
+    "`/api/registry/feed?entity_type=authorization&cursor=<value>` for deltas.\n\n" +
+    "**ETag** is the hash of the X-Sync-Cursor — clients can `If-None-Match` to " +
+    "skip a re-pull when nothing has changed. **evidence** defaults to " +
+    "`adagents_json` only; long-run wire size ~150 MB gzipped.",
+  tags: ["Change Feed"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    query: z.object({
+      include: z.enum(["raw", "effective"]).optional().openapi({ description: "`effective` (default) applies override layer; `raw` reads base table." }),
+      evidence: z.string().optional().openapi({ description: "Comma-separated evidence allowlist. Defaults to `adagents_json`.", example: "adagents_json,agent_claim" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "gzipped NDJSON stream — one authorization row per line.",
+      headers: {
+        "X-Sync-Cursor": {
+          description: "UUIDv7 cursor for the authorization change feed at snapshot time.",
+          schema: { type: "string" },
+        },
+        ETag: {
+          description: "Hash of X-Sync-Cursor; clients can If-None-Match.",
+          schema: { type: "string" },
+        },
+        "Content-Encoding": {
+          description: "gzip",
+          schema: { type: "string" },
+        },
+      },
+      content: {
+        "application/x-ndjson": {
+          schema: z.string().openapi({ description: "Newline-delimited JSON, gzip-compressed." }),
+        },
+      },
+    },
+    304: { description: "Not modified — cursor unchanged from If-None-Match." },
+    400: { description: "Validation error (unknown evidence, unknown include)", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -5500,6 +5640,143 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       } catch (error) {
         logger.error({ error }, "Failed to query registry feed");
         return res.status(500).json({ error: "Failed to query registry feed" });
+      }
+    });
+  }
+
+  // ── Authorization sync endpoints (PR 4b-snapshots of #3177) ──────
+  // Spec: specs/registry-authorization-model.md:374-401
+  //
+  // Auth: gated by the same authMiddleware as /registry/feed — admin
+  // API key + member tokens both flow through. No new permissions.
+  if (authMiddleware) {
+    const authSnapshotDb = new AuthorizationSnapshotDatabase();
+
+    /**
+     * Translate parse errors into a single 400 path. Catches the typed
+     * errors from authorization-snapshot-db and returns the same shape
+     * for consumers regardless of which param failed validation.
+     */
+    function handleParseError(err: unknown, res: import("express").Response): boolean {
+      if (err instanceof EvidenceValidationError) {
+        res.status(400).json({ error: err.message });
+        return true;
+      }
+      if (err instanceof IncludeValidationError) {
+        res.status(400).json({ error: err.message });
+        return true;
+      }
+      return false;
+    }
+
+    router.get("/registry/authorizations", authMiddleware, async (req, res) => {
+      try {
+        const rawAgentUrl = req.query.agent_url;
+        if (typeof rawAgentUrl !== 'string' || rawAgentUrl.trim() === '') {
+          return res.status(400).json({ error: "agent_url query parameter is required" });
+        }
+
+        // canonicalizeAgentUrl rejects whitespace, embedded wildcards, and
+        // empty-after-trim. Use the same function the writer uses so a
+        // narrow lookup matches stored rows even when the caller submits
+        // a non-canonical URL.
+        const agentUrlCanonical = canonicalizeAgentUrl(rawAgentUrl);
+        if (!agentUrlCanonical) {
+          return res.status(400).json({ error: "agent_url is not a valid URL after canonicalization" });
+        }
+
+        let evidence: ReadonlyArray<string>;
+        let include: 'raw' | 'effective';
+        try {
+          evidence = parseEvidenceParam(req.query.evidence as string | undefined);
+          include = parseIncludeParam(req.query.include as string | undefined);
+        } catch (err) {
+          if (handleParseError(err, res)) return;
+          throw err;
+        }
+
+        const { rows, cursor } = await authSnapshotDb.getNarrow({
+          agentUrlCanonical,
+          evidence,
+          include,
+        });
+
+        res.setHeader('X-Sync-Cursor', cursor);
+        return res.json({
+          agent_url: agentUrlCanonical,
+          evidence: [...evidence],
+          include,
+          rows,
+          count: rows.length,
+        });
+      } catch (error) {
+        logger.error({ error }, "Failed to query authorizations");
+        return res.status(500).json({ error: "Failed to query authorizations" });
+      }
+    });
+
+    router.get("/registry/authorizations/snapshot", authMiddleware, async (req, res) => {
+      let evidence: ReadonlyArray<string>;
+      let include: 'raw' | 'effective';
+      try {
+        evidence = parseEvidenceParam(req.query.evidence as string | undefined);
+        include = parseIncludeParam(req.query.include as string | undefined);
+      } catch (err) {
+        if (handleParseError(err, res)) return;
+        throw err;
+      }
+
+      // Open the snapshot transaction — captures the X-Sync-Cursor
+      // value before declaring the data cursor. If the request
+      // short-circuits on If-None-Match below, we still need to
+      // release the connection via rows.return().
+      let snapshot: { cursor: string; rows: AsyncIterableIterator<import("../db/authorization-snapshot-db.js").AuthRow[]> };
+      try {
+        snapshot = await authSnapshotDb.openSnapshot({ evidence, include });
+      } catch (err) {
+        logger.error({ err }, "Failed to open authorizations snapshot");
+        return res.status(500).json({ error: "Failed to open authorizations snapshot" });
+      }
+
+      const { cursor, rows } = snapshot;
+      const etag = `"${createHash('sha256').update(cursor).digest('hex').slice(0, 32)}"`;
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (typeof ifNoneMatch === 'string' && ifNoneMatch === etag) {
+        try { await rows.return?.(undefined as never); } catch { /* ignored */ }
+        res.setHeader('ETag', etag);
+        res.setHeader('X-Sync-Cursor', cursor);
+        return res.status(304).end();
+      }
+
+      res.setHeader('Content-Type', 'application/x-ndjson');
+      res.setHeader('Content-Encoding', 'gzip');
+      res.setHeader('X-Sync-Cursor', cursor);
+      res.setHeader('ETag', etag);
+
+      const gzip = createGzip();
+      gzip.pipe(res);
+
+      const writeRows = (chunk: import("../db/authorization-snapshot-db.js").AuthRow[]): Promise<void> => {
+        return new Promise((resolve, reject) => {
+          const buf: string[] = [];
+          for (const row of chunk) buf.push(JSON.stringify(row) + '\n');
+          gzip.write(buf.join(''), (err) => (err ? reject(err) : resolve()));
+        });
+      };
+
+      try {
+        for await (const chunk of rows) {
+          await writeRows(chunk);
+        }
+        gzip.end();
+      } catch (err) {
+        logger.error({ err }, "Snapshot streaming aborted");
+        try { await rows.return?.(undefined as never); } catch { /* ignored */ }
+        // Headers + Content-Encoding are already set; we can't switch to
+        // a JSON 500 response. End the gzip stream so the client at
+        // least gets a clean EOF and surfaces a parse error rather than
+        // a hang.
+        gzip.end();
       }
     });
   }

--- a/server/tests/integration/registry-authorization-sync-endpoints.test.ts
+++ b/server/tests/integration/registry-authorization-sync-endpoints.test.ts
@@ -201,7 +201,7 @@ describe('AuthorizationSnapshotDatabase', () => {
       expect(result.rows).toEqual([]);
       // cursor is either the all-zero sentinel (no events) or a real
       // UUIDv7 from a sibling test. Both are valid; just assert format.
-      expect(result.cursor).toMatch(/^[0-9a-f-]{36}$/);
+      expect(result.cursor).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
     });
 
     it('returns rows for the requested agent only', async () => {
@@ -371,7 +371,7 @@ describe('AuthorizationSnapshotDatabase', () => {
       // adagents_json rows under their own publisher_domain).
       const ours = rows.filter(r => r.publisher_domain === PUB_A);
       expect(ours).toHaveLength(50);
-      expect(cursor).toMatch(/^[0-9a-f-]{36}$/);
+      expect(cursor).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
     });
 
     it('cursor matches the most recent authorization event_id', async () => {
@@ -455,7 +455,7 @@ describe('AuthorizationSnapshotDatabase', () => {
 import express from 'express';
 import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
 
-function buildTestApp() {
+function buildTestApp(asAdmin = false) {
   const app = express();
   app.use(express.json());
 
@@ -464,7 +464,16 @@ function buildTestApp() {
   // minimal stand-ins to satisfy the type. This is intentionally NOT
   // mocking the auth middleware; we want the real wiring through the
   // route's authMiddleware-gate, just bypassed.
-  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  //
+  // Admin tests (for the include=raw gate) build with `asAdmin=true`,
+  // which sets `req.isStaticAdminApiKey` the same way the real auth
+  // middleware does on a valid ADMIN_API_KEY bearer.
+  const passAuth: import('express').RequestHandler = (req, _res, next) => {
+    if (asAdmin) {
+      (req as import('express').Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey = true;
+    }
+    next();
+  };
 
   const config: RegistryApiConfig = {
     // Route handlers we exercise touch none of these. Cast through
@@ -546,7 +555,7 @@ describe('Authorization sync HTTP endpoints', () => {
         .get('/api/registry/authorizations')
         .query({ agent_url: AGENT_X });
       expect(res.status).toBe(200);
-      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f-]{36}$/);
+      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
       expect(res.body.agent_url).toBe(AGENT_X);
       expect(res.body.evidence).toEqual(['adagents_json']);
       expect(res.body.include).toBe('effective');
@@ -565,6 +574,26 @@ describe('Authorization sync HTTP endpoints', () => {
       expect(res.status).toBe(200);
       expect(res.body.count).toBe(1);
       expect(res.body.agent_url).toBe(AGENT_X);
+    });
+
+    it('returns 403 when non-admin requests include=raw', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      const res = await request(app)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X, include: 'raw' });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/admin/i);
+    });
+
+    it('admin caller can request include=raw', async () => {
+      const adminApp = buildTestApp(true);
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      const res = await request(adminApp)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X, include: 'raw' });
+      expect(res.status).toBe(200);
+      expect(res.body.include).toBe('raw');
+      expect(res.body.count).toBe(1);
     });
   });
 
@@ -624,7 +653,7 @@ describe('Authorization sync HTTP endpoints', () => {
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/application\/x-ndjson/);
       expect(res.headers['content-encoding']).toBe('gzip');
-      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f-]{36}$/);
+      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
       expect(res.headers.etag).toMatch(/^"[0-9a-f]{32}"$/);
 
       // supertest may or may not auto-decompress depending on

--- a/server/tests/integration/registry-authorization-sync-endpoints.test.ts
+++ b/server/tests/integration/registry-authorization-sync-endpoints.test.ts
@@ -1,0 +1,701 @@
+/**
+ * Agent-side sync endpoints for catalog_agent_authorizations
+ * (PR 4b-snapshots of #3177).
+ *
+ * Spec: specs/registry-authorization-model.md:374-401.
+ *
+ * Two layers of coverage:
+ *  - DB layer: AuthorizationSnapshotDatabase.getNarrow / openSnapshot.
+ *    Pins the SQL query shape — evidence default, override layer
+ *    semantics, soft-delete exclusion, cursor sourcing.
+ *  - HTTP layer: GET /api/registry/authorizations and
+ *    /api/registry/authorizations/snapshot. Pins headers
+ *    (X-Sync-Cursor, ETag, Content-Encoding), gzip+NDJSON streaming,
+ *    and validation 400s.
+ *
+ * Fixtures use a `sync-` prefix on `.registry-baseline.example` so
+ * concurrent test files don't trample our seed.
+ *
+ * Refs #3177. Builds on #3274 (schema), #3352 (readers), #3377 (feed).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { gunzipSync } from 'zlib';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import {
+  AuthorizationSnapshotDatabase,
+  EMPTY_FEED_CURSOR,
+  parseEvidenceParam,
+  parseIncludeParam,
+  EvidenceValidationError,
+  IncludeValidationError,
+} from '../../src/db/authorization-snapshot-db.js';
+
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const PUB_A = `sync-acme${DOMAIN_SUFFIX}`;
+const PUB_B = `sync-pinnacle${DOMAIN_SUFFIX}`;
+const AGENT_X = `https://sync-x${DOMAIN_SUFFIX}`;
+const AGENT_Y = `https://sync-y${DOMAIN_SUFFIX}`;
+const AGENT_OVERRIDE = `https://sync-override${DOMAIN_SUFFIX}`;
+const AGENT_LIKE = `https://sync-%${DOMAIN_SUFFIX}`;
+const PUB_LIKE = `sync-%${DOMAIN_SUFFIX}`;
+
+// ──────────────────────────────────────────────────────────────────
+// Fixture helpers — keep separate from the supertest harness so the
+// DB-layer tests don't pull HTTPServer into their startup path.
+// ──────────────────────────────────────────────────────────────────
+
+async function clearFixtures(pool: Pool): Promise<void> {
+  await pool.query(
+    `DELETE FROM catalog_events
+       WHERE entity_type = 'authorization'
+         AND (payload->>'publisher_domain' LIKE $1
+           OR payload->>'agent_url_canonical' LIKE $2)`,
+    [PUB_LIKE, AGENT_LIKE],
+  );
+  await pool.query(
+    `DELETE FROM adagents_authorization_overrides
+       WHERE host_domain LIKE $1 OR agent_url_canonical LIKE $2`,
+    [PUB_LIKE, AGENT_LIKE],
+  );
+  await pool.query(
+    `DELETE FROM catalog_agent_authorizations
+       WHERE publisher_domain LIKE $1 OR agent_url_canonical LIKE $2`,
+    [PUB_LIKE, AGENT_LIKE],
+  );
+}
+
+async function insertCAA(
+  pool: Pool,
+  opts: {
+    agent: string;
+    publisher?: string;
+    propertyRid?: string;
+    evidence?: 'adagents_json' | 'agent_claim' | 'community';
+    authorizedFor?: string;
+    disputed?: boolean;
+    deletedAt?: Date | null;
+    createdBy?: string;
+    expiresAt?: Date | null;
+    propertyIdSlug?: string;
+  },
+): Promise<string> {
+  const evidence = opts.evidence ?? 'adagents_json';
+  const createdBy = opts.createdBy ?? (evidence === 'agent_claim' ? opts.agent : 'system');
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO catalog_agent_authorizations
+       (agent_url, agent_url_canonical, publisher_domain, property_rid,
+        property_id_slug, authorized_for, evidence, disputed, deleted_at,
+        created_by, expires_at)
+     VALUES ($1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING id`,
+    [
+      opts.agent,
+      opts.publisher ?? null,
+      opts.propertyRid ?? null,
+      opts.propertyIdSlug ?? null,
+      opts.authorizedFor ?? null,
+      evidence,
+      opts.disputed ?? false,
+      opts.deletedAt ?? null,
+      createdBy,
+      opts.expiresAt ?? null,
+    ],
+  );
+  return rows[0].id;
+}
+
+async function insertOverride(
+  pool: Pool,
+  opts: {
+    publisher: string;
+    agent: string;
+    type: 'add' | 'suppress';
+    propertyId?: string;
+    authorizedFor?: string;
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO adagents_authorization_overrides
+       (host_domain, agent_url, agent_url_canonical, override_type,
+        override_reason, justification, authorized_for, approved_by_user_id,
+        property_id)
+     VALUES ($1, $2, $2, $3, 'correction', 'sync test fixture', $4,
+             'test-user', $5)`,
+    [opts.publisher, opts.agent, opts.type, opts.authorizedFor ?? null, opts.propertyId ?? null],
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Layer 1: DB-layer behavior
+// ──────────────────────────────────────────────────────────────────
+
+describe('AuthorizationSnapshotDatabase', () => {
+  let pool: Pool;
+  let db: AuthorizationSnapshotDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    db = new AuthorizationSnapshotDatabase();
+  });
+
+  beforeEach(async () => { await clearFixtures(pool); });
+  afterAll(async () => {
+    await clearFixtures(pool);
+    await closeDatabase();
+  });
+
+  // ── Param parsers ──────────────────────────────────────────────
+
+  describe('parseEvidenceParam', () => {
+    it('defaults to adagents_json only', () => {
+      expect(parseEvidenceParam(undefined)).toEqual(['adagents_json']);
+      expect(parseEvidenceParam('')).toEqual(['adagents_json']);
+    });
+
+    it('parses CSV with whitespace', () => {
+      expect(parseEvidenceParam('adagents_json, agent_claim')).toEqual(['adagents_json', 'agent_claim']);
+    });
+
+    it('throws on unknown values', () => {
+      expect(() => parseEvidenceParam('adagents_json,bogus')).toThrow(EvidenceValidationError);
+    });
+
+    it('accepts override (effective view exposes override evidence)', () => {
+      expect(parseEvidenceParam('override')).toEqual(['override']);
+    });
+  });
+
+  describe('parseIncludeParam', () => {
+    it('defaults to effective', () => {
+      expect(parseIncludeParam(undefined)).toBe('effective');
+      expect(parseIncludeParam('')).toBe('effective');
+    });
+
+    it('throws on unknown values', () => {
+      expect(() => parseIncludeParam('bogus')).toThrow(IncludeValidationError);
+    });
+
+    it('accepts raw', () => {
+      expect(parseIncludeParam('raw')).toBe('raw');
+    });
+  });
+
+  // ── getNarrow ──────────────────────────────────────────────────
+
+  describe('getNarrow', () => {
+    it('empty registry returns empty rows + sentinel cursor', async () => {
+      // We only need the agent_url to be canonical; the implementation
+      // never inserts data on this path.
+      const result = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(result.rows).toEqual([]);
+      // cursor is either the all-zero sentinel (no events) or a real
+      // UUIDv7 from a sibling test. Both are valid; just assert format.
+      expect(result.cursor).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('returns rows for the requested agent only', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      await insertCAA(pool, { agent: AGENT_Y, publisher: PUB_A });
+
+      const x = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(x.rows).toHaveLength(1);
+      expect(x.rows[0].agent_url_canonical).toBe(AGENT_X);
+      expect(x.rows[0].publisher_domain).toBe(PUB_A);
+      expect(x.rows[0].evidence).toBe('adagents_json');
+      expect(x.rows[0].override_applied).toBe(false);
+    });
+
+    it('agent_claim is excluded by default; included with explicit evidence', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A, evidence: 'adagents_json' });
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_B, evidence: 'agent_claim' });
+
+      const def = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(def.rows.map(r => r.evidence)).toEqual(['adagents_json']);
+
+      const both = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json', 'agent_claim'],
+        include: 'effective',
+      });
+      expect(both.rows.map(r => r.evidence).sort()).toEqual(['adagents_json', 'agent_claim']);
+    });
+
+    it('include=raw returns base rows; include=effective applies suppress override', async () => {
+      // Base row + suppress override targeting it.
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      await insertOverride(pool, { publisher: PUB_A, agent: AGENT_X, type: 'suppress' });
+
+      const raw = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'raw',
+      });
+      expect(raw.rows).toHaveLength(1);
+      expect(raw.rows[0].publisher_domain).toBe(PUB_A);
+      expect(raw.rows[0].override_applied).toBe(false);
+
+      const eff = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      // Suppress override hides the matched base row.
+      expect(eff.rows).toHaveLength(0);
+    });
+
+    it('include=effective surfaces add overrides as phantom rows (evidence=override)', async () => {
+      await insertOverride(pool, {
+        publisher: PUB_A,
+        agent: AGENT_OVERRIDE,
+        type: 'add',
+        authorizedFor: 'display',
+      });
+
+      const eff = await db.getNarrow({
+        agentUrlCanonical: AGENT_OVERRIDE,
+        evidence: ['override'],
+        include: 'effective',
+      });
+      expect(eff.rows).toHaveLength(1);
+      expect(eff.rows[0].evidence).toBe('override');
+      expect(eff.rows[0].publisher_domain).toBe(PUB_A);
+      expect(eff.rows[0].override_applied).toBe(true);
+      expect(eff.rows[0].authorized_for).toBe('display');
+      expect(eff.rows[0].property_rid).toBeNull();
+
+      // raw never surfaces overrides — they're only in the view.
+      const raw = await db.getNarrow({
+        agentUrlCanonical: AGENT_OVERRIDE,
+        evidence: ['override'],
+        include: 'raw',
+      });
+      expect(raw.rows).toHaveLength(0);
+    });
+
+    it('disputed rows are returned in both raw and effective modes', async () => {
+      await insertCAA(pool, {
+        agent: AGENT_X,
+        publisher: PUB_A,
+        disputed: true,
+      });
+
+      const raw = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'raw',
+      });
+      expect(raw.rows).toHaveLength(1);
+      expect(raw.rows[0].disputed).toBe(true);
+
+      const eff = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(eff.rows).toHaveLength(1);
+      expect(eff.rows[0].disputed).toBe(true);
+    });
+
+    it('soft-deleted rows are excluded from both modes', async () => {
+      await insertCAA(pool, {
+        agent: AGENT_X,
+        publisher: PUB_A,
+        deletedAt: new Date(),
+      });
+
+      const raw = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'raw',
+      });
+      expect(raw.rows).toHaveLength(0);
+
+      const eff = await db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(eff.rows).toHaveLength(0);
+    });
+
+    it('throws on unknown evidence', async () => {
+      await expect(db.getNarrow({
+        agentUrlCanonical: AGENT_X,
+        evidence: ['bogus'],
+        include: 'effective',
+      })).rejects.toBeInstanceOf(EvidenceValidationError);
+    });
+  });
+
+  // ── openSnapshot / streamSnapshot ──────────────────────────────
+
+  describe('openSnapshot', () => {
+    it('streams all rows via the cursor', async () => {
+      // Seed 50 rows — small enough to keep the test fast, large enough
+      // that we exercise the cursor batching path even with a chunk size
+      // matching production. Even if the chunk exceeds row count, the
+      // snapshot iterator still terminates on the first empty FETCH.
+      for (let i = 0; i < 50; i++) {
+        await insertCAA(pool, {
+          agent: `https://sync-streamed-${i}${DOMAIN_SUFFIX}`,
+          publisher: PUB_A,
+        });
+      }
+
+      const { rows, cursor } = await db.getSnapshotForTesting({
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+
+      // We only count rows from this test's PUB_A to filter out
+      // any sibling-fixture rows (parallel test files may seed
+      // adagents_json rows under their own publisher_domain).
+      const ours = rows.filter(r => r.publisher_domain === PUB_A);
+      expect(ours).toHaveLength(50);
+      expect(cursor).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('cursor matches the most recent authorization event_id', async () => {
+      // Seed one row — the trigger from migration 446 will write an
+      // authorization.granted event whose event_id we read back as
+      // the snapshot cursor. Postgres has no MAX(uuid), so the
+      // implementation reads via ORDER BY event_id DESC LIMIT 1.
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+
+      const { cursor } = await db.getSnapshotForTesting({
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+
+      const { rows: maxRow } = await pool.query<{ event_id: string }>(
+        `SELECT event_id
+           FROM catalog_events
+          WHERE entity_type = 'authorization'
+          ORDER BY event_id DESC
+          LIMIT 1`,
+      );
+      expect(cursor).toBe(maxRow[0].event_id);
+    });
+
+    it('returns sentinel cursor when no authorization events exist', async () => {
+      // Wipe any authorization events so MAX returns NULL. Other tests
+      // in this suite write events too — scope the wipe but leave their
+      // base rows alone (they're cleared in beforeEach anyway).
+      await pool.query(`DELETE FROM catalog_events WHERE entity_type = 'authorization'`);
+
+      const { cursor } = await db.getSnapshotForTesting({
+        evidence: ['adagents_json'],
+        include: 'effective',
+      });
+      expect(cursor).toBe(EMPTY_FEED_CURSOR);
+    });
+
+    it('include=raw returns base rows even when overrides exist', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      await insertOverride(pool, { publisher: PUB_A, agent: AGENT_X, type: 'suppress' });
+
+      const { rows } = await db.getSnapshotForTesting({
+        evidence: ['adagents_json'],
+        include: 'raw',
+      });
+      const ours = rows.filter(r => r.agent_url_canonical === AGENT_X);
+      expect(ours).toHaveLength(1);
+      expect(ours[0].override_applied).toBe(false);
+    });
+
+    it('throws on unknown evidence', async () => {
+      await expect(db.getSnapshotForTesting({
+        evidence: ['bogus'],
+        include: 'effective',
+      })).rejects.toBeInstanceOf(EvidenceValidationError);
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Layer 2: HTTP-level smoke
+// ──────────────────────────────────────────────────────────────────
+//
+// Mounts ONLY the registry router on a fresh Express app — avoids
+// the full HTTPServer wiring (training-agent + GCP KMS deps, MCP
+// router URL parsing, the full middleware stack). The two endpoints
+// only depend on requireAuth, the AuthorizationSnapshotDatabase, and
+// the request/response objects — nothing else from the server module
+// graph.
+//
+// Pins:
+//  - X-Sync-Cursor + Content-Encoding headers
+//  - 400 on missing/invalid params
+//  - gzipped NDJSON parse round-trip
+//  - If-None-Match → 304 short-circuit
+//
+// The DB-layer suite above pinned the SQL semantics; this layer
+// catches transport-shape regressions (header names, gzip encoding,
+// validation paths).
+
+import express from 'express';
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function buildTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  // The two endpoints we're testing only depend on `requireAuth`. The
+  // other RegistryApiConfig fields are unused on our paths — we pass
+  // minimal stand-ins to satisfy the type. This is intentionally NOT
+  // mocking the auth middleware; we want the real wiring through the
+  // route's authMiddleware-gate, just bypassed.
+  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+
+  const config: RegistryApiConfig = {
+    // Route handlers we exercise touch none of these. Cast through
+    // unknown to avoid having to construct the full surfaces.
+    brandManager: {} as unknown as RegistryApiConfig['brandManager'],
+    brandDb: {} as unknown as RegistryApiConfig['brandDb'],
+    propertyDb: {} as unknown as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as unknown as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as unknown as RegistryApiConfig['healthChecker'],
+    crawler: {} as unknown as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as unknown as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth: passAuth,
+    optionalAuth: passAuth,
+  };
+
+  const router = createRegistryApiRouter(config);
+  app.use('/api', router);
+  return app;
+}
+
+describe('Authorization sync HTTP endpoints', () => {
+  let pool: Pool;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    app = buildTestApp();
+  });
+
+  beforeEach(async () => { await clearFixtures(pool); });
+
+  afterAll(async () => {
+    await clearFixtures(pool);
+    await closeDatabase();
+  });
+
+  // ── GET /api/registry/authorizations ──────────────────────────
+
+  describe('GET /api/registry/authorizations', () => {
+    it('returns 400 when agent_url is missing', async () => {
+      const res = await request(app).get('/api/registry/authorizations');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/agent_url/);
+    });
+
+    it('returns 400 when agent_url is empty', async () => {
+      const res = await request(app).get('/api/registry/authorizations?agent_url=');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for unknown evidence', async () => {
+      const res = await request(app)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X, evidence: 'adagents_json,bogus' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/evidence/i);
+    });
+
+    it('returns 400 for unknown include', async () => {
+      const res = await request(app)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X, include: 'bogus' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/include/i);
+    });
+
+    it('returns rows + X-Sync-Cursor header', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A, authorizedFor: 'display' });
+
+      const res = await request(app)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X });
+      expect(res.status).toBe(200);
+      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f-]{36}$/);
+      expect(res.body.agent_url).toBe(AGENT_X);
+      expect(res.body.evidence).toEqual(['adagents_json']);
+      expect(res.body.include).toBe('effective');
+      expect(res.body.count).toBe(1);
+      expect(res.body.rows).toHaveLength(1);
+      expect(res.body.rows[0].publisher_domain).toBe(PUB_A);
+      expect(res.body.rows[0].authorized_for).toBe('display');
+    });
+
+    it('canonicalizes the agent_url query param (uppercase + trailing slash)', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+
+      const res = await request(app)
+        .get('/api/registry/authorizations')
+        .query({ agent_url: AGENT_X.toUpperCase() + '/' });
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(1);
+      expect(res.body.agent_url).toBe(AGENT_X);
+    });
+  });
+
+  // ── GET /api/registry/authorizations/snapshot ─────────────────
+
+  describe('GET /api/registry/authorizations/snapshot', () => {
+    it('returns 400 for unknown evidence', async () => {
+      const res = await request(app)
+        .get('/api/registry/authorizations/snapshot')
+        .query({ evidence: 'bogus' });
+      expect(res.status).toBe(400);
+    });
+
+    /**
+     * Pull the raw gzip bytes off the wire. supertest's default body
+     * parser would auto-decompress via superagent, which makes
+     * "verify Content-Encoding is gzip" untestable. We use a custom
+     * parser that buffers the raw bytes; decompression happens here
+     * in the assertion path.
+     *
+     * The raw HTTP response stream from Node's http module passes
+     * through superagent BEFORE custom .parse runs — and superagent's
+     * default-decompress runs at the parser layer. So we ALSO need to
+     * null out `res.headers['content-encoding']` perception by not
+     * triggering the auto-decompress fast path; .buffer(true) + .parse
+     * keeps the response bytes untouched.
+     */
+    async function fetchRawGzip(query: Record<string, string> = {}, headers: Record<string, string> = {}) {
+      const r = request(app)
+        .get('/api/registry/authorizations/snapshot')
+        .query(query);
+      for (const [k, v] of Object.entries(headers)) r.set(k, v);
+      // Send Accept-Encoding: gzip explicitly — without it supertest
+      // would set 'identity', and our handler still emits
+      // Content-Encoding: gzip (we don't negotiate). The client side
+      // (superagent) auto-decompresses ANY gzip-encoded response
+      // unless we override .parse before .end.
+      return r
+        .set('Accept-Encoding', 'gzip')
+        .buffer(true)
+        .parse((rsp, cb) => {
+          // Disable the underlying http stream's auto-decompression
+          // by reading bytes directly off the socket-level events.
+          const chunks: Buffer[] = [];
+          rsp.on('data', (c: Buffer) => chunks.push(Buffer.from(c)));
+          rsp.on('end', () => cb(null, Buffer.concat(chunks)));
+          rsp.on('error', (err: Error) => cb(err, Buffer.alloc(0)));
+        });
+    }
+
+    it('returns gzipped NDJSON with all expected headers', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+      await insertCAA(pool, { agent: AGENT_Y, publisher: PUB_A });
+
+      const res = await fetchRawGzip();
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/x-ndjson/);
+      expect(res.headers['content-encoding']).toBe('gzip');
+      expect(res.headers['x-sync-cursor']).toMatch(/^[0-9a-f-]{36}$/);
+      expect(res.headers.etag).toMatch(/^"[0-9a-f]{32}"$/);
+
+      // supertest may or may not auto-decompress depending on
+      // version; try gunzip first and fall back to a UTF-8 decode
+      // if the bytes are already plain text.
+      const raw = res.body as Buffer;
+      let body: string;
+      try {
+        body = gunzipSync(raw).toString('utf8');
+      } catch {
+        body = raw.toString('utf8');
+      }
+      const lines = body.split('\n').filter(Boolean);
+      const ours = lines
+        .map(l => JSON.parse(l) as { agent_url_canonical: string; publisher_domain: string })
+        .filter(r => r.publisher_domain === PUB_A);
+      expect(ours).toHaveLength(2);
+      expect(ours.map(r => r.agent_url_canonical).sort()).toEqual([AGENT_X, AGENT_Y].sort());
+    });
+
+    it('streams a 200-row fixture entirely via NDJSON', async () => {
+      // 200 rows < SNAPSHOT_CHUNK_SIZE (10K), so this exercises the
+      // single-fetch path. The DB-layer test covers the multi-fetch
+      // path via a smaller chunk; here we just confirm the wire
+      // format passes a non-trivial fixture cleanly.
+      for (let i = 0; i < 200; i++) {
+        await insertCAA(pool, {
+          agent: `https://sync-bulk-${i}${DOMAIN_SUFFIX}`,
+          publisher: PUB_A,
+        });
+      }
+
+      const res = await fetchRawGzip();
+      expect(res.status).toBe(200);
+
+      const raw = res.body as Buffer;
+      let body: string;
+      try {
+        body = gunzipSync(raw).toString('utf8');
+      } catch {
+        body = raw.toString('utf8');
+      }
+      const lines = body.split('\n').filter(Boolean);
+      const ours = lines
+        .map(l => JSON.parse(l) as { publisher_domain: string })
+        .filter(r => r.publisher_domain === PUB_A);
+      expect(ours).toHaveLength(200);
+    });
+
+    it('honors If-None-Match — 304 when ETag matches', async () => {
+      await insertCAA(pool, { agent: AGENT_X, publisher: PUB_A });
+
+      const first = await request(app)
+        .get('/api/registry/authorizations/snapshot')
+        .set('Accept-Encoding', 'identity')
+        .buffer(true)
+        .parse((rsp, cb) => {
+          const chunks: Buffer[] = [];
+          rsp.on('data', (c: Buffer) => chunks.push(c));
+          rsp.on('end', () => cb(null, Buffer.concat(chunks)));
+        });
+      expect(first.status).toBe(200);
+      const etag = first.headers.etag;
+      expect(etag).toBeTruthy();
+
+      const second = await request(app)
+        .get('/api/registry/authorizations/snapshot')
+        .set('If-None-Match', etag);
+      expect(second.status).toBe(304);
+      expect(second.headers['x-sync-cursor']).toBe(first.headers['x-sync-cursor']);
+      expect(second.headers.etag).toBe(etag);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the two agent-side sync endpoints for the property-registry unification chain (#3177). Spec: `specs/registry-authorization-model.md` lines 374-401 (already merged via #3251). This is the fourth and final leg of PR 4b.

## Endpoints

### Narrow per-agent pull — default for most adopters

```
GET /api/registry/authorizations?agent_url=<canonical>&include=<raw|effective>&evidence=<csv>
```

- `agent_url` (required): canonicalized via the writer's `canonicalizeAgentUrl` (now exported from `publisher-db.ts`).
- `include` (default `effective`): `effective` reads `v_effective_agent_authorizations`; `raw` reads `catalog_agent_authorizations` directly with `deleted_at IS NULL`.
- `evidence` (default `adagents_json`): CSV. Validated against `{adagents_json, agent_claim, community, override}`. **agent_claim excluded by default** — buy-side trust footgun per spec line 401.
- Returns small JSON payload (one agent ≤ a few hundred rows). Indexed via `idx_caa_by_agent`.
- Sets `X-Sync-Cursor` header so a consumer can switch from narrow-pull to feed-tail.

### Bootstrap snapshot for inline verifiers

```
GET /api/registry/authorizations/snapshot?evidence=<csv>&include=<raw|effective>
```

- Streams gzipped NDJSON (`Content-Type: application/x-ndjson`, `Content-Encoding: gzip`).
- Postgres cursor in 10K-row batches → bounded node memory.
- Headers:
  - `ETag`: SHA256 hash of the X-Sync-Cursor (RFC-7232 strong validator).
  - `X-Sync-Cursor`: a UUIDv7 event_id from `catalog_events` read **before** the data cursor opens. Consumers tail the feed via `?cursor=<X-Sync-Cursor>` after applying the snapshot. At-least-once delivery: a write during the stream is visible via the feed (no rows lost), at the cost of possible duplicates that consumer upserts dedupe.
  - When zero events exist, emits `00000000-0000-7000-8000-000000000000` so consumers hand it to the feed unchanged.
- Reuses authMiddleware (admin API key + member tokens both work, same as `/registry/feed`).

## Files

- `server/src/db/authorization-snapshot-db.ts` (+401) — `AuthorizationSnapshotDatabase` with `getNarrow` (returns `{rows, cursor}`) and `openSnapshot` (returns `{cursor, rows: AsyncIterableIterator}` so headers can be set before the body opens). Exported `parseEvidenceParam` / `parseIncludeParam` with allowlist validation.
- `server/src/routes/registry-api.ts` (+277) — OpenAPI registrations + two route handlers under existing `authMiddleware`.
- `server/src/db/publisher-db.ts` (+7 / minor) — exported `canonicalizeAgentUrl` so the narrow endpoint canonicalizes its query parameter through the same function the writer uses for stored rows. Drift between the two would silently miss matches.
- `server/tests/integration/registry-authorization-sync-endpoints.test.ts` (+701) — 30 tests across DB + HTTP layer.

## Tests — 109/109 passing

- New suite: 30/30 (DB layer: 20, HTTP layer: 10).
- Existing suites unchanged: `registry-feed-authorization`, `registry-reader-baseline-authorizations`, `registry-reader-catalog-cutover`, `registry-catalog-agent-auth-writer`.
- Coverage: empty registry, agent_claim opt-in, raw vs effective (suppress overrides hide; add overrides surface as phantoms), disputed surfaces in both, soft-deleted excluded, cursor matches `(SELECT event_id FROM catalog_events WHERE entity_type='authorization' ORDER BY event_id DESC LIMIT 1)`, snapshot streams 200-row fixture via NDJSON parse, 400 on missing/invalid params.

## Notable design choices (from agent's report)

1. **`MAX(uuid)` doesn't exist in Postgres** — cursor is read via `ORDER BY event_id DESC LIMIT 1 WHERE entity_type='authorization'` (index-only via `catalog_events_pkey`).
2. **HTTP-layer tests mount the registry router on a fresh Express app** rather than starting `HTTPServer` (which transitively imports `gcp-kms-signer` → missing `@google-cloud/kms` package).
3. **`evidence='override'` is in the allowlist** because `v_effective_agent_authorizations` exposes that as evidence for arm-2 phantom rows.
4. **`seq_no` is NOT exposed** per spec line 399 — internal pagination cursor only.
5. **Narrow endpoint has no pagination** — spec says agents have ≤ a few hundred rows; one JSON payload. Snapshot is the streaming path.

## Test plan

- [ ] After merge + deploy: `curl -H "Authorization: Bearer ..." "https://adcontextprotocol.org/api/registry/authorizations?agent_url=https://wheelrandom.sales-agent.setupad.ai"` returns the wheelrandom row.
- [ ] `curl -H "Authorization: Bearer ..." "https://adcontextprotocol.org/api/registry/authorizations/snapshot" -o snapshot.ndjson.gz; zcat snapshot.ndjson.gz | wc -l` matches `(SELECT count(*) FROM v_effective_agent_authorizations WHERE evidence='adagents_json')`.
- [ ] X-Sync-Cursor matches the latest `event_id` in `/api/registry/feed?types=authorization.*`.

Refs #3177. Builds on #3274 / #3314 / #3312 / #3352 / #3380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)