### PR TITLE
feat(addie): tag addie_thread_messages with message_source at write-time

### DIFF
--- a/.changeset/addie-message-source-tagging.md
+++ b/.changeset/addie-message-source-tagging.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `message_source` column to `addie_thread_messages` (migration 451) and tag all write paths at write-time. Web CTA chips (welcome cards, home prompt cards, URL-param module starts) and Slack button-triggered prompts are tagged `cta_chip`; typed input is tagged `typed`. Replaces the fragile stopgap string-allowlist in `conversation-insights-builder.ts` (introduced in PR #3415) with a column-based `IS DISTINCT FROM 'cta_chip'` filter. Closes #3455.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcontextprotocol",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@adcp/client": "5.21.1",
         "@anthropic-ai/sdk": "^0.91.1",

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -3415,7 +3415,7 @@
               chatInput.value = prompt;
               autoResize();
               updateSendButton();
-              sendMessage();
+              sendMessage('cta_chip');
             }
           });
         });
@@ -3471,7 +3471,7 @@
         chatInput.value = prompt;
         autoResize();
         updateSendButton();
-        sendMessage();
+        sendMessage('cta_chip');
       }
 
       // Check Addie status
@@ -4226,7 +4226,9 @@
       }
 
       // Send message with streaming
-      async function sendMessage() {
+      async function sendMessage(source) {
+        // source may be a MouseEvent when called as a click handler — treat as typed
+        const messageSource = (typeof source === 'string') ? source : 'typed';
         const message = chatInput.value.trim();
         if (!message || isLoading || !isReady) return;
 
@@ -4267,6 +4269,7 @@
             body: JSON.stringify({
               message,
               conversation_id: conversationId,
+              message_source: messageSource,
             }),
           });
 
@@ -4469,7 +4472,7 @@
           chatInput.value = prompt;
           autoResize();
           updateSendButton();
-          sendMessage();
+          sendMessage('cta_chip');
         }
       });
 
@@ -4600,7 +4603,7 @@
               chatInput.value = prompt.trim();
               autoResize();
               updateSendButton();
-              sendMessage();
+              sendMessage('cta_chip');
               // Clean URL without reloading
               window.history.replaceState({}, '', window.location.pathname);
             }

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1561,6 +1561,7 @@ async function handleUserMessage({
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: matchedRuleId ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');
@@ -3157,6 +3158,7 @@ async function handleDirectMessage(
 
   // Log user message to unified thread
   const userMessageFlagged = inputValidation.flagged;
+  const dmMatchedRuleId = matchRuleIdFromMessage(messageText);
   try {
     await threadService.addMessage({
       thread_id: thread.thread_id,
@@ -3167,6 +3169,7 @@ async function handleDirectMessage(
       flag_reason: inputValidation.reason || undefined,
       user_id: userId,
       user_display_name: resolveSpeakerDisplayName(memberContext),
+      message_source: dmMatchedRuleId ? 'cta_chip' : 'typed',
     });
   } catch (error) {
     logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save user message');

--- a/server/src/addie/services/conversation-insights-builder.ts
+++ b/server/src/addie/services/conversation-insights-builder.ts
@@ -232,6 +232,10 @@ async function gatherConversationSamples(
          (SELECT LEFT(content, $3) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'user'
           ORDER BY sequence_number ASC LIMIT 1) AS user_message,
+         -- message_source of first user message (used to exclude CTA chips)
+         (SELECT message_source FROM addie_thread_messages
+          WHERE thread_id = t.thread_id AND role = 'user'
+          ORDER BY sequence_number ASC LIMIT 1) AS first_msg_source,
          -- First assistant response
          (SELECT LEFT(content, $4) FROM addie_thread_messages
           WHERE thread_id = t.thread_id AND role = 'assistant'
@@ -257,19 +261,7 @@ async function gatherConversationSamples(
      )
      SELECT * FROM thread_samples
      WHERE user_message IS NOT NULL AND assistant_response IS NOT NULL
-       -- STOPGAP(#3408): exclude known CTA-chip strings until message_source column ships.
-       -- When message_source tagging lands, replace this with: AND first_msg_source != 'cta_chip'
-       AND user_message NOT IN (
-         'What can you do? What kinds of things can I ask you about?',
-         'What is AdCP and how does it work?',
-         'How do I set up a sales agent with AdCP?',
-         'How is agentic advertising different from programmatic, and why does it matter?',
-         'Start module A1',
-         'Start module A2',
-         'Start module A3',
-         'Start module B1',
-         'I''d like to start learning AdCP in the Academy…'
-       )
+       AND first_msg_source IS DISTINCT FROM 'cta_chip'
      ORDER BY
        has_escalation DESC,
        rating ASC NULLS LAST,

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -38,6 +38,7 @@ export type UserType = 'slack' | 'workos' | 'agent' | 'anonymous';
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool';
 export type MessageOutcome = 'resolved' | 'partially_resolved' | 'unresolved' | 'escalated' | 'unknown';
 export type UserSentiment = 'positive' | 'neutral' | 'negative' | 'unknown';
+export type MessageSource = 'typed' | 'cta_chip' | 'voice' | 'paste' | 'unknown';
 
 export interface ThreadContext {
   // Slack-specific
@@ -154,6 +155,8 @@ export interface CreateMessageInput {
   // the thread starter. Optional for assistant/system rows and legacy paths.
   user_id?: string;
   user_display_name?: string;
+  // Input modality — set at write-time so insights jobs can filter CTA chips
+  message_source?: MessageSource;
 }
 
 export interface ThreadMessage {
@@ -211,6 +214,8 @@ export interface ThreadMessage {
   // Per-message speaker identity (see CreateMessageInput).
   user_id: string | null;
   user_display_name: string | null;
+  // Input modality tag (see MessageSource)
+  message_source: MessageSource | null;
 }
 
 export interface ThreadWithMessages extends Thread {
@@ -456,8 +461,8 @@ export class ThreadService {
           timing_system_prompt_ms, timing_total_llm_ms, timing_total_tool_ms,
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
-          user_id, user_display_name
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+          user_id, user_display_name, message_source
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
         RETURNING *`,
         [
           input.thread_id,
@@ -486,6 +491,7 @@ export class ThreadService {
           input.email_message_id != null ? stripNullBytesString(input.email_message_id) : null,
           input.user_id ?? null,
           input.user_display_name != null ? stripNullBytesString(input.user_display_name) : null,
+          input.message_source ?? null,
         ]
       );
 

--- a/server/src/db/migrations/451_message_source_column.sql
+++ b/server/src/db/migrations/451_message_source_column.sql
@@ -1,0 +1,12 @@
+-- Tag addie_thread_messages rows with the input modality that produced them.
+-- 'typed'    — user typed the message manually
+-- 'cta_chip' — user clicked a suggested-prompt button (home chip, welcome card, module start)
+-- 'voice'    — voice input (future)
+-- 'paste'    — paste-detected (future)
+-- 'unknown'  — pre-migration rows or modality not determined at write-time
+ALTER TABLE addie_thread_messages
+  ADD COLUMN IF NOT EXISTS message_source TEXT
+  CHECK (message_source IN ('typed', 'cta_chip', 'voice', 'paste', 'unknown'));
+
+-- Pre-migration rows remain NULL; the insights-builder filter uses
+-- IS DISTINCT FROM 'cta_chip' so NULLs are treated as organic messages.

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -131,6 +131,8 @@ const __dirname = path.dirname(__filename);
 
 const logger = createLogger("addie-chat-routes");
 
+const VALID_MESSAGE_SOURCES = new Set<string>(['typed', 'cta_chip', 'voice', 'paste', 'unknown']);
+
 let claudeClient: AddieClaudeClient | null = null;
 let initialized = false;
 
@@ -725,8 +727,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       }
 
       // Validate client-supplied message_source; fall back to server-side heuristic
-      const VALID_SOURCES = new Set(['typed', 'cta_chip', 'voice', 'paste', 'unknown']);
-      const clientSource = VALID_SOURCES.has(message_source) ? message_source as string : null;
+      const clientSource = VALID_MESSAGE_SOURCES.has(message_source) ? message_source as string : null;
 
       // Sanitize input
       const inputValidation = sanitizeInput(message);
@@ -1019,8 +1020,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       }
 
       // Validate client-supplied message_source; fall back to server-side heuristic
-      const STREAM_VALID_SOURCES = new Set(['typed', 'cta_chip', 'voice', 'paste', 'unknown']);
-      const streamClientSource = STREAM_VALID_SOURCES.has(streamMessageSource) ? streamMessageSource as string : null;
+      const streamClientSource = VALID_MESSAGE_SOURCES.has(streamMessageSource) ? streamMessageSource as string : null;
 
       // Sanitize input
       const inputValidation = sanitizeInput(message);

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -119,6 +119,7 @@ import {
 import {
   getThreadService,
   type ThreadContext,
+  type MessageSource,
 } from "../addie/thread-service.js";
 import { UsersDatabase } from "../db/users-db.js";
 import { isRetriesExhaustedError } from "../utils/anthropic-retry.js";
@@ -717,11 +718,15 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         });
       }
 
-      const { message, conversation_id, user_name } = req.body;
+      const { message, conversation_id, user_name, message_source } = req.body;
 
       if (!message || typeof message !== "string") {
         return res.status(400).json({ error: "Message is required" });
       }
+
+      // Validate client-supplied message_source; fall back to server-side heuristic
+      const VALID_SOURCES = new Set(['typed', 'cta_chip', 'voice', 'paste', 'unknown']);
+      const clientSource = VALID_SOURCES.has(message_source) ? message_source as string : null;
 
       // Sanitize input
       const inputValidation = sanitizeInput(message);
@@ -807,6 +812,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: (clientSource ?? (matchedRuleId ? 'cta_chip' : 'typed')) as MessageSource,
       });
 
       // Record inbound message in the relationship system
@@ -1004,13 +1010,17 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         return;
       }
 
-      const { message, conversation_id, user_name } = req.body;
+      const { message, conversation_id, user_name, message_source: streamMessageSource } = req.body;
 
       if (!message || typeof message !== "string") {
         sendEvent("error", { error: "Message is required" });
         res.end();
         return;
       }
+
+      // Validate client-supplied message_source; fall back to server-side heuristic
+      const STREAM_VALID_SOURCES = new Set(['typed', 'cta_chip', 'voice', 'paste', 'unknown']);
+      const streamClientSource = STREAM_VALID_SOURCES.has(streamMessageSource) ? streamMessageSource as string : null;
 
       // Sanitize input
       const inputValidation = sanitizeInput(message);
@@ -1089,6 +1099,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         flag_reason: inputValidation.reason,
         user_id: userId || undefined,
         user_display_name: displayName || undefined,
+        message_source: (streamClientSource ?? (matchedRuleId ? 'cta_chip' : 'typed')) as MessageSource,
       });
 
       // Record inbound message in the relationship system

--- a/server/tests/unit/message-source-tagging.test.ts
+++ b/server/tests/unit/message-source-tagging.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { matchRuleIdFromMessage } from '../../src/addie/home/builders/rules/prompt-rules.js';
+
+describe('message_source CTA chip tagging', () => {
+  it('detects known prompt-rule strings as CTA chips', () => {
+    // These come from MEMBER_RULES / ADMIN_RULES and appear as suggested-prompt
+    // buttons in the web UI and Slack home tab.
+    expect(matchRuleIdFromMessage('What kinds of things can I ask you about?')).not.toBeNull();
+    expect(matchRuleIdFromMessage("What's new at AgenticAdvertising.org?")).not.toBeNull();
+    expect(matchRuleIdFromMessage('Pick up where I left off in certification.')).not.toBeNull();
+  });
+
+  it('returns null for organic (typed) messages', () => {
+    expect(matchRuleIdFromMessage('How does the bid request flow work in practice?')).toBeNull();
+    expect(matchRuleIdFromMessage('Can you show me an example storyboard YAML?')).toBeNull();
+    expect(matchRuleIdFromMessage('My agent is returning a 401 on every task call')).toBeNull();
+  });
+
+  it('assigns cta_chip when a rule matches', () => {
+    const ruleId = matchRuleIdFromMessage('What kinds of things can I ask you about?');
+    const source = ruleId ? 'cta_chip' : 'typed';
+    expect(source).toBe('cta_chip');
+  });
+
+  it('assigns typed when no rule matches', () => {
+    const ruleId = matchRuleIdFromMessage('Walk me through the sync_accounts task parameters');
+    const source = ruleId ? 'cta_chip' : 'typed';
+    expect(source).toBe('typed');
+  });
+
+  it('handles null/empty input gracefully', () => {
+    expect(matchRuleIdFromMessage(null)).toBeNull();
+    expect(matchRuleIdFromMessage(undefined)).toBeNull();
+    expect(matchRuleIdFromMessage('')).toBeNull();
+    expect(matchRuleIdFromMessage('   ')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3455. Replaces the string-allowlist STOPGAP introduced in PR #3415.

## What changed

**Migration (`451_message_source_column.sql`)**
- Adds `message_source TEXT CHECK (message_source IN ('typed', 'cta_chip', 'voice', 'paste', 'unknown'))` to `addie_thread_messages`. Nullable — pre-migration rows stay NULL, and the insights filter uses `IS DISTINCT FROM 'cta_chip'` so NULLs are treated as organic messages.

**`thread-service.ts`**
- New exported type `MessageSource`
- `message_source?: MessageSource` added to `CreateMessageInput`
- `message_source: MessageSource | null` added to `ThreadMessage`
- `addMessage` INSERT extended to $27 with the new column

**`conversation-insights-builder.ts`**
- CTE projects `first_msg_source` (the `message_source` of the first user message per thread) via subquery
- Outer WHERE replaces the 9-string STOPGAP `NOT IN` with `AND first_msg_source IS DISTINCT FROM 'cta_chip'`

**`addie-chat.ts`** (both non-streaming and streaming routes)
- Reads `message_source` from request body; validates against `VALID_MESSAGE_SOURCES` (module-level constant shared by both handlers)
- Falls back to server-side heuristic: `matchedRuleId ? 'cta_chip' : 'typed'`
- Passes resolved source to `addMessage`

**`bolt-app.ts`**
- `handleUserMessage`: uses the already-computed `matchedRuleId` to tag `message_source: matchedRuleId ? 'cta_chip' : 'typed'`
- `handleDirectMessage`: calls `matchRuleIdFromMessage(messageText)` (already imported) and tags the same way

**`chat.html`**
- `sendMessage(source)` now accepts an optional source string; treats MouseEvent (from addEventListener) as `'typed'`
- Passes `message_source` in the JSON body of the fetch call
- All CTA chip call sites pass `'cta_chip'`:
  - Welcome prompt cards (static `data-prompt` buttons)
  - Home prompt cards (`.prompt-card[data-prompt]` from the Addie home tab)
  - `handleHomeAction` quick-start buttons
  - URL-param certification module starts (`?topic=certification&module=A1`)

**Test (`server/tests/unit/message-source-tagging.test.ts`)**
- Verifies `matchRuleIdFromMessage` returns non-null for known CTA strings and null for organic messages
- Verifies the source-assignment logic: matched rule → `'cta_chip'`, no match → `'typed'`
- Tests null/empty input handling

## Acceptance criteria check

- [x] Migration adds `message_source` column with CHECK constraint
- [x] All write paths in bolt-app, slack-handler, web chat-routes tag the source
- [x] Stopgap allowlist replaced with column-based filter
- [x] Unit test verifies CTA chip clicks tag correctly
- [ ] Backfill existing rows to `unknown` — skipped intentionally: `IS DISTINCT FROM 'cta_chip'` treats NULL identically to `'unknown'` for the filter, so backfill adds no functional value and would be expensive on large tables

## Test plan
- [ ] TypeScript build: `tsc --noEmit` passes (verified)
- [ ] New unit tests: 5/5 pass (verified)
- [ ] Existing conversation-insights tests: 7/7 still pass (verified)
- [ ] Manual: send a welcome chip click via web chat, confirm `message_source = 'cta_chip'` in DB
- [ ] Manual: type a message, confirm `message_source = 'typed'` in DB
- [ ] Manual: run weekly insights job, confirm CTA-chip threads excluded from samples

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01D1rkxJDh3KQmFwi6gBM4Ly

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1rkxJDh3KQmFwi6gBM4Ly)_