### PR TITLE
fix(ipr): make ledger-remote credential prefix optional in URL guard

### DIFF
--- a/.changeset/fix-ipr-ledger-remote-credential-optional.md
+++ b/.changeset/fix-ipr-ledger-remote-credential-optional.md
@@ -1,0 +1,4 @@
+---
+---
+
+`scripts/ipr/check-and-record.mjs`: make the credentials portion of `LEDGER_REMOTE_PATTERN` optional. The previous regex `[^/@]+@?` required a username segment before `@`, which only matches URLs that embed credentials (e.g. `https://x-access-token:TOKEN@github.com/...`). When the checkout uses a credential helper instead, the bare URL `https://github.com/adcontextprotocol/adcp` failed the assertion and the script refused to push, blocking signature recording from `issue_comment` runs in caller repos. New pattern `(?:[^/@]+@)?` accepts both shapes while still rejecting other repos, hosts, and SSH URLs.

--- a/scripts/ipr/check-and-record.mjs
+++ b/scripts/ipr/check-and-record.mjs
@@ -103,7 +103,7 @@ function configureGitIdentity() {
 // against contention from sibling AAO repos all writing to the same ledger.
 // Asserting the remote URL here removes a class of "future workflow edit
 // changes which checkout backs LEDGER_DIR" footguns.
-const LEDGER_REMOTE_PATTERN = /^https:\/\/[^/@]+@?github\.com\/adcontextprotocol\/adcp(\.git)?\/?$/;
+const LEDGER_REMOTE_PATTERN = /^https:\/\/(?:[^/@]+@)?github\.com\/adcontextprotocol\/adcp(\.git)?\/?$/;
 
 function assertLedgerRemote() {
   let url;


### PR DESCRIPTION
## Summary

`scripts/ipr/check-and-record.mjs` `LEDGER_REMOTE_PATTERN` required a username segment before `@` (`[^/@]+@?`), so it matched only credentialed URLs like `https://x-access-token:TOKEN@github.com/...`. When the workflow checkout uses a credential helper instead of embedding the token in the URL, `git remote get-url origin` returns a bare `https://github.com/adcontextprotocol/adcp`, which fails the assertion and the script refuses to push — so the signature is never recorded and `IPR Policy / Signature` stays pending forever.

Hit this on #3531 (issue_comment runs failed at this exact line). The pull_request_target runs succeed because they exit before reaching the push path.

## Fix

`[^/@]+@?` → `(?:[^/@]+@)?` — credentials become fully optional. Still rejects other repos, other hosts, and SSH URLs.

## Test plan

Manual regex check on representative URLs:

```
OK https://github.com/adcontextprotocol/adcp                              => true
OK https://x-access-token:TOKEN@github.com/adcontextprotocol/adcp         => true
OK https://github.com/adcontextprotocol/adcp.git                          => true
OK https://github.com/adcontextprotocol/adcp/                             => true
OK https://github.com/foo/bar                                             => false
OK https://evil.com/adcontextprotocol/adcp                                => false
OK git@github.com:adcontextprotocol/adcp.git                              => false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)