### PR TITLE
fix(registry): gate brand.json serving on source_type to prevent enriched data misrepresentation

### DIFF
--- a/.changeset/fix-brand-json-source-type-gate.md
+++ b/.changeset/fix-brand-json-source-type-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(registry): gate /brands/:domain/brand.json on source_type to prevent serving non-spec-compliant enriched data as brand-attested brand.json (closes #3528)

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1035,11 +1035,34 @@ export class HTTPServer {
         const brand = await this.brandDb.getDiscoveredBrandByDomain(domain);
         if (!brand || brand.is_public === false) return res.status(404).json({ error: 'Brand not found' });
 
-        const manifest = (brand.brand_manifest as Record<string, unknown>) || {};
-        const brandJson: Record<string, unknown> = {
-          name: brand.brand_name || domain,
-          ...manifest,
-        };
+        // Only serve brand_json and community source types. Enriched (Brandfetch) entries are
+        // not brand-attested — serving them under this URL would misrepresent third-party data
+        // as brand-authoritative. Community entries are served only when structurally valid.
+        if (brand.source_type !== 'brand_json' && brand.source_type !== 'community') {
+          return res.status(404).json({ error: 'Brand not found' });
+        }
+
+        const manifest = brand.brand_manifest as Record<string, unknown> | undefined;
+        if (!manifest) return res.status(404).json({ error: 'Brand not found' });
+
+        if (brand.source_type === 'community') {
+          // Community entries must be approved and have a recognizable brand.json root shape.
+          if (brand.review_status === 'pending') return res.status(404).json({ error: 'Brand not found' });
+          const hasValidShape =
+            (typeof manifest.house === 'object' && Array.isArray(manifest.brands)) ||
+            typeof manifest.house === 'string' ||
+            Array.isArray(manifest.agents) ||
+            Boolean(manifest.brand_agent) ||
+            typeof manifest.authoritative_location === 'string';
+          if (!hasValidShape) return res.status(404).json({ error: 'Brand not found' });
+        }
+
+        const schemaUrl = 'https://adcontextprotocol.org/schemas/v3/brand.json';
+        const brandJson: Record<string, unknown> =
+          typeof manifest.$schema === 'string' && manifest.$schema.startsWith('https://')
+            ? { ...manifest }
+            : { $schema: schemaUrl, ...manifest };
+
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Cache-Control', 'public, max-age=300');
         return res.json(brandJson);


### PR DESCRIPTION
Closes #3528

The `/brands/:domain/brand.json` endpoint was serving Brandfetch-enriched entries as if they were brand-attested brand.json files. The response spread raw Brandfetch data (`name`, `url`, `company`, `description`, `classification`) at the root level of the response, injected a non-spec `name` field, and omitted `$schema` — producing 40+ validation errors against the brand.json schema, which has `additionalProperties: false` on all four variants.

**Changes:**
- Gate on `source_type`: only `brand_json` and `community` source types are served; `enriched` (Brandfetch) and any other non-attested type returns 404. Serving third-party commercial data under a brand-attested URL path is both a protocol correctness failure and a trust/consent violation.
- Community entries additionally require `review_status !== 'pending'` and a two-field structural shape check (presence of `house+brands`, `house` string, `agents`, `brand_agent`, or `authoritative_location`) before being served.
- Inject `$schema: https://adcontextprotocol.org/schemas/v3/brand.json` when the stored manifest lacks a well-formed HTTPS `$schema` value. Uses the `/schemas/v3/` alias (released stable schema) per playbook schema URL conventions.
- Remove the erroneous root-level `name` injection — `name` is not a top-level field in any brand.json variant; its presence caused `additionalProperties: false` failures on every served document.

**Non-breaking justification:** Consumers currently receiving invalid enriched data will now receive 404. A 404 is strictly less harmful than invalid JSON that silently fails schema validation. The A2UI theming feature (`brand-viewer.html`) already has a graceful 404 fallback path and is unaffected. No schema changes.

**Pre-PR review:**
- code-reviewer: approved — raised two blockers (community `review_status` gate, `$schema` URL alias) and one nit (`$schema` pass-through validation), all addressed in the final diff
- ad-tech-protocol-expert: approved — confirmed `additionalProperties: false` on all four oneOf variants makes the root `name` injection a spec violation; confirmed 404 for enriched is protocol-correct; confirmed `/schemas/v3/` is the correct alias for this released schema

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01PR6QXBoh1GW1qqrnz6jEkY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR6QXBoh1GW1qqrnz6jEkY)_