### PR TITLE
docs(release-notes): curated 3.0.1 section

### DIFF
--- a/.changeset/3-0-1-release-notes.md
+++ b/.changeset/3-0-1-release-notes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add curated 3.0.1 release notes section to `docs/reference/release-notes.mdx` and bump the FAQ's current-version mention to 3.0.1. Frames 3.0.1 as a stable-surface no-op for 3.0-conformant agents, with an honest accounting of what did change: skills bundle in the canonical tarball, normative clarifications (no wire change), additive fields on experimental surfaces (governance, TMP) per the experimental contract, two new conformance-harness scenarios, and one docs-level deprecation (`get_signals` top-level `max_results`). Cross-links to the experimental-status contract so adopters know why patch-level additions are permitted on those surfaces.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -98,7 +98,7 @@ Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/l
 </Accordion>
 
 <Accordion title="How mature is the protocol?">
-AdCP is at **3.0.0 — General Availability**, released April 2026. The protocol is stable and production-ready. See [Release notes](/docs/reference/release-notes) for the full 3.0 change log and [What's new in v3](/docs/reference/whats-new-in-v3) for the 2.5 → 3.0 migration summary.
+AdCP is at **3.0.1 — General Availability**, with 3.0 released April 2026. The protocol is stable and production-ready. See [Release notes](/docs/reference/release-notes) for the full change log and [What's new in v3](/docs/reference/whats-new-in-v3) for the 2.5 → 3.0 migration summary.
 
 The next major version (4.0) is targeted for early 2027. Under the [release cadence policy](/docs/reference/versioning#release-cadence), majors are at least 18 months apart, the previous major receives security patches for at least 12 months after successor GA, and deprecation notices are published at least 6 months before removal. See [Versioning & Governance](/docs/reference/versioning) for the full policy and 3.x stability guarantees. AdCP 2.5 remains security-patched until 2026-08-01 — see the [v2 sunset page](/docs/reference/v2-sunset) for the end-of-life timeline.
 </Accordion>

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -9,6 +9,66 @@ High-level summaries of major AdCP releases with migration guidance. For detaile
 
 ---
 
+## Version 3.0.1
+
+**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
+
+**3.0.1 is a maintenance release.** It ships the protocol skills bundle through the canonical tarball, formalises a handful of normative clauses left underspecified in 3.0.0, and adds small additive fields on experimental surfaces (governance, TMP) and the conformance harness. The stable wire surface is unchanged.
+
+<Info>
+**Upgrading from 3.0.0?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` from `3.0.0` to `3.0.1` to receive the canonical skills via their existing sync flow.
+</Info>
+
+### Adopter action
+
+| If you are… | What you need to do |
+|---|---|
+| A 3.0-conformant production agent | Nothing. Stable schemas are unchanged. |
+| An SDK consumer | Bump `ADCP_VERSION` from `3.0.0` to `3.0.1`. JS wiring in [adcp-client#965](https://github.com/adcontextprotocol/adcp-client/pull/965); Python and Go follow-ups in [adcp-client-python#274](https://github.com/adcontextprotocol/adcp-client-python/issues/274) and [adcp-go#91](https://github.com/adcontextprotocol/adcp-go/issues/91). |
+| Implementing governance or TMP | Review the experimental-surface additions below. Per the [experimental-status contract](/docs/reference/experimental-status), additive changes are permitted within a patch release. |
+| Calling `get_signals` with top-level `max_results` | Migrate to `pagination.max_results`. Top-level field still works through 3.x; removed in 4.0. |
+
+### Why 3.0.1 exists
+
+The `skills/` directory was hoisted into the protocol root after the 3.0.0 tarball was already cosign-signed. Re-cutting at the same version would have invalidated the supply-chain attestations bound to the original 3.0.0 SHA-256. 3.0.1 ships the bundle through the normal release path. (#3116, #3117)
+
+### Spec polish — no wire change
+
+Normative clarifications and docs corrections. None of these add new fields to stable schemas; they document behaviour the spec already implied.
+
+- **`acquire_rights` request validation** — Brand agents MUST reject expired campaign windows (`campaign.end_date` in the past) with `INVALID_REQUEST`. CPM-priced rights under a governed plan must include `campaign.estimated_impressions`. Closes implementer disagreement on identical requests. (#2680, #2681)
+- **`get_signals` pagination precedence** — When both top-level `max_results` and `pagination.max_results` are present, agents MUST honor `pagination.max_results`. Top-level `max_results` deprecated; removed in 4.0.
+- **URL canonicalization** — Now applies uniformly to brand.json agent URLs (`brand_agent_entry.url`, `brand_agent.url`, `rights_agent.url`). Two URLs differing only in case, default port, or percent-encoded unreserved characters compare equal during agent resolution. New reference page at [URL canonicalization](/docs/reference/url-canonicalization).
+- **v3 envelope integrity** — Schema-level constraint on `protocol-envelope.json` formally prohibits legacy v2 `task_status` / `response_status` field names. The prose MUST NOT was already in 3.0.0; the constraint is now machine-detectable by validators. Companion universal storyboard `v3-envelope-integrity` exercises the assertion. Conformant 3.0 implementations are unaffected. (#3041)
+- **Format asset codegen** — Title annotations on `format.json` `oneOf` branches enable codegen tools (json-schema-to-typescript, datamodel-code-generator, oapi-codegen) to emit named per-asset-type interfaces instead of untyped unions. Annotation-only.
+- **Inline-enum hoisting** — Source schemas now `$ref` shared enum files for `payment-terms`, `audio-channel-layout`, `media-buy-valid-action`, `match-type`, `governance-decision`, `billing-party`, and 11 others. Bundled wire format unchanged in all cases.
+
+### Experimental surfaces — additive only
+
+Per the [experimental-surface contract](/docs/reference/experimental-status), these surfaces accept additive changes within a patch release. Changes here do not affect agents that don't implement these protocols.
+
+- **Governance** — `mode` field added to `check-governance-response.json` and `get_plan_audit_logs` audit entries. Records the enforcement posture (enforce/advisory/audit) active at check time. Closes a gap where audit and enforce modes produced identical-looking trails.
+- **Trusted Match Protocol (TMP)** — `seller_agent: { agent_url, id? }` added to `AvailablePackage`, making seller identity explicit on every package cached by a TMP provider. New `seller_not_authorized` error code for sync-time rejection when the seller's `agent_url` is not present in the property publisher's `adagents.json`. All TMP schemas now carry `x-status: experimental`.
+
+### Conformance harness — sandbox-only
+
+`comply_test_controller` is conformance-harness scaffolding, not a normative protocol task. Changes here only affect sandbox testing.
+
+- **`force_task_completion`** — Resolves a previously-submitted async task to `completed` with a buyer-supplied result payload. Closes the loop on the async `create_media_buy` submitted → completed roundtrip. Result is delivered via the seller's webhook (canonical 3.0 path); a typed result projection on the polling response is tracked for 3.1 in #3123.
+- **`seed_creative_format`** — Pre-populates a deterministic set of creative formats for pagination-integrity storyboards. Companion: `list_creative_formats` now applies cursor-based pagination matching the `list_creatives` pattern.
+
+### Release mechanics
+
+- Cosign signing on private packages so future Version Packages merges auto-tag and `changesets/action` auto-creates the GitHub Release with artifacts.
+- `dist/protocol/` retained in the Fly.io image so cosign-signed versioned tarballs ship and `/protocol/{version}.tgz` actually serves end-to-end.
+- Skills bundled at `/protocol/3.0.1.tgz`: `call-adcp-agent` plus the per-protocol `adcp-{brand,creative,governance,media-buy,si,signals}`.
+
+### Detailed changelog
+
+For the full per-PR change list, see [CHANGELOG.md § 3.0.1](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#301).
+
+---
+
 ## Version 3.0.0
 
 **Status:** General Availability | [AdCP 3.0 overview](/docs/reference/whats-new-in-v3)


### PR DESCRIPTION
## Summary

Adds the curated **Version 3.0.1** section to \`docs/reference/release-notes.mdx\` ahead of the cut, plus bumps the FAQ's current-version mention. Lands BEFORE the Version Packages PR (#3042) merges, so the 3.0.1 release ships with the curated narrative already on main.

Frames 3.0.1 as a **stable-surface no-op for 3.0-conformant agents** with an honest accounting of what did change.

## What's in the 3.0.1 narrative

- **Adopter action table** — per-audience takeaway: production agent (nothing), SDK consumer (bump \`ADCP_VERSION\`), governance/TMP implementer (review additive fields), \`get_signals\` caller using top-level \`max_results\` (migrate to \`pagination.max_results\`)
- **Why 3.0.1 exists** — skills bundle in \`/protocol/3.0.1.tgz\`. Re-cutting at 3.0.0 would have invalidated cosign attestations bound to the original 3.0.0 SHA-256.
- **Spec polish** — \`acquire_rights\` validation MUSTs, \`get_signals\` pagination precedence, URL canonicalization on brand.json agent URLs, v3 envelope integrity schema constraint, format asset codegen titles, inline-enum hoisting
- **Experimental surfaces** — governance \`mode\` field, TMP \`seller_agent\` field. Cross-links to the experimental-status contract so adopters know why patch-level additions are permitted on those surfaces.
- **Conformance harness** — \`force_task_completion\` and \`seed_creative_format\` scenarios (sandbox-only)
- **One docs-level deprecation** — \`get_signals\` top-level \`max_results\` (still works in 3.x; removed in 4.0)

## CHANGELOG.md framing (separate concern)

CHANGELOG.md follows the 3.0.0 convention — auto-generated \`### Patch Changes\` per-PR detail under \`## 3.0.1\`, with the curated narrative living in release-notes.mdx. The Version Packages PR's CHANGELOG.md content can stay as-is, OR a one-line lead-in can be added before merging:

\`\`\`
## 3.0.1

See [release notes](docs/reference/release-notes.mdx#version-301) for the curated narrative.
\`\`\`

## Test plan

- [x] release-notes.mdx renders in Mintlify (no broken cross-references — all anchors resolve to existing pages: \`/docs/reference/experimental-status\`, \`/docs/reference/url-canonicalization\`, \`/docs/reference/migration\`)
- [x] Pre-commit hooks pass
- [ ] CI green on PR
- [ ] Land before merging Version Packages PR (#3042)

🤖 Generated with [Claude Code](https://claude.com/claude-code)