### PR TITLE
feat(schemas): five missing metric scalars (CPCV, CPM, downloads, units_sold, new_to_brand_units)

### DIFF
--- a/.changeset/missing-metric-scalars.md
+++ b/.changeset/missing-metric-scalars.md
@@ -3,35 +3,42 @@
 ---
 
 Add five missing scalar metrics that production reporting carries today
-but had no enum entry: `cost_per_completed_view`, `cost_per_thousand`,
-`downloads`, `units_sold`, `new_to_brand_units`. Closes the missing-scalars
-sub-item of #3460.
+but had no enum entry: `cost_per_completed_view`, `cpm`, `downloads`,
+`units_sold`, `new_to_brand_units`. Closes the missing-scalars sub-item
+of #3460.
 
 **The scalars and where they fit.**
 
 - `cost_per_completed_view` — CTV CPCV pricing scalar. Parallels existing
   `cost_per_click` and `cost_per_acquisition`; the package's
   `pricing_model` is `cpcv` when this field is the billing basis.
-- `cost_per_thousand` — CPM is the universal pricing scalar across CTV,
-  display, audio, and DOOH inventory. Conspicuous absence next to
-  `cost_per_click` before this PR; the package's `pricing_model` is `cpm`
-  when this field is the billing basis.
+- `cpm` — Cost per thousand impressions. Universal pricing scalar across
+  CTV, display, mobile/web video, native, audio, and DOOH inventory.
+  Conspicuous absence next to `cost_per_click` before this PR; the
+  package's `pricing_model` is `cpm` when this field is the billing
+  basis. Field name aligns with the canonical `cpm` token in
+  `pricing-model.json` and `pricing-options/cpm-option.json` so buyers
+  cross-walk pricing model → reported scalar without a translation.
 - `downloads` — IAB-standard scalar for audio/podcast inventory (IAB
   Podcast Measurement Technical Guidelines 2.x methodology). Distinct
-  from `views`; what Megaphone, Art19, Spotify, and Apple Podcasts
-  report.
-- `units_sold` — Retail-media commerce scalar. Distinct from `conversions`
-  (a single transaction may carry multiple units). Used by Amazon Ads,
-  Walmart Connect, Roundel, Sam's MAP, Instacart Ads, Target Roundel.
+  from `views`.
+- `units_sold` — Retail-media commerce scalar. Distinct from
+  `conversions` (a single transaction may carry multiple units).
+  Attribution windows are platform-specific; sellers SHOULD declare the
+  window via `reporting_capabilities.measurement_windows` or
+  `measurement_terms` rather than encoding it in this scalar.
 - `new_to_brand_units` — Retail-media count of units sold to first-time
-  brand buyers. Parallel to existing `new_to_brand_rate` (which carries
-  the fraction-of-conversions metric); this is the absolute unit count.
+  brand buyers. Unit-volume parallel to existing `new_to_brand_rate`
+  (which carries the fraction-of-conversions metric); this is the
+  absolute unit count.
 
 **Wired in.**
 
 - `enums/available-metric.json`: five new enum values appended.
 - `core/delivery-metrics.json`: five new properties (`type: number,
-  minimum: 0`) added next to `cost_per_click`.
+  minimum: 0`) added next to `cost_per_click`. Existing `new_to_brand_rate`
+  description tightened to clarify it is the fraction of `conversions`
+  (transactions), distinguishing it from the new units count.
 - `docs/media-buy/media-buys/optimization-reporting.mdx`: metric list
   updated.
 
@@ -42,16 +49,14 @@ sub-item of #3460.
   structured `vendor_metrics` surface anchored on the vendor's brand.json.
 - **`completion_rate` derived ratio** — resolved by the drop-carve-out
   call in #3472's refactor. `missing_metrics` is the symmetric mirror of
-  `available_metrics` with no carve-outs; sellers either report ratios
-  or list them as missing. Buyers compute from underlying scalars when
-  preferred.
+  `available_metrics` with no carve-outs.
 
 **Sub-item that remains as a follow-up.**
 
 - **DBCFM cross-check with David Porzelt** on whether
   `engagements`/`follows`/`saves`/`profile_visits` (added in #3453)
   collide with DBCFM `Reporting`/`Performance` KPI codes. Human contact;
-  not a code change. Tracking on #3460 closure.
+  not a code change.
 
 **Backwards compatibility.** All additions are optional. Existing reports
 without these scalars stay conformant; sellers that adopt them populate

--- a/.changeset/missing-metric-scalars.md
+++ b/.changeset/missing-metric-scalars.md
@@ -1,0 +1,60 @@
+---
+"adcontextprotocol": minor
+---
+
+Add five missing scalar metrics that production reporting carries today
+but had no enum entry: `cost_per_completed_view`, `cost_per_thousand`,
+`downloads`, `units_sold`, `new_to_brand_units`. Closes the missing-scalars
+sub-item of #3460.
+
+**The scalars and where they fit.**
+
+- `cost_per_completed_view` — CTV CPCV pricing scalar. Parallels existing
+  `cost_per_click` and `cost_per_acquisition`; the package's
+  `pricing_model` is `cpcv` when this field is the billing basis.
+- `cost_per_thousand` — CPM is the universal pricing scalar across CTV,
+  display, audio, and DOOH inventory. Conspicuous absence next to
+  `cost_per_click` before this PR; the package's `pricing_model` is `cpm`
+  when this field is the billing basis.
+- `downloads` — IAB-standard scalar for audio/podcast inventory (IAB
+  Podcast Measurement Technical Guidelines 2.x methodology). Distinct
+  from `views`; what Megaphone, Art19, Spotify, and Apple Podcasts
+  report.
+- `units_sold` — Retail-media commerce scalar. Distinct from `conversions`
+  (a single transaction may carry multiple units). Used by Amazon Ads,
+  Walmart Connect, Roundel, Sam's MAP, Instacart Ads, Target Roundel.
+- `new_to_brand_units` — Retail-media count of units sold to first-time
+  brand buyers. Parallel to existing `new_to_brand_rate` (which carries
+  the fraction-of-conversions metric); this is the absolute unit count.
+
+**Wired in.**
+
+- `enums/available-metric.json`: five new enum values appended.
+- `core/delivery-metrics.json`: five new properties (`type: number,
+  minimum: 0`) added next to `cost_per_click`.
+- `docs/media-buy/media-buys/optimization-reporting.mdx`: metric list
+  updated.
+
+**Sub-items already resolved on #3460.**
+
+- **Closed-vs-open enum** — resolved by #3492 (vendor-metric extensions).
+  Closed enum stays closed; vendor-defined metrics live in the parallel
+  structured `vendor_metrics` surface anchored on the vendor's brand.json.
+- **`completion_rate` derived ratio** — resolved by the drop-carve-out
+  call in #3472's refactor. `missing_metrics` is the symmetric mirror of
+  `available_metrics` with no carve-outs; sellers either report ratios
+  or list them as missing. Buyers compute from underlying scalars when
+  preferred.
+
+**Sub-item that remains as a follow-up.**
+
+- **DBCFM cross-check with David Porzelt** on whether
+  `engagements`/`follows`/`saves`/`profile_visits` (added in #3453)
+  collide with DBCFM `Reporting`/`Performance` KPI codes. Human contact;
+  not a code change. Tracking on #3460 closure.
+
+**Backwards compatibility.** All additions are optional. Existing reports
+without these scalars stay conformant; sellers that adopt them populate
+the new fields when applicable.
+
+Closes #3460.

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -153,7 +153,12 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`viewability`**: Viewability data (measurable_impressions, viewable_impressions, viewable_rate, standard). Separates MRC and GroupM standards.
 - **`quartile_data`**: Video quartile completion data (q1-q4)
 - **`dooh_metrics`**: DOOH-specific metrics (loop plays, screens, venue breakdown)
-- **`cost_per_click`**: Cost per click
+- **`cost_per_click`**: Cost per click (`spend / clicks`)
+- **`cost_per_completed_view`**: Cost per completed view (`spend / completed_views`); CPCV pricing scalar for video/audio inventory
+- **`cost_per_thousand`**: CPM (`spend / impressions × 1000`); universal pricing scalar across CTV, display, audio, and DOOH
+- **`downloads`**: Audio/podcast downloads (IAB Podcast Measurement Technical Guidelines methodology); distinct from `views`
+- **`units_sold`**: Items sold attributed to delivery (retail-media; distinct from `conversions` — one transaction may carry multiple units)
+- **`new_to_brand_units`**: Units sold to first-time brand buyers (count parallel to `new_to_brand_rate`)
 
 Buyers can optionally request a subset via `requested_metrics` to reduce payload size and focus on relevant KPIs.
 

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -155,10 +155,10 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`dooh_metrics`**: DOOH-specific metrics (loop plays, screens, venue breakdown)
 - **`cost_per_click`**: Cost per click (`spend / clicks`)
 - **`cost_per_completed_view`**: Cost per completed view (`spend / completed_views`); CPCV pricing scalar for video/audio inventory
-- **`cost_per_thousand`**: CPM (`spend / impressions × 1000`); universal pricing scalar across CTV, display, audio, and DOOH
+- **`cpm`**: Cost per thousand impressions (`(spend / impressions) × 1000`); universal pricing scalar across CTV, display, mobile/web video, native, audio, and DOOH
 - **`downloads`**: Audio/podcast downloads (IAB Podcast Measurement Technical Guidelines methodology); distinct from `views`
-- **`units_sold`**: Items sold attributed to delivery (retail-media; distinct from `conversions` — one transaction may carry multiple units)
-- **`new_to_brand_units`**: Units sold to first-time brand buyers (count parallel to `new_to_brand_rate`)
+- **`units_sold`**: Items sold attributed to delivery (retail-media commerce scalar; distinct from `conversions` — one transaction may carry multiple units; attribution-window declared via `measurement_terms`)
+- **`new_to_brand_units`**: Unit-volume parallel to `new_to_brand_rate` — count of units sold to first-time brand buyers
 
 Buyers can optionally request a subset via `requested_metrics` to reduce payload size and focus on relevant KPIs.
 

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -64,7 +64,7 @@
     },
     "new_to_brand_rate": {
       "type": "number",
-      "description": "Fraction of conversions from first-time brand buyers (0 = none, 1 = all)",
+      "description": "Fraction of `conversions` (transactions) from first-time brand buyers, 0 = none, 1 = all. For retail-media unit-volume tracking of first-time buyers, see `new_to_brand_units` (count, not rate).",
       "minimum": 0,
       "maximum": 1
     },
@@ -286,24 +286,24 @@
       "description": "Cost per completed view (spend / completed_views). Primary CPCV pricing scalar for video/audio inventory; the package's `pricing_model` is `cpcv` when this field is the billing basis.",
       "minimum": 0
     },
-    "cost_per_thousand": {
+    "cpm": {
       "type": "number",
-      "description": "Cost per thousand impressions (CPM = spend / impressions × 1000). Universal pricing scalar across CTV, display, audio, and DOOH inventory; the package's `pricing_model` is `cpm` when this field is the billing basis.",
+      "description": "Cost per thousand impressions, computed as (spend / impressions) × 1000. Universal pricing scalar across CTV, display, mobile/web video, native, audio, and DOOH inventory; the package's `pricing_model` is `cpm` when this field is the billing basis. Field name aligns with the canonical `cpm` token in `enums/pricing-model.json` and `pricing-options/cpm-option.json` so buyers cross-walk pricing model → reported scalar without a translation table.",
       "minimum": 0
     },
     "downloads": {
       "type": "number",
-      "description": "Audio/podcast downloads. IAB-standard scalar distinct from `views` — for podcast inventory this is the count of podcast episode downloads (typically the IAB Podcast Measurement Technical Guidelines 2.x methodology); for streaming audio it is the count of stream starts that meet the platform's download threshold. Prefer this over `views` for audio inventory.",
+      "description": "Audio/podcast downloads (IAB Podcast Measurement Technical Guidelines 2.x methodology). Distinct from `views` — for podcast inventory this is the count of podcast episode downloads; for streaming audio it is the count of stream starts that meet the platform's download threshold. Prefer this over `views` for audio inventory.",
       "minimum": 0
     },
     "units_sold": {
       "type": "number",
-      "description": "Items sold attributed to this delivery. Retail-media scalar distinct from `conversions` — a single conversion (transaction) may carry multiple `units_sold`. Used by retail media platforms (Amazon Ads, Walmart Connect, Roundel, Sam's MAP, Instacart Ads, Target Roundel) where the buyer optimizes against unit movement, not transaction count.",
+      "description": "Items sold attributed to this delivery. Retail-media scalar distinct from `conversions` — a single conversion (transaction) may carry multiple `units_sold`. Used by retail media platforms where the buyer optimizes against unit movement, not transaction count. Attribution lookback windows are platform-specific (commonly 7/14/30 days, view-through and click-through variants); sellers SHOULD declare the window via `reporting_capabilities.measurement_windows` or `measurement_terms` rather than encoding it in this scalar.",
       "minimum": 0
     },
     "new_to_brand_units": {
       "type": "number",
-      "description": "Units sold to first-time brand buyers (count, not rate). Retail-media scalar parallel to `new_to_brand_rate` (which measures the fraction of conversions from first-time buyers). Used by retail media platforms where new-customer acquisition unit volume is a primary KPI.",
+      "description": "Units sold to first-time brand buyers (count, not rate). Retail-media scalar — the unit-volume parallel to the conversion-fraction `new_to_brand_rate`. Used by retail media platforms where new-customer acquisition unit volume is a primary KPI. Same attribution-window note as `units_sold` applies.",
       "minimum": 0
     },
     "by_action_source": {

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -281,6 +281,31 @@
       "description": "Cost per click (spend / clicks)",
       "minimum": 0
     },
+    "cost_per_completed_view": {
+      "type": "number",
+      "description": "Cost per completed view (spend / completed_views). Primary CPCV pricing scalar for video/audio inventory; the package's `pricing_model` is `cpcv` when this field is the billing basis.",
+      "minimum": 0
+    },
+    "cost_per_thousand": {
+      "type": "number",
+      "description": "Cost per thousand impressions (CPM = spend / impressions × 1000). Universal pricing scalar across CTV, display, audio, and DOOH inventory; the package's `pricing_model` is `cpm` when this field is the billing basis.",
+      "minimum": 0
+    },
+    "downloads": {
+      "type": "number",
+      "description": "Audio/podcast downloads. IAB-standard scalar distinct from `views` — for podcast inventory this is the count of podcast episode downloads (typically the IAB Podcast Measurement Technical Guidelines 2.x methodology); for streaming audio it is the count of stream starts that meet the platform's download threshold. Prefer this over `views` for audio inventory.",
+      "minimum": 0
+    },
+    "units_sold": {
+      "type": "number",
+      "description": "Items sold attributed to this delivery. Retail-media scalar distinct from `conversions` — a single conversion (transaction) may carry multiple `units_sold`. Used by retail media platforms (Amazon Ads, Walmart Connect, Roundel, Sam's MAP, Instacart Ads, Target Roundel) where the buyer optimizes against unit movement, not transaction count.",
+      "minimum": 0
+    },
+    "new_to_brand_units": {
+      "type": "number",
+      "description": "Units sold to first-time brand buyers (count, not rate). Retail-media scalar parallel to `new_to_brand_rate` (which measures the fraction of conversions from first-time buyers). Used by retail media platforms where new-customer acquisition unit volume is a primary KPI.",
+      "minimum": 0
+    },
     "by_action_source": {
       "type": "array",
       "description": "Conversion metrics broken down by action source (website, app, in_store, etc.). Useful for omnichannel sellers where conversions occur across digital and physical channels.",

--- a/static/schemas/source/enums/available-metric.json
+++ b/static/schemas/source/enums/available-metric.json
@@ -29,6 +29,11 @@
     "viewability",
     "quartile_data",
     "dooh_metrics",
-    "cost_per_click"
+    "cost_per_click",
+    "cost_per_completed_view",
+    "cost_per_thousand",
+    "downloads",
+    "units_sold",
+    "new_to_brand_units"
   ]
 }

--- a/static/schemas/source/enums/available-metric.json
+++ b/static/schemas/source/enums/available-metric.json
@@ -31,7 +31,7 @@
     "dooh_metrics",
     "cost_per_click",
     "cost_per_completed_view",
-    "cost_per_thousand",
+    "cpm",
     "downloads",
     "units_sold",
     "new_to_brand_units"


### PR DESCRIPTION
## Summary

Adds five scalar metrics production reporting carries today but that had no enum entry. Closes the missing-scalars sub-item of #3460.

| Scalar | Why it's needed |
|---|---|
| `cost_per_completed_view` | CTV CPCV pricing scalar; parallels existing `cost_per_click`/`cost_per_acquisition` |
| `cost_per_thousand` | CPM is universal across CTV/display/audio/DOOH; conspicuous absence before this PR |
| `downloads` | IAB-standard for audio/podcast (Podcast Measurement Technical Guidelines 2.x); distinct from `views` |
| `units_sold` | Retail-media commerce scalar; distinct from `conversions` (one transaction can carry multiple units) |
| `new_to_brand_units` | Retail-media count of units sold to first-time buyers; parallel to existing `new_to_brand_rate` |

All five added as `type: number, minimum: 0` properties on `delivery-metrics.json` plus enum entries on `available-metric.json`. Doc list in `optimization-reporting.mdx` updated.

## Other sub-items on #3460

- **Closed-vs-open enum** — resolved by #3492 (vendor-metric extensions). Closed enum stays closed; vendor-defined metrics live in the parallel structured `vendor_metrics` surface anchored on the vendor's brand.json.
- **`completion_rate` derived ratio** — resolved by the drop-carve-out call in #3472's refactor. `missing_metrics` is the symmetric mirror of `available_metrics` with no carve-outs; sellers either report ratios or they appear in `missing_metrics`.
- **DBCFM cross-check** — remains as a human follow-up (David Porzelt; whether `engagements`/`follows`/`saves`/`profile_visits` collide with DBCFM `Reporting`/`Performance` KPI codes). Not a code change.

## Skipped

- **`viewable_impressions`/`viewable_rate` as scalars** — already in the `viewability` namespace which is in the enum; adding scalars would duplicate. The namespace covers it: `required_metrics: ["viewability"]` on `get_products` matches products that report viewability data, and the seller emits the full `viewability` object on delivery.

## Backwards compatibility

All additions are optional. Existing reports stay conformant; sellers populate the new fields when applicable.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:examples` — 34/34
- [x] `npm run test:json-schema` — 255/255
- [x] `npm run test:composed` — 32/32
- [x] `npm run typecheck` — clean
- [x] precommit + pre-push — green

Closes #3460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)