### PR TITLE
fix(ipr): wrap comment body in object for GitHub API calls

### DIFF
--- a/.changeset/fix-ipr-comment-body-wrapping.md
+++ b/.changeset/fix-ipr-comment-body-wrapping.md
@@ -1,0 +1,9 @@
+---
+---
+
+fix(ipr): wrap comment body string in object for GitHub API calls
+
+`createIssueComment` and `updateIssueComment` were passing the body text
+directly as `options.body`, causing `JSON.stringify` to serialize a bare
+string instead of `{"body":"..."}`. GitHub rejects bare strings with a 422
+`links/0/schema` validation error.

--- a/scripts/ipr/github.mjs
+++ b/scripts/ipr/github.mjs
@@ -69,11 +69,11 @@ export class GitHubClient {
   }
 
   createIssueComment(owner, repo, number, body) {
-    return this.request('POST', `/repos/${owner}/${repo}/issues/${number}/comments`, { body });
+    return this.request('POST', `/repos/${owner}/${repo}/issues/${number}/comments`, { body: { body } });
   }
 
   updateIssueComment(owner, repo, commentId, body) {
-    return this.request('PATCH', `/repos/${owner}/${repo}/issues/comments/${commentId}`, { body });
+    return this.request('PATCH', `/repos/${owner}/${repo}/issues/comments/${commentId}`, { body: { body } });
   }
 
   createStatus(owner, repo, sha, { state, context, description, targetUrl }) {


### PR DESCRIPTION
## Summary

Fixes a 422 error in the IPR check CI reported on #3468. `createIssueComment` and `updateIssueComment` in `scripts/ipr/github.mjs` were passing the comment body text directly as `options.body` to `request()`. Since `request()` does `JSON.stringify(body)`, this serialized a bare JSON string (`"\"text\""`) rather than the object GitHub's API requires (`{"body": "text"}`). GitHub responds with a 422 `links/0/schema` validation error.

**Non-breaking justification:** purely defensive fix to an internal script; no protocol or schema changes.

**Pre-PR review:**
- code-reviewer: approved — no blockers. Fix is consistent with how `createStatus` (the working method) already passes a nested object; `Content-Type` header remains correct.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01X5uXrpVmhruUCvywL4r4Gj

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5uXrpVmhruUCvywL4r4Gj)_