### PR TITLE
fix(docs): broken relative link in v3.0.1 snapshot and SKILL.md acorn parse error

### DIFF
--- a/.changeset/fix-broken-links-snapshot-skillmd.md
+++ b/.changeset/fix-broken-links-snapshot-skillmd.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(docs): correct broken relative path in v3.0.1 snapshot and acorn parse error in SKILL.md
+
+- `dist/docs/3.0.1/contributing/storyboard-authoring.md`: `../../static/` → `../../../../static/` (snapshot is 4 levels deep, not 2)
+- `skills/call-adcp-agent/SKILL.md` line 228: wrap `{account_id, brand, operator, …}` in backticks to prevent acorn treating it as a JSX expression
+- `scripts/rewrite-dist-links.sh`: add sed rule so future snapshots of depth-1 docs pages automatically get the correct static-link depth

--- a/scripts/rewrite-dist-links.sh
+++ b/scripts/rewrite-dist-links.sh
@@ -49,6 +49,11 @@ rewrite_file() {
     -e "s|https://adcontextprotocol.org/schemas/v${MAJOR_VERSION}/|https://adcontextprotocol.org/schemas/$VERSION/|g" \
     -e "s|](/schemas/v${MAJOR_VERSION}/|](/schemas/$VERSION/|g" \
     -e "s|\`/schemas/v${MAJOR_VERSION}/|\`/schemas/$VERSION/|g" \
+    `# ../../static/ → ../../../../static/: correct for one-level-deep source files` \
+    `# (docs/contributing/ → dist/docs/VERSION/contributing/ adds 2 path segments).` \
+    `# Files at other depths need separate rules.` \
+    -e "s|](../../static/|](../../../../static/|g" \
+    -e "s|href=\"../../static/|href=\"../../../../static/|g" \
     "$file" > "$tmp"
 
   if ! diff -q "$file" "$tmp" > /dev/null 2>&1; then

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -225,7 +225,7 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | Symptom | What it means | Fix |
 |---|---|---|
 | `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
-| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants (`{account_id, brand, operator, …}`) | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants (`` `{account_id, brand, operator, …}` ``) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
 | `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |


### PR DESCRIPTION
Closes #3425

The v3.0.1 docs snapshot at `dist/docs/3.0.1/contributing/storyboard-authoring.md` had a relative link using `../../static/` to reach `static/compliance/source/test-kits/substitution-observer-runner.yaml`. From `docs/contributing/` that 2-level traversal is correct, but the snapshot lives at `dist/docs/3.0.1/contributing/` — 4 levels from the repo root — so Mintlify resolved it to `dist/docs/static/…` (missing). This caused `broken-links` CI to fail on every PR touching docs or dist. A second issue (`skills/call-adcp-agent/SKILL.md` line 228) had an unescaped `{account_id, brand, operator, …}` in a table cell that acorn flagged as a malformed JSX expression in local broken-links runs.

**Non-breaking justification:** docs-only patch to a versioned snapshot file, a source Markdown file (comment only), and a shell utility script. No schema, enum, API surface, or wire-format change. Existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved — no blockers; depth arithmetic verified (4 levels correct), double-backtick form valid CommonMark, sed patterns safe (no injection vector via validated `$VERSION`), idempotency safe in practice
- docs-expert: approved — blocker fixed (source comment added to document rewrite-script dependency); nits surfaced below

**Nits noted but not fixed (for reviewer to assess):**
- The double-backtick form `` `` `{…}` `` `` in the SKILL.md table cell is technically correct but slightly inconsistent with surrounding single-backtick style; could be rephrased to plain prose to avoid the escape entirely
- The `href="../../static/"` sed rule covers HTML anchor syntax but no such links exist in the current docs tree; harmless but broader than needed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Lngux4AkoYrZ75q7rXY2v1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lngux4AkoYrZ75q7rXY2v1)_