### PR TITLE
ops(slack-errors): include structured context in #aao-errors notifications

### DIFF
--- a/.changeset/slack-error-include-structured-context.md
+++ b/.changeset/slack-error-include-structured-context.md
@@ -1,0 +1,8 @@
+---
+---
+
+ops(slack-errors): include structured-log context in #aao-errors notifications
+
+Error-channel Slack posts now render the structured fields from `logger.error({ ... }, msg)` calls (e.g. HTTP `status`, `domain`, `agentUrl`, `task`) under the message, with `module`/`processRole`/secrets stripped. Previously only the message string and stack trace made it to Slack — operators had to dig into PostHog to see the actual status code or resource path that triggered the alert.
+
+Also gives `server/src/addie/mcp/adcp-tools.ts` a module-scoped logger so its errors surface as `System error: adcp-tools` instead of `unknown`.

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -13,7 +13,9 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { logger } from '../../logger.js';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('adcp-tools');
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
 import { AgentContextDatabase } from '../../db/agent-context-db.js';

--- a/server/src/utils/posthog.ts
+++ b/server/src/utils/posthog.ts
@@ -201,7 +201,7 @@ export function initPostHogErrorTracking(): boolean {
     // All error+ logs get posted to the #aao-errors channel via notifySystemError.
     // The error-notifier has its own 5-minute per-source throttle.
     if (level && level >= 50) {
-      notifyErrorChannel(module, message, error);
+      notifyErrorChannel(module, message, error, context);
     }
   });
 
@@ -230,7 +230,7 @@ function sanitizeForSlack(msg: string): string {
  */
 let notifyingErrorChannel = false;
 
-function notifyErrorChannel(module: string, message: string, error?: Error): void {
+function notifyErrorChannel(module: string, message: string, error?: Error, context?: Record<string, unknown>): void {
   if (notifyingErrorChannel) return;
   notifyingErrorChannel = true;
 
@@ -239,14 +239,50 @@ function notifyErrorChannel(module: string, message: string, error?: Error): voi
       const errorDetail = error?.message && error.message !== message
         ? sanitizeForSlack(`${message}: ${error.message}`)
         : sanitizeForSlack(message);
+      const fields = formatContextForSlack(context);
       const stack = error?.stack ? `\n\`\`\`${sanitizeForSlack(error.stack.slice(0, 500))}\`\`\`` : '';
       notifySystemError({
         source: module || 'unknown',
-        errorMessage: errorDetail + stack,
+        errorMessage: errorDetail + fields + stack,
       });
     })
     .catch(() => {})
     .finally(() => { notifyingErrorChannel = false; });
+}
+
+const SLACK_CONTEXT_DROP_KEYS = new Set(['module', 'processRole', 'pid', 'hostname', 'time', 'level', 'msg']);
+const SLACK_CONTEXT_SENSITIVE = /password|token|secret|apikey|api_key|authorization|credential|cookie|session/i;
+
+/**
+ * Render structured-log context fields under the error message so Slack
+ * readers see what the PostHog event captures (status codes, domains, IDs,
+ * resource paths). Drops noisy keys, redacts likely secrets, truncates.
+ */
+function formatContextForSlack(context?: Record<string, unknown>): string {
+  if (!context) return '';
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(context)) {
+    if (SLACK_CONTEXT_DROP_KEYS.has(key)) continue;
+    if (value === undefined || value === null) continue;
+    if (SLACK_CONTEXT_SENSITIVE.test(key)) {
+      lines.push(`• \`${key}\`: [redacted]`);
+      continue;
+    }
+    let rendered: string;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      rendered = String(value);
+    } else {
+      try {
+        rendered = JSON.stringify(value);
+      } catch {
+        rendered = '[unserializable]';
+      }
+    }
+    if (rendered.length > 200) rendered = rendered.slice(0, 197) + '...';
+    lines.push(`• \`${key}\`: ${sanitizeForSlack(rendered)}`);
+  }
+  if (lines.length === 0) return '';
+  return '\n' + lines.join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Error-channel Slack posts now render the structured fields from `logger.error({ ... }, msg)` (HTTP `status`, `domain`, `agentUrl`, `task`, resource paths, etc.) under the message text. `module`/`processRole`/`pid`/`hostname`/`time`/`level`/`msg` are dropped; keys matching `password|token|secret|apikey|authorization|credential|cookie|session` are redacted; values are truncated to 200 chars.
- `server/src/addie/mcp/adcp-tools.ts` switches from the bare logger to `createLogger('adcp-tools')` so its errors show up as `System error: adcp-tools` instead of falling through to the `unknown` source.

## Why

This morning's `:rotating_light: System error: brandfetch [web]` and `:rotating_light: System error: unknown [web]` alerts each dropped the most useful field — the HTTP status for Brandfetch, and the GCP KMS error chain (project/resource path/permission) — because the bridge in `utils/posthog.ts` only forwarded `message + error.message + stack` to Slack. The structured context was captured to PostHog but never made it to operators reading the channel.

The KMS alert also showed up as `unknown` because `adcp-tools.ts` was using the root logger instead of a module-scoped child.

## Test plan

- [x] `npx tsc --noEmit` clean in `server/`
- [ ] Trigger a `logger.error({ status: 502, domain: 'foo.com' }, 'Brandfetch API error')` in dev and confirm bullets render in the configured error Slack channel
- [ ] Confirm sensitive keys are redacted (e.g. `logger.error({ token: 'sk-...' }, 'msg')` → `\`token\`: [redacted]`)
- [ ] Confirm `adcp-tools.ts` errors land as `System error: adcp-tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)