### PR TITLE
fix(crawler): skip adagents.json properties missing required fields

### DIFF
--- a/.changeset/fix-crawler-skip-malformed-properties.md
+++ b/.changeset/fix-crawler-skip-malformed-properties.md
@@ -1,0 +1,15 @@
+---
+---
+
+fix(crawler): skip adagents.json properties missing required fields
+
+Malformed `adagents.json` files in the wild ship `properties` entries that omit
+`property_type`, `name`, or `identifiers`. The crawler used to forward these
+straight to `discovered_properties` and crash mid-batch with either
+`property.identifiers is not iterable` or a Postgres `NOT NULL` violation on
+`property_type`, taking the rest of the crawl down with them.
+
+The crawler now sanitizes each property before insert: missing required fields
+cause that one property to be skipped (with a warning), and a non-array
+`identifiers` value is coerced to `[]`. The rest of the manifest still records
+normally.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "./types.js";
 import { PropertyCrawler, getPropertyIndex, type AgentInfo, type CrawlResult } from "@adcp/client";
-import { hardenPropertyIndex } from "./discovery/property-index-guard.js";
+import { hardenPropertyIndex, sanitizeAdagentsProperty } from "./discovery/property-index-guard.js";
 import { FederatedIndexService } from "./federated-index.js";
 import { AdAgentsManager } from "./adagents-manager.js";
 import { BrandManager } from "./brand-manager.js";
@@ -649,7 +649,10 @@ export class CrawlerService {
     authorizedFor?: string,
     limitToPropertyIds?: string[]
   ): Promise<void> {
-    for (const prop of properties) {
+    for (const rawProp of properties) {
+      const prop = sanitizeAdagentsProperty(rawProp, { publisherDomain, agentUrl });
+      if (!prop) continue;
+
       // If agent has specific property_ids, only record those
       if (limitToPropertyIds && limitToPropertyIds.length > 0) {
         if (!prop.property_id || !limitToPropertyIds.includes(prop.property_id)) {

--- a/server/src/discovery/property-index-guard.ts
+++ b/server/src/discovery/property-index-guard.ts
@@ -32,3 +32,59 @@ export function hardenPropertyIndex(): void {
     return original(property, agentUrl, publisherDomain);
   };
 }
+
+export interface SanitizedAdagentsProperty {
+  property_id?: string;
+  property_type: string;
+  name: string;
+  identifiers: Array<{ type: string; value: string }>;
+  tags?: string[];
+  publisher_domain?: string;
+}
+
+/**
+ * Validate a property entry from a publisher's adagents.json before we hand it
+ * to the federated-index DB writer. Real-world manifests sometimes omit
+ * required fields (property_type/name) or ship a non-array identifiers value;
+ * upsertProperty would otherwise fail the entire crawl with a NOT NULL
+ * violation or a TypeError. Returns null for properties that can't be
+ * recovered so the caller can skip them and keep crawling.
+ */
+export function sanitizeAdagentsProperty(
+  raw: unknown,
+  context: { publisherDomain: string; agentUrl: string },
+): SanitizedAdagentsProperty | null {
+  if (!raw || typeof raw !== "object") {
+    log.warn(context, "Skipping property: not an object");
+    return null;
+  }
+  const prop = raw as Record<string, unknown>;
+  const propertyType = typeof prop.property_type === "string" ? prop.property_type : "";
+  const name = typeof prop.name === "string" ? prop.name : "";
+
+  if (!propertyType || !name) {
+    log.warn(
+      {
+        ...context,
+        propertyId: typeof prop.property_id === "string" ? prop.property_id : undefined,
+        hasPropertyType: !!propertyType,
+        hasName: !!name,
+      },
+      "Skipping property: missing required property_type or name",
+    );
+    return null;
+  }
+
+  const identifiers = Array.isArray(prop.identifiers)
+    ? (prop.identifiers as Array<{ type: string; value: string }>)
+    : [];
+
+  return {
+    property_id: typeof prop.property_id === "string" ? prop.property_id : undefined,
+    property_type: propertyType,
+    name,
+    identifiers,
+    tags: Array.isArray(prop.tags) ? (prop.tags as string[]) : undefined,
+    publisher_domain: typeof prop.publisher_domain === "string" ? prop.publisher_domain : undefined,
+  };
+}

--- a/server/tests/unit/property-index-guard.test.ts
+++ b/server/tests/unit/property-index-guard.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getPropertyIndex } from '@adcp/client';
-import { hardenPropertyIndex } from '../../src/discovery/property-index-guard.js';
+import {
+  hardenPropertyIndex,
+  sanitizeAdagentsProperty,
+} from '../../src/discovery/property-index-guard.js';
 
 describe('hardenPropertyIndex', () => {
   beforeEach(() => {
@@ -40,5 +43,62 @@ describe('hardenPropertyIndex', () => {
     const matches = index.findAgentsForProperty('domain', 'example.com');
     expect(matches).toHaveLength(1);
     expect(matches[0].agent_url).toBe('https://agent.example.com');
+  });
+});
+
+describe('sanitizeAdagentsProperty', () => {
+  const ctx = { publisherDomain: 'example.com', agentUrl: 'https://agent.example.com' };
+
+  it('returns null when property_type is missing', () => {
+    expect(sanitizeAdagentsProperty({ name: 'example.com' }, ctx)).toBeNull();
+  });
+
+  it('returns null when name is missing', () => {
+    expect(sanitizeAdagentsProperty({ property_type: 'website' }, ctx)).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(sanitizeAdagentsProperty(null, ctx)).toBeNull();
+    expect(sanitizeAdagentsProperty(undefined, ctx)).toBeNull();
+    expect(sanitizeAdagentsProperty('string', ctx)).toBeNull();
+  });
+
+  it('coerces a missing identifiers array to empty', () => {
+    const result = sanitizeAdagentsProperty(
+      { property_type: 'website', name: 'example.com' },
+      ctx,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.identifiers).toEqual([]);
+  });
+
+  it('coerces a non-array identifiers value to empty', () => {
+    const result = sanitizeAdagentsProperty(
+      { property_type: 'website', name: 'example.com', identifiers: 'not-an-array' },
+      ctx,
+    );
+    expect(result?.identifiers).toEqual([]);
+  });
+
+  it('preserves valid identifiers and optional fields', () => {
+    const result = sanitizeAdagentsProperty(
+      {
+        property_id: 'p-1',
+        property_type: 'website',
+        name: 'example.com',
+        identifiers: [{ type: 'domain', value: 'example.com' }],
+        tags: ['premium'],
+        publisher_domain: 'overridden.com',
+      },
+      ctx,
+    );
+    expect(result).toEqual({
+      property_id: 'p-1',
+      property_type: 'website',
+      name: 'example.com',
+      identifiers: [{ type: 'domain', value: 'example.com' }],
+      tags: ['premium'],
+      publisher_domain: 'overridden.com',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Crawler used to crash mid-batch with `property.identifiers is not iterable` or a Postgres `NOT NULL` violation on `property_type` whenever a publisher's `adagents.json` shipped malformed `properties` entries — a single bad entry tanked the rest of the manifest.
- Added `sanitizeAdagentsProperty` in `server/src/discovery/property-index-guard.ts` and apply it in `recordPropertiesForAgent` before any DB write. Properties missing `property_type` or `name` are skipped with a structured warning; non-array `identifiers` is coerced to `[]`.
- Existing `hardenPropertyIndex` already defends the in-memory `@adcp/client` path; this closes the parallel gap on the federated-index DB path.

## Test plan
- [x] `npm run typecheck` clean
- [x] `vitest run server/tests/unit/property-index-guard.test.ts` — 8/8 pass (added 6 sanitizer cases)
- [x] Pre-commit suite (vitest + dynamic-imports lint + typecheck) passes — 834 tests
- [ ] Verify in production logs that the next crawl no longer aborts on malformed manifests