### PR TITLE
feat(public-site): dark-mode legibility pass across registry, stories, members

### DIFF
--- a/.changeset/dark-mode-public-site-bg.md
+++ b/.changeset/dark-mode-public-site-bg.md
@@ -1,0 +1,14 @@
+---
+---
+
+Public AAo site dark-mode pass.
+
+**Backgrounds:** replace hardcoded `#fff`/`white` and raw-palette (`--color-gray-50/100`, `--color-*-50`) bgs with semantic, dark-mode-aware tokens (`--color-surface`, `--color-bg-subtle`, `--color-bg-card`, `--color-brand-bg`).
+
+**Text:** replace raw `--color-gray-600/700` with semantic `--color-text` / `--color-text-secondary`.
+
+**Tag/badge color pairs:** add new semantic aliases `--color-success-bg/-fg`, `--color-warning-bg/-fg`, `--color-error-bg/-fg` to design-system.css. Light mode aliases the existing `-100`/`-700` palette; dark mode swaps to translucent rgba bg + lighter `-300/200` text. Update `.status-badge`, `.track-pill`, `.brand-card__source--valid`, `.badge-regulation/must/standard/should/may`, member-card.js `.visibility-badge.public`, `.agent-badge`, `.data-provider-badge`, agents.html `.tool-error-box`, `.publisher-warning`, `.publisher-item--unverified`, and `.ds-pill.active` to use them. Brand-card `.brand-card__tag`, member-card `.offering-tag`, and `.publisher-badge` switch to `--color-brand-bg` / `--color-brand`.
+
+**Files:** layout.css, design-system.css, member-card.js (JS-injected styles), and per-page styles in agents/brands/certification/committees/events/members/policies/publishers, community/hub + membership/hub, and stories/the-pitch + the-shelf + the-studio. Activity-metric stat cards switch from raw pastel fills to a left-border accent over `--color-bg-subtle`.
+
+Also bundles a docker-compose fix (`ALLOW_DEV_MODE_IN_PROD=true`) needed for local Docker boot — auth.ts refuses to start when `DEV_USER_*` and `NODE_ENV=production` are both set, and the compose file was missing the documented override.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - ALLOW_INSECURE_COOKIES=true
       - DEV_USER_EMAIL=dev@example.com
       - DEV_USER_ID=dev-user-123
+      # Override the prod-shape boot guard (docker-compose intentionally sets
+      # NODE_ENV=production + DEV_USER_*; auth.ts refuses to boot without this)
+      - ALLOW_DEV_MODE_IN_PROD=true
       - AGENT_TOKEN_ENCRYPTION_SECRET=local-dev-encryption-key-32chars!
       # Override .env.local keys with dummy values (satisfies module guards, dev mode bypasses auth)
       - WORKOS_API_KEY=sk_test_dummy_local_dev_00000000000

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/layout.css">
     <style>
         body {
-            background: #fff;
+            background: var(--color-surface);
             padding-top: var(--nav-height);
         }
 
@@ -61,7 +61,8 @@
         }
         .filter-btn {
             padding: var(--space-2) var(--space-4);
-            background: var(--color-gray-100);
+            background: var(--color-bg-subtle);
+            color: var(--color-text);
             border: var(--border-2) solid var(--color-border);
             border-radius: var(--radius-lg);
             cursor: pointer;
@@ -72,7 +73,7 @@
             border-color: var(--color-brand);
         }
         .filter-btn.active {
-            background: var(--color-primary-100);
+            background: var(--color-brand-bg);
             border-color: var(--color-brand);
             color: var(--color-brand);
         }
@@ -120,12 +121,12 @@
             white-space: nowrap;
         }
         .status-badge.online {
-            background: var(--color-success-100);
-            color: var(--color-success-700);
+            background: var(--color-success-bg);
+            color: var(--color-success-fg);
         }
         .status-badge.offline {
-            background: var(--color-error-100);
-            color: var(--color-error-700);
+            background: var(--color-error-bg);
+            color: var(--color-error-fg);
         }
         .agent-description {
             color: var(--color-text-muted);
@@ -213,10 +214,10 @@
             font-size: 10px;
             font-weight: var(--font-semibold);
         }
-        .track-pill--pass { background: var(--color-success-100); color: var(--color-success-700); }
-        .track-pill--fail { background: var(--color-error-100); color: var(--color-error-700); }
-        .track-pill--partial { background: var(--color-warning-100); color: var(--color-warning-700); }
-        .track-pill--skip { background: var(--color-gray-100); color: var(--color-gray-600); }
+        .track-pill--pass { background: var(--color-success-bg); color: var(--color-success-fg); }
+        .track-pill--fail { background: var(--color-error-bg); color: var(--color-error-fg); }
+        .track-pill--partial { background: var(--color-warning-bg); color: var(--color-warning-fg); }
+        .track-pill--skip { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
 
         .format-badge {
             padding: var(--space-1) var(--space-3);
@@ -350,12 +351,12 @@
             border-radius: var(--radius-md);
         }
         .publisher-item--verified { border-left: 3px solid var(--color-success-500); }
-        .publisher-item--unverified { border-left: 3px solid var(--color-error-500); background: var(--color-error-50); }
+        .publisher-item--unverified { border-left: 3px solid var(--color-error-500); background: var(--color-error-bg); }
         .publisher-item--unchecked { border-left: 3px solid var(--color-warning-500); }
         .publisher-domain { font-weight: var(--font-semibold); margin-bottom: var(--space-1); }
         .publisher-verify-link { color: var(--color-brand); text-decoration: none; font-size: var(--text-xs); white-space: nowrap; }
         .publisher-verify-link--error { color: var(--color-error-500); }
-        .publisher-warning { margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-error-700); background: var(--color-error-100); padding: var(--space-2); border-radius: var(--radius-sm); }
+        .publisher-warning { margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-error-fg); background: var(--color-error-bg); padding: var(--space-2); border-radius: var(--radius-sm); }
         .property-metadata-toggle { margin-top: var(--space-3); font-size: var(--text-xs); cursor: pointer; color: var(--color-brand); }
         .property-metadata-pre { margin-top: var(--space-2); background: var(--color-bg-subtle); padding: var(--space-2); border-radius: var(--radius-sm); overflow-x: auto; }
 
@@ -441,9 +442,9 @@
         .info-box__contact-link { color: var(--color-brand); }
 
         /* Error states */
-        .tool-error-box { font-size: var(--text-xs); color: var(--color-error-600); padding: var(--space-2); background: var(--color-error-50); border-radius: var(--radius-sm); border-left: 3px solid var(--color-error-500); }
+        .tool-error-box { font-size: var(--text-xs); color: var(--color-error-fg); padding: var(--space-2); background: var(--color-error-bg); border-radius: var(--radius-sm); border-left: 3px solid var(--color-error-500); }
         .tool-error-box__title { font-weight: var(--font-semibold); }
-        .tool-error-box__msg { font-size: var(--text-xs); color: var(--color-error-700); font-family: monospace; word-break: break-word; }
+        .tool-error-box__msg { font-size: var(--text-xs); color: var(--color-error-fg); font-family: monospace; word-break: break-word; }
 
         .property-section-small { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); }
         .loading { text-align: center; padding: var(--space-12); color: var(--color-text-muted); }

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/layout.css">
   <style>
     body {
-      background: #fff;
+      background: var(--color-surface);
       padding-top: var(--nav-height);
     }
 
@@ -86,7 +86,8 @@
     }
     .filter-btn {
       padding: var(--space-2) var(--space-4);
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
+      color: var(--color-text);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       cursor: pointer;
@@ -97,7 +98,7 @@
       border-color: var(--color-brand);
     }
     .filter-btn.active {
-      background: var(--color-primary-100);
+      background: var(--color-brand-bg);
       border-color: var(--color-brand);
       color: var(--color-brand);
     }
@@ -192,8 +193,8 @@
       white-space: nowrap;
       flex-shrink: 0;
     }
-    .brand-card__source--valid { background: var(--color-success-100); color: var(--color-success-700); }
-    .brand-card__source--neutral { background: var(--color-gray-100); color: var(--color-gray-600); }
+    .brand-card__source--valid { background: var(--color-success-bg); color: var(--color-success-fg); }
+    .brand-card__source--neutral { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
 
     /* Details row */
     .brand-card__details {
@@ -220,8 +221,8 @@
     .brand-card__tag {
       display: inline-block;
       padding: var(--space-0_5) var(--space-2);
-      background: var(--color-primary-50);
-      color: var(--color-primary-700);
+      background: var(--color-brand-bg);
+      color: var(--color-brand);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-medium);

--- a/server/public/certification.html
+++ b/server/public/certification.html
@@ -15,7 +15,7 @@
     }
 
     body {
-      background: #fff;
+      background: var(--color-surface);
       /* padding-top handled by hero */
     }
 
@@ -430,12 +430,12 @@
     }
 
     .btn-start-secondary {
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
       color: var(--color-text);
     }
 
     .btn-start-secondary:hover {
-      background: var(--color-gray-200);
+      background: var(--color-surface-raised);
     }
 
     .btn-start:disabled {

--- a/server/public/committees.html
+++ b/server/public/committees.html
@@ -26,7 +26,7 @@
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {
-      background: #fff;
+      background: var(--color-surface);
       /* padding-top handled by hero */
     }
 
@@ -205,7 +205,7 @@
 
     .group-card-footer {
       padding: var(--space-4) var(--space-6);
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-top: var(--border-1) solid var(--color-border-light);
       display: flex;
       align-items: center;

--- a/server/public/community/hub.html
+++ b/server/public/community/hub.html
@@ -408,11 +408,11 @@
 
     /* Activity grid */
     .activity-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
-    .activity-metric { padding: var(--space-4); border-radius: var(--radius-lg); background: var(--color-bg-subtle); }
-    .activity-metric:nth-child(1) { background: var(--color-primary-50); }
-    .activity-metric:nth-child(2) { background: var(--color-success-50); }
-    .activity-metric:nth-child(3) { background: var(--color-warning-50); }
-    .activity-metric:nth-child(4) { background: var(--color-info-50); }
+    .activity-metric { padding: var(--space-4); border-radius: var(--radius-lg); background: var(--color-bg-subtle); border-left: 3px solid var(--color-border); }
+    .activity-metric:nth-child(1) { border-left-color: var(--color-primary-500); }
+    .activity-metric:nth-child(2) { border-left-color: var(--color-success-500); }
+    .activity-metric:nth-child(3) { border-left-color: var(--color-warning-500); }
+    .activity-metric:nth-child(4) { border-left-color: var(--color-info-500); }
     .activity-value { font-size: var(--text-2xl); font-weight: var(--font-bold); color: var(--color-text-heading); line-height: var(--leading-tight); margin-bottom: var(--space-1); }
     .activity-label { font-size: var(--text-xs); color: var(--color-text-secondary); }
 

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -36,6 +36,14 @@
   --color-brand-light: var(--color-primary-300);
   --color-brand-bg: var(--color-primary-50);
 
+  /* Semantic tag/badge color pairs (adapt in dark mode) */
+  --color-success-bg: var(--color-success-100);
+  --color-success-fg: var(--color-success-700);
+  --color-warning-bg: var(--color-warning-100);
+  --color-warning-fg: var(--color-warning-700);
+  --color-error-bg: var(--color-error-100);
+  --color-error-fg: var(--color-error-700);
+
   /* -----------------------------------------------------------------------------
      1.2 Neutral Colors (Gray Scale)
      ----------------------------------------------------------------------------- */
@@ -567,8 +575,8 @@ body {
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
   color: var(--color-text-secondary);
-  background: var(--color-gray-100);
-  border: 1px solid var(--color-gray-300);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border);
   cursor: pointer;
   white-space: nowrap;
   transition: var(--transition-all);
@@ -576,11 +584,11 @@ body {
 }
 .ds-pill:hover {
   color: var(--color-text-heading);
-  background: var(--color-gray-200);
+  background: var(--color-surface-raised);
 }
 .ds-pill.active {
-  color: var(--color-warning-700);
-  background: var(--color-warning-100);
+  color: var(--color-warning-fg);
+  background: var(--color-warning-bg);
   border-color: var(--color-warning-500);
 }
 
@@ -995,7 +1003,7 @@ body {
 
 /* Clean hero — white background, dark text (matches homepage feel) */
 .hero--clean {
-  background: #fff;
+  background: var(--color-surface);
   color: var(--color-text-heading);
   padding: var(--space-8) var(--space-8) var(--space-10);
 }
@@ -2169,6 +2177,12 @@ body {
     --color-brand: #6b8cef;
     --color-brand-hover: #8aa3f4;
     --color-brand-bg: rgba(107, 140, 239, 0.1);
+    --color-success-bg: rgba(16, 185, 129, 0.18);
+    --color-success-fg: #6ee7b7;
+    --color-warning-bg: rgba(245, 158, 11, 0.18);
+    --color-warning-fg: #fcd34d;
+    --color-error-bg: rgba(239, 68, 68, 0.18);
+    --color-error-fg: #fca5a5;
   }
 }
 
@@ -2189,6 +2203,12 @@ html[data-theme="dark"] {
   --color-brand: #6b8cef;
   --color-brand-hover: #8aa3f4;
   --color-brand-bg: rgba(107, 140, 239, 0.1);
+  --color-success-bg: rgba(16, 185, 129, 0.18);
+  --color-success-fg: #6ee7b7;
+  --color-warning-bg: rgba(245, 158, 11, 0.18);
+  --color-warning-fg: #fcd34d;
+  --color-error-bg: rgba(239, 68, 68, 0.18);
+  --color-error-fg: #fca5a5;
 }
 
 html[data-theme="light"] {
@@ -2206,4 +2226,10 @@ html[data-theme="light"] {
   --color-brand: #1a36b4;
   --color-brand-hover: #2d4fd6;
   --color-brand-bg: #eef4fc;
+  --color-success-bg: #d1fae5;
+  --color-success-fg: #047857;
+  --color-warning-bg: #fef3c7;
+  --color-warning-fg: #b45309;
+  --color-error-bg: #fee2e2;
+  --color-error-fg: #b91c1c;
 }

--- a/server/public/events.html
+++ b/server/public/events.html
@@ -26,7 +26,7 @@
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <style>
-    body { background: #fff; }
+    body { background: var(--color-surface); }
 
     .events-container {
       max-width: 1000px;

--- a/server/public/layout.css
+++ b/server/public/layout.css
@@ -9,7 +9,7 @@
 body {
   font-family: var(--font-sans);
   color: var(--color-text);
-  background: #fff;
+  background: var(--color-surface);
   line-height: var(--leading-relaxed);
   -webkit-font-smoothing: antialiased;
 }
@@ -23,7 +23,7 @@ body {
 .page-header {
   text-align: center;
   padding: var(--space-8) var(--space-6) var(--space-10);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .page-header h1 {
@@ -85,7 +85,7 @@ body {
 
 .panel-text {
   font-size: var(--text-lg);
-  color: var(--color-gray-700);
+  color: var(--color-text);
   line-height: var(--leading-loose);
 }
 
@@ -136,7 +136,7 @@ body {
    ============================================================================= */
 
 .sub-nav {
-  background: #fff;
+  background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 60px;
@@ -220,7 +220,7 @@ body {
 
 .homepage-hero .subtitle {
   font-size: 1.375rem;
-  color: var(--color-gray-600);
+  color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
   max-width: 720px;
   margin: 0 auto;
@@ -466,7 +466,7 @@ body {
   border-left: 4px solid var(--color-brand);
   padding: var(--space-4) var(--space-6);
   margin: var(--space-6) 0;
-  background: white;
+  background: var(--color-bg-card);
   border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
 }
 
@@ -481,7 +481,7 @@ body {
 
 .proof-quote cite {
   font-size: var(--text-base);
-  color: var(--color-gray-600);
+  color: var(--color-text-secondary);
   font-style: normal;
   font-weight: var(--font-semibold);
 }
@@ -501,7 +501,7 @@ body {
   line-height: var(--leading-relaxed);
   padding: var(--space-4) 0;
   border-bottom: 1px solid var(--color-border);
-  color: var(--color-gray-700);
+  color: var(--color-text);
 }
 
 .principles li:last-child {
@@ -526,7 +526,7 @@ body {
 
 .cta-section .closing-text {
   font-size: var(--text-xl);
-  color: var(--color-gray-700);
+  color: var(--color-text);
   line-height: var(--leading-relaxed);
   margin-bottom: var(--space-10);
   max-width: 600px;
@@ -562,7 +562,7 @@ body {
 
 .cta-card p {
   font-size: var(--text-base);
-  color: var(--color-gray-600);
+  color: var(--color-text-secondary);
   line-height: var(--leading-normal);
   margin-bottom: var(--space-4);
 }
@@ -674,7 +674,7 @@ body {
 .footer-col a {
   display: block;
   font-size: var(--text-sm);
-  color: var(--color-gray-600);
+  color: var(--color-text-secondary);
   text-decoration: none;
   padding: var(--space-1) 0;
 }

--- a/server/public/member-card.js
+++ b/server/public/member-card.js
@@ -161,7 +161,8 @@ function renderMemberCard(member, options = {}) {
 function getMemberCardStyles() {
   return `
     .member-card {
-      background: white;
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
       border-radius: 12px;
       overflow: hidden;
       box-shadow: 0 2px 8px rgba(0,0,0,0.1);
@@ -177,7 +178,7 @@ function getMemberCardStyles() {
       display: flex;
       align-items: center;
       gap: 1rem;
-      border-bottom: 1px solid #f3f4f6;
+      border-bottom: 1px solid var(--color-border);
     }
     .member-logo {
       width: 80px;
@@ -209,7 +210,7 @@ function getMemberCardStyles() {
     .member-name {
       font-size: 1.2rem;
       font-weight: 600;
-      color: #333;
+      color: var(--color-text-heading);
     }
     .member-markets {
       display: flex;
@@ -220,22 +221,22 @@ function getMemberCardStyles() {
     .member-markets .market-tag {
       font-size: 0.7rem;
       padding: 2px 6px;
-      background: #f3f4f6;
-      color: #6b7280;
+      background: var(--color-bg-subtle);
+      color: var(--color-text-secondary);
       border-radius: 3px;
     }
     .member-card-body {
       padding: 1.5rem;
     }
     .member-tagline {
-      color: #333;
+      color: var(--color-text);
       font-size: 0.95rem;
       font-weight: 500;
       line-height: 1.4;
       margin-bottom: 0.5rem;
     }
     .member-description {
-      color: #666;
+      color: var(--color-text-secondary);
       font-size: 0.95rem;
       line-height: 1.6;
       margin-bottom: 1rem;
@@ -251,15 +252,15 @@ function getMemberCardStyles() {
     }
     .offering-tag {
       padding: 4px 10px;
-      background: #dbeafe;
-      color: #1e40af;
+      background: var(--color-brand-bg);
+      color: var(--color-brand);
       border-radius: 6px;
       font-size: 12px;
       font-weight: 500;
     }
     .member-card-footer {
       padding: 1rem 1.5rem;
-      background: #f9fafb;
+      background: var(--color-bg-subtle);
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -304,26 +305,26 @@ function getMemberCardStyles() {
       border-radius: 50%;
     }
     .visibility-badge.public {
-      background: #d1fae5;
-      color: #065f46;
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
     .visibility-badge.public .dot {
-      background: #10b981;
+      background: var(--color-success-500);
     }
     .visibility-badge.private {
-      background: #f3f4f6;
-      color: #6b7280;
+      background: var(--color-bg-subtle);
+      color: var(--color-text-secondary);
     }
     .visibility-badge.private .dot {
-      background: #9ca3af;
+      background: var(--color-text-muted);
     }
     .agent-badge {
       display: inline-flex;
       align-items: center;
       gap: 4px;
       padding: 2px 8px;
-      background: #fef3c7;
-      color: #92400e;
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
       border-radius: 4px;
       font-size: 11px;
       font-weight: 500;
@@ -333,8 +334,8 @@ function getMemberCardStyles() {
       align-items: center;
       gap: 4px;
       padding: 2px 8px;
-      background: var(--color-primary-100);
-      color: var(--color-primary-700);
+      background: var(--color-brand-bg);
+      color: var(--color-brand);
       border-radius: 4px;
       font-size: 11px;
       font-weight: 500;
@@ -344,8 +345,8 @@ function getMemberCardStyles() {
       align-items: center;
       gap: 4px;
       padding: 2px 8px;
-      background: #d1fae5;
-      color: #065f46;
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
       border-radius: 4px;
       font-size: 11px;
       font-weight: 500;

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -13,7 +13,7 @@
        ============================================================================= */
 
     body {
-      background: #fff;
+      background: var(--color-surface);
       /* padding-top handled by hero */
     }
 
@@ -94,7 +94,8 @@
 
     .filter-btn {
       padding: var(--space-2) var(--space-4);
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
+      color: var(--color-text);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
@@ -107,7 +108,7 @@
     }
 
     .filter-btn.active {
-      background: var(--color-primary-100);
+      background: var(--color-brand-bg);
       border-color: var(--color-brand);
       color: var(--color-brand);
     }
@@ -142,7 +143,7 @@
 
     /* Join CTA Card */
     .join-cta {
-      background: linear-gradient(135deg, var(--color-primary-50) 0%, var(--color-primary-100) 100%);
+      background: var(--color-brand-bg);
       border: var(--border-2) solid var(--color-brand);
       border-radius: var(--card-radius);
       padding: var(--space-8);

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -965,12 +965,13 @@
       padding: var(--space-4);
       border-radius: var(--radius-lg);
       background: var(--color-bg-subtle);
+      border-left: 3px solid var(--color-border);
     }
 
-    .activity-metric:nth-child(1) { background: var(--color-primary-50); }
-    .activity-metric:nth-child(2) { background: var(--color-success-50); }
-    .activity-metric:nth-child(3) { background: var(--color-warning-50); }
-    .activity-metric:nth-child(4) { background: var(--color-info-50); }
+    .activity-metric:nth-child(1) { border-left-color: var(--color-primary-500); }
+    .activity-metric:nth-child(2) { border-left-color: var(--color-success-500); }
+    .activity-metric:nth-child(3) { border-left-color: var(--color-warning-500); }
+    .activity-metric:nth-child(4) { border-left-color: var(--color-info-500); }
 
     .activity-value { font-size: var(--text-2xl); font-weight: var(--font-bold); color: var(--color-text-heading); line-height: var(--leading-tight); margin-bottom: var(--space-1); }
     .activity-label { font-size: var(--text-xs); color: var(--color-text-secondary); }

--- a/server/public/policies.html
+++ b/server/public/policies.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="/layout.css">
   <style>
     body {
-      background: #fff;
+      background: var(--color-surface);
       padding-top: var(--nav-height);
     }
 
@@ -90,7 +90,8 @@
     }
     .filter-group select {
       padding: var(--space-2) var(--space-4);
-      background: var(--color-gray-100);
+      background: var(--color-bg-card);
+      color: var(--color-text);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       cursor: pointer;
@@ -152,24 +153,24 @@
       flex-shrink: 0;
     }
     .badge-regulation {
-      background: var(--color-danger-100);
-      color: var(--color-danger-700);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
     .badge-standard {
-      background: var(--color-info-100);
-      color: var(--color-info-700);
+      background: var(--color-brand-bg);
+      color: var(--color-brand);
     }
     .badge-must {
-      background: var(--color-danger-100);
-      color: var(--color-danger-700);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
     .badge-should {
-      background: var(--color-warning-100);
-      color: var(--color-warning-700);
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
     }
     .badge-may {
-      background: var(--color-gray-200);
-      color: var(--color-gray-600);
+      background: var(--color-bg-subtle);
+      color: var(--color-text-secondary);
     }
 
     /* Card badges row */

--- a/server/public/publishers.html
+++ b/server/public/publishers.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/layout.css">
   <style>
     body {
-      background: #fff;
+      background: var(--color-surface);
       padding-top: var(--nav-height);
     }
 
@@ -86,7 +86,8 @@
     }
     .filter-btn {
       padding: var(--space-2) var(--space-4);
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
+      color: var(--color-text);
       border: var(--border-2) solid var(--color-border);
       border-radius: var(--radius-lg);
       cursor: pointer;
@@ -97,7 +98,7 @@
       border-color: var(--color-brand);
     }
     .filter-btn.active {
-      background: var(--color-primary-100);
+      background: var(--color-brand-bg);
       border-color: var(--color-brand);
       color: var(--color-brand);
     }
@@ -149,12 +150,12 @@
       white-space: nowrap;
     }
     .status-badge.valid {
-      background: var(--color-success-100);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
     .status-badge.neutral {
-      background: var(--color-gray-100);
-      color: var(--color-gray-600);
+      background: var(--color-bg-subtle);
+      color: var(--color-text-secondary);
     }
     .publisher-meta {
       display: flex;
@@ -166,10 +167,10 @@
       align-items: center;
       gap: var(--space-1);
       padding: 2px var(--space-2);
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
-      color: var(--color-text-muted);
+      color: var(--color-text-secondary);
     }
     .stat-item {
       display: flex;
@@ -218,7 +219,7 @@
       margin-left: auto;
       margin-right: auto;
     }
-    .check-result.valid { background: var(--color-success-100); color: var(--color-success-700); }
+    .check-result.valid { background: var(--color-success-bg); color: var(--color-success-fg); }
     .check-result.invalid { background: var(--color-gray-100); color: var(--color-text-heading); }
     .check-result.checking { background: var(--color-gray-100); color: var(--color-text-muted); }
 

--- a/server/public/stories/the-pitch.html
+++ b/server/public/stories/the-pitch.html
@@ -78,7 +78,7 @@
 
     .story-content p {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-4);
     }
@@ -90,7 +90,7 @@
 
     .story-content li {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-2);
     }
@@ -119,7 +119,7 @@
 
     .callout p {
       font-size: var(--text-base);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       margin: 0;
     }
 
@@ -129,7 +129,7 @@
     }
 
     .shift-card {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-radius: var(--radius-lg);
       padding: var(--space-6) var(--space-8);
       margin: var(--space-6) 0;
@@ -161,7 +161,7 @@
     }
 
     .before-after-col--before {
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
     }
 
     .before-after-col--after {
@@ -202,9 +202,9 @@
       padding: var(--space-3) var(--space-4);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       cursor: pointer;
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-bottom: 1px solid transparent;
       list-style: none;
       display: flex;
@@ -242,7 +242,7 @@
 
     /* CTA */
     .story-cta {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
       text-align: center;
     }
@@ -256,7 +256,7 @@
 
     .story-cta p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       max-width: 560px;
       margin: 0 auto var(--space-6) auto;
       line-height: var(--leading-relaxed);
@@ -289,13 +289,13 @@
     }
 
     .btn-secondary {
-      background: #fff;
+      background: var(--color-bg-card);
       color: var(--color-brand);
       border: 1px solid var(--color-border-strong);
     }
 
     .btn-secondary:hover {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
     }
 
     .story-back {
@@ -336,14 +336,14 @@
       height: 36px;
       border-radius: 8px;
       border: 1px solid var(--color-border);
-      background: white;
+      background: var(--color-bg-card);
       color: var(--color-text-heading);
       cursor: pointer;
       transition: all 0.15s;
       text-decoration: none;
     }
     .story-share-btn:hover {
-      background: var(--color-gray-100);
+      background: var(--color-bg-subtle);
       border-color: var(--color-primary-600);
       color: var(--color-primary-600);
     }
@@ -352,7 +352,7 @@
 
     /* Partners */
     .story-partners {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
     }
 
@@ -370,7 +370,7 @@
 
     .story-partners > .story-partners-inner > p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       margin-bottom: var(--space-8);
       line-height: var(--leading-relaxed);
     }
@@ -383,7 +383,7 @@
     }
 
     .partner-card {
-      background: #fff;
+      background: var(--color-bg-card);
       border: 1px solid var(--color-border);
       border-radius: var(--radius-lg);
       padding: var(--space-5);
@@ -398,7 +398,7 @@
 
     .partner-card p {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
       margin-bottom: var(--space-3);
     }
@@ -470,7 +470,7 @@
 
     .crosslink-desc {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
     }
     .crosslink-card--walkthrough {

--- a/server/public/stories/the-shelf.html
+++ b/server/public/stories/the-shelf.html
@@ -79,7 +79,7 @@
 
     .story-content p {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-4);
     }
@@ -91,7 +91,7 @@
 
     .story-content li {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-2);
     }
@@ -121,7 +121,7 @@
 
     .callout p {
       font-size: var(--text-base);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       margin: 0;
     }
 
@@ -142,9 +142,9 @@
       padding: var(--space-3) var(--space-4);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       cursor: pointer;
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-bottom: 1px solid transparent;
       list-style: none;
       display: flex;
@@ -183,8 +183,8 @@
     .protocol-detail .detail-note {
       padding: var(--space-3) var(--space-4);
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
-      background: var(--color-gray-50);
+      color: var(--color-text-secondary);
+      background: var(--color-bg-subtle);
       border-top: 1px solid var(--color-border);
       line-height: var(--leading-relaxed);
     }
@@ -196,7 +196,7 @@
 
     /* CTA section */
     .story-cta {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
       text-align: center;
     }
@@ -210,7 +210,7 @@
 
     .story-cta p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       max-width: 560px;
       margin: 0 auto var(--space-6) auto;
       line-height: var(--leading-relaxed);
@@ -243,13 +243,13 @@
     }
 
     .btn-secondary {
-      background: #fff;
+      background: var(--color-bg-card);
       color: var(--color-brand);
       border: 1px solid var(--color-border-strong);
     }
 
     .btn-secondary:hover {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
     }
 
     /* Back link */
@@ -283,17 +283,17 @@
     .story-share-btn {
       display: inline-flex; align-items: center; justify-content: center;
       width: 36px; height: 36px; border-radius: 8px;
-      border: 1px solid var(--color-border); background: white;
+      border: 1px solid var(--color-border); background: var(--color-bg-card);
       color: var(--color-text-heading); cursor: pointer;
       transition: all 0.15s; text-decoration: none;
     }
-    .story-share-btn:hover { background: var(--color-gray-100); border-color: var(--color-primary-600); color: var(--color-primary-600); }
+    .story-share-btn:hover { background: var(--color-bg-subtle); border-color: var(--color-primary-600); color: var(--color-primary-600); }
     .story-share-btn svg { width: 18px; height: 18px; }
     .story-share-btn.copied { background: #047857; border-color: #047857; color: white; }
 
     /* Partners section */
     .story-partners {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
     }
 
@@ -311,7 +311,7 @@
 
     .story-partners > .story-partners-inner > p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       margin-bottom: var(--space-8);
       line-height: var(--leading-relaxed);
     }
@@ -324,7 +324,7 @@
     }
 
     .partner-card {
-      background: #fff;
+      background: var(--color-bg-card);
       border: 1px solid var(--color-border);
       border-radius: var(--radius-lg);
       padding: var(--space-5);
@@ -339,7 +339,7 @@
 
     .partner-card p {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
       margin-bottom: var(--space-3);
     }
@@ -411,7 +411,7 @@
 
     .crosslink-desc {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
     }
     .crosslink-card--walkthrough {

--- a/server/public/stories/the-studio.html
+++ b/server/public/stories/the-studio.html
@@ -79,7 +79,7 @@
 
     .story-content p {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-4);
     }
@@ -91,7 +91,7 @@
 
     .story-content li {
       font-size: var(--text-lg);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       line-height: var(--leading-loose);
       margin-bottom: var(--space-2);
     }
@@ -121,7 +121,7 @@
 
     .callout p {
       font-size: var(--text-base);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       margin: 0;
     }
 
@@ -142,9 +142,9 @@
       padding: var(--space-3) var(--space-4);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       cursor: pointer;
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-bottom: 1px solid transparent;
       list-style: none;
       display: flex;
@@ -191,7 +191,7 @@
     .ref-table th {
       text-align: left;
       padding: var(--space-3) var(--space-4);
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       border-bottom: 2px solid var(--color-border);
       font-weight: var(--font-semibold);
       color: var(--color-text-heading);
@@ -200,7 +200,7 @@
     .ref-table td {
       padding: var(--space-3) var(--space-4);
       border-bottom: 1px solid var(--color-border);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       vertical-align: top;
     }
 
@@ -220,7 +220,7 @@
       padding: var(--space-3) var(--space-4);
       border-bottom: 1px solid var(--color-border);
       font-size: var(--text-base);
-      color: var(--color-gray-700);
+      color: var(--color-text);
       vertical-align: top;
     }
 
@@ -232,7 +232,7 @@
 
     /* CTA section */
     .story-cta {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
       text-align: center;
     }
@@ -246,7 +246,7 @@
 
     .story-cta p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       max-width: 560px;
       margin: 0 auto var(--space-6) auto;
       line-height: var(--leading-relaxed);
@@ -279,13 +279,13 @@
     }
 
     .btn-secondary {
-      background: #fff;
+      background: var(--color-bg-card);
       color: var(--color-brand);
       border: 1px solid var(--color-border-strong);
     }
 
     .btn-secondary:hover {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
     }
 
     /* Back link */
@@ -319,17 +319,17 @@
     .story-share-btn {
       display: inline-flex; align-items: center; justify-content: center;
       width: 36px; height: 36px; border-radius: 8px;
-      border: 1px solid var(--color-border); background: white;
+      border: 1px solid var(--color-border); background: var(--color-bg-card);
       color: var(--color-text-heading); cursor: pointer;
       transition: all 0.15s; text-decoration: none;
     }
-    .story-share-btn:hover { background: var(--color-gray-100); border-color: var(--color-primary-600); color: var(--color-primary-600); }
+    .story-share-btn:hover { background: var(--color-bg-subtle); border-color: var(--color-primary-600); color: var(--color-primary-600); }
     .story-share-btn svg { width: 18px; height: 18px; }
     .story-share-btn.copied { background: #047857; border-color: #047857; color: white; }
 
     /* Partners section */
     .story-partners {
-      background: var(--color-gray-50);
+      background: var(--color-bg-subtle);
       padding: var(--space-16) var(--space-6);
     }
 
@@ -347,7 +347,7 @@
 
     .story-partners > .story-partners-inner > p {
       font-size: var(--text-lg);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       margin-bottom: var(--space-8);
       line-height: var(--leading-relaxed);
     }
@@ -360,7 +360,7 @@
     }
 
     .partner-card {
-      background: #fff;
+      background: var(--color-bg-card);
       border: 1px solid var(--color-border);
       border-radius: var(--radius-lg);
       padding: var(--space-5);
@@ -375,7 +375,7 @@
 
     .partner-card p {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
       margin-bottom: var(--space-3);
     }
@@ -447,7 +447,7 @@
 
     .crosslink-desc {
       font-size: var(--text-sm);
-      color: var(--color-gray-600);
+      color: var(--color-text-secondary);
       line-height: var(--leading-relaxed);
     }
     .crosslink-card--walkthrough {


### PR DESCRIPTION
## Summary

- Replace hardcoded `#fff`/`white` and raw-palette (`-50/-100`, `gray-600/700`) bgs and text colors across the public AAo site with semantic dark-mode-aware tokens (`--color-surface`, `--color-bg-card`, `--color-bg-subtle`, `--color-text`, `--color-brand-bg`).
- Add new semantic pairs `--color-{success,warning,error}-{bg,fg}` to `design-system.css` — alias the existing `-100`/`-700` palette in light mode, swap to translucent rgba bg + lighter foreground in dark mode — then point status pills, track pills, and tag badges at them so they read natively in both modes (e.g. `.status-badge`, `.track-pill`, policies `.badge-*`, member-card `.visibility-badge.public`/`.agent-badge`/`.data-provider-badge`, agents `.tool-error-box`, `.ds-pill.active`).
- Activity-metric stat cards on community/hub + membership/hub switch from raw pastel fills to a left-border accent over `--color-bg-subtle` so colored differentiation survives in both modes.
- Bundles a `docker-compose.yml` fix (`ALLOW_DEV_MODE_IN_PROD=true`) needed for local Docker boot — `auth.ts` refuses to start when `DEV_USER_*` and `NODE_ENV=production` coexist without the documented override (broken on `main` already).

Affects: `layout.css`, `design-system.css`, `member-card.js` (JS-injected styles), and per-page CSS in agents/brands/certification/committees/events/members/policies/publishers, community/hub, membership/hub, plus stories/the-pitch/the-shelf/the-studio. 18 files, +207/−157.

## Test plan

- [x] Puppeteer dark-mode screenshots of `/`, `/stories`, `/agents.html`, `/members`, `/certification`, `/community/`, `/committees`, `/events`, `/policies`, `/publishers`, `/brands`, `/registry/?tab=*`, `/stories/the-pitch|the-shelf|the-studio`
- [ ] Manual verification in Conductor / browser at `http://localhost:55090/registry/?tab=members` and `/certification` with `prefers-color-scheme: dark`
- [ ] Manual verification in light mode (no visual regression — semantic tokens resolve to the same hex as the originals where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)