### PR TITLE
feat(team): click-tracking on Report wrong + member-profile deep link

### DIFF
--- a/.changeset/team-page-polish.md
+++ b/.changeset/team-page-polish.md
@@ -1,0 +1,7 @@
+---
+---
+
+Two small polish items deferred from the PR #3450 review:
+
+- **Click-tracking on "Report wrong"**: new endpoint `POST /api/organizations/:orgId/brand-classification-report` records `(orgId, userId, kind, subject_domain)` to `registry_audit_log` so we have a triage queue + can detect "10 different members reported the same domain." The frontend fires `navigator.sendBeacon` on click — the `mailto:` opens regardless. Member-or-above can flag (broader than admin/owner since the report is informational).
+- **Deep link from `/member-profile` to `/team`**: tiny one-liner under "Brand identity" on the member-profile page pointing at the team page where the registry hierarchy is shown. Closes the bounce-off case where an admin lands on member-profile looking for "is my company classified right?"

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -900,9 +900,12 @@
           <!-- Brand identity (companies only) -->
           <div id="logos-section">
           <h2>Brand identity</h2>
-          <p style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-5);">
+          <p style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-3);">
             Your logo and brand colors are managed in the brand registry. As a member, we host your brand.json at
             <strong>agenticadvertising.org/brands/yourdomain.com/brand.json</strong> — a stable URL you can reference from your domain.
+          </p>
+          <p style="color: var(--color-text-tertiary); font-size: var(--text-xs); margin-bottom: var(--space-5);">
+            How your org is positioned in the registry hierarchy (parent / subsidiaries) is shown on the <a href="/team" style="color: var(--color-primary-600);">team page</a>.
           </p>
 
           <!-- Brand linked state -->

--- a/server/public/team.html
+++ b/server/public/team.html
@@ -1270,7 +1270,7 @@
         // Render the auto-provision toggle whenever there is at least one
         // verified domain. With no verified domain the toggle is a no-op
         // (autoLinkByVerifiedDomain has nothing to match), so we hide it.
-        renderBrandHierarchy(data);
+        renderBrandHierarchy(orgId, data);
         renderAutoProvisionToggle(orgId, data);
         renderAutoProvisionHierarchyToggle(orgId, data);
       } catch (error) {
@@ -1283,7 +1283,7 @@
       }
     }
 
-    function renderBrandHierarchy(data) {
+    function renderBrandHierarchy(orgId, data) {
       const row = document.getElementById('brandHierarchyRow');
       const content = document.getElementById('brandHierarchyContent');
       const classification = data.hierarchy_classification;
@@ -1305,6 +1305,21 @@
           `Please describe the correct classification:\n\n`
         );
         return `mailto:hello@agenticadvertising.org?subject=${subject}&body=${body}`;
+      };
+
+      // Fire-and-forget audit ping when a member clicks "Report wrong" so
+      // we have a triage queue + can detect "10 different members reported
+      // the same domain". The mailto opens regardless — sendBeacon doesn't
+      // block navigation/window-events.
+      const reportClickHandler = (kind, domain) => (ev) => {
+        try {
+          const payload = JSON.stringify({ kind, subject_domain: domain });
+          const blob = new Blob([payload], { type: 'application/json' });
+          navigator.sendBeacon(`/api/organizations/${orgId}/brand-classification-report`, blob);
+        } catch {
+          // Non-blocking — beacon failure shouldn't get in the way of the user.
+        }
+        // Don't preventDefault — let the mailto open.
       };
 
       // Source badge: brand_json self-asserted is authoritative ("they told
@@ -1329,7 +1344,7 @@
             <strong style="color: var(--color-text-heading);">${escapeHtml(p.brand_name || p.domain)}</strong>
             <span style="color: var(--color-text-tertiary);">— ${escapeHtml(p.domain)}</span>
             ${sourceBadge(p.source)}
-            <a href="${reportLink('parent', p.domain)}" style="margin-left: auto; color: var(--color-primary-600); font-size: var(--text-xs);">Report wrong</a>
+            <a href="${reportLink('parent', p.domain)}" data-report-kind="parent" data-report-domain="${escapeHtml(p.domain)}" style="margin-left: auto; color: var(--color-primary-600); font-size: var(--text-xs);">Report wrong</a>
           </div>
           <div style="text-align: center; color: var(--color-text-tertiary); font-size: var(--text-xs); margin-bottom: var(--space-2);">↓</div>
         `);
@@ -1376,7 +1391,7 @@
                   <span style="color: var(--color-text-tertiary);">— ${escapeHtml(s.domain)}</span>
                   ${sourceBadge(s.source)}
                   <span style="margin-left: auto; color: var(--color-text-tertiary); font-size: var(--text-xs);">last validated ${fmtDate(s.last_validated)}</span>
-                  <a href="${reportLink('child', s.domain)}" style="color: var(--color-primary-600); font-size: var(--text-xs);">Report wrong</a>
+                  <a href="${reportLink('child', s.domain)}" data-report-kind="child" data-report-domain="${escapeHtml(s.domain)}" style="color: var(--color-primary-600); font-size: var(--text-xs);">Report wrong</a>
                 </li>
               `).join('')}
             </ul>
@@ -1392,6 +1407,14 @@
       }
 
       content.innerHTML = parts.join('');
+
+      // Wire fire-and-forget audit beacons to each Report-wrong link. The
+      // anchor's mailto: still opens normally — sendBeacon doesn't block.
+      content.querySelectorAll('a[data-report-kind]').forEach((a) => {
+        const kind = a.getAttribute('data-report-kind');
+        const domain = a.getAttribute('data-report-domain');
+        if (kind && domain) a.addEventListener('click', reportClickHandler(kind, domain));
+      });
     }
 
     function renderAutoProvisionToggle(orgId, data) {

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -695,6 +695,53 @@ export function createOrganizationsRouter(): Router {
     }
   });
 
+  // POST /api/organizations/:orgId/brand-classification-report - Record that
+  // a member flagged a brand-registry classification as wrong on the team page.
+  // Writes a structured audit row so we have a triage queue + can detect
+  // "10 different members reported the same domain". Doesn't block the user
+  // — they're also opening a mailto in parallel, so this is fire-and-forget
+  // best-effort.
+  router.post('/:orgId/brand-classification-report', requireAuth, async (req, res) => {
+    try {
+      const user = req.user!;
+      const { orgId } = req.params;
+      const { kind, subject_domain } = req.body ?? {};
+
+      const VALID_KINDS = ['parent', 'self', 'child'];
+      if (!VALID_KINDS.includes(kind)) {
+        return res.status(400).json({ error: 'Invalid kind', message: `kind must be one of: ${VALID_KINDS.join(', ')}` });
+      }
+      if (typeof subject_domain !== 'string' || subject_domain.length === 0 || subject_domain.length > 253) {
+        return res.status(400).json({ error: 'Invalid subject_domain' });
+      }
+
+      // Member of the org can flag — broader than admin/owner, since the
+      // report is informational and the corrective action is admin-side.
+      const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+      if (!membership) {
+        return res.status(403).json({ error: 'Access denied', message: 'You are not a member of this organization' });
+      }
+
+      await orgDb.recordAuditLog({
+        workos_organization_id: orgId,
+        workos_user_id: user.id,
+        action: 'brand_classification_report_filed',
+        resource_type: 'brand',
+        resource_id: subject_domain.toLowerCase(),
+        details: {
+          kind,
+          subject_domain: subject_domain.toLowerCase(),
+          reported_by_email: user.email,
+        },
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error({ err: error }, 'Brand classification report error');
+      res.status(500).json({ error: 'Failed to record report' });
+    }
+  });
+
   // GET /api/organizations/:orgId/domain-users - Get Slack users from verified domains not in org (admin only)
   router.get('/:orgId/domain-users', requireAuth, async (req, res) => {
     try {

--- a/server/tests/integration/org-auto-provision-toggles.test.ts
+++ b/server/tests/integration/org-auto-provision-toggles.test.ts
@@ -48,7 +48,9 @@ vi.mock('@workos-inc/node', () => ({
     userManagement = {
       listOrganizationMemberships: workosMocks.listOrganizationMemberships,
     };
-    organizations = {};
+    organizations = {
+      listOrganizations: vi.fn().mockResolvedValue({ data: [] }),
+    };
   },
 }));
 
@@ -344,6 +346,51 @@ describe('org auto-provisioning toggles', () => {
     );
     expect(after.rows[0].auto_provision_brand_hierarchy_children).toBe(false);
     expect(after.rows[0].auto_provision_hierarchy_enabled_at).toBeNull();
+  });
+
+  it('member POST /brand-classification-report records audit row, validates kind', async () => {
+    await seedTestOrg(pool);
+    workosMocks.listOrganizationMemberships.mockResolvedValue({
+      data: [{ role: { slug: 'member' }, status: 'active' }],
+    });
+
+    // Happy path: parent kind, valid domain
+    const ok = await request(app)
+      .post(`/api/organizations/${TEST_ORG}/brand-classification-report`)
+      .send({ kind: 'parent', subject_domain: 'reported-parent.test' });
+    expect(ok.status).toBe(200);
+    expect(ok.body.success).toBe(true);
+
+    // Audit log row exists
+    const audit = await pool.query<{ action: string; details: any }>(
+      `SELECT action, details FROM registry_audit_log
+       WHERE workos_organization_id = $1 AND action = 'brand_classification_report_filed'
+       ORDER BY created_at DESC LIMIT 1`,
+      [TEST_ORG]
+    );
+    expect(audit.rows[0].action).toBe('brand_classification_report_filed');
+    expect(audit.rows[0].details).toMatchObject({
+      kind: 'parent',
+      subject_domain: 'reported-parent.test',
+    });
+
+    // Invalid kind
+    const badKind = await request(app)
+      .post(`/api/organizations/${TEST_ORG}/brand-classification-report`)
+      .send({ kind: 'spouse', subject_domain: 'x.test' });
+    expect(badKind.status).toBe(400);
+
+    // Invalid domain
+    const badDomain = await request(app)
+      .post(`/api/organizations/${TEST_ORG}/brand-classification-report`)
+      .send({ kind: 'parent', subject_domain: '' });
+    expect(badDomain.status).toBe(400);
+
+    // Cleanup audit rows we wrote
+    await pool.query(
+      `DELETE FROM registry_audit_log WHERE workos_organization_id = $1 AND action = 'brand_classification_report_filed'`,
+      [TEST_ORG]
+    );
   });
 
   it('rejects non-boolean auto_provision_brand_hierarchy_children', async () => {


### PR DESCRIPTION
## Summary

Two polish items deferred from the PR #3450 review (product expert recommendations):

1. **Click-tracking on "Report wrong"** — new endpoint `POST /api/organizations/:orgId/brand-classification-report` records `{orgId, userId, kind, subject_domain}` to `registry_audit_log` on every click. The frontend fires `navigator.sendBeacon` from the anchor's click handler; the existing `mailto:` opens normally. This gives us a triage queue and lets us detect when N different members flag the same domain — without building a full intake form yet. Member-or-above can flag (broader than admin/owner since the action is informational).

2. **Deep link from `/member-profile` to `/team`** — one-liner under "Brand identity" pointing at the team page where the registry hierarchy is now shown. Closes the "I came to member-profile to check if my company is classified right" bounce-off case.

## Test plan

- [x] `npm run typecheck` clean
- [x] New integration test covers POST happy path + invalid-kind 400 + invalid-domain 400
- [x] 13/13 pass on the toggles suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)