### PR TITLE
fix(admin): auto-approve member logo uploads that pass format/size/safety checks

### DIFF
--- a/.changeset/logo-auto-approve-onboarding.md
+++ b/.changeset/logo-auto-approve-onboarding.md
@@ -1,0 +1,30 @@
+---
+---
+
+fix(admin): auto-approve member logo uploads that pass format/size/safety validation
+
+Resolves the stalled-onboarding escalation path from issue #2568. Previously,
+community uploads sat in a `pending` queue with no admin UI to process them and no
+member-visible status beyond a hardcoded "pending review" message.
+
+**`server/src/routes/brand-logos.ts`**: Community uploads that clear the existing
+membership + ban + magic-bytes + SVG-sanitization + size gates are now
+auto-approved (`review_status: 'approved'`). The manifest is rebuilt for all
+auto-approved uploads, so logos appear immediately. The `source` field still
+distinguishes `brand_owner` from `community` for audit purposes.
+
+**`server/public/brand-viewer.html`**: Upload success message now uses
+`result.review_status` from the API response — "Logo uploaded and live." when
+approved, "Logo uploaded — pending review." as fallback — instead of always
+showing the pending message regardless of actual status.
+
+**`server/src/addie/mcp/brand-tools.ts`**: `upload_brand_logo` tool was a
+separate code path that still hardcoded `review_status: 'pending'`, bypassing the
+HTTP route's approval logic. Fixed to match: inserts as `'approved'`, rebuilds
+manifest, and returns the correct status. Tool description updated accordingly.
+
+Non-breaking: no schema changes; `review_status` was already returned in the
+HTTP response. Existing `rejected`/`deleted` paths and the `review_brand_logo`
+admin tool are unchanged.
+
+Closes #2568.

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -1638,7 +1638,10 @@
           });
           const result = await resp.json();
           if (resp.ok) {
-            status.innerHTML = '<span style="color:var(--color-success-600);">Logo uploaded — pending review.</span>';
+            const uploadMsg = result.review_status === 'approved'
+              ? 'Logo uploaded and live.'
+              : 'Logo uploaded — pending review.';
+            status.innerHTML = `<span style="color:var(--color-success-600);">${uploadMsg}</span>`;
             setTimeout(() => {
               hideUploadModal();
               window.location.reload();

--- a/server/src/addie/jobs/brand-logo-digest.ts
+++ b/server/src/addie/jobs/brand-logo-digest.ts
@@ -2,13 +2,12 @@
  * Brand Logo Pending-Review Digest
  *
  * Daily summary of brand logos sitting in the moderation queue, posted to
- * the configured admin Slack channel. The pending queue is otherwise
- * invisible — `getPendingLogos` had zero callers before #3137, and admins
- * won't poll `list_pending_brand_logos` on their own. This job is the
- * "you have N items waiting" nudge.
+ * the configured admin Slack channel.
  *
- * Skips items younger than ~12h to give #3154's auto-approve path time to
- * land owner uploads without a digest needing to mention them.
+ * As of #2568, all new uploads auto-approve at insert time, so the pending
+ * queue is permanently empty for any logo uploaded after that change ships.
+ * This job remains useful only as a drain for logos that queued before the
+ * deploy. It will silently no-op once those historical items clear.
  */
 
 import { logger } from '../../logger.js';

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -18,7 +18,11 @@ import { ToolError } from '../tool-error.js';
 import type { AddieTool } from '../types.js';
 import { COMMITTEE_TYPE_LABELS, VALID_MEMBER_OFFERINGS } from '../../types.js';
 import type { MemberContext } from '../member-context.js';
-import { invalidateMemberContextCache } from '../member-context.js';
+// invalidateMemberContextCache is imported lazily in the two handlers that
+// call it (see below). Top-level import would pull member-context.ts, which
+// imports middleware/auth.ts, which constructs a WorkOS client at module load
+// time — blowing up any test that imports admin-tools.ts without WORKOS_API_KEY.
+// Matches the pattern from PR #3258 (member-tools.ts).
 import { OrganizationDatabase, resolveMembershipTier } from '../../db/organization-db.js';
 import type { MembershipTier } from '../../db/organization-db.js';
 import { SlackDatabase } from '../../db/slack-db.js';
@@ -7727,6 +7731,7 @@ Use add_committee_leader to assign a leader.`;
           profile,
           logoUrl,
         });
+        const { invalidateMemberContextCache } = await import('../member-context.js');
         invalidateMemberContextCache();
         const action = result.wasUpdate ? 'updated' : 'set';
         logger.info({ profileId: profile.id, brandDomain: result.brandDomain, logoUrl, action }, 'Member logo updated');
@@ -7838,6 +7843,7 @@ Use add_committee_leader to assign a leader.`;
         return `❌ Failed to update profile for **${profile.display_name}**.`;
       }
 
+      const { invalidateMemberContextCache } = await import('../member-context.js');
       invalidateMemberContextCache();
       logger.info({ profileId: profile.id, slug: profile.slug, updatedFields }, 'Member profile updated by admin tool');
 

--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -14,7 +14,7 @@ import { fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } f
 import { downloadAndCacheLogos, isBrandfetchUrl } from '../../services/logo-cdn.js';
 import { BrandLogoDatabase } from '../../db/brand-logo-db.js';
 import { safeFetch } from '../../utils/url-security.js';
-import { detectContentType, sanitizeSvg, validateLogoTags, computeSha256, extractDimensions } from '../../services/brand-logo-service.js';
+import { detectContentType, sanitizeSvg, validateLogoTags, computeSha256, extractDimensions, rebuildManifestLogos } from '../../services/brand-logo-service.js';
 import { query } from '../../db/client.js';
 import { createLogger } from '../../logger.js';
 
@@ -129,7 +129,7 @@ export const BRAND_TOOLS: AddieTool[] = [
   },
   {
     name: 'upload_brand_logo',
-    description: 'Upload a logo file for a brand in the registry. The logo will be pending review.',
+    description: 'Upload a logo file for a brand in the registry. The logo is auto-approved and immediately visible.',
     usage_hints: 'Use when a user shares a logo URL (press kit, brand portal) and wants to upload it for a brand.',
     input_schema: {
       type: 'object',
@@ -598,7 +598,7 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
       width,
       height,
       source: 'community',
-      review_status: 'pending',
+      review_status: 'approved',
       uploaded_by_user_id: 'system:addie',
       upload_note: note,
     });
@@ -620,12 +620,18 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
       }
     }
 
+    // Rebuild manifest so the logo shows immediately (skip for verified hosted brands).
+    const hosted = await brandDb.getHostedBrandByDomain(domain);
+    if (!hosted || !hosted.domain_verified) {
+      await rebuildManifestLogos(domain, brandLogoDb, brandDb);
+    }
+
     // Exclude upload_note and original_filename from response (prompt injection vector)
     return JSON.stringify({
       success: true,
       domain,
       logo_id: logo.id,
-      review_status: 'pending',
+      review_status: 'approved',
       url: `/logos/brands/${domain}/${logo.id}`,
       content_type: contentType,
       tags,

--- a/server/src/db/brand-logo-db.ts
+++ b/server/src/db/brand-logo-db.ts
@@ -74,7 +74,7 @@ export class BrandLogoDatabase {
         input.width ?? null,
         input.height ?? null,
         input.source,
-        input.review_status ?? 'pending',
+        input.review_status ?? 'approved',
         input.uploaded_by_user_id ?? null,
         input.uploaded_by_email ?? null,
         input.upload_note ?? null,

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -119,13 +119,13 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         // Original filename
         const originalFilename = req.file.originalname?.slice(0, 255);
 
-        // Auto-approve when the uploader belongs to the verified-owner org for this
-        // domain (brand.json present + AAO pointer verified). The pending queue is
-        // for community uploads where ownership is unclear; an owner uploading their
-        // own logo shouldn't have to wait for human review.
+        // Auto-approve all uploads that pass format/size/safety validation. The
+        // membership + ban gate already restricts who can upload; verified owners and
+        // community members are both trusted enough that holding logos in a manual queue
+        // stalls onboarding without providing meaningful safety benefit (#2568).
         const isOwner = await isVerifiedBrandOwner(user.id, domain, brandDb);
         const source = isOwner ? 'brand_owner' : 'community';
-        const reviewStatus = isOwner ? 'approved' : 'pending';
+        const reviewStatus = 'approved';
 
         // Insert
         const logo = await brandLogoDb.insertBrandLogo({
@@ -169,20 +169,17 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           }
         }
 
-        // Auto-approved owner uploads need the manifest rebuilt so the new logo
-        // shows immediately. Verified hosted brands manage their manifest via
-        // brand.json directly — skip the rebuild for those.
-        if (isOwner) {
-          const hosted = await brandDb.getHostedBrandByDomain(domain);
-          if (!hosted || !hosted.domain_verified) {
-            await rebuildManifestLogos(domain, brandLogoDb, brandDb);
-          }
+        // Rebuild manifest so the new logo shows immediately. Verified hosted brands
+        // manage their manifest via brand.json — skip the rebuild for those.
+        const hosted = await brandDb.getHostedBrandByDomain(domain);
+        if (!hosted || !hosted.domain_verified) {
+          await rebuildManifestLogos(domain, brandLogoDb, brandDb);
         }
 
         // Create a brand revision noting the upload
         try {
           await brandDb.editDiscoveredBrand(domain, {
-            edit_summary: `Logo uploaded by ${user.email}${isOwner ? ' (verified owner — auto-approved)' : ''}`,
+            edit_summary: `Logo uploaded by ${user.email} (${isOwner ? 'verified owner' : 'community'} — auto-approved)`,
             editor_user_id: user.id,
             editor_email: user.email,
           });


### PR DESCRIPTION
Closes #2568

Member logos uploaded during onboarding sit in a `pending` review queue indefinitely — no admin UI exists to process it, the only consumer is an Addie MCP tool (`list_pending_brand_logos`) most admins don't know to invoke, and members see a hardcoded "pending review" message with no resolution path. This is the escalation source identified in the Apr 11–18 Addie insights.

This PR removes the bottleneck by auto-approving all uploads that already pass the membership + ban + magic-bytes + SVG-sanitization + size gates. Source traceability (`brand_owner` vs `community`) is preserved. The reject/delete admin path is unchanged. The `upload_brand_logo` Addie tool was a separate code path with the same hardcoded `pending` logic — it's fixed in the same diff.

**Non-breaking justification:** No schema or wire changes. `review_status` was already returned in the HTTP upload response; callers that read it now see `'approved'` instead of `'pending'`. No existing client depends on community uploads being held in pending state.

**Files changed:**
- `server/src/routes/brand-logos.ts` — `reviewStatus` always `'approved'`; manifest rebuild unconditional; edit summary records source
- `server/public/brand-viewer.html` — success message uses `result.review_status` from API response
- `server/src/addie/mcp/brand-tools.ts` — `upload_brand_logo` tool: insert `approved`, call `rebuildManifestLogos`, return correct status; description updated
- `server/src/db/brand-logo-db.ts` — `insertBrandLogo` default changed from `'pending'` to `'approved'` (latent footgun fix)
- `server/src/addie/jobs/brand-logo-digest.ts` — comment updated: job is now a drain for pre-deploy pending logos only
- `.changeset/auto-approve-verified-owner-logos.md` — removed contradicting note that community uploads still queue

**Nits surfaced in review (not fixed here):**
- `countBrandLogos` and `getByDomainAndSha256` still reference `IN ('pending', 'approved')` — functionally fine, cosmetic cleanup follow-up
- `rebuildManifestLogos` + `editDiscoveredBrand` are two sequential writes to the same brand row per request with no transaction wrap — pre-existing race under concurrent same-domain uploads; tracked separately

**Pre-PR review:**
- code-reviewer: approved — no blockers; XSS surface in HTML change is safe (message chosen from two hardcoded literals, not user input); `rebuildManifestLogos` placement correct in both code paths
- internal-tools-strategist: approved — DB default fix and digest annotation address the two operational blockers; `isOwner` is still needed for `source` field and audit summary so the call is not dead

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_019WyF5yW7B8jkypARtKHqcg

---
_Generated by [Claude Code](https://claude.ai/code/session_019WyF5yW7B8jkypARtKHqcg)_