### PR TITLE
feat(addie): env-gated admin bypass in redteam runner

### DIFF
--- a/.changeset/redteam-runner-admin-bypass.md
+++ b/.changeset/redteam-runner-admin-bypass.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds an env-gated admin bypass to the Addie redteam runner. When `ADMIN_API_KEY` is set, the runner sends `Authorization: Bearer …` on each request and is treated as admin server-side, skipping the anonymous 50-msg/IP daily limiter and the per-IP anonymous cost cap. Without this, a single 33-scenario run could exhaust the daily IP budget mid-pass and contaminate results with HTTP 429 / cost-cap responses (which contain none of the redteam's marker words and surface as spurious `missing_marker` failures). No-op when the env var is unset, so default behavior is unchanged.

--- a/server/src/addie/testing/redteam-runner.ts
+++ b/server/src/addie/testing/redteam-runner.ts
@@ -160,12 +160,21 @@ async function askAddie(
   question: string,
   csrf: { cookie: string; token: string }
 ): Promise<{ status: number; response: string }> {
+  // Optional admin bypass: when ADMIN_API_KEY is set in the env, the runner
+  // authenticates as admin so it skips the anonymous 50-msg/IP daily limiter
+  // and the per-IP anonymous-tier cost cap. Without it, a single 33-scenario
+  // run can exhaust the daily IP budget and contaminate the result with
+  // HTTP 429 / cost-cap responses (which contain none of the redteam's
+  // marker words → spurious missing_marker failures).
+  // No-op when the env var is unset, so default behavior is unchanged.
+  const adminKey = process.env.ADMIN_API_KEY;
   const res = await fetch(`${baseUrl}/api/addie/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Cookie: csrf.cookie,
       'X-CSRF-Token': csrf.token,
+      ...(adminKey ? { Authorization: `Bearer ${adminKey}` } : {}),
     },
     body: JSON.stringify({ message: question, user_name: 'RedTeam Tester' }),
   });


### PR DESCRIPTION
## Summary

Adds an env-gated admin bypass to the Addie redteam runner. When `ADMIN_API_KEY` is set in the env, the runner sends `Authorization: Bearer …` on each request and is treated as admin server-side, skipping the anonymous 50-msg/IP daily limiter and the per-IP anonymous cost cap.

## Why

A single 33-scenario redteam run can exhaust the daily anonymous IP budget mid-pass. When that happens, the remaining scenarios get HTTP 429 / cost-cap responses — which contain none of the redteam's marker words and surface as spurious `missing_marker` failures, contaminating the result with infrastructure noise instead of model-quality signal. We saw this exact pattern in a recent prod run (25/33 contaminated). With the bypass set, a clean re-run produced 29/33.

## Behavior

- Unset env var → no header sent → identical to current behavior. Default-safe.
- Set env var → `Authorization: Bearer $ADMIN_API_KEY` sent. Server-side `auth.ts` recognizes this and bypasses `anonymousDailyLimiter` (`skip: (req) => !!req.user?.id`) and the anonymous cost cap.

## Test plan

- [x] Unit tests pass locally (834/834)
- [x] Typecheck clean
- [x] Confirmed clean redteam run against prod with the bypass set (29/33 vs. 25/33 contaminated baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)