### PR TITLE
feat(addie): dark mode support for web chat interface

### DIFF
--- a/.changeset/dark-mode-addie-chat.md
+++ b/.changeset/dark-mode-addie-chat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add dark mode support to the Addie web chat interface. The design system now includes a `@media (prefers-color-scheme: dark)` token override block plus `html[data-theme="dark|light"]` attribute selectors for manual preference. chat.html respects the system preference automatically and exposes a sun/moon toggle button in the chat header that persists the choice to localStorage. Inline ad creative containers intentionally remain white (third-party content has its own contrast model).

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -8,9 +8,11 @@
   <!-- Runs before CSS to apply stored theme and avoid flash of wrong theme -->
   <script>
     (function () {
-      var stored = localStorage.getItem('addie-theme');
-      var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-      document.documentElement.setAttribute('data-theme', theme);
+      try {
+        var stored = localStorage.getItem('addie-theme');
+        var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) { /* localStorage unavailable (Safari private / sandboxed iframe) */ }
     })();
   </script>
   <link rel="stylesheet" href="/design-system.css">
@@ -2560,7 +2562,7 @@
           Ask Addie
         </h1>
         <p>Your AI guide to agentic advertising</p>
-        <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Switch to dark mode">
+        <button type="button" class="dark-mode-toggle" id="darkModeToggle">
           <!-- moon icon — shown in light mode -->
           <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
@@ -2708,8 +2710,9 @@
 
       function syncDarkModeToggle() {
         if (!darkModeToggle) return;
-        darkModeToggle.setAttribute('aria-label', getDarkModeAriaLabel());
-        darkModeToggle.setAttribute('title', getDarkModeAriaLabel());
+        var label = getDarkModeAriaLabel();
+        darkModeToggle.setAttribute('aria-label', label);
+        darkModeToggle.setAttribute('title', label);
       }
 
       if (darkModeToggle) {

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ask Addie - AgenticAdvertising.org</title>
   <link rel="icon" type="image/svg+xml" href="/addie-icon.svg">
+  <!-- Runs before CSS to apply stored theme and avoid flash of wrong theme -->
+  <script>
+    (function () {
+      var stored = localStorage.getItem('addie-theme');
+      var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -17,7 +25,7 @@
 
     body {
       font-family: var(--font-family-sans);
-      background: #fff;
+      background: var(--color-surface);
       color: var(--color-text);
       height: 100vh;
       overflow: hidden;
@@ -36,31 +44,40 @@
       position: relative;
     }
 
-    /* Chat header — hidden in welcome state, shown during conversation */
+    /* Chat header — minimal bar in welcome state (shows dark mode toggle);
+       expands to full identity header once messages are present */
     .chat-header {
-      display: none;
-      text-align: center;
-      padding: var(--space-3) 16px;
-      border-bottom: 1px solid var(--color-border);
-      background: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: var(--space-3) 0;
+      background: var(--color-surface);
       margin: 0 -16px;
       padding-left: 32px;
       padding-right: 32px;
-    }
-
-    .chat-container.has-messages .chat-header {
-      display: block;
+      position: relative;
     }
 
     .chat-header h1 {
+      display: none;
       font-size: 16px;
       font-weight: 600;
       color: var(--color-text-heading);
       margin: 0;
-      display: flex;
       align-items: center;
       justify-content: center;
       gap: 8px;
+    }
+
+    .chat-container.has-messages .chat-header {
+      display: flex;
+      text-align: center;
+      justify-content: center;
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    .chat-container.has-messages .chat-header h1 {
+      display: flex;
     }
 
     .chat-header h1 .addie-avatar {
@@ -266,7 +283,8 @@
       border-top: 1px solid var(--color-border);
     }
 
-    /* Inline HTML creative container */
+    /* Inline HTML creative container — white is intentional: ad creative HTML has
+       its own contrast model and must not be dark-themed by the host page */
     .message-content .creative-html-container {
       margin: 12px 0;
       border-radius: 8px;
@@ -460,7 +478,7 @@
     .chat-input-container {
       padding: 16px 0 20px;
       border-top: 1px solid var(--color-border);
-      background: #fff;
+      background: var(--color-surface);
     }
 
     /* Welcome state — everything centers as one cluster, offset slightly above true center */
@@ -2382,6 +2400,46 @@
         padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
       }
     }
+
+    /* Dark mode toggle button */
+    .dark-mode-toggle {
+      background: none;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-full);
+      width: 34px;
+      height: 34px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--color-text-secondary);
+      transition: background 0.2s, border-color 0.2s, color 0.2s;
+      flex-shrink: 0;
+    }
+
+    .dark-mode-toggle:hover {
+      background: var(--color-bg-subtle);
+      border-color: var(--color-border-strong);
+      color: var(--color-text);
+    }
+
+    /* In conversation state the toggle sits at the right edge of the header */
+    .chat-container.has-messages .dark-mode-toggle {
+      position: absolute;
+      right: 32px;
+    }
+
+    /* Icon visibility — sun shows in dark mode, moon in light mode */
+    .dark-mode-toggle .icon-sun { display: none; }
+    .dark-mode-toggle .icon-moon { display: block; }
+
+    html[data-theme="dark"] .dark-mode-toggle .icon-sun { display: block; }
+    html[data-theme="dark"] .dark-mode-toggle .icon-moon { display: none; }
+
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme="light"]) .dark-mode-toggle .icon-sun { display: block; }
+      html:not([data-theme="light"]) .dark-mode-toggle .icon-moon { display: none; }
+    }
   </style>
 </head>
 <body>
@@ -2502,6 +2560,24 @@
           Ask Addie
         </h1>
         <p>Your AI guide to agentic advertising</p>
+        <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Switch to dark mode" title="Switch to dark mode">
+          <!-- moon icon — shown in light mode -->
+          <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+          <!-- sun icon — shown in dark mode -->
+          <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </button>
       </div>
 
       <button class="video-call-btn" id="videoCallBtn" title="Video chat with Addie">
@@ -2620,6 +2696,40 @@
       const siModalMessages = document.getElementById('siModalMessages');
       const siModalInput = document.getElementById('siModalInput');
       const siModalSend = document.getElementById('siModalSend');
+
+      // Dark mode toggle
+      const darkModeToggle = document.getElementById('darkModeToggle');
+
+      function getDarkModeAriaLabel() {
+        return document.documentElement.getAttribute('data-theme') === 'dark'
+          ? 'Switch to light mode'
+          : 'Switch to dark mode';
+      }
+
+      function syncDarkModeToggle() {
+        if (!darkModeToggle) return;
+        darkModeToggle.setAttribute('aria-label', getDarkModeAriaLabel());
+        darkModeToggle.setAttribute('title', getDarkModeAriaLabel());
+      }
+
+      if (darkModeToggle) {
+        syncDarkModeToggle();
+        darkModeToggle.addEventListener('click', function () {
+          var html = document.documentElement;
+          var current = html.getAttribute('data-theme');
+          var next = current === 'dark' ? 'light' : 'dark';
+          html.setAttribute('data-theme', next);
+          try { localStorage.setItem('addie-theme', next); } catch (e) { /* private browsing */ }
+          syncDarkModeToggle();
+        });
+      }
+
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+        if (!localStorage.getItem('addie-theme')) {
+          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+          syncDarkModeToggle();
+        }
+      });
 
       // Video elements
       const videoCallBtn = document.getElementById('videoCallBtn');

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -2134,3 +2134,76 @@ body {
     height: calc(60px + var(--safe-area-inset-top));
   }
 }
+
+/* =============================================================================
+   14. DARK MODE TOKENS
+
+   Overrides semantic aliases for dark mode. Raw palette values are unchanged;
+   only semantic aliases are remapped so any component using var(--color-*)
+   responds automatically.
+
+   Two mechanisms:
+   1. @media (prefers-color-scheme: dark) — follows OS system preference
+   2. html[data-theme="dark|light"] — explicit user override; attribute selector
+      specificity (0,1,1) beats :root (0,1,0) so it wins over the media query
+
+   Brand note: --color-brand maps to primary-400 (#6b8cef) in dark mode.
+   This colour achieves ~4:1 on dark card surfaces (slightly below 4.5:1 WCAG AA
+   for small body text, above 3:1 for non-text). Links and icon buttons meet
+   non-text contrast. Reviewers should verify any link-heavy dark-mode surface.
+   ============================================================================= */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-text: #f9fafb;
+    --color-text-secondary: #d1d5db;
+    --color-text-muted: #9ca3af;
+    --color-text-heading: #f9fafb;
+    --color-border: #374151;
+    --color-border-strong: #4b5563;
+    --color-bg-page: #111827;
+    --color-bg-subtle: #1f2937;
+    --color-bg-card: #1f2937;
+    --color-surface: #1f2937;
+    --color-surface-raised: #374151;
+    --color-brand: #6b8cef;
+    --color-brand-hover: #8aa3f4;
+    --color-brand-bg: rgba(107, 140, 239, 0.1);
+  }
+}
+
+/* html[data-theme] — explicit user preference; beats @media :root by specificity */
+
+html[data-theme="dark"] {
+  --color-text: #f9fafb;
+  --color-text-secondary: #d1d5db;
+  --color-text-muted: #9ca3af;
+  --color-text-heading: #f9fafb;
+  --color-border: #374151;
+  --color-border-strong: #4b5563;
+  --color-bg-page: #111827;
+  --color-bg-subtle: #1f2937;
+  --color-bg-card: #1f2937;
+  --color-surface: #1f2937;
+  --color-surface-raised: #374151;
+  --color-brand: #6b8cef;
+  --color-brand-hover: #8aa3f4;
+  --color-brand-bg: rgba(107, 140, 239, 0.1);
+}
+
+html[data-theme="light"] {
+  --color-text: #1d1d1d;
+  --color-text-secondary: #6b7280;
+  --color-text-muted: #9ca3af;
+  --color-text-heading: #2d3748;
+  --color-border: #e5e7eb;
+  --color-border-strong: #d1d5db;
+  --color-bg-page: #f3f4f6;
+  --color-bg-subtle: #f9fafb;
+  --color-bg-card: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-raised: #ffffff;
+  --color-brand: #1a36b4;
+  --color-brand-hover: #2d4fd6;
+  --color-brand-bg: #eef4fc;
+}


### PR DESCRIPTION
Closes #2061

Adds OS-level dark mode (`prefers-color-scheme: dark`) and an optional manual sun/moon toggle to the Addie chat page. The toggle persists preference to `localStorage` and survives page reloads. An inline IIFE in `<head>` sets `data-theme` on `<html>` before the stylesheet loads, preventing the flash-of-wrong-theme.

**Non-breaking justification:** Purely additive CSS/JS — no API surface, schema, or protocol change. Existing light-mode users are unaffected; the dark-mode branch is opt-in via system preference or toggle.

**What changed:**

- `server/public/design-system.css` — appends Section 14 (Dark Mode Tokens): a `@media (prefers-color-scheme: dark)` block and `html[data-theme="dark|light"]` attribute overrides. Attribute-selector specificity `(0,1,1)` beats `:root` `(0,1,0)` so the manual toggle wins over the media query.
- `server/public/chat.html`:
  - Three hardcoded `#fff`/`white` backgrounds replaced with `var(--color-surface)` on `body`, `.chat-header`, and `.chat-input-container`.
  - `.creative-html-container` intentionally keeps `background: white` (ad creative HTML has its own contrast model; host page must not theme it).
  - `.chat-header` is now always `display: flex` with `h1` hidden in welcome state, revealing only the toggle button. `position: relative` added so the absolutely-positioned toggle in conversation mode is anchored to the header, not the grandparent container.
  - Dark mode toggle button (`type="button"`) added inside `.chat-header` with moon/sun SVG icons. `aria-label` and `title` are set by JS on first run (not static HTML) so the label is always correct regardless of system preference at page load.
  - Anti-FOUC IIFE in `<head>` wrapped in `try/catch` — `localStorage` throws `SecurityError` in Safari private browsing and sandboxed iframes.
  - System preference change listener updates the toggle if no explicit `localStorage` preference is stored.
- `.changeset/dark-mode-addie-chat.md` — empty changeset (no protocol bump; UI/server only).

**Brand color note:** `--color-brand` maps to `#6b8cef` (primary-400) in dark mode, achieving ~4:1 contrast on dark card surfaces. This is slightly below WCAG AA 4.5:1 for small body-text links; it clears the 3:1 non-text threshold for icon buttons. Reviewer should verify any link-heavy dark-mode surface and decide whether to bump to primary-300 for links specifically.

**Build note:** `npm run build` fails on `tsc --project server/tsconfig.json` due to a pre-existing environment issue (`@types/node` not installed in CI/local env). The error is in unrelated server source files (`posthog.ts`, `url-security.ts`) — none touched by this PR. CSS/HTML changes are not subject to TypeScript compilation.

**Pre-PR review:**
- internal-tools-strategist: approved — merged duplicate `.chat-header h1` rules (specificity ordering bug); added `position: relative` to `.chat-header`; `creative-html-container` correctly stays white
- code-reviewer: approved after two blockers fixed — `localStorage.getItem` wrapped in try/catch in anti-FOUC IIFE; `type="button"` added to toggle; static `aria-label` removed from HTML (JS sets it on first run); `getDarkModeAriaLabel()` deduplicated in `syncDarkModeToggle`

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 3402` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Hy98mBnRgXX71aNyqzMF1E