### PR TITLE
ci(triage): LABEL POLICY for ready-for-human issues — auto-apply needs-wg-review + domain

### DIFF
--- a/.changeset/triage-wg-label-policy.md
+++ b/.changeset/triage-wg-label-policy.md
@@ -1,0 +1,4 @@
+---
+---
+
+Triage workflow now sends a LABEL POLICY directive to the routine for `ready-for-human` issues: apply `needs-wg-review` plus a domain label (`media-buy`, `signals`, `creative`, `brand`, `governance`, `sponsored-intelligence`, `schema`, `compliance-suite`, `addie`, `rfc`, etc.) so the working group can route from a single label query. PR-comment runs unchanged. Pure engineering issues (CI, deps, tooling) skip the WG labels.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -199,7 +199,20 @@ jobs:
                 "pr: " + $pr_block + "\n" +
                 "MODE: PR-feedback. Treat new comment as actionable feedback on the PR diff. If the comment requests a fix, apply it as a follow-up commit on the PR head branch — do not open a new PR. If the comment asks a question, answer it as a reply comment. If the comment is conversational with no action implied, post a short acknowledgement and stop.\n"
               else
-                "is_pr: false\n"
+                "is_pr: false\n" +
+                "LABEL POLICY: When your triage status is `ready-for-human` (a real scope/policy/protocol decision is needed before code can land), apply the `needs-wg-review` label via `gh issue edit <num> --add-label needs-wg-review` AND apply the relevant domain label so the working group queue can route. Domain label vocabulary (pick one or more that match the issue's subject area):\n" +
+                "  - media-buy           — campaign / order / package / pricing / makegood / measurement\n" +
+                "  - signals             — audience / signal-marketplace / activation / data-clean-room\n" +
+                "  - creative            — assets / format / build_creative / preview / VAST / DAAST\n" +
+                "  - brand               — brand.json / brand registry / hierarchy / property catalog\n" +
+                "  - governance          — sync_governance / check_governance / IO / approval flows / audit\n" +
+                "  - sponsored-intelligence — TMP / SI sessions / context-match / identity-match\n" +
+                "  - schema              — JSON Schema source-of-truth / codegen / validation hygiene\n" +
+                "  - compliance-suite    — storyboards / conformance / certification testing\n" +
+                "  - addie               — Addie behavior / prompts / KB / chat surface / training\n" +
+                "  - rfc                 — protocol change proposal that needs WG vote\n" +
+                "  - admin-tool / website / member-tools — non-protocol surfaces\n" +
+                "Apply BOTH `needs-wg-review` AND at least one domain label on `ready-for-human`. Skip the WG labels if the issue is pure engineering (CI infra, deps, internal tooling) or already a confirmed bug awaiting only implementation. The label only fires the WG signal — it doesn't replace the triage comment.\n"
               end) +
               (if $nudge == "" then "" else $nudge + "\n" end) +
               (if $comment_body == "" then "" else


### PR DESCRIPTION
Going forward, when the triage routine returns `ready-for-human` it'll apply `needs-wg-review` + a domain label automatically. Replaces the manual bulk-labeling I just did for 24 existing issues.

## What changed

Added a LABEL POLICY directive to the routine payload (only on non-PR issue triage, not PR-comment runs). Tells the routine which labels to apply when its verdict is `ready-for-human`.

## Domain vocabulary

`media-buy`, `signals`, `creative`, `brand`, `governance`, `sponsored-intelligence`, `schema`, `compliance-suite`, `addie`, `rfc` — pick one or more matching the issue subject. Non-protocol surfaces (`admin-tool`, `website`, `member-tools`) keep working as today.

## Skip cases

Pure engineering issues (CI infra, deps, internal tooling) skip the WG labels. Bug-only issues with implementation just queued — no scope decision — also skip.

## Why

`ready-for-human` was opaque before — to find issues parked on a WG decision you had to scan triage comments. Now: `is:open label:needs-wg-review label:media-buy` answers the Media Buy WG's "what do we owe" question in one query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)