### PR TITLE
docs(versioning): add schema-publication-at-merge policy

### DIFF
--- a/.changeset/schema-publication-at-merge-policy.md
+++ b/.changeset/schema-publication-at-merge-policy.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document the schema publication invariant: the `/schemas/v3/` alias tag and source HEAD must always agree on all required fields. Adds a "Schema publication at merge" subsection to `docs/reference/versioning.mdx` covering when to cut a new tag (any PR that changes a `required` array, discriminator `const`, or validation constraint), how this applies during RC cycles, and who is responsible until a CI check enforces the invariant.

--- a/docs/reference/versioning.mdx
+++ b/docs/reference/versioning.mdx
@@ -133,6 +133,16 @@ Any change that requires an implementation to adapt — renamed field, required-
 - A section in the [migration guide](/docs/reference/migration) or a dedicated deep-dive page
 - Where possible, an alias accepting both old and new names in the release that introduces the change
 
+### Schema publication at merge
+
+The latest published tag must always reflect the same required-field set as source HEAD. A PR that changes any `required` array, changes a discriminator `const`, or tightens a validation constraint must be accompanied by a new tag cut before the change becomes the active implementation target for external consumers. This is in addition to any upstream obligations — for example, the deprecation requirement for optional→required transitions described in the stability guarantees above.
+
+**Why:** Implementors validate against a published tag (whether pinned to an exact version or resolved through the [version alias](/docs/building/schemas-and-sdks#schema-versioning)). If source HEAD's required fields grow beyond what that tag declares, an evaluator reading source and the implementor's validator reading the published tag will disagree — not because either is wrong, but because the published contract hasn't caught up. The implementor cannot reconcile the gap without reading source history.
+
+**During RC cycles:** The same invariant applies between RC tags. A schema change that lands between `rc.N` and `rc.N+1` requires cutting `rc.N+1` before the new required-field set is treated as active.
+
+**Until CI enforcement is in place:** The PR author is responsible for cutting the new release or RC tag before the change propagates to evaluators. Reviewers should not approve a PR that changes a `required` array, a discriminator `const`, or a validation constraint without confirming a new tag is ready to publish.
+
 ---
 
 ## Release cadence


### PR DESCRIPTION
Closes #2366

Adds a `### Schema publication at merge` subsection to `docs/reference/versioning.mdx`, placed immediately after the existing `### Breaking-change notice` section. The section codifies the invariant: the latest published tag and source HEAD must always reflect the same required-field set, and any PR that changes a `required` array, a discriminator `const`, or tightens a validation constraint must be accompanied by a new tag cut before the change propagates to evaluators.

The root case (source↔published drift from PR #2315 on the rc.3 tag) is resolved by the 3.0 GA tag. This doc addition is the durable Evergreen fix: it names the invariant, explains why the drift matters for pinned-tag and alias-resolving implementors alike, covers RC cycles explicitly, and describes manual responsibility until a CI check enforces the rule.

**Non-breaking justification:** adds a new subsection to an existing docs page; no schema changes, no wire changes, no API surface affected.

**Pre-PR review:**
- `code-reviewer`: approved — no blockers; nits on wording and changeset style noted, addressed in revision (reviewer trigger condition changed from commit-prefix to actual schema-change categories; "staged or already cut" → "ready to publish"; redundant RC-cycle sentence removed)
- `docs-expert`: two blockers on initial draft: (1) conflict with the 3.x stability table's deprecation-first rule for optional→required; (2) "Why" block incorrectly scoped to alias users only. Both fixed: added "in addition to any upstream obligations" clause; broadened "Why" to cover pinned-tag implementors; added cross-link to `/docs/building/schemas-and-sdks#schema-versioning`.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01PKwE7MvNkQjTBaWssihqjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKwE7MvNkQjTBaWssihqjj)_