### PR TITLE
docs(governance): per-finding attribution as audit surface for internal specialist composition

### DIFF
--- a/.changeset/governance-spec-finding-attribution-note.md
+++ b/.changeset/governance-spec-finding-attribution-note.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(governance): non-normative note on per-finding attribution as the audit surface for internal specialist composition
+
+Doc follow-up to #3015. The merged "One governance agent per account" rationale already explains that internal specialist review (pharma MLR, brand safety, legal, category) composes inside the configured governance agent. This adds one paragraph naming the audit surface that makes the internal decomposition observable: each entry on `check-governance-response.findings[]` carries `category_id` (agent-internal taxonomy — which specialism flagged it) and `policy_id` (the specific policy that triggered). Buyers and sellers see one consolidated decision; per-finding attribution lets them trace which specialist contributed to a denial or condition without the protocol needing to surface multiple agents.
+
+The schema's `category_id` description already points readers at the spec for the composition story; this paragraph completes the round-trip — spec points back at `findings[]` as the audit surface. Non-normative; zero schema impact.
+
+Closes #3433.

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -995,6 +995,8 @@ This is deliberate. A governance plan is unitary — budget authority, delivery 
 
 Buyers that need internal specialist review (legal, brand safety, category) compose those reviewers inside the governance agent they configure — the protocol does not surface the split.
 
+Internal decomposition is auditable through `check-governance-response.findings[]`. Each finding carries `category_id` (the agent-internal taxonomy — pharma MLR, brand safety, legal compliance, whichever specialism flagged it) and `policy_id` (the specific policy that triggered the finding). Buyers and sellers see one consolidated decision; per-finding attribution lets readers trace which specialist within the governance agent contributed to a denial or condition without surfacing the split as separate protocol-level agents.
+
 Related specialist reviews that sit adjacent to (not inside) campaign governance — brand-safety pre-screen of creatives, property-list policy, content-standards evaluation — are separate governance surfaces with their own agents and their own lifecycle (see [`build_creative`](/docs/creative/task-reference/build_creative), property governance, content-standards governance). Campaign governance speaks only for the plan.
 
 ### Governance checks and the governance loop


### PR DESCRIPTION
## Summary

Closes #3433. Doc follow-up to #3015.

The merged "One governance agent per account" rationale already explains that internal specialist review (pharma MLR, brand safety, legal, category) **composes inside** the configured governance agent — the protocol sees one agent. This adds one paragraph naming the **audit surface** that makes the internal decomposition observable to buyers/sellers.

Each entry on `check-governance-response.findings[]` carries:
- `category_id` — the agent-internal taxonomy (pharma MLR, brand safety, legal compliance, whichever specialism flagged it)
- `policy_id` — the specific policy that triggered the finding

Buyers and sellers see one consolidated decision; per-finding attribution lets them trace which specialist within the agent contributed to a denial or condition — without the protocol needing to surface multiple agents.

The schema's `category_id` description already points readers at the spec for the composition story:

> "See the Campaign Governance specification for how an agent composes internal specialist review behind one endpoint."

This paragraph completes the round-trip — spec points back at `findings[]` as the audit surface.

Non-normative. Zero schema impact. One paragraph in `docs/governance/campaign/specification.mdx`.

## Test plan

- [ ] Visual review of the new paragraph in context (renders cleanly, link in `category_id` description from `check-governance-response.json` reaches a doc that explicitly names the field as the audit surface)
- [ ] No schema changes; no breaking changes; no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)