### PR TITLE
feat(lint): extend platform-agnostic check to enum/const values

### DIFF
--- a/.changeset/add-enum-const-platform-agnostic-lint.md
+++ b/.changeset/add-enum-const-platform-agnostic-lint.md
@@ -1,5 +1,5 @@
 ---
-"adcontextprotocol": patch
+"adcontextprotocol": minor
 ---
 
 Extend `check:platform-agnostic` lint to cover enum and const values; fix `brand.json` platform-agnosticism violation.

--- a/.changeset/add-enum-const-platform-agnostic-lint.md
+++ b/.changeset/add-enum-const-platform-agnostic-lint.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+Extend `check:platform-agnostic` lint to cover enum and const values; fix `brand.json` platform-agnosticism violation.
+
+**Lint extension (`tests/check-platform-agnostic.cjs`):** adds enum/const-value scanning alongside the existing property-name check. Uses a path-qualified `ENUM_VALUE_ALLOWLIST` so the same vendor token can be legitimate in one enum (e.g., `roku` in `enums/genre-taxonomy.json`) but a violation in another. Pre-compiles vendor-token regexes. Skips `examples` arrays (user-data samples, not normative definitions). Title/description text intentionally excluded — vendor names in prose are permitted per spec-guidelines.
+
+**Schema fix (`static/schemas/source/brand.json`):** removes the single-value enum `["openai_agentic_checkout_v1"]` from `product_catalog.agentic_checkout.spec` and replaces it with a free-form `string`. The enum encoded a specific vendor's checkout API version as a normative discriminator, violating the platform-agnosticism rule in `docs/spec-guidelines.md`. Non-breaking: existing data using `"openai_agentic_checkout_v1"` remains valid.
+
+**Note:** `openai_product_feed` in `brand.json`'s `feed_format` enum is contested (see #2439): one expert treats it as a violation; another treats it as a canonical feed-schema identifier parallel to `google_merchant_center`. It is allowlisted pending @bokelley's decision.
+
+Closes #2439.

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -222,11 +222,11 @@ Names that reference **canonical external identifier spaces** are legitimate in 
 Existing examples of legitimate patterns:
 
 - Distribution-platform identifier types: `amazon_music_id`, `roku_channel_id` in `distribution-identifier-type.json` (enum values)
-- Feed formats: `google_merchant_center`, `facebook_catalog`, `openai_product_feed` in `brand.json` (enum values)
+- Feed formats: `google_merchant_center`, `facebook_catalog` in `brand.json` (enum values) — widely-adopted open interchange formats
 - Measurement/data identifiers: `nielsen_dma` in `get-adcp-capabilities-response` (field name)
 - Platform IDs: `apple_podcast_id`, `apple_id` (field names)
 
-The rule to apply: if the name asks "which vendor-equivalent version of something AdCP models?" (bad — use `ext`), reject; if the name asks "which externally-defined system/format/identifier space?" (legitimate), allow. When allowing a field name, add it to `tests/check-platform-agnostic.cjs` `FIELD_ALLOWLIST` with a one-line justification.
+The rule to apply: if the name asks "which vendor-equivalent version of something AdCP models?" (bad — use `ext`), reject; if the name asks "which externally-defined system/format/identifier space?" (legitimate), allow. When allowing a field name, add it to `tests/check-platform-agnostic.cjs` `FIELD_ALLOWLIST` with a one-line justification. When allowing an enum value, add it to `ENUM_VALUE_ALLOWLIST` with a path-qualified entry and a one-line justification.
 
 ### Reviewer checklist
 

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -222,7 +222,7 @@ Names that reference **canonical external identifier spaces** are legitimate in 
 Existing examples of legitimate patterns:
 
 - Distribution-platform identifier types: `amazon_music_id`, `roku_channel_id` in `distribution-identifier-type.json` (enum values)
-- Feed formats: `google_merchant_center`, `facebook_catalog` in `brand.json` (enum values) — widely-adopted open interchange formats
+- Feed formats: `google_merchant_center`, `facebook_catalog` in `brand.json` (enum values) — widely-adopted open interchange formats implemented by many third parties
 - Measurement/data identifiers: `nielsen_dma` in `get-adcp-capabilities-response` (field name)
 - Platform IDs: `apple_podcast_id`, `apple_id` (field names)
 

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -263,7 +263,7 @@
           "description": "Agentic checkout endpoint configuration",
           "properties": {
             "endpoint": { "type": "string", "format": "uri", "description": "Base URL for checkout session API" },
-            "spec": { "type": "string", "enum": ["openai_agentic_checkout_v1"], "description": "Checkout API specification" },
+            "spec": { "type": "string", "description": "Checkout API specification identifier. Use a namespaced string to identify the checkout protocol (e.g., vendor-prefixed or custom). Vendor-specific values belong under ext.{vendor}." },
             "supported_payment_providers": {
               "type": "array",
               "description": "Payment providers supported by this checkout endpoint",

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -54,14 +54,20 @@ const FIELD_ALLOWLIST = new Set([
 
 // Enum / const values that contain a vendor token but are explicitly allowed.
 // Uses path-qualified entries: each entry must match BOTH value and the schema
-// file path (substring match on the relative path). Flat-value allowlisting is
+// file path (path-suffix or exact match). Flat-value allowlisting is
 // insufficient because the same token may be legitimate in one enum but a
 // violation in another — e.g., "roku" is a valid genre taxonomy identifier in
 // genre-taxonomy.json but would be a violation in a targeting-method enum.
 //
+// pathContains is matched as: relPath === e.pathContains OR
+// relPath.endsWith('/' + e.pathContains). This is a path-separator-aware
+// suffix check — it matches the exact relative path or a path ending with
+// /<pathContains>, preventing substring collisions (e.g., 'subbrand.json'
+// would NOT match a pathContains of 'brand.json').
+//
 // When adding an entry, include:
 //   - value:       the exact enum/const string
-//   - pathContains: a substring of the relative schema path (e.g., 'enums/identifier-types.json')
+//   - pathContains: exact relative path or path suffix (e.g., 'enums/identifier-types.json')
 //   - comment:     one-line justification (inline below)
 const ENUM_VALUE_ALLOWLIST = [
   // brand.json — store property: platform names ARE the canonical app-store
@@ -75,7 +81,7 @@ const ENUM_VALUE_ALLOWLIST = [
   // widely-adopted open interchange formats implemented by many third parties.
   { value: 'google_merchant_center', pathContains: 'brand.json' },
   { value: 'facebook_catalog',       pathContains: 'brand.json' },
-  // openai_product_feed is contested (see #2439): code-reviewer treats it as
+  // openai_product_feed is contested (see #3456): code-reviewer treats it as
   // a violation; protocol expert treats it as a canonical feed schema identifier
   // parallel to google_merchant_center. Allowlisted pending @bokelley decision.
   { value: 'openai_product_feed',    pathContains: 'brand.json' },
@@ -103,7 +109,7 @@ const ENUM_VALUE_ALLOWLIST = [
 
   // enums/genre-taxonomy.json — platform taxonomy system identifiers, comparable
   // to gracenote and eidr. Note: bare 'roku' is inconsistent with the {vendor}_genres
-  // pattern; rename to 'roku_genres' is a breaking change tracked separately.
+  // pattern; rename to 'roku_genres' is a breaking change tracked in #3457.
   { value: 'apple_genres',  pathContains: 'enums/genre-taxonomy.json' },
   { value: 'google_genres', pathContains: 'enums/genre-taxonomy.json' },
   { value: 'amazon_genres', pathContains: 'enums/genre-taxonomy.json' },
@@ -141,7 +147,8 @@ function containsVendorToken(name) {
 
 function isEnumValueAllowed(value, relPath) {
   return ENUM_VALUE_ALLOWLIST.some(
-    e => e.value === value && relPath.includes(e.pathContains)
+    e => e.value === value &&
+      (relPath === e.pathContains || relPath.endsWith('/' + e.pathContains))
   );
 }
 
@@ -183,8 +190,8 @@ function walkSchema(node, ctx) {
       for (const def of Object.values(node[defsKey])) walkSchema(def, ctx);
     }
   }
-  // Intentionally skip node.examples — example payloads are user-data samples,
-  // not normative schema definitions.
+  // Intentionally skip node.examples and node.default — example payloads and
+  // default values are user-data samples, not normative value enumerations.
 }
 
 function lint() {

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -3,13 +3,18 @@
  * Platform-agnosticism lint
  *
  * Enforces the rule in docs/spec-guidelines.md#platform-agnosticism: normative
- * schema field names MUST NOT represent a specific vendor's version of a
- * general concept. Vendor-specific fields belong under `ext.{vendor}`.
+ * schema field names and enum/const values MUST NOT represent a specific
+ * vendor's version of a general concept. Vendor-specific fields belong under
+ * `ext.{vendor}`.
  *
- * This lint walks `static/schemas/source/` and flags property names containing
- * known vendor tokens. It does NOT flag enum values — values naming external
- * systems / formats / identifier spaces (e.g., `nielsen_dma`, `roku_channel_id`,
- * `google_merchant_center`) are legitimate per the spec guideline.
+ * Scans `static/schemas/source/` and flags:
+ *   - Property names containing known vendor tokens (outside ext.*)
+ *   - Enum/const values containing known vendor tokens (outside ext.*)
+ *
+ * Note: title/description text is intentionally excluded. Vendor names in
+ * prose descriptions are permitted per spec-guidelines.md — e.g., explaining
+ * that a field accepts Google Merchant Center format is legitimate context,
+ * not platform lock-in.
  *
  * Exit codes:
  *   0 — no violations
@@ -21,8 +26,8 @@ const path = require('path');
 
 const SCHEMA_BASE_DIR = path.join(__dirname, '../static/schemas/source');
 
-// Vendor tokens that indicate a platform-specific field when used in a property
-// name. Matched on whole-token boundaries (start of string, _, or end of string).
+// Vendor tokens that indicate platform-specific content when used in a property
+// name or enum/const value. Matched on whole-token boundaries (_, start, end).
 const VENDOR_TOKENS = [
   'gam', 'ttd',
   'google', 'amazon', 'apple', 'microsoft',
@@ -30,6 +35,11 @@ const VENDOR_TOKENS = [
   'openai', 'anthropic',
   'nielsen', 'scope3', 'roku',
 ];
+
+// Pre-compiled regexes for each vendor token (avoids recompiling per-value).
+const VENDOR_REGEXES = new Map(
+  VENDOR_TOKENS.map(t => [t, new RegExp(`(^|_)${t}(_|$)`)])
+);
 
 // Property names that contain a vendor token but are explicitly allowed
 // because they reference a canonical external identifier space, not a
@@ -41,6 +51,72 @@ const FIELD_ALLOWLIST = new Set([
   'nielsen_dma',      // Nielsen DMA is the industry-standard geographic division, not "Nielsen's version of geography".
 ]);
 
+// Enum / const values that contain a vendor token but are explicitly allowed.
+// Uses path-qualified entries: each entry must match BOTH value and the schema
+// file path (substring match on the relative path). Flat-value allowlisting is
+// insufficient because the same token may be legitimate in one enum but a
+// violation in another — e.g., "roku" is a valid genre taxonomy identifier in
+// genre-taxonomy.json but would be a violation in a targeting-method enum.
+//
+// When adding an entry, include:
+//   - value:       the exact enum/const string
+//   - pathContains: a substring of the relative schema path (e.g., 'enums/identifier-types.json')
+//   - comment:     one-line justification (inline below)
+const ENUM_VALUE_ALLOWLIST = [
+  // brand.json — store property: platform names ARE the canonical app-store
+  // identifiers; no platform-neutral alternative name exists.
+  { value: 'apple',  pathContains: 'brand.json' },
+  { value: 'google', pathContains: 'brand.json' },
+  { value: 'amazon', pathContains: 'brand.json' },
+  { value: 'roku',   pathContains: 'brand.json' },
+
+  // brand.json — feed_format: google_merchant_center and facebook_catalog are
+  // widely-adopted open interchange formats implemented by many third parties.
+  { value: 'google_merchant_center', pathContains: 'brand.json' },
+  { value: 'facebook_catalog',       pathContains: 'brand.json' },
+  // openai_product_feed is contested (see #2439): code-reviewer treats it as
+  // a violation; protocol expert treats it as a canonical feed schema identifier
+  // parallel to google_merchant_center. Allowlisted pending @bokelley decision.
+  { value: 'openai_product_feed',    pathContains: 'brand.json' },
+
+  // enums/demographic-system.json — Nielsen notation IS the industry-standard
+  // demographic audience measurement vocabulary (parallel to Nielsen DMA).
+  { value: 'nielsen', pathContains: 'enums/demographic-system.json' },
+
+  // enums/device-platform.json — Roku OS is a distinct CTV operating system
+  // name, same as tvos, fire_os, tizen, webos.
+  { value: 'roku_os', pathContains: 'enums/device-platform.json' },
+
+  // enums/distribution-identifier-type.json — canonical platform ID namespaces.
+  { value: 'apple_podcast_id', pathContains: 'enums/distribution-identifier-type.json' },
+  { value: 'amazon_music_id',  pathContains: 'enums/distribution-identifier-type.json' },
+  { value: 'amazon_title_id',  pathContains: 'enums/distribution-identifier-type.json' },
+  { value: 'roku_channel_id',  pathContains: 'enums/distribution-identifier-type.json' },
+
+  // enums/feed-format.json — widely-adopted open interchange formats.
+  { value: 'google_merchant_center', pathContains: 'enums/feed-format.json' },
+  { value: 'facebook_catalog',       pathContains: 'enums/feed-format.json' },
+
+  // enums/genre-taxonomy.json — platform taxonomy system identifiers, comparable
+  // to gracenote and eidr. Note: bare 'roku' is inconsistent with the {vendor}_genres
+  // pattern; rename to 'roku_genres' is a breaking change tracked separately.
+  { value: 'apple_genres',  pathContains: 'enums/genre-taxonomy.json' },
+  { value: 'google_genres', pathContains: 'enums/genre-taxonomy.json' },
+  { value: 'amazon_genres', pathContains: 'enums/genre-taxonomy.json' },
+  { value: 'roku',          pathContains: 'enums/genre-taxonomy.json' },
+
+  // enums/identifier-types.json — canonical app-store and platform ID namespaces.
+  { value: 'apple_app_store_id', pathContains: 'enums/identifier-types.json' },
+  { value: 'google_play_id',     pathContains: 'enums/identifier-types.json' },
+  { value: 'roku_store_id',      pathContains: 'enums/identifier-types.json' },
+  { value: 'apple_tv_bundle',    pathContains: 'enums/identifier-types.json' },
+  { value: 'apple_podcast_id',   pathContains: 'enums/identifier-types.json' },
+
+  // enums/metro-system.json — Nielsen DMA is the industry-standard geographic
+  // division (same justification as FIELD_ALLOWLIST entry).
+  { value: 'nielsen_dma', pathContains: 'enums/metro-system.json' },
+];
+
 function findJSONFiles(dir) {
   const out = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -51,13 +127,18 @@ function findJSONFiles(dir) {
   return out;
 }
 
-function fieldNameContainsVendorToken(name) {
+function containsVendorToken(name) {
   const lower = name.toLowerCase();
-  for (const token of VENDOR_TOKENS) {
-    const re = new RegExp(`(^|_)${token}(_|$)`);
+  for (const [token, re] of VENDOR_REGEXES) {
     if (re.test(lower)) return token;
   }
   return null;
+}
+
+function isEnumValueAllowed(value, relPath) {
+  return ENUM_VALUE_ALLOWLIST.some(
+    e => e.value === value && relPath.includes(e.pathContains)
+  );
 }
 
 function walkSchema(node, ctx) {
@@ -70,6 +151,16 @@ function walkSchema(node, ctx) {
       if (key === 'ext') continue;
       walkSchema(sub, { ...ctx, path: ctx.path.concat(key) });
     }
+  }
+
+  // Enum and const value scanning.
+  if (Array.isArray(node.enum)) {
+    for (const v of node.enum) {
+      if (typeof v === 'string') ctx.onEnumValue(v, ctx.path);
+    }
+  }
+  if (typeof node.const === 'string') {
+    ctx.onEnumValue(node.const, ctx.path);
   }
 
   for (const k of ['items', 'additionalProperties', 'then', 'else', 'if', 'not']) {
@@ -88,11 +179,14 @@ function walkSchema(node, ctx) {
       for (const def of Object.values(node[defsKey])) walkSchema(def, ctx);
     }
   }
+  // Intentionally skip node.examples — example payloads are user-data samples,
+  // not normative schema definitions.
 }
 
 function lint() {
   const files = findJSONFiles(SCHEMA_BASE_DIR);
-  const violations = [];
+  const fieldViolations = [];
+  const enumViolations = [];
   const seen = new Set();
 
   for (const file of files) {
@@ -108,34 +202,53 @@ function lint() {
       path: [],
       onPropertyName: (name, pathArr) => {
         if (FIELD_ALLOWLIST.has(name)) return;
-        const token = fieldNameContainsVendorToken(name);
+        const token = containsVendorToken(name);
         if (!token) return;
-        const key = `${rel}:${pathArr.join('.')}`;
+        const key = `field:${rel}:${pathArr.join('.')}`;
         if (seen.has(key)) return;
         seen.add(key);
-        violations.push({ file: rel, fieldPath: pathArr.join('.'), field: name, token });
+        fieldViolations.push({ file: rel, fieldPath: pathArr.join('.'), field: name, token });
+      },
+      onEnumValue: (value, pathArr) => {
+        if (isEnumValueAllowed(value, rel)) return;
+        const token = containsVendorToken(value);
+        if (!token) return;
+        const key = `enum:${rel}:${value}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        enumViolations.push({ file: rel, fieldPath: pathArr.join('.'), value, token });
       },
     });
   }
 
-  const cyan = (s) => `\x1b[36m${s}\x1b[0m`;
-  const red = (s) => `\x1b[31m${s}\x1b[0m`;
-  const green = (s) => `\x1b[32m${s}\x1b[0m`;
+  const cyan  = s => `\x1b[36m${s}\x1b[0m`;
+  const red   = s => `\x1b[31m${s}\x1b[0m`;
+  const green = s => `\x1b[32m${s}\x1b[0m`;
 
   console.log(cyan('🧪 Platform-agnosticism lint'));
   console.log(cyan('=============================='));
-  console.log(`Scanned ${files.length} schema files for vendor tokens in property names.`);
+  console.log(`Scanned ${files.length} schema files.`);
+  console.log(`Checked: property names, enum values, const values (${VENDOR_TOKENS.length} vendor tokens: ${VENDOR_TOKENS.join(', ')}).`);
+  console.log(`Note: title/description text intentionally excluded — see docs/spec-guidelines.md.\n`);
 
-  if (violations.length === 0) {
-    console.log(green(`✅ No violations (${VENDOR_TOKENS.length} vendor tokens checked: ${VENDOR_TOKENS.join(', ')}).`));
+  const total = fieldViolations.length + enumViolations.length;
+
+  if (total === 0) {
+    console.log(green(`✅ No violations.`));
     process.exit(0);
   }
 
-  console.error(red(`\n❌ ${violations.length} violation(s) found:\n`));
-  for (const v of violations) {
+  console.error(red(`\n❌ ${total} violation(s) found:\n`));
+  for (const v of fieldViolations) {
     console.error(`  ${v.file}`);
-    console.error(`    Field ${red(v.field)} (token: ${v.token}) at ${v.fieldPath}`);
+    console.error(`    Property ${red(v.field)} (token: ${v.token}) at ${v.fieldPath}`);
     console.error(`    Fix: move to ext.${v.token} — see docs/spec-guidelines.md#platform-agnosticism\n`);
+  }
+  for (const v of enumViolations) {
+    console.error(`  ${v.file}`);
+    console.error(`    Enum/const value ${red(v.value)} (token: ${v.token}) near ${v.fieldPath || 'root'}`);
+    console.error(`    Fix: use a vendor-neutral value or add to ENUM_VALUE_ALLOWLIST with`);
+    console.error(`    a path-qualified justification — see docs/spec-guidelines.md#platform-agnosticism\n`);
   }
   process.exit(1);
 }

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -34,6 +34,7 @@ const VENDOR_TOKENS = [
   'meta', 'facebook', 'instagram',
   'openai', 'anthropic',
   'nielsen', 'scope3', 'roku',
+  'linkedin',
 ];
 
 // Pre-compiled regexes for each vendor token (avoids recompiling per-value).
@@ -96,6 +97,9 @@ const ENUM_VALUE_ALLOWLIST = [
   // enums/feed-format.json — widely-adopted open interchange formats.
   { value: 'google_merchant_center', pathContains: 'enums/feed-format.json' },
   { value: 'facebook_catalog',       pathContains: 'enums/feed-format.json' },
+  // linkedin_jobs names LinkedIn's job-listing feed format, the canonical format
+  // for ATS/job-board integrations — parallel to google_merchant_center for retail.
+  { value: 'linkedin_jobs', pathContains: 'enums/feed-format.json' },
 
   // enums/genre-taxonomy.json — platform taxonomy system identifiers, comparable
   // to gracenote and eidr. Note: bare 'roku' is inconsistent with the {vendor}_genres
@@ -213,7 +217,7 @@ function lint() {
         if (isEnumValueAllowed(value, rel)) return;
         const token = containsVendorToken(value);
         if (!token) return;
-        const key = `enum:${rel}:${value}`;
+        const key = `enum:${rel}:${pathArr.join('.')}:${value}`;
         if (seen.has(key)) return;
         seen.add(key);
         enumViolations.push({ file: rel, fieldPath: pathArr.join('.'), value, token });


### PR DESCRIPTION
Closes #2439

## Summary

Extends `check:platform-agnostic` (already wired into `npm run test`) to scan **enum values** and **const values** in addition to property names. Property-name scanning was already shipped; this closes the remaining scope from #2404's follow-up note.

Also fixes one genuine violation uncovered by the new check.

## What changed

### `tests/check-platform-agnostic.cjs`

- Adds enum/const value scanning alongside existing property-name scanning
- Introduces a **path-qualified `ENUM_VALUE_ALLOWLIST`** (`{value, pathContains}` tuples) — flat-value allowlisting is insufficient because the same token can be legitimate in one enum (e.g., `"roku"` in `enums/genre-taxonomy.json`) but a violation in another (e.g., a `targeting_method` enum)
- Pre-compiles vendor-token regexes at module load (one-time cost vs. per-value)
- Explicitly skips `node.examples` — example payloads are user-data samples, not normative schema definitions
- Updates the stale header comment that said "does NOT flag enum values"
- Title/description text is **intentionally excluded**: 80+ occurrences of `meta` and 22 of `google` in description text are all legitimate explanatory prose, per spec-guidelines.md

### `static/schemas/source/brand.json`

Removes the single-value enum `["openai_agentic_checkout_v1"]` from `product_catalog.agentic_checkout.spec` and replaces it with a free-form `string`.

The field encoded one vendor's versioned checkout API as the only normative value — a clear violation of the platform-agnosticism rule ("does this name ask 'which vendor's version of something AdCP already models?'"). The `agentic_checkout` concept is the general model; `spec` was selecting among vendor implementations of it, which belongs under `ext.{vendor}`.

**Non-breaking:** existing data using `"openai_agentic_checkout_v1"` continues to validate (the constraint is loosened, not tightened).

### `docs/spec-guidelines.md`

- Removes `openai_product_feed` from the "legitimate patterns" list (see decision point below)
- Adds `ENUM_VALUE_ALLOWLIST` to the reviewer checklist

## Non-breaking justification

- Lint script: infra/CI, no wire-format change
- `brand.json` spec field: existing constraint loosened; every previously-valid value remains valid
- `brand.json` enum not modified for `feed_format`
- All allowlisted enum values continue to pass the lint

## Decision point for @bokelley — `openai_product_feed`

**Two experts disagreed on this.** The allowlist entry at line 80 of the updated `check-platform-agnostic.cjs` is explicitly annotated "contested."

- **Code-reviewer position:** `openai_product_feed` is a violation — unlike `google_merchant_center` and `facebook_catalog` (widely-adopted open interchange formats with third-party implementations), `openai_product_feed` is a single-vendor proprietary format. It should be removed from `brand.json`'s `feed_format` enum or moved to `ext.openai`.
- **Protocol expert position:** it's legitimate — `openai_product_feed` names a real externally-defined feed schema that a brand agent must parse, the same way `google_merchant_center` does.

**What the allowlist entry does:** keeps CI green today (the lint would otherwise immediately fail on a pre-existing value). **It does NOT resolve the policy question.**

Options:
```diff
// Option A — accept as legitimate (remove the "contested" comment, it stays)
{ value: 'openai_product_feed', pathContains: 'brand.json' },

// Option B — rule it a violation; needs a follow-on PR to remove from feed_format enum
// (removing an enum value = major version bump per spec-guidelines.md)
// Remove this allowlist entry + open a follow-on issue
```

Pick whichever option you agree with and remove/keep the entry + comment during review.

## Known gaps (not in scope for this PR)

- **`VENDOR_TOKENS` coverage:** `samsung`, `spotify`, `youtube`, `tiktok`, `twitch`, `fire`, `pluto`, `tubi`, `peacock` appear as enum values in identifier-type schemas but are not in `VENDOR_TOKENS`. Those enums contain only legitimate ID-namespace values, so the gap causes false negatives (not false positives). Tracked as a follow-on.
- **`roku` in `genre-taxonomy.json`:** bare `"roku"` is inconsistent with the `{vendor}_genres` pattern used by every other platform. Renaming to `"roku_genres"` is a breaking change (major bump); tracked separately.
- **Description/title text scanning:** explicitly excluded; 80+ `meta` hits and 22 `google` hits in description text are all legitimate explanatory prose.
- **`brand.json` inline `feed_format` enum vs. `enums/feed-format.json`:** these enums have diverged (different values). Not in scope here, but worth reconciling per spec-guidelines "single canonical enum" rule.
- **`brand.json/agentic_checkout.spec` experimental status:** `x-status: experimental` marker is missing from `brand.json` despite `agentic_checkout` being a new feature. A human should backfill this marker.

## Routing note

The `brand.json` change is `patch`-level (loosening a constraint). No `3.0.x` branch is open. This PR targets `main`; milestone routing (3.1.0 vs. a new 3.0.x branch) is @bokelley's call.

## Pre-PR review

- **ad-tech-protocol-expert:** approved — `spec` fix is non-breaking; path-qualified allowlist design is correct; examples exclusion is correct. One contested entry (`openai_product_feed`) documented as a decision point for reviewer.
- **code-reviewer:** review in progress (launched async; findings will be addressed before merge if blockers are flagged).

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_019LD4LcGgLLpMBdTfSfK4WZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019LD4LcGgLLpMBdTfSfK4WZ)_