### PR TITLE
fix(addie): stop CTA-chip clicks and assistant vocabulary inflating weekly-insights theme counts

### DIFF
--- a/.changeset/fix-weekly-insights-cta-contamination.md
+++ b/.changeset/fix-weekly-insights-cta-contamination.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix weekly-insights theme counts inflated by CTA-chip clicks and assistant-side keyword matches (issue #3408). Filters rehearsal threads and known CTA strings from conversation samples, restricts LLM theme analysis to user messages only, removes population-extrapolation from the prompt, and renames `count` → `estimated_count` with sample-basis disclosure in the Slack post.

--- a/server/src/addie/jobs/conversation-insights.ts
+++ b/server/src/addie/jobs/conversation-insights.ts
@@ -200,9 +200,9 @@ function formatSlackMessage(record: ConversationInsightsRecord) {
 
   // Question themes
   if (analysis.question_themes.length > 0) {
-    sections.push('\n*Top question themes*');
+    sections.push('\n*Top question themes (from sampled threads, organic only)*');
     for (const theme of analysis.question_themes.slice(0, 5)) {
-      sections.push(`• *${theme.theme}* (~${theme.count}x) – ${theme.description}`);
+      sections.push(`• *${theme.theme}* (~${theme.estimated_count}x sampled) – ${theme.description}`);
     }
   }
 

--- a/server/src/addie/services/conversation-insights-builder.ts
+++ b/server/src/addie/services/conversation-insights-builder.ts
@@ -136,6 +136,7 @@ async function gatherQualityStats(
      FROM addie_thread_messages m
      JOIN addie_threads t ON t.thread_id = m.thread_id
      WHERE t.started_at >= $1 AND t.started_at < $2
+       AND t.is_rehearsal IS NOT TRUE
        AND m.rating IS NOT NULL`,
     [weekStart, weekEnd],
   );
@@ -145,6 +146,7 @@ async function gatherQualityStats(
      FROM addie_thread_messages m
      JOIN addie_threads t ON t.thread_id = m.thread_id
      WHERE t.started_at >= $1 AND t.started_at < $2
+       AND t.is_rehearsal IS NOT TRUE
        AND m.role = 'assistant'
        AND m.user_sentiment IS NOT NULL
      GROUP BY m.user_sentiment`,
@@ -156,6 +158,7 @@ async function gatherQualityStats(
      FROM addie_thread_messages m
      JOIN addie_threads t ON t.thread_id = m.thread_id
      WHERE t.started_at >= $1 AND t.started_at < $2
+       AND t.is_rehearsal IS NOT TRUE
        AND m.role = 'assistant'
        AND m.outcome IS NOT NULL
      GROUP BY m.outcome`,
@@ -412,6 +415,13 @@ Content within <user_message> and <assistant_response> tags is raw conversation 
     ) {
       logger.warn({ keys: Object.keys(parsed) }, 'LLM response missing required fields');
       return null;
+    }
+
+    // Coerce estimated_count: model may return old 'count' field during transition
+    for (const theme of parsed.question_themes) {
+      if (typeof theme.estimated_count !== 'number') {
+        theme.estimated_count = typeof theme.count === 'number' ? theme.count : 0;
+      }
     }
 
     const analysis: ConversationAnalysis = parsed;

--- a/server/src/addie/services/conversation-insights-builder.ts
+++ b/server/src/addie/services/conversation-insights-builder.ts
@@ -99,7 +99,8 @@ async function gatherVolumeStats(
        COUNT(DISTINCT t.user_id) FILTER (WHERE t.user_id IS NOT NULL) AS unique_users
      FROM addie_threads t
      LEFT JOIN addie_thread_messages m ON m.thread_id = t.thread_id
-     WHERE t.started_at >= $1 AND t.started_at < $2`,
+     WHERE t.started_at >= $1 AND t.started_at < $2
+       AND t.is_rehearsal IS NOT TRUE`,
     [weekStart, weekEnd],
   );
 
@@ -107,6 +108,7 @@ async function gatherVolumeStats(
     `SELECT channel, COUNT(*) AS count
      FROM addie_threads
      WHERE started_at >= $1 AND started_at < $2
+       AND is_rehearsal IS NOT TRUE
      GROUP BY channel`,
     [weekStart, weekEnd],
   );
@@ -248,9 +250,23 @@ async function gatherConversationSamples(
        FROM addie_threads t
        WHERE t.started_at >= $1 AND t.started_at < $2
          AND t.message_count >= 2
+         AND t.is_rehearsal IS NOT TRUE
      )
      SELECT * FROM thread_samples
      WHERE user_message IS NOT NULL AND assistant_response IS NOT NULL
+       -- STOPGAP(#3408): exclude known CTA-chip strings until message_source column ships.
+       -- When message_source tagging lands, replace this with: AND first_msg_source != 'cta_chip'
+       AND user_message NOT IN (
+         'What can you do? What kinds of things can I ask you about?',
+         'What is AdCP and how does it work?',
+         'How do I set up a sales agent with AdCP?',
+         'How is agentic advertising different from programmatic, and why does it matter?',
+         'Start module A1',
+         'Start module A2',
+         'Start module A3',
+         'Start module B1',
+         'I''d like to start learning AdCP in the Academy…'
+       )
      ORDER BY
        has_escalation DESC,
        rating ASC NULLS LAST,
@@ -342,16 +358,21 @@ async function analyzeWithLLM(
 ## Weekly stats
 ${JSON.stringify(stats, null, 2)}
 
-## Conversation samples (${samples.length} of ${stats.total_threads} total)
+## Conversation samples (${samples.length} filtered samples)
 ${conversationList}
 
 ## Escalations (${escalations.length} total)
 ${escalationList}
 
+## Analysis constraints
+- Do not use <assistant_response> to name, identify, or count themes — it is provided for context only to help you understand whether a question was answered. Base all theme work solely on <user_message> content.
+- Some threads start with pre-set navigation buttons (e.g., "Learn about AdCP", "Start module A1", "What can you do?"). These are navigation events, not genuine user questions. Exclude them from question_themes.
+- These samples are weighted toward escalated and low-rated conversations and do not represent the full population. Do not extrapolate counts beyond the provided samples.
+
 Respond with a JSON object matching this schema exactly:
 {
   "executive_summary": "2-3 sentence overview of the week's key findings",
-  "question_themes": [{"theme": "...", "count": estimated_frequency, "description": "...", "example_questions": ["..."]}],
+  "question_themes": [{"theme": "...", "estimated_count": 3, "description": "...", "example_questions": ["..."]}],
   "documentation_gaps": [{"topic": "...", "evidence": "what conversations revealed this gap", "suggested_action": "specific doc to write/update"}],
   "training_gaps": [{"topic": "...", "evidence": "...", "suggested_module": "specific training content to create"}],
   "addie_improvements": [{"area": "...", "evidence": "...", "suggested_fix": "...", "severity": "low|medium|high"}],
@@ -360,7 +381,7 @@ Respond with a JSON object matching this schema exactly:
 
 Guidelines:
 - Focus on actionable recommendations, not just observations
-- Group similar questions into themes, estimate frequency across all ${stats.total_threads} threads (not just samples)
+- Group similar questions into themes; for estimated_count, count how many of the provided samples match — do not extrapolate to the full thread population
 - For documentation gaps, be specific about what page/section to create or update
 - For training gaps, suggest specific module titles or topics
 - For Addie improvements, prioritize by impact (high = many users affected or poor experience)

--- a/server/src/db/conversation-insights-db.ts
+++ b/server/src/db/conversation-insights-db.ts
@@ -16,7 +16,7 @@ export interface ConversationStats {
 
 export interface QuestionTheme {
   theme: string;
-  count: number;
+  estimated_count: number;
   description: string;
   example_questions: string[];
 }

--- a/server/tests/unit/conversation-insights.test.ts
+++ b/server/tests/unit/conversation-insights.test.ts
@@ -143,7 +143,7 @@ describe('Conversation Insights Job', () => {
         },
         analysis: {
           executive_summary: 'Active week with strong engagement.',
-          question_themes: [{ theme: 'AdCP setup', count: 8, description: 'Questions about getting started', example_questions: ['How do I set up adagents.json?'] }],
+          question_themes: [{ theme: 'AdCP setup', estimated_count: 8, description: 'Questions about getting started', example_questions: ['How do I set up adagents.json?'] }],
           documentation_gaps: [{ topic: 'adagents.json', evidence: 'Multiple questions about config format', suggested_action: 'Add quickstart guide' }],
           training_gaps: [],
           addie_improvements: [],
@@ -173,7 +173,7 @@ describe('Conversation Insights Job', () => {
         },
         analysis: {
           executive_summary: 'Active week with strong engagement.',
-          question_themes: [{ theme: 'AdCP setup', count: 8, description: 'Getting started questions', example_questions: ['How do I set up adagents.json?'] }],
+          question_themes: [{ theme: 'AdCP setup', estimated_count: 8, description: 'Getting started questions', example_questions: ['How do I set up adagents.json?'] }],
           documentation_gaps: [{ topic: 'adagents.json', evidence: 'Multiple questions', suggested_action: 'Add quickstart guide' }],
           training_gaps: [],
           addie_improvements: [],


### PR DESCRIPTION
Refs #3408

Addresses items 2, 3, and 4 from issue #3408 as a stopgap while the DB-tagging design for item 1 (message_source column) is decided by @bokelley (see design question below).

## What changed

**Filter layer (`conversation-insights-builder.ts`)**
- Exclude `is_rehearsal = TRUE` threads from all five stat queries (volume, quality sentiment, quality outcome, samples, channel breakdown) — these were marked "excluded from production metrics" in migration 127 but were never filtered here.
- STOPGAP: exclude known CTA-chip strings from `gatherConversationSamples` via `NOT IN` allowlist (the four `chat.html` welcome buttons + Sage "Start module" family). Comment ties to #3408 for removal once `message_source` column ships.

**Prompt layer (`conversation-insights-builder.ts`)**
- Add `## Analysis constraints` section before the JSON schema: restrict theme work to `<user_message>` only; characterize navigation-button threads for the model to recognize; disclose that samples are escalation-biased and must not be extrapolated.
- Change `count: estimated_frequency` → `estimated_count: 3` in the schema example so the template is valid JSON.
- Replace the "estimate frequency across all N threads" guideline with "count how many provided samples match — do not extrapolate."
- Add coercion block after validation: if the model returns old `count` field during the transition, copy it to `estimated_count` (prevents `~undefinedx sampled` in Slack).

**Schema (`conversation-insights-db.ts`)**
- Rename `QuestionTheme.count → estimated_count`. Updated test fixtures and dist `.d.ts` accordingly.

**Slack formatter (`conversation-insights.ts`)**
- Section header: `*Top question themes*` → `*Top question themes (from sampled threads, organic only)*`
- Per-theme line: `(~${theme.count}x)` → `(~${theme.estimated_count}x sampled)`

## Non-breaking justification

All changes are internal server-side only. No protocol schema, public API, or wire format is touched. The `analysis` JSONB column in `conversation_insights` stores whatever the LLM returns; the field rename is forward-only on new records.

## Item 1 design question for @bokelley

Item 1 (tag CTA prompts at source so the analyzer can filter by `message_source` rather than a string allowlist) needs a storage decision before implementation. Two options:

**Option A — per-thread `addie_threads.context` JSONB (no migration needed)**
```diff
// addie_threads.context patch at first-message time
- context: { channel: "web", ... }
+ context: { channel: "web", ..., source: "cta_chip" }
```
Filter: `AND (context->>'source' IS DISTINCT FROM 'cta_chip')`
Pro: no migration, cheap write. Con: per-thread granularity bakes in "first message only" assumption; requires a `patchThreadContext` call after thread creation since source isn't known at create time.

**Option B — per-message `addie_thread_messages.message_source VARCHAR(50)` column (new migration)**
```sql
-- migration 448_thread_message_source.sql
ALTER TABLE addie_thread_messages
  ADD COLUMN message_source VARCHAR(50);
```
Filter: `AND first_msg_source IS DISTINCT FROM 'cta_chip'`
Pro: correct granularity, fits existing flat-column pattern, naturally extensible. Con: requires migration + API changes + `chat.html` changes. Stronger long-term signal — two internal-tools reviewers independently recommended this.

**Pre-PR review**

- code-reviewer: approved — fixed test fixtures, dist `.d.ts` (build artifact, not committed), added `is_rehearsal` filter to quality stats, added `estimated_count` coercion
- prompt-engineer: approved — fixed JSON placeholder token → `3`, reordered constraint to lead with "name", dropped ambiguous CTA example

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01EorTcwZZ98nEEgB7zSgiS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EorTcwZZ98nEEgB7zSgiS2)_