### PR TITLE
feat(schema): add search_brands discovery verb to brand protocol

### DIFF
--- a/.changeset/search-brands-verb.md
+++ b/.changeset/search-brands-verb.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `search_brands` task to the brand protocol.
+
+Provides a natural-language brand discovery verb for IP desks that need to find brands on an agent's roster before they have a known `brand_id`. Returns lightweight brand stubs (public identity tier) that feed directly into `get_brand_identity` or `get_rights` without an extra identity-resolution round-trip.
+
+New schemas (experimental): `search-brands-request.json`, `search-brands-response.json`. New task type `search_brands` added to stable `task-type.json` enum.
+
+Closes #3480.

--- a/static/schemas/source/brand/search-brands-request.json
+++ b/static/schemas/source/brand/search-brands-request.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/brand/search-brands-request.json",
+  "title": "Search Brands Request",
+  "description": "Discover brands on a brand agent's roster using a natural language query. Returns lightweight brand stubs — use get_brand_identity to fetch full identity data for a selected brand_id, and get_rights to fetch pricing options. Read-only; naturally idempotent.",
+  "x-status": "experimental",
+  "type": "object",
+  "properties": {
+    "adcp_major_version": {
+      "type": "integer",
+      "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
+    "query": {
+      "type": "string",
+      "description": "Natural language description of the brands to find. The agent interprets intent, category, and roster coverage from this text.",
+      "maxLength": 2000
+    },
+    "industries": {
+      "type": "array",
+      "description": "Optional industry filter. The agent restricts results to brands operating in these industries. Values follow the advertiser-industry taxonomy; the agent SHOULD accept unknown values gracefully per the advertiser-industry extension policy.",
+      "items": {
+        "$ref": "/schemas/enums/advertiser-industry.json"
+      },
+      "minItems": 1
+    },
+    "countries": {
+      "type": "array",
+      "description": "Optional market filter. Returns brands with rights availability in at least one of the specified countries (ISO 3166-1 alpha-2).",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "minItems": 1
+    },
+    "buyer_brand": {
+      "$ref": "/schemas/core/brand-ref.json",
+      "description": "The buyer's brand. When provided, the agent SHOULD apply the same compatibility filtering as get_rights — filtering out brands with category conflicts, competitor exclusions, or dietary restrictions that would prevent licensing. When omitted, results are returned without compatibility filtering."
+    },
+    "pagination": {
+      "$ref": "/schemas/core/pagination-request.json",
+      "description": "Pagination parameters for large result sets"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "query"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/brand/search-brands-response.json
+++ b/static/schemas/source/brand/search-brands-response.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/brand/search-brands-response.json",
+  "title": "Search Brands Response",
+  "description": "Brand stubs matching the search query. Each stub carries the public identity tier — enough to evaluate a brand and follow up with get_brand_identity (for full identity) or get_rights (for pricing). Rich authorized data (voice synthesis, high-res assets, tone guidelines) is not included.",
+  "x-status": "experimental",
+  "definitions": {
+    "SearchBrandResult": {
+      "type": "object",
+      "description": "Lightweight brand stub returned by search_brands. Contains the public identity tier sufficient for discovery. Follow up with get_brand_identity for authorized fields.",
+      "properties": {
+        "brand_id": {
+          "type": "string",
+          "description": "Brand identifier. Pass to get_brand_identity or get_rights for the next step.",
+          "x-entity": "advertiser_brand"
+        },
+        "house": {
+          "type": "object",
+          "description": "The house (corporate entity) this brand belongs to.",
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "House domain (e.g., acme-corp.com)"
+            },
+            "name": {
+              "type": "string",
+              "description": "House display name"
+            }
+          },
+          "required": ["domain", "name"],
+          "additionalProperties": true
+        },
+        "names": {
+          "type": "array",
+          "description": "Localized brand names with BCP 47 locale code keys (e.g., 'en_US', 'fr_CA').",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Brand description"
+        },
+        "industries": {
+          "type": "array",
+          "items": { "$ref": "/schemas/enums/advertiser-industry.json" },
+          "minItems": 1,
+          "description": "Brand industries, following the advertiser-industry taxonomy"
+        },
+        "keller_type": {
+          "type": "string",
+          "enum": ["master", "sub_brand", "endorsed", "independent"],
+          "description": "Brand architecture type: master (primary brand of house), sub_brand (carries parent name), endorsed (independent identity backed by parent), independent (operates separately)"
+        },
+        "logos": {
+          "type": "array",
+          "description": "Standard-resolution logos for display during discovery. High-res variants are gated behind get_brand_identity with account authorization.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": { "type": "string", "format": "uri", "description": "URL to the logo asset" },
+              "orientation": {
+                "type": "string",
+                "enum": ["square", "horizontal", "vertical", "stacked"],
+                "description": "Logo aspect ratio orientation"
+              },
+              "background": {
+                "type": "string",
+                "enum": ["dark-bg", "light-bg", "transparent-bg"],
+                "description": "Background compatibility"
+              },
+              "variant": {
+                "type": "string",
+                "enum": ["primary", "secondary", "icon", "wordmark", "full-lockup"],
+                "description": "Logo variant type"
+              }
+            },
+            "required": ["url"],
+            "additionalProperties": true
+          }
+        },
+        "rights": {
+          "type": "object",
+          "description": "Rights availability summary. Signals whether this brand has licensable rights and in which markets. For detailed pricing and rights records, use get_rights.",
+          "properties": {
+            "available_uses": {
+              "type": "array",
+              "items": { "$ref": "/schemas/enums/right-use.json" }
+            },
+            "countries": {
+              "type": "array",
+              "description": "Countries where rights are available (ISO 3166-1 alpha-2). If omitted, rights are available worldwide.",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$"
+              }
+            },
+            "excluded_countries": {
+              "type": "array",
+              "description": "Countries excluded from availability (ISO 3166-1 alpha-2)",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$"
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["brand_id", "house", "names"],
+      "additionalProperties": true
+    }
+  },
+  "type": "object",
+  "oneOf": [
+    {
+      "title": "SearchBrandsSuccess",
+      "properties": {
+        "brands": {
+          "type": "array",
+          "description": "Brand stubs matching the query, ranked by relevance",
+          "items": {
+            "$ref": "#/definitions/SearchBrandResult"
+          }
+        },
+        "pagination": {
+          "$ref": "/schemas/core/pagination-response.json",
+          "description": "Pagination metadata. Present when has_more is true or total_count is known."
+        },
+        "context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": ["brands"],
+      "additionalProperties": true,
+      "not": { "required": ["errors"] }
+    },
+    {
+      "title": "SearchBrandsError",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/error.json" },
+          "minItems": 1
+        },
+        "context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": ["errors"],
+      "additionalProperties": true,
+      "not": { "required": ["brands"] }
+    }
+  ]
+}

--- a/static/schemas/source/enums/task-type.json
+++ b/static/schemas/source/enums/task-type.json
@@ -23,6 +23,7 @@
     "sync_catalogs",
     "log_event",
     "get_brand_identity",
+    "search_brands",
     "get_rights",
     "acquire_rights"
   ],
@@ -45,6 +46,7 @@
     "sync_catalogs": "Media-buy domain: Sync catalog feeds (products, inventory, stores, promotions, offerings) to a platform with approval workflow",
     "log_event": "Media-buy domain: Send conversion or marketing events for attribution",
     "get_brand_identity": "Brand domain: Retrieve brand identity data (logos, colors, tone, assets, voice config) from a brand agent",
+    "search_brands": "Brand domain: Discover brands on a brand agent's roster via natural language query; returns lightweight identity stubs",
     "get_rights": "Brand domain: Search for licensable rights across a brand agent's roster with pricing",
     "acquire_rights": "Brand domain: Acquire rights from a brand agent with contractual clearance and generation credentials"
   },


### PR DESCRIPTION
Closes #3480

## Summary

Adds a `search_brands` wire task to the brand protocol — a natural-language brand discovery verb for IP desks that need to find brands on an agent's roster before they have a known `brand_id`.

Today the only path is: call `get_rights` → extract `brand_id` values → fan out to `get_brand_identity` per unique brand. Two RTTs minimum plus a shape mismatch (`rights` records vs. identity records). `search_brands` eliminates the fan-out by returning lightweight identity stubs directly, letting buyers pick a `brand_id` and jump straight to `get_rights` for pricing.

**Changes:**
- `static/schemas/source/brand/search-brands-request.json` — new experimental schema. Requires `query` (NL). Optional: `industries[]`, `countries[]`, `buyer_brand` (optional compatibility filtering, same SHOULD semantics as `get_rights`), `pagination`.
- `static/schemas/source/brand/search-brands-response.json` — new experimental schema. Success variant returns `brands: SearchBrandResult[]` — a lightweight public-tier stub (`brand_id`, `house`, `names`, `description`, `industries`, `keller_type`, `logos`, `rights` availability summary). Does NOT return full `GetBrandIdentitySuccess` — authorized-gated fields (`voice_synthesis`, `assets`, `tone`, `visual_guidelines`) stay behind `get_brand_identity`.
- `static/schemas/source/enums/task-type.json` — adds `search_brands` to the stable task-type enum.
- `.changeset/search-brands-verb.md` — `minor` bump (new enum value on stable schema governs over experimental-schema patch rate; see playbook mixed-diff rule).

**Non-breaking justification:** Adds a new optional task and new experimental schemas. No existing fields, enums, or task definitions are modified. Existing clients that don't implement `search_brands` continue to work unchanged.

**Milestone:** 3.1.0 (minor bump on `main`)

## Pre-PR review

- **code-reviewer:** approved with 2 nits (redundant `anyOf` wrapper in error `not` clause — fixed before push; `industries` items type alignment between request filter and response stub — fixed before push)
- **ad-tech-protocol-expert:** approved-with-nits — shape is sound; `buyer_brand` ref correct; `minor` bump classification correct; nits on normative language around filter fidelity and `right_type` in rights summary (both appropriate to address in follow-on during experimental phase)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WPatSCTvQGLwPaEQK5rJCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPatSCTvQGLwPaEQK5rJCE)_