### PR TITLE
fix(announcement-drafter): stop using membership tier as a label in welcome copy

### DIFF
--- a/.changeset/announcement-drafter-no-tier-label.md
+++ b/.changeset/announcement-drafter-no-tier-label.md
@@ -1,0 +1,9 @@
+---
+---
+
+Stop the announcement drafter from referring to the membership tier as a label
+in Slack and LinkedIn copy ("as a Company member", "ICL member", etc.). The
+tier is internal context for shaping tone; the public copy should just call
+the member "the newest member of AgenticAdvertising.org". Per Mary Mason
+feedback after the Mogl welcome post — "Company member" reads like a tier
+name and confuses the membership model.

--- a/server/src/services/announcement-drafter.ts
+++ b/server/src/services/announcement-drafter.ts
@@ -76,6 +76,14 @@ Rules:
 - If the tagline is generic, lean on the offerings and agents for
   specificity. If those are thin too, stay short rather than padding.
 - Do not use the member's voice ("we're ...") — write as AAO.
+- Do not refer to the member's tier as a label or noun phrase
+  ("as a Company member", "Company-tier member", "ICL member",
+  "Individual Professional member"). Tier is internal context only;
+  it does not appear in the output. Call them a member of
+  AgenticAdvertising.org. Vary your opener; example shapes:
+  "Welcome <Name>, the newest member of AgenticAdvertising.org",
+  "<Name> just joined AgenticAdvertising.org",
+  "AgenticAdvertising.org has a new member: <Name>".
 - Never include @channel, @here, @everyone, or Slack channel mentions.
 - Never include URLs other than the profile URL provided below.
 - Slack copy: Slack mrkdwn only. Use <url|label> for links.


### PR DESCRIPTION
## Summary

- Mary Mason flagged that the LinkedIn welcome for Mogl said "as a Company member" — "Company" is the internal seat tier (Company / ICL / Individual Professional / Individual Academic), not a public membership type. AAO has one membership; tier shouldn't appear as a noun phrase in welcome copy.
- Adds a system-prompt rule in `announcement-drafter.ts` telling the model not to render the tier as a label, with three structurally different opener shapes to keep output varied.
- Tier still flows in as trusted context for tone — it just never appears in the output.

## Test plan

- [x] `vitest run tests/announcement/announcement-drafter.test.ts` — 19/19 pass
- [x] precommit hooks (test:unit, typecheck, dynamic-imports) clean
- [ ] Spot-check the next live welcome card in `#admin-editorial-review` doesn't say "Company member" / "ICL member"
- [ ] If anything reads stiff, vary the opener examples — they're explicitly framed as illustrative shapes, not a template

🤖 Generated with [Claude Code](https://claude.com/claude-code)