### PR TITLE
ops(fly): drop worker min_machines_running from 2 to 1

### DIFF
--- a/.changeset/fly-worker-min-1.md
+++ b/.changeset/fly-worker-min-1.md
@@ -1,0 +1,8 @@
+---
+---
+
+ops(fly): drop worker `min_machines_running` from 2 to 1
+
+Workers run scheduled jobs only — they don't take external traffic, so the HA story is weak. One worker handles the full cron schedule, and brief gaps during rolling deploys (≤60s) are invisible for the kinds of jobs we run (cache sweeps, newsletter triggers, crawlers, member sync). Cuts worker compute roughly in half.
+
+Pairs with `fly scale count worker=1 -a adcp-docs` already applied to production.

--- a/fly.toml
+++ b/fly.toml
@@ -64,7 +64,9 @@ primary_region = 'iad'
   processes = ["worker"]
   auto_start_machines = true
   auto_stop_machines = "off"
-  min_machines_running = 2
+  # Workers run scheduled jobs only — no external traffic, no HA story.
+  # One worker is plenty; brief gaps during deploys are invisible.
+  min_machines_running = 1
 
   [[services.http_checks]]
     interval = "15s"


### PR DESCRIPTION
## Summary

Workers run scheduled jobs only (cron-style: cache sweeps, newsletter triggers, crawlers, member sync, replay-cache sweeper, etc.) — they don't take external traffic. One worker handles the full schedule. The HA story is weak: brief gaps during rolling deploys (≤60s) are invisible for time-triggered work, and Fly's \`auto_start_machines = true\` brings a worker back if it crashes.

Cuts worker compute roughly in half. Pairs with the production scale-down already applied via \`fly scale count worker=1 -a adcp-docs\`.

Web tier stays at \`min_machines_running = 2\` since it serves user traffic.

## Test plan

- [x] \`fly scale count worker=1 -a adcp-docs\` already applied; site still healthy at https://agenticadvertising.org/health
- [ ] Next deploy: rolling-deploy of single worker briefly leaves zero workers running for ≤60s — confirm no scheduled-job alarms fire in that window
- [ ] Confirm \`min_machines_running = 1\` prevents auto-stop in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)