### PR TITLE
feat(compliance): enforce vendor_metrics semantic uniqueness key at build time

### DIFF
--- a/.changeset/vendor-metric-uniqueness-lint.md
+++ b/.changeset/vendor-metric-uniqueness-lint.md
@@ -1,0 +1,27 @@
+---
+---
+
+Add build-time enforcement for vendor_metrics semantic uniqueness key.
+
+Two new lint checks enforce the `(vendor.domain, vendor.brand_id, metric_id)` MUST
+constraint documented in `reporting-capabilities.json` and `delivery-metrics.json`
+but previously unenforceable by JSON Schema `uniqueItems` (BrandRef optional fields
+defeat deep-equal):
+
+1. `scripts/build-schemas.cjs` — scans `examples` arrays in schema JSON files for
+   duplicate tuples. Fails the build if violated.
+2. `scripts/lint-vendor-metric-uniqueness.cjs` — walks storyboard YAML fixtures and
+   checks `sample_request` / `params` fields for duplicate tuples. Wired into
+   `build-compliance.cjs`.
+
+Both checks normalize absent `brand_id` to `""` (empty string), distinguishing
+`{domain:"x"}` from `{domain:"x",brand_id:"sub"}` as separate brands (house-of-brands
+semantics) while still catching accidental duplicates where `brand_id` is dropped on
+one copy. The `|` separator is safe — all three key components have patterns that
+exclude `|`.
+
+Storyboard check kind `field_unique_by_keys` (issue #3502 item 2) deferred — requires
+adcp-client runner implementation. Issue #3501 (vendor-metric storyboard fixture) is
+the companion tracker for the conformance storyboard work.
+
+Refs #3502.

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -511,6 +511,22 @@ function main() {
     process.exit(1);
   }
 
+  // Vendor metric uniqueness lint: storyboard fixture inline payloads MUST NOT
+  // contain duplicate (vendor.domain, vendor.brand_id, metric_id) tuples in
+  // vendor_metric_values or vendor_metrics arrays. Enforces the MUST constraint
+  // documented in reporting-capabilities.json and delivery-metrics.json that
+  // JSON Schema uniqueItems cannot enforce (BrandRef optional fields defeat
+  // deep-equal). Companion schema-examples lint runs in build-schemas.cjs.
+  // adcontextprotocol/adcp#3502.
+  try {
+    execSync('node scripts/lint-vendor-metric-uniqueness.cjs', {
+      cwd: path.join(__dirname, '..'),
+      stdio: 'inherit',
+    });
+  } catch {
+    process.exit(1);
+  }
+
   console.log(isRelease
     ? `🚀 RELEASE BUILD: Creating compliance artifacts for AdCP v${version}`
     : `📦 Development build: Updating latest/ compliance`);

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -254,7 +254,7 @@ function collectVendorMetricExamples(obj, schemaPath, out = []) {
   // If this object has vendor_metric_values or vendor_metrics, scan them.
   for (const field of ['vendor_metric_values', 'vendor_metrics']) {
     const arr = obj[field];
-    if (!Array.isArray(arr) || arr.length === 0) continue;
+    if (!Array.isArray(arr) || arr.length < 2) continue;
     const tuples = [];
     for (const entry of arr) {
       if (!entry || typeof entry !== 'object' || !entry.vendor) continue;

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -214,6 +214,107 @@ function lintMutatingRequestsRequireIdempotencyKey(sourceDir) {
   }
 }
 
+// ── Vendor metric semantic uniqueness lint ────────────────────────────────
+//
+// The reporting-capabilities.json `vendor_metrics` array and the
+// delivery-metrics.json `vendor_metric_values` array both carry a semantic
+// uniqueness key `(vendor.domain, vendor.brand_id, metric_id)`. JSON Schema
+// `uniqueItems` was deliberately omitted because BrandRef carries optional
+// fields whose absence/presence defeats deep-equal (e.g., `{domain:"x"}` and
+// `{domain:"x",brand_id:"y"}` are structurally different objects even if they
+// describe the same brand). This lint enforces the MUST constraint by
+// normalizing the semantic tuple and checking for duplicates.
+//
+// Key normalization: use `|`-delimited string `domain|brand_id|metric_id`.
+// The `|` separator is safe because domain (`[a-z0-9.-]`), brand_id
+// (`[a-z0-9_]`), and metric_id (`[a-z][a-z0-9_]*`) cannot contain `|`. Absent
+// brand_id normalizes to "" (empty string) — the empty string is distinct from
+// any valid brand_id so `{domain:"x"}` and `{domain:"x",brand_id:""}` cannot
+// collide with each other. This normalization is documented so the storyboard
+// runner's future `field_unique_by_keys` implementation must match it.
+//
+// Scan surfaces:
+//   1. `examples` arrays inside JSON schema files (at any depth).
+//   2. TypeScript training-agent fixtures (`server/src/training-agent/**/*.ts`)
+//      are explicitly called out in issue #3502 but currently contain no vendor
+//      metric data. TS scanning would require a parser — deferred until a
+//      fixture adds vendor metrics, at which point build failures will surface
+//      the gap. See #3502 item 1 for the tracking comment.
+
+/**
+ * Recursively collect all `examples` values that contain vendor metric arrays.
+ * Returns an array of { schemaPath, arrayField, tuples[] } objects.
+ */
+function collectVendorMetricExamples(obj, schemaPath, out = []) {
+  if (!obj || typeof obj !== 'object') return out;
+  if (Array.isArray(obj)) {
+    for (const item of obj) collectVendorMetricExamples(item, schemaPath, out);
+    return out;
+  }
+  // If this object has vendor_metric_values or vendor_metrics, scan them.
+  for (const field of ['vendor_metric_values', 'vendor_metrics']) {
+    const arr = obj[field];
+    if (!Array.isArray(arr) || arr.length === 0) continue;
+    const tuples = [];
+    for (const entry of arr) {
+      if (!entry || typeof entry !== 'object' || !entry.vendor) continue;
+      const domain = typeof entry.vendor.domain === 'string' ? entry.vendor.domain : '';
+      const brandId = typeof entry.vendor.brand_id === 'string' ? entry.vendor.brand_id : '';
+      const metricId = typeof entry.metric_id === 'string' ? entry.metric_id : '';
+      tuples.push(`${domain}|${brandId}|${metricId}`);
+    }
+    if (tuples.length > 0) out.push({ schemaPath, arrayField: field, tuples });
+  }
+  // Recurse into all object values (handles nested examples inside `examples` arrays, etc.).
+  for (const val of Object.values(obj)) collectVendorMetricExamples(val, schemaPath, out);
+  return out;
+}
+
+function lintVendorMetricSemanticUniqueness(sourceDir) {
+  const violations = [];
+
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'extensions' || entry.name === 'bundled') continue;
+        walk(p);
+        continue;
+      }
+      if (!entry.name.endsWith('.json')) continue;
+      let schema;
+      try { schema = JSON.parse(fs.readFileSync(p, 'utf8')); }
+      catch { continue; }
+      // Collect from top-level `examples` array and from any nested examples.
+      const exampleValues = collectVendorMetricExamples(schema, path.relative(sourceDir, p));
+      for (const { schemaPath, arrayField, tuples } of exampleValues) {
+        const seen = new Set();
+        for (const tuple of tuples) {
+          if (seen.has(tuple)) {
+            violations.push({ schemaPath, arrayField, tuple });
+          }
+          seen.add(tuple);
+        }
+      }
+    }
+  }
+
+  walk(sourceDir);
+
+  if (violations.length > 0) {
+    const lines = violations.map(v =>
+      `  ${v.schemaPath} — ${v.arrayField}: duplicate tuple "${v.tuple}" (key: domain|brand_id|metric_id)`
+    );
+    throw new Error(
+      `Vendor metric uniqueness lint: ${violations.length} duplicate tuple(s) found in schema examples.\n\n` +
+      lines.join('\n') +
+      `\n\nFix: each (vendor.domain, vendor.brand_id, metric_id) tuple MUST appear at most once per array.\n` +
+      `See static/schemas/source/core/reporting-capabilities.json and delivery-metrics.json for the\n` +
+      `normative uniqueness constraint. Issue: adcontextprotocol/adcp#3502.`
+    );
+  }
+}
+
 /**
  * Compare two minor versions (e.g., "2.5" vs "2.6")
  * Returns: negative if a < b, 0 if equal, positive if a > b
@@ -967,6 +1068,14 @@ async function main() {
   // that's supposed to be mutating but forgets idempotency_key is a
   // latent spec bug that silently bypasses the storyboard-level lint.
   lintMutatingRequestsRequireIdempotencyKey(SOURCE_DIR);
+
+  // Lint vendor metric uniqueness: enforce the semantic uniqueness key
+  // (vendor.domain, vendor.brand_id, metric_id) documented in
+  // reporting-capabilities.json and delivery-metrics.json. JSON Schema
+  // uniqueItems was deliberately omitted because BrandRef's optional
+  // fields defeat deep-equal; this build-time check enforces the MUST
+  // constraint on example payloads embedded in schema files. Issue #3502.
+  lintVendorMetricSemanticUniqueness(SOURCE_DIR);
 
   // Update source registry version
   updateSourceRegistry(version);

--- a/scripts/lint-vendor-metric-uniqueness.cjs
+++ b/scripts/lint-vendor-metric-uniqueness.cjs
@@ -96,6 +96,13 @@ function findDuplicatesInPayload(payload) {
   return duplicates;
 }
 
+// Scope note: lint() checks sample_request (buyer/agent call payloads) and params
+// (comply_test_controller scenario params) but does NOT scan expected_response or any
+// assert_response/response fields. Seller-side response fixtures authored in those
+// fields are intentionally out of scope here — they are not authored by storyboard
+// writers as fixtures, and no existing storyboard uses them with vendor metrics.
+// If storyboard conventions change to include inline response fixtures, extend this
+// function to also check step.expected_response and step.assert_response.
 function lint() {
   const files = walkYaml(SOURCE_DIR);
   const violations = [];

--- a/scripts/lint-vendor-metric-uniqueness.cjs
+++ b/scripts/lint-vendor-metric-uniqueness.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if any storyboard step inlines vendor_metric_values or
+ * vendor_metrics arrays that violate the semantic uniqueness key
+ * (vendor.domain, vendor.brand_id, metric_id).
+ *
+ * JSON Schema `uniqueItems` was deliberately omitted from these arrays because
+ * BrandRef carries optional fields whose absence/presence defeats deep-equal.
+ * The MUST constraint ("sellers MUST de-duplicate before emission") is
+ * normatively documented in reporting-capabilities.json and delivery-metrics.json
+ * but was not enforced at build time. This lint closes that gap for storyboard
+ * fixtures. The companion check in scripts/build-schemas.cjs enforces the same
+ * constraint on schema file `examples` arrays. Issue: adcontextprotocol/adcp#3502.
+ *
+ * Key normalization: `domain|brand_id|metric_id` where absent brand_id → "".
+ * The `|` separator is safe: domain (`[a-z0-9.-]`), brand_id (`[a-z0-9_]`), and
+ * metric_id (`[a-z][a-z0-9_]*`) cannot contain `|`. Absent brand_id is the empty
+ * string — distinct from any valid brand_id so `{domain:"x"}` and
+ * `{domain:"x",brand_id:""}` cannot collide.
+ *
+ * Scans both sample_request and params fields on every storyboard step.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'compliance', 'source');
+
+/** Walk a directory for *.yaml / *.yml files. */
+function walkYaml(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkYaml(full));
+    else if (entry.isFile() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml'))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// js-yaml is loaded lazily so that requiring this module for unit tests
+// (which only exercise the pure helper functions) does not fail in environments
+// where node_modules are not installed.
+function loadYaml() {
+  return require('js-yaml'); // eslint-disable-line global-require
+}
+
+/** Pull out every step from a parsed storyboard document. */
+function iterSteps(doc) {
+  const out = [];
+  const phases = Array.isArray(doc?.phases) ? doc.phases : [];
+  for (const phase of phases) {
+    const steps = Array.isArray(phase?.steps) ? phase.steps : [];
+    for (const step of steps) {
+      if (step && typeof step === 'object') {
+        out.push({ phaseId: phase.id ?? '<unnamed>', step });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the semantic key string for a vendor metric entry.
+ * Normalizes absent brand_id to "" so {domain:"x"} ≠ {domain:"x",brand_id:"sub"}.
+ */
+function vendorMetricKey(entry) {
+  if (!entry || typeof entry !== 'object' || !entry.vendor) return null;
+  const domain = typeof entry.vendor.domain === 'string' ? entry.vendor.domain : '';
+  const brandId = typeof entry.vendor.brand_id === 'string' ? entry.vendor.brand_id : '';
+  const metricId = typeof entry.metric_id === 'string' ? entry.metric_id : '';
+  return `${domain}|${brandId}|${metricId}`;
+}
+
+/**
+ * Check one payload object for vendor metric duplicate tuples.
+ * Returns an array of duplicate key strings found.
+ */
+function findDuplicatesInPayload(payload) {
+  if (!payload || typeof payload !== 'object') return [];
+  const duplicates = [];
+  for (const field of ['vendor_metric_values', 'vendor_metrics']) {
+    const arr = payload[field];
+    if (!Array.isArray(arr) || arr.length < 2) continue;
+    const seen = new Set();
+    for (const entry of arr) {
+      const key = vendorMetricKey(entry);
+      if (key === null) continue;
+      if (seen.has(key)) duplicates.push(`${field}[]: "${key}"`);
+      seen.add(key);
+    }
+  }
+  return duplicates;
+}
+
+function lint() {
+  const files = walkYaml(SOURCE_DIR);
+  const violations = [];
+
+  for (const file of files) {
+    let doc;
+    try {
+      doc = loadYaml().load(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!doc || typeof doc !== 'object') continue;
+
+    for (const { phaseId, step } of iterSteps(doc)) {
+      const stepId = step.id ?? '<unnamed>';
+      const relFile = path.relative(SOURCE_DIR, file);
+
+      // Check sample_request (buyer/agent payloads)
+      const fromRequest = findDuplicatesInPayload(step.sample_request);
+      for (const dup of fromRequest) {
+        violations.push({ file: relFile, phaseId, stepId, source: 'sample_request', dup });
+      }
+
+      // Check params (comply_test_controller scenario params)
+      const fromParams = findDuplicatesInPayload(step.params);
+      for (const dup of fromParams) {
+        violations.push({ file: relFile, phaseId, stepId, source: 'params', dup });
+      }
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const violations = lint();
+  if (violations.length === 0) {
+    console.log('✓ vendor metric uniqueness lint: no duplicate (vendor.domain, vendor.brand_id, metric_id) tuples in storyboard fixtures');
+    return;
+  }
+
+  console.error(`✗ vendor metric uniqueness lint: ${violations.length} violation(s)\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.phaseId}/${v.stepId} (${v.source}) — ${v.dup}`);
+  }
+  console.error('\nFix: each (vendor.domain, vendor.brand_id, metric_id) tuple MUST appear at most once per array.');
+  console.error('See static/schemas/source/core/reporting-capabilities.json and delivery-metrics.json for the');
+  console.error('normative constraint. Sellers MUST de-duplicate before emission. adcontextprotocol/adcp#3502.');
+  process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = { lint, findDuplicatesInPayload, vendorMetricKey };

--- a/tests/lint-vendor-metric-uniqueness.test.cjs
+++ b/tests/lint-vendor-metric-uniqueness.test.cjs
@@ -28,12 +28,13 @@ test('vendorMetricKey: absent brand_id normalizes to empty string', () => {
   assert.equal(vendorMetricKey(entry), 'acme.example||gco2e_per_impression');
 });
 
-test('vendorMetricKey: {domain:"x"} and {domain:"x",brand_id:""} produce different keys from {domain:"x",brand_id:"sub"}', () => {
-  const noId  = vendorMetricKey({ vendor: { domain: 'x.example' }, metric_id: 'm' });
+test('vendorMetricKey: absent brand_id and explicit empty string normalize identically; both differ from a populated brand_id', () => {
+  const noId    = vendorMetricKey({ vendor: { domain: 'x.example' }, metric_id: 'm' });
   const emptyId = vendorMetricKey({ vendor: { domain: 'x.example', brand_id: '' }, metric_id: 'm' });
-  const subId = vendorMetricKey({ vendor: { domain: 'x.example', brand_id: 'sub' }, metric_id: 'm' });
-  // Both absent and explicit-empty stringify to the same normalized form.
+  const subId   = vendorMetricKey({ vendor: { domain: 'x.example', brand_id: 'sub' }, metric_id: 'm' });
+  // Absent and explicit-empty both normalize to "x.example||m".
   assert.equal(noId, emptyId);
+  // A populated brand_id is a distinct subsidiary — not the same key.
   assert.notEqual(noId, subId);
 });
 

--- a/tests/lint-vendor-metric-uniqueness.test.cjs
+++ b/tests/lint-vendor-metric-uniqueness.test.cjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/lint-vendor-metric-uniqueness.cjs
+ *
+ * Validates that the lint correctly identifies duplicate
+ * (vendor.domain, vendor.brand_id, metric_id) tuples in storyboard
+ * fixture payloads (sample_request and params), and that it passes
+ * when tuples are distinct.
+ *
+ * adcontextprotocol/adcp#3502
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { findDuplicatesInPayload, vendorMetricKey } = require('../scripts/lint-vendor-metric-uniqueness.cjs');
+
+// ── vendorMetricKey ───────────────────────────────────────────────────────────
+
+test('vendorMetricKey: builds correct key from full BrandRef', () => {
+  const entry = { vendor: { domain: 'acme.example', brand_id: 'spark' }, metric_id: 'attention_units' };
+  assert.equal(vendorMetricKey(entry), 'acme.example|spark|attention_units');
+});
+
+test('vendorMetricKey: absent brand_id normalizes to empty string', () => {
+  const entry = { vendor: { domain: 'acme.example' }, metric_id: 'gco2e_per_impression' };
+  assert.equal(vendorMetricKey(entry), 'acme.example||gco2e_per_impression');
+});
+
+test('vendorMetricKey: {domain:"x"} and {domain:"x",brand_id:""} produce different keys from {domain:"x",brand_id:"sub"}', () => {
+  const noId  = vendorMetricKey({ vendor: { domain: 'x.example' }, metric_id: 'm' });
+  const emptyId = vendorMetricKey({ vendor: { domain: 'x.example', brand_id: '' }, metric_id: 'm' });
+  const subId = vendorMetricKey({ vendor: { domain: 'x.example', brand_id: 'sub' }, metric_id: 'm' });
+  // Both absent and explicit-empty stringify to the same normalized form.
+  assert.equal(noId, emptyId);
+  assert.notEqual(noId, subId);
+});
+
+test('vendorMetricKey: returns null for entry without vendor', () => {
+  assert.equal(vendorMetricKey({ metric_id: 'foo' }), null);
+  assert.equal(vendorMetricKey(null), null);
+  assert.equal(vendorMetricKey({}), null);
+});
+
+// ── findDuplicatesInPayload ───────────────────────────────────────────────────
+
+test('findDuplicatesInPayload: returns empty for null/non-object', () => {
+  assert.deepEqual(findDuplicatesInPayload(null), []);
+  assert.deepEqual(findDuplicatesInPayload('string'), []);
+  assert.deepEqual(findDuplicatesInPayload(42), []);
+});
+
+test('findDuplicatesInPayload: no duplicates — distinct vendors', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'attention_units', value: 4.2 },
+      { vendor: { domain: 'vendor-b.example' }, metric_id: 'attention_units', value: 3.1 },
+    ],
+  };
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: no duplicates — same vendor, different metric_id', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'attention_units', value: 4.2 },
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'gco2e_per_impression', value: 0.85 },
+    ],
+  };
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: no duplicates — same domain, different brand_id', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'house.example', brand_id: 'brand_a' }, metric_id: 'lift', value: 1.1 },
+      { vendor: { domain: 'house.example', brand_id: 'brand_b' }, metric_id: 'lift', value: 1.2 },
+    ],
+  };
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: detects duplicate vendor_metric_values', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'attention_units', value: 4.2 },
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'attention_units', value: 4.5 },
+    ],
+  };
+  const result = findDuplicatesInPayload(payload);
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('vendor_metric_values'));
+  assert.ok(result[0].includes('vendor-a.example||attention_units'));
+});
+
+test('findDuplicatesInPayload: detects duplicate vendor_metrics declarations', () => {
+  const payload = {
+    vendor_metrics: [
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'reach' },
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'reach' },
+    ],
+  };
+  const result = findDuplicatesInPayload(payload);
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('vendor_metrics'));
+});
+
+test('findDuplicatesInPayload: brand_id absent vs present are not duplicates', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'house.example' }, metric_id: 'lift', value: 1.1 },
+      { vendor: { domain: 'house.example', brand_id: 'tide' }, metric_id: 'lift', value: 1.2 },
+    ],
+  };
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: skips entries with no vendor field', () => {
+  const payload = {
+    vendor_metric_values: [
+      { metric_id: 'attention_units', value: 4.2 },
+      { metric_id: 'attention_units', value: 4.5 },
+    ],
+  };
+  // Both entries lack `vendor` — vendorMetricKey returns null — should not be flagged.
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: only one entry — no possible duplicate', () => {
+  const payload = {
+    vendor_metric_values: [
+      { vendor: { domain: 'vendor-a.example' }, metric_id: 'attention_units', value: 4.2 },
+    ],
+  };
+  assert.deepEqual(findDuplicatesInPayload(payload), []);
+});
+
+test('findDuplicatesInPayload: empty arrays produce no violations', () => {
+  assert.deepEqual(findDuplicatesInPayload({ vendor_metric_values: [] }), []);
+  assert.deepEqual(findDuplicatesInPayload({ vendor_metrics: [] }), []);
+});


### PR DESCRIPTION
Refs #3502

## Summary

Adds two complementary build-time lint checks for the `(vendor.domain, vendor.brand_id, metric_id)` semantic uniqueness key documented as MUST in `reporting-capabilities.json` (`vendor_metrics[]`) and `delivery-metrics.json` (`vendor_metric_values[]`). JSON Schema `uniqueItems` was deliberately omitted from both arrays because BrandRef carries optional fields whose absence/presence defeats deep-equal; this PR closes the enforcement gap at build time for the surfaces where violations could be authored: schema file `examples` arrays and storyboard fixture payloads.

**Changes:**

1. `scripts/build-schemas.cjs` — `lintVendorMetricSemanticUniqueness()`: recursively scans `examples` arrays in all schema JSON files for duplicate tuples. Wired into `main()` alongside the idempotency-key lint.
2. `scripts/lint-vendor-metric-uniqueness.cjs` (new): walks `static/compliance/source/` YAML storyboards, checks `sample_request` and `params` on each step for duplicates. Exports `{ lint, findDuplicatesInPayload, vendorMetricKey }` for testing.
3. `tests/lint-vendor-metric-uniqueness.test.cjs` (new): 14 unit tests covering key normalization, duplicate detection, and edge cases. All pass.
4. `scripts/build-compliance.cjs` — wires the new storyboard lint after the pagination invariant block.

**Key normalization:** `domain|brand_id|metric_id` where absent `brand_id` → `""` (empty string). This treats `{domain:"x"}` (single-brand) as structurally distinct from `{domain:"x",brand_id:"sub"}` (subsidiary) — preserving house-of-brands semantics while still catching accidental duplicates where `brand_id` is dropped on one copy. The `|` separator is safe: all three components have regex patterns that exclude `|`.

**Deferred:** Issue #3502 item 2 (storyboard `field_unique_by_keys` check kind) requires an adcp-client runner implementation — out of scope for this repo. Issue #3501 (vendor-metric storyboard fixture) is the companion tracker.

**Nit (not fixed):** `collectVendorMetricExamples` recurses via `Object.values` after processing each object, which re-visits array elements of `vendor_metric_values`/`vendor_metrics`. For current schemas this is harmless (individual metric entries carry no nested `vendor_metric_values` property), but a visited-set guard would harden this for unusual future schemas. Tracked as a follow-up.

## Non-breaking justification

Adds new build-time validation scripts only. No protocol schemas, task definitions, or exported types are changed. Build failures only occur if an author introduces a violation in new schema examples or storyboard fixtures — zero violations exist today.

## Pre-PR review

- **ad-tech-protocol-expert:** approved — absent-brand_id → empty-string normalization is correct per house-of-brands semantics (consistent with `brand-ref.json` docs); `|` separator provably safe given all three component patterns; scan surface (schema examples + storyboard fixtures) is appropriate; recursion nit noted above is non-blocking
- **code-reviewer:** approved — implementation follows established lint patterns (idempotency-key lint in build-schemas.cjs, pagination-invariant lint pattern); js-yaml lazy-loaded correctly to allow unit tests without package install; 14/14 unit tests pass; no blocker findings

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01KmzEE12JNqdc8goGxfTSn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmzEE12JNqdc8goGxfTSn4)_