### PR TITLE
fix(admin): add IP+UA to org-settings audit log; preserve disabled_at for forensic history

### DIFF
--- a/.changeset/audit-log-ip-disabled-at.md
+++ b/.changeset/audit-log-ip-disabled-at.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add IP + user-agent to org-settings audit log and preserve `auto_provision_hierarchy_disabled_at` for forensic history. Follow-up to #3430 security review.

--- a/server/src/db/migrations/452_auto_provision_hierarchy_disabled_at.sql
+++ b/server/src/db/migrations/452_auto_provision_hierarchy_disabled_at.sql
@@ -1,0 +1,45 @@
+-- Preserve forensic history for the auto_provision_brand_hierarchy_children toggle.
+--
+-- Migration 450 added auto_provision_hierarchy_enabled_at as a cohort gate:
+-- autoLinkByVerifiedDomain only auto-joins users created after this timestamp.
+-- Before this migration, flipping the flag OFF cleared enabled_at to NULL,
+-- erasing the "when was this last on?" record needed for incident response.
+--
+-- This migration adds disabled_at so both timestamps survive the on→off cycle.
+-- The cohort gate continues to read enabled_at (unchanged). disabled_at is
+-- forensic-only: it tells incident responders when the feature was last disabled.
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS auto_provision_hierarchy_disabled_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN organizations.auto_provision_hierarchy_disabled_at IS
+  'Set when auto_provision_brand_hierarchy_children transitions from true to false. '
+  'Forensic-only — does not affect the cohort gate. '
+  'auto_provision_hierarchy_enabled_at remains authoritative for autoLinkByVerifiedDomain.';
+
+-- Update trigger: on flip-on, set enabled_at (COALESCE preserves the original
+-- timestamp on re-enable — intentional, so users who joined after the first
+-- enable but before a re-enable are not retroactively excluded from the cohort
+-- gate); on flip-off, set disabled_at and leave enabled_at intact (was: clear
+-- enabled_at to NULL).
+CREATE OR REPLACE FUNCTION track_auto_provision_hierarchy_enabled_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.auto_provision_brand_hierarchy_children IS DISTINCT FROM NEW.auto_provision_brand_hierarchy_children THEN
+    IF NEW.auto_provision_brand_hierarchy_children = true THEN
+      NEW.auto_provision_hierarchy_enabled_at := COALESCE(NEW.auto_provision_hierarchy_enabled_at, NOW());
+    ELSE
+      NEW.auto_provision_hierarchy_disabled_at := NOW();
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Re-bind the trigger (matches migration 450 pattern; ensures idempotency
+-- if the trigger is ever dropped and migrations are re-run).
+DROP TRIGGER IF EXISTS organizations_auto_provision_hierarchy_enabled_at ON organizations;
+CREATE TRIGGER organizations_auto_provision_hierarchy_enabled_at
+BEFORE UPDATE ON organizations
+FOR EACH ROW
+EXECUTE FUNCTION track_auto_provision_hierarchy_enabled_at();

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -145,6 +145,7 @@ export interface Organization {
   auto_provision_verified_domain: boolean;
   auto_provision_brand_hierarchy_children: boolean;
   auto_provision_hierarchy_enabled_at: Date | null;
+  auto_provision_hierarchy_disabled_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -1841,7 +1841,14 @@ export function createOrganizationsRouter(): Router {
         action: 'organization_settings_updated',
         resource_type: 'organization',
         resource_id: orgId,
-        details: updates,
+        // ip and user_agent are stored here for forensic use. registry_audit_log.details
+        // is exposed only via /api/admin/audit-logs (requireAdmin). Do not widen that
+        // endpoint without reviewing PII exposure for these fields.
+        details: {
+          ip: req.ip ?? null,
+          user_agent: req.get('User-Agent') ?? null,
+          ...updates,
+        },
       });
 
       logger.info({ orgId, updates, userId: user.id }, 'Organization settings updated');

--- a/server/tests/integration/org-auto-provision-toggles.test.ts
+++ b/server/tests/integration/org-auto-provision-toggles.test.ts
@@ -317,7 +317,7 @@ describe('org auto-provisioning toggles', () => {
     currentMockEmail = 'owner@apt-co.test';
   });
 
-  it('flipping the flag back to false clears the enabled_at timestamp', async () => {
+  it('flipping the flag back to false preserves enabled_at and sets disabled_at', async () => {
     await seedTestOrg(pool, { hierarchyOptIn: true });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
       data: [{ role: { slug: 'owner' }, status: 'active' }],
@@ -339,13 +339,59 @@ describe('org auto-provisioning toggles', () => {
     const after = await pool.query<{
       auto_provision_brand_hierarchy_children: boolean;
       auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
     }>(
-      `SELECT auto_provision_brand_hierarchy_children, auto_provision_hierarchy_enabled_at
+      `SELECT auto_provision_brand_hierarchy_children,
+              auto_provision_hierarchy_enabled_at,
+              auto_provision_hierarchy_disabled_at
        FROM organizations WHERE workos_organization_id = $1`,
       [TEST_ORG]
     );
     expect(after.rows[0].auto_provision_brand_hierarchy_children).toBe(false);
-    expect(after.rows[0].auto_provision_hierarchy_enabled_at).toBeNull();
+    // enabled_at is preserved — cohort gate remains for re-enable audits
+    expect(after.rows[0].auto_provision_hierarchy_enabled_at).not.toBeNull();
+    // disabled_at is set — forensic record of when it was turned off
+    expect(after.rows[0].auto_provision_hierarchy_disabled_at).not.toBeNull();
+  });
+
+  it('enable→disable cycle preserves both timestamps', async () => {
+    await seedTestOrg(pool, { hierarchyOptIn: false });
+    workosMocks.listOrganizationMemberships.mockResolvedValue({
+      data: [{ role: { slug: 'owner' }, status: 'active' }],
+    });
+
+    // Enable
+    await request(app)
+      .patch(`/api/organizations/${TEST_ORG}/settings`)
+      .send({ auto_provision_brand_hierarchy_children: true });
+
+    const afterEnable = await pool.query<{
+      auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
+    }>(
+      `SELECT auto_provision_hierarchy_enabled_at, auto_provision_hierarchy_disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG]
+    );
+    expect(afterEnable.rows[0].auto_provision_hierarchy_enabled_at).not.toBeNull();
+    expect(afterEnable.rows[0].auto_provision_hierarchy_disabled_at).toBeNull();
+
+    // Disable
+    await request(app)
+      .patch(`/api/organizations/${TEST_ORG}/settings`)
+      .send({ auto_provision_brand_hierarchy_children: false });
+
+    const afterDisable = await pool.query<{
+      auto_provision_hierarchy_enabled_at: Date | null;
+      auto_provision_hierarchy_disabled_at: Date | null;
+    }>(
+      `SELECT auto_provision_hierarchy_enabled_at, auto_provision_hierarchy_disabled_at
+       FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG]
+    );
+    // Both timestamps survive the full cycle
+    expect(afterDisable.rows[0].auto_provision_hierarchy_enabled_at).not.toBeNull();
+    expect(afterDisable.rows[0].auto_provision_hierarchy_disabled_at).not.toBeNull();
   });
 
   it('member POST /brand-classification-report records audit row, validates kind', async () => {
@@ -424,7 +470,8 @@ async function seedTestOrg(pool: Pool, opts: { hierarchyOptIn?: boolean } = {}) 
      ) VALUES ($1, 'APT Test Co', $2, 'active', false, NOW(), NOW())
      ON CONFLICT (workos_organization_id) DO UPDATE
        SET auto_provision_brand_hierarchy_children = false,
-           auto_provision_hierarchy_enabled_at = NULL`,
+           auto_provision_hierarchy_enabled_at = NULL,
+           auto_provision_hierarchy_disabled_at = NULL`,
     [TEST_ORG, TEST_DOMAIN]
   );
   if (opts.hierarchyOptIn === true) {


### PR DESCRIPTION
Closes #3466. Follow-up to PR #3430 security review.

## Summary

- **Audit log IP + user-agent:** The `organization_settings_updated` audit entry on `PATCH /api/organizations/:orgId/settings` now records `ip` and `user_agent` in the `details` JSONB blob alongside the settings changes. Stored forensic-only; an inline comment documents that `registry_audit_log.details` is exposed exclusively via `/api/admin/audit-logs` (`requireAdmin`) — widen that endpoint with caution.
- **`auto_provision_hierarchy_disabled_at` column (migration 452):** Before this PR, flipping the auto-provision flag OFF cleared `enabled_at` to NULL, erasing the "when was this last on?" record. Migration 452 adds a nullable `disabled_at` column and updates the trigger so flip-off sets `disabled_at = NOW()` and leaves `enabled_at` intact. `enabled_at` remains authoritative for the cohort gate in `autoLinkByVerifiedDomain`; `disabled_at` is forensic-only.
- **`Organization` TypeScript interface** updated with `auto_provision_hierarchy_disabled_at: Date | null`.
- **Tests** updated to reflect the new trigger behavior; new `enable→disable cycle` test confirms both timestamps survive.

## Non-breaking justification

Adds optional fields to an existing JSONB blob and a nullable column to `organizations` with no default — existing rows are NULL, all read paths that don't select the column are unaffected. No interface renames, no required fields added, no enum changes.

## Pre-PR review

- **code-reviewer:** approved — both blockers (missing `Organization` interface field; no access-model comment) fixed in-pass; `req.ip ?? null` and spread order corrected after second pass
- **internal-tools-strategist:** approved — migration sequencing clean (452 independent of 451); trigger `DROP/CREATE` pair added for idempotency; `--empty` changeset correct for server/infra change

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01LvoWBWSVtcMSrYBqmEYu8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvoWBWSVtcMSrYBqmEYu8m)_