### PR TITLE
addie: add message_source column to addie_thread_messages (#3455)

### DIFF
--- a/.changeset/addie-message-source-column.md
+++ b/.changeset/addie-message-source-column.md
@@ -1,0 +1,12 @@
+---
+---
+
+Add `message_source` column to `addie_thread_messages` to distinguish
+CTA chip clicks from typed messages at write-time. Migration 451 adds
+the column (`NOT NULL DEFAULT 'unknown'`) with a CHECK constraint on
+values `typed | cta_chip | voice | paste | unknown`. All `addMessage`
+call sites in `bolt-app.ts` and `addie-chat.ts` are updated to tag the
+source using the existing `matchRuleIdFromMessage` heuristic. Removes
+the hardcoded NOT IN stopgap from `conversation-insights-builder.ts`
+(introduced in #3415) in favour of `AND first_msg_source != 'cta_chip'`.
+Resolves #3408 / #3455.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1561,6 +1561,7 @@ async function handleUserMessage({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: matchedRuleId ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -2188,6 +2189,7 @@ async function handleAppMention({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(mentionMemberContext ?? memberContext),
+      message_source: 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -3167,6 +3169,7 @@ async function handleDirectMessage(
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: matchRuleIdFromMessage(messageText) ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -3530,6 +3533,7 @@ async function handleActiveThreadReply({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -4016,6 +4020,7 @@ async function handleChannelMessage({
         router_decision: buildRouterDecision(plan),
         user_id: userId,
         user_display_name: resolveSpeakerDisplayName(memberContext),
+        message_source: 'typed',
       });
     } catch (error) {
       logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -4915,6 +4920,7 @@ async function handleReactionAdded({
       content_sanitized: userInput,
       user_id: reactingUserId,
       user_display_name: resolveSpeakerDisplayName(reactingMemberContext),
+      message_source: 'unknown',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save reaction message');

--- a/server/src/addie/services/conversation-insights-builder.ts
+++ b/server/src/addie/services/conversation-insights-builder.ts
@@ -232,6 +232,10 @@ async function gatherConversationSamples(
          (SELECT LEFT(content, $3) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'user'
           ORDER BY sequence_number ASC LIMIT 1) AS user_message,
+         -- message_source of first user message (for CTA chip filtering)
+         (SELECT message_source FROM addie_thread_messages
+          WHERE thread_id = t.thread_id AND role = 'user'
+          ORDER BY sequence_number ASC LIMIT 1) AS first_msg_source,
          -- First assistant response
          (SELECT LEFT(content, $4) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'assistant'
@@ -257,19 +261,7 @@ async function gatherConversationSamples(
      )
      SELECT * FROM thread_samples
      WHERE user_message IS NOT NULL AND assistant_response IS NOT NULL
-       -- STOPGAP(#3408): exclude known CTA-chip strings until message_source column ships.
-       -- When message_source tagging lands, replace this with: AND first_msg_source != 'cta_chip'
-       AND user_message NOT IN (
-         'What can you do? What kinds of things can I ask you about?',
-         'What is AdCP and how does it work?',
-         'How do I set up a sales agent with AdCP?',
-         'How is agentic advertising different from programmatic, and why does it matter?',
-         'Start module A1',
-         'Start module A2',
-         'Start module A3',
-         'Start module B1',
-         'I''d like to start learning AdCP in the Academy…'
-       )
+       AND (first_msg_source IS NULL OR first_msg_source != 'cta_chip')
      ORDER BY
        has_escalation DESC,
        rating ASC NULLS LAST,

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -154,6 +154,7 @@ export interface CreateMessageInput {
   // the thread starter. Optional for assistant/system rows and legacy paths.
   user_id?: string;
   user_display_name?: string;
+  message_source?: 'typed' | 'cta_chip' | 'voice' | 'paste' | 'unknown';
 }
 
 export interface ThreadMessage {
@@ -211,6 +212,7 @@ export interface ThreadMessage {
   // Per-message speaker identity (see CreateMessageInput).
   user_id: string | null;
   user_display_name: string | null;
+  message_source: string;
 }
 
 export interface ThreadWithMessages extends Thread {
@@ -456,8 +458,8 @@ export class ThreadService {
           timing_system_prompt_ms, timing_total_llm_ms, timing_total_tool_ms,
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
-          user_id, user_display_name
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+          user_id, user_display_name, message_source
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
         RETURNING *`,
         [
           input.thread_id,
@@ -486,6 +488,7 @@ export class ThreadService {
           input.email_message_id != null ? stripNullBytesString(input.email_message_id) : null,
           input.user_id ?? null,
           input.user_display_name != null ? stripNullBytesString(input.user_display_name) : null,
+          input.message_source ?? 'unknown',
         ]
       );
 

--- a/server/src/db/migrations/451_thread_message_source.sql
+++ b/server/src/db/migrations/451_thread_message_source.sql
@@ -1,0 +1,14 @@
+-- Add message_source to addie_thread_messages.
+-- Tracks how the message was initiated: 'typed' (user typed it), 'cta_chip'
+-- (user clicked a suggested-prompt chip), 'voice', 'paste', or 'unknown'
+-- (legacy rows and paths not yet classified).
+--
+-- NOT NULL DEFAULT 'unknown' is metadata-only in Postgres 11+ — no table
+-- rewrite. Existing rows get 'unknown'; new rows supply the source at write-time.
+
+ALTER TABLE addie_thread_messages
+  ADD COLUMN message_source TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (message_source IN ('typed', 'cta_chip', 'voice', 'paste', 'unknown'));
+
+COMMENT ON COLUMN addie_thread_messages.message_source IS
+  'How the message was initiated. typed=user typed it; cta_chip=suggested-prompt chip click; voice=voice input; paste=detected paste; unknown=legacy/unclassified.';

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -1529,6 +1529,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
         flagged: inputValidation.flagged,
         flag_reason: inputValidation.reason || undefined,
         router_decision: routerDecision,
+        message_source: 'typed',
       });
 
       logger.info({

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -807,6 +807,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: matchedRuleId ? 'cta_chip' : 'typed',
       });
 
       // Record inbound message in the relationship system
@@ -1089,6 +1090,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: matchedRuleId ? 'cta_chip' : 'typed',
       });
 
       // Record inbound message in the relationship system

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -489,6 +489,7 @@ export function createTavusRouter() {
         content: currentMessage,
         user_id: voiceUserId ?? undefined,
         user_display_name: voiceSpeakerName,
+        message_source: 'voice',
       }).catch((err) => logger.error({ err }, "Tavus: Failed to log user message"));
     }
 


### PR DESCRIPTION
## Summary

- Migration 451 adds `message_source TEXT NOT NULL DEFAULT 'unknown'` to `addie_thread_messages` with `CHECK (message_source IN ('typed', 'cta_chip', 'voice', 'paste', 'unknown'))`
- All `role: 'user'` `addMessage` call sites tagged using the existing `matchRuleIdFromMessage` heuristic — no frontend changes required:
  - `handleUserMessage` (Slack DM assistant thread): `cta_chip` when `matchRuleIdFromMessage` matches, otherwise `typed`
  - `handleDirectMessage` (old-style Slack DM): same heuristic
  - `handleAppMention`, `handleActiveThreadReply`, `handleChannelMessage`: `typed`
  - `handleReactionAdded`: `unknown` (synthesized from emoji reaction, not a typed message)
  - Tavus voice path: `voice`
  - Web chat (both non-streaming and streaming endpoints): `cta_chip` / `typed` via existing `matchRuleIdFromMessage` call
  - Admin test-router endpoint: `typed`
  - Email handler: `unknown` (email is not one of the defined surface values)
- Removes the hardcoded NOT IN stopgap from `conversation-insights-builder.ts` (introduced in #3415 as `STOPGAP(#3408)`) in favour of `AND (first_msg_source IS NULL OR first_msg_source != 'cta_chip')`
- `CreateMessageInput.message_source` typed as a union literal (not bare `string`) for compile-time enforcement
- `ThreadMessage` interface updated to include `message_source: string`

## Design notes

- Server-side heuristic detection (reuses `matchRuleIdFromMessage` already called at every web/Slack entry point) — no client contract change needed
- `NOT NULL DEFAULT 'unknown'` is metadata-only in Postgres 11+ (no table rewrite); existing rows get `'unknown'`
- The `IS NULL OR` guard in the insights filter handles any edge-case threads with no user messages without silently dropping them

## Test plan

- [ ] Run migration 451 against staging DB; confirm column present with DEFAULT `'unknown'`
- [ ] Click a suggested-prompt chip in the Slack AI assistant panel → `message_source = 'cta_chip'`
- [ ] Type a message in the Slack AI assistant panel → `message_source = 'typed'`
- [ ] Click a suggested-prompt chip in web chat → `message_source = 'cta_chip'`
- [ ] Type a message in web chat → `message_source = 'typed'`
- [ ] Trigger a Tavus voice turn → `message_source = 'voice'`
- [ ] Confirm weekly insights query excludes CTA-chip-opened threads

Closes #3455

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ttyfvK8NPqopdsqnxVot)_