### PR TITLE
fix(compliance): add envelope_field_present check type for protocol-envelope scope assertions

### DIFF
--- a/.changeset/envelope-field-present-check-type.md
+++ b/.changeset/envelope-field-present-check-type.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add `envelope_field_present` check type to the storyboard schema and update `v3-envelope-integrity.yaml` to use it for the `status` presence assertion. The new check type walks `protocol-envelope.json` rather than the step's `response_schema_ref`, eliminating the static-analysis `VERIFIER_UNREACHABLE` gap in adcp-client's storyboard-drift verifier. Requires adcp-client#1045.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -445,15 +445,16 @@ function classifyOutcome(step) {
     return { kind: 'error', codes };
   }
 
-  // Looks like a success assertion path (field_present, response_schema,
-  // field_value on happy-path fields). Distinguish from "unspecified" —
-  // we need at least one positive assertion to call it success.
+  // Looks like a success assertion path (field_present, envelope_field_present,
+  // response_schema, field_value on happy-path fields). Distinguish from
+  // "unspecified" — we need at least one positive assertion to call it success.
   const hasPositiveAssertion = validations.some((v) => {
     if (!v || typeof v !== 'object') return false;
     const check = v.check;
     return (
       check === 'response_schema' ||
       check === 'field_present' ||
+      check === 'envelope_field_present' ||
       check === 'field_value' ||
       check === 'field_value_or_absent' ||
       check === 'http_status' ||

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -70,7 +70,8 @@ validation_result:
     field carries the transport failure).
   required_fields:
     - check                   # Validation kind from storyboard-schema.yaml:
-                              # response_schema | field_present | field_value |
+                              # response_schema | field_present |
+                              # envelope_field_present | field_value |
                               # field_value_or_absent | status_code | http_status |
                               # http_status_in | error_code | on_401_require_header |
                               # resource_equals_agent_url | any_of | refs_resolve
@@ -91,6 +92,8 @@ validation_result:
                               #   field_value_or_absent → value or allowed_values array
                               #                          from the storyboard validation
                               #   field_present        → the path that should resolve
+                              #   envelope_field_present → the path that should resolve
+                              #                          in the protocol envelope
                               #   status_code          → expected status
                               #   error_code           → expected error code
                               #   any_of               → array of acceptable forms
@@ -105,6 +108,9 @@ validation_result:
                               #   field_present        → null (the field was missing)
                               #                          or the observed non-object
                               #                          value
+                              #   envelope_field_present → null (the field was missing)
+                              #                          or the observed non-object
+                              #                          value (scoped to envelope)
     - schema_id               # $id of the response schema applied. Required
                               # when check == response_schema, null otherwise.
     - schema_url              # Resolvable URL the implementor can fetch to

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -575,7 +575,10 @@
 #
 # --- Validation ---
 #
-# check: string (what to validate: "response_schema", "field_present", "field_value",
+# check: string (what to validate: "response_schema", "field_present",
+#                "envelope_field_present" (walks protocol-envelope.json instead of
+#                response_schema_ref — use for top-level envelope fields like `status`),
+#                "field_value",
 #                "field_value_or_absent", "status_code", "http_status", "http_status_in",
 #                "error_code", "on_401_require_header", "resource_equals_agent_url",
 #                "any_of", "refs_resolve", "a2a_submitted_artifact")

--- a/static/compliance/source/universal/v3-envelope-integrity.yaml
+++ b/static/compliance/source/universal/v3-envelope-integrity.yaml
@@ -15,7 +15,9 @@ narrative: |
   docs/building/implementation/task-lifecycle.mdx.
 
   This storyboard documents the machine-check assertion and asserts the canonical v3
-  `status` field is present. The explicit envelope-root field-absence checks
+  `status` field is present using the `envelope_field_present` check type (added in
+  adcp-client#1045), which walks the protocol envelope rather than the inner response
+  schema. The explicit envelope-root field-absence checks
   (asserting task_status and response_status are absent) require `field_absent`
   runner support in @adcp/client — those checks are marked TODO below and are not
   executed until the runner ships that check type. The schema-level constraint
@@ -82,7 +84,7 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
-          - check: field_present
+          - check: envelope_field_present
             path: "status"
             description: "Envelope carries the canonical v3 status field"
           # TODO: restore these as field_absent checks once @adcp/client runner ships

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -164,6 +164,16 @@ test('classifyOutcome extracts error_code allowed_values as a Set', () => {
   assert.deepEqual([...outcome.codes].sort(), ['A', 'B']);
 });
 
+test('classifyOutcome treats envelope_field_present as success assertion', () => {
+  const step = {
+    validations: [
+      { check: 'envelope_field_present', path: 'status' },
+    ],
+  };
+  const outcome = classifyOutcome(step);
+  assert.equal(outcome.kind, 'success');
+});
+
 test('outcomesAgree: error sets with overlap agree, disjoint disagree', () => {
   const a = { kind: 'error', codes: new Set(['X', 'Y']) };
   const b = { kind: 'error', codes: new Set(['Y', 'Z']) };


### PR DESCRIPTION
Closes #3429

`v3-envelope-integrity.yaml` used `check: field_present` to assert `status` is present on the protocol envelope, but `response_schema_ref` points to the inner response schema — not the envelope. This caused the adcp-client storyboard-drift verifier to flag `VERIFIER_UNREACHABLE` (adcp-client#1039). @bokelley chose Option B: a new `envelope_field_present` check type that explicitly scopes to the protocol envelope.

## Changes

- `static/compliance/source/universal/v3-envelope-integrity.yaml` — `check: field_present` → `check: envelope_field_present` on the `status` assertion; narrative updated to reference adcp-client#1045
- `static/compliance/source/universal/storyboard-schema.yaml` — `envelope_field_present` added to the `check:` enum comment with scope description
- `static/compliance/source/universal/runner-output-contract.yaml` — `envelope_field_present` added to the check kind enum and `expected`/`actual` failure-shape entries
- `scripts/lint-storyboard-contradictions.cjs` — `envelope_field_present` added to `hasPositiveAssertion` so steps using it classify as `success`
- `tests/lint-storyboard-contradictions.test.cjs` — unit test for `classifyOutcome` with `envelope_field_present`
- `.changeset/envelope-field-present-check-type.md` — `patch` bump (conformance harness additive check type, patch-eligible per playbook)

**Requires:** adcp-client#1045 for runtime + static drift support. The VERIFIER_UNREACHABLE exemption in adcp-client#1039 can be dropped once both land.

**Non-breaking justification:** additive — new check type alongside existing ones; no existing check type changed or removed; no storyboard currently uses `envelope_field_present`.

**Milestone:** expected 3.0.2 (patch line). No open 3.0.2 milestone found via API — needs @bokelley to create and assign.

**Pre-PR review:**
- code-reviewer: approved — lint change correct, unit test added for `classifyOutcome`, dist/3.0.1 frozen by design (ships as 3.0.2), no blockers
- ad-tech-protocol-expert: approved — semantics correct, `runner-output-contract.yaml` updated with check enum + expected/actual shape entries, `patch` bump confirmed correct per playbook conformance-harness rule

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Kwks2uGQS3ZVX7g4kujdGp