### PR TITLE
feat(addie): introduce Sage as certification teaching persona

### DIFF
--- a/.changeset/sage-as-certification-instructor.md
+++ b/.changeset/sage-as-certification-instructor.md
@@ -1,0 +1,4 @@
+---
+---
+
+Introduce Sage as the AdCP protocol certification instructor. Updates TEACHING_METHODOLOGY, BUILD_PROJECT_METHODOLOGY, and CAPSTONE_METHODOLOGY to identify as Sage; adds Sage identity injection in buildCertificationContext; updates instructional-design.mdx and personnel-qualifications.mdx to reference Sage as the AI teaching assistant across all credential tiers. Addie retains community onboarding and recertification notification roles. No schema or API changes.

--- a/docs/learning/instructional-design.mdx
+++ b/docs/learning/instructional-design.mdx
@@ -24,11 +24,11 @@ This document describes how the AdCP certification program is designed, delivere
 
 The certification program is built on five principles:
 
-**Socratic method.** Addie teaches through conversation, not lecture. Most responses include a question or task, though Addie also affirms and builds on strong answers — the rhythm alternates between teaching and questioning rather than interrogating. Learners build understanding by reasoning through problems, not by receiving answers.
+**Socratic method.** Sage teaches through conversation, not lecture. Most responses include a question or task, though Sage also affirms and builds on strong answers — the rhythm alternates between teaching and questioning rather than interrogating. Learners build understanding by reasoning through problems, not by receiving answers.
 
-**Mastery-based progression.** There is no failing — only "not yet." Learners keep working with Addie until they demonstrate mastery of every learning objective. Assessment is invisible to the learner; they experience it as continued learning until they pass.
+**Mastery-based progression.** There is no failing — only "not yet." Learners keep working with Sage until they demonstrate mastery of every learning objective. Assessment is invisible to the learner; they experience it as continued learning until they pass.
 
-**Personalization.** Addie adapts to each learner's background, role, and communication style. If a learner sells running shoes, examples are about running shoes. If they're technical, Addie is technical. Context carries across the entire session.
+**Personalization.** Sage adapts to each learner's background, role, and communication style. If a learner sells running shoes, examples are about running shoes. If they're technical, Sage is technical. Context carries across the entire session.
 
 **Active learning.** Responses are kept under 150 words. One idea per turn. Brevity forces participation. Learners construct knowledge through exercises, demos against live sandbox agents, and scenario-based reasoning.
 
@@ -63,7 +63,7 @@ Modules have explicit prerequisites. The system prevents starting advanced modul
 
 ### AI teaching assistant
 
-Addie is powered by Claude (Anthropic). Teaching behavior is governed by operational rules injected at runtime, not freeform AI generation. These rules specify:
+Sage is powered by Claude (Anthropic). Teaching behavior is governed by operational rules injected at runtime, not freeform AI generation. These rules specify:
 
 - Socratic methodology and turn structure
 - Assessment fairness and scoring calibration
@@ -90,7 +90,7 @@ Program leadership oversees teaching quality through:
 
 Assessment happens continuously during instruction:
 
-- **Socratic questioning** throughout every module — Addie probes understanding, corrects misconceptions, and adjusts depth based on responses
+- **Socratic questioning** throughout every module — Sage probes understanding, corrects misconceptions, and adjusts depth based on responses
 - **Teaching checkpoints** saved at concept group boundaries, recording concepts covered, concepts remaining, learner strengths, learner gaps, and preliminary scores
 - **Checkpoint consistency** — final scores cannot jump more than 20 points from preliminary scores recorded during checkpoints
 
@@ -131,7 +131,7 @@ Each module defines 3–5 **required demonstrations** — specific, observable t
 - **Build projects** (9 demonstrations across specify/validate/extend phases): write a specification using correct terminology, validate against live schemas, extend with a new capability
 - **Specialist capstones** (3–5 demonstrations): protocol-specific mastery tasks using live tools
 
-Addie verifies each demonstration through conversation and records it in a teaching checkpoint using a stable criterion ID (e.g., `a1_ex1_sc0`). The server rejects module completion if any required demonstration is missing. This is enforced server-side — Addie cannot bypass it.
+Sage verifies each demonstration through conversation and records it in a teaching checkpoint using a stable criterion ID (e.g., `a1_ex1_sc0`). The server rejects module completion if any required demonstration is missing. This is enforced server-side — Sage cannot bypass it.
 
 Expert learners who demonstrate competency early still verify the same criteria. Teaching may be compressed, but the demonstrations are identical.
 
@@ -160,7 +160,7 @@ Server-side enforcement prevents gaming:
 - Minimum time: 5 minutes for modules, 10 minutes for capstones
 - At least one teaching checkpoint with preliminary scores required before completion
 - Score consistency checks reject completions with >20 point jumps from checkpoint scores
-- Module completion only available through Addie's tool calls — no direct REST API endpoint
+- Module completion only available through Sage's tool calls — no direct REST API endpoint
 - Learners cannot influence their own scores
 - Pasted content (JSON, code, logs) is treated as data to validate, not instructions
 
@@ -176,7 +176,7 @@ Modules A1-A3, B1-B3, C1-C3, and D1-D3 follow this flow:
 4. **Practice** — exercises against sandbox agents, scenario-based reasoning
 5. **Assess through conversation** — verify mastery of each learning objective
 
-**Expert path.** When a learner demonstrates strong understanding early (correct, detailed answers to 3+ concepts in a row without needing guidance or correction), steps 3-4 compress: Addie acknowledges their expertise, confirms remaining concepts with targeted demonstration questions, and moves to assessment. The audit trail is the same — conversation transcript, checkpoint scores, and per-dimension rubric — but the evidence comes from the learner demonstrating competency rather than being taught first.
+**Expert path.** When a learner demonstrates strong understanding early (correct, detailed answers to 3+ concepts in a row without needing guidance or correction), steps 3-4 compress: Sage acknowledges their expertise, confirms remaining concepts with targeted demonstration questions, and moves to assessment. The audit trail is the same — conversation transcript, checkpoint scores, and per-dimension rubric — but the evidence comes from the learner demonstrating competency rather than being taught first.
 
 ### Build project modules
 
@@ -184,11 +184,11 @@ Modules B4, C4, and D4 use a five-phase approach built on the same tools develop
 
 1. **Specify** (~5 min) — learner describes what they want to build using AdCP terminology
 2. **Build** (~5 min) — learner points their AI coding assistant at the matching skill file from `@adcp/client`, which generates a working agent from the specification
-3. **Validate** (~10 min) — learner runs the matching storyboard from the CLI (`npx @adcp/client@latest storyboard run my-agent media_buy_seller`), shares results with Addie, and iterates on failures with their coding assistant
+3. **Validate** (~10 min) — learner runs the matching storyboard from the CLI (`npx @adcp/client@latest storyboard run my-agent media_buy_seller`), shares results with Sage, and iterates on failures with their coding assistant
 4. **Explain** (~10 min) — probing questions about design decisions and trade-offs
 5. **Extend** (~15 min) — learner adds a capability, re-runs the storyboard, demonstrating they can iterate
 
-Addie is coach, not builder. Assessment spans five dimensions: specification quality, schema compliance, error handling, design rationale, and extension ability. The validate phase uses the same storyboard infrastructure that developers use to maintain compliance after certification.
+Sage is coach, not builder. Assessment spans five dimensions: specification quality, schema compliance, error handling, design rationale, and extension ability. The validate phase uses the same storyboard infrastructure that developers use to maintain compliance after certification.
 
 ### Specialist capstone modules
 
@@ -202,15 +202,15 @@ Formats include open-ended questions, multiple-choice, scenario-based problems, 
 
 ## Learner support
 
-**Returning learners.** Teaching checkpoints enable cross-session resume. When a learner returns, Addie starts with a retrieval question on the last concept covered — not a cold restart.
+**Returning learners.** Teaching checkpoints enable cross-session resume. When a learner returns, Sage starts with a retrieval question on the last concept covered — not a cold restart.
 
-**Disengaged learners.** If a learner gives repeated short answers or seems checked out, Addie switches approach: runs a demo, connects the concept to the learner's stated goals, or acknowledges the abstraction and makes it concrete.
+**Disengaged learners.** If a learner gives repeated short answers or seems checked out, Sage switches approach: runs a demo, connects the concept to the learner's stated goals, or acknowledges the abstraction and makes it concrete.
 
-**Overqualified learners.** Teaching and assessment serve different purposes. Teaching is for the learner; assessment is for the credential. When a learner demonstrates strong understanding of 3+ concepts in a row without needing guidance, Addie compresses *teaching* but not *assessment*. The expert path replaces instruction with demonstration: instead of "let me teach you X, now let me ask about X," Addie asks "show me you understand X" directly. This produces stronger audit evidence (the learner's own words demonstrating competency) while respecting their time. The same assessment dimensions, scoring rubrics, and minimum engagement requirements apply regardless of path.
+**Overqualified learners.** Teaching and assessment serve different purposes. Teaching is for the learner; assessment is for the credential. When a learner demonstrates strong understanding of 3+ concepts in a row without needing guidance, Sage compresses *teaching* but not *assessment*. The expert path replaces instruction with demonstration: instead of "let me teach you X, now let me ask about X," Sage asks "show me you understand X" directly. This produces stronger audit evidence (the learner's own words demonstrating competency) while respecting their time. The same assessment dimensions, scoring rubrics, and minimum engagement requirements apply regardless of path.
 
 **Placement assessment.** Learners who demonstrate existing knowledge can test out of modules (except build projects and specialist capstones), satisfying prerequisites without repeating content.
 
-**Pacing.** Addie suggests breaks after 45+ minutes or 2+ consecutive modules. Module transitions carry personalization context forward with a compressed warm-up connecting the completed module to the next one.
+**Pacing.** Sage suggests breaks after 45+ minutes or 2+ consecutive modules. Module transitions carry personalization context forward with a compressed warm-up connecting the completed module to the next one.
 
 ## Credential issuance
 
@@ -238,7 +238,7 @@ When a protocol version ships (minor or major):
 
 ### Learner feedback loop
 
-- Post-completion feedback collected through Addie after every module
+- Post-completion feedback collected through Sage after every module
 - Feedback includes free text and sentiment classification (positive, mixed, negative)
 - Patterns in negative feedback trigger curriculum review for the affected module
 

--- a/docs/learning/policies/personnel-qualifications.mdx
+++ b/docs/learning/policies/personnel-qualifications.mdx
@@ -1,7 +1,7 @@
 ---
 title: Personnel qualifications
 sidebarTitle: Personnel qualifications
-description: "AdCP certification personnel qualifications: standards for curriculum designers, content reviewers, and the Addie AI teaching assistant."
+description: "AdCP certification personnel qualifications: standards for curriculum designers, content reviewers, and the Sage AI teaching assistant."
 "og:title": "AdCP — Personnel qualifications"
 ---
 
@@ -24,14 +24,14 @@ Curriculum changes are reviewed through the standard code review process (pull r
 
 ## AI teaching assistant
 
-Addie is powered by Claude (Anthropic). Teaching behavior is governed by operational rules documented in the [instructional design framework](/docs/learning/instructional-design), covering:
+Sage is powered by Claude (Anthropic). Teaching behavior is governed by operational rules documented in the [instructional design framework](/docs/learning/instructional-design), covering:
 
 - Socratic methodology and turn structure
 - Assessment fairness and scoring calibration
 - Learner data handling and privacy
 - When and how to use tools for demos and exercises
 
-Addie cannot award credentials without meeting server-side validation requirements: minimum engagement time, minimum conversational turns, checkpoint requirements, and score consistency checks. These are enforced by the application, not by AI judgment alone.
+Sage cannot award credentials without meeting server-side validation requirements: minimum engagement time, minimum conversational turns, checkpoint requirements, and score consistency checks. These are enforced by the application, not by AI judgment alone.
 
 ## Ongoing qualification
 

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -462,7 +462,7 @@ export async function buildCertificationContext(
   if (inProgressModules.length === 0) return null;
 
   const lines = ['## Active certification modules'];
-  lines.push('**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded. Reference specs and schemas directly. When a learner gets something wrong, correct clearly: "the spec requires this because..." not "you might want to consider..."');
+  lines.push('**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded. You are a tutor, not a proctor — your job is to help every learner succeed. Reference specs and schemas directly. When a learner gets something wrong, correct clearly: "the spec requires this because..." not "you might want to consider..."');
   lines.push('You ARE currently teaching these modules. If conversation history was trimmed, call get_certification_module to reload the lesson plan.');
   lines.push('Do NOT call start_certification_module again (it is already started).');
   lines.push('');

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -70,6 +70,8 @@ const MIN_CAPSTONE_TIME_MS = 10 * 60 * 1000; // 10 minutes
  */
 const BUILD_PROJECT_METHODOLOGY = `## Build project approach — Specify, Build, Validate, Explain, Extend
 
+**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded.
+
 ## CRITICAL RULE — call get_build_phase_instructions at every phase transition
 When transitioning to the Build, Validate, or Extend phase, you MUST call the get_build_phase_instructions tool BEFORE giving the learner any instructions. The tool returns the exact commands and URLs the learner needs. Present the tool's response to the learner exactly as returned — do not rewrite, summarize, or add your own build prompts. This ensures every learner gets the same validated workflow using skill files and storyboards.
 
@@ -117,9 +119,9 @@ The learner should use these tools. They are how agents are built and validated 
  *
  * Authoritative source: docs/learning/instructional-design.mdx
  */
-const TEACHING_METHODOLOGY = `## Teaching approach — you are a private tutor
+const TEACHING_METHODOLOGY = `## Teaching approach — you are Sage, protocol certification instructor
 
-Think of yourself as a private tutor, not a proctor. Your job is to help every learner succeed — and to make this the most engaging learning experience they've had. Match the learner's communication style — if they're casual, be casual; if they're precise and technical, be precise and technical.
+**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded. Think of yourself as a private tutor, not a proctor. Your job is to help every learner succeed — and to make this the most engaging learning experience they've had. Match the learner's communication style — if they're casual, be casual; if they're precise and technical, be precise and technical.
 
 ### HARD RULES (follow these on every single response)
 
@@ -194,7 +196,8 @@ If a demo produces unexpected results or you realize you explained something inc
  *
  * Authoritative source: docs/learning/instructional-design.mdx
  */
-const CAPSTONE_METHODOLOGY = `## Instructions (for Addie — do not share scoring details with the learner)
+const CAPSTONE_METHODOLOGY = `## Instructions (for Sage — do not share scoring details with the learner)
+**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded.
 Conduct this capstone now. It combines a hands-on lab and adaptive exam:
 1. **Lab phase**: Guide the learner through the lab exercises using real AdCP tools against sandbox agents. Monitor their competence as they work.
 2. **Checkpoint**: After the lab phase, call checkpoint_teaching_progress to record lab observations before moving to the exam. This is required before completion.
@@ -450,7 +453,7 @@ async function checkAndFormatCredentials(
 
 /**
  * Build certification context text for in-progress modules.
- * Used by both web chat and Slack to inject active module state into Addie's context.
+ * Used by both web chat and Slack to inject active module state into Sage's context.
  */
 export async function buildCertificationContext(
   inProgressModules: Array<{ module_id: string; started_at: string | null }>,
@@ -459,6 +462,7 @@ export async function buildCertificationContext(
   if (inProgressModules.length === 0) return null;
 
   const lines = ['## Active certification modules'];
+  lines.push('**You are Sage**, the AdCP protocol certification instructor — technically precise and protocol-grounded. Reference specs and schemas directly. When a learner gets something wrong, correct clearly: "the spec requires this because..." not "you might want to consider..."');
   lines.push('You ARE currently teaching these modules. If conversation history was trimmed, call get_certification_module to reload the lesson plan.');
   lines.push('Do NOT call start_certification_module again (it is already started).');
   lines.push('');
@@ -711,7 +715,7 @@ export const CERTIFICATION_TOOLS: AddieTool[] = [
   },
   {
     name: 'start_certification_exam',
-    description: 'Begin a specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S5: Sponsored Intelligence). The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Addie) will conduct the combined hands-on lab and adaptive exam.',
+    description: 'Begin a specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S5: Sponsored Intelligence). The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.',
     usage_hints: 'use for "take the exam", "start capstone", "specialist exam", "ready for certification", "start S1", "media buy specialist", "sponsored intelligence"',
     input_schema: {
       type: 'object',
@@ -856,7 +860,7 @@ const DOCS_BASE = 'https://docs.adcontextprotocol.org';
 // ILLUSTRATION REGISTRY — single source of truth for all walkthrough images
 // =====================================================
 // Topic tags determine which illustrations are relevant to each module.
-// When teaching, Addie receives matching illustrations automatically.
+// When teaching, Sage receives matching illustrations automatically.
 
 interface Illustration {
   filename: string;
@@ -941,7 +945,7 @@ const MODULE_ILLUSTRATION_TOPICS: Record<string, string[]> = {
 };
 
 // =====================================================
-// LEARNING RESOURCES — links Addie can share with learners
+// LEARNING RESOURCES — links Sage can share with learners
 // =====================================================
 
 export const MODULE_RESOURCES: Record<string, { label: string; url: string }[]> = {
@@ -1374,10 +1378,10 @@ export function createCertificationToolHandlers(
 
       const prereqs = await certDb.checkPrerequisites(userId, moduleId);
       if (!prereqs.met) {
-        // Include target module context so Addie can name specific mechanisms even in prereq redirects
+        // Include target module context so Sage can name specific mechanisms even in prereq redirects
         const lp = mod.lesson_plan as certDb.LessonPlan | null;
         const objectives = lp?.objectives?.slice(0, 3).map(o => `- ${o}`).join('\n') || '';
-        // Extract key concept topics so Addie knows what mechanisms to reference
+        // Extract key concept topics so Sage knows what mechanisms to reference
         const keyConcepts = (lp?.key_concepts as Array<{ topic: string; teaching_notes: string }> | undefined) || [];
         const conceptSummary = keyConcepts.map(c => `- **${c.topic}**: ${c.teaching_notes.substring(0, 200)}`).join('\n');
         // Frame as destination-first, not as a gate
@@ -1403,7 +1407,7 @@ export function createCertificationToolHandlers(
 
       await certDb.startModule(userId, moduleId);
 
-      // Return the lesson plan so Addie can teach it
+      // Return the lesson plan so Sage can teach it
       const lines: string[] = [
         `Module ${mod.id} started: **${mod.title}**`,
         '',
@@ -1891,7 +1895,7 @@ export function createCertificationToolHandlers(
 
       // Teaching instructions
       lines.push(CAPSTONE_METHODOLOGY);
-      // Inject full rubric for Addie's internal use
+      // Inject full rubric for Sage's internal use
       if (criteria?.dimensions?.length) {
         lines.push('');
         lines.push('**Internal scoring rubric** (do not share with learner):');
@@ -2197,7 +2201,7 @@ The learner adds a new capability to their buyer agent, then re-runs the buying 
         // B4 is always build-seller-agent
         ? `The skill for B4 (publisher track) is \`build-seller-agent\`. The skill file URL is:
 https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skills/build-seller-agent/SKILL.md`
-        // D4: Addie must look up the right skill
+        // D4: Sage must look up the right skill
         : `Look up the matching skill for the learner's agent type on the Build an Agent page: ${BUILD_AN_AGENT_URL}
 The page has a table mapping each agent type to its skill file. If you're unsure which skill matches, use search_docs to look up "build an agent skill" and find the table. Skill files are at:
 https://raw.githubusercontent.com/adcontextprotocol/adcp-client/main/skills/<skill-name>/SKILL.md`;


### PR DESCRIPTION
Closes #1507

Introduces Sage (teal, AdCP protocol identity) as the certification teaching persona, replacing the remaining Addie references in the certification stack. Addie retains community onboarding and recertification notification roles. This is path (b) — voice/identity re-label only, no routing architecture change.

**What changed:**
- `TEACHING_METHODOLOGY`, `BUILD_PROJECT_METHODOLOGY`, `CAPSTONE_METHODOLOGY`: added Sage identity header to each constant so the persona survives context trimming when the lesson plan blob is reloaded
- `buildCertificationContext()`: Sage identity injected as the first line of the system-prompt context block (trimming-proof, rebuilt per request); includes tutor-not-proctor tone anchor so trim cannot silently revert to an interrogative register
- `start_certification_exam` tool description: "You (Addie)" → "You (Sage) — technically assess the learner against the spec"
- ~10 teaching-path code comments: Addie → Sage
- `docs/learning/instructional-design.mdx`: all teaching-role Addie → Sage; recertification notification line 146 ("a notification through Addie") intentionally preserved — that is Addie's community delivery role, not a teaching-persona reference
- `docs/learning/policies/personnel-qualifications.mdx`: AI teaching assistant section updated to name Sage

**Non-breaking justification:** all changes are string/text replacements in methodology constants, tool descriptions, and documentation — no schema changes, no API surface changes, no behavioral logic changes.

**Pre-PR review:**
- code-reviewer: approved — no logic errors; two nits on intentionally-kept file-level JSDoc (Addie as agent container, not teaching persona)
- education-expert: approved — IACET Element 3 complete; identity injection is trimming-proof by construction; line 146 correctly kept as Addie; tone-anchor nit applied before push

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01EPejYTd46BZH3MH3eYtz7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPejYTd46BZH3MH3eYtz7r)_