### PR TITLE
feat(verification-panel): per-specialism marks + concrete heartbeat ETA

### DIFF
--- a/.changeset/verification-panel-stage1-marks-and-eta.md
+++ b/.changeset/verification-panel-stage1-marks-and-eta.md
@@ -1,0 +1,10 @@
+---
+---
+
+dashboard(verification-panel): mark each declared specialism with pass/fail/untested status and replace abstract "next heartbeat" copy with the concrete check-cycle window. The per-agent compliance card no longer requires the developer to cross-reference the storyboard track pills above to know which declared specialism is the cause of an overall `failing` status.
+
+Per-specialism marks: ✓ (passing), ✕ with strike-through (failing), · (untested or not in catalog). Computed server-side via `computeSpecialismStatus()` so the storyboard-id mapping has one source of truth. `unknown` is returned for specialisms the catalog doesn't recognize (e.g. preview specialisms or future additions an older server hasn't learned yet).
+
+ETA: "on the next heartbeat" → "within the next check cycle (12h)" — pulled from `agent_registry_metadata.check_interval_hours` (default 12), now flowed to the compliance detail response.
+
+Implements stage 1 of #3525. Tier-inline (stage 2) ships separately because it touches auth/billing surfaces.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -327,6 +327,7 @@
       gap: 3px;
       margin-right: 6px;
       vertical-align: middle;
+      white-space: nowrap;
     }
     .verification-spec-chip code {
       margin-right: 0;
@@ -1523,11 +1524,11 @@
 
       const declaredSpecialisms = Array.isArray(cs?.declared_specialisms) ? cs.declared_specialisms : [];
       const specialismStatus = (cs && typeof cs.specialism_status === 'object' && cs.specialism_status) ? cs.specialism_status : {};
-      const checkIntervalHours = Number.isFinite(cs?.check_interval_hours) ? cs.check_interval_hours : 12;
+      const checkIntervalHours = Number.isFinite(cs?.check_interval_hours) && cs.check_interval_hours > 0 ? cs.check_interval_hours : 12;
 
       // "On the next heartbeat" is jargon; surface the actual interval so
       // the developer knows what window they're waiting for.
-      const nextCheckCopy = `within the next check cycle (${checkIntervalHours}h)`;
+      const nextCheckCopy = `within ${checkIntervalHours} hours`;
 
       // No badges yet — show diagnostic hint scoped to the actual situation.
       // The branch order here mirrors pickVerificationHint() in
@@ -1560,7 +1561,7 @@
             : '<span class="verification-spec-mark" aria-hidden="true">·</span>';
           const title = st === 'passing' ? 'Storyboard passing'
             : st === 'failing' ? 'Storyboard failing'
-            : st === 'unknown' ? 'Not in storyboard catalog'
+            : st === 'unknown' ? 'Specialism not recognized — check spelling or update agent capabilities'
             : 'Not yet tested';
           return `<span class="${className}" title="${escapeHtml(title)}">${symbol}<code>${escapeHtml(s)}</code></span>`;
         };

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -320,7 +320,45 @@
       background: var(--color-gray-100, #f3f4f6);
       padding: 1px 6px;
       border-radius: 3px;
-      margin-right: 4px;
+    }
+    .verification-spec-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+    .verification-spec-chip code {
+      margin-right: 0;
+    }
+    .verification-spec-mark {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      font-size: 10px;
+      font-weight: var(--font-semibold);
+      line-height: 1;
+    }
+    .verification-spec-passing .verification-spec-mark {
+      background: var(--color-success-100, #d1fae5);
+      color: var(--color-success-700, #047857);
+    }
+    .verification-spec-failing .verification-spec-mark {
+      background: var(--color-error-100, #fee2e2);
+      color: var(--color-error-700, #b91c1c);
+    }
+    .verification-spec-failing code {
+      text-decoration: line-through;
+      text-decoration-color: var(--color-error-500, #ef4444);
+      text-decoration-thickness: 1px;
+    }
+    .verification-spec-untested .verification-spec-mark,
+    .verification-spec-unknown .verification-spec-mark {
+      background: var(--color-gray-200, #e5e7eb);
+      color: var(--color-text-muted);
     }
     .history-run {
       display: flex;
@@ -1484,6 +1522,12 @@
       };
 
       const declaredSpecialisms = Array.isArray(cs?.declared_specialisms) ? cs.declared_specialisms : [];
+      const specialismStatus = (cs && typeof cs.specialism_status === 'object' && cs.specialism_status) ? cs.specialism_status : {};
+      const checkIntervalHours = Number.isFinite(cs?.check_interval_hours) ? cs.check_interval_hours : 12;
+
+      // "On the next heartbeat" is jargon; surface the actual interval so
+      // the developer knows what window they're waiting for.
+      const nextCheckCopy = `within the next check cycle (${checkIntervalHours}h)`;
 
       // No badges yet — show diagnostic hint scoped to the actual situation.
       // The branch order here mirrors pickVerificationHint() in
@@ -1493,23 +1537,36 @@
         const status = cs?.status;
         let hint;
         if (!hasAuth) {
-          hint = 'Authorize your agent (above) so AAO can run compliance checks. Once storyboards pass and your AAO membership is on an API-access tier, you\'ll earn AAO Verified (Spec) automatically.';
+          hint = `Authorize your agent (above) so AAO can run compliance checks. Once storyboards pass and your AAO membership is on an API-access tier, you'll earn AAO Verified (Spec) automatically.`;
         } else if (status === 'opted_out') {
           hint = 'Compliance monitoring is opted out for this agent — no badges will issue. Re-enable monitoring to be eligible.';
         } else if (status === 'passing' && declaredSpecialisms.length === 0) {
           hint = 'Storyboards are passing, but your agent isn\'t declaring any specialisms in <code>get_adcp_capabilities</code> — without that declaration, AAO doesn\'t know which badges to issue. <a href="/docs/building/aao-verified#declare-specialisms" target="_blank" rel="noopener">How to declare specialisms</a>.';
         } else if (status === 'passing') {
-          hint = 'Storyboards are passing — your badge should issue on the next heartbeat. If it doesn\'t, check that your AAO membership is on an API-access tier.';
+          hint = `Storyboards are passing — your badge should issue ${nextCheckCopy}. If it doesn't, check that your AAO membership is on an API-access tier.`;
         } else if (status === 'failing' || status === 'degraded') {
           hint = declaredSpecialisms.length === 0
             ? 'Storyboards are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.'
             : 'Some declared specialisms are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
         } else {
-          hint = 'Compliance check will run on the next heartbeat. Earn AAO Verified (Spec) by declaring specialisms in <code>get_adcp_capabilities</code> and passing their storyboards. <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
+          hint = `Compliance check will run ${nextCheckCopy}. Earn AAO Verified (Spec) by declaring specialisms in <code>get_adcp_capabilities</code> and passing their storyboards. <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.`;
         }
+
+        const renderSpecialismChip = (s) => {
+          const st = specialismStatus[s] || 'untested';
+          const className = `verification-spec-chip verification-spec-${st}`;
+          const symbol = st === 'passing' ? '<span class="verification-spec-mark" aria-hidden="true">✓</span>'
+            : st === 'failing' ? '<span class="verification-spec-mark" aria-hidden="true">✕</span>'
+            : '<span class="verification-spec-mark" aria-hidden="true">·</span>';
+          const title = st === 'passing' ? 'Storyboard passing'
+            : st === 'failing' ? 'Storyboard failing'
+            : st === 'unknown' ? 'Not in storyboard catalog'
+            : 'Not yet tested';
+          return `<span class="${className}" title="${escapeHtml(title)}">${symbol}<code>${escapeHtml(s)}</code></span>`;
+        };
         const declaredHtml = declaredSpecialisms.length
           ? '<div class="verification-declared-row"><span class="verification-declared-label">Declared specialisms:</span> ' +
-            declaredSpecialisms.slice().sort().map(s => '<code>' + escapeHtml(s) + '</code>').join(' ') +
+            declaredSpecialisms.slice().sort().map(renderSpecialismChip).join(' ') +
             '</div>'
           : '';
         return `

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -358,6 +358,51 @@ export interface VerificationResult {
   }>;
 }
 
+export type SpecialismStatus = 'passing' | 'failing' | 'untested' | 'unknown';
+
+/**
+ * Map declared specialisms to per-specialism pass/fail/untested status by
+ * looking up each specialism's storyboard in the latest run's storyboard
+ * statuses. Used by the dashboard to mark which declared specialisms are
+ * the cause of a `failing` overall status without forcing the user to
+ * cross-reference the storyboard track pills.
+ *
+ * `unknown` is returned for specialisms not in `SPECIALISM_CATALOG` (e.g.
+ * preview-status specialisms that the agent declared but the catalog
+ * doesn't recognize as stable).
+ */
+export function computeSpecialismStatus(
+  declaredSpecialisms: string[],
+  storyboardStatuses: StoryboardStatusEntry[],
+): Record<string, SpecialismStatus> {
+  const statusMap = new Map<string, StoryboardStatusEntry>();
+  for (const entry of storyboardStatuses) {
+    statusMap.set(entry.storyboard_id, entry);
+  }
+
+  const result: Record<string, SpecialismStatus> = {};
+  for (const specialism of declaredSpecialisms) {
+    const info = SPECIALISM_CATALOG[specialism];
+    if (!info) {
+      result[specialism] = 'unknown';
+      continue;
+    }
+    const sbStatus = statusMap.get(info.storyboard_id);
+    if (!sbStatus) {
+      result[specialism] = 'untested';
+      continue;
+    }
+    if (sbStatus.status === 'passing') {
+      result[specialism] = 'passing';
+    } else if (sbStatus.status === 'failing' || sbStatus.status === 'partial') {
+      result[specialism] = 'failing';
+    } else {
+      result[specialism] = 'untested';
+    }
+  }
+  return result;
+}
+
 /**
  * Determine which badge roles an agent qualifies for based on its
  * declared specialisms and their pass/fail status.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -25,6 +25,7 @@ import {
   complianceResultToDbInput,
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
+  computeSpecialismStatus,
 } from "../addie/services/compliance-testing.js";
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
@@ -3800,6 +3801,28 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         logger.warn({ err, agentUrl }, "Latest declared specialisms query failed");
       }
 
+      // Per-specialism status — the dashboard renders pass/fail/untested
+      // dots so the developer can see which declared specialism is the
+      // cause of an overall `failing` status without cross-referencing
+      // the storyboard track pills.
+      let specialismStatus: Record<string, string> = {};
+      if (declaredSpecialisms.length > 0) {
+        try {
+          const sbStatuses = await complianceDb.getStoryboardStatuses(agentUrl);
+          specialismStatus = computeSpecialismStatus(
+            declaredSpecialisms,
+            sbStatuses.map(s => ({
+              storyboard_id: s.storyboard_id,
+              status: s.status as 'passing' | 'failing' | 'partial' | 'untested',
+              steps_passed: s.steps_passed,
+              steps_total: s.steps_total,
+            })),
+          );
+        } catch (err) {
+          logger.warn({ err, agentUrl }, "Per-specialism status query failed");
+        }
+      }
+
       const encodedUrl = encodeURIComponent(agentUrl);
 
       res.json({
@@ -3816,7 +3839,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         status_changed_at: status.status_changed_at?.toISOString() || null,
         storyboards_passing: sbCounts.passing,
         storyboards_total: sbCounts.total,
+        check_interval_hours: metadata?.check_interval_hours ?? 12,
         declared_specialisms: declaredSpecialisms,
+        specialism_status: specialismStatus,
         verified: badges.length > 0,
         verified_badges: badges.map(b => ({
           role: b.role,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3813,6 +3813,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
             declaredSpecialisms,
             sbStatuses.map(s => ({
               storyboard_id: s.storyboard_id,
+              // Cast is bounded by the `valid_storyboard_status` CHECK
+              // constraint in agent_storyboard_status (migration 390).
               status: s.status as 'passing' | 'failing' | 'partial' | 'untested',
               steps_passed: s.steps_passed,
               steps_total: s.steps_total,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -296,7 +296,9 @@ export const AgentComplianceDetailSchema = z
     status_changed_at: z.string().nullable().optional(),
     storyboards_passing: z.number().int().optional(),
     storyboards_total: z.number().int().optional(),
+    check_interval_hours: z.number().int().optional().openapi({ description: "How often the heartbeat re-tests this agent, in hours" }),
     declared_specialisms: z.array(z.string()).optional().openapi({ description: "Specialisms the agent declared in get_adcp_capabilities, from the latest run" }),
+    specialism_status: z.record(z.string(), z.enum(['passing', 'failing', 'untested', 'unknown'])).optional().openapi({ description: "Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status" }),
     verified: z.boolean().optional(),
     verified_badges: z.array(VerificationBadgeSchema).optional(),
   })

--- a/server/tests/unit/specialism-status.test.ts
+++ b/server/tests/unit/specialism-status.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { computeSpecialismStatus } from '../../src/addie/services/compliance-testing.js';
+
+describe('computeSpecialismStatus', () => {
+  it('returns passing for specialisms whose storyboard passed', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'passing', steps_passed: 5, steps_total: 5 }],
+    );
+    expect(result).toEqual({ 'sales-broadcast-tv': 'passing' });
+  });
+
+  it('returns failing for specialisms whose storyboard failed', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'failing', steps_passed: 2, steps_total: 5 }],
+    );
+    expect(result).toEqual({ 'sales-broadcast-tv': 'failing' });
+  });
+
+  it('treats partial as failing — partial means at least one step did not pass', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'partial', steps_passed: 4, steps_total: 5 }],
+    );
+    expect(result).toEqual({ 'sales-broadcast-tv': 'failing' });
+  });
+
+  it('returns untested when the matching storyboard has no status row', () => {
+    const result = computeSpecialismStatus(['sales-broadcast-tv'], []);
+    expect(result).toEqual({ 'sales-broadcast-tv': 'untested' });
+  });
+
+  it('returns untested when storyboard status is "untested"', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'untested', steps_passed: 0, steps_total: 5 }],
+    );
+    expect(result).toEqual({ 'sales-broadcast-tv': 'untested' });
+  });
+
+  it('returns unknown for specialisms not in SPECIALISM_CATALOG', () => {
+    const result = computeSpecialismStatus(
+      ['some-future-specialism'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'passing', steps_passed: 5, steps_total: 5 }],
+    );
+    expect(result).toEqual({ 'some-future-specialism': 'unknown' });
+  });
+
+  it('handles a mixed declaration — passing, failing, untested, unknown', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv', 'sales-non-guaranteed', 'creative-ad-server', 'made-up-specialism'],
+      [
+        { storyboard_id: 'sales_broadcast_tv', status: 'passing', steps_passed: 5, steps_total: 5 },
+        { storyboard_id: 'sales_non_guaranteed', status: 'failing', steps_passed: 1, steps_total: 5 },
+        // creative_ad_server not in storyboardStatuses → untested
+      ],
+    );
+    expect(result).toEqual({
+      'sales-broadcast-tv': 'passing',
+      'sales-non-guaranteed': 'failing',
+      'creative-ad-server': 'untested',
+      'made-up-specialism': 'unknown',
+    });
+  });
+
+  it('returns an empty object when no specialisms are declared', () => {
+    expect(computeSpecialismStatus([], [])).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of #3525. Two diagnostic improvements to the per-agent verification panel:

- **Per-specialism status marks.** Each declared specialism in the empty-state panel now carries its own ✓/✕/· mark so the developer can see which declaration is the cause of an overall \`failing\` status without cross-referencing the storyboard track pills. Failing specialisms get strike-through too. Computed server-side via \`computeSpecialismStatus()\` — \`SPECIALISM_CATALOG\` stays the single source of truth.
- **Concrete heartbeat ETA.** "On the next heartbeat" is jargon. Replaced with "within the next check cycle (12h)" — pulled from \`agent_registry_metadata.check_interval_hours\` (default 12) and now flowed to the compliance detail response. Different agents see different intervals.

Stage 2 (membership tier inline) is a separate PR — it touches auth/billing surfaces and benefits from independent review.

## What you'll see

| Before | After |
|--------|-------|
| `media-buy-seller` `media-buy-non-guaranteed` (which is failing?) | ✕ ~~media-buy-seller~~ ✓ media-buy-non-guaranteed |
| "your badge should issue on the next heartbeat" | "your badge should issue within the next check cycle (12h)" |

Static preview: \`.context/badge-showcase/verification-panel-stage1.html\` (gitignored).

## API change

\`GET /api/registry/agents/:url/compliance\` now returns:

\`\`\`jsonc
{
  // existing fields…
  "check_interval_hours": 12,
  "declared_specialisms": ["media-buy-seller", "media-buy-non-guaranteed"],
  "specialism_status": {
    "media-buy-seller": "failing",
    "media-buy-non-guaranteed": "passing"
  }
}
\`\`\`

\`specialism_status\` values: \`passing\` | \`failing\` | \`untested\` | \`unknown\`. \`unknown\` covers specialisms not in the catalog (preview specialisms or future additions an older server hasn't learned).

## Test plan

- [x] 8 new unit tests for \`computeSpecialismStatus\` (passing/failing/partial/untested/unknown/missing-row/empty)
- [x] All 64 existing verification + badge tests pass
- [x] TypeScript typecheck clean
- [x] Static preview renders correctly across all four states
- [ ] Sanity check on dashboard once deployed

## Follow-up

Stage 2 PR will surface actual membership tier inline — that's the highest-leverage diagnostic but it touches the auth/billing boundary so it ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)