### PR TITLE
feat(registry): ?verification_mode and ?verified filters for GET /api/registry/agents

### DIFF
--- a/.changeset/add-verified-mode-registry-filter.md
+++ b/.changeset/add-verified-mode-registry-filter.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `?verification_mode` and `?verified` query parameters to `GET /api/registry/agents`. Wires up the filter capability the docs at `aao-verified.mdx#registry-filter` already advertise. Supports AND semantics (repeat param for multiple axes) and reuses the prefetched badge map when `?compliance=true` is also set. Closes #3505.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -80,6 +80,7 @@ import { PropertyCheckService } from "../services/property-check.js";
 import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
+import { VERIFICATION_MODES, isVerificationMode } from "../services/adcp-taxonomy.js";
 import { AgentSnapshotDatabase } from "../db/agent-snapshot-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk } from "../services/sdk-auth-adapter.js";
@@ -554,6 +555,14 @@ registry.registerPath({
       capabilities: z.enum(["true"]).optional(),
       properties: z.enum(["true"]).optional(),
       compliance: z.enum(["true"]).optional(),
+      verification_mode: z.array(z.enum(["spec", "live"])).optional().openapi({
+        description:
+          "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: " +
+          "?verification_mode=spec&verification_mode=live returns only agents verified on both axes.",
+      }),
+      verified: z.enum(["true"]).optional().openapi({
+        description: "When true, filter to agents that hold any active verification badge.",
+      }),
     }),
   },
   responses: {
@@ -566,6 +575,14 @@ registry.registerPath({
             count: z.number().int(),
             sources: z.object({ registered: z.number().int(), discovered: z.number().int() }),
           }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid query parameter",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.string(), valid_values: z.array(z.string()).optional() }),
         },
       },
     },
@@ -3558,6 +3575,22 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const withProperties = req.query.properties === "true";
       const withCompliance = req.query.compliance === "true";
 
+      const rawVerificationMode = req.query.verification_mode;
+      const verificationModes: string[] | undefined = rawVerificationMode
+        ? (Array.isArray(rawVerificationMode) ? (rawVerificationMode as string[]) : [rawVerificationMode as string])
+        : undefined;
+      const withVerified = req.query.verified === "true";
+
+      if (verificationModes?.length) {
+        const invalid = verificationModes.filter((m) => !isVerificationMode(m));
+        if (invalid.length > 0) {
+          return res.status(400).json({
+            error: `Invalid verification_mode value(s): ${invalid.join(", ")}`,
+            valid_values: [...VERIFICATION_MODES],
+          });
+        }
+      }
+
       // members_only agents are discoverable to authenticated API-access
       // members (Professional+). Crawlers and anonymous callers only see
       // public agents.
@@ -3572,7 +3605,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       const federatedAgents = await federatedIndex.listAllAgents(type, { includeMembersOnly });
 
-      const agents = federatedAgents.map((fa) => ({
+      let agents = federatedAgents.map((fa) => ({
         name: fa.name || fa.url,
         url: fa.url,
         type: isValidAgentType(fa.type) ? fa.type : ("unknown" as const),
@@ -3590,9 +3623,32 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         discovered_from: fa.discovered_from,
       }));
 
+      // Apply verification filter before enrichment so bySource and downstream
+      // enrichment only see the filtered set.
+      let prefetchedBadgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>> | null = null;
+      if (verificationModes?.length || withVerified) {
+        let verificationBadgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>>;
+        try {
+          verificationBadgeMap = await complianceDb.bulkGetActiveBadges(agents.map((a) => a.url));
+        } catch (err) {
+          logger.error({ err }, "Verification mode filter failed");
+          return res.status(503).json({ error: "Verification filter temporarily unavailable" });
+        }
+        agents = agents.filter((a) => {
+          const badges = verificationBadgeMap.get(a.url) || [];
+          // Both params additive (AND): badge must satisfy mode constraints AND have any mode.
+          return badges.some((b) => {
+            const modesOk = !verificationModes?.length || verificationModes.every((m) => b.verification_modes.includes(m));
+            const verifiedOk = !withVerified || b.verification_modes.length > 0;
+            return modesOk && verifiedOk;
+          });
+        });
+        prefetchedBadgeMap = verificationBadgeMap;
+      }
+
       const bySource = {
-        registered: federatedAgents.filter((a) => a.source === "registered").length,
-        discovered: federatedAgents.filter((a) => a.source === "discovered").length,
+        registered: agents.filter((a) => a.source === "registered").length,
+        discovered: agents.filter((a) => a.source === "discovered").length,
       };
 
       if (!withHealth && !withCapabilities && !withProperties && !withCompliance) {
@@ -3614,7 +3670,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       let badgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>> | null = null;
       if (withCompliance) {
         try {
-          badgeMap = await complianceDb.bulkGetActiveBadges(agentUrls);
+          // Reuse the badge map already fetched for verification filtering when available,
+          // since it covers the same filtered agent set.
+          badgeMap = prefetchedBadgeMap ?? await complianceDb.bulkGetActiveBadges(agentUrls);
         } catch (err) {
           logger.warn({ err }, "Badge bulk query failed (table may not exist yet)");
         }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -91,6 +91,7 @@ import { PropertyCheckService } from "../services/property-check.js";
 import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
+import { VERIFICATION_MODES, isVerificationMode } from "../services/adcp-taxonomy.js";
 import { AgentSnapshotDatabase } from "../db/agent-snapshot-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk, type SdkAuth } from "../services/sdk-auth-adapter.js";
@@ -634,6 +635,14 @@ registry.registerPath({
         description: "Measurement-vendor filter: case-insensitive substring match against `measurement.metrics[].metric_id`. v1 scope: metric_id only (description/standard search is a follow-up). Max 64 chars; SQL wildcard characters are escaped. Implies `type=measurement`.",
         example: "attention",
       }),
+      verification_mode: z.array(z.enum(["spec", "live"])).optional().openapi({
+        description:
+          "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: " +
+          "?verification_mode=spec&verification_mode=live returns only agents verified on both axes.",
+      }),
+      verified: z.enum(["true"]).optional().openapi({
+        description: "When true, filter to agents that hold any active verification badge.",
+      }),
     }),
   },
   responses: {
@@ -648,7 +657,14 @@ registry.registerPath({
         },
       },
     },
-    400: { description: "Invalid query parameter", content: { "application/json": { schema: ErrorSchema } } },
+    400: {
+      description: "Invalid query parameter",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.string(), valid_values: z.array(z.string()).optional() }),
+        },
+      },
+    },
   },
 });
 
@@ -4013,6 +4029,24 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
       }
 
+      // Verification-mode filters (#3505). Repeatable param normalized to
+      // string[]; `verified=true` is the any-axis shortcut.
+      const rawVerificationMode = req.query.verification_mode;
+      const verificationModes: string[] | undefined = rawVerificationMode
+        ? (Array.isArray(rawVerificationMode) ? (rawVerificationMode as string[]) : [rawVerificationMode as string])
+        : undefined;
+      const withVerified = req.query.verified === "true";
+
+      if (verificationModes?.length) {
+        const invalid = verificationModes.filter((m) => !isVerificationMode(m));
+        if (invalid.length > 0) {
+          return res.status(400).json({
+            error: `Invalid verification_mode value(s): ${invalid.join(", ")}`,
+            valid_values: [...VERIFICATION_MODES],
+          });
+        }
+      }
+
       // members_only agents are discoverable to authenticated API-access
       // members (Professional+). Crawlers and anonymous callers only see
       // public agents.
@@ -4039,7 +4073,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         federatedAgents = federatedAgents.filter((fa) => matchingUrls.has(fa.url));
       }
 
-      const agents = federatedAgents.map((fa) => ({
+      let agents = federatedAgents.map((fa) => ({
         name: fa.name || fa.url,
         url: fa.url,
         type: isValidAgentType(fa.type) ? fa.type : ("unknown" as const),
@@ -4053,6 +4087,30 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         },
         member: fa.member,
       }));
+
+      // Apply verification filter before enrichment so downstream enrichment
+      // only sees the filtered set.
+      let prefetchedBadgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>> | null = null;
+      if (verificationModes?.length || withVerified) {
+        let verificationBadgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>>;
+        try {
+          verificationBadgeMap = await complianceDb.bulkGetActiveBadges(agents.map((a) => a.url));
+        } catch (err) {
+          logger.error({ err }, "Verification mode filter failed");
+          return res.status(503).json({ error: "Verification filter temporarily unavailable" });
+        }
+        agents = agents.filter((a) => {
+          const badges = verificationBadgeMap.get(a.url) || [];
+          // Both params additive (AND): badge must satisfy mode constraints AND have any mode.
+          return badges.some((b) => {
+            const modesOk = !verificationModes?.length || verificationModes.every((m) => b.verification_modes.includes(m));
+            const verifiedOk = !withVerified || b.verification_modes.length > 0;
+            return modesOk && verifiedOk;
+          });
+        });
+        prefetchedBadgeMap = verificationBadgeMap;
+      }
+
 
       if (!withHealth && !withCapabilities && !withProperties && !withCompliance) {
         return res.json({ agents, count: agents.length });
@@ -4073,7 +4131,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       let badgeMap: Map<string, Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>>> | null = null;
       if (withCompliance) {
         try {
-          badgeMap = await complianceDb.bulkGetActiveBadges(agentUrls);
+          // Reuse the badge map already fetched for verification filtering when available,
+          // since it covers the same filtered agent set.
+          badgeMap = prefetchedBadgeMap ?? await complianceDb.bulkGetActiveBadges(agentUrls);
         } catch (err) {
           logger.warn({ err }, "Badge bulk query failed (table may not exist yet)");
         }


### PR DESCRIPTION
Closes #3505

`docs/building/aao-verified.mdx#registry-filter` has advertised verification-mode filtering on the federated agent listing since PR #2153, but `GET /api/registry/agents` never wired up the parameter. This PR closes that gap.

## What changed

Two new optional query parameters on `GET /api/registry/agents`:

| Param | Accepted values | Behavior |
|---|---|---|
| `?verification_mode` | `spec`, `live` (repeat for AND) | Filter to agents whose active badge covers all listed axes |
| `?verified` | `true` | Filter to agents with any active verification badge |

Both params are additive: `?verified=true&verification_mode=live` requires a badge covering `live` (the `withVerified` check is then a strict subset of the `verificationModes` check, so no redundancy).

**Filter semantics** — AND across repeated params, via a single-badge predicate:
```
badges.some(b =>
  modesOk  // badge.verification_modes ⊇ requested_modes
  && verifiedOk  // badge.verification_modes non-empty (if ?verified=true)
)
```

**Validation** — unknown `verification_mode` values get a 400 with `valid_values: ["spec","live"]`.

**Error handling** — DB failure returns 503 (not silently unfiltered, which would leak unverified agents to callers who asked for verified-only).

**Badge map reuse** — when `?compliance=true` is also set, the badge map fetched for the filter is reused in the enrichment step (saves one round-trip).

**`bySource` counts** now reflect the filtered agent set (previously always reflected the full unfiltered listing).

## Non-breaking justification

Both params are optional. Callers that omit them hit the unchanged `listAllAgents` + early-return path (`if (!withHealth && !withCapabilities...)`) with no behavioral change.

## Pre-PR review

- **code-reviewer**: approved after fixes — three blockers resolved: (1) combined `withVerified`+`verificationModes` predicate, (2) `z.enum(["true"])` consistent with sibling params, (3) 503 on badge-fetch failure
- **adtech-product-expert**: approved — AND semantics correct for current single-badge data model; naming `?verified` + `?verification_mode` natural for buyers

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01K5MAwn6xWdaQLNP4hf1sCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5MAwn6xWdaQLNP4hf1sCy)_