### PR TITLE
fix(schema): promote asset-variant oneOf to canonical asset-union.json

### DIFF
--- a/.changeset/fix-asset-union-dedup.md
+++ b/.changeset/fix-asset-union-dedup.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Promote the shared asset-variant `oneOf` union to a canonical `core/assets/asset-union.json` schema. Both `creative-asset.json` and `creative-manifest.json` now reference this single file instead of inlining identical `oneOf` arrays. This eliminates the `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, and `CatalogAsset1` codegen artifacts emitted by `json-schema-to-typescript` when the same union is encountered through multiple parent schemas. Wire format and validation semantics are unchanged.

--- a/static/schemas/source/core/assets/asset-union.json
+++ b/static/schemas/source/core/assets/asset-union.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/assets/asset-union.json",
+  "title": "AssetVariant",
+  "description": "Canonical union of all asset variant schemas. Referenced from creative-asset.json and creative-manifest.json to ensure a single named type is emitted by schema-to-TypeScript tooling. Add new asset types here and to the creative/asset-types registry.",
+  "oneOf": [
+    { "$ref": "/schemas/core/assets/image-asset.json" },
+    { "$ref": "/schemas/core/assets/video-asset.json" },
+    { "$ref": "/schemas/core/assets/audio-asset.json" },
+    { "$ref": "/schemas/core/assets/vast-asset.json" },
+    { "$ref": "/schemas/core/assets/text-asset.json" },
+    { "$ref": "/schemas/core/assets/url-asset.json" },
+    { "$ref": "/schemas/core/assets/html-asset.json" },
+    { "$ref": "/schemas/core/assets/javascript-asset.json" },
+    { "$ref": "/schemas/core/assets/webhook-asset.json" },
+    { "$ref": "/schemas/core/assets/css-asset.json" },
+    { "$ref": "/schemas/core/assets/daast-asset.json" },
+    { "$ref": "/schemas/core/assets/markdown-asset.json" },
+    { "$ref": "/schemas/core/assets/brief-asset.json" },
+    { "$ref": "/schemas/core/assets/catalog-asset.json" }
+  ],
+  "discriminator": {
+    "propertyName": "asset_type"
+  }
+}

--- a/static/schemas/source/core/creative-asset.json
+++ b/static/schemas/source/core/creative-asset.json
@@ -23,25 +23,7 @@
       "description": "Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.",
       "patternProperties": {
         "^[a-z0-9_]+$": {
-          "oneOf": [
-            { "$ref": "/schemas/core/assets/image-asset.json" },
-            { "$ref": "/schemas/core/assets/video-asset.json" },
-            { "$ref": "/schemas/core/assets/audio-asset.json" },
-            { "$ref": "/schemas/core/assets/vast-asset.json" },
-            { "$ref": "/schemas/core/assets/text-asset.json" },
-            { "$ref": "/schemas/core/assets/url-asset.json" },
-            { "$ref": "/schemas/core/assets/html-asset.json" },
-            { "$ref": "/schemas/core/assets/javascript-asset.json" },
-            { "$ref": "/schemas/core/assets/webhook-asset.json" },
-            { "$ref": "/schemas/core/assets/css-asset.json" },
-            { "$ref": "/schemas/core/assets/daast-asset.json" },
-            { "$ref": "/schemas/core/assets/markdown-asset.json" },
-            { "$ref": "/schemas/core/assets/brief-asset.json" },
-            { "$ref": "/schemas/core/assets/catalog-asset.json" }
-          ],
-          "discriminator": {
-            "propertyName": "asset_type"
-          }
+          "$ref": "/schemas/core/assets/asset-union.json"
         }
       },
       "additionalProperties": true

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -14,25 +14,7 @@
       "description": "Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.\n\nEach asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.",
       "patternProperties": {
         "^[a-z0-9_]+$": {
-          "oneOf": [
-            { "$ref": "/schemas/core/assets/image-asset.json" },
-            { "$ref": "/schemas/core/assets/video-asset.json" },
-            { "$ref": "/schemas/core/assets/audio-asset.json" },
-            { "$ref": "/schemas/core/assets/vast-asset.json" },
-            { "$ref": "/schemas/core/assets/text-asset.json" },
-            { "$ref": "/schemas/core/assets/url-asset.json" },
-            { "$ref": "/schemas/core/assets/html-asset.json" },
-            { "$ref": "/schemas/core/assets/javascript-asset.json" },
-            { "$ref": "/schemas/core/assets/webhook-asset.json" },
-            { "$ref": "/schemas/core/assets/css-asset.json" },
-            { "$ref": "/schemas/core/assets/daast-asset.json" },
-            { "$ref": "/schemas/core/assets/markdown-asset.json" },
-            { "$ref": "/schemas/core/assets/brief-asset.json" },
-            { "$ref": "/schemas/core/assets/catalog-asset.json" }
-          ],
-          "discriminator": {
-            "propertyName": "asset_type"
-          }
+          "$ref": "/schemas/core/assets/asset-union.json"
         }
       },
       "additionalProperties": true

--- a/static/schemas/source/core/offering-asset-group.json
+++ b/static/schemas/source/core/offering-asset-group.json
@@ -15,7 +15,7 @@
     },
     "items": {
       "type": "array",
-      "description": "The assets in this group. Each item carries an `asset_type` discriminator that selects the matching asset schema. Note: the group-level `asset_type` declares the expected type; individual items must also self-tag so validators can narrow errors.",
+      "description": "The assets in this group. Each item carries an `asset_type` discriminator that selects the matching asset schema. Note: the group-level `asset_type` declares the expected type; individual items must also self-tag so validators can narrow errors. Intentionally excludes `brief-asset` and `catalog-asset` — those are campaign-input metadata types, not delivery-ready creative assets suitable for a pooled offering group. See core/assets/asset-union.json for the full asset-variant union.",
       "items": {
         "oneOf": [
           { "$ref": "/schemas/core/assets/text-asset.json" },

--- a/static/schemas/source/creative/list-creatives-response.json
+++ b/static/schemas/source/creative/list-creatives-response.json
@@ -87,25 +87,7 @@
             "description": "Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.",
             "patternProperties": {
               "^[a-z0-9_]+$": {
-                "oneOf": [
-                  { "$ref": "/schemas/core/assets/image-asset.json" },
-                  { "$ref": "/schemas/core/assets/video-asset.json" },
-                  { "$ref": "/schemas/core/assets/audio-asset.json" },
-                  { "$ref": "/schemas/core/assets/vast-asset.json" },
-                  { "$ref": "/schemas/core/assets/text-asset.json" },
-                  { "$ref": "/schemas/core/assets/url-asset.json" },
-                  { "$ref": "/schemas/core/assets/html-asset.json" },
-                  { "$ref": "/schemas/core/assets/javascript-asset.json" },
-                  { "$ref": "/schemas/core/assets/webhook-asset.json" },
-                  { "$ref": "/schemas/core/assets/css-asset.json" },
-                  { "$ref": "/schemas/core/assets/daast-asset.json" },
-                  { "$ref": "/schemas/core/assets/markdown-asset.json" },
-                  { "$ref": "/schemas/core/assets/brief-asset.json" },
-                  { "$ref": "/schemas/core/assets/catalog-asset.json" }
-                ],
-                "discriminator": {
-                  "propertyName": "asset_type"
-                }
+                "$ref": "/schemas/core/assets/asset-union.json"
               }
             },
             "additionalProperties": true


### PR DESCRIPTION
Closes #3459

## Summary

`json-schema-to-typescript` emits `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, and `CatalogAsset1` as codegen artifacts because `creative-asset.json` and `creative-manifest.json` both inline an identical 14-arm `oneOf` over asset variant schemas. When the generator encounters the same anonymous union through two different parent paths, it suffixes the second occurrence.

This PR promotes that union to a single canonical `core/assets/asset-union.json` (`title: AssetVariant`) and replaces both inline blocks with a `$ref` to that schema. The fix follows the same pattern as the prior `AgeVerificationMethod`/`AgeVerificationMethod1` fix — dedup at the schema source, not in post-processing.

Also adds a description note to `offering-asset-group.json` explaining its intentional 12-arm subset (`brief` and `catalog` excluded as campaign-input metadata, not delivery-ready asset types).

**Non-breaking justification:** A `$ref` that resolves to a `oneOf` is structurally equivalent to inlining that `oneOf` at the reference site under JSON Schema draft-07. Wire format, required properties, and enum constants on each variant are unchanged. The `discriminator` annotation moves inside `asset-union.json` alongside its `oneOf`, which is the correct placement per OAS 3.1 §4.8.24. Validators that were passing before will continue to pass identically.

**Note on `asset-union.json` stability:** Once shipped, the 14-arm union at `/schemas/core/assets/asset-union.json` becomes an implicitly stable `$id`. Adding or removing arms in a subsequent patch release would be a protocol change, not a codegen fix.

**Changeset bump note:** Protocol expert assessed `patch` (structural equivalence, no new semantics). Code reviewer flagged `minor` (new `$id`-addressable schema file is additive). Reviewer discretion on final bump — the PR body calls it out rather than papering over the disagreement.

## Pre-PR review

- **ad-tech-protocol-expert:** approved — non-breaking per JSON Schema draft-07; `patch` is correct; `$ref`-to-`$ref` resolution semantically transparent; discriminator placement correct per OAS 3.1. 0 blockers.
- **code-reviewer:** approved with nits — 0 blockers; flagged `minor` vs `patch` bump (see note above) and `offering-asset-group.json` intentional subset (addressed in second commit).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017XYv1Yt2m9NSj4bsNR22qo

---
_Generated by [Claude Code](https://claude.ai/code/session_017XYv1Yt2m9NSj4bsNR22qo)_