### PR TITLE
fix(registry): backfill member-registered sales agents + agents.html UI

### DIFF
--- a/.changeset/backfill-registered-sales-agents-and-ui.md
+++ b/.changeset/backfill-registered-sales-agents-and-ui.md
@@ -1,0 +1,10 @@
+---
+---
+
+Backfill member-registered sales agents that were flipped to `'buying'` by migration 387, and update the public registry UI (`server/public/agents.html`) so `'sales'` renders correctly and is filterable.
+
+Migration 454 conservatively flips `member_profiles.agents[].type` from `'buying'` → `'sales'` only when (a) the agent URL appears in `discovered_agents` with `agent_type = 'sales'` (PR #3496's migration 453 backfill is the authoritative source), or (b) the member's `offerings` declares `'sales_agent'` and does not declare `'buyer_agent'`. Members offering both are skipped to avoid misclassifying legitimate buyer agents — those will be corrected by the prevention layer in PR #3.
+
+UI changes: add a "Sales" filter button, expand `typeLabel()` to handle `'sales'` → `"Sales"`, and replace the four hard-coded `agent.type === 'buying'` checks with an `isCommerceType()` helper that covers both sell-side and buy-side commerce agents (publishers, properties, products, and AdCP spec checks apply to both).
+
+Refs #3495. Merges after #3496.

--- a/.changeset/backfill-registered-sales-agents-and-ui.md
+++ b/.changeset/backfill-registered-sales-agents-and-ui.md
@@ -3,8 +3,8 @@
 
 Backfill member-registered sales agents that were flipped to `'buying'` by migration 387, and update the public registry UI (`server/public/agents.html`) so `'sales'` renders correctly and is filterable.
 
-Migration 454 conservatively flips `member_profiles.agents[].type` from `'buying'` → `'sales'` only when (a) the agent URL appears in `discovered_agents` with `agent_type = 'sales'` (PR #3496's migration 453 backfill is the authoritative source), or (b) the member's `offerings` declares `'sales_agent'` and does not declare `'buyer_agent'`. Members offering both are skipped to avoid misclassifying legitimate buyer agents — those will be corrected by the prevention layer in PR #3.
+Migration 455 flips `member_profiles.agents[].type` from `'buying'` → `'sales'` only when the agent URL appears in `discovered_agents` with `agent_type = 'sales'` (PR #3496's migration 454 backfill is the authoritative source).
 
-UI changes: add a "Sales" filter button, expand `typeLabel()` to handle `'sales'` → `"Sales"`, and replace the four hard-coded `agent.type === 'buying'` checks with an `isCommerceType()` helper that covers both sell-side and buy-side commerce agents (publishers, properties, products, and AdCP spec checks apply to both).
+UI changes: add a "Sales" filter button, expand `typeLabel()` to handle `'sales'` → `"Sales"`, and scope the four hard-coded `agent.type === 'buying'` checks for publishers / properties / spec compliance to `agent.type === 'sales'` only — buying agents don't have publishers in adagents.json and don't expose `list_authorized_properties`.
 
 Refs #3495. Merges after #3496.

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -612,13 +612,6 @@
         return 'Unclassified';
     }
 
-    // Sales agents (sell-side, expose get_products / create_media_buy) and
-    // buying agents (buy-side) share the same commerce-tool surface — publishers,
-    // properties, products, AdCP spec checks all apply to both.
-    function isCommerceType(type) {
-        return type === 'sales' || type === 'buying';
-    }
-
     function renderAgents() {
         const container = document.getElementById('agents-grid');
 
@@ -694,7 +687,7 @@
                 `;
             }
 
-            if (isCommerceType(agent.type) && agent.properties.length > 0) {
+            if (agent.type === 'sales' && agent.properties.length > 0) {
                 metaHtml += `
                     <div class="meta-item">
                         <span class="meta-value">${agent.properties.length}</span> properties
@@ -746,7 +739,7 @@
 
             let extrasHtml = '';
 
-            if (isCommerceType(agent.type) && agent.properties.length > 0) {
+            if (agent.type === 'sales' && agent.properties.length > 0) {
                 extrasHtml = `
                     <div class="agent-properties">
                         <div class="property-section-small">
@@ -922,7 +915,7 @@
             if (agentWithCaps?.capabilities) {
                 const caps = agentWithCaps.capabilities;
 
-                if (isCommerceType(agent.type) && caps.tools) {
+                if (agent.type === 'sales' && caps.tools) {
                     const toolNames = new Set(caps.tools.map(t => t.name.toLowerCase()));
                     const coreTools = ['get_products', 'create_media_buy', 'update_media_buy', 'get_media_buy_delivery'];
                     const optionalTools = ['sync_creatives', 'list_authorized_properties', 'list_creative_formats', 'build_creative'];
@@ -1009,8 +1002,11 @@
                 `;
             }
 
-            // Type-specific sections
-            if (isCommerceType(agent.type)) {
+            // Type-specific sections — Publishers & properties is sales-only.
+            // Buying agents don't have publishers in adagents.json and don't
+            // expose list_authorized_properties, so this surface is meaningless
+            // for them.
+            if (agent.type === 'sales') {
                 html += `
                     <div class="detail-section">
                         <h3>Publishers &amp; properties</h3>
@@ -1087,7 +1083,7 @@
 
             // Fetch tools and additional data
             fetchTools(agent);
-            if (isCommerceType(agent.type)) {
+            if (agent.type === 'sales') {
                 fetchPublishers(agent);
 
                 const productsDetails = document.querySelector('#products-section').closest('details');

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -488,6 +488,7 @@
                 <div class="filter-group">
                     <label>Type:</label>
                     <button class="filter-btn active" data-type="all" onclick="setTypeFilter('all')">All</button>
+                    <button class="filter-btn" data-type="sales" onclick="setTypeFilter('sales')">Sales</button>
                     <button class="filter-btn" data-type="buying" onclick="setTypeFilter('buying')">Buying</button>
                     <button class="filter-btn" data-type="creative" onclick="setTypeFilter('creative')">Creative</button>
                     <button class="filter-btn" data-type="signals" onclick="setTypeFilter('signals')">Signals</button>
@@ -604,10 +605,18 @@
     }
 
     function typeLabel(type) {
+        if (type === 'sales') return 'Sales';
         if (type === 'buying') return 'Buying';
         if (type === 'creative') return 'Creative';
         if (type === 'signals') return 'Signals';
         return 'Unclassified';
+    }
+
+    // Sales agents (sell-side, expose get_products / create_media_buy) and
+    // buying agents (buy-side) share the same commerce-tool surface — publishers,
+    // properties, products, AdCP spec checks all apply to both.
+    function isCommerceType(type) {
+        return type === 'sales' || type === 'buying';
     }
 
     function renderAgents() {
@@ -685,7 +694,7 @@
                 `;
             }
 
-            if (agent.type === 'buying' && agent.properties.length > 0) {
+            if (isCommerceType(agent.type) && agent.properties.length > 0) {
                 metaHtml += `
                     <div class="meta-item">
                         <span class="meta-value">${agent.properties.length}</span> properties
@@ -737,7 +746,7 @@
 
             let extrasHtml = '';
 
-            if (agent.type === 'buying' && agent.properties.length > 0) {
+            if (isCommerceType(agent.type) && agent.properties.length > 0) {
                 extrasHtml = `
                     <div class="agent-properties">
                         <div class="property-section-small">
@@ -913,7 +922,7 @@
             if (agentWithCaps?.capabilities) {
                 const caps = agentWithCaps.capabilities;
 
-                if (agent.type === 'buying' && caps.tools) {
+                if (isCommerceType(agent.type) && caps.tools) {
                     const toolNames = new Set(caps.tools.map(t => t.name.toLowerCase()));
                     const coreTools = ['get_products', 'create_media_buy', 'update_media_buy', 'get_media_buy_delivery'];
                     const optionalTools = ['sync_creatives', 'list_authorized_properties', 'list_creative_formats', 'build_creative'];
@@ -1001,7 +1010,7 @@
             }
 
             // Type-specific sections
-            if (agent.type === 'buying') {
+            if (isCommerceType(agent.type)) {
                 html += `
                     <div class="detail-section">
                         <h3>Publishers &amp; properties</h3>
@@ -1078,7 +1087,7 @@
 
             // Fetch tools and additional data
             fetchTools(agent);
-            if (agent.type === 'buying') {
+            if (isCommerceType(agent.type)) {
                 fetchPublishers(agent);
 
                 const productsDetails = document.querySelector('#products-section').closest('details');

--- a/server/src/db/migrations/454_backfill_member_registered_sales_agents.sql
+++ b/server/src/db/migrations/454_backfill_member_registered_sales_agents.sql
@@ -1,0 +1,51 @@
+-- Backfill sales agents misclassified as 'buying' in member_profiles.agents JSONB.
+--
+-- Migration 387 (since corrected by 392 + the inference fix in 453) included a
+-- JSONB-aware rewrite that flipped elem->>'type' = 'sales' to '"buying"' inside
+-- member_profiles.agents. Migration 392 only restored the agent_contexts CHECK
+-- constraint and left the JSONB rewrite in place, so member-registered sales
+-- agents are still persisted as 'buying'.
+--
+-- Unlike discovered_agents (where every 'buying' row was a misclassification),
+-- a member can legitimately register a buy-side agent. We use a conservative
+-- discriminator that flips only when we have strong evidence the agent is
+-- sell-side:
+--
+--   1. The agent URL appears in discovered_agents with agent_type = 'sales'.
+--      Migration 453 already back-filled discovered_agents, so this is the
+--      authoritative source: if we crawled the URL via adagents.json, we know
+--      what the agent's exposed tools say.
+--   2. The member's offerings declare 'sales_agent' AND do NOT declare
+--      'buyer_agent'. An unambiguous self-declaration: the member only offers
+--      sales agents, so any registered agent typed 'buying' must be a 387
+--      victim.
+--
+-- Members offering BOTH 'buyer_agent' and 'sales_agent' are skipped to avoid
+-- flipping a legitimately-registered buyer agent. Those rows can be corrected
+-- once they're discovered through the federated index, or by the prevention
+-- layer in PR #3 (server-side inference at registration time).
+
+UPDATE member_profiles mp
+SET agents = (
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem->>'type' = 'buying' AND (
+        EXISTS (
+          SELECT 1 FROM discovered_agents da
+          WHERE da.agent_url = elem->>'url'
+            AND da.agent_type = 'sales'
+        )
+        OR (
+          'sales_agent' = ANY(mp.offerings)
+          AND NOT ('buyer_agent' = ANY(mp.offerings))
+        )
+      )
+      THEN jsonb_set(elem, '{type}', '"sales"')
+      ELSE elem
+    END
+  )
+  FROM jsonb_array_elements(mp.agents) elem
+)
+WHERE mp.agents IS NOT NULL
+  AND mp.agents != '[]'::jsonb
+  AND mp.agents::text LIKE '%"buying"%';

--- a/server/src/db/migrations/454_backfill_member_registered_sales_agents.sql
+++ b/server/src/db/migrations/454_backfill_member_registered_sales_agents.sql
@@ -1,44 +1,35 @@
 -- Backfill sales agents misclassified as 'buying' in member_profiles.agents JSONB.
 --
--- Migration 387 (since corrected by 392 + the inference fix in 453) included a
--- JSONB-aware rewrite that flipped elem->>'type' = 'sales' to '"buying"' inside
--- member_profiles.agents. Migration 392 only restored the agent_contexts CHECK
--- constraint and left the JSONB rewrite in place, so member-registered sales
--- agents are still persisted as 'buying'.
+-- Migration 387 included a JSONB-aware rewrite that flipped elem->>'type' = 'sales'
+-- to '"buying"' inside member_profiles.agents. Migration 392 only restored the
+-- agent_contexts CHECK constraint and left the JSONB rewrite in place, so
+-- member-registered sales agents are still persisted as 'buying'.
 --
 -- Unlike discovered_agents (where every 'buying' row was a misclassification),
--- a member can legitimately register a buy-side agent. We use a conservative
--- discriminator that flips only when we have strong evidence the agent is
--- sell-side:
+-- a member can legitimately register a buy-side agent. The discriminator must
+-- not produce false positives — flipping a real buyer agent to 'sales' would
+-- corrupt the registry. We use the strongest available signal:
 --
---   1. The agent URL appears in discovered_agents with agent_type = 'sales'.
---      Migration 453 already back-filled discovered_agents, so this is the
---      authoritative source: if we crawled the URL via adagents.json, we know
---      what the agent's exposed tools say.
---   2. The member's offerings declare 'sales_agent' AND do NOT declare
---      'buyer_agent'. An unambiguous self-declaration: the member only offers
---      sales agents, so any registered agent typed 'buying' must be a 387
---      victim.
+--   The agent URL exists in discovered_agents with agent_type = 'sales'.
+--   Post-453, this means the agent's MCP tool listing actually advertises
+--   SALES_TOOLS (get_products / create_media_buy / list_authorized_properties).
+--   The agent IS sell-side regardless of how the member labelled it.
 --
--- Members offering BOTH 'buyer_agent' and 'sales_agent' are skipped to avoid
--- flipping a legitimately-registered buyer agent. Those rows can be corrected
--- once they're discovered through the federated index, or by the prevention
--- layer in PR #3 (server-side inference at registration time).
+-- An earlier draft also used `member_profiles.offerings @> 'sales_agent' AND
+-- NOT 'buyer_agent'` as a fallback, but migration 388 strips those values
+-- from offerings entirely, so that branch is dead at runtime. Dropped here
+-- for clarity. Sales agents that haven't been crawled yet (no discovered_agents
+-- row) stay as 'buying' until either a future crawl picks them up or the
+-- prevention layer in PR #3 corrects them at the next registration write.
 
 UPDATE member_profiles mp
 SET agents = (
   SELECT jsonb_agg(
     CASE
-      WHEN elem->>'type' = 'buying' AND (
-        EXISTS (
-          SELECT 1 FROM discovered_agents da
-          WHERE da.agent_url = elem->>'url'
-            AND da.agent_type = 'sales'
-        )
-        OR (
-          'sales_agent' = ANY(mp.offerings)
-          AND NOT ('buyer_agent' = ANY(mp.offerings))
-        )
+      WHEN elem->>'type' = 'buying' AND EXISTS (
+        SELECT 1 FROM discovered_agents da
+        WHERE da.agent_url = elem->>'url'
+          AND da.agent_type = 'sales'
       )
       THEN jsonb_set(elem, '{type}', '"sales"')
       ELSE elem

--- a/server/src/db/migrations/455_backfill_member_registered_sales_agents.sql
+++ b/server/src/db/migrations/455_backfill_member_registered_sales_agents.sql
@@ -11,7 +11,7 @@
 -- corrupt the registry. We use the strongest available signal:
 --
 --   The agent URL exists in discovered_agents with agent_type = 'sales'.
---   Post-453, this means the agent's MCP tool listing actually advertises
+--   Post-454, this means the agent's MCP tool listing actually advertises
 --   SALES_TOOLS (get_products / create_media_buy / list_authorized_properties).
 --   The agent IS sell-side regardless of how the member labelled it.
 --
@@ -20,7 +20,7 @@
 -- from offerings entirely, so that branch is dead at runtime. Dropped here
 -- for clarity. Sales agents that haven't been crawled yet (no discovered_agents
 -- row) stay as 'buying' until either a future crawl picks them up or the
--- prevention layer in PR #3 corrects them at the next registration write.
+-- prevention layer in PR #3498 corrects them at the next registration write.
 
 UPDATE member_profiles mp
 SET agents = (


### PR DESCRIPTION
## Summary

Refs #3495. **Merges after #3496.**

PR #3496 fixed the **discovered** side of the sales/buying misclassification. This PR fixes the **registered** side — member-declared agents stored in `member_profiles.agents` JSONB — plus the public registry UI that hard-codes `'buying'` and has no rendering or filter for `'sales'` at all.

## What's broken

Migration 387 had a JSONB-aware rewrite that flipped `elem->>'type' = 'sales'` → `'"buying"'` inside `member_profiles.agents`. Migration 392 only restored the `agent_contexts` CHECK constraint — it did **not** revert the JSONB rewrite. So:

- `server/src/federated-index.ts:35` reads `agentConfig.type || 'unknown'` verbatim out of the JSONB → registry shows the wrong type.
- `server/public/agents.html` only knows about `'buying'`: line 491 filter button, lines 688/916/1004/1081 hard-coded `=== 'buying'` checks, line 606 `typeLabel()` returning `'Unclassified'` for any unrecognized value. So even after the data is fixed, sell-side agents would render as "Unclassified" until the UI is updated.

## Changes

### `server/src/db/migrations/454_backfill_member_registered_sales_agents.sql`

Conservative backfill — `'buying'` → `'sales'` in `member_profiles.agents[].type` only when at least one of:

1. **The agent URL exists in `discovered_agents` with `agent_type = 'sales'`** — authoritative ground truth from the federated crawl. Depends on migration 453 (#3496) having run, which is enforced by migration ordering.
2. **The member's `offerings` declares `'sales_agent'` and does NOT declare `'buyer_agent'`** — unambiguous self-declaration.

Members offering both `'buyer_agent'` AND `'sales_agent'` are skipped to avoid misclassifying a legitimate buyer agent. Those rows can be corrected by:
- The next federated crawl, when it discovers and types the URL → next run of 454-style logic, OR
- The prevention layer in PR #3 (server-side inference at registration time).

### `server/public/agents.html`

- Added a "Sales" filter button (line 491)
- Expanded `typeLabel()` to map `'sales'` → `"Sales"`
- Added `isCommerceType()` helper — sales and buying agents share the same commerce-tool surface (publishers, properties, products, AdCP spec checks all apply to both), so the four hard-coded `agent.type === 'buying'` checks are now type-agnostic over commerce types.

## Why merges after #3496

- Migration 454's primary discriminator reads `discovered_agents.agent_type = 'sales'`. Migration 453 (in #3496) is what populates that. Migration ordering (453 < 454) enforces this on every fresh apply, so even if PRs land out of order in main, runtime is correct.
- The UI changes don't depend on #3496 codewise, but conceptually they only make sense once `'sales'` is a value that can actually appear in the data (which #3496 produces from discovery).

## Out of scope (PR #3, follow-up)

- Server-side validation + inference override in `PUT /api/me/member-profile` so future registrations can't store `'buying'` for a sales agent.
- Tighten `AgentConfig.type` from `AgentType | 'buyer'` to `AgentType`.
- Fix hard-coded `'buying'` defaults in `dev-setup.ts:88, 109-110` and `adcp-tools.ts:767`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:migrations` — naming/version/duplicate checks pass
- [x] Pre-commit hooks (test:unit, test:test-dynamic-imports, typecheck) pass
- [ ] Verify on staging after #3496 + this merge: existing member-registered sales agents flip from "Buying" → "Sales", new "Sales" filter button works, public registry counts agree with the issue's screenshot