### PR TITLE
fix(csrf): exempt /mcp-strict variants so the conformance grader can probe

### DIFF
--- a/.changeset/csrf-exempt-mcp-strict-routes.md
+++ b/.changeset/csrf-exempt-mcp-strict-routes.md
@@ -1,0 +1,6 @@
+---
+---
+
+CSRF middleware now exempts `/mcp-strict`, `/mcp-strict-required`, and `/mcp-strict-forbidden` — the training agent's RFC 9421 conformance routes. These are server-to-server endpoints authenticated by signature or bearer token; CSRF is the wrong protection layer.
+
+Without these exemptions the conformance grader's signed POSTs were rejected with `CSRF validation failed` (HTTP 403, no error code) before the signing verifier could run, producing a misleading "every vector failed" report instead of the spec-mandated 401 with RFC 9421 error codes. Closes the demo-blocking half of #2368 — the verifier middleware, JWKS, replay store, and test-kit contract were all already wired; only the CSRF exemption was missing.

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -43,6 +43,15 @@ const EXEMPT_PREFIXES = [
 /** Exact paths exempt from CSRF (not prefix-matched to avoid over-matching). */
 const EXEMPT_EXACT = [
   "/mcp",                // MCP Streamable HTTP (Bearer-token auth)
+  // Training agent strict-mode MCP endpoints. Server-to-server, authenticated
+  // by RFC 9421 signature or bearer token (per the route's own auth chain) —
+  // CSRF doesn't apply. Without these exemptions the conformance grader's
+  // signed POSTs bounce at CSRF before the signing verifier runs, producing
+  // 403/no-error-code on every vector instead of the spec-mandated 401 with
+  // signing error codes.
+  "/mcp-strict",
+  "/mcp-strict-required",
+  "/mcp-strict-forbidden",
   "/stripe-webhook",     // Stripe webhook (raw body route)
   "/auth/bridge-callback", // Cross-domain session bridge (origin-validated)
   "/token",              // OAuth token endpoint (mcpAuthRouter)

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -44,11 +44,7 @@ const EXEMPT_PREFIXES = [
 const EXEMPT_EXACT = [
   "/mcp",                // MCP Streamable HTTP (Bearer-token auth)
   // Training agent strict-mode MCP endpoints. Server-to-server, authenticated
-  // by RFC 9421 signature or bearer token (per the route's own auth chain) —
-  // CSRF doesn't apply. Without these exemptions the conformance grader's
-  // signed POSTs bounce at CSRF before the signing verifier runs, producing
-  // 403/no-error-code on every vector instead of the spec-mandated 401 with
-  // signing error codes.
+  // by RFC 9421 signature or bearer token; CSRF doesn't apply.
   "/mcp-strict",
   "/mcp-strict-required",
   "/mcp-strict-forbidden",

--- a/server/tests/unit/csrf-middleware.test.ts
+++ b/server/tests/unit/csrf-middleware.test.ts
@@ -144,6 +144,31 @@ describe('csrfProtection', () => {
     expect(res._status).toBe(403);
   });
 
+  // Guards EXEMPT_EXACT against a future refactor that switches `Array.includes`
+  // to `startsWith`. Today's check is exact equality, so these paths must
+  // continue to be rejected even though they look like exempt entries.
+  const nearMissExactPaths = [
+    '/mcp-stricter',           // strict-prefix only
+    '/mcp-strict-extra',       // appended segment, no slash
+    '/mcp-strict/extra',       // appended path
+    '/mcps',                   // ambiguous bare /mcp variant
+    '/mcp-strictly',           // strict-prefix variant
+  ];
+
+  it.each(nearMissExactPaths)('rejects POST to %s — must NOT match exempt-exact entries', (path) => {
+    const token = 'a'.repeat(64);
+    const req = mockReq({
+      method: 'POST',
+      path,
+      cookies: { 'csrf-token': token },
+      headers: {} as Record<string, string>,
+    });
+    const res = mockRes();
+    csrfProtection(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res._status).toBe(403);
+  });
+
   // --- Valid CSRF token ---
 
   it('allows POST with matching cookie and header', () => {

--- a/server/tests/unit/csrf-middleware.test.ts
+++ b/server/tests/unit/csrf-middleware.test.ts
@@ -114,6 +114,9 @@ describe('csrfProtection', () => {
 
   const exemptExactPaths = [
     '/mcp',
+    '/mcp-strict',
+    '/mcp-strict-required',
+    '/mcp-strict-forbidden',
     '/stripe-webhook',
     '/auth/bridge-callback',
     '/token',


### PR DESCRIPTION
## Summary

The training agent's RFC 9421 conformance routes — `/mcp-strict`, `/mcp-strict-required`, `/mcp-strict-forbidden` — were caught by the global CSRF middleware. Server-to-server callers (the `@adcp/client grade request-signing` runner) don't carry CSRF cookies, so every signed POST got rejected with HTTP 403 + `CSRF validation failed` before the signing verifier could run.

The grader read those 403s as "every vector failed, no error codes" — which is exactly the symptom #2368 was tracking. Surfaced when [`grade_agent_signing` shipped in #3397](https://github.com/adcontextprotocol/adcp/pull/3397) and Brian ran the first live demo against `test-agent.adcontextprotocol.org`.

Adds the three strict paths to `EXEMPT_EXACT` alongside the existing `/mcp` entry. The training agent's own auth chain (bearer or RFC 9421 signature, per `buildStrictModeAuthenticator` at `server/src/training-agent/index.ts:189`) is the proper protection for these endpoints; CSRF is the wrong layer.

## Why this is a one-line fix and not the full #2368 scope

Issue #2368 was originally scoped as "stand up signed-requests on the test agent." When I went to write the work, the explorer surfaced that the verifier middleware, JWKS (with `test-ed25519-2026`, `test-es256-2026`), `PostgresReplayStore`, revocation list (`test-revoked-2026`), and `signed-requests-runner.yaml` test-kit contract were all already wired and published. Only the CSRF exemption was missing — that's what the live grader run revealed.

After this lands, `npx @adcp/client grade request-signing https://test-agent.adcontextprotocol.org/mcp-strict --skip-rate-abuse` (and the equivalent Addie tool call) will produce a real per-vector report instead of a 403-on-everything precondition failure. Demo path unblocked.

## Test plan

- [x] `npx vitest run tests/unit/csrf-middleware.test.ts` — 39 tests pass (was 36; the parameterized exempt-paths test picks up the three new entries automatically). `rejects POST to path that resembles but does not match exempt prefix` still guards against over-matching.
- [x] Server typecheck clean.
- [ ] After deploy: re-run `grade_agent_signing` against `https://test-agent.adcontextprotocol.org/mcp-strict` and confirm the report is now real per-vector verification rather than 403/no-error-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)