### PR TITLE
ops(migrate): bound migration advisory-lock acquisition with statement_timeout

### DIFF
--- a/.changeset/migration-lock-timeout.md
+++ b/.changeset/migration-lock-timeout.md
@@ -1,0 +1,10 @@
+---
+---
+
+ops(migrate): bound migration advisory-lock acquisition with a 5-minute statement_timeout
+
+If a prior `runMigrations()` session crashed while holding `pg_advisory_lock`, the next deploy currently waits until Postgres' TCP keepalive reaps the dead session — by default ~2 hours. With the 15-minute Fly `release_command_timeout`, that means the deploy "hangs" until manual intervention.
+
+Now `acquireMigrationLock` sets `statement_timeout = '5min'` while waiting for the lock, then clears it once acquired (so the migration itself isn't capped). On timeout (pg code `57014`), we throw a diagnostic error that names the lock key and shows the SQL to find and terminate the wedged session.
+
+Behavior is unchanged in the happy path: legitimate concurrent callers (release_command + a dev's docker-compose) still serialize on the blocking `pg_advisory_lock`, just with a bound on stale-session waits.

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import type { PoolClient } from "pg";
 import { getPool, initializeDatabase } from "./client.js";
 import { DatabaseConfig } from "../config.js";
 
@@ -174,7 +175,7 @@ export async function runMigrations(config?: DatabaseConfig): Promise<void> {
   const pool = getPool();
   const lockClient = await pool.connect();
   try {
-    await lockClient.query("SELECT pg_advisory_lock($1)", [MIGRATION_LOCK_KEY]);
+    await acquireMigrationLock(lockClient);
     await runMigrationsLocked();
   } finally {
     // Don't let unlock failures shadow a real migration error. Session-scoped
@@ -185,6 +186,37 @@ export async function runMigrations(config?: DatabaseConfig): Promise<void> {
       console.warn("Failed to release migration advisory lock:", err);
     }
     lockClient.release();
+  }
+}
+
+/**
+ * Acquire the migration advisory lock, bounded by a 5-minute statement_timeout
+ * so a wedged prior session doesn't hang the deploy until pg keepalive reaps it
+ * (default ≈2 hours). The timeout only caps how long we *wait* for the lock —
+ * once acquired, we clear the timeout so the migration itself can run as long
+ * as it needs.
+ *
+ * pg error code 57014 = query_canceled (statement_timeout fired).
+ */
+const ACQUIRE_LOCK_TIMEOUT = "5min";
+
+async function acquireMigrationLock(client: PoolClient): Promise<void> {
+  await client.query(`SET statement_timeout = '${ACQUIRE_LOCK_TIMEOUT}'`);
+  try {
+    await client.query("SELECT pg_advisory_lock($1)", [MIGRATION_LOCK_KEY]);
+  } catch (err) {
+    if ((err as { code?: string })?.code === "57014") {
+      throw new Error(
+        `Could not acquire migration advisory lock (key=${MIGRATION_LOCK_KEY}) within ${ACQUIRE_LOCK_TIMEOUT}. ` +
+        `A prior runMigrations() session is likely wedged. Find the holder:\n` +
+        `  SELECT pid, state, query_start, query FROM pg_stat_activity\n` +
+        `  WHERE pid IN (SELECT pid FROM pg_locks WHERE locktype='advisory' AND objid=${MIGRATION_LOCK_KEY});\n` +
+        `Then terminate it: SELECT pg_terminate_backend(<pid>);`
+      );
+    }
+    throw err;
+  } finally {
+    await client.query("SET statement_timeout = 0");
   }
 }
 

--- a/server/tests/unit/migrate.test.ts
+++ b/server/tests/unit/migrate.test.ts
@@ -373,5 +373,40 @@ describe("Database Migrations", () => {
 
       warnSpy.mockRestore();
     });
+
+    it("bounds lock acquisition with statement_timeout, then clears it", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([] as any);
+      mockPool.query
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rows: [] });
+
+      await runMigrations();
+
+      const calls = mockClient.query.mock.calls.map((c: any[]) => c[0]);
+      const setTimeoutIdx = calls.findIndex((q: string) => /SET statement_timeout = '5min'/.test(q));
+      const lockIdx = calls.findIndex((q: string) => q === "SELECT pg_advisory_lock($1)");
+      const clearTimeoutIdx = calls.findIndex((q: string) => /SET statement_timeout = 0/.test(q));
+
+      expect(setTimeoutIdx).toBeGreaterThanOrEqual(0);
+      expect(lockIdx).toBeGreaterThan(setTimeoutIdx);
+      expect(clearTimeoutIdx).toBeGreaterThan(lockIdx);
+    });
+
+    it("surfaces a clear error when lock acquisition times out (pg 57014)", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([] as any);
+      mockClient.query.mockImplementation((text: string) => {
+        if (text === "SELECT pg_advisory_lock($1)") {
+          const err = new Error("canceling statement due to statement timeout") as Error & { code: string };
+          err.code = "57014";
+          return Promise.reject(err);
+        }
+        return Promise.resolve({});
+      });
+
+      await expect(runMigrations()).rejects.toThrow(/A prior runMigrations\(\) session is likely wedged/);
+
+      // Even on the timeout path, the connection must be released.
+      expect(mockClient.release).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Defensive follow-up to PR #3491. Today, if a previous \`runMigrations()\` session crashes while holding \`pg_advisory_lock\` (release_command OOM, machine kill mid-migration, etc.), the next deploy waits until Postgres' TCP keepalive reaps the dead session — by default ≈2 hours. Fly's \`release_command_timeout\` is 15 minutes, so the deploy fails with no diagnostic about *why* it's waiting.

This PR caps the wait at 5 minutes via \`SET statement_timeout = '5min'\` on the lock-acquisition query, then clears the timeout immediately after the lock is held so the migration itself isn't capped. On timeout (pg code \`57014\`), we throw a clear error that names the lock key and the SQL to find and terminate the wedged session:

\`\`\`
SELECT pid, state, query_start, query FROM pg_stat_activity
WHERE pid IN (SELECT pid FROM pg_locks WHERE locktype='advisory' AND objid=1835102578);
\`\`\`

Happy path is unchanged: legitimate concurrent callers (release_command + a dev's docker-compose containers) still serialize on the blocking \`pg_advisory_lock\`. We just bound the stale-session wait.

## Test plan

- [x] 19 migrate.test.ts cases pass (added 2: \`statement_timeout\` is set→cleared in order, and the 57014 path produces a clear error and still releases the connection)
- [x] \`npx tsc --noEmit\` clean
- [x] Pre-commit hook (unit + dynamic imports + typecheck) green
- [ ] Manually verify the diagnostic error fires on a deliberately wedged session in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)