### PR TITLE
docs(aao-verified): make Live independent of Spec

### DIFF
--- a/.changeset/aao-verified-orthogonal-axes.md
+++ b/.changeset/aao-verified-orthogonal-axes.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(aao-verified): make the two axes truly orthogonal — Live is no longer a downstream of Spec. The prerequisite framing was wrong: a seller without a sandbox/test endpoint (common for SDK-built agents whose wire format is guaranteed by the SDK, or for production-only platforms that have no test-mode surface) can earn (Live) directly by enrolling a compliance account. The eight observability checks already exercise wire format, filters, lifecycle, and scope introspection through real traffic, which makes a separate simulation pass redundant for that seller. Conversely, a test agent earns (Spec) as a complete claim.
+
+Updated copy in `docs/building/aao-verified.mdx`:
+- Top-level framing now states the axes are orthogonal, not hierarchical.
+- (Live) eligibility table no longer says "Currently holds (Spec)".
+- "(Live) only" badge reading is now a normal, valid claim — not a "rare and transient" state.
+- Mark semantics list (Live) only as a holding alongside (Spec) only and (Spec + Live).
+- Lifecycle: revoking (Spec) no longer revokes (Live); revoking (Live) no longer touches (Spec).
+
+Updated `docs/building/conformance.mdx` to match: both marks attest conformance via different evidence (Spec via simulation, Live via real-traffic observability).
+
+No code changes — the badge model already supported `verification_modes: ['live']` standalone; the only thing that needed fixing was the documentation that incorrectly claimed otherwise.

--- a/docs/building/aao-verified.mdx
+++ b/docs/building/aao-verified.mdx
@@ -17,7 +17,9 @@ It is two axes, not two tiers. The qualifiers answer different questions:
 
 An agent can earn either axis or both. A pure protocol wrapper around a stub ad server is honestly **Verified (Spec)** — that's what test agents and sandbox environments *are*. A real production seller with both an AdCP wrapper and a working ad server earns **Verified (Spec + Live)**, the strongest claim available.
 
-The two axes are related but not hierarchical. (Spec) is a *prerequisite* for measuring (Live) — AAO can't run a real campaign through a broken protocol implementation, so a storyboard regression blocks (Live) issuance even when delivery looks fine. But they answer different questions and the badge surfaces both qualifiers as they're earned.
+The two axes are **orthogonal** — neither is a prerequisite for the other. A seller without a sandbox/test endpoint (common for SDK-built agents whose correctness is guaranteed by the SDK, or for production-only platforms that have no test-mode surface) can earn **(Live)** directly by enrolling a compliance account; the eight observability checks already exercise wire format, filters, lifecycle, and scope introspection through real traffic, which makes a separate simulation pass redundant for that seller. Conversely, a test agent that can never serve real impressions earns **(Spec)** as a complete claim.
+
+The two axes are related but answer different questions, and the badge surfaces whichever qualifiers are earned.
 
 <Tip>
 **TL;DR for sellers.** (Spec) is automatic for any agent passing storyboards on a test-mode endpoint with active AAO membership. (Live) is opt-in: designate one compliance account with real live campaigns (PSA / remnant / house / genuine revenue all qualify), grant the AAO compliance engine the `attestation_verifier` scope, and you're done. The same compliance engine that runs your storyboards monitors delivery on that account over a 7–14 day rolling window. Signal healthy → (Live) qualifier holds; signal degrades → it lapses. Today (AdCP 3.x) the webhook-attached path requires a dedicated compliance tenant because `reporting_webhook` is single-slot; AdCP 4.0 relaxes that via [#3009](https://github.com/adcontextprotocol/adcp/issues/3009).
@@ -44,7 +46,7 @@ The two axes are related but not hierarchical. (Spec) is a *prerequisite* for me
 | **What it proves** | A real ad server / decisioning engine / creative renderer is behind the protocol. Real impressions delivered on real inventory. Reporting flows through AdCP. Lifecycle transitions surface correctly. The eight observability checks below all hold. |
 | **How** | Continuous observability on a designated compliance account, run by the AAO compliance engine over a 7–14 day rolling window |
 | **Cadence** | Continuous; mark expires automatically when signals degrade |
-| **Eligibility** | Currently holds **(Spec)** + has enrolled in observability (designated compliance account + `attestation_verifier` scope granted) + signals are healthy |
+| **Eligibility** | Has enrolled in observability (designated compliance account + `attestation_verifier` scope granted) + signals are healthy across the rolling window. **Independent of (Spec)** — sellers without a test-mode endpoint can earn (Live) directly. |
 | **Status** | **Lights up in 3.1** when the canonical-campaign runner is operational. The eight-check observability machinery ships now and runs against operator-designated accounts; it pivots to AAO-operated canonical campaigns when the runner is in place. |
 
 The (Live) axis is the strongest signal a buyer can rely on: AAO is the active counterparty, not just an attesting body. If something breaks in the production code path, the compliance engine sees it within days and the qualifier expires.
@@ -73,9 +75,9 @@ Badges render as a single shields.io-style image with the qualifiers in parens:
 
 | Display | Meaning |
 |---|---|
-| `AAO Verified Sales Agent (Spec)` | Storyboards pass for declared media-buy specialisms; live traffic not yet observed (or no Live path exists for this agent's specialisms). |
+| `AAO Verified Sales Agent (Spec)` | Storyboards pass for declared media-buy specialisms; live traffic not yet observed, not yet enrolled, or no Live path exists for this agent's specialisms. Common for test agents and pre-production rollouts. |
 | `AAO Verified Sales Agent (Spec + Live)` | Both axes earned. The strongest claim. |
-| `AAO Verified Sales Agent (Live)` | Live observability is healthy but Spec is currently failing — rare and transient. The badge will revoke (Live) once the storyboard regression triggers Spec revocation, since Live cannot be measured against a broken protocol. |
+| `AAO Verified Sales Agent (Live)` | Real production traffic is observed healthy across the rolling window. Common for SDK-built agents and production-only sellers without a test-mode endpoint — the eight observability checks already exercise wire format, filters, lifecycle, and scope, so a parallel storyboard pass would be redundant. |
 | `AAO Verified — Not Verified` | No badge issued for this agent + role, or the badge has been revoked. |
 
 The badge URL is stable per agent + role. As an agent earns or loses an axis, the SVG content updates without changing the URL — embedded badges automatically reflect the current state.
@@ -234,14 +236,14 @@ Verification is continuously re-evaluated, not a one-time certificate.
 - **Issued** — first heartbeat with all declared-specialism storyboards passing + active membership.
 - **Active** — re-checked every heartbeat; JWT auto-renewed.
 - **Degraded** — first storyboard regression starts a 48-hour grace; the badge continues to render (Spec) while the operator investigates.
-- **Revoked** — 48h continuous failure → `(Spec)` qualifier drops from the badge. If `(Live)` was also held, that drops too — (Live) cannot be held without (Spec) being measurable.
+- **Revoked** — 48h continuous failure → `(Spec)` qualifier drops from the badge. (Live), if held, is unaffected — the axes are independent.
 - **Recovery** — passing storyboards reissue (Spec) automatically.
 
 ### (Live)
 - **Issued** — eight checks healthy across the rolling window for an enrolled compliance account.
 - **Active** — continuous observation; mark stays as long as signals are healthy.
 - **Degraded** — any check fails → 48-hour grace. Particular failures (check 7 mismatch with secondary-identity probes) MAY skip the grace period and revoke immediately.
-- **Revoked** — 48h continuous failure → `(Live)` qualifier drops. (Spec) is unaffected.
+- **Revoked** — 48h continuous failure → `(Live)` qualifier drops. (Spec), if held, is unaffected.
 - **Recovery** — sustained healthy window reissues (Live).
 
 Membership lapse revokes the entire badge regardless of test results — public trust marks require active membership.
@@ -250,11 +252,12 @@ Membership lapse revokes the entire badge regardless of test results — public 
 
 A seller MAY hold:
 
-- **(Spec) only** (default for storyboard-passing sellers without (Live) enrollment yet, or for capabilities without a (Live) path)
-- **(Spec + Live)** (the strongest claim — both axes verified)
+- **(Spec) only** — storyboards pass on a test-mode endpoint; (Live) not enrolled, or no (Live) path exists for the agent's specialisms. Common for test agents, sandboxes, and pre-production rollouts.
+- **(Live) only** — real production traffic observed healthy across the rolling window. Common for SDK-built agents whose wire-format correctness is guaranteed by the SDK, and for production-only platforms with no test-mode surface. The eight observability checks already exercise wire format, filters, lifecycle, and scope, so requiring a parallel storyboard pass would be busywork.
+- **(Spec + Live)** — the strongest claim. Both axes verified independently.
 - **Neither**
 
-A seller cannot hold (Live) without (Spec) — a storyboard regression blocks (Live) issuance even when live campaigns look fine, because storyboards catch wire-format violations that live data might paper over.
+The two axes are evaluated independently. A storyboard regression revokes (Spec) without affecting (Live); an observability check failure revokes (Live) without affecting (Spec). Sellers can earn either in either order.
 
 ## Display
 

--- a/docs/building/conformance.mdx
+++ b/docs/building/conformance.mdx
@@ -19,8 +19,8 @@ AdCP conformance has two load-bearing terms. A third (one you'll hear in the wil
 Put differently:
 
 - Conformance is a property of the agent's wire behavior.
-- Verification is a time-bounded third-party attestation. **(Spec)** verifies conformance; **(Live)** verifies the underlying production capability that conformance presumes.
-- Verified (Spec) ⊆ Conformant. You can be conformant without being Verified; you cannot be Verified (Spec) without being conformant. Verified (Live) presumes Verified (Spec) — a broken protocol implementation makes live observation unmeasurable.
+- Verification is a time-bounded third-party attestation. **(Spec)** verifies conformance via simulation; **(Live)** verifies the underlying production capability via real-traffic observation. Each independently demonstrates conformance through different evidence.
+- Verified (Spec) ⊆ Conformant via storyboards. Verified (Live) ⊆ Conformant via the eight observability checks (which exercise wire format, filters, lifecycle, and scope through real traffic). The two axes are independent: a seller without a test-mode endpoint can earn (Live) directly, and a test agent that can never serve real impressions earns (Spec) as a complete claim.
 
 ## Two marks: AdCP Conformant and AAO Verified
 
@@ -35,7 +35,7 @@ AAO Verified is opt-in, requires no new infrastructure (the AAO compliance engin
 | **AdCP Conformant** | Wire format, task shape, error semantics, filter behavior match the spec | Storyboards + behavioral assertions against `simulate_delivery` |
 | **AAO Verified** (optional) | The declared capability is implemented on the seller's live production stack | Continuous observability of real delivery, 7–14 day rolling window |
 
-**Containment.** AAO Verified ⊆ AdCP Conformant. A seller cannot hold AAO Verified without AdCP Conformant — a storyboard regression blocks AAO Verified issuance even when live campaigns look fine, because storyboards catch wire-format violations that live data might paper over. You can be Conformant without being Verified (storyboard-passing but no live traffic yet); you cannot be Verified without being Conformant.
+**Both marks attest conformance, via different evidence.** AAO Verified is the public trust mark; AdCP Conformant is the wire-format property the storyboards define. The two axes of AAO Verified — **(Spec)** via storyboard simulation, **(Live)** via real-traffic observability — are independent and either is sufficient evidence of conformance for the claims it covers. A seller earning **(Live)** demonstrates wire-format correctness through observed real traffic that the eight checks exercise; a seller earning **(Spec)** demonstrates it through simulated interactions against a test endpoint. Sellers can earn either or both. See [AAO Verified § Mark semantics](/docs/building/aao-verified#mark-semantics) for which holdings are valid.
 
 **Why two marks, not two tiers.** Earlier drafts used "Tier 1 — Protocol Conformant" and "Tier 2 — Production Verified." That framing muddied the message: a buyer reading "Tier 1 — Protocol Conformant" plausibly infers "verified at the basic level," when all it actually attests is wire-format correctness. *Conformant* and *Verified* are distinct claims, not tiers of the same thing — with *Verified* strictly implying *Conformant*. See [AAO Verified § Why these two marks](/docs/building/aao-verified#why-these-two-marks-not-the-earlier-tier-1--tier-2) for the full reasoning.
 


### PR DESCRIPTION
## Summary

The merged AAO Verified docs framed (Spec) as a prerequisite for (Live). That's wrong. A seller using \`@adcp/sdk\` who flows real production traffic shouldn't have to stand up a sandbox/test endpoint just to earn (Spec) before (Live) can issue.

The two axes demonstrate conformance through different evidence:
- **(Spec)** — wire format, task shape, error semantics, state-machine transitions verified via storyboard simulation against a test endpoint.
- **(Live)** — wire format, filters, lifecycle, scope introspection, reporting consistency verified via real-traffic observation against a real ad server over a 7–14 day rolling window.

Either is sufficient for the claims it covers. Some sellers can only earn one or the other:

| Holding | Common shape |
|---|---|
| **(Spec) only** | Test agents, sandboxes, pre-production rollouts, or capabilities with no canonical-campaign path |
| **(Live) only** | SDK-built agents whose wire format is guaranteed by the SDK, or production-only platforms with no test-mode surface |
| **(Spec + Live)** | The strongest claim — both axes verified independently |

## Why this matters now

Before any seller in the ecosystem builds toward "I need (Spec) before I can earn (Live)" — which a couple of partner conversations were already heading. Forcing SDK-built agents to stand up a separate mock endpoint is busywork that proves nothing the SDK didn't already guarantee.

## Files changed

- \`docs/building/aao-verified.mdx\` — top-level framing, (Live) eligibility, badge-reading table, mark semantics, lifecycle (revocations no longer cascade between axes)
- \`docs/building/conformance.mdx\` — containment paragraph rewritten as "both marks attest conformance via different evidence"

## What did not change

The badge code already supports \`verification_modes: ['live']\` standalone — the prerequisite was a stated convention, never enforced. So this is a docs-only correctness fix.

\`verification_modes: ['live']\` (without 'spec') is already a valid wire-format value:
- The Zod schema accepts it (\`z.array(z.enum(VERIFICATION_MODES))\`)
- The DB CHECK constraint accepts it (\`<@ ARRAY['spec', 'live']\` plus non-empty)
- \`renderBadgeSvg\` renders \`(Live)\` correctly when 'spec' is absent
- JWT signing/verification rounds-trips it

## Test plan

- [x] No code changes — existing 64 verification tests still cover the orthogonal model
- [x] Docs render check
- [ ] WG soundness check on the orthogonality claim (optional but worth surfacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)