### PR TITLE
feat(addie): tag thread messages with message_source at write-time

### DIFF
--- a/.changeset/addie-message-source-tagging.md
+++ b/.changeset/addie-message-source-tagging.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tag addie_thread_messages with message_source at write-time (typed, cta_chip, voice, email, unknown). Replaces the stopgap CTA-chip string allowlist in conversation-insights-builder with a column-based filter using IS DISTINCT FROM 'cta_chip' (Refs #3408, Closes #3455).

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -3302,6 +3302,7 @@
               chatInput.value = prompt;
               autoResize();
               updateSendButton();
+              pendingMessageSource = 'cta_chip';
               sendMessage();
             }
           });
@@ -3358,6 +3359,7 @@
         chatInput.value = prompt;
         autoResize();
         updateSendButton();
+        pendingMessageSource = 'cta_chip';
         sendMessage();
       }
 
@@ -4046,6 +4048,7 @@
             // Send message to Addie to connect to this agent
             const connectMessage = `Connect me to ${agent.display_name}`;
             chatInput.value = connectMessage;
+            pendingMessageSource = 'cta_chip';
             await sendMessage();
           });
 
@@ -4112,10 +4115,20 @@
         }
       }
 
+      // Set to 'cta_chip' by chip click handlers before calling sendMessage().
+      // Reset to null after each send so subsequent typed messages get 'typed'.
+      let pendingMessageSource = null;
+
       // Send message with streaming
       async function sendMessage() {
         const message = chatInput.value.trim();
-        if (!message || isLoading || !isReady) return;
+        if (!message || isLoading || !isReady) {
+          pendingMessageSource = null;
+          return;
+        }
+
+        const messageSource = pendingMessageSource || 'typed';
+        pendingMessageSource = null;
 
         isLoading = true;
         updateSendButton();
@@ -4154,6 +4167,7 @@
             body: JSON.stringify({
               message,
               conversation_id: conversationId,
+              message_source: messageSource,
             }),
           });
 
@@ -4356,6 +4370,7 @@
           chatInput.value = prompt;
           autoResize();
           updateSendButton();
+          pendingMessageSource = 'cta_chip';
           sendMessage();
         }
       });
@@ -4487,6 +4502,7 @@
               chatInput.value = prompt.trim();
               autoResize();
               updateSendButton();
+              pendingMessageSource = 'cta_chip';
               sendMessage();
               // Clean URL without reloading
               window.history.replaceState({}, '', window.location.pathname);

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1561,6 +1561,7 @@ async function handleUserMessage({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: matchedRuleId ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -2188,6 +2189,7 @@ async function handleAppMention({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(mentionMemberContext ?? memberContext),
+      message_source: 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -3156,6 +3158,7 @@ async function handleDirectMessage(
   }
 
   // Log user message to unified thread
+  const matchedRuleIdDm = matchRuleIdFromMessage(messageText);
   const userMessageFlagged = inputValidation.flagged;
   try {
     await threadService.addMessage({
@@ -3167,6 +3170,7 @@ async function handleDirectMessage(
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: matchedRuleIdDm ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -3530,6 +3534,7 @@ async function handleActiveThreadReply({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -4016,6 +4021,7 @@ async function handleChannelMessage({
         router_decision: buildRouterDecision(plan),
         user_id: userId,
         user_display_name: resolveSpeakerDisplayName(memberContext),
+        message_source: 'typed',
       });
     } catch (error) {
       logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -4915,6 +4921,7 @@ async function handleReactionAdded({
       content_sanitized: userInput,
       user_id: reactingUserId,
       user_display_name: resolveSpeakerDisplayName(reactingMemberContext),
+      message_source: 'unknown',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save reaction message');

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -28,7 +28,7 @@ import { loadRules } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.5';
+export const CODE_VERSION = '2026.04.6';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/email-conversation-handler.ts
+++ b/server/src/addie/email-conversation-handler.ts
@@ -165,6 +165,7 @@ export async function handleEmailConversation(
       email_message_id: input.messageId,
       user_id: input.senderEmail,
       user_display_name: speakerName,
+      message_source: 'email',
     });
 
     // 3. Get conversation history

--- a/server/src/addie/home/builders/rules/prompt-rules.ts
+++ b/server/src/addie/home/builders/rules/prompt-rules.ts
@@ -481,6 +481,18 @@ export const MEMBER_RULES: PromptRule[] = [
     label: "What's new?",
     prompt: "What's new at AgenticAdvertising.org?",
   },
+  // Sentinel rule for Sage module-start CTAs (e.g. "Start module A1").
+  // These strings are synthesized at runtime from URL params in chat.html
+  // and never appear in PROMPT_TO_RULE_ID, so they need a matchClick callback.
+  // when: () => false means this rule never renders in the suggestion list.
+  {
+    id: 'sage.start_module',
+    priority: 0,
+    when: () => false,
+    label: 'Start module',
+    prompt: 'Start module',
+    matchClick: (msg) => /^Start module \w+$/.test(msg),
+  },
 ];
 
 export const ALL_RULES: PromptRule[] = [...ADMIN_RULES, ...MEMBER_RULES];

--- a/server/src/addie/services/conversation-insights-builder.ts
+++ b/server/src/addie/services/conversation-insights-builder.ts
@@ -232,6 +232,10 @@ async function gatherConversationSamples(
          (SELECT LEFT(content, $3) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'user'
           ORDER BY sequence_number ASC LIMIT 1) AS user_message,
+         -- Source of first user message (used to exclude CTA-chip-initiated threads)
+         (SELECT message_source FROM addie_thread_messages
+          WHERE thread_id = t.thread_id AND role = 'user'
+          ORDER BY sequence_number ASC LIMIT 1) AS first_msg_source,
          -- First assistant response
          (SELECT LEFT(content, $4) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'assistant'
@@ -257,19 +261,7 @@ async function gatherConversationSamples(
      )
      SELECT * FROM thread_samples
      WHERE user_message IS NOT NULL AND assistant_response IS NOT NULL
-       -- STOPGAP(#3408): exclude known CTA-chip strings until message_source column ships.
-       -- When message_source tagging lands, replace this with: AND first_msg_source != 'cta_chip'
-       AND user_message NOT IN (
-         'What can you do? What kinds of things can I ask you about?',
-         'What is AdCP and how does it work?',
-         'How do I set up a sales agent with AdCP?',
-         'How is agentic advertising different from programmatic, and why does it matter?',
-         'Start module A1',
-         'Start module A2',
-         'Start module A3',
-         'Start module B1',
-         'I''d like to start learning AdCP in the Academy…'
-       )
+       AND first_msg_source IS DISTINCT FROM 'cta_chip'
      ORDER BY
        has_escalation DESC,
        rating ASC NULLS LAST,

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -154,6 +154,9 @@ export interface CreateMessageInput {
   // the thread starter. Optional for assistant/system rows and legacy paths.
   user_id?: string;
   user_display_name?: string;
+  // How the user initiated this message. Only populated on role='user' rows.
+  // NULL on rows predating migration 451 (2026-04-28).
+  message_source?: 'typed' | 'cta_chip' | 'voice' | 'paste' | 'email' | 'unknown';
 }
 
 export interface ThreadMessage {
@@ -211,6 +214,7 @@ export interface ThreadMessage {
   // Per-message speaker identity (see CreateMessageInput).
   user_id: string | null;
   user_display_name: string | null;
+  message_source: 'typed' | 'cta_chip' | 'voice' | 'paste' | 'email' | 'unknown' | null;
 }
 
 export interface ThreadWithMessages extends Thread {
@@ -456,8 +460,8 @@ export class ThreadService {
           timing_system_prompt_ms, timing_total_llm_ms, timing_total_tool_ms,
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
-          user_id, user_display_name
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+          user_id, user_display_name, message_source
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
         RETURNING *`,
         [
           input.thread_id,
@@ -486,6 +490,7 @@ export class ThreadService {
           input.email_message_id != null ? stripNullBytesString(input.email_message_id) : null,
           input.user_id ?? null,
           input.user_display_name != null ? stripNullBytesString(input.user_display_name) : null,
+          input.message_source ?? null,
         ]
       );
 

--- a/server/src/db/migrations/451_addie_thread_message_source.sql
+++ b/server/src/db/migrations/451_addie_thread_message_source.sql
@@ -1,0 +1,15 @@
+-- Tag messages by input source so the insights pipeline can exclude CTA-chip
+-- clicks from theme analysis without relying on a fragile string allowlist
+-- (stopgap in conversation-insights-builder.ts, Refs #3408/#3455).
+--
+-- NULL = row predates tagging (2026-04-28). The insights filter uses
+-- IS DISTINCT FROM 'cta_chip' which keeps NULLs in the sample — correct
+-- behavior; old untagged rows are treated as organic conversations.
+-- No backfill needed.
+
+ALTER TABLE addie_thread_messages
+  ADD COLUMN IF NOT EXISTS message_source TEXT
+  CHECK (message_source IN ('typed', 'cta_chip', 'voice', 'paste', 'email', 'unknown'));
+
+COMMENT ON COLUMN addie_thread_messages.message_source IS
+  'How the user initiated this message. typed=keyboard input, cta_chip=welcome/suggested-prompt button click, voice=Tavus voice session, paste=clipboard paste (reserved), email=inbound email reply, unknown=automated/system paths. NULL on rows predating 2026-04-28.';

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -1529,6 +1529,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
         flagged: inputValidation.flagged,
         flag_reason: inputValidation.reason || undefined,
         router_decision: routerDecision,
+        message_source: 'unknown',
       });
 
       logger.info({

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -147,6 +147,10 @@ let authenticatedOnlyTools: RequestTools | null = null;
 
 const ANONYMOUS_MAX_ITERATIONS = 5;
 
+// Sources the web client is permitted to assert. Voice / email / unknown are
+// set server-side only (tavus.ts, email-conversation-handler.ts, bolt-app.ts).
+const VALID_WEB_SOURCES = new Set<'typed' | 'cta_chip'>(['typed', 'cta_chip']);
+
 /**
  * Merge per-request member tools with cached authenticated-only tools,
  * and select model + iteration limits based on auth status.
@@ -717,7 +721,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         });
       }
 
-      const { message, conversation_id, user_name } = req.body;
+      const { message, conversation_id, user_name, message_source: rawMessageSource } = req.body;
 
       if (!message || typeof message !== "string") {
         return res.status(400).json({ error: "Message is required" });
@@ -735,6 +739,13 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       if (matchedRuleId && req.user?.id) {
         void recordPromptClicked(req.user.id, matchedRuleId);
       }
+
+      // Accept message_source from client (chip click vs typed); fall back to
+      // heuristic detection so old clients without the field still tag correctly.
+      const messageSource: 'typed' | 'cta_chip' =
+        typeof rawMessageSource === 'string' && VALID_WEB_SOURCES.has(rawMessageSource as 'typed' | 'cta_chip')
+          ? rawMessageSource as 'typed' | 'cta_chip'
+          : matchedRuleId ? 'cta_chip' : 'typed';
 
       // Get or create thread using unified service
       // For web chat, the external_id is the conversation_id (UUID)
@@ -807,6 +818,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: messageSource,
       });
 
       // Record inbound message in the relationship system
@@ -1004,7 +1016,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         return;
       }
 
-      const { message, conversation_id, user_name } = req.body;
+      const { message, conversation_id, user_name, message_source: rawMessageSourceStream } = req.body;
 
       if (!message || typeof message !== "string") {
         sendEvent("error", { error: "Message is required" });
@@ -1024,6 +1036,11 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       if (matchedRuleId && req.user?.id) {
         void recordPromptClicked(req.user.id, matchedRuleId);
       }
+
+      const messageSourceStream: 'typed' | 'cta_chip' =
+        typeof rawMessageSourceStream === 'string' && VALID_WEB_SOURCES.has(rawMessageSourceStream as 'typed' | 'cta_chip')
+          ? rawMessageSourceStream as 'typed' | 'cta_chip'
+          : matchedRuleId ? 'cta_chip' : 'typed';
 
       // Get or create thread
       const impersonator = req.user?.impersonator;
@@ -1089,6 +1106,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: messageSourceStream,
       });
 
       // Record inbound message in the relationship system

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -489,6 +489,7 @@ export function createTavusRouter() {
         content: currentMessage,
         user_id: voiceUserId ?? undefined,
         user_display_name: voiceSpeakerName,
+        message_source: 'voice',
       }).catch((err) => logger.error({ err }, "Tavus: Failed to log user message"));
     }
 

--- a/server/tests/unit/message-source-tagging.test.ts
+++ b/server/tests/unit/message-source-tagging.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { matchRuleIdFromMessage } from '../../src/addie/home/builders/rules/prompt-rules.js';
+
+// The message_source inference used by bolt-app.ts and addie-chat.ts:
+// matchRuleIdFromMessage(text) != null → 'cta_chip', else → 'typed'
+function inferMessageSource(text: string | null | undefined): 'cta_chip' | 'typed' {
+  return matchRuleIdFromMessage(text) ? 'cta_chip' : 'typed';
+}
+
+describe('message_source tagging', () => {
+  describe('CTA chip detection', () => {
+    it('tags Sage "Start module" prompts as cta_chip', () => {
+      // These were in the old string-based stopgap (migration 451 replaces it).
+      expect(inferMessageSource('Start module A1')).toBe('cta_chip');
+      expect(inferMessageSource('Start module A2')).toBe('cta_chip');
+      expect(inferMessageSource('Start module A3')).toBe('cta_chip');
+      expect(inferMessageSource('Start module B1')).toBe('cta_chip');
+    });
+
+    it('tags cert continue-in-progress prompts as cta_chip', () => {
+      // Dynamic matchClick patterns for in-progress modules
+      expect(inferMessageSource("Let's keep going with A1. Where did we leave off?")).toBe('cta_chip');
+      expect(inferMessageSource("Let's keep going with B2. Where did we leave off?")).toBe('cta_chip');
+    });
+
+    it('tags known suggested-prompt text as cta_chip', () => {
+      expect(inferMessageSource('Pick up where I left off in certification.')).toBe('cta_chip');
+    });
+  });
+
+  describe('typed message detection', () => {
+    it('tags an organic question as typed', () => {
+      expect(inferMessageSource('What is the difference between DSP and SSP?')).toBe('typed');
+    });
+
+    it('tags a free-form message as typed', () => {
+      expect(inferMessageSource('hi can you help me with my agent')).toBe('typed');
+    });
+
+    it('tags paraphrased CTA text as typed (heuristic is verbatim-only)', () => {
+      expect(inferMessageSource('How do I start module A1?')).toBe('typed');
+    });
+
+    it('returns typed for null/undefined/empty', () => {
+      expect(inferMessageSource(null)).toBe('typed');
+      expect(inferMessageSource(undefined)).toBe('typed');
+      expect(inferMessageSource('')).toBe('typed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `message_source TEXT CHECK(...)` column to `addie_thread_messages` (migration 451) with values `typed | cta_chip | voice | paste | email | unknown`; nullable so pre-migration rows are unaffected
- Tags all user-role `addMessage` write paths: Slack DM/mention/channel (bolt-app), web chat POST+stream (addie-chat), voice (tavus), email (email-conversation-handler), admin sim (addie-admin)
- Replaces the fragile 9-string `NOT IN` stopgap in `conversation-insights-builder` with `IS DISTINCT FROM 'cta_chip'` — NULL rows from pre-migration data correctly pass through

## Key design decisions

- **No backfill**: `NULL IS DISTINCT FROM 'cta_chip'` is `TRUE` in Postgres, so historic rows are treated as organic questions automatically
- **Web client restriction**: `addie-chat.ts` only accepts `'typed' | 'cta_chip'` from the client body (`VALID_WEB_SOURCES`); `voice`, `email`, and `unknown` are set server-side only
- **Sage module CTAs**: Added `sage.start_module` sentinel rule with `matchClick: (msg) => /^Start module \w+$/.test(msg)` so Slack DM paths can detect `"Start module A1"` strings that are synthesized at runtime and not in the static `PROMPT_TO_RULE_ID` index
- **`pendingMessageSource` guard**: Reset to `null` on early-return in `sendMessage()` so a chip click while `isLoading` doesn't bleed into the next typed message

## Test plan

- [ ] Run `npm test server/tests/unit/message-source-tagging.test.ts` — all 8 cases should pass including `Start module A1/A2/A3/B1` → `cta_chip`
- [ ] Apply migration 451 against staging DB; verify column exists with correct CHECK constraint
- [ ] Send a message via web chat; confirm `message_source = 'typed'` in `addie_thread_messages`
- [ ] Click a suggested-prompt chip in web chat; confirm `message_source = 'cta_chip'`
- [ ] Attempt to POST `message_source: 'voice'` directly to `/api/addie/chat`; verify it falls back to `'typed'`
- [ ] Run `buildConversationInsights` job; verify CTA-chip-initiated threads are excluded from samples

Refs #3408, Closes #3455

---
_Generated by [Claude Code](https://claude.ai/code/session_013pFCGEr7vaA3C8EV2RSehT)_