### PR TITLE
fix(admin): preserve hierarchy enabled_at on flip-off; add disabled_at for forensics

### DIFF
--- a/.changeset/preserve-hierarchy-disabled-at-forensic.md
+++ b/.changeset/preserve-hierarchy-disabled-at-forensic.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(admin): preserve auto_provision_hierarchy_enabled_at on flag flip-off; add disabled_at for forensic preservation
+
+Migration 450 nulled `auto_provision_hierarchy_enabled_at` when `auto_provision_brand_hierarchy_children` was flipped off, destroying the forensic record of when the feature was last active. This migration adds `auto_provision_hierarchy_disabled_at TIMESTAMPTZ NULL` and updates the trigger so flip-off sets `disabled_at = NOW()` and preserves `enabled_at` (which the cohort gate in `autoLinkByVerifiedDomain` reads exclusively). A complete `(enabled_at, disabled_at)` pair lets incident response trace the full on/off cycle without losing the original opt-in timestamp. Partial fix for #3466 — IP/user-agent audit enrichment deferred pending compliance decision.

--- a/server/src/db/migrations/452_auto_provision_hierarchy_disabled_at.sql
+++ b/server/src/db/migrations/452_auto_provision_hierarchy_disabled_at.sql
@@ -1,0 +1,38 @@
+-- Forensic preservation for auto_provision_brand_hierarchy_children toggle history.
+--
+-- Migration 450 set enabled_at when the flag flips on, but nulled it on flip-off,
+-- destroying the forensic record of when the feature was last active.
+-- This migration:
+--   1. Adds auto_provision_hierarchy_disabled_at to record when the flag was last
+--      flipped off.
+--   2. Updates the trigger so flip-off sets disabled_at and PRESERVES enabled_at.
+--      enabled_at remains the sole authoritative input for the cohort gate in
+--      autoLinkByVerifiedDomain — this migration does not change that semantics.
+--
+-- Follow-up to PR #3430 security review. See issue #3466.
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS auto_provision_hierarchy_disabled_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN organizations.auto_provision_hierarchy_disabled_at IS
+  'Set when auto_provision_brand_hierarchy_children transitions from true to false. Preserved alongside auto_provision_hierarchy_enabled_at for incident-response forensics. The cohort gate in autoLinkByVerifiedDomain reads only enabled_at as authoritative.';
+
+-- Replace the trigger function body.
+-- The trigger binding (organizations_auto_provision_hierarchy_enabled_at) is
+-- unchanged — only the function logic is updated.
+CREATE OR REPLACE FUNCTION track_auto_provision_hierarchy_enabled_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.auto_provision_brand_hierarchy_children IS DISTINCT FROM NEW.auto_provision_brand_hierarchy_children THEN
+    IF NEW.auto_provision_brand_hierarchy_children = true THEN
+      NEW.auto_provision_hierarchy_enabled_at := COALESCE(NEW.auto_provision_hierarchy_enabled_at, NOW());
+    ELSE
+      -- Record when the feature was last turned off; do NOT null enabled_at.
+      -- A complete (enabled_at, disabled_at) pair lets incident response trace
+      -- the full on/off cycle without losing the original opt-in timestamp.
+      NEW.auto_provision_hierarchy_disabled_at := NOW();
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -145,6 +145,7 @@ export interface Organization {
   auto_provision_verified_domain: boolean;
   auto_provision_brand_hierarchy_children: boolean;
   auto_provision_hierarchy_enabled_at: Date | null;
+  auto_provision_hierarchy_disabled_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/server/tests/integration/find-paying-org-for-domain.test.ts
+++ b/server/tests/integration/find-paying-org-for-domain.test.ts
@@ -52,7 +52,9 @@ async function seedPayingOrg(pool: Pool, orgId: string, domain: string, opts: {
            subscription_status = EXCLUDED.subscription_status,
            subscription_canceled_at = EXCLUDED.subscription_canceled_at,
            auto_provision_verified_domain = EXCLUDED.auto_provision_verified_domain,
-           auto_provision_brand_hierarchy_children = EXCLUDED.auto_provision_brand_hierarchy_children`,
+           auto_provision_brand_hierarchy_children = EXCLUDED.auto_provision_brand_hierarchy_children,
+           auto_provision_hierarchy_enabled_at = NULL,
+           auto_provision_hierarchy_disabled_at = NULL`,
     [
       orgId,
       `Org ${orgId}`,
@@ -421,15 +423,19 @@ describe('resolveEffectiveMembership coherence with findPayingOrgForDomain', () 
     );
     expect(after.rows[0].enabled_at).not.toBeNull();
 
-    // Flip back to false → trigger clears the timestamp.
+    // Flip back to false → trigger preserves enabled_at and sets disabled_at.
     await pool.query(
       'UPDATE organizations SET auto_provision_brand_hierarchy_children = false WHERE workos_organization_id = $1',
       [TEST_PARENT_ORG],
     );
-    const cleared = await pool.query<{ enabled_at: Date | null }>(
-      'SELECT auto_provision_hierarchy_enabled_at AS enabled_at FROM organizations WHERE workos_organization_id = $1',
+    const cleared = await pool.query<{ enabled_at: Date | null; disabled_at: Date | null }>(
+      `SELECT auto_provision_hierarchy_enabled_at AS enabled_at,
+              auto_provision_hierarchy_disabled_at AS disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
       [TEST_PARENT_ORG],
     );
-    expect(cleared.rows[0].enabled_at).toBeNull();
+    // enabled_at is preserved (authoritative cohort-gate input); disabled_at is set.
+    expect(cleared.rows[0].enabled_at).not.toBeNull();
+    expect(cleared.rows[0].disabled_at).not.toBeNull();
   });
 });

--- a/server/tests/integration/org-auto-provision-toggles.test.ts
+++ b/server/tests/integration/org-auto-provision-toggles.test.ts
@@ -317,7 +317,7 @@ describe('org auto-provisioning toggles', () => {
     currentMockEmail = 'owner@apt-co.test';
   });
 
-  it('flipping the flag back to false clears the enabled_at timestamp', async () => {
+  it('flipping the flag back to false sets disabled_at and preserves enabled_at', async () => {
     await seedTestOrg(pool, { hierarchyOptIn: true });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
       data: [{ role: { slug: 'owner' }, status: 'active' }],
@@ -339,13 +339,82 @@ describe('org auto-provisioning toggles', () => {
     const after = await pool.query<{
       auto_provision_brand_hierarchy_children: boolean;
       auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
     }>(
-      `SELECT auto_provision_brand_hierarchy_children, auto_provision_hierarchy_enabled_at
+      `SELECT auto_provision_brand_hierarchy_children,
+              auto_provision_hierarchy_enabled_at,
+              auto_provision_hierarchy_disabled_at
        FROM organizations WHERE workos_organization_id = $1`,
       [TEST_ORG]
     );
     expect(after.rows[0].auto_provision_brand_hierarchy_children).toBe(false);
-    expect(after.rows[0].auto_provision_hierarchy_enabled_at).toBeNull();
+    // enabled_at must be preserved — it is the authoritative cohort-gate input.
+    expect(after.rows[0].auto_provision_hierarchy_enabled_at).not.toBeNull();
+    // disabled_at must be set for forensic incident review.
+    expect(after.rows[0].auto_provision_hierarchy_disabled_at).not.toBeNull();
+  });
+
+  it('enable → disable → re-enable cycle preserves full timestamp history', async () => {
+    await seedTestOrg(pool, { hierarchyOptIn: false });
+    workosMocks.listOrganizationMemberships.mockResolvedValue({
+      data: [{ role: { slug: 'owner' }, status: 'active' }],
+    });
+
+    // Enable.
+    await request(app)
+      .patch(`/api/organizations/${TEST_ORG}/settings`)
+      .send({ auto_provision_brand_hierarchy_children: true });
+
+    const afterEnable = await pool.query<{
+      auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
+    }>(
+      `SELECT auto_provision_hierarchy_enabled_at, auto_provision_hierarchy_disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG]
+    );
+    expect(afterEnable.rows[0].auto_provision_hierarchy_enabled_at).not.toBeNull();
+    expect(afterEnable.rows[0].auto_provision_hierarchy_disabled_at).toBeNull();
+
+    const firstEnabledAt = afterEnable.rows[0].auto_provision_hierarchy_enabled_at!;
+
+    // Disable.
+    await request(app)
+      .patch(`/api/organizations/${TEST_ORG}/settings`)
+      .send({ auto_provision_brand_hierarchy_children: false });
+
+    const afterDisable = await pool.query<{
+      auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
+    }>(
+      `SELECT auto_provision_hierarchy_enabled_at, auto_provision_hierarchy_disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG]
+    );
+    // Both timestamps preserved.
+    expect(afterDisable.rows[0].auto_provision_hierarchy_enabled_at).toEqual(firstEnabledAt);
+    expect(afterDisable.rows[0].auto_provision_hierarchy_disabled_at).not.toBeNull();
+
+    // Re-enable: COALESCE keeps the original enabled_at; a new disabled_at
+    // would only be overwritten on the next flip-off (not re-enable).
+    await request(app)
+      .patch(`/api/organizations/${TEST_ORG}/settings`)
+      .send({ auto_provision_brand_hierarchy_children: true });
+
+    const afterReEnable = await pool.query<{
+      auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
+    }>(
+      `SELECT auto_provision_hierarchy_enabled_at, auto_provision_hierarchy_disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG]
+    );
+    // COALESCE: original enabled_at is preserved (grandfathered cohort gate).
+    expect(afterReEnable.rows[0].auto_provision_hierarchy_enabled_at).toEqual(firstEnabledAt);
+    // disabled_at unchanged since the last flip-off.
+    expect(afterReEnable.rows[0].auto_provision_hierarchy_disabled_at).toEqual(
+      afterDisable.rows[0].auto_provision_hierarchy_disabled_at
+    );
   });
 
   it('member POST /brand-classification-report records audit row, validates kind', async () => {
@@ -424,7 +493,8 @@ async function seedTestOrg(pool: Pool, opts: { hierarchyOptIn?: boolean } = {}) 
      ) VALUES ($1, 'APT Test Co', $2, 'active', false, NOW(), NOW())
      ON CONFLICT (workos_organization_id) DO UPDATE
        SET auto_provision_brand_hierarchy_children = false,
-           auto_provision_hierarchy_enabled_at = NULL`,
+           auto_provision_hierarchy_enabled_at = NULL,
+           auto_provision_hierarchy_disabled_at = NULL`,
     [TEST_ORG, TEST_DOMAIN]
   );
   if (opts.hierarchyOptIn === true) {


### PR DESCRIPTION
Refs #3466. Delivers acceptance criteria items 2–4 only. Item 1 (IP + user-agent in audit details) is deferred — see triage comment on #3466 for the compliance decision needed first.

## Summary

Migration 450 nulled `auto_provision_hierarchy_enabled_at` when `auto_provision_brand_hierarchy_children` was flipped off, silently destroying the forensic record of when the feature was last active. This PR:

- Adds `auto_provision_hierarchy_disabled_at TIMESTAMPTZ NULL` to `organizations` (migration 452)
- Updates the `track_auto_provision_hierarchy_enabled_at` trigger so flip-off sets `disabled_at = NOW()` and **preserves** `enabled_at` (which the cohort gate in `autoLinkByVerifiedDomain` reads exclusively — gate semantics unchanged)
- Adds the field to the `Organization` TS interface
- Updates both integration test suites (`org-auto-provision-toggles`, `find-paying-org-for-domain`) to match the new semantics and adds an enable → disable → re-enable cycle test

A complete `(enabled_at, disabled_at)` pair lets incident response trace the full on/off cycle without losing the original opt-in timestamp.

## Non-breaking justification

Adds a single nullable column with no DEFAULT; existing rows get NULL (no table rewrite). No read path or gate logic changed. The `Organization` interface addition is additive.

## Pre-PR review

- **code-reviewer:** approved — trigger replacement via `CREATE OR REPLACE FUNCTION` is correct (PostgreSQL binds triggers by function name); test cycle assertions are sound; no flakiness risk. Nit: add trigger name to migration comment (not blocking).
- **internal-tools-strategist:** approved — `disabled_at` correctly DB-only (not surfaced in GET /domains API); `ADD COLUMN IF NOT EXISTS` on nullable column is metadata-only in PG 11+, no lock concern. Identified blocker (stale assertion in `find-paying-org-for-domain.test.ts`) — fixed in this commit.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Pn9rJFGQxPJpKGfUyF6W2v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn9rJFGQxPJpKGfUyF6W2v)_