### PR TITLE
test(member-tools): regression coverage for proposer edit-button + co-author add (#2569)

### DIFF
--- a/.changeset/regression-tests-2569-proposer-coauthor.md
+++ b/.changeset/regression-tests-2569-proposer-coauthor.md
@@ -1,0 +1,14 @@
+---
+---
+
+test(member-tools): regression coverage for proposer edit-button and co-author add flow (#2569)
+
+Adds 10 integration tests to `server/tests/integration/content-my-content.test.ts` covering the two bugs fixed in PR #2241:
+
+1. **Proposer relationship in `GET /api/me/content`** — verifies that a user who is only the proposer (no `content_authors` row) sees `relationships: ['proposer']`, which drives the `canEdit` check in `admin-content.html`. Without this the Edit button disappears after first save.
+
+2. **Co-author add/remove via `POST`/`DELETE /api/me/content/:id/authors`** — happy path with DB verification, 400 on missing `user_id` (the original bug), 400 on missing `display_name`, 403 non-owner, upsert deduplication with `display_order` preservation, proposer-removes success, co-author-cannot-delete 403, and 404 for a missing `authorId`.
+
+Also adds a user-existence check to `POST /api/me/content/:id/authors` before the `INSERT` to prevent a Postgres FK violation from surfacing as 500 when a non-existent `user_id` is submitted. Returns 400 with a clear message instead.
+
+Refs #2569.

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -1803,6 +1803,18 @@ export function createMyContentRouter(): Router {
         });
       }
 
+      // Verify the target user exists — prevents FK violation from surfacing as 500
+      const userCheck = await pool.query(
+        `SELECT 1 FROM users WHERE workos_user_id = $1`,
+        [user_id]
+      );
+      if (userCheck.rows.length === 0) {
+        return res.status(400).json({
+          error: 'User not found',
+          message: `No account found for user_id: ${user_id}. Only people with a public AAO profile can be added as co-authors.`,
+        });
+      }
+
       // Get current max display_order
       const orderResult = await pool.query(
         `SELECT COALESCE(MAX(display_order), -1) + 1 as next_order

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -564,6 +564,213 @@ describe('My Content — body, admin scope, status, delete', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // #2569 — proposer relationship in GET /api/me/content (edit-button fix)
+  //
+  // After saving, a user's relationship can resolve to only `proposer` (no
+  // content_authors row). The canEdit check in admin-content.html must see
+  // `relationships.includes('proposer')` or the Edit button disappears.
+  // ---------------------------------------------------------------------------
+
+  describe('GET /api/me/content — proposer relationship (#2569)', () => {
+    it('includes "proposer" in relationships when user is only the proposer (no content_authors row)', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-proposer-rel',
+        title: 'Proposer only',
+        proposerUserId: USER_ID,
+      });
+
+      const response = await request(app).get('/api/me/content').expect(200);
+      const item = response.body.items.find((i: any) => i.id === id);
+      expect(item).toBeDefined();
+      // Positive exhaustive assertion: a proposer-only user has exactly ['proposer']
+      expect(item.relationships).toEqual(['proposer']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #2569 — co-author add/remove via POST/DELETE /api/me/content/:id/authors
+  //
+  // Original bug: the form POSTed { display_name } only; the endpoint requires
+  // both user_id and display_name and returned 400. Fixed in PR #2241.
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/me/content/:id/authors (#2569)', () => {
+    it('adds a co-author and persists the DB row when user_id + display_name provided', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-add',
+        title: 'Co-author add',
+        proposerUserId: USER_ID,
+      });
+
+      const response = await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: OTHER_USER_ID, display_name: 'Other User' })
+        .expect(201);
+
+      expect(response.body.user_id).toBe(OTHER_USER_ID);
+      expect(response.body.display_name).toBe('Other User');
+
+      const db = await pool.query(
+        `SELECT user_id, display_name FROM content_authors WHERE perspective_id = $1 AND user_id = $2`,
+        [id, OTHER_USER_ID]
+      );
+      expect(db.rows).toHaveLength(1);
+      expect(db.rows[0].display_name).toBe('Other User');
+    });
+
+    it('returns 400 with a message naming user_id when user_id is missing (regression for original bug)', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-no-userid',
+        title: 'Co-author missing user_id',
+        proposerUserId: USER_ID,
+      });
+
+      const response = await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ display_name: 'Name Only' })
+        .expect(400);
+
+      expect(response.body.message).toMatch(/user_id/i);
+    });
+
+    it('returns 400 when display_name is missing', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-no-displayname',
+        title: 'Co-author missing display_name',
+        proposerUserId: USER_ID,
+      });
+
+      const response = await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: OTHER_USER_ID })
+        .expect(400);
+
+      expect(response.body.message).toMatch(/display_name/i);
+    });
+
+    it('returns 403 when the requester is neither proposer nor lead nor admin', async () => {
+      // OTHER_USER_ID owns this perspective; USER_ID is unrelated (not proposer, not lead, not admin)
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-forbidden',
+        title: 'Co-author forbidden',
+        proposerUserId: OTHER_USER_ID,
+      });
+
+      // authState defaults to USER_ID from beforeEach — confirmed neither proposer nor lead
+      adminState.isAdmin = false;
+      await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: USER_ID, display_name: 'Mary Content' })
+        .expect(403);
+    });
+
+    it('upserts cleanly: adding the same user_id twice results in one row with the latest display_name', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-upsert',
+        title: 'Co-author upsert',
+        proposerUserId: USER_ID,
+      });
+
+      await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: OTHER_USER_ID, display_name: 'First Name' })
+        .expect(201);
+
+      await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: OTHER_USER_ID, display_name: 'Updated Name' })
+        .expect(201);
+
+      const db = await pool.query(
+        `SELECT display_name, display_order FROM content_authors WHERE perspective_id = $1 AND user_id = $2`,
+        [id, OTHER_USER_ID]
+      );
+      expect(db.rows).toHaveLength(1);
+      expect(db.rows[0].display_name).toBe('Updated Name');
+      // display_order is set on insert only — upsert must not reset it to the incremented value
+      expect(db.rows[0].display_order).toBe(0);
+    });
+
+    it('returns 400 when user_id is not a known account (prevents FK 500)', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-unknown-user',
+        title: 'Co-author unknown user',
+        proposerUserId: USER_ID,
+      });
+
+      const response = await request(app)
+        .post(`/api/me/content/${id}/authors`)
+        .send({ user_id: 'nonexistent-workos-user-xyz', display_name: 'Ghost' })
+        .expect(400);
+
+      expect(response.body.error).toBe('User not found');
+      expect(response.body.message).toMatch(/No account found/i);
+    });
+  });
+
+  describe('DELETE /api/me/content/:id/authors/:authorId (#2569)', () => {
+    it('removes the co-author row and returns deleted user_id when called by the proposer', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-remove',
+        title: 'Co-author remove',
+        proposerUserId: USER_ID,
+      });
+
+      // Seed a co-author row directly so we can test deletion independently of POST
+      await pool.query(
+        `INSERT INTO content_authors (perspective_id, user_id, display_name, display_order)
+         VALUES ($1, $2, 'To Remove', 0)`,
+        [id, OTHER_USER_ID]
+      );
+
+      const response = await request(app)
+        .delete(`/api/me/content/${id}/authors/${OTHER_USER_ID}`)
+        .expect(200);
+
+      expect(response.body.deleted).toBe(OTHER_USER_ID);
+
+      const db = await pool.query(
+        `SELECT user_id FROM content_authors WHERE perspective_id = $1 AND user_id = $2`,
+        [id, OTHER_USER_ID]
+      );
+      expect(db.rows).toHaveLength(0);
+    });
+
+    it('returns 403 when a co-author (not the proposer) tries to remove someone', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-delete-forbidden',
+        title: 'Co-author delete forbidden',
+        proposerUserId: OTHER_USER_ID, // OTHER_USER is proposer
+      });
+
+      // USER_ID is just a co-author, not the proposer
+      await pool.query(
+        `INSERT INTO content_authors (perspective_id, user_id, display_name, display_order)
+         VALUES ($1, $2, 'Mary Content', 0)`,
+        [id, USER_ID]
+      );
+
+      // authState is USER_ID per beforeEach; USER_ID is NOT proposer/lead/admin here
+      adminState.isAdmin = false;
+      await request(app)
+        .delete(`/api/me/content/${id}/authors/${OTHER_USER_ID}`)
+        .expect(403);
+    });
+
+    it('returns 404 when the authorId does not exist on the content', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-coauthor-delete-missing',
+        title: 'Co-author delete missing',
+        proposerUserId: USER_ID,
+      });
+
+      await request(app)
+        .delete(`/api/me/content/${id}/authors/nonexistent-user-id`)
+        .expect(404);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // #2539 — review modal needs enough fields to actually review a submission
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Refs #2569

Both bugs fixed in PR #2241 (merged Apr 16) lacked integration test coverage — easy to regress. This PR adds 10 test cases and one route guard to the existing vitest+supertest suite.

## What changed

**`server/tests/integration/content-my-content.test.ts`** — 10 new test cases in three new `describe` blocks:

- **Proposer relationship (`GET /api/me/content`):** A user who is only the `proposer` (no `content_authors` row) gets `relationships: ['proposer']` exclusively. This is the exact condition that made the Edit button disappear after first save — the `canEdit` check in `admin-content.html` needs `'proposer'` in the array.

- **Co-author add (`POST /api/me/content/:id/authors`):** Happy path with DB verification, 400 on missing `user_id` (the original bug regression guard), 400 on missing `display_name`, 403 non-owner, upsert deduplication asserting `display_name` updated and `display_order` preserved (not reset on second insert).

- **Co-author remove (`DELETE /api/me/content/:id/authors/:authorId`):** Proposer-removes success with `deleted` field check + DB row gone; 403 co-author-not-proposer; 404 missing `authorId`.

**`server/src/routes/content.ts`** — user-existence check before `INSERT INTO content_authors`: a non-existent `user_id` now returns 400 with "No account found for user_id: …" instead of a Postgres FK violation surfacing as 500. Non-breaking additive validation.

## Non-breaking justification

Test additions are additive. The route guard is additive input validation — callers supplying a valid `user_id` (i.e., all correct clients) are unaffected; only previously-500-returning invalid requests now return 400.

## Pre-PR review

- **code-reviewer:** approved (1 nit noted — `user_id` echoed in error message without length validation; low-severity in JSON context, tracked as a follow-up)
- **internal-tools-strategist:** approved — test coverage is proportionate to launch-quality bar; route guard closes the FK 500 gap flagged as a Mary-launch concern

## Known gaps (out of scope for this PR)

- The client-side autocomplete wiring (`admin-content.html:searchCoauthors`) is not covered — testing that would require Playwright. The 400 guard on missing `user_id` is the correct server-side backstop.
- `POST /api/me/content/:id/authors` does not test the 404 path (non-existent content `id`). Tracked as a future gap.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01CiDo7DVzNYNnAYNN6qoZi5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiDo7DVzNYNnAYNN6qoZi5)_