### PR TITLE
fix(registry): P0 follow-ups — type reclassification guard, docs IA, source trust clarity

### DIFF
--- a/.changeset/registry-p0-followups-type-guard-docs-ia.md
+++ b/.changeset/registry-p0-followups-type-guard-docs-ia.md
@@ -1,0 +1,10 @@
+---
+---
+
+Registry P0 follow-ups from #3495: fix crawler type reclassification guard so agents with
+wrong non-unknown types can be corrected on future crawl passes; rename OpenAPI tag from
+"Lookups & Authorization" to "Authorization Lookups" to fix the %26-encoded URL slug; add
+trust-level descriptions to source/member/discovered_from schema fields; document auth-aware
+visibility on /operator; add missing operator/publisher rows to docs/registry/index.mdx
+overview table; add docs/registry/registering-an-agent.mdx explaining the two registration
+paths and trust levels.

--- a/docs.json
+++ b/docs.json
@@ -505,7 +505,8 @@
                       "directory": "docs/registry/api-reference"
                     },
                     "pages": [
-                      "docs/registry/index"
+                      "docs/registry/index",
+                      "docs/registry/registering-an-agent"
                     ]
                   },
                   "docs/reference/gmsf-reference",
@@ -997,7 +998,8 @@
                   "directory": "docs/registry/api-reference"
                 },
                 "pages": [
-                  "docs/registry/index"
+                  "docs/registry/index",
+                  "docs/registry/registering-an-agent"
                 ]
               },
               "docs/reference/gmsf-reference",

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -84,8 +84,11 @@ Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded
   <Card title="Change Feed" icon="clock-rotate-left" href="/docs/registry/index#change-feed">
     Poll a cursor-based feed of registry changes for local sync.
   </Card>
-  <Card title="Lookups & Authorization" icon="shield-check" href="/docs/registry/index#lookups--authorization">
+  <Card title="Authorization Lookups" icon="shield-check" href="/docs/registry/index#authorization-lookups">
     Look up agents by domain, validate product authorization, and check property authorization in real time.
+  </Card>
+  <Card title="Registering an Agent" icon="circle-plus" href="/docs/registry/registering-an-agent">
+    How agents appear in the registry, what trust level each path produces, and what membership unlocks.
   </Card>
 </CardGroup>
 
@@ -139,16 +142,29 @@ All sources produce the same resolution response structure. To get full brand id
 | GET | `/api/registry/feed` | Poll cursor-based registry change feed (auth required) |
 
 
-### Lookups & Authorization
+### Authorization Lookups
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/api/registry/operator` | What agents does this domain operate? (auth-aware — see [operator lookup](#operator-and-publisher-lookup)) |
+| GET | `/api/registry/publisher` | What does this domain publish and which agents does it authorize? |
 | GET | `/api/registry/lookup/domain/{domain}` | Find agents authorized for a domain |
 | GET | `/api/registry/lookup/property` | Find agents by property identifier |
 | GET | `/api/registry/lookup/agent/{agentUrl}/domains` | Get all domains for an agent |
 | POST | `/api/registry/validate/product-authorization` | Validate agent product authorization |
 | POST | `/api/registry/expand/product-identifiers` | Expand property selectors to identifiers |
 | GET | `/api/registry/validate/property-authorization` | Real-time authorization check |
+
+#### Operator and publisher lookup
+
+`/api/registry/operator` and `/api/registry/publisher` answer different questions about the same domain:
+
+| Endpoint | Question | Typical caller |
+|----------|----------|----------------|
+| `/api/registry/operator?domain=X` | What agents does this entity operate? Which publishers trust it? | Buy-side: validating a sell-side counterparty |
+| `/api/registry/publisher?domain=X` | What inventory does this entity publish? Which agents does it authorize? | Sell-side: inspecting a publisher's authorization set |
+
+The operator endpoint returns more data for authenticated callers: anonymous callers see public agents only; callers with an AgenticAdvertising.org API-access token additionally see `members_only` agents; callers who are the profile owner additionally see `private` agents. [See registering an agent](/docs/registry/registering-an-agent) for how trust levels map to registration source.
 
 Authorization validation checks both sides: the publisher's `adagents.json` (does it authorize this agent with the claimed `delegation_type`?) and the operator's `brand.json` (does it declare this property with a matching `relationship`?).
 

--- a/docs/registry/registering-an-agent.mdx
+++ b/docs/registry/registering-an-agent.mdx
@@ -16,7 +16,7 @@ Agents appear in the AgenticAdvertising.org registry through two paths. The path
 
 ## What trust level looks like in API responses
 
-The `source` field is returned on every agent in `GET /api/registry/agents` and on the `operators` list in `GET /api/registry/operator`.
+The `source` field is returned on every agent in `GET /api/registry/agents`.
 
 ```json Registered agent (member direct)
 {
@@ -54,4 +54,4 @@ To enroll as an AgenticAdvertising.org member, visit [agenticadvertising.org/joi
 
 If you are not yet an AgenticAdvertising.org member, the only path into the registry is through a member publisher's `adagents.json`. Ask the publisher to add your agent URL with the appropriate `authorized_for` value. The registry crawler runs on a regular schedule and will pick up the entry on its next pass.
 
-Self-registration without AgenticAdvertising.org membership is on the roadmap — follow [#3538](https://github.com/adcontextprotocol/adcp/issues/3538) for status.
+Self-registration without AgenticAdvertising.org membership is on the roadmap. A separate tracking issue will be filed once the trust-tier model for self-attested agents is decided.

--- a/docs/registry/registering-an-agent.mdx
+++ b/docs/registry/registering-an-agent.mdx
@@ -1,0 +1,57 @@
+---
+title: Registering an Agent
+sidebarTitle: Registering an Agent
+description: "How agents appear in the AgenticAdvertising.org registry, what trust level each path produces, and what AgenticAdvertising.org membership unlocks."
+"og:title": "AdCP — Registering an Agent"
+---
+
+Agents appear in the AgenticAdvertising.org registry through two paths. The path determines the agent's `source` value in API responses and the trust level assigned to it.
+
+## Registration paths
+
+| Path | How | `source` in API | Trust level |
+|------|-----|-----------------|-------------|
+| **Member direct registration** | An AgenticAdvertising.org member organization enrolls the agent via the member dashboard. The member has accepted AgenticAdvertising.org terms on the agent's behalf. | `registered` | Full — appears in `public`, `members_only`, and `private` tiers depending on visibility settings |
+| **Discovery via adagents.json** | A member publisher lists the agent in their `adagents.json`. The registry crawler finds and indexes it automatically. The agent itself has not opted in. | `discovered` | Public only — always visible as a `public` agent, regardless of caller authentication |
+
+## What trust level looks like in API responses
+
+The `source` field is returned on every agent in `GET /api/registry/agents` and on the `operators` list in `GET /api/registry/operator`.
+
+```json Registered agent (member direct)
+{
+  "url": "https://ads.streamhaus.example.com",
+  "type": "sales",
+  "source": "registered",
+  "member": { "slug": "streamhaus", "display_name": "StreamHaus" }
+}
+```
+
+```json Discovered agent (via publisher adagents.json)
+{
+  "url": "https://agent.examplepub.com",
+  "type": "sales",
+  "source": "discovered",
+  "discovered_from": { "publisher_domain": "examplepub.com" }
+}
+```
+
+A `discovered` agent's `member` field is absent. It was listed by a publisher, not enrolled by the agent operator. If you are the operator of a `discovered` agent and want to upgrade to `registered` status, the path is AgenticAdvertising.org membership (see below).
+
+## What AgenticAdvertising.org membership unlocks
+
+Member organizations that enroll agents gain:
+
+- **`registered` source** — callers can distinguish your agent from crawl-discovered entries
+- **Visibility tiers** — choose `public` (default), `members_only` (visible only to authenticated AgenticAdvertising.org API callers), or `private` (visible only when you are the caller)
+- **`member` field populated** — your organization name and slug appear alongside the agent in registry responses
+- **Verified badge** — displayed in the public registry UI
+- **Storyboard testing access** — run your agent against the AdCP compliance suite
+
+To enroll as an AgenticAdvertising.org member, visit [agenticadvertising.org/join](https://agenticadvertising.org/join).
+
+## Getting a non-member agent discovered
+
+If you are not yet an AgenticAdvertising.org member, the only path into the registry is through a member publisher's `adagents.json`. Ask the publisher to add your agent URL with the appropriate `authorized_for` value. The registry crawler runs on a regular schedule and will pick up the entry on its next pass.
+
+Self-registration without AgenticAdvertising.org membership is on the roadmap — follow [#3538](https://github.com/adcontextprotocol/adcp/issues/3538) for status.

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -89,7 +89,7 @@ const TAG_DESCRIPTIONS: Record<string, string> = {
   "Property Resolution": "Resolve publisher domains to their property configurations and authorized agents.",
   "Agent Discovery": "Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.",
   "Change Feed": "Poll cursor-based registry change events for local sync.",
-  "Lookups & Authorization": "Look up agents by domain or property, and validate ad-serving authorization.",
+  "Authorization Lookups": "Look up agents by domain or property, and validate ad-serving authorization.",
   "Validation Tools": "Validate publisher adagents.json files and generate compliant configurations.",
   "Search": "Cross-entity search across brands, publishers, agents, and properties.",
   "Agent Probing": "Connect to live agents and inspect their capabilities, formats, and inventory.",

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -577,7 +577,7 @@ export class CrawlerService {
             this.snapshotDb.upsertHealth(agent.url, health, stats),
           ]);
 
-          if (!knownTypes.has(agent.url) && inferredType !== 'unknown') {
+          if (inferredType !== 'unknown' && inferredType !== knownTypes.get(agent.url)) {
             await this.federatedIndex.updateAgentMetadata(agent.url, {
               agent_type: inferredType,
               protocol: profile.protocol,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -608,14 +608,14 @@ registry.registerPath({
   },
 });
 
-// Lookups & Authorization
+// Authorization Lookups
 registry.registerPath({
   method: "get",
   path: "/api/registry/lookup/domain/{domain}",
   operationId: "lookupDomain",
   summary: "Domain lookup",
   description: "Find all agents authorized for a given publisher domain.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: { params: z.object({ domain: z.string().openapi({ example: "examplepub.com" }) }) },
   responses: {
     200: { description: "Domain lookup result", content: { "application/json": { schema: DomainLookupResultSchema } } },
@@ -628,7 +628,7 @@ registry.registerPath({
   operationId: "lookupProperty",
   summary: "Property identifier lookup",
   description: "Find agents that hold a specific property identifier.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: { query: z.object({ type: z.string(), value: z.string() }) },
   responses: {
     200: { description: "Matching agents", content: { "application/json": { schema: z.object({ type: z.string(), value: z.string(), agents: z.array(z.unknown()), count: z.number().int() }) } } },
@@ -641,7 +641,7 @@ registry.registerPath({
   operationId: "getAgentDomains",
   summary: "Agent domain lookup",
   description: "Get all publisher domains associated with an agent.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: { params: z.object({ agentUrl: z.string() }) },
   responses: {
     200: { description: "Domains for the agent", content: { "application/json": { schema: z.object({ agent_url: z.string(), domains: z.array(z.string()), count: z.number().int() }) } } },
@@ -653,8 +653,12 @@ registry.registerPath({
   path: "/api/registry/operator",
   operationId: "lookupOperator",
   summary: "Operator lookup",
-  description: "Given a domain, returns the agents this entity operates and which publishers trust them.",
-  tags: ["Lookups & Authorization"],
+  description:
+    "Given a domain, returns the agents this entity operates and which publishers trust them. " +
+    "Response visibility is caller-dependent: anonymous callers see public agents only; " +
+    "callers with an AgenticAdvertising.org API-access token additionally see members_only agents; " +
+    "callers who are the profile owner additionally see private agents.",
+  tags: ["Authorization Lookups"],
   request: {
     query: z.object({
       domain: z.string().openapi({ example: "pubmatic.com" }),
@@ -672,7 +676,7 @@ registry.registerPath({
   operationId: "lookupPublisher",
   summary: "Publisher lookup",
   description: "Given a domain, returns the inventory this entity publishes and which agents it authorizes.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: {
     query: z.object({
       domain: z.string().openapi({ example: "voxmedia.com" }),
@@ -691,7 +695,7 @@ registry.registerPath({
   summary: "Validate product authorization",
   description:
     "Check whether an agent is authorized to sell a product based on its publisher_properties.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: {
     body: {
       content: {
@@ -715,7 +719,7 @@ registry.registerPath({
   operationId: "expandProductIdentifiers",
   summary: "Expand product identifiers",
   description: "Expand publisher_properties selectors into concrete property identifiers for caching.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: {
     body: {
       content: {
@@ -753,7 +757,7 @@ registry.registerPath({
   operationId: "validatePropertyAuthorization",
   summary: "Property authorization check",
   description: "Quick check if a property identifier is authorized for an agent. Optimized for real-time ad request validation.",
-  tags: ["Lookups & Authorization"],
+  tags: ["Authorization Lookups"],
   request: {
     query: z.object({
       agent_url: z.string(),
@@ -5160,7 +5164,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  // ── Lookups & Authorization ───────────────────────────────────
+  // ── Authorization Lookups ─────────────────────────────────────
 
   router.get("/registry/operator", optAuth, async (req, res) => {
     const rawDomain = req.query.domain as string;

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -353,9 +353,23 @@ export const FederatedAgentWithDetailsSchema = z
       })
       .optional(),
     added_date: z.string().optional(),
-    source: z.enum(["registered", "discovered"]).optional(),
-    member: MemberRefSchema.optional(),
-    discovered_from: DiscoveredFromSchema.optional(),
+    source: z
+      .enum(["registered", "discovered"])
+      .optional()
+      .openapi({
+        description:
+          "How this agent entered the registry. 'registered' means the operator directly enrolled " +
+          "via AgenticAdvertising.org and has accepted its terms. 'discovered' means the agent was " +
+          "found in a member publisher's adagents.json and has not explicitly opted in.",
+      }),
+    member: MemberRefSchema.optional().openapi({
+      description:
+        "AgenticAdvertising.org member organization that registered this agent. Present only when source='registered'.",
+    }),
+    discovered_from: DiscoveredFromSchema.optional().openapi({
+      description:
+        "The member publisher whose adagents.json referenced this agent. Present only when source='discovered'.",
+    }),
     health: AgentHealthSchema.optional(),
     stats: AgentStatsSchema.optional(),
     capabilities: AgentCapabilitiesSchema.optional(),

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2579,7 +2579,7 @@ paths:
       summary: Domain lookup
       description: Find all agents authorized for a given publisher domain.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -2600,7 +2600,7 @@ paths:
       summary: Property identifier lookup
       description: Find agents that hold a specific property identifier.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -2640,7 +2640,7 @@ paths:
       summary: Agent domain lookup
       description: Get all publisher domains associated with an agent.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -2673,7 +2673,7 @@ paths:
       summary: Operator lookup
       description: Given a domain, returns the agents this entity operates and which publishers trust them.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -2700,7 +2700,7 @@ paths:
       summary: Publisher lookup
       description: Given a domain, returns the inventory this entity publishes and which agents it authorizes.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -2727,7 +2727,7 @@ paths:
       summary: Validate product authorization
       description: Check whether an agent is authorized to sell a product based on its publisher_properties.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       requestBody:
         content:
           application/json:
@@ -2768,7 +2768,7 @@ paths:
       summary: Expand product identifiers
       description: Expand publisher_properties selectors into concrete property identifiers for caching.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       requestBody:
         content:
           application/json:
@@ -2834,7 +2834,7 @@ paths:
       summary: Property authorization check
       description: Quick check if a property identifier is authorized for an agent. Optimized for real-time ad request validation.
       tags:
-        - Lookups & Authorization
+        - Authorization Lookups
       parameters:
         - schema:
             type: string
@@ -6000,7 +6000,7 @@ tags:
     description: Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.
   - name: Change Feed
     description: Poll cursor-based registry change events for local sync.
-  - name: Lookups & Authorization
+  - name: Authorization Lookups
     description: Look up agents by domain or property, and validate ad-serving authorization.
   - name: Validation Tools
     description: Validate publisher adagents.json files and generate compliant configurations.


### PR DESCRIPTION
Refs #3538

Ships the P0-ready subset from issue #3538 (registry follow-ups from #3495). Migrations 454+455 already landed the member_profiles backfill; this PR addresses the remaining P0 items that were code + docs, not data.

## What ships

**1. Crawler type reclassification guard (`server/src/crawler.ts:580`)**
Old guard: `!knownTypes.has(agent.url) && inferredType !== 'unknown'` — skipped agents that already had *any* non-unknown type, even a wrong one (the root cause of Bidcliq/Swivel staying as `buying`).
New guard: `inferredType !== 'unknown' && inferredType !== knownTypes.get(agent.url)` — updates the stored type whenever the new inferred type is non-unknown *and* differs from what's stored. Refuses to downgrade to `unknown`. Prevents recurrence without needing another one-shot migration.

**2. OpenAPI tag rename: `"Lookups & Authorization"` → `"Authorization Lookups"`**
Changed across 4 source files: `registry-api.ts` (8 tags + 2 comments), `static/openapi/registry.yaml` (8 tags + tag definition), `scripts/generate-openapi.ts` (map key), `docs/registry/index.mdx` (CardGroup card + section heading + anchor href). Fixes the `lookups-%26-authorization` URL slug that was unshareable and unsearchable in Mintlify. Versioned snapshots under `dist/` are frozen historical artifacts and were intentionally not updated.

**3. OpenAPI description annotations on `source`, `member`, `discovered_from` fields (`server/src/schemas/registry.ts`)**
Trust-level semantics added: `source` explains `registered` vs `discovered`; `member` clarifies it's present only for registered agents; `discovered_from` clarifies it's present only for discovered agents. Annotations placed on the `.optional()` wrapper — consistent with how `source` is annotated and correct for zod-to-openapi.

**4. Auth-aware note on `/api/registry/operator` OpenAPI description**
Documents the three-tier visibility already implemented in the runtime handler: anonymous → public only; API-access token → adds `members_only`; profile owner → adds `private`. Zero runtime change.

**5. `docs/registry/index.mdx` — missing operator/publisher rows + subsection**
Added `/api/registry/operator` and `/api/registry/publisher` to the Authorization Lookups overview table (they were documented in sub-pages but absent from the overview). Added a short subsection explaining when to call each and the operator endpoint's auth-aware behavior.

**6. New `docs/registry/registering-an-agent.mdx`**
Two-path registration table (member direct vs discovered via adagents.json), JSON examples showing `source` field differences, what AgenticAdvertising.org membership unlocks, path for non-member agents. Problem 5 Option B (`community_agents` / `self_attested`) flagged for human product decision.

## What's deferred (stays open on #3538)

- **P0.1 member_profiles backfill** — migration 455 already handles this. The remaining gap (agents never crawled) closes on next write via the prevention layer in #3498.
- **P1: `?source=` query param + UI segmentation** — author's P1 phasing; additive but requires more UI work.
- **P1: Re-probe loop for `type: 'unknown'` agents** — needs `group by discovery_error` data investigation before building retry logic; also needs `last_probe_attempt_at` schema change.
- **P2: Endpoint split** — breaking change, needs RFC + deprecation period.
- **Problem 5 Option B** — product decision on trust tier model for self-attested agents, flagged for human review.
- **`buying` enum question** — explicitly out of scope per issue author.

## Non-breaking justification

All six changes are non-breaking: the crawler guard is a server-internal logic fix with no wire format change; the tag rename affects only the generated docs slug (not any wire field); the schema annotations add optional OpenAPI metadata to existing fields; the operator description change adds documentation to an existing endpoint; the docs changes are additive.

## Pre-PR review

**Blocker found and fixed:** Both reviewers independently flagged that `registering-an-agent.mdx` incorrectly claimed `source` appears on the `/api/registry/operator` response — `OperatorAgentSchema` has no `source` field. Fixed in commit `31ece72`: sentence now reads "The `source` field is returned on every agent in `GET /api/registry/agents`."

- **code-reviewer**: approved after fix — crawler guard logic correct; tag rename complete; `.openapi()` placement on optional wrapper is correct for zod-to-openapi. Nit: link text in `index.mdx:167` could be reworded for readability.
- **ad-tech-protocol-expert**: approved after fix — all changes non-breaking per spec; `OperatorAgentSchema` confirmed to have no `source` field; discovered agents are returned unconditionally by `/api/registry/agents` (no visibility gate), consistent with "public only" trust-level claim in the new docs page.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01LpZQ7dcUTFgreLrUkKsLht