### PR TITLE
fix(docs): correct dist/docs/3.0.1 snapshot relative path + SKILL.md MDX bare brace

### DIFF
--- a/.changeset/fix-broken-links-snapshot-skill.md
+++ b/.changeset/fix-broken-links-snapshot-skill.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix CI-blocking broken-links: correct relative path depth in dist/docs/3.0.1 snapshot (2 levels → 4 levels to reach repo root) and escape bare curly braces in SKILL.md symptom table to prevent MDX/acorn parse error.

--- a/dist/docs/3.0.1/contributing/storyboard-authoring.md
+++ b/dist/docs/3.0.1/contributing/storyboard-authoring.md
@@ -287,7 +287,7 @@ SHOULD include a substitution-safety phase covering the rule set at
 **Start from the template, don't copy-paste from a sibling specialism.** The
 canonical three-step phase (`sync_*_probe_catalog` → `build_*_probe_creative`
 → `expect_substitution_safe`) lives as a `phase_template:` comment block in
-[`static/compliance/source/test-kits/substitution-observer-runner.yaml`](../../static/compliance/source/test-kits/substitution-observer-runner.yaml).
+[`static/compliance/source/test-kits/substitution-observer-runner.yaml`](../../../../static/compliance/source/test-kits/substitution-observer-runner.yaml).
 The block uses `<<PLACEHOLDER>>` tokens for the specialism-specific bits
 (brand domain, catalog_id prefix, idempotency prefix) so you can materialize a
 new phase by doing a simple text substitution against those tokens.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -225,7 +225,7 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | Symptom | What it means | Fix |
 |---|---|---|
 | `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
-| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants (`{account_id, brand, operator, …}`) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
 | `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |


### PR DESCRIPTION
Closes #3425

## Summary

Two fixes for the CI-blocking `broken-links` check failures on `main`:

1. **Snapshot path depth** (`dist/docs/3.0.1/contributing/storyboard-authoring.md`): The relative link to `static/compliance/source/test-kits/substitution-observer-runner.yaml` used `../../` (correct in the source at `docs/contributing/`, which is 2 levels from repo root) but the dist snapshot nests 4 levels deep (`dist/docs/3.0.1/contributing/`). Fixed to `../../../../static/…`. This is the primary CI blocker — the `broken-links` workflow triggers on any `dist/docs/**` path change and `mintlify broken-links` traverses the snapshot.

2. **MDX bare brace** (`skills/call-adcp-agent/SKILL.md`): `{account_id, brand, operator, …}` in the symptom table was not wrapped in backticks, causing acorn "Could not parse expression" when the MDX pipeline encounters it. Wrapped with backticks (consistent with adjacent rows using `` `{amount, currency}` `` and `` `{agent_url, id}` ``). Note: `skills/` is not currently in the `broken-links` workflow's path triggers; this surfaced in a local `mintlify broken-links` run — included proactively.

**Known follow-up (not in this PR):** `scripts/rewrite-dist-links.sh` rewrites `/docs/` and `/schemas/` absolute paths but does not handle relative `../../static/` paths in `contributing/` files. The next patch snapshot (`3.0.2`) will reproduce this breakage unless the script is extended or the source switches to a root-relative/absolute URL.

**⚠️ Depth asymmetry — do NOT apply this fix to the source file:** `docs/contributing/storyboard-authoring.md` is at 2 levels from repo root, so its existing `../../static/…` is correct. Applying `../../../../` to the source would break the live docs site. Only the `dist/` snapshot needed the deeper path.

**Non-breaking justification:** docs-only changes — no schema, protocol, or API surface touched. The link target file exists at the corrected path (`static/compliance/source/test-kits/substitution-observer-runner.yaml`).

**Pre-PR review:**
- code-reviewer: approved — path arithmetic verified (4 levels correct for dist snapshot, 2 levels correct for source); MDX backtick fix consistent with adjacent table rows; noted `skills/` not currently in broken-links CI scope (confirmed via `.github/workflows/broken-links.yml`)
- docs-expert: approved — both fixes correct and non-breaking; confirmed source file must NOT receive the same depth change; generator gap documented as known follow-up

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012dh24nfo6NMf42QnUi6TQQ